### PR TITLE
expose #commits to allow accessing this object directly

### DIFF
--- a/lib/git/log.rb
+++ b/lib/git/log.rb
@@ -95,6 +95,11 @@ module Git
       @commits.last rescue nil
     end
 
+    def commits
+      check_log
+      @commits rescue nil
+    end
+
     def [](index)
       check_log
       @commits[index] rescue nil


### PR DESCRIPTION
I've found myself needing to aggregate and collate sets of commits to find commonalities, and it would be very useful to be able to pull the @commits array as an object directly.
