### PR TITLE
Drop ruby-2.3 CI build and add ruby-3.1 and ruby-3.2 CI builds

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.3, 2.7, 3.0]
+        ruby: [2.7, 3.0, 3.1, 3.2]
         operating-system: [ubuntu-latest]
         include:
           - ruby: head


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
Drop the ruby-2.3 build from the GitHub actions build. Add ruby-3.1 and ruby3.2 builds.
