### PR TITLE
Change how the git CLI subprocess is executed

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -13,17 +13,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0, 3.1, 3.2]
+        ruby: [2.7, 3.0, 3.1, 3.2, head]
         operating-system: [ubuntu-latest]
         include:
-          - ruby: head
-            operating-system: ubuntu-latest
-          - ruby: truffleruby-head
-            operating-system: ubuntu-latest
-          - ruby: 2.7
-            operating-system: windows-latest
           - ruby: jruby-head
+            operating-system: ubuntu-latest
+          - ruby: 3.0
             operating-system: windows-latest
+          # - ruby: jruby-head
+          #   operating-system: windows-latest
+          # - ruby: truffleruby-head
+          #   operating-system: ubuntu-latest
 
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
 

--- a/git.gemspec
+++ b/git.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.requirements = ['git 1.6.0.0, or greater']
 
   s.add_runtime_dependency 'addressable', '~> 2.8'
+  s.add_runtime_dependency 'process_executer', '~> 0.6'
   s.add_runtime_dependency 'rchardet', '~> 1.8'
 
   s.add_development_dependency 'bump', '~> 0.10'

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -6,6 +6,9 @@ require 'test/unit'
 
 require "git"
 
+$stdout.sync = true
+$stderr.sync = true
+
 class Test::Unit::TestCase
 
   TEST_ROOT = File.expand_path(__dir__)
@@ -92,21 +95,6 @@ class Test::Unit::TestCase
     end
   end
 
-  # Runs a block inside an environment with customized ENV variables.
-  # It restores the ENV after execution.
-  #
-  # @param [Proc] block block to be executed within the customized environment
-  #
-  def with_custom_env_variables(&block)
-    saved_env = {}
-    begin
-      Git::Lib::ENV_VARIABLE_NAMES.each { |k| saved_env[k] = ENV[k] }
-      return block.call
-    ensure
-      Git::Lib::ENV_VARIABLE_NAMES.each { |k| ENV[k] = saved_env[k] }
-    end
-  end
-
   # Assert that the expected command line args are generated for a given Git::Lib method
   #
   # This assertion generates an empty git repository and then runs calls
@@ -149,7 +137,7 @@ class Test::Unit::TestCase
   #
   # @return [void]
   #
-  def assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  def assert_command_line(expected_command_line, git_cmd, git_cmd_args, method: :command)
     actual_command_line = nil
 
     in_temp_dir do |path|
@@ -159,7 +147,7 @@ class Test::Unit::TestCase
         yield(git) if block_given?
 
         # Mock the Git::Lib#command method to capture the actual command line args
-        git.lib.define_singleton_method(:command) do |cmd, *opts, &block|
+        git.lib.define_singleton_method(method) do |cmd, *opts, &block|
           actual_command_line = [cmd, *opts.flatten]
         end
 

--- a/tests/units/test_archive.rb
+++ b/tests/units/test_archive.rb
@@ -11,53 +11,79 @@ class TestArchive < Test::Unit::TestCase
   end
 
   def teardown
-    @tempfiles.clear
+    @tempfiles.each { |f| File.delete(f) }
   end
 
   def tempfile
-    tempfile_object = Tempfile.new('archive-test')
-    @tempfiles << tempfile_object # prevent deletion until teardown
-    tempfile_object.close # close to avoid locking from git processes
-    tempfile_object.path
+    Dir::Tmpname.create('test-archive') { }.tap do |f|
+      @tempfiles << f
+    end
   end
 
   def test_archive
     f = @git.archive('v2.6', tempfile)
     assert(File.exist?(f))
+  end
 
+  def test_archive_object
     f = @git.object('v2.6').archive(tempfile)  # writes to given file
-    assert(File.exist?(f))
-
-    f = @git.object('v2.6').archive # returns path to temp file
-    assert(File.exist?(f))
-
-    f = @git.object('v2.6').archive(nil, :format => 'tar') # returns path to temp file
-    assert(File.exist?(f))
-
-    lines = Minitar::Input.open(f).each.to_a.map(&:full_name)
-    assert_match(%r{ex_dir/}, lines[1])
-    assert_match(/ex_dir\/ex\.txt/, lines[2])
-    assert_match(/example\.txt/, lines[3])
-
-    f = @git.object('v2.6').archive(tempfile, :format => 'zip')
-    assert(File.file?(f))
-
-    f = @git.object('v2.6').archive(tempfile, :format => 'tgz', :prefix => 'test/')
-    assert(File.exist?(f))
-
-    lines = Minitar::Input.open(Zlib::GzipReader.new(File.open(f, 'rb'))).each.to_a.map(&:full_name)
-    assert_match(%r{test/}, lines[1])
-    assert_match(%r{test/ex_dir/ex\.txt}, lines[3])
-
-    f = @git.object('v2.6').archive(tempfile, :format => 'tar', :prefix => 'test/', :path => 'ex_dir/')
-    assert(File.exist?(f))
-
-    lines = Minitar::Input.open(f).each.to_a.map(&:full_name)
-    assert_match(%r{test/}, lines[1])
-    assert_match(%r{test/ex_dir/ex\.txt}, lines[3])
-
-    f = @git.remote('working').branch('master').archive(tempfile, :format => 'tgz')
     assert(File.exist?(f))
   end
 
