### PR TITLE
`Git.init "a.git", bare:true` should create "a.git" bare repository

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -30,6 +30,7 @@ module Git
         :bare => opts[:bare]
       }
 
+      opts[:repository] = opts[:working_directory] if opts[:bare]
       opts.delete(:working_directory) if opts[:bare]
 
       Git::Lib.new(opts).init(init_opts)

--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -42,8 +42,8 @@ class TestInit < Test::Unit::TestCase
   def test_git_init_bare
     in_temp_dir do |path|
       repo = Git.init(path, :bare => true)
-      assert(File.directory?(File.join(path, '.git')))
-      assert(File.exists?(File.join(path, '.git', 'config')))
+      assert(File.directory?(path))
+      assert(File.exists?(File.join(path, 'config')))
       assert_equal('true', repo.config('core.bare'))
     end
   end


### PR DESCRIPTION
`Git.init "a.git", bare:true` should create "a.git" bare repository
instead of "a.git/.git" bare repository,
because `$ git init a.git --bare` create "a.git" bare repository.
Otherwise, we have to call `Git.init "a.git", bare:true, repository:"a.git"`.
