### PR TITLE
feat: add --gpg-sign option on commits

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -642,6 +642,7 @@ module Git
     #  :date
     #  :no_verify
     #  :allow_empty_message
+    #  :sign
     #
     # @param [String] message the commit message to be used
     # @param [Hash] opts the commit options to be used
@@ -655,6 +656,7 @@ module Git
       arr_opts << "--date=#{opts[:date]}" if opts[:date].is_a? String
       arr_opts << '--no-verify' if opts[:no_verify]
       arr_opts << '--allow-empty-message' if opts[:allow_empty_message]
+      arr_opts << "--gpg-sign=#{opts[:sign]}" if opts[:sign] || "--gpg-sign" if opts[:sign]=''
 
       command('commit', arr_opts)
     end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -656,7 +656,7 @@ module Git
       arr_opts << "--date=#{opts[:date]}" if opts[:date].is_a? String
       arr_opts << '--no-verify' if opts[:no_verify]
       arr_opts << '--allow-empty-message' if opts[:allow_empty_message]
-      arr_opts << "--gpg-sign=#{opts[:sign]}" if opts[:sign] || "--gpg-sign" if opts[:sign]=''
+      arr_opts << '--gpg-sign' if opts[:sign]
 
       command('commit', arr_opts)
     end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -642,7 +642,7 @@ module Git
     #  :date
     #  :no_verify
     #  :allow_empty_message
-    #  :sign
+    #  :gpg_sign
     #
     # @param [String] message the commit message to be used
     # @param [Hash] opts the commit options to be used
@@ -656,7 +656,7 @@ module Git
       arr_opts << "--date=#{opts[:date]}" if opts[:date].is_a? String
       arr_opts << '--no-verify' if opts[:no_verify]
       arr_opts << '--allow-empty-message' if opts[:allow_empty_message]
-      arr_opts << '--gpg-sign' if opts[:sign]
+      arr_opts << '--gpg-sign' if opts[:gpg_sign] == true || "--gpg-sign=#{opts[:gpg_sign]}" if opts[:gpg_sign]
 
       command('commit', arr_opts)
     end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
This pull request add and option on `opts` hash to sign your commits using the default key that has been set in the config file