### PR TITLE
Add support for the `git merge --no-commit` argument

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -772,6 +772,7 @@ module Git
 
     def merge(branch, message = nil, opts = {})
       arr_opts = []
+      arr_opts << '--no-commit' if opts[:no_commit]
       arr_opts << '--no-ff' if opts[:no_ff]
       arr_opts << '-m' << message if message
       arr_opts += [branch]

--- a/tests/units/test_merge.rb
+++ b/tests/units/test_merge.rb
@@ -130,4 +130,33 @@ class TestMerge < Test::Unit::TestCase
       end
     end
   end
+
+  def test_merge_no_commit
+    in_temp_dir do |path|
+      g = Git.clone(@wbare, 'branch_merge_test')
+      g.chdir do
+        g.branch('new_branch_1').in_branch('first commit message') do
+          new_file('new_file_1', 'foo')
+          g.add
+          true
+        end
+
+        g.branch('new_branch_2').in_branch('first commit message') do
+          new_file('new_file_2', 'bar')
+          g.add
+          true
+        end
+
+        g.checkout('new_branch_2')
+        before_merge = g.show
+        g.merge('new_branch_1', nil, no_commit: true)
+        # HEAD is the same as before.
+        assert_equal(before_merge, g.show)
+        # File has not been merged in.
+        status = g.status['new_file_1']
+        assert_equal('new_file_1', status.path)
+        assert_equal('A', status.type)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Docs at:
https://git-scm.com/docs/git-merge#Documentation/git-merge.txt---no-commit

Signed-off-by: Jon Dufresne <jon.dufresne@gmail.com>
