### PR TITLE
Fix use of spaces instead of tab in lib/git/base.rb

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -387,7 +387,7 @@ module Git
     #  @git.pull('upstream', 'develope')  # pulls from upstream/develop
     #
     def pull(remote='origin', branch='master')
-			self.lib.pull(remote, branch)
+      self.lib.pull(remote, branch)
     end
 
     # returns an array of Git:Remote objects


### PR DESCRIPTION
This PR fixes a minor oversight in the text spacing.
