### PR TITLE
Enabling support for git-describe --first-parent option (+bugfixes)

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -949,16 +949,11 @@ module Git
 
       output = nil
 
-      command_thread = nil;
-
       exitstatus = nil
 
       with_custom_env_variables do
-        command_thread = Thread.new do
           output = run_command(git_cmd, &block)
           exitstatus = $?.exitstatus
-        end
-        command_thread.join
       end
 
       if @logger

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -97,6 +97,7 @@ module Git
     #  :long
     #  :always
     #  :match
+    #  :first_parent
     #
     #  @param [String|NilClass] committish target commit sha or object name
     #  @param [{Symbol=>Object}] opts the given options
@@ -119,6 +120,7 @@ module Git
       arr_opts << "--abbrev=#{opts[:abbrev]}" if opts[:abbrev]
       arr_opts << "--candidates=#{opts[:candidates]}" if opts[:candidates]
       arr_opts << "--match=#{opts[:match]}" if opts[:match]
+      arr_opts << '--first-parent' if opts[:first_parent]
 
       arr_opts << committish if committish
 

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -96,7 +96,7 @@ module Git
     #  :candidates
     #  :long
     #  :always
-    #  :math
+    #  :match
     #
     #  @param [String|NilClass] committish target commit sha or object name
     #  @param [{Symbol=>Object}] opts the given options
@@ -113,12 +113,12 @@ module Git
       arr_opts << '--always' if opts[:always]
       arr_opts << '--exact-match' if opts[:exact_match] || opts[:"exact-match"]
 
-      arr_opts << '--dirty' if opts['dirty'] == true
-      arr_opts << "--dirty=#{opts['dirty']}" if opts['dirty'].is_a?(String)
+      arr_opts << '--dirty' if opts[:dirty] == true
+      arr_opts << "--dirty=#{opts[:dirty]}" if opts[:dirty].is_a?(String)
 
-      arr_opts << "--abbrev=#{opts['abbrev']}" if opts[:abbrev]
-      arr_opts << "--candidates=#{opts['candidates']}" if opts[:candidates]
-      arr_opts << "--match=#{opts['match']}" if opts[:match]
+      arr_opts << "--abbrev=#{opts[:abbrev]}" if opts[:abbrev]
+      arr_opts << "--candidates=#{opts[:candidates]}" if opts[:candidates]
+      arr_opts << "--match=#{opts[:match]}" if opts[:match]
 
       arr_opts << committish if committish
 

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -2,6 +2,7 @@ require 'date'
 require 'fileutils'
 require 'logger'
 require 'test/unit'
+require 'tmpdir'
 
 require "#{File.expand_path(File.dirname(__FILE__))}/../lib/git"
 
@@ -33,7 +34,7 @@ class Test::Unit::TestCase
 
   def create_temp_repo(clone_path)
     filename = 'git_test' + Time.now.to_i.to_s + rand(300).to_s.rjust(3, '0')
-    @tmp_path = File.join("/tmp/", filename)
+    @tmp_path = File.join(Dir.tmpdir, filename)
     FileUtils.mkdir_p(@tmp_path)
     FileUtils.cp_r(clone_path, @tmp_path)
     tmp_path = File.join(@tmp_path, 'working')
@@ -47,7 +48,7 @@ class Test::Unit::TestCase
     tmp_path = nil
     while tmp_path.nil? || File.directory?(tmp_path)
       filename = 'git_test' + Time.now.to_i.to_s + rand(300).to_s.rjust(3, '0')
-      tmp_path = File.join("/tmp/", filename)
+      tmp_path = File.join(Dir.tmpdir, filename)
     end
     FileUtils.mkdir(tmp_path)
     Dir.chdir tmp_path do

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -6,9 +6,9 @@ require 'test/unit'
 require "#{File.expand_path(File.dirname(__FILE__))}/../lib/git"
 
 class Test::Unit::TestCase
-  
+
   def set_file_paths
-    cwd = `pwd`.chomp
+    cwd = Dir.pwd
     if File.directory?(File.join(cwd, 'files'))
       @test_dir = File.join(cwd, 'files')
     elsif File.directory?(File.join(cwd, '..', 'files'))
@@ -16,21 +16,21 @@ class Test::Unit::TestCase
     elsif File.directory?(File.join(cwd, 'tests', 'files'))
       @test_dir = File.join(cwd, 'tests', 'files')
     end
