### PR TITLE
Add commit --allow-empty-message option and fix empty message parsing in process_commit_log_data

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -243,6 +243,8 @@ module Git
           next
         end
 
+        in_message = false if in_message && line[0..3] != "    "
+
         if in_message
           hsh['message'] << "#{line[4..-1]}\n"
           next
@@ -559,9 +561,10 @@ module Git
     #  :author
     #  :date
     #  :no_verify
+    #  :allow_empty_message
     #
     # @param [String] message the commit message to be used
-    # @param [Array] opts the commit options to be used
+    # @param [Hash] opts the commit options to be used
     def commit(message, opts = {})
       arr_opts = []
       arr_opts << "--message=#{message}" if message
@@ -571,6 +574,7 @@ module Git
       arr_opts << "--author=#{opts[:author]}" if opts[:author]
       arr_opts << "--date=#{opts[:date]}" if opts[:date].is_a? String
       arr_opts << '--no-verify' if opts[:no_verify]
+      arr_opts << '--allow-empty-message' if opts[:allow_empty_message]
 
       command('commit', arr_opts)
     end

--- a/tests/units/test_commit_with_empty_message.rb
+++ b/tests/units/test_commit_with_empty_message.rb
@@ -1,0 +1,25 @@
+#!/usr/bin/env ruby
+require File.dirname(__FILE__) + '/../test_helper'
+
+class TestCommitWithEmptyMessage < Test::Unit::TestCase
+  def setup
+    set_file_paths
+  end
+
+  def test_without_allow_empty_message_option
+    Dir.mktmpdir do |dir|
+      git = Git.init(dir)
+      assert_raises Git::GitExecuteError do
+        git.commit('', { allow_empty: true })
+      end
+    end
+  end
+
+  def test_with_allow_empty_message_option
+    Dir.mktmpdir do |dir|
+      git = Git.init(dir)
+      git.commit('', { allow_empty: true, allow_empty_message: true})
+      assert_equal(1, git.log.to_a.size)
+    end
+  end
+end

--- a/tests/units/test_log.rb
+++ b/tests/units/test_log.rb
@@ -78,5 +78,17 @@ class TestLog < Test::Unit::TestCase
       @git.log.object('no-exist.txt').size
     end
   end
-  
+
+  def test_log_with_empty_commit_message
+    Dir.mktmpdir do |dir|
+      git = Git.init(dir)
+      expected_message = 'message'
+      git.commit(expected_message, { allow_empty: true })
+      git.commit('', { allow_empty: true, allow_empty_message: true })
+      log = git.log
+      assert_equal(2, log.to_a.size)
+      assert_equal('', log[0].message)
+      assert_equal(expected_message, log[1].message)
+    end
+  end
 end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
If the commit doesn't contain a message, parsing the output of "git log"
results in an error, which occures because the end of the commit message
can't be detected.

fixes #481