### PR TITLE
Fix Ruby 2.7 Deprecation Warning About Keyword Args

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -945,6 +945,7 @@ module Git
       global_opts = []
       global_opts << "--git-dir=#{@git_dir}" if !@git_dir.nil?
       global_opts << "--work-tree=#{@git_work_dir}" if !@git_work_dir.nil?
+      global_opts << ["-c", "color.ui=false"]
 
       opts = [opts].flatten.map {|s| escape(s) }.join(' ')
 
@@ -1051,9 +1052,9 @@ module Git
     def normalize_encoding(str)
       return str if str.valid_encoding? && str.encoding == default_encoding
 
-      return str.encode(default_encoding, str.encoding, encoding_options) if str.valid_encoding?
+      return str.encode(default_encoding, str.encoding, **encoding_options) if str.valid_encoding?
 
-      str.encode(default_encoding, detected_encoding(str), encoding_options)
+      str.encode(default_encoding, detected_encoding(str), **encoding_options)
     end
 
     def run_command(git_cmd, &block)

--- a/tests/units/test_logger.rb
+++ b/tests/units/test_logger.rb
@@ -19,7 +19,7 @@ class TestLogger < Test::Unit::TestCase
     @git.branches.size
     
     logc = File.read(log.path)
-    assert(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' branch '-a'/.match(logc))
+    assert(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' '-c' 'color.ui=false' branch '-a'/.match(logc))
     assert(/DEBUG -- :   diff_over_patches/.match(logc))
 
     log = Tempfile.new('logfile')
@@ -31,7 +31,7 @@ class TestLogger < Test::Unit::TestCase
     @git.branches.size
     
     logc = File.read(log.path)
-    assert(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' branch '-a'/.match(logc))
+    assert(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' '-c' 'color.ui=false' branch '-a'/.match(logc))
     assert(!/DEBUG -- :   diff_over_patches/.match(logc))
   end
   


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [*] Ensure all commits include DCO sign-off.
- [*] Ensure that your contributions pass unit testing.
- [*] Ensure that your contributions contain documentation if applicable.

### Description

This code call Ruby warning:

```
return str.encode(default_encoding, str.encoding, encoding_options) if str.valid_encoding?
# => warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
```

@see https://piechowski.io/post/last-arg-keyword-deprecated-ruby-2-7/

Signed-off-by: Sergey Blohin <sblohin@yandex.ru>

