### PR TITLE
Allow the CI build to be run manually using the GitHub interface

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -5,6 +5,7 @@ on:
     branches: [master]
   pull_request:
     branches: [master]
+  workflow_dispatch:
 
 jobs:
   continuous_integration_build:


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
It would be nice to be able to run the `master` branch build to see if it is still working even though gem dependencies or latest OS versions were updated.

With this change, the build can be triggered from [the CI workflow on the GitHub actions page for this repository](https://github.com/ruby-git/ruby-git/actions/workflows/continuous_integration.yml)