### PR TITLE
Update version for 1.6.0.pre1 pre-release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## 1.6.0.pre1
+
+See https://github.com/ruby-git/ruby-git/releases/tag/v1.6.0.pre1
+
 ## 1.5.0
 
 See https://github.com/ruby-git/ruby-git/releases/tag/v1.5.0

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -1,5 +1,5 @@
 module Git
   # The current gem version
   # @return [String] the current gem version.
-  VERSION='1.5.0'
+  VERSION='1.6.0.pre1'
 end


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

Bump version to build a 1.6.0.pre1 release.

This is in preparation for the 1.6.0 release.  Since it has been a while since the last release ([1.5.0](https://github.com/ruby-git/ruby-git/releases/tag/v1.5.0) Aug 18th, 2018), we have decided to put out a pre-release version of this gem (1.6.0.pre1) for people to test.

The maintainers will need to determine the release criteria for 1.6.0 and communicate this to the community in issue #434.

My hope is that after the 1.6.0 release, we can start to accept all the great contributions people have made.