### PR TITLE
Fix ls-files for git 2.16

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -396,6 +396,7 @@ module Git
     end
 
     def ls_files(location=nil)
+      location ||= '.'
       hsh = {}
       command_lines('ls-files', ['--stage', location]).each do |line|
         (info, file) = line.split("\t")


### PR DESCRIPTION
Since GIT version 2.16.0 empty pathspecs as alias to "everything" has
been made illegal.

A more detailed study this change's impact has been made at:

https://github.com/ruby-git/ruby-git/issues/345#issuecomment-369260500

Closes #345