### PR TITLE
implicit cast breaks RBX 

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -711,7 +711,7 @@ module Git
         @logger.debug(out)
       end
             
-      if $?.exitstatus > 0
+      if $?.exitstatus.to_i > 0
         if $?.exitstatus == 1 && out == ''
           return ''
         end


### PR DESCRIPTION
Explicitly casting this string to a int and then comparing is universally compatible 
