### PR TITLE
Reset improvements

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -426,7 +426,9 @@ module Git
     def reset(commit, opts = {})
       arr_opts = []
       arr_opts << '--hard' if opts[:hard]
-      arr_opts << commit.sha if commit
+      if commit
+        arr_opts << (commit.respond_to?(:sha) ? commit.sha : commit)
+      end
       command('reset', arr_opts)
     end
     

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -426,7 +426,7 @@ module Git
     def reset(commit, opts = {})
       arr_opts = []
       arr_opts << '--hard' if opts[:hard]
-      arr_opts << commit if commit
+      arr_opts << commit.sha if commit
       command('reset', arr_opts)
     end
     


### PR DESCRIPTION
Premise: Once I create an Object, it should be immutable and always refer to the Git object with the same SHA.

Scenario: I want to merge a bunch of topic branches into an integration branch across several repositories.  I want each topic branch to be merged or not atomically: that is, if the merge of the topic produces conflicts in any repository, I want to undo the merge across all repositories.

To accomplish this, I tried using Base.object("topic-branch") to store a commit as a save point.  This ended up not working as expected for a couple reasons:
1. Commit.sha is initialized lazily.  So if I don't call it before applying some commits, I lose my save point.
2. Commit.to_s is used as the argument to git-reset when calling Base.reset_hard.  When creating a Commit object from a branch name, to_s returns the branch name.  So even if I had loaded the right SHA, calling reset_hard could reset my tree to the wrong commit.

With these things I mind, I made some changes to initialize the SHA of an object immediately, and always use the SHA for command arguments.
