### PR TITLE
Fix symbols in options Hash examples (:repository, :index)

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ And here are the operations that will need to write to your git repository.
       g = Git.init
        Git.init('project')
        Git.init('/home/schacon/proj',
-        { :git_dir => '/opt/git/proj.git',
-           :index_file => '/tmp/index'} )
+        { :repository => '/opt/git/proj.git',
+           :index => '/tmp/index'} )
 
      g = Git.clone(URI, NAME, :path => '/tmp/checkout')
      g.config('user.name', 'Scott Chacon')


### PR DESCRIPTION
Fix Readme.md to use correct symbols for options Hash.

According to `base.rb` in v.1.2.6, the options Hash symbols are `:repository` instead of `:git_dir`, and `:index` instead of `:index_file`, as in:
https://github.com/schacon/ruby-git/blob/v1.2.6/lib/git/base.rb#L25
https://github.com/schacon/ruby-git/blob/v1.2.6/lib/git/base.rb#L72
