### PR TITLE
Fix describe opts handling to work and be consistent with documentation

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -112,12 +112,12 @@ module Git
       arr_opts << '--always' if opts[:always]
       arr_opts << '--exact-match' if opts[:exact_match] || opts[:"exact-match"]
 
-      arr_opts << '--dirty' if opts['dirty'] == true
-      arr_opts << "--dirty=#{opts['dirty']}" if opts['dirty'].is_a?(String)
+      arr_opts << '--dirty' if opts[:dirty] == true
+      arr_opts << "--dirty=#{opts[:dirty]}" if opts[:dirty].is_a?(String)
 
-      arr_opts << "--abbrev=#{opts['abbrev']}" if opts[:abbrev]
-      arr_opts << "--candidates=#{opts['candidates']}" if opts[:candidates]
-      arr_opts << "--match=#{opts['match']}" if opts[:match]
+      arr_opts << "--abbrev=#{opts[:abbrev]}" if opts[:abbrev]
+      arr_opts << "--candidates=#{opts[:candidates]}" if opts[:candidates]
+      arr_opts << "--match=#{opts[:match]}" if opts[:match]
 
       arr_opts << committish if committish
 

--- a/tests/units/test_describe.rb
+++ b/tests/units/test_describe.rb
@@ -13,4 +13,9 @@ class TestDescribe < Test::Unit::TestCase
     assert_equal(@git.describe(nil, {:tags => true}), 'v2.8')
   end
 
+  def test_describe_match_argument
+    # Make sure arguments are properly passed
+    assert_equal(@git.describe(nil, {:tags => true, :match => 'v*'}), 'v2.8')
+  end
+
 end


### PR DESCRIPTION
Documentation describes the second param (opts) as

>  @param [{Symbol=>Object}] opts the given options

  internally the value was however accessed as string for: dirty, abbrev,
  candidates, match. The key's validity was however checked via symbolized
  names.

> arr_opts << "--abbrev=#{opts['abbrev']}" if opts[:abbrev]

  One notes the opts['abbrev'] versus opts[:abbrev].

This ultimately leads to the need that one would have had to call

> describe(nil, { :abbrev => 0, 'abbrev' => 0 })

  to get actually working behavior

Resolved this by aligning everything with what the documentation and using
symbols all around.
