### PR TITLE
Include version.rb, providing Git::VERSION

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -19,6 +19,7 @@ require 'git/repository'
 require 'git/status'
 require 'git/stash'
 require 'git/stashes'
+require 'git/version'
 require 'git/working_directory'
 
 lib = Git::Lib.new(nil, nil)
@@ -34,7 +35,7 @@ end
 # and more.  You should be able to do most fundamental git
 # operations with this library.
 #
-# This module provides the basic functions to open a git 
+# This module provides the basic functions to open a git
 # reference to work with. You can open a working directory,
 # open a bare repository, initialize a new repo or clone an
 # existing remote repository.
@@ -42,7 +43,7 @@ end
 # Author::    Scott Chacon (mailto:schacon@gmail.com)
 # License::   MIT License
 module Git
-  
+
   #g.config('user.name', 'Scott Chacon') # sets value
   #g.config('user.email', 'email@email.com')  # sets value
   #g.config('user.name')  # returns 'Scott Chacon'
@@ -82,7 +83,7 @@ module Git
   def self.bare(git_dir, options = {})
     Base.bare(git_dir, options)
   end
-    
+
   # clones a remote repository
   #
   # options
@@ -110,7 +111,7 @@ module Git
     repo.checkout("origin/#{options[:branch]}") if options[:branch]
     Dir.chdir(repo.dir.to_s) { FileUtils.rm_r '.git' }
   end
-  
+
   # Same as g.config, but forces it to be at the global level
   #
   #g.config('user.name', 'Scott Chacon') # sets value
@@ -139,8 +140,8 @@ module Git
   def self.init(working_dir = '.', options = {})
     Base.init(working_dir, options)
   end
-    
-  # returns a Hash containing information about the references 
+
+  # returns a Hash containing information about the references
   # of the target repository
   #
   # @param [String|NilClass] location the target repository location or nil for '.'
@@ -150,7 +151,7 @@ module Git
   end
 
   # open an existing git working directory
-  # 
+  #
   # this will most likely be the most common way to create
   # a git reference, referring to a working directory.
   # if not provided in the options, the library will assume
@@ -162,5 +163,5 @@ module Git
   def self.open(working_dir, options = {})
     Base.open(working_dir, options)
   end
-    
+
 end


### PR DESCRIPTION
`VERSION` was previously defined in `lib/git.rb`. It was moved into `lib/git/version.rb` in commit a308cc9, but the file was not required.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the
    best of my knowledge, is covered under an appropriate open
    source license and I have the right under that license to
    submit that work with modifications, whether created in whole
    or in part by me, under the same open source license (unless
    I am permitted to submit under a different license), as
    Indicated in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including
    all personal information I submit with it, including my
    sign-off) is maintained indefinitely and may be redistributed
    consistent with this project or the open source license(s)
    involved.