### PR TITLE
Fix exception when Git is autoloaded

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -27,11 +27,6 @@ require 'git/working_directory'
 require 'git/worktree'
 require 'git/worktrees'
 
-lib = Git::Lib.new(nil, nil)
-unless lib.meets_required_version?
-  $stderr.puts "[WARNING] The git gem requires git #{lib.required_command_version.join('.')} or later, but only found #{lib.current_command_version.join('.')}. You should probably upgrade."
-end
-
 # The Git module provides the basic functions to open a git
 # reference to work with. You can open a working directory,
 # open a bare repository, initialize a new repo or clone an

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -63,6 +63,8 @@ module Git
         @git_work_dir = base[:working_directory]
       end
       @logger = logger
+
+      Git::Lib.warn_if_old_command(self)
     end
 
     # creates or reinitializes the repository
@@ -1027,6 +1029,13 @@ module Git
       (self.current_command_version <=>  self.required_command_version) >= 0
     end
 
+    def self.warn_if_old_command(lib)
+      return true if @version_checked
+      unless lib.meets_required_version?
+        $stderr.puts "[WARNING] The git gem requires git #{lib.required_command_version.join('.')} or later, but only found #{lib.current_command_version.join('.')}. You should probably upgrade."
+      end
+      @version_checked = true
+    end
 
     private
 

--- a/tests/all_tests.rb
+++ b/tests/all_tests.rb
@@ -1,5 +1,8 @@
 Dir.chdir(File.dirname(__FILE__)) do
-  Dir.glob('**/test_*.rb') do |test_case| 
-    require "#{File.expand_path(File.dirname(__FILE__))}/#{test_case}" 
+  Dir.glob('**/test_*.rb') do |test_case|
+    require "#{File.expand_path(File.dirname(__FILE__))}/#{test_case}"
   end
 end
+
+# To run a single test:
+# require_relative 'units/test_lib_meets_required_version'

--- a/tests/units/test_lib_meets_required_version.rb
+++ b/tests/units/test_lib_meets_required_version.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+require File.dirname(__FILE__) + '/../test_helper'
+
+class TestLibMeetsRequiredVersion < Test::Unit::TestCase
+  def test_with_supported_command_version
+    lib = Git::Lib.new(nil, nil)
+    major_version, minor_version = lib.required_command_version
+    lib.define_singleton_method(:current_command_version) { [major_version, minor_version] }
+    assert lib.meets_required_version?
+  end
+
+  def test_with_old_command_version
+    lib = Git::Lib.new(nil, nil)
+    major_version, minor_version = lib.required_command_version
+
+    # Set the major version to be returned by #current_command_version to be an
+    # earlier version than required
+    major_version = major_version - 1
+
+    lib.define_singleton_method(:current_command_version) { [major_version, minor_version] }
+    assert !lib.meets_required_version?
+  end
+end


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
Fixes #564.

Does not fetch the current git version number until a Git::Lib instance is created. This avoids creating threads to shell out commands during code loading which caused autoload to break.
