### PR TITLE
Adding ruby-head and ruby 2.6 to Travis, removing C ext from repo

### DIFF
--- a/.jrubyrc
+++ b/.jrubyrc
@@ -1,1 +1,0 @@
-cext.enabled=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.5
   - ruby-head
   - jruby
-    env: JRUBY_OPTS=''
+    env: JRUBY_OPTS=""
 
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,10 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - ruby-head
   - jruby
 matrix:
   allow_failures:
   - rvm: jruby
+  - rvm: ruby-head
   fast_finish: true
-before_install:
-  - gem install bundler
-  - bundle --version
-  - git --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,15 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
   - ruby-head
 
 matrix:
   include:
     - rvm: jruby
       env: JRUBY_OPTS="--server -Dcext.enabled=true -Xcompile.invokedynamic=false"
+      before_install:
+        - gem install bundler
   allow_failures:
   - rvm: jruby
   - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,9 @@ rvm:
   - 2.5
   - 2.6
   - ruby-head
+  - jruby
 
 matrix:
-  include:
-    - rvm: jruby
-      env: JRUBY_OPTS="--server -Dcext.enabled=true -Xcompile.invokedynamic=false"
-      before_install:
-        - gem install bundler
   allow_failures:
   - rvm: jruby
   - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ rvm:
   - 2.5
   - ruby-head
   - jruby
+    env: JRUBY_OPTS=''
+
 matrix:
   allow_failures:
   - rvm: jruby

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,13 @@ rvm:
   - 2.5
   - ruby-head
   - jruby
-    env: JRUBY_OPTS=""
 
 matrix:
   allow_failures:
   - rvm: jruby
   - rvm: ruby-head
   fast_finish: true
+
+env:
+  jruby:
+    JRUBY_OPTS="--server -Dcext.enabled=true -Xcompile.invokedynamic=false"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,12 @@ rvm:
   - 2.4
   - 2.5
   - ruby-head
-  - jruby
 
 matrix:
+  include:
+    - rvm: jruby
+      env: JRUBY_OPTS="--server -Dcext.enabled=true -Xcompile.invokedynamic=false"
   allow_failures:
   - rvm: jruby
   - rvm: ruby-head
   fast_finish: true
-
-env:
-  jruby:
-    JRUBY_OPTS="--server -Dcext.enabled=true -Xcompile.invokedynamic=false"


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
I am adding ruby-head (allows failure) and ruby 2.6 which is in its second preview which should be a release candidate soon if following Ruby's release patterns.

Removing .jrubyrc from the repo as jruby has deprecated C ext support from the the library as of 1.7 and we are testing at 9.2 (Ruby 2.5 equiv.).

Source: 
https://github.com/jruby/jruby-cext#status
https://twitter.com/headius/statuses/281091403919003649

Removing the before_install section as all of those steps are standard parts of Travis CI and appear under the `ruby.versions` section.
