### PR TITLE
Do not allow changes to ENV to leak from test to test

### DIFF
--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -79,5 +79,18 @@ class Test::Unit::TestCase
       f.puts contents
     end
   end
-  
+
+  # Runs a block inside an environment with customized ENV variables.
+  # It restores the ENV after execution.
+  #
+  # @param [Proc] block block to be executed within the customized environment
+  def with_custom_env_variables(&block)
+    saved_env = {}
+    begin
+      Git::Lib::ENV_VARIABLE_NAMES.each { |k| saved_env[k] = ENV[k] }
+      return block.call
+    ensure
+      Git::Lib::ENV_VARIABLE_NAMES.each { |k| ENV[k] = saved_env[k] }
+    end
+  end
 end

--- a/tests/units/test_config.rb
+++ b/tests/units/test_config.rb
@@ -29,27 +29,29 @@ class TestConfig < Test::Unit::TestCase
   end  
 
   def test_env_config
-    assert_equal(Git::Base.config.git_ssh, nil)
-    
-    ENV['GIT_SSH'] = '/env/git/ssh'
+    with_custom_env_variables do
+      begin
+        assert_equal(Git::Base.config.git_ssh, nil)
+        ENV['GIT_SSH'] = '/env/git/ssh'
 
-    assert_equal(Git::Base.config.git_ssh, '/env/git/ssh')
+        assert_equal(Git::Base.config.git_ssh, '/env/git/ssh')
 
-    Git.configure do |config|
-      config.binary_path = '/usr/bin/git'
-      config.git_ssh = '/path/to/ssh/script'
-    end
-    
-    assert_equal(Git::Base.config.git_ssh, '/path/to/ssh/script')
+        Git.configure do |config|
+          config.binary_path = '/usr/bin/git'
+          config.git_ssh = '/path/to/ssh/script'
+        end
 
-    @git.log
-  ensure
-    ENV['GIT_SSH'] = nil
+        assert_equal(Git::Base.config.git_ssh, '/path/to/ssh/script')
 
-    Git.configure do |config|
-      config.binary_path = nil
-      config.git_ssh = nil
+        @git.log
+      ensure
+        ENV['GIT_SSH'] = nil
+
+        Git.configure do |config|
+          config.binary_path = nil
+          config.git_ssh = nil
+        end
+      end
     end
   end
-  
 end

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -77,38 +77,42 @@ class TestLib < Test::Unit::TestCase
   end
   
   def test_environment_reset
-    ENV['GIT_DIR'] = '/my/git/dir'
-    ENV['GIT_WORK_TREE'] = '/my/work/tree'
-    ENV['GIT_INDEX_FILE'] = 'my_index'
+    with_custom_env_variables do
+      ENV['GIT_DIR'] = '/my/git/dir'
+      ENV['GIT_WORK_TREE'] = '/my/work/tree'
+      ENV['GIT_INDEX_FILE'] = 'my_index'
 
-    @lib.log_commits :count => 10
+      @lib.log_commits :count => 10
 
-    assert_equal(ENV['GIT_DIR'], '/my/git/dir')
-    assert_equal(ENV['GIT_WORK_TREE'], '/my/work/tree')
-    assert_equal(ENV['GIT_INDEX_FILE'],'my_index')
+      assert_equal(ENV['GIT_DIR'], '/my/git/dir')
+      assert_equal(ENV['GIT_WORK_TREE'], '/my/work/tree')
+      assert_equal(ENV['GIT_INDEX_FILE'],'my_index')
+    end
   end
 
   def test_git_ssh_from_environment_is_passed_to_binary
-    ENV['GIT_SSH'] = 'my/git-ssh-wrapper'
+    with_custom_env_variables do
+      begin
+        ENV['GIT_SSH'] = 'my/git-ssh-wrapper'
 
-    Dir.mktmpdir do |dir|
-      output_path = File.join(dir, 'git_ssh_value')
-      binary_path = File.join(dir, 'git')
-      Git::Base.config.binary_path = binary_path
-      File.open(binary_path, 'w') { |f|
-        f << "echo $GIT_SSH > #{output_path}"
-      }
-      FileUtils.chmod(0700, binary_path)
-      @lib.checkout('something')
-      assert_equal("my/git-ssh-wrapper\n", File.read(output_path))
+        Dir.mktmpdir do |dir|
+          output_path = File.join(dir, 'git_ssh_value')
+          binary_path = File.join(dir, 'git')
+          Git::Base.config.binary_path = binary_path
+          File.open(binary_path, 'w') { |f|
+            f << "echo $GIT_SSH > #{output_path}"
+          }
+          FileUtils.chmod(0700, binary_path)
+          @lib.checkout('something')
+          assert_equal("my/git-ssh-wrapper\n", File.read(output_path))
+        end
+      ensure
+        Git.configure do |config|
+          config.binary_path = nil
+          config.git_ssh = nil
+        end
+      end
     end
-  ensure
-    Git.configure do |config|
-      config.binary_path = nil
-      config.git_ssh = nil
-    end
-
-    ENV['GIT_SSH'] = nil
   end
 
   def test_revparse


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
Currently, the TestThreadSafety test case occasionally fails when executed as part of the build with this error:

```
#<Thread:0x00007fd08ea136f8@/Users/couballj/SynologyDrive/Documents/Projects/ruby-git-master-2/tests/units/test_thread_safty.rb:19 run> terminated with exception (report_on_exception is true):
Traceback (most recent call last):
	4: from /Users/couballj/SynologyDrive/Documents/Projects/ruby-git-master-2/tests/units/test_thread_safty.rb:20:in `block (2 levels) in test_git_init_bare'
	3: from /Users/couballj/SynologyDrive/Documents/Projects/ruby-git-master-2/lib/git.rb:140:in `init'
	2: from /Users/couballj/SynologyDrive/Documents/Projects/ruby-git-master-2/lib/git/base.rb:67:in `init'
	1: from /Users/couballj/SynologyDrive/Documents/Projects/ruby-git-master-2/lib/git/lib.rb:40:in `init'
/Users/couballj/SynologyDrive/Documents/Projects/ruby-git-master-2/lib/git/lib.rb:983:in `command': git '--git-dir=/var/folders/xv/2j9g0mgs5vgcdrl0s9pn9l_40000gn/T/d20190129-61742-zetuf4/.git' init '--bare'  2>&1:fatal: GIT_WORK_TREE (or --work-tree=<directory>) not allowed without specifying GIT_DIR (or --git-dir=<directory>) (Git::GitExecuteError)
```

It can be made to fail consistently by greatly increasing the thread count.  50 threads on my test machine makes if fail every time.

I found that one or two of the other tests change the global value ENV which makes the thread safety test fail.

This change makes it so that tests that change ENV restore ENV to its previous value.

Developer's Certificate of Origin (DCO) signed-off-by James Couball 