### PR TITLE
branch_new should use checkout -b

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -490,7 +490,7 @@ module Git
     end
     
     def branch_new(branch)
-      command('branch', branch)
+      command('checkout', ['-b', branch])
     end
     
     def branch_delete(branch)


### PR DESCRIPTION
Fix the creation of new branches by using git checkout -b branch_name instead of git branch branch_name
