### PR TITLE
Simplify git commands

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -993,8 +993,7 @@ module Git
 
     def command(cmd, opts = [], chdir = true, redirect = '', &block)
       global_opts = []
-      global_opts << "--git-dir=#{@git_dir}" if !@git_dir.nil?
-      global_opts << "--work-tree=#{@git_work_dir}" if !@git_work_dir.nil?
+      global_opts << ["-C", "#{@git_work_dir}"] if !@git_work_dir.nil?
       global_opts << ["-c", "color.ui=false"]
 
       opts = [opts].flatten.map {|s| escape(s) }.join(' ')

--- a/tests/units/test_logger.rb
+++ b/tests/units/test_logger.rb
@@ -19,7 +19,7 @@ class TestLogger < Test::Unit::TestCase
     @git.branches.size
     
     logc = File.read(log.path)
-    assert(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' '-c' 'color.ui=false' branch '-a'/.match(logc))
+    assert(/INFO -- : git '-C' '[^']+' '-c' 'color.ui=false' branch '-a'/.match(logc))
     assert(/DEBUG -- :   diff_over_patches/.match(logc))
 
     log = Tempfile.new('logfile')
@@ -31,7 +31,7 @@ class TestLogger < Test::Unit::TestCase
     @git.branches.size
     
     logc = File.read(log.path)
-    assert(/INFO -- : git '--git-dir=[^']+' '--work-tree=[^']+' '-c' 'color.ui=false' branch '-a'/.match(logc))
+    assert(/INFO -- : git '-C' '[^']+' '-c' 'color.ui=false' branch '-a'/.match(logc))
     assert(!/DEBUG -- :   diff_over_patches/.match(logc))
   end
   


### PR DESCRIPTION
### Description
`git -C` to replace the confusing pair of `--git-dir` and `--work-tree`