### PR TITLE
fixing file descriptor leakage

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -604,10 +604,12 @@ module Git
       arr = []
       filename = File.join(@git_dir, 'logs/refs/stash')
       if File.exist?(filename)
-        File.open(filename).each_with_index { |line, i|
-          m = line.match(/:(.*)$/)
-          arr << [i, m[1].strip]
-        }
+        File.open(filename) do |f|
+          f.each_with_index do |line, i|
+            m = line.match(/:(.*)$/)
+            arr << [i, m[1].strip]
+          end
+        end
       end
       arr
     end

--- a/lib/git/stashes.rb
+++ b/lib/git/stashes.rb
@@ -13,6 +13,17 @@ module Git
         @stashes.unshift(Git::Stash.new(@base, message, true))
       end
     end
+
+    #
+    # Returns an multi-dimensional Array of elements that have been stash saved.
+    # Array is based on position and name. See Example
+    #
+    # @example Returns Array of items that have been stashed
+    #     .all - [0, "testing-stash-all"]]
+    # @return [Array]
+    def all
+      @base.lib.stashes_all
+    end
     
     def save(message)
       s = Git::Stash.new(@base, message)

--- a/tests/units/test_stashes.rb
+++ b/tests/units/test_stashes.rb
@@ -32,5 +32,27 @@ class TestStashes < Test::Unit::TestCase
       end
     end
   end
+
+  def test_stashes_all
+    in_temp_dir do |path|
+      g = Git.clone(@wbare, 'stash_test')
+      Dir.chdir('stash_test') do
+        assert_equal(0, g.branch.stashes.size)
+        new_file('test-file1', 'blahblahblah1')
+        new_file('test-file2', 'blahblahblah2')
+        assert(g.status.untracked.assoc('test-file1'))
+
+        g.add
+
+        assert(g.status.added.assoc('test-file1'))
+
+        g.branch.stashes.save('testing-stash-all')
+
+        stashes = g.branch.stashes.all
+
+        assert(stashes[0].include?('testing-stash-all'))
+      end
+    end
+  end
   
 end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
using File as a block so that it tears down once everything has completed - We operated on the each and left the file descriptor open.
adding a API directly in stashes
adding testing around it.

fixes #312
