### PR TITLE
Bug with a .gitignore

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -428,8 +428,11 @@ module Git
     def ignored_files
       command_lines('ls-files', ['--others', '-i', '--exclude-standard'])
     end
-
-
+    
+    def untracked_files
+      command_lines('ls-files', ['--others','--exclude-standard'])
+    end
+    
     def config_remote(name)
       hsh = {}
       config_list.each do |key, value|

--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -170,14 +170,11 @@ module Git
     end
 
     def fetch_untracked
-      ignore = @base.lib.ignored_files
+      untracked = @base.lib.untracked_files
 
       Dir.chdir(@base.dir.path) do
         Dir.glob('**/*', File::FNM_DOTMATCH) do |file|
-          next if @files[file] || File.directory?(file) ||
-                  ignore.include?(file) || file =~ %r{^.git\/.+}
-
-          @files[file] = { path: file, untracked: true }
+          @files[file] = { path: file, untracked: true } if untracked.include?(file)
         end
       end
     end

--- a/tests/units/test_status.rb
+++ b/tests/units/test_status.rb
@@ -83,4 +83,21 @@ class TestStatus < Test::Unit::TestCase
       assert(!git.status.untracked?('test_file_2'))
     end
   end
+
+  def test_submodule_untracked_boolean
+    in_temp_dir do |path|
+      git = Git.clone(@wdir, 'test_dot_files_status')
+      git_sub = Git.clone(@wdir, 'test_dot_files_status/sub')
+
+      create_file('test_dot_files_status/.gitignore', 'sub')
+
+      create_file('test_dot_files_status/sub/test_file_1', 'content tets_file_1')
+      create_file('test_dot_files_status/sub/test_file_2', 'content tets_file_2')      
+      git_sub.add('test_file_2')
+
+      assert(!git.status.untracked?('sub/test_file_1'))
+      assert(git_sub.status.untracked?('test_file_1'))
+      assert(!git_sub.status.untracked?('test_file_2'))
+    end
+  end    
 end


### PR DESCRIPTION
When you use directories or masks in a .gitignore, the files ignored by git fall into the list of untracked files
