### PR TITLE
Disable GPG Signing in Test Config

### DIFF
--- a/tests/files/working/dot_git/config
+++ b/tests/files/working/dot_git/config
@@ -1,6 +1,8 @@
 [user]
-        name = Scott Chacon
-        email = schacon@gmail.com
+	name = Scott Chacon
+	email = schacon@gmail.com
+[commit]
+	gpgsign = false
 [core]
 	repositoryformatversion = 0
 	filemode = true


### PR DESCRIPTION
### Your checklist for this pull request

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description

If a user has GPG signing set to true in their global `.gitconfig` file, the test suite will fail. This is because the test suit now includes a check of a commit message (the `test_commit_with_no_verify` test in `tests/units/test_lib.rb` that was added by #454) but did not update the test config file. This commit updates the config file to set the `gpgsign` option to false.