### PR TITLE
fix broken link in a PR template again

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 ### Your checklist for this pull request
-🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.
+🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.
 
 - [ ] Ensure all commits include DCO sign-off.
 - [ ] Ensure that your contributions pass unit testing.


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
This PR changes a relative link to an absolutely link.
Please see https://github.com/ruby-git/ruby-git/pull/444#issuecomment-581560817 .
