### PR TITLE
Make the first commit its own parent (issues #25 & #159)

### DIFF
--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -182,7 +182,7 @@ module Git
       end
       
       def parent
-        parents.first
+        parents.first || self
       end
       
       # array of all parent commits

--- a/tests/units/test_object.rb
+++ b/tests/units/test_object.rb
@@ -41,6 +41,9 @@ class TestObject < Test::Unit::TestCase
     o = @git.gcommit('test_object')
     assert(o.is_a?(Git::Object::Commit))
     assert(o.commit?)
+
+    o = @git.gcommit('545ffc79786f268524c35e1e05b1770c7c74faf1')
+    assert('545ffc79786f268524c35e1e05b1770c7c74faf1', o.parent.sha)
   end
   
   def test_commit_contents


### PR DESCRIPTION
Both issues #159 and #25 appear to be due to the fact that for [only] the initial commit in a repo, the Git::Object ends up not having a parent. a la "file system semantics" [at the root of the file system], I made the initial commit be it's own parent, and it seems to fix both of these issues.
