### PR TITLE
Fix log parsing error when commit have no comment

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -167,8 +167,12 @@ module Git
         end
        
         if in_message
-          hsh['message'] << "#{line[4..-1]}\n"
-          next
+          if line[0..5] != "commit" # if commit have no comment
+            hsh['message'] << "#{line[4..-1]}\n"
+            next
+          else
+            in_message = !in_message
+          end
         end
 
         key, *value = line.split


### PR DESCRIPTION
Fix error: if commit have no comment `in_message` state will remain incorrect and all following commits won't have parsed at all.

ruby-git repo contains such commit, so you can see this error by opening this repo in 'ruby-git' itself.
After loading, ruby-git will show only top 126 commits, rejecting other 148.
