### PR TITLE
Fix build on Ruby 3.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,9 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-gemspec :name => 'git'
+git 'https://github.com/lsegal/yard', branch: 'main' do
+  gem 'yard'
+end
 
+gemspec name: 'git'


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
This PR fixes the ruby-head build (Ruby 3.2) which fails because `yard` calls Ruby's `taint` API. lsegal/yard#1419 fixes this issue in `yard` which was merged months ago but there has not yet been a new release of `yard`.

Rather than live with the `ruby-head` builds failing for the `git` gem, this PR installs `yard` from the Github `main` branch. This is a temporary work around which should be removed after `yard` releases a new version that includes the fix for `taint`.

More info on the `taint` API in Ruby:

In Ruby 2.7, the taint checking mechanism [was removed](https://bugs.ruby-lang.org/issues/16131). `Object#taint`, `Object#trust`, `Object#untaint`, `Object#untrust` and related functions in the C-API have been made no-op methods. It means they do nothing and just return self.

In Ruby 3.2, `Object#taint`, `Object#trust`, `Object#untaint`, `Object#untrust` and the C functions have been completely removed.