### PR TITLE
process_full_diff: Don't reencode diffs which are already UTF-8

### DIFF
--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -127,10 +127,11 @@ module Git
         }
         final = {}
         current_file = nil
-        full_diff_utf8_encoded = @full_diff.encode("UTF-8", "binary", {
-			:invalid => :replace,
-			:undef => :replace
-		})
+        if @full_diff.encoding.name != "UTF-8"
+          full_diff_utf8_encoded = @full_diff.encode("UTF-8", "binary", { :invalid => :replace, :undef => :replace })
+        else
+          full_diff_utf8_encoded = @full_diff
+        end
         full_diff_utf8_encoded.split("\n").each do |line|
           if m = /^diff --git a\/(.*?) b\/(.*?)/.match(line)
             current_file = m[1]


### PR DESCRIPTION
## Abstract

I'm heavy user of https://github.com/danger/danger and it internally uses this gem.
Danger frequently refers the `git diff`.

I noticed when `git diff` contains multi bytes text, the `full_diff_utf8_encoded` includes invalid chars like below.

<img width="482" alt="2018-06-11 17 37 36" src="https://user-images.githubusercontent.com/3483230/41221096-2d7e7386-6d9e-11e8-92e1-e646f3fb84eb.png">

I saw https://github.com/ruby-git/ruby-git/pull/276 and I could understand the background of the code.
The `command_lines` method had been fixed for it (https://github.com/ruby-git/ruby-git/commit/fe680f8c64d4b78280d541fe58e30ed1f3b9c6e0) but the `process_full_diff` had not.

## Changes

Do not force to encode diff patch when the encoding type of it is UTF-8.