### PR TITLE
Fix encoding of command output

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -859,10 +859,7 @@ module Git
 
     def command_lines(cmd, opts = [], chdir = true, redirect = '')
       cmd_op = command(cmd, opts, chdir)
-      op = cmd_op.encode("UTF-8", "binary", {
-	  	:invalid => :replace,
-		:undef => :replace
-	  })
+      op = cmd_op.chars.map { |c| c.valid_encoding? && c || '�' }.join
       op.split("\n")
     end
 


### PR DESCRIPTION
With the current solution and on Ruby 2.2 all non-ASCII are replaced even if they are valid UTF-8. I guess that solution works on Ruby 1.9 as the default encoding changed in 2.0, but I did not try that.

It looks like I'm not the only one experiencing the issue, see e.g. #295. 
