### PR TITLE
Lib.ls_files raises error on newer git versions

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -396,6 +396,7 @@ module Git
     end
 
     def ls_files(location=nil)
+      location ||= '.'
       hsh = {}
       command_lines('ls-files', ['--stage', location]).each do |line|
         (info, file) = line.split("\t")


### PR DESCRIPTION
I get this error when using ruby-git after updating my local `git` version:

```
Git::GitExecuteError: git "--git-dir=C:/temp/.git" "--work-tree=C:/temp" ls-files "--stage" ""  2>&1:fatal: empty string is not a valid pathspec. please use . instead if you meant to match all paths
C:/Ruby23/lib/ruby/gems/2.3.0/gems/git-1.3.0/lib/git/lib.rb:937:in `command'
C:/Ruby23/lib/ruby/gems/2.3.0/gems/git-1.3.0/lib/git/lib.rb:861:in `command_lines'
C:/Ruby23/lib/ruby/gems/2.3.0/gems/git-1.3.0/lib/git/lib.rb:400:in `ls_files'
C:/Ruby23/lib/ruby/gems/2.3.0/gems/git-1.3.0/lib/git/status.rb:88:in `construct_status'
C:/Ruby23/lib/ruby/gems/2.3.0/gems/git-1.3.0/lib/git/status.rb:8:in `initialize'
C:/Ruby23/lib/ruby/gems/2.3.0/gems/git-1.3.0/lib/git/base/factory.rb:63:in `new'
C:/Ruby23/lib/ruby/gems/2.3.0/gems/git-1.3.0/lib/git/base/factory.rb:63:in `status'
...
```

Do you see that strange command with this empty `""` after `"--stage"`?

## My environment

```
$ git --version
git version 2.16.2.windows.1

$ ruby -v
ruby 2.3.1p112 (2016-04-26 revision 54768) [i386-mingw32]
```