### PR TITLE
Updating non working usage example of Git.clone

### DIFF
--- a/README
+++ b/README
@@ -135,7 +135,7 @@ And here are the operations that will need to write to your git repository.
 	 	  { :git_dir => '/opt/git/proj.git', 
 		     :index_file => '/tmp/index'} )
  	  
-   g = Git.clone(URI, :name => 'name', :path => '/tmp/checkout')   
+   g = Git.clone(URI, NAME, :path => '/tmp/checkout')   
    g.config('user.name', 'Scott Chacon')
    g.config('user.email', 'email@email.com')      
    


### PR DESCRIPTION
Git.clone expects a name to be present as the second param. The `Git.clone(uri, opts)` is not supported (by Git, Base or Lib).

`lib/git.rb`

```
def self.clone(repository, name, options = {})
  Base.clone(repository, name, options)
end
```

`lib/git/lib.rb`

```
def clone(repository, name, opts = {})
...
```

`lib/git/base.rb`

```
def self.clone(repository, name, opts = {})
...
```
