### PR TITLE
Enable allow_failures and fast_finish for 1.8 based Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,10 @@ rvm:
   - rbx-19mode
   - ree
 #  - ruby-head
+matrix:
+  allow_failures:
+    - 1.8.7
+    - jruby-18mode
+    - rbx-18mode
+    - ree
+  fast_finish: true


### PR DESCRIPTION
:information_desk_person: Ruby 1.8.7 has been deprecated since mid-2013. This change allows build failures for versions based on this Ruby branch. The question of maintaining support is outside the scope of this pull request.
