### PR TITLE
ruby version compatibility conflict solution

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1052,9 +1052,9 @@ module Git
     def normalize_encoding(str)
       return str if str.valid_encoding? && str.encoding == default_encoding
 
-      return str.encode(default_encoding, str.encoding, encoding_options) if str.valid_encoding?
+      return str.encode(default_encoding, str.encoding, **encoding_options) if str.valid_encoding?
 
-      str.encode(default_encoding, detected_encoding(str), encoding_options)
+      str.encode(default_encoding, detected_encoding(str), **encoding_options)
     end
 
     def run_command(git_cmd, &block)


### PR DESCRIPTION
```
$ ruby --version 
# => 2.7.0

$ irb -r git
# => .rvm/gems/ruby-2.7.0/gems/git-1.6.0/lib/git/lib.rb:1054: 
# => warning: Using the last argument as keyword parameters is deprecated
```

This warning call because https://github.com/ruby-git/ruby-git/blob/c10ca28d273df9d2c0578229553c9c40578b082b/lib/git/lib.rb#L1055 (and L1057) have old Ruby syntax.

https://piechowski.io/post/last-arg-keyword-deprecated-ruby-2-7/

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Ensure all commits include DCO sign-off.
- [*] Ensure that your contributions pass unit testing.
- [*] Ensure that your contributions contain documentation if applicable.

### Description
Please describe your pull request.
