### PR TITLE
Update index before fetching modified files

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1065,6 +1065,8 @@ module Git
     # @param [Array] opts the diff options to be used
     # @return [Hash] the diff as Hash
     def diff_as_hash(diff_command, opts=[])
+      # update index before diffing to avoid spurious diffs
+      command('status')
       command_lines(diff_command, opts).inject({}) do |memo, line|
         info, file = line.split("\t")
         mode_src, mode_dest, sha_src, sha_dest, type = info.split

--- a/tests/units/test_status.rb
+++ b/tests/units/test_status.rb
@@ -97,4 +97,20 @@ class TestStatus < Test::Unit::TestCase
       assert(!git.status.untracked?('test_file_2'))
     end
   end
+
+  def test_changed_cache
+    in_temp_dir do |path|
+      git = Git.clone(@wdir, 'test_dot_files_status')
+
+      create_file('test_dot_files_status/test_file_1', 'hello')
+
+      git.add('test_file_1')
+      git.commit('message')
+
+      delete_file('test_dot_files_status/test_file_1')
+      create_file('test_dot_files_status/test_file_1', 'hello')
+
+      assert(!git.status.changed?('test_file_1'))
+    end
+  end
 end


### PR DESCRIPTION
According to the [git-diff-index docs][1], git commands like diff-index
and diff-files typically don't look at the actual contents of files in
the working tree. This means that these commands can be easily fooled by
operations that don't change the content of a file such as deleting and
recreating it, or even running `touch` on a file.

The docs then say that one may update the index to make it be in sync
with the actual contents of the working directory. The recommended
command would seem to be `git update-index --refresh`, but in my
testing, this caused "needs update" errors in some of the tests. So I've
resorted to using `git status`, which is probably a slightly more
heavyweight command, but does pass the tests.

If this is a concern, an alternative approach might be to specifically look for the presence of the special all-zero SHA1s returned by `git diff-files`, which indicate that the file is not in sync with the index. Please let me know what you think.

[1]: https://git-scm.com/docs/git-diff-index