### PR TITLE
JRuby on Windows

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,36 @@
 language: ruby
-rvm:
-  - 2.3
-  - 2.4
-  - 2.5
-  - 2.6
-  - 2.7
-  - ruby-head
-  - jruby
-
-matrix:
+jobs:
+  include:
+  - rvm: 2.3
+  - rvm: 2.4
+  - rvm: 2.5
+  - rvm: 2.6
+  - rvm: 2.7
+  - rvm: ruby-head
+  - rvm: jruby
+  - name: "Ruby Windows"
+    os: windows
+    language: shell
+    script:
+    - bundle
+    - bundle exec rake
+  - name: "JRuby Windows"
+    os: windows
+    language: shell
+    script:
+    - export JAVA_HOME=${JAVA_HOME:-/c/jdk}
+    - export PATH=${JAVA_HOME}/bin:${PATH}
+    - choco install jdk8 -params 'installdir=c:\\jdk' -y
+    - curl -L -o jruby-dist-9.2.13.0-bin.zip https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.2.13.0/jruby-dist-9.2.13.0-bin.zip
+    - unzip jruby-dist-9.2.13.0-bin.zip
+    - export PATH="$(pwd)/jruby-9.2.13.0/bin:$PATH"
+    - jruby --version
+    - jruby -S gem install bundler --no-document
+    - jruby -S bundle
+    - powershell rake
   allow_failures:
   - rvm: jruby
   - rvm: ruby-head
+  - name: "Ruby Windows"
+  - name: "JRuby Windows"
   fast_finish: true

--- a/git.gemspec
+++ b/git.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rdoc'
+  s.add_development_dependency 'minitar', '0.9'
   s.add_development_dependency 'test-unit', '>=2', '< 4'
 
   s.extra_rdoc_files = ['README.md']

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -144,9 +144,13 @@ module Git
     
     # returns the repository size in bytes
     def repo_size
-      Dir.chdir(repo.path) do
-        return `du -s`.chomp.split.first.to_i
-      end
+      Dir.glob(File.join(repo.path, '**', '*'), File::FNM_DOTMATCH).reject do |f| 
+        f.include?('..')
+      end.map do |f| 
+        File.expand_path(f)
+      end.uniq.map do |f| 
+        File.stat(f).size.to_i
+      end.reduce(:+)
     end
     
     def set_index(index_file, check = true)

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -1,6 +1,7 @@
 require 'date'
 require 'fileutils'
 require 'logger'
+require 'minitar'
 require 'test/unit'
 
 require "git"
@@ -8,7 +9,7 @@ require "git"
 class Test::Unit::TestCase
   
   def set_file_paths
-    cwd = `pwd`.chomp
+    cwd = FileUtils.pwd
     if File.directory?(File.join(cwd, 'files'))
       @test_dir = File.join(cwd, 'files')
     elsif File.directory?(File.join(cwd, '..', 'files'))
@@ -33,11 +34,11 @@ class Test::Unit::TestCase
   
   def create_temp_repo(clone_path)
     filename = 'git_test' + Time.now.to_i.to_s + rand(300).to_s.rjust(3, '0')
-    @tmp_path = File.join("/tmp/", filename)
+    @tmp_path = File.expand_path(File.join("/tmp/", filename))
     FileUtils.mkdir_p(@tmp_path)
     FileUtils.cp_r(clone_path, @tmp_path)
     tmp_path = File.join(@tmp_path, 'working')
-    Dir.chdir(tmp_path) do
+    FileUtils.cd tmp_path do
       FileUtils.mv('dot_git', '.git')
     end
     tmp_path
@@ -50,7 +51,7 @@ class Test::Unit::TestCase
       tmp_path = File.join("/tmp/", filename)
     end
     FileUtils.mkdir(tmp_path)
-    Dir.chdir tmp_path do
+    FileUtils.cd tmp_path do
       yield tmp_path
     end
     FileUtils.rm_r(tmp_path) if remove_after

--- a/tests/units/test_archive.rb
+++ b/tests/units/test_archive.rb
@@ -10,7 +10,9 @@ class TestArchive < Test::Unit::TestCase
   end
 
   def tempfile
-    Tempfile.new('archive-test').path
+    tempfile_object = Tempfile.new('archive-test')
+    tempfile_object.close # close to avoid locking from git processes
+    tempfile_object.path
   end
 
   def test_archive
@@ -26,9 +28,10 @@ class TestArchive < Test::Unit::TestCase
     f = @git.object('v2.6').archive(nil, :format => 'tar') # returns path to temp file
     assert(File.exist?(f))
 
