### PR TITLE
Keep original timezone in author/committer date

### DIFF
--- a/lib/git/author.rb
+++ b/lib/git/author.rb
@@ -3,10 +3,11 @@ module Git
     attr_accessor :name, :email, :date
     
     def initialize(author_string)
-      if m = /(.*?) <(.*?)> (\d+) (.*)/.match(author_string)
+      if m = /(.*?) <(.*?)> (\d+) ([-\+]\d+)/.match(author_string)
         @name = m[1]
         @email = m[2]
         @date = Time.at(m[3].to_i)
+        @date.localtime(m[4].gsub(/([-\+]\d{2})(\d{2})/, '\1:\2'))
       end
     end
     

--- a/lib/git/author.rb
+++ b/lib/git/author.rb
@@ -7,7 +7,7 @@ module Git
         @name = m[1]
         @email = m[2]
         @date = Time.at(m[3].to_i)
-        @date.localtime(m[4].gsub(/([-\+]\d{2})(\d{2})/, '\1:\2'))
+        @date.localtime(m[4].gsub(/([-\+]\d{2})(\d{2})/, '\1:\2')) unless Time.instance_method(:localtime).arity == 0
       end
     end
     

--- a/lib/git/author.rb
+++ b/lib/git/author.rb
@@ -1,15 +1,23 @@
 module Git
   class Author
-    attr_accessor :name, :email, :date
+    attr_accessor :name, :email, :date, :timezone
     
     def initialize(author_string)
       if m = /(.*?) <(.*?)> (\d+) ([-\+]\d+)/.match(author_string)
         @name = m[1]
         @email = m[2]
         @date = Time.at(m[3].to_i)
-        @date.localtime(m[4].gsub(/([-\+]\d{2})(\d{2})/, '\1:\2')) unless Time.instance_method(:localtime).arity == 0
+        @timezone = m[4].gsub(/([-\+]\d{2})(\d{2})/, '\1:\2')
       end
     end
-    
+
+    def local_date
+      if Time.instance_method(:localtime).arity != 0
+        return @date.localtime(@timezone)
+      else # Time class in Ruby 1.8.7 does not have an method to change its timezone
+        return @date
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Keep original commit timezone instead leaving it undefined (local)