-    
+
     @wdir_dot = File.expand_path(File.join(@test_dir, 'working'))
     @wbare = File.expand_path(File.join(@test_dir, 'working.git'))
     @index = File.expand_path(File.join(@test_dir, 'index'))
-    
+
     @wdir = create_temp_repo(@wdir_dot)
   end
-  
+
   teardown
   def git_teardown
     if @tmp_path
       FileUtils.rm_r(@tmp_path)
     end
   end
-  
+
   def create_temp_repo(clone_path)
     filename = 'git_test' + Time.now.to_i.to_s + rand(300).to_s.rjust(3, '0')
     @tmp_path = File.join("/tmp/", filename)
@@ -42,7 +42,7 @@ class Test::Unit::TestCase
     end
     tmp_path
   end
-  
+
   def in_temp_dir(remove_after = true) # :yields: the temporary dir's path
     tmp_path = nil
     while tmp_path.nil? || File.directory?(tmp_path)
@@ -55,7 +55,7 @@ class Test::Unit::TestCase
     end
     FileUtils.rm_r(tmp_path) if remove_after
   end
-  
+
   def create_file(path, content)
     File.open(path,'w') do |file|
       file.puts(content)
@@ -69,7 +69,7 @@ class Test::Unit::TestCase
   def delete_file(path)
     File.delete(path)
   end
-  
+
   def new_file(name, contents)
     create_file(name,contents)
   end
@@ -79,5 +79,5 @@ class Test::Unit::TestCase
       f.puts contents
     end
   end
-  
+
 end

--- a/tests/units/test_archive.rb
+++ b/tests/units/test_archive.rb
@@ -26,7 +26,7 @@ class TestArchive < Test::Unit::TestCase
     f = @git.object('v2.6').archive(nil, :format => 'tar') # returns path to temp file
     assert(File.exist?(f))
 
-    lines = `cd /tmp; tar xvpf #{f} 2>&1`.split("\n")
+    lines = `cd #{Dir.tmpdir}; tar xvpf #{f} 2>&1`.split("\n")
     assert_match(%r{ex_dir/}, lines[0])
     assert_match(/example.txt/, lines[2])
 
@@ -39,7 +39,7 @@ class TestArchive < Test::Unit::TestCase
     f = @git.object('v2.6').archive(tempfile, :format => 'tar', :prefix => 'test/', :path => 'ex_dir/')
     assert(File.exist?(f))
 
-    lines = `cd /tmp; tar xvpf #{f} 2>&1`.split("\n")
+    lines = `cd #{Dir.tmpdir}; tar xvpf #{f} 2>&1`.split("\n")
     assert_match(%r{test/}, lines[0])
     assert_match(%r{test/ex_dir/ex\.txt}, lines[2])
 

--- a/tests/units/test_describe.rb
+++ b/tests/units/test_describe.rb
@@ -29,4 +29,24 @@ class TestDescribe < Test::Unit::TestCase
 
   end
 
+  def test_describe_first_parent
+
+    # Set-up a merged branch with a newer tag on it
+    main_branch = @git.current_branch
+    @git.branch('first_parent').checkout
+    @git.commit 'change', allow_empty: true
+    @git.add_tag 'v2.8.1'
+    @git.branches[main_branch].checkout
+    @git.commit 'change', allow_empty: true
+    @git.merge 'first_parent'
+    @git.commit 'change', allow_empty: true
+
+    assert_equal 'v2.8.1', @git.describe(main_branch, tags: true, abbrev: 0),
+        'git-describe should return the newer tag when first_parent not used.'
+
+    assert_equal 'v2.8', @git.describe(main_branch, tags: true, abbrev: 0, first_parent: true),
+        'git-describe should return the older tag when first_parent is used.'
+
+  end
+
 end

--- a/tests/units/test_describe.rb
+++ b/tests/units/test_describe.rb
@@ -3,14 +3,14 @@
 require File.dirname(__FILE__) + '/../test_helper'
 
 class TestDescribe < Test::Unit::TestCase
-  
+
   def setup
     set_file_paths
     @git = Git.open(@wdir)
   end
 
   def test_describe
-    assert_equal(@git.describe(nil, {:tags => true}), 'v2.8')
+    assert_equal'v2.8', @git.describe(nil, tags: true)
   end
 
 end

