### PR TITLE
Support multiple --config options in Git.clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,9 @@ And here are the operations that will need to write to your git repository.
         { :repository => '/opt/git/proj.git',
            :index => '/tmp/index'} )
 
-     g = Git.clone(URI, NAME, :path => '/tmp/checkout')
+     g = Git.clone(URI, NAME, :path => '/tmp/checkout', :config => [
+       'core.sshCommand=ssh -i /home/user/.ssh/id_rsa',
+       'submodule.recurse=true'])
      g.config('user.name', 'Scott Chacon')
      g.config('user.email', 'email@email.com')
 

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -65,7 +65,8 @@ module Git
       arr_opts << '--bare' if opts[:bare]
       arr_opts << '--branch' << opts[:branch] if opts[:branch]
       arr_opts << '--depth' << opts[:depth].to_i if opts[:depth] && opts[:depth].to_i > 0
-      arr_opts << '--config' << opts[:config] if opts[:config]
+      arr_opts << '--config' << opts[:config] if opts[:config] && opts[:config].is_a?(String)
+      opts[:config].each { |c| arr_opts << '--config' << c } if opts[:config].is_a?(Array)
       arr_opts << '--origin' << opts[:remote] || opts[:origin] if opts[:remote] || opts[:origin]
       arr_opts << '--recursive' if opts[:recursive]
       arr_opts << "--mirror" if opts[:mirror]

--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -90,10 +90,21 @@ class TestInit < Test::Unit::TestCase
     end
   end
 
-  def test_git_clone_config
+  def test_git_clone_config_single
     in_temp_dir do |path|
       g = Git.clone(@wbare, 'config.git', :config => "receive.denyCurrentBranch=ignore")
       assert_equal('ignore', g.config['receive.denycurrentbranch'])
+      assert(File.exist?(File.join(g.repo.path, 'config')))
+      assert(g.dir)
+    end
+  end
+
+  def test_git_clone_config_multi
+    conf = ["receive.denyCurrentBranch=ignore", "submodule.recurse=true"]
+    in_temp_dir do |path|
+      g = Git.clone(@wbare, 'config.git', :config => conf)
+      assert_equal('ignore', g.config['receive.denycurrentbranch'])
+      assert_equal('true', g.config['submodule.recurse'])
       assert(File.exist?(File.join(g.repo.path, 'config')))
       assert(g.dir)
     end


### PR DESCRIPTION
Makes opts[:config] in Git.clone accept an Array of <key>=<value> pairs
so that multiple --config options can be passed to the clone command.
A single config entry can still be passed as a String.

Signed-off-by: Marco Rüdisüli <git@rudisu.li>


