### PR TITLE
Add options to allow no-ff merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ And here are the operations that will need to write to your git repository.
 
      g.branch(name).in_branch(message) { # add files }  # auto-commits
      g.merge('new_branch')
+     g.merge('new_branch', message: 'merge message')
+     g.merge('new_branch', message: 'merge message', no_ff: true) # Merge with --no-ff option
      g.merge('origin/remote_branch')
      g.merge(g.branch('master'))
      g.merge([branch1, branch2])

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -333,7 +333,7 @@ module Git
     #
     # you can specify more than one branch to merge by passing an array of branches
     def merge(branch, message = 'merge')
-      self.lib.merge(branch, message)
+      self.lib.merge(branch, message: message)
     end
 
     # iterates over the files which are unmerged

--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -62,8 +62,8 @@ module Git
     
     def merge(branch = nil, message = nil)
       if branch
-        in_branch do 
-          @base.merge(branch, message)
+        in_branch do
+          @base.merge(branch, message: message)
           false
         end
         # merge a branch into this one

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -635,10 +635,12 @@ module Git
       arr_opts << file
       command('checkout', arr_opts)
     end
-    
-    def merge(branch, message = nil)      
+
+    def merge(branch, opts = {})
       arr_opts = []
+      message = opts[:message] || opts[:m]
       arr_opts << '-m' << message if message
+      arr_opts << '--no-ff' if opts[:no_ff]
       arr_opts += [branch]
       command('merge', arr_opts)
     end


### PR DESCRIPTION
Merge command now take options.
It allow us to use the `--no-ff` options. Also fix #154 
Didn't have time to implement all merge options.
