### PR TITLE
Support the commit --no-gpg-sign flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,9 @@ g.commit('message', gpg_sign: true)
 key_id = '0A46826A'
 g.commit('message', gpg_sign: key_id)
 
+# Skip signing a commit (overriding any global gpgsign setting)
+g.commit('message', gpg_sign: false)
+
 g = Git.clone(repo, 'myrepo')
 g.chdir do
 new_file('test-file', 'blahblahblah')

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ key_id = '0A46826A'
 g.commit('message', gpg_sign: key_id)
 
 # Skip signing a commit (overriding any global gpgsign setting)
-g.commit('message', gpg_sign: false)
+g.commit('message', no_gpg_sign: true)
 
 g = Git.clone(repo, 'myrepo')
 g.chdir do

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -647,7 +647,8 @@ module Git
     #  :date
     #  :no_verify
     #  :allow_empty_message
-    #  :gpg_sign (accepts true, false, or a gpg key ID as a String)
+    #  :gpg_sign (accepts true or a gpg key ID as a String)
+    #  :no_gpg_sign (conflicts with :gpg_sign)
     #
     # @param [String] message the commit message to be used
     # @param [Hash] opts the commit options to be used
@@ -661,15 +662,18 @@ module Git
       arr_opts << "--date=#{opts[:date]}" if opts[:date].is_a? String
       arr_opts << '--no-verify' if opts[:no_verify]
       arr_opts << '--allow-empty-message' if opts[:allow_empty_message]
-      if opts.has_key?(:gpg_sign)
+
+      if opts[:gpg_sign] && opts[:no_gpg_sign]
+        raise ArgumentError, 'cannot specify :gpg_sign and :no_gpg_sign'
+      elsif opts[:gpg_sign]
         arr_opts <<
           if opts[:gpg_sign] == true
             '--gpg-sign'
-          elsif opts[:gpg_sign] == false
-            '--no-gpg-sign'
           else
             "--gpg-sign=#{opts[:gpg_sign]}"
           end
+      elsif opts[:no_gpg_sign]
+        arr_opts << '--no-gpg-sign'
       end
 
       command('commit', arr_opts)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -647,7 +647,7 @@ module Git
     #  :date
     #  :no_verify
     #  :allow_empty_message
-    #  :gpg_sign
+    #  :gpg_sign (accepts true, false, or a gpg key ID as a String)
     #
     # @param [String] message the commit message to be used
     # @param [Hash] opts the commit options to be used
@@ -661,10 +661,12 @@ module Git
       arr_opts << "--date=#{opts[:date]}" if opts[:date].is_a? String
       arr_opts << '--no-verify' if opts[:no_verify]
       arr_opts << '--allow-empty-message' if opts[:allow_empty_message]
-      if opts[:gpg_sign]
+      if opts.has_key?(:gpg_sign)
         arr_opts <<
           if opts[:gpg_sign] == true
             '--gpg-sign'
+          elsif opts[:gpg_sign] == false
+            '--no-gpg-sign'
           else
             "--gpg-sign=#{opts[:gpg_sign]}"
           end

--- a/tests/units/test_commit_with_gpg.rb
+++ b/tests/units/test_commit_with_gpg.rb
@@ -44,8 +44,19 @@ class TestCommitWithGPG < Test::Unit::TestCase
         `true`
       end
       message = 'My commit message'
-      git.commit(message, gpg_sign: false)
+      git.commit(message, no_gpg_sign: true)
       assert_match(/commit.*--no-gpg-sign['"]/, actual_cmd)
+    end
+  end
+
+  def test_conflicting_gpg_sign_options
+    Dir.mktmpdir do |dir|
+      git = Git.init(dir)
+      message = 'My commit message'
+
+      assert_raises ArgumentError do
+        git.commit(message, gpg_sign: true, no_gpg_sign: true)
+      end
     end
   end
 end

--- a/tests/units/test_commit_with_gpg.rb
+++ b/tests/units/test_commit_with_gpg.rb
@@ -34,4 +34,18 @@ class TestCommitWithGPG < Test::Unit::TestCase
       assert_match(/commit.*--gpg-sign=keykeykey['"]/, actual_cmd)
     end
   end
+
+  def test_disabling_gpg_sign
+    Dir.mktmpdir do |dir|
+      git = Git.init(dir)
+      actual_cmd = nil
+      git.lib.define_singleton_method(:run_command) do |git_cmd, &block|
+        actual_cmd = git_cmd
+        `true`
+      end
+      message = 'My commit message'
+      git.commit(message, gpg_sign: false)
+      assert_match(/commit.*--no-gpg-sign['"]/, actual_cmd)
+    end
+  end
 end


### PR DESCRIPTION
### Description

Add the ability to send the `--no-gpg-sign` option to git. This is the default behavior in a "vanilla" git install, but if gpg signing is configured elsewhere (i.e. in `~/.gitconfig`) then you can use this option to override and disable it for a particular commit.

Triggered by `gpg_sign: false` - see test and README updates.