### PR TITLE
Fixed documentation around invocation of Git.clone()

### DIFF
--- a/README
+++ b/README
@@ -135,7 +135,7 @@ And here are the operations that will need to write to your git repository.
 	 	  { :git_dir => '/opt/git/proj.git', 
 		     :index_file => '/tmp/index'} )
  	  
-   g = Git.clone(URI, :name => 'name', :path => '/tmp/checkout')   
+   g = Git.clone(URI, 'name', :path => '/tmp/checkout')   
    g.config('user.name', 'Scott Chacon')
    g.config('user.email', 'email@email.com')      
    


### PR DESCRIPTION
The documentation suggested invoking with (URL, :name => 'name', :path => 'path'),
However, this results in a TypeError as the Git#clone method accepts (URL, name, :path => 'path').
