### PR TITLE
Branch-related bugfixes

### DIFF
--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -78,7 +78,11 @@ module Git
     end
     
     def update_ref(commit)
-      @base.lib.update_ref(@full, commit)
+      if @remote
+        @base.lib.update_ref("refs/remotes/#{@remote.name}/#{@name}", commit)
+      else
+        @base.lib.update_ref("refs/heads/#{@name}", commit)
+      end
     end
     
     def to_a
@@ -114,7 +118,7 @@ module Git
       # param [String] name branch full name.
       # return [<Git::Remote,NilClass,String>] an Array containing the remote and branch names. 
       def parse_name(name)
-        if name.match(/^(?:remotes)?\/([^\/]+)\/(.+)/)
+        if name.match(/^(?:remotes\/)?([^\/]+)\/(.+)/)
           return [Git::Remote.new(@base, $1), $2]
         end
 

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -974,8 +974,8 @@ module Git
       command('commit-tree', *arr_opts, redirect: "< #{escape t.path}")
     end
 
-    def update_ref(branch, commit)
-      command('update-ref', branch, commit)
+    def update_ref(ref, commit)
+      command('update-ref', ref, commit)
     end
 
     def checkout_index(opts = {})


### PR DESCRIPTION
Fixes both ruby-git#599 and ruby-git#600

Also fixes argument name of update_ref.  I'm assuming it's supposed to be analogous to the command line `git update-ref`, which doesn't directly use a branch name.

Signed-off-by: Matt Blythe <mblythester+git@gmail.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [N/A] Ensure that your contributions contain documentation if applicable.

### Description
Fixes for #599 and #600
