### PR TITLE
Allows a logger to be given during cloning

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -25,10 +25,11 @@ module Git
     #    :index_file
     #
     def self.clone(repository, name, opts = {})
-      # run git-clone 
-      self.new(Git::Lib.new.clone(repository, name, opts))
+      # run git-clone
+      log = opts[:log]
+      new(Git::Lib.new(nil, log).clone(repository, name, opts).merge(log: log))
     end
-    
+
     # Returns (and initialize if needed) a Git::Config instance
     #
     # @return [Git::Config] the current config instance.

--- a/tests/units/test_base.rb
+++ b/tests/units/test_base.rb
@@ -1,11 +1,25 @@
 #!/usr/bin/env ruby
 
+require 'stringio'
+
 require File.dirname(__FILE__) + '/../test_helper'
 
 class TestBase < Test::Unit::TestCase
 
   def setup
     set_file_paths
+  end
+
+  def test_clone
+    in_temp_dir do |_path|
+      # Tests that the given logger object is used during the cloning phase as
+      # well as passed to the Base class's initialize method.
+
+      buffer = StringIO.new
+      Git.clone(@wdir, 'test_add', log: Logger.new(buffer))
+      assert_match(/Cloning into 'test_add'/, buffer.string) # Comes from the Cloning Process
+      assert_match(/Starting Git/, buffer.string) # Comes from the Base's initialize method
+    end
   end
 
   def test_add


### PR DESCRIPTION
### Your checklist for this pull request

🚨 Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable. (N/A)

### Description

Currently, if you pass a logger to the `clone` method in the Base class it is completely ignored, not only it is not used during the cloning phase but the resulting `Base` instance doesn't have the logger attached to it, meaning that all subsequent operations over that repository are not logged.

This Pull Request attempts to remedy that by adding code to pass the logger object to the constructor of the `Git::Lib` class as well as to the constructor of the `Base` class itself.

In order to avoid coupling the classes (more than they already are) I decided to merge the logger to the Hash returned by the `clone` method of the `Git::Lib` class instead of passing it and then having the method return it in the resulting `Hash`.
