### PR TITLE
Enable adding untracked files to diff

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -505,6 +505,7 @@ module Git
       arr_opts = []
       
       arr_opts << '--all' if options[:all]
+      arr_opts << '--intent-to-add' if options[:intent_to_add]
       arr_opts << '--force' if options[:force]
 
       arr_opts << '--' 


### PR DESCRIPTION
`git add --all --intent-to-add` adds untracked files to diff, so that you can then `git push if g.diff.size > 0`. Pushing when diff.size equals 0 raises an error, and now there's no way to avoid this error at pushing if the only changes to commit is adding an untracked file. (`git add --all` does not add untracked files to `git diff`.)
