### PR TITLE
Workaround to get JRuby build working

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -28,6 +28,9 @@ jobs:
 
     runs-on: ${{ matrix.operating-system }}
 
+    env:
+      JAVA_OPTS: -Djdk.io.File.enableADS=true
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v2


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
This is a workaround for the problem in JRuby with the JDK being used as described in jruby/jruby#7182 where it is report that there is a bug in the JDK that causes JRuby to raise an error when opening the NULL device for write. The underlying JDK bug is reported and fixed in [JDK-8285445](https://bugs.openjdk.java.net/browse/JDK-8285445) which is targeted to a July 2022 release.

In the meantime, the workaround adds the following environment variable `JAVA_OPTS: -Djdk.io.File.enableADS=true` to all build steps so JRuby can function. This setting is detailed in the [JDK Patch 8u333 Release Notes](https://www.oracle.com/java/technologies/javase/8u333-relnotes.html#JDK-8285660)
