### PR TITLE
Removed blank after method name to fix warning

### DIFF
--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -37,7 +37,7 @@ module Git
     #   # do other stuff
     #   return true # auto commits and switches back
     # end
-    def in_branch (message = 'in branch work')
+    def in_branch(message = 'in branch work')
       old_current = @base.lib.branch_current
       checkout
       if yield


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
This change fixes the warning:

Users/USER/rvm/gems/ruby-2.7.0-rc1@ruby2.7-no-rails/gems/git-1.5.0/lib/git/branch.rb:40:
warning: parentheses after method name is interpreted as an argument list, not a decomposed argument

This fix was originally proposed by @jasnow