### PR TITLE
Remove JRuby on Windows workaround

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -42,32 +42,6 @@ unless RUBY_PLATFORM == 'java'
   # default_tasks << :yardstick
 end
 
-if RUBY_PLATFORM == 'java' && Gem.win_platform?
-  # Reimplement the :build and :install task for JRuby on Windows
-  # There is a bug in JRuby on Windows that makes the `build` task from `bundler/gem_tasks` fail.
-  # Once https://github.com/jruby/jruby/issues/6516 is fixed, this block can be deleted.
-  version = Git::VERSION
-  pkg_name = 'git'
-  gem_file = "pkg/#{pkg_name}-#{version}.gem"
-
-  Rake::Task[:build].clear
-  task :build do
-    FileUtils.mkdir 'pkg' unless File.exist? 'pkg'
-    `gem build #{pkg_name}.gemspec --output "#{gem_file}" --quiet`
-    raise 'Gem build failed' unless $CHILD_STATUS.success?
-    puts "#{pkg_name} #{version} built to #{gem_file}."
-  end
-
-  Rake::Task[:install].clear
-  task :install => :build do
-    `gem install #{gem_file} --quiet`
-    raise 'Gem install failed' unless $CHILD_STATUS.success?
-    puts "#{pkg_name} (#{version}) installed."
-  end
-
-  CLOBBER << gem_file
-end
-
 default_tasks << :build
 
 task default: default_tasks


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
In PR #509, a workaround was created because of a bug in JRuby (see jruby/jruby#6516).  That bug has since been fixed. This PR removes the workaround.