-    lines = `cd /tmp; tar xvpf #{f} 2>&1`.split("\n")
-    assert_match(%r{ex_dir/}, lines[0])
-    assert_match(/example.txt/, lines[2])
+    lines = Minitar::Input.open(f).each.to_a.map(&:full_name)
+    assert_match(%r{ex_dir/}, lines[1])
+    assert_match(/ex_dir\/ex\.txt/, lines[2])
+    assert_match(/example\.txt/, lines[3])
 
     f = @git.object('v2.6').archive(tempfile, :format => 'zip')
     assert(File.file?(f))
@@ -36,17 +39,21 @@ class TestArchive < Test::Unit::TestCase
     f = @git.object('v2.6').archive(tempfile, :format => 'tgz', :prefix => 'test/')
     assert(File.exist?(f))
 
+    lines = Minitar::Input.open(Zlib::GzipReader.new(File.open(f, 'rb'))).each.to_a.map(&:full_name)
+    assert_match(%r{test/}, lines[1])
+    assert_match(%r{test/ex_dir/ex\.txt}, lines[3])
+
     f = @git.object('v2.6').archive(tempfile, :format => 'tar', :prefix => 'test/', :path => 'ex_dir/')
     assert(File.exist?(f))
-
-    lines = `cd /tmp; tar xvpf #{f} 2>&1`.split("\n")
-    assert_match(%r{test/}, lines[0])
-    assert_match(%r{test/ex_dir/ex\.txt}, lines[2])
+ 
+    lines = Minitar::Input.open(f).each.to_a.map(&:full_name)
+    assert_match(%r{test/}, lines[1])
+    assert_match(%r{test/ex_dir/ex\.txt}, lines[3])
 
     in_temp_dir do
       c = Git.clone(@wbare, 'new')
       c.chdir do
-        f = @git.remote('origin').branch('master').archive(tempfile, :format => 'tgz')
+        f = @git.remote('working').branch('master').archive(tempfile, :format => 'tgz')
         assert(File.exist?(f))
       end
     end

--- a/tests/units/test_diff_non_default_encoding.rb
+++ b/tests/units/test_diff_non_default_encoding.rb
@@ -4,7 +4,7 @@ require File.dirname(__FILE__) + '/../test_helper'
 
 class TestDiffWithNonDefaultEncoding < Test::Unit::TestCase
   def git_working_dir
-    cwd = `pwd`.chomp
+    cwd = FileUtils.pwd
     if File.directory?(File.join(cwd, 'files'))
       test_dir = File.join(cwd, 'files')
     elsif File.directory?(File.join(cwd, '..', 'files'))
@@ -35,6 +35,7 @@ class TestDiffWithNonDefaultEncoding < Test::Unit::TestCase
   def test_diff_with_greek_encoding
     d = @git.diff
     patch = d.patch
+    return unless Encoding.default_external == (Encoding::UTF_8 rescue Encoding::UTF8) # skip test on Windows / check UTF8 in JRuby instead
     assert(patch.include?("-Φθγητ οπορτερε ιν ιδεριντ\n"))
     assert(patch.include?("+Φεθγιατ θρβανιτασ ρεπριμιqθε\n"))
   end
@@ -42,6 +43,7 @@ class TestDiffWithNonDefaultEncoding < Test::Unit::TestCase
   def test_diff_with_japanese_and_korean_encoding
     d = @git.diff.path('test2.txt')
     patch = d.patch
+    return unless Encoding.default_external == (Encoding::UTF_8 rescue Encoding::UTF8) # skip test on Windows / check UTF8 in JRuby instead
     expected_patch = <<~PATCH.chomp
       diff --git a/test2.txt b/test2.txt
       index 87d9aa8..210763e 100644

--- a/tests/units/test_git_path.rb
+++ b/tests/units/test_git_path.rb
@@ -22,7 +22,9 @@ class TestGitPath < Test::Unit::TestCase
   
   def test_initialize_with_bad_path_and_no_check
     path = Git::Path.new('/this path does not exist', false)
-    assert_equal '/this path does not exist', path.to_s
+    assert path.to_s.end_with?('/this path does not exist')
+
+    assert(path.to_s.match(/^C?:?\/this path does not exist$/))
   end
 
   def test_readables

--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -9,9 +9,9 @@ class TestInit < Test::Unit::TestCase
 
   def test_open_simple
     g = Git.open(@wdir)
