### PR TITLE
Allow creating new config entries

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -502,10 +502,14 @@ module Git
 
     def config_set(name, value)
       command('config', [name, value])
+    rescue Git::GitExecuteError
+      command('config', ['--add', name, value])
     end
 
     def global_config_set(name, value)
       command('config', ['--global', name, value], false)
+    rescue Git::GitExecuteError
+      command('config', ['--global', '--add', name, value], false)
     end
 
     # updates the repository index using the working directory content


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description

[Git 2.1.2 introduced setting values even if they did not previously exist.](https://github.com/git/git/blob/master/Documentation/RelNotes/2.1.2.txt#L16-L17)
The git-ruby library [keeps compatibility](https://github.com/ruby-git/ruby-git/blob/master/lib/git.rb#L25) with Git [1.6](https://github.com/ruby-git/ruby-git/blob/master/lib/git/lib.rb#L887), this fixes the
problem of older versions not being able to create new values.

#### Other options

- bump the minimal required git version to `2.1.2`