### PR TITLE
Allow consumers to point git binary via env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,9 +66,9 @@ Git env config
     # If you need to use a custom SSH script
     config.git_ssh = '/path/to/ssh/script'
   end
-
 ```
 
+_NOTE: Another way to specify where is the `git` binary is through the environment variable `GIT_PATH`_
 
 Here are the operations that need read permission only.
 

--- a/lib/git/config.rb
+++ b/lib/git/config.rb
@@ -10,7 +10,7 @@ module Git
     end
 
     def binary_path
-      @binary_path || 'git'
+      @binary_path || ENV['GIT_PATH'] && File.join(ENV['GIT_PATH'], 'git') || 'git'
     end
 
     def git_ssh

--- a/tests/units/test_config.rb
+++ b/tests/units/test_config.rb
@@ -31,9 +31,13 @@ class TestConfig < Test::Unit::TestCase
   def test_env_config
     with_custom_env_variables do
       begin
+        assert_equal(Git::Base.config.binary_path, 'git')
         assert_equal(Git::Base.config.git_ssh, nil)
+
+        ENV['GIT_PATH'] = '/env/bin'
         ENV['GIT_SSH'] = '/env/git/ssh'
 
+        assert_equal(Git::Base.config.binary_path, '/env/bin/git')
         assert_equal(Git::Base.config.git_ssh, '/env/git/ssh')
 
         Git.configure do |config|
@@ -41,11 +45,13 @@ class TestConfig < Test::Unit::TestCase
           config.git_ssh = '/path/to/ssh/script'
         end
 
+        assert_equal(Git::Base.config.binary_path, '/usr/bin/git')
         assert_equal(Git::Base.config.git_ssh, '/path/to/ssh/script')
 
         @git.log
       ensure
         ENV['GIT_SSH'] = nil
+        ENV['GIT_PATH'] = nil
 
         Git.configure do |config|
           config.binary_path = nil


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
By adding a new environment variable called `GIT_PATH` we can allow
consumers, that is, a user of a gem that the gem itself uses the git gem,
to customize the location of the git binary.

Example: Having a gem called `git-tool` that uses this gem `git`, if I,
as a user wants to modify the git bin location, I could do:
```
GIT_PATH=/foo/bin git-tool bar
```

Signed-off-by: Salim Afiune <afiune@chef.io>