### PR TITLE
Fix string with wrongly detected cp

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -186,7 +186,11 @@ module Git
       }
 
       loop do
-        key, *value = data.shift.split
+        datum = data.shift
+
+        break if datum.nil?
+
+        key, *value = datum.split
 
         break if key.nil?
 

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -902,14 +902,24 @@ module Git
     def command_lines(cmd, opts = [], chdir = true, redirect = '')
       cmd_op = command(cmd, opts, chdir)
       if cmd_op.encoding.name != "UTF-8"
-        op = cmd_op.encode("UTF-8", "binary", {
-          :invalid => :replace,
-          :undef => :replace
-        })
+        op = command_line_convert(cmd_op)
       else
         op = cmd_op
       end
-      op.split("\n")
+
+      begin
+        op.split("\n")
+      rescue ArgumentError
+        op = command_line_convert(cmd_op)
+        retry
+      end
+    end
+
+    def command_line_convert(cmd_op)
+      cmd_op.encode("UTF-8", "binary", {
+        :invalid => :replace,
+        :undef => :replace
+      })
     end
 
     # Takes the current git's system ENV variables and store them.


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
- fixes conversion from the invalid detectedfsource codepage string when
  used String#split method

The bug can be reproduced as follows:
1. Clone git: git://git.altlinux.org/gears/g/gdesklets.git
2. See the commit message has an invalid char, but is detected by the git-lib as UTF-8
$ git show 606eae4fd5f5b9f772e1feedddf4b97016494ece 
3. Use the method "#command_lines" of **Git::Lib** on the commit.
