### PR TITLE
Fixing a minor typo in the README for getting all of the tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Here are the operations that need read permission only.
     g.config('user.name')  # returns 'Scott Chacon'
     g.config # returns whole config hash
 
-    g.tag # returns array of Git::Tag objects
+    g.tags # returns array of Git::Tag objects
 ```
 
 And here are the operations that will need to write to your git repository.


### PR DESCRIPTION
Checking out the gem and noticed a minor typo in the README markdown.  Also figured this would be a good way for me test out creating pull requests ;-)
