### PR TITLE
Release v1.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 # Change Log
 
+## v1.13.1 (2023-01-12)
+
+[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v1.13.0...v1.13.1)
+
+* 667b830 Update the GitHub Action step "actions/checkout" from v2 to v3 (#608)
+* 23a0ac4 Fix version parsing (#605)
+* 429f0bb Update release instructions (#606)
+* 68d76b8 Drop ruby 2.3 build and add 3.1 and 3.2 builds (#607)
+
 ## v1.13.0 (2022-12-10)
 
 [Full Changelog](https://github.com/ruby-git/ruby-git/compare/v1.12.0...v1.13.0)

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -1,5 +1,5 @@
 module Git
   # The current gem version
   # @return [String] the current gem version.
-  VERSION='1.13.0'
+  VERSION='1.13.1'
 end


### PR DESCRIPTION
## Change Log
[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v1.13.0...v1.13.1)

* 667b830 Update the GitHub Action step "actions/checkout" from v2 to v3 (#608)
* 23a0ac4 Fix version parsing (#605)
* 429f0bb Update release instructions (#606)
* 68d76b8 Drop ruby 2.3 build and add 3.1 and 3.2 builds (#607)