### PR TITLE
Allow users to provide '--refs' to 'ls-remote'

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -146,10 +146,13 @@ module Git
   # returns a Hash containing information about the references
   # of the target repository
   #
+  # options
+  #   :refs
+  #
   # @param [String|NilClass] location the target repository location or nil for '.'
   # @return [{String=>Hash}] the available references of the target repo.
-  def self.ls_remote(location=nil)
-    Git::Lib.new.ls_remote(location)
+  def self.ls_remote(location = nil, options = {})
+    Git::Lib.new.ls_remote(location, options)
   end
 
   # open an existing git working directory

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -448,10 +448,13 @@ module Git
       hsh
     end
 
-    def ls_remote(location=nil)
-      location ||= '.'
+    def ls_remote(location=nil, opts={})
+      arr_opts = []
+      arr_opts << ['--refs'] if opts[:refs]
+      arr_opts << (location || '.')
+
       Hash.new{ |h,k| h[k] = {} }.tap do |hsh|
-        command_lines('ls-remote', location).each do |line|
+        command_lines('ls-remote', arr_opts).each do |line|
           (sha, info) = line.split("\t")
           (ref, type, name) = info.split('/', 3)
           type ||= 'head'

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -90,17 +90,17 @@ class TestLib < Test::Unit::TestCase
     a = @lib.log_commits :count => 10
     assert(a.first.is_a?(String))
     assert_equal(10, a.size)
-    
+
     a = @lib.log_commits :count => 20, :since => "#{Date.today.year - 2006} years ago"
     assert(a.first.is_a?(String))
     assert_equal(20, a.size)
-    
+
     a = @lib.log_commits :count => 20, :since => '1 second ago'
     assert_equal(0, a.size)
-    
+
     a = @lib.log_commits :count => 20, :between => ['v2.5', 'v2.6']
     assert_equal(2, a.size)
-    
+
     a = @lib.log_commits :count => 20, :path_limiter => 'ex_dir/'
     assert_equal(1, a.size)
 
@@ -150,21 +150,21 @@ class TestLib < Test::Unit::TestCase
     assert_equal('94c827875e2cadb8bc8d4cdd900f19aa9e8634c7', @lib.revparse('1cc8667014381^{tree}')) #tree
     assert_equal('ba492c62b6227d7f3507b4dcc6e6d5f13790eabf', @lib.revparse('v2.5:example.txt')) #blob
   end
-  
+
   def test_object_type
     assert_equal('commit', @lib.object_type('1cc8667014381')) # commit
     assert_equal('tree', @lib.object_type('1cc8667014381^{tree}')) #tree
     assert_equal('blob', @lib.object_type('v2.5:example.txt')) #blob
     assert_equal('commit', @lib.object_type('v2.5'))
   end
-  
+
   def test_object_size
     assert_equal(265, @lib.object_size('1cc8667014381')) # commit
     assert_equal(72, @lib.object_size('1cc8667014381^{tree}')) #tree
     assert_equal(128, @lib.object_size('v2.5:example.txt')) #blob
     assert_equal(265, @lib.object_size('v2.5'))
   end
-  
+
   def test_object_contents
     commit =  "tree 94c827875e2cadb8bc8d4cdd900f19aa9e8634c7\n"
     commit << "parent 546bec6f8872efa41d5d97a369f669165ecda0de\n"
@@ -172,36 +172,36 @@ class TestLib < Test::Unit::TestCase
     commit << "committer scott Chacon <schacon@agadorsparticus.corp.reactrix.com> 1194561188 -0800\n"
     commit << "\ntest"
     assert_equal(commit, @lib.object_contents('1cc8667014381')) # commit
-    
+
     tree =  "040000 tree 6b790ddc5eab30f18cabdd0513e8f8dac0d2d3ed\tex_dir\n"
     tree << "100644 blob 3aac4b445017a8fc07502670ec2dbf744213dd48\texample.txt"
     assert_equal(tree, @lib.object_contents('1cc8667014381^{tree}')) #tree
-    
+
     blob = "1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n2"
     assert_equal(blob, @lib.object_contents('v2.5:example.txt')) #blob
-    
+
   end
-  
+
   def test_object_contents_with_block
     commit =  "tree 94c827875e2cadb8bc8d4cdd900f19aa9e8634c7\n"
     commit << "parent 546bec6f8872efa41d5d97a369f669165ecda0de\n"
     commit << "author scott Chacon <schacon@agadorsparticus.corp.reactrix.com> 1194561188 -0800\n"
     commit << "committer scott Chacon <schacon@agadorsparticus.corp.reactrix.com> 1194561188 -0800\n"
     commit << "\ntest"
