### PR TITLE
Add support for git 2.25 and ruby 2.7

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1052,9 +1052,9 @@ module Git
     def normalize_encoding(str)
       return str if str.valid_encoding? && str.encoding == default_encoding
 
-      return str.encode(default_encoding, str.encoding, encoding_options) if str.valid_encoding?
+      return str.encode(default_encoding, str.encoding, **encoding_options) if str.valid_encoding?
 
-      str.encode(default_encoding, detected_encoding(str), encoding_options)
+      str.encode(default_encoding, detected_encoding(str), **encoding_options)
     end
 
     def run_command(git_cmd, &block)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -616,7 +616,7 @@ module Git
     end
 
     def stash_save(message)
-      output = command('stash save', ['--', message])
+      output = command('stash save', [message])
       output =~ /HEAD is now at/
     end
 

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -3,7 +3,7 @@ require 'fileutils'
 require 'logger'
 require 'test/unit'
 
-require "#{File.expand_path(File.dirname(__FILE__))}/../lib/git"
+require "git"
 
 class Test::Unit::TestCase
   


### PR DESCRIPTION
I made these changes while preparing a new upload of ruby-git for Debian.

The last commit is not necessarily related to supporting the new git and ruby, but it has no effect for upstream developers while making the life of downstream maintainers easier. Please consider accepting it as well, but if not I can drop it from this PR.