### PR TITLE
Added UTF-8 Fix

### DIFF
--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -130,7 +130,7 @@ module Git
         if @full_diff.encoding.name != "UTF-8"
           full_diff_utf8_encoded = @full_diff.encode("UTF-8", "binary", { :invalid => :replace, :undef => :replace })
         else
-          full_diff_utf8_encoded = @full_diff
+          full_diff_utf8_encoded = @full_diff.encode("UTF-8", "UTF-8", { :invalid => :replace, :undef => :replace })
         end
         full_diff_utf8_encoded.split("\n").each do |line|
           if m = /^diff --git a\/(.*?) b\/(.*?)/.match(line)


### PR DESCRIPTION
Signed-off-by: invist@thinkpwn <cf@cw>

### Description
When files contain bad characters (e.g. \255) and commits are compared an ArgumentError is thrown. 
This PR changes handling bad characters in the else statement. 

In addition to PR #369 when converting from UTF-8 to UTF-8 no valid high acii characters are changed.
### Proof of Concept
#### Test script
```ruby
#!/bin/env ruby
# encoding: UTF-8
# Purpose: Encoding testing

# --[Test strings]--
test_strs = [
    "红宝石",
    "\255",
    "红宝石\255",
]

puts "Encoding Name is UTF-8:"
puts ["String","UTF-8","Valid?"].join("\t\t")
test_strs.each do |str| 
    puts [
        str,
        str.encoding.name == "UTF-8",
        str.valid_encoding?
    ].join("\t\t")
end
puts "------------------------"

puts "Get Encoding (fixed):"
puts ["String","Encoded","Split"].join("\t\t")
test_strs.each do |str|
    if str.encoding.name != "UTF-8"
        encoded = str.encode("UTF-8", "binary", { :invalid => :replace, :undef => :replace })
    else
        encoded = str.encode("UTF-8", "UTF-8",  { :invalid => :replace, :undef => :replace })
    end  
    puts [
        str,
        encoded,
        encoded.split("").join(""),
    ].join("\t\t")
end
puts "------------------------"

puts "Get Encoding (current):"
test_strs.each do |str|
    puts str.split("").join("")
end
puts "------------------------"
```

#### Output 
```
Encoding Name is UTF-8:
String		UTF-8		Valid?
红宝石		true		true
�		true		false
红宝石�		true		false
------------------------
Get Encoding (fixed):
String		Encoded		Split
红宝石		红宝石		红宝石
�		�		�
红宝石�		红宝石�		红宝石�
------------------------
Get Encoding (current):
String		Encoded		Split
红宝石		红宝石		红宝石
Traceback (most recent call last):
	3: from test_utf8.rb:42:in `<main>'
	2: from test_utf8.rb:42:in `each'
	1: from test_utf8.rb:51:in `block in <main>'
test_utf8.rb:51:in `split': invalid byte sequence in UTF-8 (ArgumentError)
```