### PR TITLE
Allow a logger to be passed to Git.clone

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,6 +184,10 @@ g = Git.clone(URI, NAME, :path => '/tmp/checkout')
 g.config('user.name', 'Scott Chacon')
 g.config('user.email', 'email@email.com')
 
+# Clone can take an optional logger
+logger = Logger.new
+g = Git.clone(URI, NAME, :log => logger)
+
 g.add                                   # git add -- "."
 g.add(:all=>true)                       # git add --all -- "."
 g.add('file_path')                      # git add -- "file_path"

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -25,8 +25,7 @@ module Git
     #    :index_file
     #
     def self.clone(repository, name, opts = {})
-      # run git-clone
-      self.new(Git::Lib.new.clone(repository, name, opts))
+      self.new(Git::Lib.new(nil, opts[:log]).clone(repository, name, opts))
     end
 
     # Returns (and initialize if needed) a Git::Config instance

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -78,9 +78,16 @@ module Git
 
       command('clone', arr_opts)
 
-      (opts[:bare] or opts[:mirror]) ? {:repository => clone_dir} : {:working_directory => clone_dir}
+      return_base_opts_from_clone(clone_dir, opts)
     end
 
+    def return_base_opts_from_clone(clone_dir, opts)
+      base_opts = {}
+      base_opts[:repository] = clone_dir if (opts[:bare] || opts[:mirror])
+      base_opts[:working_directory] = clone_dir unless (opts[:bare] || opts[:mirror])
+      base_opts[:log] = opts[:log] if opts[:log]
+      base_opts
+    end
 
     ## READ COMMANDS ##
 

--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -1,6 +1,8 @@
 #!/usr/bin/env ruby
 
 require File.dirname(__FILE__) + '/../test_helper'
+require 'stringio'
+require 'logger'
 
 class TestInit < Test::Unit::TestCase
   def setup
@@ -96,6 +98,36 @@ class TestInit < Test::Unit::TestCase
       assert_equal('ignore', g.config['receive.denycurrentbranch'])
       assert(File.exist?(File.join(g.repo.path, 'config')))
       assert(g.dir)
+    end
+  end
+
+  # If the :log option is not passed to Git.clone, the result should not
+  # have a logger
+  #
+  def test_git_clone_without_log
+    in_temp_dir do |path|
+      g = Git.clone(@wbare, 'bare-co')
+      actual_logger = g.instance_variable_get(:@logger)
+      assert_equal(nil, actual_logger)
+    end
+  end
+
+  # If the :log option is passed to Git.clone, the result should have
+  # a logger set to the value of :log
+  #
+  def test_git_clone_log
+    log_io = StringIO.new
+    expected_logger = Logger.new(log_io)
+
+    in_temp_dir do |path|
+      g = Git.clone(@wbare, 'bare-co', { log: expected_logger })
+      actual_logger = g.instance_variable_get(:@logger)
+      assert_equal(expected_logger.object_id, actual_logger.object_id)
+
+      # Ensure that both the clone and Git::Base creation are logged to the logger
+      #
+      assert_includes(log_io.string, "Cloning into 'bare-co'...")
+      assert_includes(log_io.string, 'Starting Git')
     end
   end
 


### PR DESCRIPTION
### Your checklist for this pull request

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

Add new `:log` option log to Git.clone which logs the clone operation and returns the new Git::Base object with its logger set to the value passed in `:log`.