### PR TITLE
Add support for '--delete' in push

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -755,6 +755,7 @@ module Git
 
       arr_opts = []
       arr_opts << '--mirror'  if opts[:mirror]
+      arr_opts << '--delete'  if opts[:delete]
       arr_opts << '--force'  if opts[:force] || opts[:f]
       arr_opts << remote
 


### PR DESCRIPTION
I needed to delete a remote branch. And the way to do it is by using the `--delete` argument in the `git push` command [(as seen in the Git docs)](https://git-scm.com/book/en/v2/Git-Branching-Remote-Branches#_delete_branches).