### PR TITLE
Add support for renaming branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ And here are the operations that will need to write to your git repository.
      g.branch('new_branch').checkout
      g.branch('new_branch').delete
      g.branch('existing_branch').checkout
+     g.branch('existing_branch').rename('new_name')
      g.branch('master').contains?('existing_branch')
 
      g.checkout('new_branch')

--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -76,6 +76,20 @@ module Git
         @base.merge(@name)
       end
     end
+
+    # Renames the current branch
+    #
+    # Example:
+    #   branch.name # => 'branch'
+    #   branch.rename('new_name') # => 'new_name'
+    #   branch.name # => 'new_name'
+    #
+    # param [String] name name of new branch
+    # return [String] name of new branch
+    def rename(new_name)
+      @base.lib.branch_rename(name, new_name)
+      @name = new_name
+    end
     
     def update_ref(commit)
       @base.lib.update_ref(@full, commit)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -644,6 +644,14 @@ module Git
       command('branch', ['-D', branch])
     end
 
+    # Renames specified branch
+    #
+    # param [String] branch name of branch to be renamed
+    # param [String] new new name of branch
+    def branch_rename(branch, new_name)
+      command('branch', ['-m', branch, new_name])
+    end
+
     def checkout(branch, opts = {})
       arr_opts = []
       arr_opts << '-b' if opts[:new_branch] || opts[:b]

--- a/tests/units/test_branch.rb
+++ b/tests/units/test_branch.rb
@@ -14,6 +14,14 @@ class TestBranch < Test::Unit::TestCase
     @branches = @git.branches
   end
   
+  def test_branch_rename
+    branch = @branches[:test]
+    new_name = 'test_renamed'
+
+    assert_equal(branch.rename(new_name), new_name)
+    assert(@git.branches.map(&:name).include? new_name)
+  end
+
   def test_branches_all
     assert(@git.branches[:master].is_a?(Git::Branch))
     assert(@git.branches.size > 5)

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -189,6 +189,17 @@ class TestLib < Test::Unit::TestCase
     assert(branches.select { |b| /master/.match(b[0]) }.size > 0)  # has a master branch
   end
 
+  def test_branch_rename
+    branch_names = @lib.branches_all.map { |b| b[0] }
+    assert(branch_names.include? 'test')
+
+    @lib.branch_rename('test', 'test_renamed')
+
+    branch_names = @lib.branches_all.map { |b| b[0] }
+    refute(branch_names.include? 'test')
+    assert(branch_names.include? 'test_renamed')
+  end
+
   def test_config_remote
     config = @lib.config_remote('working')
     assert_equal('../working.git', config['url'])


### PR DESCRIPTION
Create methods:
```
  Git::Lib#branch_rename(branch, new_name)
  Git::Branch#rename(new_name)
```
Signed-off-by: Jonathan Ellington <ellingtonjp@gmail.com>