### PR TITLE
fix broken link in a PR template

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ### Your checklist for this pull request
-🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
+🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.
 
 - [ ] Ensure all commits include DCO sign-off.
 - [ ] Ensure that your contributions pass unit testing.


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
This PR fixes the broken link to `CONTRIBUTING.md` in a PR template.
