### PR TITLE
Allow a block to receive push output

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -322,11 +322,11 @@ module Git
     #
     #  @git.config('remote.remote-name.push', 'refs/heads/master:refs/heads/master')
     #
-    def push(remote = 'origin', branch = 'master', opts = {})
+    def push(remote = 'origin', branch = 'master', opts = {}, &block)
       # Small hack to keep backwards compatibility with the 'push(remote, branch, tags)' method signature.
       opts = {:tags => opts} if [true, false].include?(opts)
 
-      self.lib.push(remote, branch, opts)
+      self.lib.push(remote, branch, opts, &block)
     end
     
     # merges one or more branches into the current working branch

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -751,7 +751,7 @@ module Git
       command('fetch', arr_opts)
     end
 
-    def push(remote, branch = 'master', opts = {})
+    def push(remote, branch = 'master', opts = {}, &block)
       # Small hack to keep backwards compatibility with the 'push(remote, branch, tags)' method signature.
       opts = {:tags => opts} if [true, false].include?(opts)
 
@@ -762,10 +762,10 @@ module Git
       arr_opts << remote
 
       if opts[:mirror]
-          command('push', arr_opts)
+          command('push', arr_opts, &block)
       else
-          command('push', arr_opts + [branch])
-          command('push', ['--tags'] + arr_opts) if opts[:tags]
+          command('push', arr_opts + [branch], &block)
+          command('push', ['--tags'] + arr_opts, &block) if opts[:tags]
       end
     end
 

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -190,5 +190,25 @@ class TestRemotes < Test::Unit::TestCase
     end
   end
 
+  def test_push_with_block
+    in_temp_dir do |path|
+      loc = Git.clone(@wbare, 'local')
+      rem = Git.clone(@wbare, 'remote', :config => 'receive.denyCurrentBranch=ignore')
 
+      loc.add_remote('testrem', rem)
+
+      loc.chdir do
+        new_file('test-file', 'blahblahblah')
+        loc.add
+        loc.commit('master commit')
+      end
+
+      block_called = false
+      loc.push('testrem') do |output|
+        assert_match(/master -> master/, output.read, 'expected block to receive output of push command.')
+        block_called = true
+      end
+      assert(block_called, 'block was not called.')
+    end
+  end
 end


### PR DESCRIPTION
This allows for an optional block to receive a pipe that it can print to stdout (useful when deploying to Heroku for example).
