### PR TITLE
Add YARD documentation to ruby-git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 *.sw?
 .DS_Store
 coverage
+doc
+.yardoc
 pkg
 rdoc
 Gemfile.lock

--- a/.yardopts
+++ b/.yardopts
@@ -1,0 +1,9 @@
+--default-return=::Object
+--markup-provider=redcarpet
+--markup=markdown
+-
+README.md
+CHANGELOG.md
+CONTRIBUTING.md
+RELEASING.md
+MAINTAINERS.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+<!--
+# @markup markdown
+# @title Change Log
+-->
+
 # Change Log
 
 ## 1.6.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,8 @@
+<!--
+# @markup markdown
+# @title Contributing
+-->
+
 # Contributing to ruby-git
 
 Thank you for your interest in contributing to the ruby-git project.
@@ -8,7 +13,7 @@ judgement.
 
 Propose changes to these guidelines with a pull request.
 
-## How to contribute to ruby-git
+## How to contribute
 
 You can contribute in two ways:
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,3 +1,8 @@
+<!--
+# @markup markdown
+# @title Maintainers
+-->
+
 # Maintainers
 
 When making changes in this repository, one of the maintainers below must review and approve your pull request.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,35 @@
-# Git Library for Ruby
+<!--
+# @markup markdown
+# @title README
+-->
 
-Library for using Git in Ruby.
+# Git Gem
+
+The Git Gem provides an API that can be used to create, read, and manipulate
+Git repositories by wrapping system calls to the `git` binary. The API can be
+used for working with Git in complex interactions including branching and
+merging, object inspection and manipulation, history, patch generation and
+more.
 
 ## Homepage
 
-Git public hosting of the project source code is at:
+The project source code is at:
 
 http://github.com/ruby-git/ruby-git
