### PR TITLE
allow for making diff from the current working directory to HEAD

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ Here are the operations that need read permission only.
     g.diff('gitsearch1', @git.gtree('v2.5'))
     g.diff('gitsearch1', 'v2.5').path('docs/').patch
     g.gtree('v2.5').diff('v2.6').patch
+    g.diff # diff between your working directory and HEAD
 
     g.gtree('v2.5').diff('v2.6').each do |file_diff|
        puts file_diff.path

--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -6,8 +6,8 @@ module Git
     
     def initialize(base, from = nil, to = nil)
       @base = base
-      @from = from.to_s
-      @to = to.to_s
+      @from = from && from.to_s
+      @to = to && to.to_s
 
       @path = nil
       @full_diff = nil


### PR DESCRIPTION
I wanted to get a patch with the changes I had in my working directory from HEAD. 
It turns out that calling nil.to_s  is causing to create a command like:
git diff "-p" "HEAD" ""  2>&1

This small change makes the nil survive till the where the command is created and it becomes
git diff "-p" "HEAD"  2>&1
which works as expected.

BTW, 3 tests failed in master for me, even when I see they pass in your CI. The same 3 tests fail in my branch so I guess all the tests will pass.
