### PR TITLE
Fix the gpg_sign commit option

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,14 @@ g.remove('file.txt', :cached => true)		# git rm -f --cached -- "file.txt"
 g.commit('message')
 g.commit_all('message')
 
+# Sign a commit using the gpg key configured in the user.signingkey config setting
+g.config('user.signingkey', '0A46826A')
+g.commit('message', gpg_sign: true)
+
+# Sign a commit using a specified gpg key
+key_id = '0A46826A'
+g.commit('message', gpg_sign: key_id)
+
 g = Git.clone(repo, 'myrepo')
 g.chdir do
 new_file('test-file', 'blahblahblah')

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -660,7 +660,14 @@ module Git
       arr_opts << "--date=#{opts[:date]}" if opts[:date].is_a? String
       arr_opts << '--no-verify' if opts[:no_verify]
       arr_opts << '--allow-empty-message' if opts[:allow_empty_message]
-      arr_opts << '--gpg-sign' if opts[:gpg_sign] == true || "--gpg-sign=#{opts[:gpg_sign]}" if opts[:gpg_sign]
+      if opts[:gpg_sign]
+        arr_opts <<
+          if opts[:gpg_sign] == true
+            '--gpg-sign'
+          else
+            "--gpg-sign=#{opts[:gpg_sign]}"
+          end
+      end
 
       command('commit', arr_opts)
     end

--- a/tests/units/test_commit_with_gpg.rb
+++ b/tests/units/test_commit_with_gpg.rb
@@ -1,0 +1,37 @@
+#!/usr/bin/env ruby
+
+require File.dirname(__FILE__) + '/../test_helper'
+
+class TestCommitWithGPG < Test::Unit::TestCase
+  def setup
+    set_file_paths
+  end
+
+  def test_with_configured_gpg_keyid
+    Dir.mktmpdir do |dir|
+      git = Git.init(dir)
+      actual_cmd = nil
+      git.lib.define_singleton_method(:run_command) do |git_cmd, &block|
+        actual_cmd = git_cmd
+        `true`
+      end
+      message = 'My commit message'
+      git.commit(message, gpg_sign: true)
+      assert_match(/commit.*--gpg-sign['"]/, actual_cmd)
+    end
+  end
+
+  def test_with_specific_gpg_keyid
+    Dir.mktmpdir do |dir|
+      git = Git.init(dir)
+      actual_cmd = nil
+      git.lib.define_singleton_method(:run_command) do |git_cmd, &block|
+        actual_cmd = git_cmd
+        `true`
+      end
+      message = 'My commit message'
+      git.commit(message, gpg_sign: 'keykeykey')
+      assert_match(/commit.*--gpg-sign=keykeykey['"]/, actual_cmd)
+    end
+  end
+end


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
When support for the `gpg_sign` option was added to the `Git::Lib#commit` in #518, it did not actually work properly for the case of the key being passed into the commit command.

This PR does the following:
* Correctly allows specification of a GPG Key in the `gpg-sign` option as follows:
```Ruby
key_id = '0A46826A'
g.commit('message', gpg_sign: key_id)
```
* Add tests to make sure the commit command line is built correctly for the two use cases of gpg_sign.
* Add examples in the `README.md`

This fix also fixes the warning introduced in #518 the was output by Ruby when requiring the `git` gem:

```
$ irb
3.0.1 :001 > require 'git'
/Users/couballj/.rvm/gems/ruby-3.0.1/gems/git-1.9.0/lib/git/lib.rb:663: warning: string literal in condition
 => true
3.0.1 :002 >
```