### PR TITLE
make Lib class work with git submodules

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -22,6 +22,15 @@ module Git
         @git_index_file = base[:index] 
         @git_work_dir = base[:working_directory]
       end
+      if not @git_dir.nil? and not File.directory?(@git_dir)
+        File.open(@git_dir).each do |line|
+          /^gitdir: (.*)$/ =~ line
+          if not $~.nil? and $~.length == 2
+            @git_dir = $~[1]
+            break
+          end
+        end
+      end
       @logger = logger
     end
     


### PR DESCRIPTION
for git submodules .git is not a directory but a file containing the location of the real .git dir.

the above patch resolves @git_dir to this real .git dir location if .git is a file.