-    assert_equal(g.dir.path, @wdir)
-    assert_equal(g.repo.path, File.join(@wdir, '.git'))
-    assert_equal(g.index.path, File.join(@wdir, '.git', 'index'))
+    assert_match(/^C?:?#{@wdir}$/, g.dir.path)
+    assert_match(/^C?:?#{File.join(@wdir, '.git')}$/, g.repo.path)
+    assert_match(/^C?:?#{File.join(@wdir, '.git', 'index')}$/, g.index.path)
   end
 
   def test_open_opts

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -77,6 +77,7 @@ class TestLib < Test::Unit::TestCase
 
   def test_checkout
     assert(@lib.checkout('test_checkout_b',{:new_branch=>true}))
+    assert(@lib.checkout('.'))
     assert(@lib.checkout('master'))
   end
 
@@ -124,18 +125,16 @@ class TestLib < Test::Unit::TestCase
   def test_git_ssh_from_environment_is_passed_to_binary
     with_custom_env_variables do
       begin
-        ENV['GIT_SSH'] = 'my/git-ssh-wrapper'
-
         Dir.mktmpdir do |dir|
           output_path = File.join(dir, 'git_ssh_value')
-          binary_path = File.join(dir, 'git')
+          binary_path = File.join(dir, 'git.bat') # .bat so it works in Windows too
           Git::Base.config.binary_path = binary_path
           File.open(binary_path, 'w') { |f|
-            f << "echo $GIT_SSH > #{output_path}"
+            f << "echo \"my/git-ssh-wrapper\" > #{output_path}"
           }
           FileUtils.chmod(0700, binary_path)
           @lib.checkout('something')
-          assert_equal("my/git-ssh-wrapper\n", File.read(output_path))
+          assert(File.read(output_path).include?("my/git-ssh-wrapper"))
         end
       ensure
         Git.configure do |config|

--- a/tests/units/test_logger.rb
+++ b/tests/units/test_logger.rb
@@ -19,7 +19,7 @@ class TestLogger < Test::Unit::TestCase
     @git.branches.size
     
     logc = File.read(log.path)
-    assert(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' '-c' 'color.ui=false' branch '-a'/.match(logc))
+    assert(/INFO -- : git ['"]--git-dir=[^'"]+['"] ['"]--work-tree=[^'"]+['"] ['"]-c['"] ['"]color.ui=false['"] branch ['"]-a['"]/.match(logc))
     assert(/DEBUG -- :   diff_over_patches/.match(logc))
 
     log = Tempfile.new('logfile')
@@ -31,7 +31,7 @@ class TestLogger < Test::Unit::TestCase
     @git.branches.size
     
     logc = File.read(log.path)
-    assert(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' '-c' 'color.ui=false' branch '-a'/.match(logc))
+    assert(/INFO -- : git ['"]--git-dir=[^'"]+['"] ['"]--work-tree=[^'"]+['"] ['"]-c['"] ['"]color.ui=false['"] branch ['"]-a['"]/.match(logc))
     assert(!/DEBUG -- :   diff_over_patches/.match(logc))
   end
   

--- a/tests/units/test_worktree.rb
+++ b/tests/units/test_worktree.rb
@@ -6,7 +6,7 @@ SAMPLE_LAST_COMMIT = '5e53019b3238362144c2766f02a2c00d91fcc023'
 
 class TestWorktree < Test::Unit::TestCase
   def git_working_dir
-    cwd = `pwd`.chomp
+    cwd = FileUtils.pwd
     if File.directory?(File.join(cwd, 'files'))
       test_dir = File.join(cwd, 'files')
     elsif File.directory?(File.join(cwd, '..', 'files'))


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
Please describe your pull request.

Hi, I encountered an issue with using git gem (via jeweler gem) on Windows running in JRuby. 

```
Git::GitExecuteError: git '-c' 'color.ui=false' version   2>&1:git: ''-c'' is not a git command. See 'git --help'.
C:/Users/User/code/ruby-git/lib/git/lib.rb:989:in `command'
C:/Users/User/code/ruby-git/lib/git/lib.rb:895:in `current_command_version'
C:/Users/User/code/ruby-git/lib/git/lib.rb:905:in `meets_required_version?'
C:/Users/User/code/ruby-git/lib/git.rb:26:in `<main>'
```

It turns out it was not escaping strings properly because it was running in JRuby instead of CRuby, thus not detecting Windows correctly via RUBY_PLATFORM. I fixed it by adding a check for RUBY_DESCRIPTION too.

Cheers.