### PR TITLE
Don't let Ruby auto-delete temporary archives

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -699,8 +699,14 @@ module Git
         opts[:add_gzip] = true
       end
       
-      file ||= Tempfile.new('archive').path
-      
+      if !file
+        tempfile = Tempfile.new('archive')
+        file = tempfile.path
+        # delete it now, before we write to it, so that Ruby doesn't delete it
+        # when it finalizes the Tempfile.
+        tempfile.close!
+      end
+
       arr_opts = []
       arr_opts << "--format=#{opts[:format]}" if opts[:format]
       arr_opts << "--prefix=#{opts[:prefix]}" if opts[:prefix]


### PR DESCRIPTION
Ruby's Tempfile class unlinks the filename it creates at an arbitrary point in the future.

So this logic won't work:

``` ruby
archive_path = repo.object('7c1a2c9f3fe3da53a043496f7128c472f204d074').archive(nil, format: 'tgz')
# Tempfile may be deleted here
stat = File::State.new(archive_path)
```

The guarantee has to change. When using Tempfile to construct a filename, the user can't rely on Tempfile to delete it.
