### PR TITLE
Fix checkout when branch and files same name

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -642,6 +642,7 @@ module Git
       arr_opts << '-b' if opts[:new_branch] || opts[:b]
       arr_opts << '--force' if opts[:force] || opts[:f]
       arr_opts << branch
+      arr_opts << '--'
 
       command('checkout', arr_opts)
     end


### PR DESCRIPTION
When trying to checkout a remote branch with the same name as a file or directory, the current system checks out the file (and doesn't checkout the remote). 
This change should fix it.
You can see more information here
https://stackoverflow.com/questions/25322335/git-change-branch-when-file-of-same-name-is-present