+  def test_archive_object_with_no_filename
+    f = @git.object('v2.6').archive # returns path to temp file
+    assert(File.exist?(f))
+  end
+
+  def test_archive_to_tar
+    f = @git.object('v2.6').archive(nil, :format => 'tar') # returns path to temp file
+    assert(File.exist?(f))
+
+    lines = []
+    Minitar::Input.open(f) do |tar_reader|
+      lines = tar_reader.to_a.map(&:full_name)
+    end
+
+    assert_match(%r{ex_dir/}, lines[1])
+    assert_match(/ex_dir\/ex\.txt/, lines[2])
+    assert_match(/example\.txt/, lines[3])
+  end
+
+  def test_archive_to_zip
+    f = @git.object('v2.6').archive(tempfile, :format => 'zip')
+    assert(File.file?(f))
+  end
+
+  def test_archive_to_tgz
+    f = @git.object('v2.6').archive(tempfile, :format => 'tgz', :prefix => 'test/')
+    assert(File.exist?(f))
+
+    lines = []
+    File.open(f, 'rb') do |file_reader|
+      Zlib::GzipReader.open(file_reader) do |gz_reader|
+        Minitar::Input.open(gz_reader) do |tar_reader|
+          lines = tar_reader.to_a.map(&:full_name)
+        end
+      end
+    end
+
+    assert_match(%r{test/}, lines[1])
+    assert_match(%r{test/ex_dir/ex\.txt}, lines[3])
+  end
+
+  def test_archive_with_prefix_and_path
+    f = @git.object('v2.6').archive(tempfile, :format => 'tar', :prefix => 'test/', :path => 'ex_dir/')
+    assert(File.exist?(f))
+
+    tar_file = Minitar::Input.open(f)
+    lines = tar_file.each.to_a.map(&:full_name)
+    tar_file.close
+    assert_match(%r{test/}, lines[1])
+    assert_match(%r{test/ex_dir/ex\.txt}, lines[3])
+  end
+
+  def test_archive_branch
+    f = @git.remote('working').branch('master').archive(tempfile, :format => 'tgz')
+    assert(File.exist?(f))
+  end
 end

--- a/tests/units/test_commit_with_gpg.rb
+++ b/tests/units/test_commit_with_gpg.rb
@@ -10,42 +10,42 @@ class TestCommitWithGPG < Test::Unit::TestCase
   def test_with_configured_gpg_keyid
     Dir.mktmpdir do |dir|
       git = Git.init(dir)
-      actual_cmd = nil
-      git.lib.define_singleton_method(:run_command) do |git_cmd, &block|
-        actual_cmd = git_cmd
-        `true`
+      actual_opts = nil
+      git.lib.define_singleton_method(:command) do |cmd, *opts, &block|
+        actual_opts = opts.flatten
+        ''
       end
       message = 'My commit message'
       git.commit(message, gpg_sign: true)
