### PR TITLE
Fix miss encode trouble

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -859,10 +859,10 @@ module Git
 
     def command_lines(cmd, opts = [], chdir = true, redirect = '')
       cmd_op = command(cmd, opts, chdir)
-      op = cmd_op.encode("UTF-8", "binary", {
-	  	:invalid => :replace,
-		:undef => :replace
-	  })
+      op = cmd_op.encode("UTF-8", {
+        :invalid => :replace,
+        :undef => :replace
+      })
       op.split("\n")
     end
 


### PR DESCRIPTION
sample code

``` ruby
require 'rubygems'
require 'git'
git = Git.clone('https://github.com/u-ichi/retry-handler', 'retry-handler')
puts git.log.first.message
```

original

```
Exception���������StandardError������������������
```

this patch

```
ExceptionよりもStandardErrorのほうが適切
```
