### PR TITLE
Added git ls-remote command to Git::Lib

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -304,6 +304,18 @@ module Git
       hsh
     end
 
+    def ls_remote(location=nil)
+      Hash.new{ |h,k| h[k] = {} }.tap do |hsh|
+        command_lines('ls-remote', [location], false).each do |line|
+          (sha, info) = line.split("\t")
+          (ref, type, name) = info.split('/', 3)
+          type ||= 'head'
+          type = 'branches' if type == 'heads'
+          value = {:ref => ref, :sha => sha}
+          hsh[type].update( name.nil? ? value : { name => value })
+        end
+      end
+    end
 
     def ignored_files
       command_lines('ls-files', ['--others', '-i', '--exclude-standard'])

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -137,6 +137,23 @@ class TestLib < Test::Unit::TestCase
     assert(tree['tree'])
   end
 
+  def test_ls_remote
+    in_temp_dir do |path|
+      lib = Git::Lib.new
+      ls = lib.ls_remote(@wbare)
+
+      assert_equal(%w( gitsearch1 v2.5 v2.6 v2.7 v2.8 ), ls['tags'].keys)
+      assert_equal("935badc874edd62a8629aaf103418092c73f0a56", ls['tags']['gitsearch1'][:sha])
+
+      assert_equal(%w( git_grep master test test_branches test_object ), ls['branches'].keys)
+      assert_equal("5e392652a881999392c2757cf9b783c5d47b67f7", ls['branches']['master'][:sha])
+
+      assert_equal("HEAD", ls['head'][:ref])
+      assert_equal("5e392652a881999392c2757cf9b783c5d47b67f7", ls['head'][:sha])
+      assert_equal(nil, ls['head'][:name])
+    end
+  end
+
 
   # options this will accept
   #  :treeish


