### PR TITLE
preserve former git environment variables

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -734,6 +734,10 @@ module Git
     end
     
     def command(cmd, opts = [], chdir = true, redirect = '', &block)
+      old_git_dir = ENV['GIT_DIR']
+      old_git_work_dir = ENV['GIT_WORK_TREE']
+      old_git_index_file = ENV['GIT_INDEX_FILE']
+
       ENV['GIT_DIR'] = @git_dir
       ENV['GIT_WORK_TREE'] = @git_work_dir
       ENV['GIT_INDEX_FILE'] = @git_index_file
@@ -762,6 +766,10 @@ module Git
       end
 
       return output
+    ensure
+      ENV['GIT_DIR'] = old_git_dir
+      ENV['GIT_WORK_TREE'] = old_git_work_dir
+      ENV['GIT_INDEX_FILE'] = old_git_index_file
     end
 
     # Takes the diff command line output (as Array) and parse it into a Hash

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -49,6 +49,18 @@ class TestLib < Test::Unit::TestCase
     assert_equal(20, a.size)
   end
   
+  def test_environment_reset
+    ENV['GIT_DIR'] = '/my/git/dir'
+    ENV['GIT_WORK_TREE'] = '/my/work/tree'
+    ENV['GIT_INDEX_FILE'] = 'my_index'
+
+    @lib.log_commits :count => 10
+
+    assert_equal(ENV['GIT_DIR'], '/my/git/dir')
+    assert_equal(ENV['GIT_WORK_TREE'], '/my/work/tree')
+    assert_equal(ENV['GIT_INDEX_FILE'],'my_index')
+  end
+
   def test_revparse
     assert_equal('1cc8667014381e2788a94777532a788307f38d26', @lib.revparse('1cc8667014381')) # commit
     assert_equal('94c827875e2cadb8bc8d4cdd900f19aa9e8634c7', @lib.revparse('1cc8667014381^{tree}')) #tree


### PR DESCRIPTION
This ensures that the git environment variables are restored to their original values after every git command. 

In the event that this gem is included in an application that interacts with the git CLI, after calling into this gem, those command line calls may fail with mysterious errors complaining about a working tree that already exists.

I was seeing this in a chef cookbook repository where this gem is used to create versions based on number of commits and a subsequent Berksfile sync attempting to pull a git based cookbook was failing.
