### PR TITLE
Proof of concept fix for git diff parsing failure on warn [Issue #574]

### DIFF
--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -133,6 +133,7 @@ module Git
             current_file = Git::EscapedPath.new(m[2]).unescape
             final[current_file] = defaults.merge({:patch => line, :path => current_file})
           else
+            next unless current_file # Protects against warnings or other garbage output preceeding the diff
             if m = /^index ([0-9a-f]{4,40})\.\.([0-9a-f]{4,40})( ......)*/.match(line)
               final[current_file][:src] = m[1]
               final[current_file][:dst] = m[2]

--- a/tests/units/test_diff.rb
+++ b/tests/units/test_diff.rb
@@ -120,5 +120,11 @@ class TestDiff < Test::Unit::TestCase
     assert_equal(160, files['scott/newfile'].patch.size)
   end
   
-  
+  def test_diff_process_full_with_warnings
+    @diff.send(:cache_full) # prime the cache
+    warning = "Warning: Permanently added the ECDSA host key for IP address '000.00.000.0' to the list of known hosts.\n"
+    @diff.instance_variable_set(:@full_diff, warning + @diff.instance_variable_get(:@full_diff))
+
+    assert_equal('5d46068', @diff["scott/newfile"].src)
+  end
 end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
SSH warnings and other unexpected output from `git diff` can create cryptic errors, as the diff parser assumes that the first line of a diff will always provide a file name for consideration. To mitigate this, ignore lines with unexpected formatting until the first line with a file header is reached. 

Given that the problem code is deep in the internals of diff.rb, I have taken a somewhat aggressive white-box testing approach to my accompanying unit test, which I acknowledge may prove brittle if the internals of the class change. I am open to alternative strategies as per the maintainers' recommendations. 

Prospective fix for Issue #574