+
+## Documentation
+
+Detailed documentation can be found at:
+
+https://rubydoc.info/gems/git/Git.html
+
+Get started by obtaining a repository object by:
+
+* opening an existing working copy with `Git.open` 
+* initializing a new repository with `Git.init`
+* cloning a repository with `Git.clone`
+
+Methods that can be called on a repository object are documented in `Git::Base`
 
 ## Install
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,4 +1,9 @@
-# How to release a new git.gem
+<!--
+# @markup markdown
+# @title Releasing
+-->
+
+# How to release the git gem
 
 Releasing a new version of the `git` gem requires these steps:
   * [Prepare the release](#prepare-the-release)

--- a/Rakefile
+++ b/Rakefile
@@ -5,6 +5,21 @@ require "#{File.expand_path(File.dirname(__FILE__))}/lib/git/version"
 
 task :default => :test
 
+require 'yard'
+YARD::Rake::YardocTask.new
+CLEAN << '.yardoc'
+CLEAN << 'doc'
+
+require 'yardstick/rake/verify'
+Yardstick::Rake::Verify.new do |verify|
+  verify.threshold = 100
+end
+
+desc 'Run yardstick to check yard docs'
+task :yardstick do
+  sh "yardstick 'lib/**/*.rb'"
+end
+
 desc 'Run Unit Tests'
 task :test do |t|
   sh 'git config --global user.email "git@example.com"' if `git config user.email`.empty?

--- a/git.gemspec
+++ b/git.gemspec
@@ -7,8 +7,19 @@ Gem::Specification.new do |s|
   s.homepage = 'http://github.com/ruby-git/ruby-git'
   s.license = 'MIT'
   s.name = 'git'
-  s.summary = 'Ruby/Git is a Ruby library that can be used to create, read and manipulate Git repositories by wrapping system calls to the git binary.'
+  s.summary = 'An API to create, read, and manipulate Git repositories'
+  s.description = <<~DESCRIPTION
+    The Git Gem provides an API that can be used to create, read, and manipulate
+    Git repositories by wrapping system calls to the `git` binary. The API can be
+    used for working with Git in complex interactions including branching and
+    merging, object inspection and manipulation, history, patch generation and
+    more.
+  DESCRIPTION
   s.version = Git::VERSION
+
+  s.metadata['homepage_uri'] = spec.homepage
+  s.metadata['source_code_uri'] = spec.homepage
+  s.metadata['changelog_uri'] = 'http://rubydoc.info/gems/git/file.CHANGELOG.html'
 
   s.require_paths = ['lib']
   s.required_ruby_version = '>= 1.9'
@@ -19,36 +30,17 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'
+  s.add_development_dependency 'redcarpet', '~> 3.5'
   s.add_development_dependency 'test-unit', '>=2', '< 4'
+  s.add_development_dependency 'yard', '~> 0.9'
+  s.add_development_dependency 'yardstick', '~> 0.9'
 
   s.extra_rdoc_files = ['README.md']
   s.rdoc_options = ['--charset=UTF-8']
 
-  s.files = [
-    'CHANGELOG.md',
-    'CONTRIBUTING.md',
-    'MAINTAINERS.md',
-    'LICENSE',
-    'README.md',
-    'lib/git.rb',
-    'lib/git/author.rb',
-    'lib/git/base.rb',
-    'lib/git/base/factory.rb',
-    'lib/git/branch.rb',
-    'lib/git/branches.rb',
-    'lib/git/config.rb',
-    'lib/git/diff.rb',
-    'lib/git/index.rb',
-    'lib/git/lib.rb',
-    'lib/git/log.rb',
-    'lib/git/object.rb',
-    'lib/git/path.rb',
-    'lib/git/remote.rb',
-    'lib/git/repository.rb',
-    'lib/git/stash.rb',
-    'lib/git/stashes.rb',
-    'lib/git/status.rb',
-    'lib/git/version.rb',
-    'lib/git/working_directory.rb'
-  ]
+  # Specify which files should be added to the gem when it is released.
+  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  s.files = Dir.chdir(File.expand_path(__dir__)) do
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  end
 end

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -27,23 +27,14 @@ unless lib.meets_required_version?
   $stderr.puts "[WARNING] The git gem requires git #{lib.required_command_version.join('.')} or later, but only found #{lib.current_command_version.join('.')}. You should probably upgrade."
 end
 
-# Git/Ruby Library
-#
-# This provides bindings for working with git in complex
-# interactions, including branching and merging, object
-# inspection and manipulation, history, patch generation
-# and more.  You should be able to do most fundamental git
-# operations with this library.
-#
-# This module provides the basic functions to open a git
+# The Git module provides the basic functions to open a git
 # reference to work with. You can open a working directory,
 # open a bare repository, initialize a new repo or clone an
 # existing remote repository.
 #
-# Author::    Scott Chacon (mailto:schacon@gmail.com)
-# License::   MIT License
+# @author Scott Chacon (mailto:schacon@gmail.com)
+#
 module Git
-
   #g.config('user.name', 'Scott Chacon') # sets value
   #g.config('user.email', 'email@email.com')  # sets value
   #g.config('user.name')  # returns 'Scott Chacon'
@@ -74,25 +65,93 @@ module Git
     self.class.global_config(name, value)
   end
 
-  # open a bare repository
+  # Open a bare repository
   #
-  # this takes the path to a bare git repo
-  # it expects not to be able to use a working directory
-  # so you can't checkout stuff, commit things, etc.
-  # but you can do most read operations
+  # Opens a bare repository located in the `git_dir` directory.
+  # Since there is no working copy, you can not checkout or commit
+  # but you can do most read operations.
+  #
+  # @see https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefbarerepositoryabarerepository
+  #    What is a bare repository?
+  #
+  # @example Open a bare repository and retrieve the first commit SHA
+  #   repository = Git.bare('ruby-git.git')
+  #   puts repository.log[0].sha #=> "64c6fa011d3287bab9158049c85f3e85718854a0"
+  #
+  # @param [Pathname] git_dir The path to the bare repository directory
+  #   containing an initialized Git repository. If a relative path is given, it
+  #   is converted to an absolute path using
+  #   [File.expand_path](https://www.rubydoc.info/stdlib/core/File.expand_path).
+  #
+  # @param [Hash] options The options for this command (see list of valid
+  #   options below)
+  #
+  # @option options [Logger] :log A logger to use for Git operations.  Git commands
+  #   are logged at the `:info` level.  Additional logging is done at the `:debug`
+  #   level.
+  #
+  # @return [Git::Base] an object that can execute git commands in the context
+  #   of the bare repository.
+  #
   def self.bare(git_dir, options = {})
     Base.bare(git_dir, options)
   end
 
-  # clones a remote repository
+  # Clone a repository into an empty or newly created directory
   #
-  # options
-  #   :bare => true (does a bare clone)
-  #   :repository => '/path/to/alt_git_dir'
-  #   :index => '/path/to/alt_index_file'
+  # @see https://git-scm.com/docs/git-clone git clone
+  # @see https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a GIT URLs
   #
-  # example
-  #  Git.clone('git://repo.or.cz/rubygit.git', 'clone.git', :bare => true)
+  # @param [URI, Pathname] repository The (possibly remote) repository to clone
+  #   from. See [GIT URLS](https://git-scm.com/docs/git-clone#_git_urls_a_id_urls_a)
+  #   for more information.
+  #
+  # @param [Pathname] name The directory to clone into.
+  #
+  # @param [Hash] options The options for this command (see list of valid
+  #   options below)
+  #
+  # @option options [Boolean] :bare Make a bare Git repository. See
+  #   [what is a bare repository?](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefbarerepositoryabarerepository).
+  #
+  # @option options [String] :branch The name of a branch or tag to checkout
+  #   instead of the default branch.
+  #
+  # @option options [Integer] :depth Create a shallow clone with a history
+  #   truncated to the specified number of commits.
+  #
+  # @option options [Logger] :log A logger to use for Git operations.  Git
+  #   commands are logged at the `:info` level.  Additional logging is done
+  #   at the `:debug` level.
+  #
+  # @option options [Boolean] :mirror Set up a mirror of the source repository.
+  #
+  # @option options [String] :origin Use the value instead `origin` to track
+  #   the upstream repository.
+  #
+  # @option options [Pathname] :path The directory to clone into.  May be used
+  #   as an alternative to the `directory` parameter.  If specified, the
+  #   `path` option is used instead of the `directory` parameter.
+  #
+  # @option options [Boolean] :recursive After the clone is created, initialize
+  #   all submodules within, using their default settings.
+  #
+  # @example Clone into the default directory `ruby-git`
+  #   git = Git.clone('https://github.com/ruby-git/ruby-git.git')
+  #
+  # @example Clone and then checkout the `development` branch
+  #   git = Git.clone('https://github.com/ruby-git/ruby-git.git', branch: 'development')
+  #
+  # @example Clone into a different directory `my-ruby-git`
+  #   git = Git.clone('https://github.com/ruby-git/ruby-git.git', 'my-ruby-git')
+  #   # or:
+  #   git = Git.clone('https://github.com/ruby-git/ruby-git.git', path: 'my-ruby-git')
+  #
+  # @example Create a bare repository in the directory `ruby-git.git`
+  #   git = Git.clone('https://github.com/ruby-git/ruby-git.git', bare: true)
+  #
+  # @return [Git::Base] an object that can execute git commands in the context
+  #   of the cloned local working copy or cloned repository.
   #
   def self.clone(repository, name, options = {})
     Base.clone(repository, name, options)
@@ -132,11 +191,53 @@ module Git
     end
   end
 
-  # initialize a new git repository, defaults to the current working directory
+  # Create an empty Git repository or reinitialize an existing Git repository
   #
-  # options
-  #   :repository => '/path/to/alt_git_dir'
-  #   :index => '/path/to/alt_index_file'
+  # @param [Pathname] directory If the `:bare` option is NOT given or is not
+  #   `true`, the repository will be created in `"#{directory}/.git"`.
+  #   Otherwise, the repository is created in `"#{directory}"`.
+  #
+  #   All directories along the path to `directory` are created if they do not exist.
+  #
+  #   A relative path is referenced from the current working directory of the process
+  #   and converted to an absolute path using
+  #   [File.expand_path](https://www.rubydoc.info/stdlib/core/File.expand_path).
+  #
+  # @param [Hash] options The options for this command (see list of valid
+  #   options below)
+  #
+  # @option options [Boolean] :bare Instead of creating a repository at
+  #   `"#{directory}/.git"`, create a bare repository at `"#{directory}"`.
+  #   See [what is a bare repository?](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefbarerepositoryabarerepository).
+  #
+  # @option options [Pathname] :repository the path to put the newly initialized
+  #   Git repository. The default for non-bare repository is `"#{directory}/.git"`.
+  #
+  #   A relative path is referenced from the current working directory of the process
+  #   and converted to an absolute path using
+  #   [File.expand_path](https://www.rubydoc.info/stdlib/core/File.expand_path).
+  #
+  # @option options [Logger] :log A logger to use for Git operations.  Git
+  #   commands are logged at the `:info` level.  Additional logging is done
+  #   at the `:debug` level.
+  #
+  # @return [Git::Base] an object that can execute git commands in the context
+  #   of the newly initialized repository
+  #
+  # @example Initialize a repository in the current directory
+  #   git = Git.init
+  #
+  # @example Initialize a repository in some other directory
+  #   git = Git.init '~/code/ruby-git'
+  #
+  # @example Initialize a bare repository
+  #   git = Git.init '~/code/ruby-git.git', bare: true
+  #
+  # @example Initialize a repository in a non-default location (outside of the working copy)
+  #   git = Git.init '~/code/ruby-git', repository: '~/code/ruby-git.git'
+  #
+  # @see https://git-scm.com/docs/git-init git init
+  #
   def self.init(working_dir = '.', options = {})
     Base.init(working_dir, options)
   end
@@ -150,16 +251,50 @@ module Git
     Git::Lib.new.ls_remote(location)
   end
 
-  # open an existing git working directory
+  # Open a an existing Git working directory
   #
-  # this will most likely be the most common way to create
-  # a git reference, referring to a working directory.
-  # if not provided in the options, the library will assume
-  # your git_dir and index are in the default place (.git/, .git/index)
+  # Git.open will most likely be the most common way to create
+  # a git reference, referring to an existing working directory.
   #
-  # options
-  #   :repository => '/path/to/alt_git_dir'
-  #   :index => '/path/to/alt_index_file'
+  # If not provided in the options, the library will assume
+  # the repository and index are in the default places (`.git/`, `.git/index`).
+  #
+  # @example Open the Git working directory in the current directory
+  #   git = Git.open
+  #
+  # @example Open a Git working directory in some other directory
+  #   git = Git.open('~/Projects/ruby-git')
+  #
+  # @example Use a logger to see what is going on
+  #   logger = Logger.new(STDOUT)
+  #   git = Git.open('~/Projects/ruby-git', log: logger)
+  #
+  # @example Open a working copy whose repository is in a non-standard directory
+  #   git = Git.open('~/Projects/ruby-git', repository: '~/Project/ruby-git.git')
+  #
+  # @param [Pathname] working_dir the path to the working directory to use
+  #   for git commands.
+  #
+  #   A relative path is referenced from the current working directory of the process
+  #   and converted to an absolute path using
+  #   [File.expand_path](https://www.rubydoc.info/stdlib/core/File.expand_path).
+  #
+  # @param [Hash] options The options for this command (see list of valid
+  #   options below)
+  #
+  # @option options [Pathname] :repository used to specify a non-standard path to
+  #   the repository directory.  The default is `"#{working_dir}/.git"`.
+  #
+  # @option options [Pathname] :index used to specify a non-standard path to an
+  #   index file.  The default is `"#{working_dir}/.git/index"`
+  #
+  # @option options [Logger] :log A logger to use for Git operations.  Git
+  #   commands are logged at the `:info` level.  Additional logging is done
+  #   at the `:debug` level.
+  #
+  # @return [Git::Base] an object that can execute git commands in the context
+  #   of the opened working copy
+  #
   def self.open(working_dir, options = {})
     Base.open(working_dir, options)
   end

--- a/lib/git/base/factory.rb
+++ b/lib/git/base/factory.rb
@@ -4,39 +4,43 @@ module Git
 
     module Factory
       
-      # returns a Git::Branch object for branch_name
+      # @return [Git::Branch] an object for branch_name
       def branch(branch_name = 'master')
         Git::Branch.new(self, branch_name)
       end
 
-      # returns a Git::Branches object of all the Git::Branch 
-      # objects for this repo
+      # @return [Git::Branches] a collection of all the branches in the repository.
+      #   Each branch is represented as a {Git::Branch}.
       def branches
         Git::Branches.new(self)
       end
-      
+
+      # @return [Git::Object::Commit] a commit object
       def commit_tree(tree = nil, opts = {})
         Git::Object::Commit.new(self, self.lib.commit_tree(tree, opts))
       end
 
-      # returns a Git::Diff object
+      # @return [Git::Diff] a Git::Diff object
       def diff(objectish = 'HEAD', obj2 = nil)
         Git::Diff.new(self, objectish, obj2)
       end
-      
+
+      # @return [Git::Object] a Git object
       def gblob(objectish)
         Git::Object.new(self, objectish, 'blob')
       end
-      
+
+      # @return [Git::Object] a Git object
       def gcommit(objectish)
         Git::Object.new(self, objectish, 'commit')
       end
 
+      # @return [Git::Object] a Git object
       def gtree(objectish)
         Git::Object.new(self, objectish, 'tree')
       end
-      
-      # returns a Git::Log object with count commits
+
+      # @return [Git::Log] a log with the specified number of commits
       def log(count = 30)
         Git::Log.new(self, count)
       end
@@ -48,29 +52,32 @@ module Git
       #
       # @git.object calls a factory method that will run a rev-parse 
       # on the objectish and determine the type of the object and return 
-      # an appropriate object for that type 
+      # an appropriate object for that type
+      #
+      # @return [Git::Object] an instance of the appropriate type of Git::Object
       def object(objectish)
         Git::Object.new(self, objectish)
       end
   
-      # returns a Git::Remote object
+      # @return [Git::Remote] a remote of the specified name
       def remote(remote_name = 'origin')
         Git::Remote.new(self, remote_name)
       end
 
-      # returns a Git::Status object
+      # @return [Git::Status] a status object
       def status
         Git::Status.new(self)
       end
     
-      # returns a Git::Tag object
+      # @return [Git::Object::Tag] a tag object
       def tag(tag_name)
         Git::Object.new(self, tag_name, 'tag', true)
       end
 
       # Find as good common ancestors as possible for a merge
       # example: g.merge_base('master', 'some_branch', 'some_sha', octopus: true)
-      # returns Array<Git::Object::Commit>
+      #
+      # @return [Array<Git::Object::Commit>] a collection of common ancestors
       def merge_base(*args)
         shas = self.lib.merge_base(*args)
         shas.map { |sha| gcommit(sha) }

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -6,10 +6,48 @@ module Git
   class GitExecuteError < StandardError
   end
 
+
   class Lib
 
     @@semaphore = Mutex.new
 
+    # The path to the Git working copy.  The default is '"./.git"'.
+    #
+    # @return [Pathname] the path to the Git working copy.
+    #
+    # @see [Git working tree](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefworkingtreeaworkingtree)
+    #
+    attr_reader :git_work_dir
+
+    # The path to the Git repository directory.  The default is
+    # `"#{git_work_dir}/.git"`.
+    #
+    # @return [Pathname] the Git repository directory.
+    #
+    # @see [Git repository](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefrepositoryarepository)
+    #
+    attr_reader :git_dir
+
+    # The Git index file used to stage changes (using `git add`) before they
+    # are committed.
+    #
+    # @return [Pathname] the Git index file
+    #
+    # @see [Git index file](https://git-scm.com/docs/gitglossary#Documentation/gitglossary.txt-aiddefindexaindex)
+    #
+    attr_reader :git_index_file
+
+    # Create a new Git::Lib object
+    #
+    # @param [Git::Base, Hash] base An object that passes in values for
+    #   @git_work_dir, @git_dir, and @git_index_file
+    #
+    # @param [Logger] logger
+    #
+    # @option base [Pathname] :working_directory
+    # @option base [Pathname] :repository
+    # @option base [Pathname] :index
+    #
     def initialize(base = nil, logger = nil)
       @git_dir = nil
       @git_index_file = nil


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Ensure all commits include DCO sign-off.
- [ ] Ensure that your contributions pass unit testing.
- [ ] Ensure that your contributions contain documentation if applicable.

### Description

Create YARD documentation for ruby-git instead of rdoc. Make improvements to the documentation.