### PR TITLE
Fix windows build

### DIFF
--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require File.dirname(__FILE__) + '/../test_helper'
+require "fileutils"
 
 # tests all the low level git communication
 #
@@ -51,8 +52,13 @@ class TestLib < Test::Unit::TestCase
     move_file(pre_commit_path, pre_commit_path_bak)
 
     # Adds a pre-commit file that should throw an error
-    create_file(pre_commit_path, 'echo Pre-commit file. Shoud not execute; exit 1') # Error when executed
-    File.chmod(0111, pre_commit_path)
+    create_file(pre_commit_path, <<~PRE_COMMIT_SCRIPT)
+      #!/bin/sh
+      echo "pre-commit script exits with an error"
+      exit 1
+    PRE_COMMIT_SCRIPT
+
+    FileUtils.chmod("+x", pre_commit_path)
 
     create_file("#{@wdir}/test_file_2", 'content test_file_2')
     @lib.add('test_file_2')


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
When testing `git commit --no-verify`, the `pre-commit` script was created in such a way that failed on the current Windows build configuration. This change creates the file properly with the `#!/bin/sh` hash bang to ensure the script runs on all platforms including Windows.
