### PR TITLE
Properly escape double quotes in shell commands on Windows

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1191,8 +1191,9 @@ module Git
     end
 
     def escape_for_windows(s)
-      # Windows does not need single quote escaping inside double quotes
-      %Q{"#{s}"}
+      # Escape existing double quotes in s and then wrap the result with double quotes
+      escaped_string = s.to_s.gsub('"','\\"')
+      %Q{"#{escaped_string}"}
     end
 
     def windows_platform?

--- a/tests/units/test_windows_cmd_escaping.rb
+++ b/tests/units/test_windows_cmd_escaping.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# encoding: utf-8
+
+require File.dirname(__FILE__) + '/../test_helper'
+
+# Test diff when the file path has to be quoted according to core.quotePath
+# See https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath
+#
+class TestWindowsCmdEscaping < Test::Unit::TestCase
+  def test_commit_with_double_quote_in_commit_message
+    expected_commit_message = 'Commit message with "double quotes"'
+    in_temp_dir do |path|
+      create_file('README.md', "# README\n")
+      git = Git.init('.')
+      git.add
+      git.commit(expected_commit_message)
+      commits = git.log(1)
+      actual_commit_message = commits.first.message
+      assert_equal(expected_commit_message, actual_commit_message)
+    end
+  end
+end


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
This PR addresses issue #495.

On windows, double quotes in shell command arguments should be escaped.