### PR TITLE
Tabs to spaces in lib.rb

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -575,9 +575,9 @@ module Git
       command('push', ['--tags', remote]) if tags
     end
 
-		def pull(remote='origin', branch='master')
-			command('pull', [remote, branch])
-		end
+    def pull(remote='origin', branch='master')
+      command('pull', [remote, branch])
+    end
 
     def tag_sha(tag_name)
       head = File.join(@git_dir, 'refs', 'tags', tag_name)


### PR DESCRIPTION
`pull` method was indented with tabs. I replaced them with spaces because I'm an indentation nazi.
