### PR TITLE
Add git_ssl_no_verify option to disable SSL verification for HTTPS repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,9 @@ Git env config
 
     # If you need to use a custom SSH script
     config.git_ssh = '/path/to/ssh/script'
+
+    # If you need to ignore SSL verification
+    config.git_ssl_no_verify = true
   end
 
 ```

--- a/lib/git/config.rb
+++ b/lib/git/config.rb
@@ -2,11 +2,12 @@ module Git
 
   class Config
 
-    attr_writer :binary_path, :git_ssh
+    attr_writer :binary_path, :git_ssh, :git_ssl_no_verify
 
     def initialize
       @binary_path = nil
       @git_ssh = nil
+      @git_ssl_no_verify = nil
     end
 
     def binary_path
@@ -15,6 +16,11 @@ module Git
 
     def git_ssh
       @git_ssh || ENV['GIT_SSH']
+    end
+
+    def git_ssl_no_verify
+      return 'true' if @git_ssl_no_verify
+      ENV['GIT_SSL_NO_VERIFY']
     end
 
   end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -897,7 +897,7 @@ module Git
     # Systen ENV variables involved in the git commands.
     #
     # @return [<String>] the names of the EVN variables involved in the git commands
-    ENV_VARIABLE_NAMES = ['GIT_DIR', 'GIT_WORK_TREE', 'GIT_INDEX_FILE', 'GIT_SSH']
+    ENV_VARIABLE_NAMES = %w(GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_SSH GIT_SSL_NO_VERIFY)
 
     def command_lines(cmd, opts = [], chdir = true, redirect = '')
       cmd_op = command(cmd, opts, chdir)
@@ -933,6 +933,7 @@ module Git
       ENV['GIT_WORK_TREE'] = @git_work_dir
       ENV['GIT_INDEX_FILE'] = @git_index_file
       ENV['GIT_SSH'] = Git::Base.config.git_ssh
+      ENV['GIT_SSL_NO_VERIFY'] = Git::Base.config.git_ssl_no_verify
     end
 
     # Runs a block inside an environment with customized ENV variables.

--- a/tests/units/test_config.rb
+++ b/tests/units/test_config.rb
@@ -39,9 +39,11 @@ class TestConfig < Test::Unit::TestCase
         Git.configure do |config|
           config.binary_path = '/usr/bin/git'
           config.git_ssh = '/path/to/ssh/script'
+          config.git_ssl_no_verify = true
         end
 
         assert_equal(Git::Base.config.git_ssh, '/path/to/ssh/script')
+        assert_equal(Git::Base.config.git_ssl_no_verify, 'true')
 
         @git.log
       ensure
@@ -50,6 +52,7 @@ class TestConfig < Test::Unit::TestCase
         Git.configure do |config|
           config.binary_path = nil
           config.git_ssh = nil
+          config.git_ssl_no_verify = nil
         end
       end
     end

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -81,12 +81,14 @@ class TestLib < Test::Unit::TestCase
       ENV['GIT_DIR'] = '/my/git/dir'
       ENV['GIT_WORK_TREE'] = '/my/work/tree'
       ENV['GIT_INDEX_FILE'] = 'my_index'
+      ENV['GIT_SSL_NO_VERIFY'] = 'true'
 
       @lib.log_commits :count => 10
 
       assert_equal(ENV['GIT_DIR'], '/my/git/dir')
       assert_equal(ENV['GIT_WORK_TREE'], '/my/work/tree')
       assert_equal(ENV['GIT_INDEX_FILE'],'my_index')
+      assert_equal(ENV['GIT_SSL_NO_VERIFY'], 'true')
     end
   end
 
@@ -110,6 +112,22 @@ class TestLib < Test::Unit::TestCase
         Git.configure do |config|
           config.binary_path = nil
           config.git_ssh = nil
+        end
+      end
+    end
+  end
+
+  def test_git_ssl_no_verify
+    with_custom_env_variables do
+      begin
+        ENV['GIT_SSL_NO_VERIFY'] = 'false'
+        assert_equal(Git::Base.config.git_ssl_no_verify, 'false')
+
+        Git::Base.config.git_ssl_no_verify = true
+        assert_equal(Git::Base.config.git_ssl_no_verify, 'true')
+      ensure
+        Git.configure do |config|
+          config.git_ssl_no_verify = nil
         end
       end
     end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
Fixes https://github.com/ruby-git/ruby-git/issues/419.

This PR adds a new `git_ssl_no_verify` configuration option like so:

```ruby
  Git.configure do |config|
    config.git_ssl_no_verify = true
  end
```

This option sets `ENV['GIT_SSL_NO_VERIFY']` to `'true'` via `Git::Lib#set_custom_git_env_variables` when `Git::Base.config.git_ssl_no_verify` is truthy.  It allows users to clone git repos over HTTPS without verifying SSL.  This can sometimes ease friction in corporate environments with custom CAs, for example.