### PR TITLE
Prevent git from using color in git log

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -64,7 +64,7 @@ module Git
     
     
     def log_commits(opts = {})
-      arr_opts = ['--pretty=oneline']
+      arr_opts = ['--pretty=oneline', '--no-color']
       arr_opts << "-#{opts[:count]}" if opts[:count]
       arr_opts << "--since=#{opts[:since]}" if opts[:since].is_a? String
       arr_opts << "--until=#{opts[:until]}" if opts[:until].is_a? String
@@ -78,7 +78,7 @@ module Git
     end
     
     def full_log_commits(opts = {})
-      arr_opts = ['--pretty=raw']
+      arr_opts = ['--pretty=raw', '--no-color']
       arr_opts << "-#{opts[:count]}" if opts[:count]
       arr_opts << "--skip=#{opts[:skip]}" if opts[:skip]
       arr_opts << "--since=#{opts[:since]}" if opts[:since].is_a? String


### PR DESCRIPTION
This pull request is incomplete. It fixes an issue with git log that is logged here:
https://github.com/schacon/ruby-git/issues/30
https://github.com/mroth/lolcommits/issues/50

Before proceeding i'd like to add a test, and see where else the "--no-color" argument should go. There also might be a better way to do this, by overriding config rather than passing --no-color (this would be less brittle too).
