### PR TITLE
Ref #246 save the git command, output and exit status on 'Git::GitExecuteError' exception object

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,16 @@ Some examples of more low-level index and tree operations
      end
 ```
 
+## Git::GitExecuteError
+
+**Git::GitExecuteError** - Whenever a `git` command fails, a `Git::GitExecuteError` exception is raised. The exception object rescued stores the `git` command executed along with the output of the command and the exit status. You can access these using `command`, `output` and `exit_status` (getter) methods.
+
+If you are contributing to this gem and need to raise a custom `Git::GitExecuteError` for your `git` command, you can set the `command`, `output`, and `exit_status` as follows:
+
+```ruby
+raise Git::GitExecuteError.new("this is a test", command: "test", output: "It didn't work!!!", exit_status: 1)
+```
+
 ## License
 
 licensed under MIT License Copyright (c) 2008  Scott Chacon. See LICENSE for further details.

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1,12 +1,20 @@
 require 'tempfile'
 
 module Git
-  
-  class GitExecuteError < StandardError 
+
+  class GitExecuteError < StandardError
+    attr_reader :command, :output, :exit_status
+
+    def initialize(msg, options={})
+      super(msg)
+      @command = options[:command]
+      @output = options[:output]
+      @exit_status = options[:exit_status]
+    end
   end
-  
+
   class Lib
-     
+
     @@semaphore = Mutex.new
 
     def initialize(base = nil, logger = nil)
@@ -914,7 +922,7 @@ module Git
       end
             
       if exitstatus > 1 || (exitstatus == 1 && output != '')
-        raise Git::GitExecuteError.new(git_cmd + ':' + output.to_s) 
+        raise Git::GitExecuteError.new(git_cmd + ':' + output.to_s, command: git_cmd, output: output, exit_status: exitstatus)
       end
 
       return output

--- a/tests/units/test_branch.rb
+++ b/tests/units/test_branch.rb
@@ -73,9 +73,13 @@ class TestBranch < Test::Unit::TestCase
         assert(g.status.untracked.assoc('test-file1'))
         assert(!g.status.added.assoc('test-file1'))
 
-        assert_raise Git::GitExecuteError do
-          g.branch('new_branch').delete 
+        e = assert_raise Git::GitExecuteError do
+          g.branch('new_branch').delete
         end
+        assert_not_nil(e.command)
+        assert_not_nil(e.output)
+        assert_not_nil(e.exit_status)
+
         assert_equal(1, g.branches.select { |b| b.name == 'new_branch' }.size)
 
         g.branch('master').checkout

--- a/tests/units/test_log.rb
+++ b/tests/units/test_log.rb
@@ -72,11 +72,14 @@ class TestLog < Test::Unit::TestCase
     log = @git.log.path(['example.txt','scott/text.txt'])
     assert_equal(30, log.size)
   end
-  
+
   def test_log_file_noexist
-    assert_raise Git::GitExecuteError do
+    e = assert_raise Git::GitExecuteError do
       @git.log.object('no-exist.txt').size
     end
+    assert_not_nil(e.command)
+    assert_not_nil(e.output)
+    assert_not_nil(e.exit_status)
   end
-  
+
 end

--- a/tests/units/test_tags.rb
+++ b/tests/units/test_tags.rb
@@ -47,12 +47,15 @@ class TestTags < Test::Unit::TestCase
 
       assert(r2.tags.detect{|t| t.name == 'third'}.objectish == r2.tags.detect{|t| t.name == 'fifth'}.objectish)
 
-      assert_raise Git::GitExecuteError do
+      e = assert_raise Git::GitExecuteError do
         r2.add_tag('third')
       end
+      assert_not_nil(e.command)
+      assert_not_nil(e.output)
+      assert_not_nil(e.exit_status)
 
       r2.add_tag('third', {:f => true})
-      
+
       r2.delete_tag('third')
       
       assert_raise Git::GitTagNameDoesNotExist do

--- a/tests/units/test_tree_ops.rb
+++ b/tests/units/test_tree_ops.rb
@@ -71,7 +71,11 @@ class TestTreeOps < Test::Unit::TestCase
               # Adding nothig is now validd on Git 1.7.x
               # If an error ocurres (Git 1.6.x) it MUST rise Git::GitExecuteError
               assert_equal(e.class, Git::GitExecuteError)
+              assert_not_nil(e.command)
+              assert_not_nil(e.output)
+              assert_not_nil(e.exit_status)
             end
+
             g.read_tree('testbranch1', :prefix => 'b1/')
             g.read_tree('testbranch3', :prefix => 'b1/b3/')
             index = g.ls_files


### PR DESCRIPTION
-updated README
-updated testcases
