### PR TITLE
Suppress unneeded test output

### DIFF
--- a/tests/units/test_git_dir.rb
+++ b/tests/units/test_git_dir.rb
@@ -84,7 +84,7 @@ class TestGitDir < Test::Unit::TestCase
       Dir.chdir(work_tree) do
         `git init`
         `git commit --allow-empty -m 'init'`
-        `git worktree add child`
+        `git worktree add --quiet child`
         Dir.chdir('child') do
           result = Git.open('.').diff.to_a
           assert_equal([], result)

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -289,7 +289,6 @@ class TestLib < Test::Unit::TestCase
   end
 
   def test_show
-    puts @lib.show
     assert_match(/^commit 46abbf07e3c564c723c7c039a43ab3a39e5d02dd.+\+Grep regex doesn't like this:4342: because it is bad\n$/m, @lib.show)
     assert(/^commit 935badc874edd62a8629aaf103418092c73f0a56.+\+nothing!$/m.match(@lib.show('gitsearch1')))
     assert(/^hello.+nothing!$/m.match(@lib.show('gitsearch1', 'scott/text.txt')))


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
Two tests emit unnecessary output while running. This PR removes this particular test output.
