### PR TITLE
Enable set url on remotes

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -372,6 +372,17 @@ module Git
       Git::Remote.new(self, name)
     end
 
+    # sets the url for a remote
+    # url can be a git url or a Git::Base object if it's a local reference
+    #
+    #  @git.set_remote_url('scotts_git', 'git://repo.or.cz/rubygit.git')
+    #
+    def set_remote_url(name, url)
+      url = url.repo.path if url.is_a?(Git::Base)
+      self.lib.remote_set_url(name, url)
+      Git::Remote.new(self, name)
+    end
+
     # removes a remote from this repository
     #
     # @git.remove_remote('scott_git')

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -688,6 +688,14 @@ module Git
       command('remote', arr_opts)
     end
 
+    def remote_set_url(name, url)
+      arr_opts = ['set-url']
+      arr_opts << name
+      arr_opts << url
+
+      command('remote', arr_opts)
+    end
+
     def remote_remove(name)
       command('remote', ['rm', name])
     end

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -46,6 +46,21 @@ class TestRemotes < Test::Unit::TestCase
     end
   end
   
+  def test_set_remote_url
+    in_temp_dir do |path|
+      local = Git.clone(@wbare, 'local')
+      remote1 = Git.clone(@wbare, 'remote1')
+      remote2 = Git.clone(@wbare, 'remote2')
+
+      local.add_remote('testremote', remote1)
+      local.set_remote_url('testremote', remote2)
+
+      assert(local.remotes.map{|b| b.name}.include?('testremote'))
+      assert(local.remote('testremote').url != remote1.repo.path)
+      assert(local.remote('testremote').url == remote2.repo.path)
+    end
+  end
+
   def test_remote_fun
     in_temp_dir do |path|
       loc = Git.clone(@wbare, 'local')


### PR DESCRIPTION
I need to update the URL on remotes, which isn't currently possible with the library. This patch adds a simple version of that ability.