### PR TITLE
Reduce and isolate usage of Dir.chdir

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -108,7 +108,7 @@ module Git
     options.delete(:remote)
     repo = clone(repository, name, {:depth => 1}.merge(options))
     repo.checkout("origin/#{options[:branch]}") if options[:branch]
-    Dir.chdir(repo.dir.to_s) { FileUtils.rm_r '.git' }
+    FileUtils.rm_r(File.join(repo.dir.to_s, '.git'))
   end
   
   # Same as g.config, but forces it to be at the global level

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -3,6 +3,12 @@ require 'git/base/factory'
 module Git
   
   class Base
+    # Adding a mutex to the class because each repo should be sharing the same mutex 
+    # in case we need to Dir.chdir and we don't have fork() support to isolate that
+    @chdir_semaphore = Mutex.new
+    class << self
+      attr_accessor :chdir_semaphore
+    end
 
     include Git::Base::Factory
 
@@ -92,8 +98,11 @@ module Git
       @index = options[:index] ? Git::Index.new(options[:index], false) : nil
     end
     
-    # changes current working directory for a block
-    # to the git working directory
+    # changes current working directory for a block to the git working directory.
+    #
+    # Note: If we can fork() or spawn(), Dir.chdir will happen in a new process
+    # otherwise, we will use a mutex to prevent threading errors
+    # See https://github.com/ruby-git/ruby-git/issues/355 for more info
     #
     # example
     #  @git.chdir do 
@@ -101,9 +110,25 @@ module Git
     #    @git.add
     #    @git.commit('message')
     #  end
-    def chdir # :yields: the Git::Path
-      Dir.chdir(dir.path) do
-        yield dir.path
+    def chdir(&block) # :yields: the Git::Path
+      chdir_block = Proc.new do
+        Dir.chdir(dir.path) do
+          block.call(dir.path)
+        end
+      end
+
+      if Process.respond_to?(:fork)
+        # Forking this process so that we can be threadsafe
+        pid = Process.fork do
+          chdir_block.call
+        end
+        Process.wait(pid)
+      else
+        # JRuby and Windows don't support fork()
+        # let's use a mutex to prevent race conditions with threads
+        Git::Base.chdir_semaphore.synchronize do
+          chdir_block.call
+        end
       end
     end
     
@@ -144,9 +169,7 @@ module Git
     
     # returns the repository size in bytes
     def repo_size
-      Dir.chdir(repo.path) do
-        return `du -s`.chomp.split.first.to_i
-      end
+      return `du -s #{repo.path}`.chomp.split.first.to_i
     end
     
     def set_index(index_file, check = true)
@@ -348,7 +371,7 @@ module Git
     #  @git.pull('upstream', 'develope')  # pulls from upstream/develop
     #
     def pull(remote='origin', branch='master')
-			self.lib.pull(remote, branch)
+      self.lib.pull(remote, branch)
     end
     
     # returns an array of Git:Remote objects

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -8,6 +8,7 @@ module Git
   class Lib
 
     @@semaphore = Mutex.new
+    @@config_semaphore = Mutex.new
 
     def initialize(base = nil, logger = nil)
       @git_dir = nil
@@ -310,7 +311,7 @@ module Git
     def list_files(ref_dir)
       dir = File.join(@git_dir, 'refs', ref_dir)
       files = []
-      Dir.chdir(dir) { files = Dir.glob('**/*').select { |f| File.file?(f) } } rescue nil
+      files = Dir.glob(File.join(dir, '**/*')).select { |f| File.file?(f) } rescue nil
       files
     end
 
@@ -441,14 +442,16 @@ module Git
     end
 
     def config_get(name)
-      do_get = lambda do |path|
-        command('config', ['--get', name])
-      end
+      @@config_semaphore.synchronize do
+        do_get = lambda do |path|
+          command('config', ['--get', name])
+        end
 
-      if @git_dir
-        Dir.chdir(@git_dir, &do_get)
-      else
-        do_get.call
+        if @git_dir
+          Dir.chdir(@git_dir, &do_get)
+        else
+          do_get.call
+        end
       end
     end
 
@@ -457,14 +460,16 @@ module Git
     end
 
     def config_list
-      build_list = lambda do |path|
-        parse_config_list command_lines('config', ['--list'])
-      end
+      @@config_semaphore.synchronize do
+        build_list = lambda do |path|
+          parse_config_list command_lines('config', ['--list'])
+        end
 
-      if @git_dir
-        Dir.chdir(@git_dir, &build_list)
-      else
-        build_list.call
+        if @git_dir
+          Dir.chdir(@git_dir, &build_list)
+        else
+          build_list.call
+        end
       end
     end
 

--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -171,14 +171,14 @@ module Git
 
     def fetch_untracked
       ignore = @base.lib.ignored_files
+      root_base_dir_path_length = File.join(@base.dir.path, '/').length
+      Dir.glob(File.join(@base.dir.path, '**/*'), File::FNM_DOTMATCH) do |file|
+        # Strip off the `base.dir.path` to make these relative paths
+        relative_file_name = file.slice(root_base_dir_path_length..file.length)
+        next if @files[relative_file_name] || File.directory?(file) ||
+                ignore.include?(relative_file_name) || relative_file_name =~ %r{^.git\/.+}
 
-      Dir.chdir(@base.dir.path) do
-        Dir.glob('**/*', File::FNM_DOTMATCH) do |file|
-          next if @files[file] || File.directory?(file) ||
-                  ignore.include?(file) || file =~ %r{^.git\/.+}
-
-          @files[file] = { path: file, untracked: true }
-        end
+        @files[relative_file_name] = { path: relative_file_name, untracked: true }
       end
     end
 


### PR DESCRIPTION
Instead of using chdir blocks, we should use absolute paths so that we can enable threaded usage of the library
If Process.fork() is available, we'll use that for git.chdir actions, otherwise, we'll use a global mutex to
prevent threads from calling git.chdir before the previous execution has completed.
- fork() when using Dir.chdir, otherwise, use a mutex
- wrap calls to in a semaphore
- replace Dir.chdir with paths
- fixes #355

Note: if you do async work in git.chdir all bets are off.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

Signed-off-by: Joshua Liebowitz <taquitos@google.com>

