### PR TITLE
log should not limit count to 30

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -168,7 +168,7 @@ module Git
     end
     
     # returns a Git::Log object with count commits
-    def log(count = 30)
+    def log(count=nil)
       Git::Log.new(self, count)
     end
 

--- a/lib/git/log.rb
+++ b/lib/git/log.rb
@@ -4,7 +4,7 @@ module Git
   class Log
     include Enumerable
     
-    def initialize(base, count = 30)
+    def initialize(base, count=nil)
       dirty_log
       @base = base
       @count = count

--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -59,7 +59,7 @@ module Git
         Git::Diff.new(@base, @objectish, objectish)
       end
       
-      def log(count = 30)
+      def log(count=nil)
         Git::Log.new(@base, count).object(@objectish)
       end
       


### PR DESCRIPTION
Default log count was set 30 makes it hard to get all the available commits. Seems more correct to  specify a limit if needed.