-    
+
     @lib.object_contents('1cc8667014381') do |f|
       assert_equal(commit, f.read.chomp)
     end
-    
+
      # commit
-    
+
     tree =  "040000 tree 6b790ddc5eab30f18cabdd0513e8f8dac0d2d3ed\tex_dir\n"
     tree << "100644 blob 3aac4b445017a8fc07502670ec2dbf744213dd48\texample.txt"
 
     @lib.object_contents('1cc8667014381^{tree}') do |f|
       assert_equal(tree, f.read.chomp) #tree
     end
-    
+
     blob = "1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n1\n2"
 
     @lib.object_contents('v2.5:example.txt') do |f|
@@ -224,8 +224,8 @@ class TestLib < Test::Unit::TestCase
     assert_equal('../working.git', config['url'])
     assert_equal('+refs/heads/*:refs/remotes/working/*', config['fetch'])
   end
-  
-  
+
+
   def test_ls_tree
     tree = @lib.ls_tree('94c827875e2cadb8bc8d4cdd900f19aa9e8634c7')
     assert_equal("3aac4b445017a8fc07502670ec2dbf744213dd48", tree['blob']['example.txt'][:sha])
@@ -247,6 +247,12 @@ class TestLib < Test::Unit::TestCase
       assert_equal("HEAD", ls['head'][:ref])
       assert_equal("5e392652a881999392c2757cf9b783c5d47b67f7", ls['head'][:sha])
       assert_equal(nil, ls['head'][:name])
+
+      ls = lib.ls_remote(@wbare, :refs => true)
+
+      assert_equal({}, ls['head']) # head is not a ref
+      assert_equal(%w( gitsearch1 v2.5 v2.6 v2.7 v2.8 ), ls['tags'].keys.sort)
+      assert_equal(%w( git_grep master test test_branches test_object ), ls['branches'].keys.sort)
     end
   end
 
@@ -261,28 +267,28 @@ class TestLib < Test::Unit::TestCase
     assert_equal('to search one', match['gitsearch1:scott/text.txt'].assoc(6)[1])
     assert_equal(2, match['gitsearch1:scott/text.txt'].size)
     assert_equal(2, match.size)
-    
+
     match = @lib.grep('search', :object => 'gitsearch1', :path_limiter => 'scott/new*')
     assert_equal("you can't search me!", match["gitsearch1:scott/newfile"].first[1])
     assert_equal(1, match.size)
 
     match = @lib.grep('SEARCH', :object => 'gitsearch1')
     assert_equal(0, match.size)
-        
+
     match = @lib.grep('SEARCH', :object => 'gitsearch1', :ignore_case => true)
     assert_equal("you can't search me!", match["gitsearch1:scott/newfile"].first[1])
     assert_equal(2, match.size)
-    
+
     match = @lib.grep('search', :object => 'gitsearch1', :invert_match => true)
     assert_equal(6, match['gitsearch1:scott/text.txt'].size)
     assert_equal(2, match.size)
   end
-  
+
   def test_show
     assert(/^commit 5e53019b3238362144c2766f02a2c00d91fcc023.+\+replace with new text - diff test$/m.match(@lib.show))
     assert(/^commit 935badc874edd62a8629aaf103418092c73f0a56.+\+nothing!$/m.match(@lib.show('gitsearch1')))
     assert(/^hello.+nothing!$/m.match(@lib.show('gitsearch1', 'scott/text.txt')))
     assert(@lib.show('gitsearch1', 'scott/text.txt') == "hello\nthis is\na file\nthat is\nput here\nto search one\nto search two\nnothing!\n")
   end
-  
+
 end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description

Allow passing `--refs` to `ls-remote`

The default behavior of ls-remote shows dereferenced tags 
    
Including on this very repo. Try `$ git ls-remote https://github.com/ruby-git/ruby-git.git` and get `^{}` at the end of dereferenceable tags:
    
```
...
99b11561a64740285872f4c0a8b72e3e69308ed2        refs/tags/v1.2.9^{}
4bc7f14b62714853c1bd0c53930172356116e6a1        refs/tags/v1.2.9.1
cc6d6efc1b7eaf63609c4c06969b0f839dc80095        refs/tags/v1.2.9.1^{}
03524b251812019da4fed3fc7d6c835f03f47c3d        refs/tags/v1.3.0
a223fcf873bd99658cd1d0bdee1818adc7e3e92c        refs/tags/v1.3.0^{}
...
```

If one is only interested in tags, the dereferenceable tags get in the way and have to be filtered manually. By allowing the `refs` option, users can get the tags without having to manually filter the result
