### PR TITLE
Handle commits with newlines in the message.

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -130,7 +130,7 @@ module Git
     
       data.each do |line|
         line = line.chomp
-        if line == ''
+        if !in_message and line == ''
           in_message = !in_message
         elsif in_message
           hsh['message'] << line[indent..-1] << "\n"


### PR DESCRIPTION
process_commit_data was toggling between message and header parsing for every bare newline encountered in the data, which led to the elision of every other paragraph in a commit message. Now the switch to message parsing is permanent; once the headers have been found we don't need to look for them any more.
