### PR TITLE
In ls-files do not unescape file paths with eval

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -488,7 +488,9 @@ module Git
       command_lines('ls-files', '--stage', location).each do |line|
         (info, file) = line.split("\t")
         (mode, sha, stage) = info.split
-        file = eval(file) if file =~ /^\".*\"$/ # This takes care of quoted strings returned from git
+        if file.start_with?('"') && file.end_with?('"')
+          file = Git::EscapedPath.new(file[1..-2]).unescape
+        end
         hsh[file] = {:path => file, :mode_index => mode, :sha_index => sha, :stage => stage}
       end
       hsh

--- a/tests/units/test_ls_files_with_escaped_path.rb
+++ b/tests/units/test_ls_files_with_escaped_path.rb
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+# encoding: utf-8
+
+require File.dirname(__FILE__) + '/../test_helper'
+
+# Test diff when the file path has to be quoted according to core.quotePath
+# See https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath
+#
+class TestLsFilesWithEscapedPath < Test::Unit::TestCase
+  def test_diff_with_non_ascii_filename
+    in_temp_dir do |path|
+      create_file('my_other_file_☠', "First Line\n")
+      create_file('README.md', '# My Project')
+      `git init`
+      `git add .`
+      `git config --local core.safecrlf false` if Gem.win_platform?
+      `git commit -m "First Commit"`
+      paths = Git.open('.').ls_files.keys.sort
+      assert_equal(["my_other_file_☠", 'README.md'].sort, paths)
+    end
+  end
+end


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
In `Lib#ls_files`, do not use `eval` to unescape paths. Instead, use `Git::EscapedPath` to unescape the path.