### PR TITLE
Fix worktree test when git dir includes symlinks

### DIFF
--- a/tests/units/test_worktree.rb
+++ b/tests/units/test_worktree.rb
@@ -32,23 +32,24 @@ class TestWorktree < Test::Unit::TestCase
 
   def setup
     @git = Git.open(git_working_dir)
-    
+
     @commit = @git.object('1cc8667014381')
     @tree = @git.object('1cc8667014381^{tree}')
     @blob = @git.object('v2.5:example.txt')
-    
+
     @worktrees = @git.worktrees
   end
-  
+
   def test_worktrees_all
     assert(@git.worktrees.is_a?(Git::Worktrees))
     assert(@git.worktrees.first.is_a?(Git::Worktree))
     assert_equal(@git.worktrees.size, 2)
   end
-  
+
   def test_worktrees_single
     worktree = @git.worktrees.first
-    assert_equal(worktree.dir, @git.dir.to_s)
+    git_dir = Pathname.new(@git.dir.to_s).realpath.to_s
+    assert_equal(worktree.dir, git_dir)
     assert_equal(worktree.gcommit, SAMPLE_LAST_COMMIT)
   end
 


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
This is a fix for running unit tests on Mac where /tmp is actually a symlink to /private/tmp. `Git#dir` returns the directory you give it and `Worktree#dir` returns the expanded path since that is what `git workspace list` returns.

Some additional thought will have to be put into considering if `Git#dir` should also return the expanded path. 