### PR TITLE
Add gem build, install, and sanity test to the CI build

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -40,3 +40,6 @@ jobs:
 
       - name: Run Build
         run: bundle exec rake default
+
+      - name: Test Gem
+        run: bundle exec rake test:gem

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,12 +78,14 @@ In order to ensure high quality, all pull requests must meet these requirements:
 
 ### Unit tests
   * All changes must be accompanied by new or modified unit tests
-  * The entire test suite must pass when `bundle exec rake test` is run from the
-    project's local working copy
+  * The entire test suite must pass when `bundle exec rake default` is run from the
+    project's local working copy.
 
-### Continuous Integration
-  * All tests must pass in the project's [Travis CI](https://travis-ci.org/ruby-git/ruby-git)
-    build before the pull request will be merged
+### Continuous integration
+  * All tests must pass in the project's [GitHub Continuous Integration build](https://github.com/ruby-git/ruby-git/actions?query=workflow%3ACI)
+    before the pull request will be merged.
+  * The [Continuous Integration workflow](https://github.com/ruby-git/ruby-git/blob/master/.github/workflows/continuous_integration.yml)
+    runs both `bundle exec rake default` and `bundle exec rake test:gem` from the project's [Rakefile](https://github.com/ruby-git/ruby-git/blob/master/Rakefile).
 
 ### Documentation
   * New and updated public methods must have [YARD](https://yardoc.org/)

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require 'bundler/gem_tasks'
+require 'English'
 
 require "#{File.expand_path(File.dirname(__FILE__))}/lib/git/version"
 
@@ -41,4 +42,41 @@ unless RUBY_PLATFORM == 'java'
   # default_tasks << :yardstick
 end
 
+if RUBY_PLATFORM == 'java' && Gem.win_platform?
+  # Reimplement the :build and :install task for JRuby on Windows
+  # There is a bug in JRuby on Windows that makes the `build` task from `bundler/gem_tasks` fail.
+  # Once https://github.com/jruby/jruby/issues/6516 is fixed, this block can be deleted.
+  version = Git::VERSION
+  pkg_name = 'git'
+  gem_file = "pkg/#{pkg_name}-#{version}.gem"
+
+  Rake::Task[:build].clear
+  task :build do
+    FileUtils.mkdir 'pkg' unless File.exist? 'pkg'
+    `gem build #{pkg_name}.gemspec --output "#{gem_file}" --quiet`
+    raise 'Gem build failed' unless $CHILD_STATUS.success?
+    puts "#{pkg_name} #{version} built to #{gem_file}."
+  end
+
+  Rake::Task[:install].clear
+  task :install => :build do
+    `gem install #{gem_file} --quiet`
+    raise 'Gem install failed' unless $CHILD_STATUS.success?
+    puts "#{pkg_name} (#{version}) installed."
+  end
+
+  CLOBBER << gem_file
+end
+
+default_tasks << :build
+
 task default: default_tasks
+
+desc 'Build and install the git gem and run a sanity check'
+task :'test:gem' => :install do
+  output = `ruby -e "require 'git'; g = Git.open('.'); puts g.log.size"`.chomp
+  raise 'Gem test failed' unless $CHILD_STATUS.success?
+  raise 'Expected gem test to return an integer' unless output =~ /^\d+$/
+
+  puts 'Gem Test Succeeded'
+end


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
The current CI build runs the unit tests but does not actually build the gem, install it, or try to use the gem that was built to make sure it was built correctly.

This change is meant to stop issues like the one reported in #506 from being published as a gem.

This change addresses all that by:
* Updating the `default` Rake task to build the gem.
* Adding a new Rake task `test:gem` that installs the gem and runs a sanity test using the installed gem.
* Add a new step to the CI build that runs the `test:gem` rake task.