### PR TITLE
Refactor how working, repository, and index directories are initialized

### DIFF
--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -44,8 +44,7 @@ class TestInit < Test::Unit::TestCase
   def test_git_init_bare
     in_temp_dir do |path|
       repo = Git.init(path, :bare => true)
-      assert(File.directory?(File.join(path, '.git')))
-      assert(File.exist?(File.join(path, '.git', 'config')))
+      assert(File.exist?(File.join(path, 'config')))
       assert_equal('true', repo.config('core.bare'))
     end
   end

--- a/tests/units/test_submodule_open.rb
+++ b/tests/units/test_submodule_open.rb
@@ -1,0 +1,52 @@
+#!/usr/bin/env ruby
+
+require File.dirname(__FILE__) + '/../test_helper'
+require 'English'
+
+class TestShow < Test::Unit::TestCase
+  def setup
+    @temp_dir = Dir.mktmpdir
+
+    @submodule_working_tree_path = File.join(@temp_dir, 'submodule')
+    @main_working_tree_path = File.join(@temp_dir, 'main')
+    @submodule_path_in_main = 'my_submodule'
+
+    FileUtils.mkdir_p(@submodule_working_tree_path)
+
+    g = Git.init(@submodule_working_tree_path)
+    File.write(File.join(@submodule_working_tree_path, 'submodule_file.md'), '# Submodule File')
+    g.add('submodule_file.md')
+    g.commit('Initial submodule commit')
+    @submodule_head = g.log[0].sha
+
+    FileUtils.mkdir(@main_working_tree_path)
+    g = Git.init(@main_working_tree_path)
+    File.write(File.join(@main_working_tree_path, 'README.md'), '# Main Repository')
+    g.add('README.md')
+    g.commit('Initial commit')
+    Dir.chdir @main_working_tree_path do
+      `git submodule -q add #{@submodule_working_tree_path}/.git my_submodule`
+      assert_true($CHILD_STATUS.success?)
+    end
+    @main_head = g.log[0].sha
+
+    assert_not_equal(@submodule_head, @main_head)
+  end
+
+  def teardown
+    FileUtils.rm_rf(@temp_dir)
+  end
+
+  def test_open_in_current_directory
+    Dir.chdir File.join(@main_working_tree_path, @submodule_path_in_main) do
+      g = Git.open('.')
+      assert_equal(@submodule_head, g.log[0].sha)
+    end
+  end
+
+  def test_not_in_current_directory
+    working_tree_directory = File.join(@main_working_tree_path, @submodule_path_in_main)
+    g = Git.open(working_tree_directory)
+    assert_equal(@submodule_head, g.log[0].sha)
+  end
+end

--- a/tests/units/test_thread_safety.rb
+++ b/tests/units/test_thread_safety.rb
@@ -24,7 +24,7 @@ class TestThreadSafety < Test::Unit::TestCase
     threads.each(&:join)
 
     dirs.each do |dir|
-      Git.bare("#{dir}/.git").ls_files
+      Git.bare(dir).ls_files
     end
   end
 end


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
When opening a submodule or secondary working tree which exist in a directory different than the current directory, the command would fail.

The logic for how to set working tree, repository, and index directories is scattered all over the place.  This PR tries to centralize that logic.