### PR TITLE
Fix error when trying to get diff with nil parent

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -279,12 +279,17 @@ module Git
     def diff_stats(obj1 = 'HEAD', obj2 = nil, opts = {})
       diff_opts = ['--numstat']
       diff_opts << obj1
-      diff_opts << obj2 if obj2.is_a?(String) && !obj2.empty?
+
+      if obj2.is_a?(String) && !obj2.empty?
+        diff_command = 'diff'
+        diff_opts << obj2
+      else
+        diff_command = 'show'
+        diff_opts << '--pretty=format:'
+      end
       diff_opts << '--' << opts[:path_limiter] if opts[:path_limiter].is_a? String
 
       hsh = {:total => {:insertions => 0, :deletions => 0, :lines => 0, :files => 0}, :files => {}}
-
-      diff_command = obj2.is_a?(String) && !obj2.empty? ? 'diff' : 'show'
 
       command_lines(diff_command, diff_opts).each do |file|
         (insertions, deletions, filename) = file.split("\t")

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -279,12 +279,14 @@ module Git
     def diff_stats(obj1 = 'HEAD', obj2 = nil, opts = {})
       diff_opts = ['--numstat']
       diff_opts << obj1
-      diff_opts << obj2 if obj2.is_a?(String)
+      diff_opts << obj2 if obj2.is_a?(String) && !obj2.empty?
       diff_opts << '--' << opts[:path_limiter] if opts[:path_limiter].is_a? String
 
       hsh = {:total => {:insertions => 0, :deletions => 0, :lines => 0, :files => 0}, :files => {}}
-      
-      command_lines('diff', diff_opts).each do |file|
+
+      diff_command = obj2.is_a?(String) && !obj2.empty? ? 'diff' : 'show'
+
+      command_lines(diff_command, diff_opts).each do |file|
         (insertions, deletions, filename) = file.split("\t")
         hsh[:total][:insertions] += insertions.to_i
         hsh[:total][:deletions] += deletions.to_i


### PR DESCRIPTION
Every initial commit have no parent, thus if you try to fetch full log, you'll receive error like this:
`git diff '--numstat' 'f5baa11a1c82dc42ade5c291e9f061c13b66bc2f' '' 2>&1:fatal: ambiguous argument ''`

To fix this we can use `git show` command if current object have no parent. This command can accept all options from `git diff`, the only difference is that we should not pass (empty) parent commit hash.
