### PR TITLE
Add --all flag to fetch method

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -877,15 +877,16 @@ module Git
 
     def fetch(remote, opts)
       arr_opts = []
+      arr_opts << '--all' if opts[:all]
       arr_opts << '--tags' if opts[:t] || opts[:tags]
       arr_opts << '--prune' if opts[:p] || opts[:prune]
       arr_opts << '--prune-tags' if opts[:P] || opts[:'prune-tags']
       arr_opts << '--force' if opts[:f] || opts[:force]
       arr_opts << '--unshallow' if opts[:unshallow]
       arr_opts << '--depth' << opts[:depth] if opts[:depth]
-      arr_opts << '--'
-      arr_opts << remote
-      arr_opts << opts[:ref] if opts[:ref]
+      arr_opts << '--' unless opts[:all]
+      arr_opts << remote unless opts[:all]
+      arr_opts << opts[:ref] if opts[:ref] unless opts[:all]
 
       command('fetch', arr_opts)
     end


### PR DESCRIPTION
The fix for CVE-2022-25648 broke a workflow for us by removing the ability
to fetch all remotes.

This adds --all to the list of available flags for the #fetch method. It does
not add `:a` as an alternative flag, as `git fetch -a` and `git fetch --all` are
not the same thing.

Signed-off-by: Matthew Riedel <matthew.riedel@fluxfederation.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [ ] Ensure that your contributions pass unit testing.
- [ ] Ensure that your contributions contain documentation if applicable.

### Description
Please describe your pull request.