### PR DESCRIPTION
I needed the functionality of git-ls-remote ([see docs](http://linux.die.net/man/1/git-ls-remote)). It allows you to pull down the branches and tags of a remote repo without necessarily having it checked out locally.

So, for example, without even being in a git repo of any kind, I can simply issue this from the command line:

```
$ git ls-remote https://github.com/schacon/ruby-git.git
b79de3a8955a5211a9b7aefaccef888db51e6523    HEAD
10b880b418879e662feb91ce7af98560adeaa8bb    refs/heads/integrate
6a9db968e8563bc27b8f56f9d413159a2e14cf67    refs/heads/internals
b79de3a8955a5211a9b7aefaccef888db51e6523    refs/heads/master
2d749e3aa69d7bfedf814f59618f964fdbc300d5    refs/heads/test
eeab421f5ca7f240e85f390d27e043b519c528a6    refs/pull/14/head
c83c5983efd9db26719fa17e6b1330222e7244ca    refs/pull/19/head
a3165fefd627ff5a9dfff12b5493859fe6085065    refs/pull/20/head
31520a59828d2419d15376141a32cce996a15c96    refs/pull/20/merge
f12bb1023d7dcfc10a93ce98d00ccfddcced0bda    refs/pull/21/head
7e073aeedbfada57dfec4073fdea1fecc64e57c2    refs/pull/22/head
6e68259422cb39b55c75fac33c79240c3e20afb0    refs/pull/26/head
404e2b8a012357bd621416345bb5f6cdf93e7972    refs/pull/26/merge
3985512332435893d8366a81cc49b83258a50d6a    refs/pull/27/head
4a8c712af3af3a0e1d927494795c6860b4aa9bc9    refs/pull/29/head
0f10c110712b62d13dd5d6bf77a752f8e00daebe    refs/pull/34/head
9dd1e18b43e305a4f61ce2e186f474093e90793b    refs/pull/34/merge
0e986047d759d9ff34ef86512639090f613d628b    refs/pull/35/head
7ab6d44b30a0ccd716adc8928e70e08b67011d3b    refs/pull/35/merge
be47ad8aea4f854fc2d6773456fb28f3e9f519e7    refs/tags/1.0.3
6c4af60f5fc5193b956a4698b604ad96ef3c51c6    refs/tags/1.0.5
3d26fb201e724814c6dd61cdb7ac8605c35a1dc0    refs/tags/1.0.5.1
ae106e2a3569e5ea874852c613ed060d8e232109    refs/tags/1.0.5.1^{}
2bc4103245a4e8d9f79ec59c2814c47b857d3a0b    refs/tags/v1.0.7
1adc5b8136c2cd6c694629947e1dbc49c8bffe6a    refs/tags/v1.0.7^{}
cfad76700b3d38eb3be97e2d5ef75cc0a398f818    refs/tags/v1.2.0
f85cef0b1916f09ceb38f778ada98b23c8610da7    refs/tags/v1.2.1
85fa6ec3a68b6ff8acfa69c59fbdede1385f63bb    refs/tags/v1.2.2
2962356828cc0ce07674b1c1fa39fde893732344    refs/tags/v1.2.3
1987b5010ed1abff915bd87146753323754bfb13    refs/tags/v1.2.4
94f389bf5d9af4511597d035e69d1be9510b50c7    refs/tags/v1.2.5
```

I put this in `Git::Lib` because it made the most sense there I thought, considering you don't necessarily need to be in an instantiated git repo (i.e. `Git::Base` instance) in order to use it. Also, there are similar commands there like `ls_files`.

Also, I made the passed location optional, because if you _are_ in a git repo and issue `git ls-remote` without any arguments, it just calls it using the current repo's tracked remote.

And finally, I made a judgement call on the format of the output. Currently, it looks like this:

``` ruby
ruby-1.9.2-p290 :007 > l = Git::Lib.new
 => #<Git::Lib:0x000001042b0d18 @git_dir=nil, @git_index_file=nil, @git_work_dir=nil, @path=nil, @logger=nil> 
ruby-1.9.2-p290 :008 > l.ls_remote('https://github.com/schacon/ruby-git.git')
 => {
  "head"=>{:ref=>"HEAD", :sha=>"b79de3a8955a5211a9b7aefaccef888db51e6523"},
  "branches"=>{
    "integrate"=>{:ref=>"refs", :sha=>"10b880b418879e662feb91ce7af98560adeaa8bb"},
    "internals"=>{:ref=>"refs", :sha=>"6a9db968e8563bc27b8f56f9d413159a2e14cf67"},
    "master"=>{:ref=>"refs", :sha=>"b79de3a8955a5211a9b7aefaccef888db51e6523"},
    "test"=>{:ref=>"refs", :sha=>"2d749e3aa69d7bfedf814f59618f964fdbc300d5"}
  },
  "pull"=>{
    "14/head"=>{:ref=>"refs", :sha=>"eeab421f5ca7f240e85f390d27e043b519c528a6"},
    "19/head"=>{:ref=>"refs", :sha=>"c83c5983efd9db26719fa17e6b1330222e7244ca"},
    "20/head"=>{:ref=>"refs", :sha=>"a3165fefd627ff5a9dfff12b5493859fe6085065"},
    "20/merge"=>{:ref=>"refs", :sha=>"31520a59828d2419d15376141a32cce996a15c96"},
    "21/head"=>{:ref=>"refs", :sha=>"f12bb1023d7dcfc10a93ce98d00ccfddcced0bda"},
    "22/head"=>{:ref=>"refs", :sha=>"7e073aeedbfada57dfec4073fdea1fecc64e57c2"},
    "26/head"=>{:ref=>"refs", :sha=>"6e68259422cb39b55c75fac33c79240c3e20afb0"},
    "26/merge"=>{:ref=>"refs", :sha=>"404e2b8a012357bd621416345bb5f6cdf93e7972"},
    "27/head"=>{:ref=>"refs", :sha=>"3985512332435893d8366a81cc49b83258a50d6a"},
    "29/head"=>{:ref=>"refs", :sha=>"4a8c712af3af3a0e1d927494795c6860b4aa9bc9"},
    "34/head"=>{:ref=>"refs", :sha=>"0f10c110712b62d13dd5d6bf77a752f8e00daebe"},
    "34/merge"=>{:ref=>"refs", :sha=>"9dd1e18b43e305a4f61ce2e186f474093e90793b"},
    "35/head"=>{:ref=>"refs", :sha=>"0e986047d759d9ff34ef86512639090f613d628b"},
    "35/merge"=>{:ref=>"refs", :sha=>"7ab6d44b30a0ccd716adc8928e70e08b67011d3b"}
  },
  "tags"=>{
    "1.0.3"=>{:ref=>"refs", :sha=>"be47ad8aea4f854fc2d6773456fb28f3e9f519e7"},
    "1.0.5"=>{:ref=>"refs", :sha=>"6c4af60f5fc5193b956a4698b604ad96ef3c51c6"},
    "1.0.5.1"=>{:ref=>"refs", :sha=>"3d26fb201e724814c6dd61cdb7ac8605c35a1dc0"},
    "1.0.5.1^{}"=>{:ref=>"refs", :sha=>"ae106e2a3569e5ea874852c613ed060d8e232109"},
    "v1.0.7"=>{:ref=>"refs", :sha=>"2bc4103245a4e8d9f79ec59c2814c47b857d3a0b"},
    "v1.0.7^{}"=>{:ref=>"refs", :sha=>"1adc5b8136c2cd6c694629947e1dbc49c8bffe6a"},
    "v1.2.0"=>{:ref=>"refs", :sha=>"cfad76700b3d38eb3be97e2d5ef75cc0a398f818"},
    "v1.2.1"=>{:ref=>"refs", :sha=>"f85cef0b1916f09ceb38f778ada98b23c8610da7"},
    "v1.2.2"=>{:ref=>"refs", :sha=>"85fa6ec3a68b6ff8acfa69c59fbdede1385f63bb"},
    "v1.2.3"=>{:ref=>"refs", :sha=>"2962356828cc0ce07674b1c1fa39fde893732344"},
    "v1.2.4"=>{:ref=>"refs", :sha=>"1987b5010ed1abff915bd87146753323754bfb13"},
    "v1.2.5"=>{:ref=>"refs", :sha=>"94f389bf5d9af4511597d035e69d1be9510b50c7"}
  }
}
```