-      assert_match(/commit.*--gpg-sign['"]/, actual_cmd)
+      assert(actual_opts.include?('--gpg-sign'))
     end
   end
 
   def test_with_specific_gpg_keyid
     Dir.mktmpdir do |dir|
       git = Git.init(dir)
-      actual_cmd = nil
-      git.lib.define_singleton_method(:run_command) do |git_cmd, &block|
-        actual_cmd = git_cmd
-        `true`
+      actual_opts = nil
+      git.lib.define_singleton_method(:command) do |cmd, *opts, &block|
+        actual_opts = opts.flatten
+        ''
       end
       message = 'My commit message'
       git.commit(message, gpg_sign: 'keykeykey')
-      assert_match(/commit.*--gpg-sign=keykeykey['"]/, actual_cmd)
+      assert(actual_opts.include?('--gpg-sign=keykeykey'))
     end
   end
 
   def test_disabling_gpg_sign
     Dir.mktmpdir do |dir|
       git = Git.init(dir)
-      actual_cmd = nil
-      git.lib.define_singleton_method(:run_command) do |git_cmd, &block|
-        actual_cmd = git_cmd
-        `true`
+      actual_opts = nil
+      git.lib.define_singleton_method(:command) do |cmd, *opts, &block|
+        actual_opts = opts.flatten
+        ''
       end
       message = 'My commit message'
       git.commit(message, no_gpg_sign: true)
-      assert_match(/commit.*--no-gpg-sign['"]/, actual_cmd)
+      assert(actual_opts.include?('--no-gpg-sign'))
     end
   end
 

--- a/tests/units/test_config.rb
+++ b/tests/units/test_config.rb
@@ -38,34 +38,32 @@ class TestConfig < Test::Unit::TestCase
   end
 
   def test_env_config
-    with_custom_env_variables do
-      begin
-        assert_equal(Git::Base.config.binary_path, 'git')
-        assert_equal(Git::Base.config.git_ssh, nil)
+    begin
+      assert_equal(Git::Base.config.binary_path, 'git')
+      assert_equal(Git::Base.config.git_ssh, nil)
 
-        ENV['GIT_PATH'] = '/env/bin'
-        ENV['GIT_SSH'] = '/env/git/ssh'
+      ENV['GIT_PATH'] = '/env/bin'
+      ENV['GIT_SSH'] = '/env/git/ssh'
 
-        assert_equal(Git::Base.config.binary_path, '/env/bin/git')
-        assert_equal(Git::Base.config.git_ssh, '/env/git/ssh')
+      assert_equal(Git::Base.config.binary_path, '/env/bin/git')
+      assert_equal(Git::Base.config.git_ssh, '/env/git/ssh')
 
-        Git.configure do |config|
-          config.binary_path = '/usr/bin/git'
-          config.git_ssh = '/path/to/ssh/script'
-        end
+      Git.configure do |config|
+        config.binary_path = '/usr/bin/git'
+        config.git_ssh = '/path/to/ssh/script'
+      end
 
-        assert_equal(Git::Base.config.binary_path, '/usr/bin/git')
-        assert_equal(Git::Base.config.git_ssh, '/path/to/ssh/script')
+      assert_equal(Git::Base.config.binary_path, '/usr/bin/git')
+      assert_equal(Git::Base.config.git_ssh, '/path/to/ssh/script')
 
-        @git.log
-      ensure
-        ENV['GIT_SSH'] = nil
-        ENV['GIT_PATH'] = nil
+      @git.log
+    ensure
+      ENV['GIT_SSH'] = nil
+      ENV['GIT_PATH'] = nil
 
-        Git.configure do |config|
-          config.binary_path = nil
-          config.git_ssh = nil
-        end
+      Git.configure do |config|
+        config.binary_path = nil
+        config.git_ssh = nil
       end
     end
   end

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -91,13 +91,14 @@ class TestLib < Test::Unit::TestCase
     assert(@lib.reset(nil, hard: true)) # to get around worktree status on windows
 
     actual_cmd = nil
-    @lib.define_singleton_method(:run_command) do |git_cmd, &block|
-      actual_cmd = git_cmd
-      super(git_cmd, &block)
+    @lib.define_singleton_method(:command) do |cmd, *options|
+      actual_cmd = [cmd, *options].flatten
+      super(cmd, *options)
     end
 
     assert(@lib.checkout('test_checkout_b2', {new_branch: true, start_point: 'master'}))
-    assert_match(%r/checkout ['"]-b['"] ['"]test_checkout_b2['"] ['"]master['"]/, actual_cmd)
+
+    assert_equal(['checkout', '-b', 'test_checkout_b2', 'master'], actual_cmd)
   end
 
   # takes parameters, returns array of appropriate commit objects
@@ -127,41 +128,27 @@ class TestLib < Test::Unit::TestCase
     assert_equal(20, a.size)
   end
 
-  def test_environment_reset
-    with_custom_env_variables do
-      ENV['GIT_DIR'] = '/my/git/dir'
-      ENV['GIT_WORK_TREE'] = '/my/work/tree'
-      ENV['GIT_INDEX_FILE'] = 'my_index'
-
-      @lib.log_commits :count => 10
-
-      assert_equal(ENV['GIT_DIR'], '/my/git/dir')
-      assert_equal(ENV['GIT_WORK_TREE'], '/my/work/tree')
-      assert_equal(ENV['GIT_INDEX_FILE'],'my_index')
-    end
-  end
-
   def test_git_ssh_from_environment_is_passed_to_binary
-    with_custom_env_variables do
-      begin
-        Dir.mktmpdir do |dir|
-          output_path = File.join(dir, 'git_ssh_value')
-          binary_path = File.join(dir, 'git.bat') # .bat so it works in Windows too
-          Git::Base.config.binary_path = binary_path
-          File.open(binary_path, 'w') { |f|
-            f << "echo \"my/git-ssh-wrapper\" > #{output_path}"
-          }
-          FileUtils.chmod(0700, binary_path)
-          @lib.checkout('something')
-          assert(File.read(output_path).include?("my/git-ssh-wrapper"))
-        end
-      ensure
-        Git.configure do |config|
-          config.binary_path = nil
-          config.git_ssh = nil
-        end
-      end
+    saved_binary_path = Git::Base.config.binary_path
+    saved_git_ssh = Git::Base.config.git_ssh
+
+    Dir.mktmpdir do |dir|
+      output_path = File.join(dir, 'git_ssh_value')
+      binary_path = File.join(dir, 'my_own_git.bat') # .bat so it works in Windows too
+      Git::Base.config.binary_path = binary_path
+      Git::Base.config.git_ssh = 'GIT_SSH_VALUE'
+      File.write(binary_path, <<~SCRIPT)
+        #!/bin/sh
+        set > "#{output_path}"
+      SCRIPT
+      FileUtils.chmod(0700, binary_path)
+      @lib.checkout('something')
+      env = File.read(output_path)
+      assert_match(/^GIT_SSH=(["']?)GIT_SSH_VALUE\1$/, env, 'GIT_SSH should be set in the environment')
     end
+  ensure
+    Git::Base.config.binary_path = saved_binary_path
+    Git::Base.config.git_ssh = saved_git_ssh
   end
 
   def test_revparse

--- a/tests/units/test_logger.rb
+++ b/tests/units/test_logger.rb
@@ -28,10 +28,10 @@ class TestLogger < Test::Unit::TestCase
 
     logc = File.read(log.path)
 
-    expected_log_entry = /INFO -- : git (?<global_options>.*?) branch ['"]-a['"]/
+    expected_log_entry = /INFO -- : .*git.*branch.*-a/
     assert_match(expected_log_entry, logc, missing_log_entry)
 
-    expected_log_entry = /DEBUG -- :   cherry/
+    expected_log_entry = /DEBUG -- : stdout:   cherry/
     assert_match(expected_log_entry, logc, missing_log_entry)
   end
 
@@ -46,7 +46,7 @@ class TestLogger < Test::Unit::TestCase
 
     logc = File.read(log.path)
 
-    expected_log_entry = /INFO -- : git (?<global_options>.*?) branch ['"]-a['"]/
+    expected_log_entry = /INFO -- : .*git.*branch.*-a/
     assert_match(expected_log_entry, logc, missing_log_entry)
 
     expected_log_entry = /DEBUG -- :   cherry/

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -123,28 +123,28 @@ class TestRemotes < Test::Unit::TestCase
     expected_command_line = ['fetch', '--', 'origin']
     git_cmd = :fetch
     git_cmd_args = []
-    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args, method: :command_merged_output)
   end
 
   def test_fetch_cmd_with_origin_and_branch
     expected_command_line = ['fetch', '--depth', '2', '--', 'origin', 'master']
     git_cmd = :fetch
     git_cmd_args = ['origin', ref: 'master', depth: '2']
-    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args, method: :command_merged_output)
   end
 
   def test_fetch_cmd_with_all
     expected_command_line = ['fetch', '--all']
     git_cmd = :fetch
     git_cmd_args = [all: true]
-    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args, method: :command_merged_output)
   end
 
   def test_fetch_cmd_with_all_with_other_args
     expected_command_line = ['fetch', '--all', '--force', '--depth', '2']
     git_cmd = :fetch
     git_cmd_args = [all: true, force: true, depth: '2']
-    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args, method: :command_merged_output)
   end
 
   def test_fetch_command_injection


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

## Description

In the current implementation, all calls to `git` are done using backticks which has several disadvantages:
* STDERR is not captured so can not be processed by this gem
* STDERR is always passed through to the terminal
* Changes to the environment's subprocess have to be global which could impact users of this gem
* Arguments passed on the command line go through the system shell making it difficult to escape args correctly for all platforms AND leaving this gem open to security vulnerabilities

## Desired Result

Implement a cross platform (Windows, Linux, and Mac) solution that can:
* Independently capture STDOUT and STDERR
* Stream STDOUT and STDERR to the terminal if needed for debugging
* Provide a customized environment for the `git` command that does not impact users of this gem
* Pass command line args to the `git` command without being interpreted by the system shell

