### PR TITLE
Put force first, and use -B if both force and new_branch is set

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -637,8 +637,13 @@ module Git
 
     def checkout(branch, opts = {})
       arr_opts = []
-      arr_opts << '--force' if opts[:force] || opts[:f]
-      arr_opts << '-b' if opts[:new_branch] || opts[:b]
+      if (opts[:force] || opts[:f]) && (opts[:new_branch] || opts[:b])
+        arr_opts << '--force'
+        arr_opts << '-B' # enables checkout of the branch if it already exists
+      else
+        arr_opts << '--force' if opts[:force] || opts[:f]
+        arr_opts << '-b' if opts[:new_branch] || opts[:b]
+      end
       arr_opts << branch
 
       command('checkout', arr_opts)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -637,8 +637,8 @@ module Git
 
     def checkout(branch, opts = {})
       arr_opts = []
-      arr_opts << '-b' if opts[:new_branch] || opts[:b]
       arr_opts << '--force' if opts[:force] || opts[:f]
+      arr_opts << '-b' if opts[:new_branch] || opts[:b]
       arr_opts << branch
 
       command('checkout', arr_opts)


### PR DESCRIPTION
Stumbeled on an issue where we could not checkout/create a branch.

First of all, adding `force: true` rendered an error where the branch `--force` could not be checked out. This was due to the order of the arguments.

The first commit changes the order of the commands.

The next error said that the branch already exists, which it does.
After reading the the git documentation I found `-B` and using that, our issue went away.

(all this testing was done on travis)

ref: https://www.git-scm.com/docs/git-checkout#git-checkout--Bltnewbranchgt
