### PR TITLE
Added options to tag method.

### DIFF
--- a/git.gemspec
+++ b/git.gemspec
@@ -6,7 +6,7 @@
 Gem::Specification.new do |s|
   s.name = %q{git}
   s.version = "1.2.5"
-
+  
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
   s.authors = ["Scott Chacon"]
   s.date = %q{2009-10-17}

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -345,7 +345,7 @@ module Git
 
     # returns an array of all Git::Tag objects for this repository
     def tags
-      self.lib.tags.map { |r| tag(r) }
+      tags.map { |r| tag(r) }
     end
     
     # returns a Git::Tag object
@@ -354,8 +354,8 @@ module Git
     end
 
     # creates a new git tag (Git::Tag)
-    def add_tag(tag_name)
-      self.lib.tag(tag_name)
+    def add_tag(tag_name, opts={})
+      self.lib.tag(tag_name, opts)
       tag(tag_name)
     end
     

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -549,8 +549,12 @@ module Git
       command_lines('tag')
     end
 
-    def tag(tag)
-      command('tag', tag)
+    def tag(tag, opts={})
+      arr_opts = [tag]
+      arr_opts << opts[:sha] unless opts[:sha].nil?
+      arr_opts << '-f' if opts[:force]
+      
+      command('tag', arr_opts)
     end
 
     

--- a/tests/units/test_tags.rb
+++ b/tests/units/test_tags.rb
@@ -30,6 +30,15 @@ class TestTags < Test::Unit::TestCase
       
       assert(r2.tags.map{|t| t.name}.include?('third'))
       assert(!r2.tags.map{|t| t.name}.include?('second'))
+      
+      #can't tag same name twice
+      assert_raise do
+        r1.tag('third')
+      end
+      
+      # can tag same name twice with force
+      r2.add_tag('third'.{:force=>true})
+      assert(r2.tags.map{|t| t.name}.include?('third'))
     end
   end
 end


### PR DESCRIPTION
Adding a tag through base.tag takes an optional hash of options.
- sha=>[sha commit id]  - adds tag to given commit
- force=>[true|false]   - adds -f option to command, will overwrite an existing tag with the same name.

Usage:```
repo.tag("tag_name_1")
repo.tag("tag_name_1", {:force=>true})
repo.tag("tag_name_2", {:sha=>12345678910})
repo.tag("tag_name_2", {:sha=>92345678911, :force=>true})

```
```
