### PR TITLE
Require pathname module

### DIFF
--- a/tests/units/test_worktree.rb
+++ b/tests/units/test_worktree.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 require 'fileutils'
+require 'pathname'
 require File.dirname(__FILE__) + '/../test_helper'
 
 SAMPLE_LAST_COMMIT = '5e53019b3238362144c2766f02a2c00d91fcc023'


### PR DESCRIPTION
... otherwise the test fails with:

```
TestWorktree:
  test_worktree_add_and_remove:				.: (0.080734)
  test_worktree_prune:					.: (0.055268)
  test_worktrees_all:					.: (0.037409)
  test_worktrees_single:				E
===============================================================================
Error: test_worktrees_single(TestWorktree): NameError: uninitialized constant TestWorktree::Pathname
/<<PKGBUILDDIR>>/tests/units/test_worktree.rb:51:in `test_worktrees_single'
     48:
     49:   def test_worktrees_single
     50:     worktree = @git.worktrees.first
  => 51:     git_dir = Pathname.new(@git.dir.to_s).realpath.to_s
     52:     assert_equal(worktree.dir, git_dir)
     53:     assert_equal(worktree.gcommit, SAMPLE_LAST_COMMIT)
     54:   end
===============================================================================
: (0.041215)
```

Requiring `pathname` fixes the issue.

closes #535

Signed-off-by: Daniel Leidert <daniel.leidert@wgdd.de>