### PR TITLE
Add start_point option for checkout command

### DIFF
--- a/README.md
+++ b/README.md
@@ -265,6 +265,7 @@ g.branch('existing_branch').checkout
 g.branch('master').contains?('existing_branch')
 
 g.checkout('new_branch')
+g.checkout('new_branch', new_branch: true, start_point: 'master')
 g.checkout(g.branch('new_branch'))
 
 g.branch(name).merge(branch2)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -764,11 +764,21 @@ module Git
       command('branch', '-D', branch)
     end
 
+    # Runs checkout command to checkout or create branch
+    #
+    # accepts options:
+    #  :new_branch
+    #  :force
+    #  :start_point
+    #
+    # @param [String] branch
+    # @param [Hash] opts
     def checkout(branch, opts = {})
       arr_opts = []
       arr_opts << '-b' if opts[:new_branch] || opts[:b]
       arr_opts << '--force' if opts[:force] || opts[:f]
       arr_opts << branch
+      arr_opts << opts[:start_point] if opts[:start_point] && arr_opts.include?('-b')
 
       command('checkout', arr_opts)
     end

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -87,6 +87,19 @@ class TestLib < Test::Unit::TestCase
     assert(@lib.checkout('master'))
   end
 
+  def test_checkout_with_start_point
+    assert(@lib.reset(nil, hard: true)) # to get around worktree status on windows
+
+    actual_cmd = nil
+    @lib.define_singleton_method(:run_command) do |git_cmd, &block|
+      actual_cmd = git_cmd
+      super(git_cmd, &block)
+    end
+
+    assert(@lib.checkout('test_checkout_b2', {new_branch: true, start_point: 'master'}))
+    assert_match(%r/checkout ['"]-b['"] ['"]test_checkout_b2['"] ['"]master['"]/, actual_cmd)
+  end
+
   # takes parameters, returns array of appropriate commit objects
   # :count
   # :since


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
This adds support for `start-point` git option when creating a new branch during checkout.
Fixes https://github.com/ruby-git/ruby-git/issues/249
