### PR TITLE
Git::Lib#normalize_encoding early return fix

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1050,7 +1050,7 @@ module Git
     end
 
     def normalize_encoding(str)
-      return str if str.valid_encoding? && str.encoding == default_encoding
+      return str if str.valid_encoding? && str.encoding.name == default_encoding
 
       return str.encode(default_encoding, str.encoding, encoding_options) if str.valid_encoding?
 


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
`Git::Lib#normalize_encoding`: when checking to see if the given string
is already in the desired encoding, fix the comparison check to compare
string value to string value, not class to string value.
