### PR TITLE
Update the GitHub Action step "actions/checkout" from v2 to v3

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -48,7 +48,7 @@ Steps:
 - Check out the code with `git clone https://github.com/ruby-git/ruby-git ruby-git-v1.6.0 && cd ruby-git-v1.6.0`
 - Install development dependencies using bundle `bundle install`
 - Based upon the nature of the changes, decide on the type of release: `major`, `minor`, or `patch` (in this example we will use `minor`)
-- Run the release script `bundle exec create-github-realese minor`
+- Run the release script `bundle exec create-github-release minor`
 
 ## Review and Merge the Release
 


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
This change removes the following build warning:

[Ruby 3.2 on ubuntu-latest](https://github.com/ruby-git/ruby-git/actions/runs/3906105562/jobs/6673899529)
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.