### PR TITLE
Fix JRuby Build on Windows

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1050,15 +1050,12 @@ module Git
         @logger.debug(output)
       end
 
-      if exitstatus > 1 || (exitstatus == 1 && output != '')
-        raise Git::GitExecuteError.new(git_cmd + ':' + output.to_s)
-      end
+      raise Git::GitExecuteError, "#{git_cmd}:#{output}" if
+        exitstatus > 1 || (exitstatus == 1 && output != '')
 
-      if command_opts[:chomp]
-        output.chomp! if output
-      end
+      output.chomp! if output && command_opts[:chomp] && !block_given?
 
-      return output
+      output
     end
 
     # Takes the diff command line output (as Array) and parse it into a Hash


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
The JRuby build on Windows fails because `#chomp!` is called on an IO object.  When a block is passed to `#command`, `output` is an `IO` object instead of a `String` (this is done in `#run_command`).  Create a special case to not call `#chomp` when a block is passed to `#command`.

