### PR TITLE
added feature to create orphan branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ And here are the operations that will need to write to your git repository.
      g.branch('new_branch').checkout
      g.branch('new_branch').delete
      g.branch('existing_branch').checkout
+               
+     # creates a new orphan branch and switches to it 
+     g.branch('new_branch').checkout({:orphan=>true}) 
+     # note: branch will be lost if you do not create any commit in it before switching to another branch
+     
+     # creates a new orphan branch, switches to it and copies a defined file from the master branch to the new orphan branch 
+     # and commits the copied file as the initial commit
+     g.branch('new_branch').checkout({:orphan=>true,:orphaninit=>'.orphan_init'})
+     g.branch('new_branch').checkout({:orphan=>true,:orphaninit=>'example.txt'})
 
      g.checkout('new_branch')
      g.checkout(g.branch('new_branch'))

--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -23,9 +23,11 @@ module Git
       @stashes ||= Git::Stashes.new(@base)
     end
     
-    def checkout
-      check_if_create
-      @base.checkout(@full)
+    def checkout(opts={:orphan=>false,:orphaninit=>nil}) 
+      if !opts[:orphan]
+        check_if_create
+      end
+      @base.lib.checkout(@full,opts)  
     end
     
     def archive(file, opts = {})

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -522,7 +522,7 @@ module Git
     def checkout(branch, opts = {})
       arr_opts = []
       arr_opts << '-f' if opts[:force]
-      arr_opts << '-b' << opts[:new_branch] if opts[:new_branch]
+      arr_opts << '-b' if opts[:new_branch]
       arr_opts << branch
       
       command('checkout', arr_opts)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -535,6 +535,12 @@ module Git
       command('checkout', arr_opts)
     end
     
+    def checkout_file_from_branch(file,branch='master')
+      arr_opts = []
+      arr_opts << file
+      command("checkout #{branch} --", arr_opts)
+    end
+    
     def merge(branch, message = nil)      
       arr_opts = []
       arr_opts << '-m' << message if message

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -521,11 +521,21 @@ module Git
     
     def checkout(branch, opts = {})
       arr_opts = []
+      arr_opts << '--orphan' if opts[:orphan]
       arr_opts << '-f' if opts[:force]
       arr_opts << '-b' if opts[:new_branch]
       arr_opts << branch
       
-      command('checkout', arr_opts)
+      result = command('checkout', arr_opts)
+      if (opts[:orphan] && opts[:orphaninit] != nil)
+        ## start orphan headless repo with an empty .gitignore
+        r1 = remove('.',{:recursive => true})
+        r2 = checkout_file_from_branch(opts[:orphaninit])
+        r3 = add(opts[:orphaninit])
+        r4 = commit("initial commit: copied #{opts[:orphaninit]} from master",{:all=>true})  
+        result = (result != nil && r1 != nil && r2 != nil && r3 != nil && r4 != nil)
+      end
+      result
     end
 
     def checkout_file(version, file)

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -24,7 +24,9 @@ class Test::Unit::TestCase
     @wdir = create_temp_repo(@wdir_dot)
   end
   
-  teardown
+  def teardown
+    git_teardown
+  end
   def git_teardown
     if @tmp_path
       FileUtils.rm_r(@tmp_path)

--- a/tests/units/test_branch.rb
+++ b/tests/units/test_branch.rb
@@ -89,7 +89,9 @@ class TestBranch < Test::Unit::TestCase
 
         g.checkout(g.branch('other_branch'))
         assert(g.branch('other_branch').current)
-        
+        g.checkout('orphan_branch',{:orphan=>true,:orphaninit=>'example.txt'})
+        assert(g.branch('orphan_branch').current)
+        assert_equal('initial commit: copied example.txt from master',g.log[0].message)
       end
     end
   end

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -16,6 +16,10 @@ class TestLib < Test::Unit::TestCase
   
   def test_checkout
     assert(@lib.checkout('test_checkout_-b',{:new_branch=>true}))
+    assert(@lib.checkout('master'))
+    assert(@lib.checkout('test_checkout_--orphan',{:orphan=>true}))
+    assert(@lib.checkout('master'))
+    assert(@lib.checkout('test_checkout_--orphan_with_initial_commit',{:orphan=>true,:orphaninit=>'example.txt'}))
   end
   
   def test_checkout_file_from_branch

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -14,6 +14,10 @@ class TestLib < Test::Unit::TestCase
     @lib = Git.open(@wdir).lib
   end
   
+  def test_checkout
+    assert(@lib.checkout('test_checkout_-b',{:new_branch=>true}))
+  end
+  
   def test_checkout_file_from_branch
     assert(@lib.checkout_file_from_branch('example.txt'))
   end

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -14,6 +14,10 @@ class TestLib < Test::Unit::TestCase
     @lib = Git.open(@wdir).lib
   end
   
+  def test_checkout_file_from_branch
+    assert(@lib.checkout_file_from_branch('example.txt'))
+  end
+  
   def test_commit_data
     data = @lib.commit_data('1cc8667014381')
     assert_equal('scott Chacon <schacon@agadorsparticus.corp.reactrix.com> 1194561188 -0800', data['author'])


### PR DESCRIPTION
This pull request also contains two fixes: one for test execution under Ruby 2.1.1 and one for the usage of '-b' used in lib.checkout. Just merge the orphan support commits, if you do not want to merge these fixes. I added/extended the test cases for all the changes I have made.

By the way: when will be the next release date, so that I can switch back from my custom gem to the rubyforge-release as soon as the feature to create orphan branches is merged?