--- a/tests/units/test_describe.rb
+++ b/tests/units/test_describe.rb
@@ -41,6 +41,9 @@ class TestDescribe < Test::Unit::TestCase
     @git.merge 'first_parent'
     @git.commit 'change', allow_empty: true
 
+    # Display current state of test structure on console
+    @git.chdir { puts `git --no-pager log --oneline --graph --decorate --all -n 10` }
+
     assert_equal 'v2.8.1', @git.describe(main_branch, tags: true, abbrev: 0),
         'git-describe should return the newer tag when first_parent not used.'
 

--- a/tests/units/test_describe.rb
+++ b/tests/units/test_describe.rb
@@ -33,13 +33,13 @@ class TestDescribe < Test::Unit::TestCase
 
     # Set-up a merged branch with a newer tag on it
     main_branch = @git.current_branch
-    @git.branch('first_parent').checkout
-    @git.commit 'change', allow_empty: true
-    @git.add_tag 'v2.8.1'
-    @git.branches[main_branch].checkout
-    @git.commit 'change', allow_empty: true
-    @git.merge 'first_parent'
-    @git.commit 'change', allow_empty: true
+    @git.branch('first_parent').checkout;    sleep(0.2)
+    @git.commit 'change', allow_empty: true; sleep(0.2)
+    @git.add_tag 'v2.8.1';                   sleep(0.2)
+    @git.branches[main_branch].checkout;     sleep(0.2)
+    @git.commit 'change', allow_empty: true; sleep(0.2)
+    @git.merge 'first_parent';               sleep(0.2)
+    @git.commit 'change', allow_empty: true; sleep(0.2)
 
     # Display current state of test structure on console
     @git.chdir { puts `git --no-pager log --oneline --graph --decorate --all -n 10` }

--- a/tests/units/test_describe.rb
+++ b/tests/units/test_describe.rb
@@ -13,4 +13,20 @@ class TestDescribe < Test::Unit::TestCase
     assert_equal'v2.8', @git.describe(nil, tags: true)
   end
 
+  def test_describe_abbrev
+
+    # Make sure we're not on the tag.
+    @git.commit 'change', allow_empty: true
+
+    assert_match /^v2\.8-1-g\h{7}$/, @git.describe(nil, tags: true),
+        'git-describe should return the full describe if abbrev isn\'t provided'
+
+    assert_match /^v2\.8-1-g\h{1,8}$/, @git.describe(nil, tags: true, abbrev: 1),
+        'git-describe should use the minimum digits required for a unique object name.'
+
+    assert_equal 'v2.8', @git.describe(nil, tags: true, abbrev: 0),
+        'git-describe should just return the last tag if abbrev is 0'
+
+  end
+
 end

--- a/tests/units/test_logger.rb
+++ b/tests/units/test_logger.rb
@@ -7,32 +7,32 @@ class TestLogger < Test::Unit::TestCase
   def setup
     set_file_paths
   end
-  
+
   def test_logger
     log = Tempfile.new('logfile')
     log.close
-    
+
     logger = Logger.new(log.path)
     logger.level = Logger::DEBUG
-    
+
     @git = Git.open(@wdir, :log => logger)
     @git.branches.size
-    
+
     logc = File.read(log.path)
-    assert(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' branch '-a'/.match(logc))
-    assert(/DEBUG -- :   diff_over_patches/.match(logc))
+    assert_match(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' branch '-a'/, logc)
+    assert_match(/DEBUG -- :   diff_over_patches/, logc)
 
     log = Tempfile.new('logfile')
     log.close
     logger = Logger.new(log.path)
     logger.level = Logger::INFO
-    
+
     @git = Git.open(@wdir, :log => logger)
     @git.branches.size
-    
+
     logc = File.read(log.path)
-    assert(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' branch '-a'/.match(logc))
-    assert(!/DEBUG -- :   diff_over_patches/.match(logc))
+    assert_match(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' branch '-a'/, logc)
+    assert_not_match(/DEBUG -- :   diff_over_patches/, logc)
   end
-  
+
 end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
These changes add support for the `--first-parent` option of `git-describe`, and fix inconsistent and/or non-functional option handling for the `describe` method, specifically for the `--abbrev` option.

I've split the commits into several parts to make the changes as clear as possible, but they can of course be squashed prior to merging if requested.