### PR TITLE
Removed all `Dir.chdir` calls from private use

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -99,7 +99,7 @@ module Git
     options.delete(:remote)
     repo = clone(repository, name, {:depth => 1}.merge(options))
     repo.checkout("origin/#{options[:branch]}") if options[:branch]
-    Dir.chdir(repo.dir.to_s) { FileUtils.rm_r '.git' }
+    FileUtils.rm_r "#{repo.dir.to_s}/.git"
   end
   
   # Same as g.config, but forces it to be at the global level

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -118,8 +118,16 @@ module Git
     end
     
     # returns the repository size in bytes
-    def repo_size
-      return IO.popen("du -s", {:chdir => repo.path}).read.chomp.split.first.to_i
+    if (RUBY_VERSION.to_f < 1.9)
+      def repo_size
+        Dir.chdir(repo.path) do
+          return IO.popen("du -s").read.chomp.split.first.to_i
+        end
+      end
+    else
+      def repo_size
+        return IO.popen("du -s", {:chdir => repo.path}).read.chomp.split.first.to_i
+      end
     end
     
     #g.config('user.name', 'Scott Chacon') # sets value

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -119,9 +119,7 @@ module Git
     
     # returns the repository size in bytes
     def repo_size
-      Dir.chdir(repo.path) do
-        return `du -s`.chomp.split.first.to_i
-      end
+      return IO.popen("du -s", {chdir: repo.path}).read.chomp.split.first.to_i
     end
     
     #g.config('user.name', 'Scott Chacon') # sets value

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -119,7 +119,7 @@ module Git
     
     # returns the repository size in bytes
     def repo_size
-      return IO.popen("du -s", {chdir: repo.path}).read.chomp.split.first.to_i
+      return IO.popen("du -s", {:chdir => repo.path}).read.chomp.split.first.to_i
     end
     
     #g.config('user.name', 'Scott Chacon') # sets value

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -340,15 +340,7 @@ module Git
     end
     
     def config_list
-      build_list = lambda do |path|
-        parse_config_list command_lines('config', ['--list'])
-      end
-      
-      if @git_dir
-        Dir.chdir(@git_dir, &build_list)
-      else
-        build_list.call
-      end
+      parse_config_list command_lines('config', ['--list'])
     end
 
     def global_config_list

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1,4 +1,5 @@
 require 'tempfile'
+require 'open3' unless (RUBY_VERSION.to_f < 1.9)
 
 module Git
   

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -808,7 +808,7 @@ module Git
     
     def run_command(git_cmd, chdir = nil, &block)
       commands = [git_cmd]
-      commands << {chdir: chdir} unless chdir.nil?
+      commands << {:chdir => chdir} unless chdir.nil?
       if block_given?
         retval = IO.popen(*commands, &block)
         return retval, $?

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -332,15 +332,7 @@ module Git
     end
 
     def config_get(name)
-      do_get = lambda do |path|
-        command('config', ['--get', name])
-      end
-
-      if @git_dir
-        Dir.chdir(@git_dir, &do_get)
-      else
-        build_list.call
-      end
+      command('config', ['--get', name])
     end
 
     def global_config_get(name)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -233,9 +233,7 @@ module Git
 
     def list_files(ref_dir)
       dir = File.join(@git_dir, 'refs', ref_dir)
-      files = []
-      Dir.chdir(dir) { files = Dir.glob('**/*').select { |f| File.file?(f) } } rescue nil
-      files
+      Dir.glob("#{dir}/**/*").select { |f| File.file?(f) } rescue nil
     end
     
     def branch_current

--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -89,12 +89,12 @@ FILE
         ignore = @base.lib.ignored_files
         
         # find untracked in working dir
-        Dir.chdir(@base.dir.path) do
-          Dir.glob('**/*', File::FNM_DOTMATCH) do |file|
-            next if @files[file] || File.directory?(file) || ignore.include?(file) || file =~ /^.git\/.+/
+        prefix = "#{@base.dir.path}/"
+        Dir.glob(prefix+"**/*", File::FNM_DOTMATCH) do |abs_file|
+          file = abs_file.byteslice(prefix.length..-1)
+          next if @files[file] || File.directory?(file) || ignore.include?(file) || file =~ /^.git\/.+/
 
-            @files[file] = {:path => file, :untracked => true}
-          end
+          @files[file] = {:path => file, :untracked => true}
         end
         
         # find modified in tree

--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -91,7 +91,7 @@ FILE
         # find untracked in working dir
         prefix = "#{@base.dir.path}/"
         Dir.glob(prefix+"**/*", File::FNM_DOTMATCH) do |abs_file|
-          file = abs_file.byteslice(prefix.length..-1)
+          file = abs_file.slice(prefix.length..-1)
           next if @files[file] || File.directory?(file) || ignore.include?(file) || file =~ /^.git\/.+/
 
           @files[file] = {:path => file, :untracked => true}


### PR DESCRIPTION
When writing command-line tools that use ruby-git to interface with git, there are often ways to achieve better performance by running git query commands in parallel. This is unworkable with `ruby-git` given it's extensive use of the non-thread-safe `Dir.chdir` call. With all implicit calls to `Dir.chdir` removed, `ruby-git` is one step closer to being usable amongst threads.

From  the [`Dir.chdir` documentation](http://www.ruby-doc.org/core-2.1.5/Dir.html#method-c-chdir):

> The return value of chdir is the value of the block. chdir blocks can be nested, but in a multi-threaded program an error will be raised if a thread attempts to open a chdir block while another thread has one open.
