### PR TITLE
`current_branch` contains color escape codes

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -945,6 +945,7 @@ module Git
       global_opts = []
       global_opts << "--git-dir=#{@git_dir}" if !@git_dir.nil?
       global_opts << "--work-tree=#{@git_work_dir}" if !@git_work_dir.nil?
+      global_opts << ["-c", "color.ui=false"]
 
       opts = [opts].flatten.map {|s| escape(s) }.join(' ')
 

--- a/tests/units/test_logger.rb
+++ b/tests/units/test_logger.rb
@@ -19,7 +19,7 @@ class TestLogger < Test::Unit::TestCase
     @git.branches.size
     
     logc = File.read(log.path)
-    assert(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' branch '-a'/.match(logc))
+    assert(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' '-c' 'color.ui=false' branch '-a'/.match(logc))
     assert(/DEBUG -- :   diff_over_patches/.match(logc))
 
     log = Tempfile.new('logfile')
@@ -31,7 +31,7 @@ class TestLogger < Test::Unit::TestCase
     @git.branches.size
     
     logc = File.read(log.path)
-    assert(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' branch '-a'/.match(logc))
+    assert(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' '-c' 'color.ui=false' branch '-a'/.match(logc))
     assert(!/DEBUG -- :   diff_over_patches/.match(logc))
   end
   


### PR DESCRIPTION
### `current_branch` contains color escape codes
Similar to #30 I just found an issue with `ruby-git` when trying to match the string returned from `current_branch` with e.g. `"master"`. I just recently found this issue and I guess it's related to a recent update of my `git` on my machine which came in just recently.

### Your environment
* `git@2.24.0.windows.2` 
* `ruby-git@1.5.0` (also had `1.3.0` before - same issue)
* `ruby@2.3.1p112 (2016-04-26 revision 54768) [i386-mingw32]`

### Steps to reproduce

```ruby
$ irb
irb(main):002:0> require 'git'; git = Git.open '.'; git.current_branch
master
=> "\e[32mmaster\e[m"
```

Hence, `"\e[32mmaster\e[m"` is not equal to `"master"`.

### Expected behaviour
`git.current_branch` should return the string of the current branch without coloring.

In fact, the underlying run of `git branch` should include `--no-color` option (which is a nested call inside `branches_all`).

### Actual behaviour
`git.current_branch` contains `"\e[32m"` color escape codes.

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [ ] Ensure all commits include DCO sign-off.
- [ ] Ensure that your contributions pass unit testing.
- [ ] Ensure that your contributions contain documentation if applicable.

