### PR TITLE
GIT PULL: pass a remote to a merge() function

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -334,7 +334,7 @@ module Git
     # fetches a branch from a remote and merges it into the current working branch
     def pull(remote = 'origin', branch = 'master', message = 'origin pull')
       fetch(remote)
-      merge(branch, message)
+      merge(remote + "/" + branch, message)
     end
     
     # returns an array of Git:Remote objects


### PR DESCRIPTION
- make sure to pass remote to merge() function called from pull()
  amending it improperly reports "Already up-to-date"
  i.e.: local "HEAD" and "origin/master" differ (after g.fetch)
  -- do g.pull, it will try to merge local "master" to local "HEAD"
    and will say "Already up-to-date"
  -- try explicit 'git.pull("origin","master","origin pull")'
    it will call 'fetch("origin"), then 'merge("master","origin pull")
    without taking remote into account

or am I misunderstanding what it supposed to do?
