### PR TITLE
fixed tests on MacOSX

### DIFF
--- a/tests/units/test_archive.rb
+++ b/tests/units/test_archive.rb
@@ -25,11 +25,11 @@ class TestArchive < Test::Unit::TestCase
     
     f = @git.object('v2.6').archive(nil, :format => 'tar') # returns path to temp file
     assert(File.exist?(f))
-    
-    lines = `cd /tmp; tar xvpf #{f}`.split("\n")
-    assert_equal('ex_dir/', lines[0])
-    assert_equal('example.txt', lines[2])
-    
+
+    lines = `cd /tmp; tar xvpf #{f} 2>&1`.split("\n")
+    assert_match('ex_dir/', lines[0])
+    assert_match('example.txt', lines[2])
+
     f = @git.object('v2.6').archive(tempfile, :format => 'zip')
     assert(File.file?(f))
 
@@ -38,10 +38,10 @@ class TestArchive < Test::Unit::TestCase
     
     f = @git.object('v2.6').archive(tempfile, :format => 'tar', :prefix => 'test/', :path => 'ex_dir/')
     assert(File.exist?(f))
-    
-    lines = `cd /tmp; tar xvpf #{f}`.split("\n")
-    assert_equal('test/', lines[0])
-    assert_equal('test/ex_dir/ex.txt', lines[2])
+
+    lines = `cd /tmp; tar xvpf #{f} 2>&1`.split("\n")
+    assert_match('test/', lines[0])
+    assert_match('test/ex_dir/ex.txt', lines[2])
 
     in_temp_dir do
       c = Git.clone(@wbare, 'new')


### PR DESCRIPTION
on OSX `tar` utility prefix each line of verbose output with 'x'
that fails archive tests
fixed using `assert_match` instead of `assert_equal` for `tar` output
also `tar` outputs in STDERR on Mac so used pipeline redirect "2>&1" for capture
