### PR TITLE
config_get: Fix incorrect block name

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -445,7 +445,7 @@ module Git
       if @git_dir
         Dir.chdir(@git_dir, &do_get)
       else
-        build_list.call
+        do_get.call
       end
     end
 


### PR DESCRIPTION
Signed-off-by: Joshua Liebowitz
- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

Looks like a copy paste error with the wrong block name.