### PR TITLE
Use yard gem version 0.9.8 or later

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,4 @@
 
 source 'https://rubygems.org'
 
-git 'https://github.com/lsegal/yard', branch: 'main' do
-  gem 'yard'
-end
-
 gemspec name: 'git'

--- a/git.gemspec
+++ b/git.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
 
   unless RUBY_PLATFORM == 'java'
     s.add_development_dependency 'redcarpet', '~> 3.5'
-    s.add_development_dependency 'yard', '~> 0.9'
+    s.add_development_dependency 'yard', '~> 0.9', '>= 0.9.28'
     s.add_development_dependency 'yardstick', '~> 0.9'
   end
 


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
This PR reverses the changes made in #573 which installed the yard gem from the GitHub `main` branch instead of pulling the gem from rubygems. See #573 for why this was done.

`yard-0.9.8` has the fix for the `Object#taint` call that was failing the build on Ruby 3.2.
