### PR TITLE
Do not assume the default branch is 'master' in tests

### DIFF
--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -38,7 +38,10 @@ class TestInit < Test::Unit::TestCase
       assert(File.directory?(File.join(path, '.git')))
       assert(File.exist?(File.join(path, '.git', 'config')))
       assert_equal('false', repo.config('core.bare'))
-      assert_equal("ref: refs/heads/master\n", File.read("#{path}/.git/HEAD"))
+
+      branch = `git config --get init.defaultBranch`.strip
+      branch = 'master' if branch.empty?
+      assert_equal("ref: refs/heads/#{branch}\n", File.read("#{path}/.git/HEAD"))
     end
   end
 


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description

Fix test case by extracting `init.defaultBranch` into variable
https://github.com/ruby-git/ruby-git/issues/587
