### PR TITLE
Add "g.current_branch" to Readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ g.revparse('v2.5:Makefile')
 
 g.branches # returns Git::Branch objects
 g.branches.local
+g.current_branch
 g.branches.remote
 g.branches[:master].gcommit
 g.branches['origin/master'].gcommit


### PR DESCRIPTION
### Description
In my opinion .current_branch is a fairly common operation, and it would be nice to have it listed on the readme file.
