### PR TITLE
Fix for config in Ruby 1.9

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -321,7 +321,7 @@ module Git
     end
 
     def config_get(name)
-      do_get = lambda do
+      do_get = lambda do |path|
         command('config', ['--get', name])
       end
 


### PR DESCRIPTION
In 1.9, Dir.chdir accepts a block with one argument, that is the path
after it changed the directory.
