### PR TITLE
fix that Git#checkout will work with :new_branch

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -522,7 +522,7 @@ module Git
     def checkout(branch, opts = {})
       arr_opts = []
       arr_opts << '-f' if opts[:force]
-      arr_opts << '-b' << opts[:new_branch] if opts[:new_branch]
+      arr_opts << '-b' << if opts[:new_branch]
       arr_opts << branch
       
       command('checkout', arr_opts)


### PR DESCRIPTION
this small fix, will makes Git#checkout work if :new_branch is given as an argument, like

git = Git.open 'path/to/repo'
git.checkout 'branchName', :new_branch => true
