### PR TITLE
Calculate the default for index relative to git_dir instead of work_tree

### DIFF
--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -26,7 +26,7 @@ class Test::Unit::TestCase
   
   teardown
   def git_teardown
-    if @tmp_path
+    if instance_variable_defined?(:@tmp_path)
       FileUtils.rm_r(@tmp_path)
     end
   end

--- a/tests/units/test_git_dir.rb
+++ b/tests/units/test_git_dir.rb
@@ -1,0 +1,73 @@
+#!/usr/bin/env ruby
+
+require File.dirname(__FILE__) + '/../test_helper'
+
+class TestGitDir < Test::Unit::TestCase
+  def test_index_calculated_from_git_dir
+    Dir.mktmpdir do |work_tree|
+      Dir.mktmpdir do |git_dir|
+        git = Git.open(work_tree, repository: git_dir)
+
+        assert_equal(work_tree, git.dir.path)
+        assert_equal(git_dir, git.repo.path)
+
+        # Since :index was not given in the options to Git#open, index should
+        # be defined automatically based on the git_dir.
+        #
+        index = File.join(git_dir, 'index')
+        assert_equal(index, git.index.path)
+      end
+    end
+  end
+
+  # Test the case where the git-dir is not a subdirectory of work-tree
+  #
+  def test_git_dir_outside_work_tree
+    Dir.mktmpdir do |work_tree|
+      Dir.mktmpdir do |git_dir|
+        # Setup a bare repository
+        #
+        source_git_dir = File.expand_path(File.join('tests', 'files', 'working.git'))
+        FileUtils.cp_r(Dir["#{source_git_dir}/*"], git_dir, preserve: true)
+        git = Git.open(work_tree, repository: git_dir)
+
+        assert_equal(work_tree, git.dir.path)
+        assert_equal(git_dir, git.repo.path)
+
+        # Reconstitute the work tree from the bare repository
+        #
+        branch = 'master'
+        git.checkout(branch, force: true)
+
+        # Make sure the work tree contains the expected files
+        #
+        expected_files = %w[ex_dir example.txt]
+        actual_files = Dir[File.join(work_tree, '*')].map { |f| File.basename(f) }
+        assert_equal(expected_files, actual_files)
+
+        # None of the expected files should have a status that says it has been changed
+        #
+        expected_files.each do |file|
+          assert_equal(false, git.status.changed?(file))
+        end
+
+        # Change a file and make sure it's status says it has been changed
+        #
+        file = 'example.txt'
+        File.open(File.join(work_tree, file), "a") { |f| f.write("A new line") }
+        assert_equal(true, git.status.changed?(file))
+
+        # Add and commit the file and then check that:
+        # * the file is not flagged as changed anymore
+        # * the commit was added to the log
+        #
+        max_log_size = 100
+        assert_equal(64, git.log(max_log_size).size)
+        git.add(file)
+        git.commit('This is a new commit')
+        assert_equal(false, git.status.changed?(file))
+        assert_equal(65, git.log(max_log_size).size)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description

`index` when not given, defaults to `"#{work_tree}/.git/index"`.  This only works as long as `git_dir` is `"#{work_tree}/.git"`. In the general case, the `index` default should be `#{git_dir}/index`.

This PR adds two tests:
* `TestGitDir#test_index_calculated_from_git_dir` which tests that `index` is calculated correctly when `git_dir` is not `"#{work_tree}/.git/index"`
* `TestGitDir#test_git_dir_outside_work_tree` which tests that when `git_dir` is in a non-standard location, Git.open and option functions work.

Fix the case in `Base#open` where the `--git-dir` is a file as is the case with Submodules and (non-main) Worktrees.  This case was handled for `Base.init` but not `Base.open`.

`tests/test_helper.rb` was changed so that MiniTest classes that do not call `set_file_paths` do not output a warning because `@tmp_path` is referenced without being defined.
