### PR TITLE
Fix version parsing

### DIFF
--- a/tests/units/test_lib_meets_required_version.rb
+++ b/tests/units/test_lib_meets_required_version.rb
@@ -21,4 +21,31 @@ class TestLibMeetsRequiredVersion < Test::Unit::TestCase
     lib.define_singleton_method(:current_command_version) { [major_version, minor_version] }
     assert !lib.meets_required_version?
   end
+
+  def test_parse_version
+    lib = Git::Lib.new(nil, nil)
+
+    versions_to_test = [
+      { version_string: 'git version 2.1', expected_result: [2, 1, 0] },
+      { version_string: 'git version 2.28.4', expected_result: [2, 28, 4] },
+      { version_string: 'git version 2.32.GIT', expected_result: [2, 32, 0] },
+    ]
+
+    lib.instance_variable_set(:@next_version_index, 0)
+
+    lib.define_singleton_method(:command) do |cmd, *opts, &block|
+      raise ArgumentError unless cmd == 'version'
+      versions_to_test[@next_version_index][:version_string].tap { @next_version_index += 1 }
+    end
+
+    lib.define_singleton_method(:next_version_index) { @next_version_index }
+
+    expected_version = versions_to_test[lib.next_version_index][:expected_result]
+    actual_version = lib.current_command_version
+    assert_equal(expected_version, actual_version)
+
+    expected_version = versions_to_test[lib.next_version_index][:expected_result]
+    actual_version = lib.current_command_version
+    assert_equal(expected_version, actual_version)
+  end
 end


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

FIXES #604 

If git was built from source, the version output from the `git version` command is as follows:

```shell
$ git version
git version 2.39.GIT
$
```

In this case, calling Git::Lib#current_command_version causes the following error whenever the a Git::Lib object is created:

```
../.local/share/gem/ruby/3.0.0/gems/git-1.13.0/lib/git/lib.rb:1034:in current_command_version': undefined method split' for nil:NilClass (NoMethodError)
```

This PR relaxes the requirement such that a version number of '2.39.GIT' returns a version array [2, 39, 0].

The following changes were made in this PR:

* Git::Lib.warn_if_old_command is no longer called when a Git::Lib object is created. Instead, it is called when a command is executed. This helps testing since a Git::Lib object can be created without calling an external command. This means that the message displayed on STDERR when your version of Git is too old is delayed until you explicitly try tot run a git command.
* The regex used to parse the output of `git version` was changed to require only two numeric version components and will pad the resulting version array with zeros.  For example, if `git version` outputs `git version 2.39.GIT`, then calling `Git::Lib#current_command_version` will return [2, 39, 0].
* Tests were added to test `Git::Lib#current_command_veresion`