### PR TITLE
Fix tests failing if run between Nov 7 16:50:57 and Jan 1 00:00:00

### DIFF
--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -32,7 +32,7 @@ class TestLib < Test::Unit::TestCase
     assert(a.first.is_a?(String))
     assert_equal(10, a.size)
     
-    a = @lib.log_commits :count => 20, :since => "#{Date.today.year - 2007} years ago"
+    a = @lib.log_commits :count => 20, :since => "#{Date.today.year - 2006} years ago"
     assert(a.first.is_a?(String))
     assert_equal(20, a.size)
     

--- a/tests/units/test_log.rb
+++ b/tests/units/test_log.rb
@@ -40,7 +40,7 @@ class TestLog < Test::Unit::TestCase
     l = @git.log.since("2 seconds ago")
     assert_equal(0, l.size)
     
-    l = @git.log.since("#{Date.today.year - 2007} years ago")
+    l = @git.log.since("#{Date.today.year - 2006} years ago")
     assert_equal(30, l.size)
   end
   


### PR DESCRIPTION
I wanted to work a few open issues. When I first ran the tests, two tests failed. There were two spots where the git log was being check based on historical dates, and basically, they were attempting to get all history, but they were inadvertently coming up short if the tests ran after "Nov 7 16:50:57 -0800" (the first commit in the log) and "Jan 1 00:00:00 -0800" (that start of a new year).

I just bumped the "year comparison" back a year and it appears to be fixed.
