### PR TITLE
Update commit to return an object, matching the documentation

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -291,6 +291,8 @@ module Git
     #
     def commit(message, opts = {})
       self.lib.commit(message, opts)
+
+      gcommit('HEAD')
     end
         
     # commits all pending changes in the index file to the git repository,
@@ -299,6 +301,8 @@ module Git
     def commit_all(message, opts = {})
       opts = {:add_all => true}.merge(opts)
       self.lib.commit(message, opts)
+
+      gcommit('HEAD')
     end
 
     # checks out a branch as the new git working directory

--- a/tests/units/test_base.rb
+++ b/tests/units/test_base.rb
@@ -91,9 +91,11 @@ class TestBase < Test::Unit::TestCase
 
       base_commit_id = git.log[0].objectish
 
-      git.commit("Test Commit")
+      o = git.commit("Test Commit")
+      assert(o.is_a?(Git::Object::Commit))
 
       original_commit_id = git.log[0].objectish
+      assert(o.sha == original_commit_id)
 
       create_file('test_commit/test_file_3', 'content test_file_3')
       


### PR DESCRIPTION
Signed-off-by: James Armes <jamesiarmes@gmail.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
According to the [documentation](https://www.rubydoc.info/gems/git/1.6.0/Git/Base#commit-instance_method), both the `commit` and `commit_all` methods should return an object, but instead they return the output from running `git commit` as a string. This pull requests update these methods to return an object, matching the documentation.
