### PR TITLE
Simplify test execution

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,6 +81,18 @@ In order to ensure high quality, all pull requests must meet these requirements:
   * The entire test suite must pass when `bundle exec rake default` is run from the
     project's local working copy.
 
+While working on specific features you can run individual test files or
+a group of tests using `bin/test`:
+
+    # run a single file:
+    $ bin/test tests/units/test_object.rb
+
+    # run multiple files:
+    $ bin/test tests/units/test_object.rb tests/units/test_archive.rb
+
+    # run all unit tests:
+    $ bin/test
+
 ### Continuous integration
   * All tests must pass in the project's [GitHub Continuous Integration build](https://github.com/ruby-git/ruby-git/actions?query=workflow%3ACI)
     before the pull request will be merged.

--- a/Rakefile
+++ b/Rakefile
@@ -1,16 +1,20 @@
 require 'bundler/gem_tasks'
 require 'English'
 
-require "#{File.expand_path(File.dirname(__FILE__))}/lib/git/version"
+require 'git/version'
 
 default_tasks = []
 
 desc 'Run Unit Tests'
 task :test do
-  sh 'git config --global user.email "git@example.com"' if `git config user.email`.empty?
-  sh 'git config --global user.name "GitExample"' if `git config user.name`.empty?
+  sh 'ruby bin/test'
 
-  require File.dirname(__FILE__) + '/tests/all_tests.rb'
+  # You can run individual test files (or multiple files) from the command
+  # line with:
+  #
+  # $ bin/test tests/units/test_archive.rb
+  #
+  # $ bin/test tests/units/test_archive.rb tests/units/test_object.rb
 end
 default_tasks << :test
 

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,19 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require 'bundler/setup'
+
+`git config --global user.email "git@example.com"` if `git config user.email`.empty?
+`git config --global user.name "GitExample"` if `git config user.name`.empty?
+
+project_root = File.expand_path(File.join(__dir__, '..'))
+
+$LOAD_PATH.unshift(File.join(project_root, 'tests'))
+
+if ARGV.empty?
+  paths = Dir.glob(File.join(project_root, 'tests/**/test_*.rb'))
+else
+  paths = ARGV.map { |p| File.join(project_root, p) }
+end
+
+paths.each { |p| require p }

--- a/tests/all_tests.rb
+++ b/tests/all_tests.rb
@@ -1,8 +1,0 @@
-Dir.chdir(File.dirname(__FILE__)) do
-  Dir.glob('**/test_*.rb') do |test_case|
-    require "#{File.expand_path(File.dirname(__FILE__))}/#{test_case}"
-  end
-end
-
-# To run a single test:
-# require_relative 'units/test_lib_meets_required_version'

--- a/tests/units/test_archive.rb
+++ b/tests/units/test_archive.rb
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestArchive < Test::Unit::TestCase
 
   def setup
-    set_file_paths
+    clone_working_repo
     @git = Git.open(@wdir)
     @tempfiles = []
   end
@@ -56,13 +56,8 @@ class TestArchive < Test::Unit::TestCase
     assert_match(%r{test/}, lines[1])
     assert_match(%r{test/ex_dir/ex\.txt}, lines[3])
 
-    in_temp_dir do
-      c = Git.clone(@wbare, 'new')
-      c.chdir do
-        f = @git.remote('working').branch('master').archive(tempfile, :format => 'tgz')
-        assert(File.exist?(f))
-      end
-    end
+    f = @git.remote('working').branch('master').archive(tempfile, :format => 'tgz')
+    assert(File.exist?(f))
   end
 
 end

--- a/tests/units/test_bare.rb
+++ b/tests/units/test_bare.rb
@@ -1,12 +1,11 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestBare < Test::Unit::TestCase
 
   def setup
-    set_file_paths
-    @git = Git.bare(@wbare)
+    @git = Git.bare(BARE_REPO_PATH)
   end
 
   def test_commit

--- a/tests/units/test_base.rb
+++ b/tests/units/test_base.rb
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestBase < Test::Unit::TestCase
 
   def setup
-    set_file_paths
+    clone_working_repo
   end
 
   def test_add

--- a/tests/units/test_branch.rb
+++ b/tests/units/test_branch.rb
@@ -1,24 +1,24 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestBranch < Test::Unit::TestCase
   def setup
-    set_file_paths
+    clone_working_repo
     @git = Git.open(@wdir)
-    
+
     @commit = @git.object('1cc8667014381')
     @tree = @git.object('1cc8667014381^{tree}')
     @blob = @git.object('v2.5:example.txt')
-    
+
     @branches = @git.branches
   end
-  
+
   def test_branches_all
     assert(@git.branches[:master].is_a?(Git::Branch))
     assert(@git.branches.size > 5)
   end
-  
+
   def test_branches_local
     bs = @git.branches.local
     assert(bs.size > 4)
@@ -28,14 +28,14 @@ class TestBranch < Test::Unit::TestCase
     bs = @git.branches.remote
     assert_equal(1, bs.size)
   end
-  
+
   def test_branches_single
     branch = @git.branches[:test_object]
     assert_equal('test_object', branch.name)
 
     %w{working/master remotes/working/master}.each do |branch_name|
       branch = @git.branches[branch_name]
-     
+
       assert_equal('master', branch.name)
       assert_equal('remotes/working/master', branch.full)
       assert_equal('working', branch.remote.name)
@@ -43,7 +43,7 @@ class TestBranch < Test::Unit::TestCase
       assert_equal('../working.git', branch.remote.url)
     end
   end
-  
+
   def test_true_branch_contains?
     assert(@git.branch('git_grep').contains?('master'))
   end
@@ -55,52 +55,47 @@ class TestBranch < Test::Unit::TestCase
   def test_branch_commit
     assert_equal(270, @git.branches[:test_branches].gcommit.size)
   end
-  
+
   def test_branch_create_and_switch
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'branch_test')
-      Dir.chdir('branch_test') do
-        assert(!g.branch('new_branch').current)
-        g.branch('other_branch').create
-        assert(!g.branch('other_branch').current)
-        g.branch('new_branch').checkout
-        assert(g.branch('new_branch').current)
+    in_bare_repo_clone do |git|
+      assert(!git.branch('new_branch').current)
+      git.branch('other_branch').create
+      assert(!git.branch('other_branch').current)
+      git.branch('new_branch').checkout
+      assert(git.branch('new_branch').current)
 
-        assert_equal(1, g.branches.select { |b| b.name == 'new_branch' }.size)
+      assert_equal(1, git.branches.select { |b| b.name == 'new_branch' }.size)
 
-        new_file('test-file1', 'blahblahblah1')
-        new_file('test-file2', 'blahblahblah2')
-        new_file('.test-dot-file1', 'blahblahblahdot1')
-        assert(g.status.untracked.assoc('test-file1'))
-        assert(g.status.untracked.assoc('.test-dot-file1'))
-        
-        g.add(['test-file1', 'test-file2'])
-        assert(!g.status.untracked.assoc('test-file1'))
-        
-        g.reset
-        assert(g.status.untracked.assoc('test-file1'))
-        assert(!g.status.added.assoc('test-file1'))
+      new_file('test-file1', 'blahblahblah1')
+      new_file('test-file2', 'blahblahblah2')
+      new_file('.test-dot-file1', 'blahblahblahdot1')
+      assert(git.status.untracked.assoc('test-file1'))
+      assert(git.status.untracked.assoc('.test-dot-file1'))
 
-        assert_raise Git::GitExecuteError do
-          g.branch('new_branch').delete 
-        end
-        assert_equal(1, g.branches.select { |b| b.name == 'new_branch' }.size)
+      git.add(['test-file1', 'test-file2'])
+      assert(!git.status.untracked.assoc('test-file1'))
 
-        g.branch('master').checkout
-        g.branch('new_branch').delete
-        assert_equal(0, g.branches.select { |b| b.name == 'new_branch' }.size)
-        
-        g.checkout('other_branch')
-        assert(g.branch('other_branch').current)
+      git.reset
+      assert(git.status.untracked.assoc('test-file1'))
+      assert(!git.status.added.assoc('test-file1'))
 
-        g.checkout('master')
-        assert(!g.branch('other_branch').current)
-
-        g.checkout(g.branch('other_branch'))
-        assert(g.branch('other_branch').current)
-        
+      assert_raise Git::GitExecuteError do
+        git.branch('new_branch').delete
       end
+      assert_equal(1, git.branches.select { |b| b.name == 'new_branch' }.size)
+
+      git.branch('master').checkout
+      git.branch('new_branch').delete
+      assert_equal(0, git.branches.select { |b| b.name == 'new_branch' }.size)
+
+      git.checkout('other_branch')
+      assert(git.branch('other_branch').current)
+
+      git.checkout('master')
+      assert(!git.branch('other_branch').current)
+
+      git.checkout(@git.branch('other_branch'))
+      assert(git.branch('other_branch').current)
     end
   end
-  
 end

--- a/tests/units/test_commit_with_empty_message.rb
+++ b/tests/units/test_commit_with_empty_message.rb
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestCommitWithEmptyMessage < Test::Unit::TestCase
   def setup
-    set_file_paths
+    clone_working_repo
   end
 
   def test_without_allow_empty_message_option

--- a/tests/units/test_commit_with_gpg.rb
+++ b/tests/units/test_commit_with_gpg.rb
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestCommitWithGPG < Test::Unit::TestCase
   def setup
-    set_file_paths
+    clone_working_repo
   end
 
   def test_with_configured_gpg_keyid

--- a/tests/units/test_config.rb
+++ b/tests/units/test_config.rb
@@ -1,42 +1,38 @@
 #!/usr/bin/env ruby
 
-require_relative '../test_helper'
+require 'test_helper'
 
 class TestConfig < Test::Unit::TestCase
   def setup
-    set_file_paths
+    clone_working_repo
     @git = Git.open(@wdir)
   end
-  
+
   def test_config
     c = @git.config
     assert_equal('Scott Chacon', c['user.name'])
     assert_equal('false', c['core.bare'])
   end
-  
+
   def test_read_config
     assert_equal('Scott Chacon', @git.config('user.name'))
     assert_equal('false', @git.config('core.bare'))
   end
-  
+
   def test_set_config
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'bare')
-      assert_not_equal('bully', g.config('user.name'))
-      g.config('user.name', 'bully')
-      assert_equal('bully', g.config('user.name'))
-    end
+    assert_not_equal('bully', @git.config('user.name'))
+    @git.config('user.name', 'bully')
+    assert_equal('bully', @git.config('user.name'))
   end
 
   def test_set_config_with_custom_file
-    in_temp_dir do |_path|
-      custom_config_path = "#{Dir.pwd}/bare/.git/custom-config"
-      g = Git.clone(@wbare, 'bare')
-      assert_not_equal('bully', g.config('user.name'))
-      g.config('user.name', 'bully', file: custom_config_path)
-      assert_not_equal('bully', g.config('user.name'))
-      g.config('include.path', custom_config_path)
-      assert_equal('bully', g.config('user.name'))
+    Dir.chdir(@wdir) do
+      custom_config_path = "#{Dir.pwd}/.git/custom-config"
+      assert_not_equal('bully', @git.config('user.name'))
+      @git.config('user.name', 'bully', file: custom_config_path)
+      assert_not_equal('bully', @git.config('user.name'))
+      @git.config('include.path', custom_config_path)
+      assert_equal('bully', @git.config('user.name'))
       assert_equal("[user]\n\tname = bully\n", File.read(custom_config_path))
     end
   end

--- a/tests/units/test_config_module.rb
+++ b/tests/units/test_config_module.rb
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestConfigModule < Test::Unit::TestCase
   def setup
-    set_file_paths
+    clone_working_repo
     git_class = Class.new do
       include Git
     end
@@ -12,29 +12,26 @@ class TestConfigModule < Test::Unit::TestCase
     @old_dir = Dir.pwd
     Dir.chdir(@wdir)
   end
-  
+
   teardown
   def test_teardown
     Dir.chdir(@old_dir)
   end
-  
+
   def test_config
     c = @git.config
     assert_equal('Scott Chacon', c['user.name'])
     assert_equal('false', c['core.bare'])
   end
-  
+
   def test_read_config
     assert_equal('Scott Chacon', @git.config('user.name'))
     assert_equal('false', @git.config('core.bare'))
   end
-  
+
   def test_set_config
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'bare')
-      assert_not_equal('bully', g.config('user.name'))
-      g.config('user.name', 'bully')
-      assert_equal('bully', g.config('user.name'))
-    end
+    assert_not_equal('bully', @git.config('user.name'))
+    @git.config('user.name', 'bully')
+    assert_equal('bully', @git.config('user.name'))
   end
 end

--- a/tests/units/test_describe.rb
+++ b/tests/units/test_describe.rb
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestDescribe < Test::Unit::TestCase
 
   def setup
-    set_file_paths
+    clone_working_repo
     @git = Git.open(@wdir)
   end
 

--- a/tests/units/test_diff.rb
+++ b/tests/units/test_diff.rb
@@ -1,14 +1,14 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestDiff < Test::Unit::TestCase
   def setup
-    set_file_paths
+    clone_working_repo
     @git = Git.open(@wdir)
     @diff = @git.diff('gitsearch1', 'v2.5')
   end
-  
+
   #def test_diff
   #  g.diff
   #  assert(1, d.size)
@@ -30,7 +30,7 @@ class TestDiff < Test::Unit::TestCase
     assert_equal(64, d.insertions)
   end
 
-  # Patch files on diff outputs used to be parsed as 
+  # Patch files on diff outputs used to be parsed as
   # part of the diff adding invalid modificaction
   # to the diff results.
   def test_diff_patch
@@ -47,35 +47,35 @@ class TestDiff < Test::Unit::TestCase
     assert_equal(9, d.deletions)
     assert_equal(0, d.insertions)
   end
-  
+
   def test_diff_objects
     d = @git.diff('gitsearch1', @git.gtree('v2.5'))
     assert_equal(3, d.size)
   end
-  
+
   def test_object_diff
     d = @git.gtree('v2.5').diff('gitsearch1')
     assert_equal(3, d.size)
     assert_equal(74, d.lines)
     assert_equal(10, d.insertions)
     assert_equal(64, d.deletions)
-    
+
     d = @git.gtree('v2.6').diff(@git.gtree('gitsearch1'))
     assert_equal(2, d.size)
     assert_equal(9, d.lines)
   end
-  
+
   def test_diff_stats
     s = @diff.stats
     assert_equal(3, s[:total][:files])
     assert_equal(74, s[:total][:lines])
     assert_equal(10, s[:total][:deletions])
     assert_equal(64, s[:total][:insertions])
-    
+
     # per file
     assert_equal(1, s[:files]["scott/newfile"][:deletions])
   end
-  
+
   def test_diff_hashkey_default
     assert_equal('5d46068', @diff["scott/newfile"].src)
     assert_nil(@diff["scott/newfile"].blob(:dst))
@@ -83,7 +83,6 @@ class TestDiff < Test::Unit::TestCase
   end
 
   def test_diff_hashkey_min
-    set_file_paths
     git = Git.open(@wdir)
     git.config('core.abbrev', 4)
     diff = git.diff('gitsearch1', 'v2.5')
@@ -93,7 +92,6 @@ class TestDiff < Test::Unit::TestCase
   end
 
   def test_diff_hashkey_max
-    set_file_paths
     git = Git.open(@wdir)
     git.config('core.abbrev', 40)
     diff = git.diff('gitsearch1', 'v2.5')
@@ -101,24 +99,24 @@ class TestDiff < Test::Unit::TestCase
     assert_nil(diff["scott/newfile"].blob(:dst))
     assert(diff["scott/newfile"].blob(:src).is_a?(Git::Object::Blob))
   end
-  
+
   def test_patch
     p = @git.diff('v2.8^', 'v2.8').patch
     diff = "diff --git a/example.txt b/example.txt\nindex 1f09f2e..8dc79ae 100644\n--- a/example.txt\n+++ b/example.txt\n@@ -1 +1 @@\n-replace with new text\n+replace with new text - diff test"
     assert_equal(diff, p)
   end
-  
+
   def test_diff_each
     files = {}
     @diff.each do |d|
       files[d.path] = d
     end
-    
+
     assert(files['example.txt'])
     assert_equal('100644', files['scott/newfile'].mode)
     assert_equal('deleted', files['scott/newfile'].type)
     assert_equal(160, files['scott/newfile'].patch.size)
   end
-  
-  
+
+
 end

--- a/tests/units/test_diff_non_default_encoding.rb
+++ b/tests/units/test_diff_non_default_encoding.rb
@@ -1,31 +1,10 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestDiffWithNonDefaultEncoding < Test::Unit::TestCase
   def git_working_dir
-    cwd = FileUtils.pwd
-    if File.directory?(File.join(cwd, 'files'))
-      test_dir = File.join(cwd, 'files')
-    elsif File.directory?(File.join(cwd, '..', 'files'))
-      test_dir = File.join(cwd, '..', 'files')
-    elsif File.directory?(File.join(cwd, 'tests', 'files'))
-      test_dir = File.join(cwd, 'tests', 'files')
-    end
-
-    create_temp_repo(File.expand_path(File.join(test_dir, 'encoding')))
-  end
-
-  def create_temp_repo(clone_path)
-    filename = 'git_test' + Time.now.to_i.to_s + rand(300).to_s.rjust(3, '0')
-    @tmp_path = File.join("/tmp/", filename)
-    FileUtils.mkdir_p(@tmp_path)
-    FileUtils.cp_r(clone_path, @tmp_path)
-    tmp_path = File.join(@tmp_path, File.basename(clone_path))
-    Dir.chdir(tmp_path) do
-      FileUtils.mv('dot_git', '.git')
-    end
-    tmp_path
+    create_temp_repo('encoding')
   end
 
   def setup
@@ -60,4 +39,3 @@ class TestDiffWithNonDefaultEncoding < Test::Unit::TestCase
     assert(patch.include?(expected_patch))
   end
 end
-

--- a/tests/units/test_diff_with_escaped_path.rb
+++ b/tests/units/test_diff_with_escaped_path.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # encoding: utf-8
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 # Test diff when the file path has to be quoted according to core.quotePath
 # See https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath

--- a/tests/units/test_each_conflict.rb
+++ b/tests/units/test_each_conflict.rb
@@ -1,49 +1,37 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestEachConflict < Test::Unit::TestCase
-  
-  def setup
-    set_file_paths
-    #@git = Git.open(@wdir, :log => Logger.new(STDOUT))
-    @git = Git.open(@wdir)
-  end
-  
+
   def test_conflicts
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'branch_merge_test')
-      Dir.chdir('branch_merge_test') do
+    in_temp_repo('working') do
+      g = Git.open('.')
 
-        g.branch('new_branch').in_branch('test') do
-          new_file('example.txt', "1\n2\n3")
-          g.add
-          true
-        end
+      g.branch('new_branch').in_branch('test') do
+        new_file('example.txt', "1\n2\n3")
+        g.add
+        true
+      end
 
-        g.branch('new_branch2').in_branch('test') do
-          new_file('example.txt', "1\n4\n3")
-          g.add
-          true
-        end
+      g.branch('new_branch2').in_branch('test') do
+        new_file('example.txt', "1\n4\n3")
+        g.add
+        true
+      end
 
-        
-        g.merge('new_branch')
-        begin
-          g.merge('new_branch2')
-        rescue 
-        end
-        
-        g.each_conflict do |file, your, their|
-          assert_equal('example.txt', file)
-          assert_equal("1\n2\n3\n", File.read(your))
-          assert_equal("1\n4\n3\n", File.read(their))
-        end
-        
+
+      g.merge('new_branch')
+      begin
+        g.merge('new_branch2')
+      rescue
+      end
+
+      g.each_conflict do |file, your, their|
+        assert_equal('example.txt', file)
+        assert_equal("1\n2\n3\n", File.read(your))
+        assert_equal("1\n4\n3\n", File.read(their))
       end
     end
   end
-  
-  
-  
 end

--- a/tests/units/test_escaped_path.rb
+++ b/tests/units/test_escaped_path.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-require "#{File.dirname(__FILE__)}/../test_helper"
+require 'test_helper'
 
 # Test diff when the file path has escapes according to core.quotePath
 # See https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath

--- a/tests/units/test_git_clone.rb
+++ b/tests/units/test_git_clone.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'test/unit'
-require_relative '../test_helper'
+require 'test_helper'
 
 # Tests for Git.clone
 class TestGitClone < Test::Unit::TestCase

--- a/tests/units/test_git_dir.rb
+++ b/tests/units/test_git_dir.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestGitDir < Test::Unit::TestCase
   def test_index_calculated_from_git_dir

--- a/tests/units/test_git_path.rb
+++ b/tests/units/test_git_path.rb
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestGitPath < Test::Unit::TestCase
 
   def setup
-    set_file_paths
+    clone_working_repo
     @git = Git.open(@wdir)
   end
 

--- a/tests/units/test_index_ops.rb
+++ b/tests/units/test_index_ops.rb
@@ -1,168 +1,153 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestIndexOps < Test::Unit::TestCase
-  
-  def setup
-    set_file_paths
-    @git = Git.open(@wdir)
-  end
-  
+
   def test_add
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'new')
-      Dir.chdir('new') do
-        assert_equal('100644', g.status['example.txt'].mode_index)
-        
-        new_file('test-file', 'blahblahblah')
-        assert(g.status.untracked.assoc('test-file'))
-        
-        g.add
-        assert(g.status.added.assoc('test-file'))
-        assert(!g.status.untracked.assoc('test-file'))
-        assert(!g.status.changed.assoc('example.txt'))
-        
-        new_file('example.txt', 'hahahaha')
-        assert(g.status.changed.assoc('example.txt'))
-        
-        g.add
-        assert(g.status.changed.assoc('example.txt'))
-        
-        g.commit('my message')
-        assert(!g.status.changed.assoc('example.txt'))
-        assert(!g.status.added.assoc('test-file'))
-        assert(!g.status.untracked.assoc('test-file')) 
-        assert_equal('hahahaha', g.status['example.txt'].blob.contents)
-      end
+    in_bare_repo_clone do |g|
+      assert_equal('100644', g.status['example.txt'].mode_index)
+
+      new_file('test-file', 'blahblahblah')
+      assert(g.status.untracked.assoc('test-file'))
+
+      g.add
+      assert(g.status.added.assoc('test-file'))
+      assert(!g.status.untracked.assoc('test-file'))
+      assert(!g.status.changed.assoc('example.txt'))
+
+      new_file('example.txt', 'hahahaha')
+      assert(g.status.changed.assoc('example.txt'))
+
+      g.add
+      assert(g.status.changed.assoc('example.txt'))
+
+      g.commit('my message')
+      assert(!g.status.changed.assoc('example.txt'))
+      assert(!g.status.added.assoc('test-file'))
+      assert(!g.status.untracked.assoc('test-file'))
+      assert_equal('hahahaha', g.status['example.txt'].blob.contents)
     end
   end
 
   def test_clean
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'clean_me')
-      Dir.chdir('clean_me') do
-        new_file('test-file', 'blahblahbal')
-        new_file('ignored_file', 'ignored file contents')
-        new_file('.gitignore', 'ignored_file')
+    in_bare_repo_clone do
+      g = Git.open('.')
 
-        g.add
-        g.commit("first commit")
+      new_file('test-file', 'blahblahbal')
+      new_file('ignored_file', 'ignored file contents')
+      new_file('.gitignore', 'ignored_file')
 
-        FileUtils.mkdir_p("nested")
-        Dir.chdir('nested') do
-          Git.init
-        end
+      g.add
+      g.commit("first commit")
 
-        new_file('file-to-clean', 'blablahbla')
-        FileUtils.mkdir_p("dir_to_clean")
-
-        Dir.chdir('dir_to_clean') do
-          new_file('clean-me-too', 'blablahbla')
-        end
-
-        assert(File.exist?('file-to-clean'))
-        assert(File.exist?('dir_to_clean'))
-        assert(File.exist?('ignored_file'))
-
-        g.clean(:force => true)
-        
-        assert(!File.exist?('file-to-clean'))
-        assert(File.exist?('dir_to_clean'))
-        assert(File.exist?('ignored_file'))
-
-        new_file('file-to-clean', 'blablahbla')
-        
-        g.clean(:force => true, :d => true)
-
-        assert(!File.exist?('file-to-clean'))
-        assert(!File.exist?('dir_to_clean'))
-        assert(File.exist?('ignored_file'))
-
-        g.clean(:force => true, :x => true)
-        assert(!File.exist?('ignored_file'))
-
-        assert(File.exist?('nested'))
-
-        g.clean(:ff => true, :d => true)
-        assert(!File.exist?('nested'))
+      FileUtils.mkdir_p("nested")
+      Dir.chdir('nested') do
+        Git.init
       end
+
+      new_file('file-to-clean', 'blablahbla')
+      FileUtils.mkdir_p("dir_to_clean")
+
+      Dir.chdir('dir_to_clean') do
+        new_file('clean-me-too', 'blablahbla')
+      end
+
+      assert(File.exist?('file-to-clean'))
+      assert(File.exist?('dir_to_clean'))
+      assert(File.exist?('ignored_file'))
+
+      g.clean(:force => true)
+
+      assert(!File.exist?('file-to-clean'))
+      assert(File.exist?('dir_to_clean'))
+      assert(File.exist?('ignored_file'))
+
+      new_file('file-to-clean', 'blablahbla')
+
+      g.clean(:force => true, :d => true)
+
+      assert(!File.exist?('file-to-clean'))
+      assert(!File.exist?('dir_to_clean'))
+      assert(File.exist?('ignored_file'))
+
+      g.clean(:force => true, :x => true)
+      assert(!File.exist?('ignored_file'))
+
+      assert(File.exist?('nested'))
+
+      g.clean(:ff => true, :d => true)
+      assert(!File.exist?('nested'))
     end
   end
-  
+
   def test_revert
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'new')
-      Dir.chdir('new') do
-        new_file('test-file', 'blahblahbal')
-        g.add
-        g.commit("first commit")
-        first_commit = g.gcommit('HEAD')
+    in_bare_repo_clone do
+      g = Git.open('.')
 
-        new_file('test-file2', 'blablahbla')
-        g.add
-        g.commit("second-commit")
-        g.gcommit('HEAD')
+      new_file('test-file', 'blahblahbal')
+      g.add
+      g.commit("first commit")
+      first_commit = g.gcommit('HEAD')
 
-        commits = g.log(10000).count
-        g.revert(first_commit.sha)
-        assert_equal(commits + 1, g.log(10000).count)
-        assert(!File.exist?('test-file2'))
-      end
+      new_file('test-file2', 'blablahbla')
+      g.add
+      g.commit("second-commit")
+      g.gcommit('HEAD')
+
+      commits = g.log(10000).count
+      g.revert(first_commit.sha)
+      assert_equal(commits + 1, g.log(10000).count)
+      assert(!File.exist?('test-file2'))
     end
   end
 
   def test_add_array
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'new')
-      Dir.chdir('new') do
-        
-        new_file('test-file1', 'blahblahblah1')
-        new_file('test-file2', 'blahblahblah2')
-        assert(g.status.untracked.assoc('test-file1'))
-        
-        g.add(['test-file1', 'test-file2'])
-        assert(g.status.added.assoc('test-file1'))
-        assert(g.status.added.assoc('test-file1'))
-        assert(!g.status.untracked.assoc('test-file1'))
-                
-        g.commit('my message')
-        assert(!g.status.added.assoc('test-file1'))
-        assert(!g.status.untracked.assoc('test-file1')) 
-        assert_equal('blahblahblah1', g.status['test-file1'].blob.contents)
-      end
+    in_bare_repo_clone do
+      g = Git.open('.')
+
+      new_file('test-file1', 'blahblahblah1')
+      new_file('test-file2', 'blahblahblah2')
+      assert(g.status.untracked.assoc('test-file1'))
+
+      g.add(['test-file1', 'test-file2'])
+      assert(g.status.added.assoc('test-file1'))
+      assert(g.status.added.assoc('test-file1'))
+      assert(!g.status.untracked.assoc('test-file1'))
+
+      g.commit('my message')
+      assert(!g.status.added.assoc('test-file1'))
+      assert(!g.status.untracked.assoc('test-file1'))
+      assert_equal('blahblahblah1', g.status['test-file1'].blob.contents)
     end
   end
-  
+
   def test_remove
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'remove_test')
-      Dir.chdir('remove_test') do
-        assert(g.status['example.txt'])
-        g.remove('example.txt')
-        assert(g.status.deleted.assoc('example.txt')) 
-        g.commit('deleted file')
-        assert(!g.status['example.txt'])
-      end
+    in_bare_repo_clone do
+      g = Git.open('.')
+
+      assert(g.status['example.txt'])
+      g.remove('example.txt')
+      assert(g.status.deleted.assoc('example.txt'))
+      g.commit('deleted file')
+      assert(!g.status['example.txt'])
     end
   end
-  
+
   def test_reset
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'reset_test')
-      Dir.chdir('reset_test') do
-        new_file('test-file1', 'blahblahblah1')
-        new_file('test-file2', 'blahblahblah2')
-        assert(g.status.untracked.assoc('test-file1'))
-        
-        g.add(['test-file1', 'test-file2'])
-        assert(!g.status.untracked.assoc('test-file1'))
-        
-        g.reset
-        assert(g.status.untracked.assoc('test-file1'))
-        assert(!g.status.added.assoc('test-file1'))
-      end
+    in_bare_repo_clone do
+      g = Git.open('.')
+
+      new_file('test-file1', 'blahblahblah1')
+      new_file('test-file2', 'blahblahblah2')
+      assert(g.status.untracked.assoc('test-file1'))
+
+      g.add(['test-file1', 'test-file2'])
+      assert(!g.status.untracked.assoc('test-file1'))
+
+      g.reset
+      assert(g.status.untracked.assoc('test-file1'))
+      assert(!g.status.added.assoc('test-file1'))
     end
   end
-  
 end

--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -1,15 +1,12 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 require 'stringio'
 require 'logger'
 
 class TestInit < Test::Unit::TestCase
-  def setup
-    set_file_paths
-  end
-
   def test_open_simple
+    clone_working_repo
     g = Git.open(@wdir)
     assert_match(/^C?:?#{@wdir}$/, g.dir.path)
     assert_match(/^C?:?#{File.join(@wdir, '.git')}$/, g.repo.path)
@@ -17,14 +14,16 @@ class TestInit < Test::Unit::TestCase
   end
 
   def test_open_opts
-    g = Git.open @wdir, :repository => @wbare, :index => @index
-    assert_equal(g.repo.path, @wbare)
-    assert_equal(g.index.path, @index)
+    clone_working_repo
+    index = File.join(TEST_FIXTURES, 'index')
+    g = Git.open @wdir, :repository => BARE_REPO_PATH, :index => index
+    assert_equal(g.repo.path, BARE_REPO_PATH)
+    assert_equal(g.index.path, index)
   end
 
   def test_git_bare
-    g = Git.bare @wbare
-    assert_equal(g.repo.path, @wbare)
+    g = Git.bare BARE_REPO_PATH
+    assert_equal(g.repo.path, BARE_REPO_PATH)
   end
 
   #g = Git.init
@@ -76,7 +75,7 @@ class TestInit < Test::Unit::TestCase
 
   def test_git_clone
     in_temp_dir do |path|
-      g = Git.clone(@wbare, 'bare-co')
+      g = Git.clone(BARE_REPO_PATH, 'bare-co')
       assert(File.exist?(File.join(g.repo.path, 'config')))
       assert(g.dir)
     end
@@ -84,14 +83,14 @@ class TestInit < Test::Unit::TestCase
 
   def test_git_clone_with_branch
     in_temp_dir do |path|
-      g = Git.clone(@wbare, 'clone-branch', :branch => 'test')
+      g = Git.clone(BARE_REPO_PATH, 'clone-branch', :branch => 'test')
       assert_equal(g.current_branch, 'test')
     end
   end
 
   def test_git_clone_bare
     in_temp_dir do |path|
-      g = Git.clone(@wbare, 'bare.git', :bare => true)
+      g = Git.clone(BARE_REPO_PATH, 'bare.git', :bare => true)
       assert(File.exist?(File.join(g.repo.path, 'config')))
       assert_nil(g.dir)
     end
@@ -99,7 +98,7 @@ class TestInit < Test::Unit::TestCase
 
   def test_git_clone_mirror
     in_temp_dir do |path|
-      g = Git.clone(@wbare, 'bare.git', :mirror => true)
+      g = Git.clone(BARE_REPO_PATH, 'bare.git', :mirror => true)
       assert(File.exist?(File.join(g.repo.path, 'config')))
       assert_nil(g.dir)
     end
@@ -107,7 +106,7 @@ class TestInit < Test::Unit::TestCase
 
   def test_git_clone_config
     in_temp_dir do |path|
-      g = Git.clone(@wbare, 'config.git', :config => "receive.denyCurrentBranch=ignore")
+      g = Git.clone(BARE_REPO_PATH, 'config.git', :config => "receive.denyCurrentBranch=ignore")
       assert_equal('ignore', g.config['receive.denycurrentbranch'])
       assert(File.exist?(File.join(g.repo.path, 'config')))
       assert(g.dir)
@@ -119,7 +118,7 @@ class TestInit < Test::Unit::TestCase
   #
   def test_git_clone_without_log
     in_temp_dir do |path|
-      g = Git.clone(@wbare, 'bare-co')
+      g = Git.clone(BARE_REPO_PATH, 'bare-co')
       actual_logger = g.instance_variable_get(:@logger)
       assert_equal(nil, actual_logger)
     end
@@ -133,7 +132,7 @@ class TestInit < Test::Unit::TestCase
     expected_logger = Logger.new(log_io)
 
     in_temp_dir do |path|
-      g = Git.clone(@wbare, 'bare-co', { log: expected_logger })
+      g = Git.clone(BARE_REPO_PATH, 'bare-co', { log: expected_logger })
       actual_logger = g.instance_variable_get(:@logger)
       assert_equal(expected_logger.object_id, actual_logger.object_id)
 
@@ -147,7 +146,7 @@ class TestInit < Test::Unit::TestCase
   # trying to open a git project using a bare repo - rather than using Git.repo
   def test_git_open_error
     assert_raise ArgumentError do
-      Git.open @wbare
+      Git.open BARE_REPO_PATH
     end
   end
 

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 require "fileutils"
 
 # tests all the low level git communication
@@ -11,7 +11,7 @@ require "fileutils"
 
 class TestLib < Test::Unit::TestCase
   def setup
-    set_file_paths
+    clone_working_repo
     @lib = Git.open(@wdir).lib
   end
 
@@ -255,7 +255,7 @@ class TestLib < Test::Unit::TestCase
   def test_ls_remote
     in_temp_dir do |path|
       lib = Git::Lib.new
-      ls = lib.ls_remote(@wbare)
+      ls = lib.ls_remote(BARE_REPO_PATH)
 
       assert_equal(%w( gitsearch1 v2.5 v2.6 v2.7 v2.8 ), ls['tags'].keys.sort)
       assert_equal("935badc874edd62a8629aaf103418092c73f0a56", ls['tags']['gitsearch1'][:sha])
@@ -267,7 +267,7 @@ class TestLib < Test::Unit::TestCase
       assert_equal("5e392652a881999392c2757cf9b783c5d47b67f7", ls['head'][:sha])
       assert_equal(nil, ls['head'][:name])
 
-      ls = lib.ls_remote(@wbare, :refs => true)
+      ls = lib.ls_remote(BARE_REPO_PATH, :refs => true)
 
       assert_equal({}, ls['head']) # head is not a ref
       assert_equal(%w( gitsearch1 v2.5 v2.6 v2.7 v2.8 ), ls['tags'].keys.sort)

--- a/tests/units/test_lib_meets_required_version.rb
+++ b/tests/units/test_lib_meets_required_version.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestLibMeetsRequiredVersion < Test::Unit::TestCase
   def test_with_supported_command_version

--- a/tests/units/test_log.rb
+++ b/tests/units/test_log.rb
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 require 'logger'
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestLog < Test::Unit::TestCase
   def setup
-    set_file_paths
+    clone_working_repo
     #@git = Git.open(@wdir, :log => Logger.new(STDOUT))
     @git = Git.open(@wdir)
   end

--- a/tests/units/test_logger.rb
+++ b/tests/units/test_logger.rb
@@ -1,11 +1,11 @@
 #!/usr/bin/env ruby
 require 'logger'
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestLogger < Test::Unit::TestCase
 
   def setup
-    set_file_paths
+    clone_working_repo
   end
 
   def missing_log_entry

--- a/tests/units/test_ls_files_with_escaped_path.rb
+++ b/tests/units/test_ls_files_with_escaped_path.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # encoding: utf-8
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 # Test diff when the file path has to be quoted according to core.quotePath
 # See https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath

--- a/tests/units/test_merge.rb
+++ b/tests/units/test_merge.rb
@@ -1,162 +1,139 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestMerge < Test::Unit::TestCase
-  def setup
-    set_file_paths
-  end
-  
   def test_branch_and_merge
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'branch_merge_test')
-      Dir.chdir('branch_merge_test') do
-
-        g.branch('new_branch').in_branch('test') do
-          assert_equal('new_branch', g.current_branch)
-          new_file('new_file_1', 'hello')
-          new_file('new_file_2', 'hello')
-          g.add
-          true
-        end
-
-        assert_equal('master', g.current_branch)
-
-        new_file('new_file_3', 'hello')
+    in_bare_repo_clone do |g|
+      g.branch('new_branch').in_branch('test') do
+        assert_equal('new_branch', g.current_branch)
+        new_file('new_file_1', 'hello')
+        new_file('new_file_2', 'hello')
         g.add
-        
-        assert(!g.status['new_file_1'])  # file is not there
-        
-        assert(g.branch('new_branch').merge)
-        assert(g.status['new_file_1'])  # file has been merged in
+        true
       end
+
+      assert_equal('master', g.current_branch)
+
+      new_file('new_file_3', 'hello')
+      g.add
+
+      assert(!g.status['new_file_1'])  # file is not there
+
+      assert(g.branch('new_branch').merge)
+      assert(g.status['new_file_1'])  # file has been merged in
     end
   end
-  
+
   def test_branch_and_merge_two
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'branch_merge_test')
-      Dir.chdir('branch_merge_test') do
-
-        g.branch('new_branch').in_branch('test') do
-          assert_equal('new_branch', g.current_branch)
-          new_file('new_file_1', 'hello')
-          new_file('new_file_2', 'hello')
-          g.add
-          true
-        end
-
-        g.branch('new_branch2').in_branch('test') do
-          assert_equal('new_branch2', g.current_branch)
-          new_file('new_file_3', 'hello')
-          new_file('new_file_4', 'hello')
-          g.add
-          true
-        end
-
-        g.branch('new_branch').merge('new_branch2')
-        assert(!g.status['new_file_3'])  # still in master branch
-
-        g.branch('new_branch').checkout
-        assert(g.status['new_file_3'])  # file has been merged in
-        
-        g.branch('master').checkout
-        g.merge(g.branch('new_branch'))
-        assert(g.status['new_file_3'])  # file has been merged in
-        
+    in_bare_repo_clone do |g|
+      g.branch('new_branch').in_branch('test') do
+        assert_equal('new_branch', g.current_branch)
+        new_file('new_file_1', 'hello')
+        new_file('new_file_2', 'hello')
+        g.add
+        true
       end
+
+      g.branch('new_branch2').in_branch('test') do
+        assert_equal('new_branch2', g.current_branch)
+        new_file('new_file_3', 'hello')
+        new_file('new_file_4', 'hello')
+        g.add
+        true
+      end
+
+      g.branch('new_branch').merge('new_branch2')
+      assert(!g.status['new_file_3'])  # still in master branch
+
+      g.branch('new_branch').checkout
+      assert(g.status['new_file_3'])  # file has been merged in
+
+      g.branch('master').checkout
+      g.merge(g.branch('new_branch'))
+      assert(g.status['new_file_3'])  # file has been merged in
+
     end
   end
-  
+
   def test_branch_and_merge_multiple
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'branch_merge_test')
-      Dir.chdir('branch_merge_test') do
-
-        g.branch('new_branch').in_branch('test') do
-          assert_equal('new_branch', g.current_branch)
-          new_file('new_file_1', 'hello')
-          new_file('new_file_2', 'hello')
-          g.add
-          true
-        end
-
-        g.branch('new_branch2').in_branch('test') do
-          assert_equal('new_branch2', g.current_branch)
-          new_file('new_file_3', 'hello')
-          new_file('new_file_4', 'hello')
-          g.add
-          true
-        end
-
-        assert(!g.status['new_file_1'])  # still in master branch
-        assert(!g.status['new_file_3'])  # still in master branch
-
-        g.merge(['new_branch', 'new_branch2'])
-
-        assert(g.status['new_file_1'])  # file has been merged in
-        assert(g.status['new_file_3'])  # file has been merged in
-                
+    in_bare_repo_clone do |g|
+      g.branch('new_branch').in_branch('test') do
+        assert_equal('new_branch', g.current_branch)
+        new_file('new_file_1', 'hello')
+        new_file('new_file_2', 'hello')
+        g.add
+        true
       end
+
+      g.branch('new_branch2').in_branch('test') do
+        assert_equal('new_branch2', g.current_branch)
+        new_file('new_file_3', 'hello')
+        new_file('new_file_4', 'hello')
+        g.add
+        true
+      end
+
+      assert(!g.status['new_file_1'])  # still in master branch
+      assert(!g.status['new_file_3'])  # still in master branch
+
+      g.merge(['new_branch', 'new_branch2'])
+
+      assert(g.status['new_file_1'])  # file has been merged in
+      assert(g.status['new_file_3'])  # file has been merged in
+
     end
   end
-  
+
   def test_no_ff_merge
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'branch_merge_test')
-      Dir.chdir('branch_merge_test') do
-
-        g.branch('new_branch').in_branch('first commit message') do
-          new_file('new_file_1', 'hello')
-          g.add
-          true
-        end
-
-        g.branch('new_branch2').checkout
-        g.merge('new_branch', 'merge commit message') # ff merge
-        assert(g.status['new_file_1']) # file has been merged in
-        assert_equal('first commit message', g.log.first.message) # merge commit message was ignored
-
-        g.branch('new_branch').in_branch('second commit message') do
-          new_file('new_file_2', 'hello')
-          g.add
-          true
-        end
-
-        assert_equal('new_branch2', g.current_branch) # still in new_branch2 branch
-        g.merge('new_branch', 'merge commit message', no_ff: true) # no-ff merge
-        assert(g.status['new_file_2']) # file has been merged in
-        assert_equal('merge commit message', g.log.first.message)
+    in_bare_repo_clone do |g|
+      g.branch('new_branch').in_branch('first commit message') do
+        new_file('new_file_1', 'hello')
+        g.add
+        true
       end
+
+      g.branch('new_branch2').checkout
+      g.merge('new_branch', 'merge commit message') # ff merge
+      assert(g.status['new_file_1']) # file has been merged in
+      assert_equal('first commit message', g.log.first.message) # merge commit message was ignored
+
+      g.branch('new_branch').in_branch('second commit message') do
+        new_file('new_file_2', 'hello')
+        g.add
+        true
+      end
+
+      assert_equal('new_branch2', g.current_branch) # still in new_branch2 branch
+      g.merge('new_branch', 'merge commit message', no_ff: true) # no-ff merge
+      assert(g.status['new_file_2']) # file has been merged in
+      assert_equal('merge commit message', g.log.first.message)
     end
   end
 
   def test_merge_no_commit
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'branch_merge_test')
-      g.chdir do
-        g.branch('new_branch_1').in_branch('first commit message') do
-          new_file('new_file_1', 'foo')
-          g.add
-          true
-        end
-
-        g.branch('new_branch_2').in_branch('first commit message') do
-          new_file('new_file_2', 'bar')
-          g.add
-          true
-        end
-
-        g.checkout('new_branch_2')
-        before_merge = g.show
-        g.merge('new_branch_1', nil, no_commit: true)
-        # HEAD is the same as before.
-        assert_equal(before_merge, g.show)
-        # File has not been merged in.
-        status = g.status['new_file_1']
-        assert_equal('new_file_1', status.path)
-        assert_equal('A', status.type)
+    in_bare_repo_clone do |g|
+      g.branch('new_branch_1').in_branch('first commit message') do
+        new_file('new_file_1', 'foo')
+        g.add
+        true
       end
+
+      g.branch('new_branch_2').in_branch('first commit message') do
+        new_file('new_file_2', 'bar')
+        g.add
+        true
+      end
+
+      g.checkout('new_branch_2')
+      before_merge = g.show
+      g.merge('new_branch_1', nil, no_commit: true)
+      # HEAD is the same as before.
+      assert_equal(before_merge, g.show)
+      # File has not been merged in.
+      status = g.status['new_file_1']
+      assert_equal('new_file_1', status.path)
+      assert_equal('A', status.type)
     end
   end
 end

--- a/tests/units/test_merge_base.rb
+++ b/tests/units/test_merge_base.rb
@@ -1,131 +1,109 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestMergeBase < Test::Unit::TestCase
-  def setup
-    set_file_paths
-  end
-
   def test_branch_and_master_merge_base
-    in_temp_dir do |_path|
-      repo = Git.clone(@wbare, 'branch_merge_test')
-      Dir.chdir('branch_merge_test') do
-        true_ancestor_sha = repo.gcommit('master').sha
+    in_bare_repo_clone do |repo|
+      true_ancestor_sha = repo.gcommit('master').sha
 
-        add_commit(repo, 'new_branch')
-        add_commit(repo, 'master')
+      add_commit(repo, 'new_branch')
+      add_commit(repo, 'master')
 
-        ancestors = repo.merge_base('master', 'new_branch')
-        assert_equal(ancestors.size, 1) # there is only one true ancestor
-        assert_equal(ancestors.first.sha, true_ancestor_sha) # proper common ancestor
-      end
+      ancestors = repo.merge_base('master', 'new_branch')
+      assert_equal(ancestors.size, 1) # there is only one true ancestor
+      assert_equal(ancestors.first.sha, true_ancestor_sha) # proper common ancestor
     end
   end
 
   def test_branch_and_master_independent_merge_base
-    in_temp_dir do |_path|
-      repo = Git.clone(@wbare, 'branch_merge_test')
-      Dir.chdir('branch_merge_test') do
-        true_ancestor_sha = repo.gcommit('master').sha
+    in_bare_repo_clone do |repo|
+      true_ancestor_sha = repo.gcommit('master').sha
 
-        add_commit(repo, 'new_branch')
-        add_commit(repo, 'master')
+      add_commit(repo, 'new_branch')
+      add_commit(repo, 'master')
 
-        independent_commits = repo.merge_base(true_ancestor_sha, 'master', 'new_branch', independent: true)
-        assert_equal(independent_commits.size, 2) # both new master and a branch are unreachable from each other
-        true_independent_commits_shas = [repo.gcommit('master').sha, repo.gcommit('new_branch').sha]
-        assert_equal(independent_commits.map(&:sha).sort, true_independent_commits_shas.sort)
-      end
+      independent_commits = repo.merge_base(true_ancestor_sha, 'master', 'new_branch', independent: true)
+      assert_equal(independent_commits.size, 2) # both new master and a branch are unreachable from each other
+      true_independent_commits_shas = [repo.gcommit('master').sha, repo.gcommit('new_branch').sha]
+      assert_equal(independent_commits.map(&:sha).sort, true_independent_commits_shas.sort)
     end
   end
 
   def test_branch_and_master_fork_point_merge_base
-    in_temp_dir do |_path|
-      repo = Git.clone(@wbare, 'branch_merge_test')
-      Dir.chdir('branch_merge_test') do
-        add_commit(repo, 'master')
+    in_bare_repo_clone do |repo|
+      add_commit(repo, 'master')
 
-        true_ancestor_sha = repo.gcommit('master').sha
+      true_ancestor_sha = repo.gcommit('master').sha
 
-        add_commit(repo, 'new_branch')
+      add_commit(repo, 'new_branch')
 
-        repo.reset_hard(repo.gcommit('HEAD^'))
+      repo.reset_hard(repo.gcommit('HEAD^'))
 
-        add_commit(repo, 'master')
+      add_commit(repo, 'master')
 
-        ancestors = repo.merge_base('master', 'new_branch', fork_point: true)
-        assert_equal(ancestors.size, 1) # there is only one true ancestor
-        assert_equal(ancestors.first.sha, true_ancestor_sha) # proper common ancestor
-      end
+      ancestors = repo.merge_base('master', 'new_branch', fork_point: true)
+      assert_equal(ancestors.size, 1) # there is only one true ancestor
+      assert_equal(ancestors.first.sha, true_ancestor_sha) # proper common ancestor
     end
   end
 
   def test_branch_and_master_all_merge_base
-    in_temp_dir do |_path|
-      repo = Git.clone(@wbare, 'branch_merge_test')
-      Dir.chdir('branch_merge_test') do
-        add_commit(repo, 'new_branch_1')
+    in_bare_repo_clone do |repo|
+      add_commit(repo, 'new_branch_1')
 
-        first_commit_sha = repo.gcommit('new_branch_1').sha
+      first_commit_sha = repo.gcommit('new_branch_1').sha
 
-        add_commit(repo, 'new_branch_2')
+      add_commit(repo, 'new_branch_2')
 
-        second_commit_sha = repo.gcommit('new_branch_2').sha
+      second_commit_sha = repo.gcommit('new_branch_2').sha
 
-        repo.branch('new_branch_1').merge('new_branch_2')
-        repo.branch('new_branch_2').merge('new_branch_1^')
+      repo.branch('new_branch_1').merge('new_branch_2')
+      repo.branch('new_branch_2').merge('new_branch_1^')
 
-        add_commit(repo, 'new_branch_1')
-        add_commit(repo, 'new_branch_2')
+      add_commit(repo, 'new_branch_1')
+      add_commit(repo, 'new_branch_2')
 
-        true_ancestors_shas = [first_commit_sha, second_commit_sha]
+      true_ancestors_shas = [first_commit_sha, second_commit_sha]
 
-        ancestors = repo.merge_base('new_branch_1', 'new_branch_2')
-        assert_equal(ancestors.size, 1) # default behavior returns only one ancestor
-        assert(true_ancestors_shas.include?(ancestors.first.sha))
+      ancestors = repo.merge_base('new_branch_1', 'new_branch_2')
+      assert_equal(ancestors.size, 1) # default behavior returns only one ancestor
+      assert(true_ancestors_shas.include?(ancestors.first.sha))
 
-        all_ancestors = repo.merge_base('new_branch_1', 'new_branch_2', all: true)
-        assert_equal(all_ancestors.size, 2) # there are two best ancestors in such case
-        assert_equal(all_ancestors.map(&:sha).sort, true_ancestors_shas.sort)
-      end
+      all_ancestors = repo.merge_base('new_branch_1', 'new_branch_2', all: true)
+      assert_equal(all_ancestors.size, 2) # there are two best ancestors in such case
+      assert_equal(all_ancestors.map(&:sha).sort, true_ancestors_shas.sort)
     end
   end
 
   def test_branches_and_master_merge_base
-    in_temp_dir do |_path|
-      repo = Git.clone(@wbare, 'branch_merge_test')
-      Dir.chdir('branch_merge_test') do
-        add_commit(repo, 'new_branch_1')
-        add_commit(repo, 'master')
+    in_bare_repo_clone do |repo|
+      add_commit(repo, 'new_branch_1')
+      add_commit(repo, 'master')
 
-        non_octopus_ancestor_sha = repo.gcommit('master').sha
+      non_octopus_ancestor_sha = repo.gcommit('master').sha
 
-        add_commit(repo, 'new_branch_2')
-        add_commit(repo, 'master')
+      add_commit(repo, 'new_branch_2')
+      add_commit(repo, 'master')
 
-        ancestors = repo.merge_base('master', 'new_branch_1', 'new_branch_2')
-        assert_equal(ancestors.size, 1) # there is only one true ancestor
-        assert_equal(ancestors.first.sha, non_octopus_ancestor_sha) # proper common ancestor
-      end
+      ancestors = repo.merge_base('master', 'new_branch_1', 'new_branch_2')
+      assert_equal(ancestors.size, 1) # there is only one true ancestor
+      assert_equal(ancestors.first.sha, non_octopus_ancestor_sha) # proper common ancestor
     end
   end
 
   def test_branches_and_master_octopus_merge_base
-    in_temp_dir do |_path|
-      repo = Git.clone(@wbare, 'branch_merge_test')
-      Dir.chdir('branch_merge_test') do
-        true_ancestor_sha = repo.gcommit('master').sha
+    in_bare_repo_clone do |repo|
+      true_ancestor_sha = repo.gcommit('master').sha
 
-        add_commit(repo, 'new_branch_1')
-        add_commit(repo, 'master')
-        add_commit(repo, 'new_branch_2')
-        add_commit(repo, 'master')
+      add_commit(repo, 'new_branch_1')
+      add_commit(repo, 'master')
+      add_commit(repo, 'new_branch_2')
+      add_commit(repo, 'master')
 
-        ancestors = repo.merge_base('master', 'new_branch_1', 'new_branch_2', octopus: true)
-        assert_equal(ancestors.size, 1) # there is only one true ancestor
-        assert_equal(ancestors.first.sha, true_ancestor_sha) # proper common ancestor
-      end
+      ancestors = repo.merge_base('master', 'new_branch_1', 'new_branch_2', octopus: true)
+      assert_equal(ancestors.size, 1) # there is only one true ancestor
+      assert_equal(ancestors.first.sha, true_ancestor_sha) # proper common ancestor
     end
   end
 

--- a/tests/units/test_object.rb
+++ b/tests/units/test_object.rb
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestObject < Test::Unit::TestCase
   def setup
-    set_file_paths
+    clone_working_repo
     @git = Git.open(@wdir)
 
     @commit = @git.gcommit('1cc8667014381')

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -1,16 +1,12 @@
 #!/usr/bin/env ruby
 
-require_relative '../test_helper'
+require 'test_helper'
 
 class TestRemotes < Test::Unit::TestCase
-  def setup
-    set_file_paths
-  end
-
   def test_add_remote
     in_temp_dir do |path|
-      local = Git.clone(@wbare, 'local')
-      remote = Git.clone(@wbare, 'remote')
+      local = Git.clone(BARE_REPO_PATH, 'local')
+      remote = Git.clone(BARE_REPO_PATH, 'remote')
 
       local.add_remote('testremote', remote)
 
@@ -31,8 +27,8 @@ class TestRemotes < Test::Unit::TestCase
 
   def test_remove_remote_remove
     in_temp_dir do |path|
-      local = Git.clone(@wbare, 'local')
-      remote = Git.clone(@wbare, 'remote')
+      local = Git.clone(BARE_REPO_PATH, 'local')
+      remote = Git.clone(BARE_REPO_PATH, 'remote')
 
       local.add_remote('testremote', remote)
       local.remove_remote('testremote')
@@ -48,9 +44,9 @@ class TestRemotes < Test::Unit::TestCase
 
   def test_set_remote_url
     in_temp_dir do |path|
-      local = Git.clone(@wbare, 'local')
-      remote1 = Git.clone(@wbare, 'remote1')
-      remote2 = Git.clone(@wbare, 'remote2')
+      local = Git.clone(BARE_REPO_PATH, 'local')
+      remote1 = Git.clone(BARE_REPO_PATH, 'remote1')
+      remote2 = Git.clone(BARE_REPO_PATH, 'remote2')
 
       local.add_remote('testremote', remote1)
       local.set_remote_url('testremote', remote2)
@@ -63,8 +59,8 @@ class TestRemotes < Test::Unit::TestCase
 
   def test_remote_fun
     in_temp_dir do |path|
-      loc = Git.clone(@wbare, 'local')
-      rem = Git.clone(@wbare, 'remote')
+      loc = Git.clone(BARE_REPO_PATH, 'local')
+      rem = Git.clone(BARE_REPO_PATH, 'remote')
 
       r = loc.add_remote('testrem', rem)
 
@@ -98,8 +94,8 @@ class TestRemotes < Test::Unit::TestCase
 
   def test_fetch
     in_temp_dir do |path|
-      loc = Git.clone(@wbare, 'local')
-      rem = Git.clone(@wbare, 'remote')
+      loc = Git.clone(BARE_REPO_PATH, 'local')
+      rem = Git.clone(BARE_REPO_PATH, 'remote')
 
       r = loc.add_remote('testrem', rem)
 
@@ -172,8 +168,8 @@ class TestRemotes < Test::Unit::TestCase
 
   def test_fetch_ref_adds_ref_option
     in_temp_dir do |path|
-      loc = Git.clone(@wbare, 'local')
-      rem = Git.clone(@wbare, 'remote', :config => 'receive.denyCurrentBranch=ignore')
+      loc = Git.clone(BARE_REPO_PATH, 'local')
+      rem = Git.clone(BARE_REPO_PATH, 'remote', :config => 'receive.denyCurrentBranch=ignore')
       loc.add_remote('testrem', rem)
 
       loc.chdir do
@@ -200,8 +196,8 @@ class TestRemotes < Test::Unit::TestCase
 
   def test_push
     in_temp_dir do |path|
-      loc = Git.clone(@wbare, 'local')
-      rem = Git.clone(@wbare, 'remote', :config => 'receive.denyCurrentBranch=ignore')
+      loc = Git.clone(BARE_REPO_PATH, 'local')
+      rem = Git.clone(BARE_REPO_PATH, 'remote', :config => 'receive.denyCurrentBranch=ignore')
 
       loc.add_remote('testrem', rem)
 

--- a/tests/units/test_repack.rb
+++ b/tests/units/test_repack.rb
@@ -1,30 +1,22 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestRepack < Test::Unit::TestCase
-  def setup
-    set_file_paths
-  end
-  
   def test_repack
-    in_temp_dir do |path|
-      r1 = Git.clone(@wbare, 'repo1')
-        
+    in_bare_repo_clone do |r1|
+      new_file('new_file', 'new content')
 
-      r1.chdir do 
-        new_file('new_file', 'new content')
-      end
       r1.add
       r1.commit('my commit')
 
-      # see how big the repo is      
+      # see how big the repo is
       size1 = r1.repo_size
 
       r1.repack
-      
+
       # see how big the repo is now, should be smaller
-      assert(size1 > r1.repo_size)      
+      assert(size1 > r1.repo_size)
     end
   end
 end

--- a/tests/units/test_show.rb
+++ b/tests/units/test_show.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestShow < Test::Unit::TestCase
   def test_do_not_chomp_contents

--- a/tests/units/test_signed_commits.rb
+++ b/tests/units/test_signed_commits.rb
@@ -1,6 +1,6 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 require "fileutils"
 
 class TestSignedCommits < Test::Unit::TestCase

--- a/tests/units/test_stashes.rb
+++ b/tests/units/test_stashes.rb
@@ -1,58 +1,47 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestStashes < Test::Unit::TestCase
-  def setup
-    set_file_paths
-  end
-  
   def test_stash_unstash
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'stash_test')
-      Dir.chdir('stash_test') do
-        assert_equal(0, g.branch.stashes.size)
-        new_file('test-file1', 'blahblahblah1')
-        new_file('test-file2', 'blahblahblah2')
-        assert(g.status.untracked.assoc('test-file1'))
+    in_bare_repo_clone do |g|
+      assert_equal(0, g.branch.stashes.size)
+      new_file('test-file1', 'blahblahblah1')
+      new_file('test-file2', 'blahblahblah2')
+      assert(g.status.untracked.assoc('test-file1'))
 
-        g.add
+      g.add
 
-        assert(g.status.added.assoc('test-file1'))
-      
-        g.branch.stashes.save('testing')
-      
-        g.reset
-        assert_nil(g.status.untracked.assoc('test-file1'))
-        assert_nil(g.status.added.assoc('test-file1'))
+      assert(g.status.added.assoc('test-file1'))
 
-        g.branch.stashes.apply
+      g.branch.stashes.save('testing')
 
-        assert(g.status.added.assoc('test-file1'))
-      end
+      g.reset
+      assert_nil(g.status.untracked.assoc('test-file1'))
+      assert_nil(g.status.added.assoc('test-file1'))
+
+      g.branch.stashes.apply
+
+      assert(g.status.added.assoc('test-file1'))
     end
   end
 
   def test_stashes_all
-    in_temp_dir do |path|
-      g = Git.clone(@wbare, 'stash_test')
-      Dir.chdir('stash_test') do
-        assert_equal(0, g.branch.stashes.size)
-        new_file('test-file1', 'blahblahblah1')
-        new_file('test-file2', 'blahblahblah2')
-        assert(g.status.untracked.assoc('test-file1'))
+    in_bare_repo_clone do |g|
+      assert_equal(0, g.branch.stashes.size)
+      new_file('test-file1', 'blahblahblah1')
+      new_file('test-file2', 'blahblahblah2')
+      assert(g.status.untracked.assoc('test-file1'))
 
-        g.add
+      g.add
 
-        assert(g.status.added.assoc('test-file1'))
+      assert(g.status.added.assoc('test-file1'))
 
-        g.branch.stashes.save('testing-stash-all')
+      g.branch.stashes.save('testing-stash-all')
 
-        stashes = g.branch.stashes.all
+      stashes = g.branch.stashes.all
 
-        assert(stashes[0].include?('testing-stash-all'))
-      end
+      assert(stashes[0].include?('testing-stash-all'))
     end
   end
-  
 end

--- a/tests/units/test_status.rb
+++ b/tests/units/test_status.rb
@@ -1,12 +1,12 @@
 
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestStatus < Test::Unit::TestCase
 
   def setup
-    set_file_paths
+    clone_working_repo
   end
 
   def test_status_pretty

--- a/tests/units/test_tags.rb
+++ b/tests/units/test_tags.rb
@@ -1,48 +1,44 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestTags < Test::Unit::TestCase
-  def setup
-    set_file_paths
-  end
-  
   def test_tags
     in_temp_dir do |path|
-      r1 = Git.clone(@wbare, 'repo1')
-      r2 = Git.clone(@wbare, 'repo2')
+      r1 = Git.clone(BARE_REPO_PATH, 'repo1')
+      r2 = Git.clone(BARE_REPO_PATH, 'repo2')
       r1.config('user.name', 'Test User')
       r1.config('user.email', 'test@email.com')
       r2.config('user.name', 'Test User')
       r2.config('user.email', 'test@email.com')
-        
+
       assert_raise Git::GitTagNameDoesNotExist do
         r1.tag('first')
       end
-      
+
       r1.add_tag('first')
-      r1.chdir do 
+      r1.chdir do
         new_file('new_file', 'new content')
       end
       r1.add
       r1.commit('my commit')
       r1.add_tag('second')
-      
+
       assert(r1.tags.any?{|t| t.name == 'first'})
-      
+
       r2.add_tag('third')
-      
+
       assert(r2.tags.any?{|t| t.name == 'third'})
       assert(r2.tags.none?{|t| t.name == 'second'})
-      
+
       assert_raise RuntimeError do
         r2.add_tag('fourth', {:a => true})
       end
-        
+
       r2.add_tag('fourth', {:a => true, :m => 'test message'})
 
       assert(r2.tags.any?{|t| t.name == 'fourth'})
-      
+
       r2.add_tag('fifth', r2.tags.detect{|t| t.name == 'third'}.objectish)
 
       assert(r2.tags.detect{|t| t.name == 'third'}.objectish == r2.tags.detect{|t| t.name == 'fifth'}.objectish)
@@ -52,9 +48,9 @@ class TestTags < Test::Unit::TestCase
       end
 
       r2.add_tag('third', {:f => true})
-      
+
       r2.delete_tag('third')
-      
+
       assert_raise Git::GitTagNameDoesNotExist do
         r2.tag('third')
       end
@@ -75,8 +71,7 @@ class TestTags < Test::Unit::TestCase
   end
 
   def test_tag_message_not_prefixed_with_space
-    in_temp_dir do |path|
-      repo = Git.clone(@wbare, 'repo1')
+    in_bare_repo_clone do |repo|
       repo.add_tag('donkey', :annotated => true, :message => 'hello')
       tag = repo.tag('donkey')
       assert_equal(tag.message, 'hello')

--- a/tests/units/test_thread_safety.rb
+++ b/tests/units/test_thread_safety.rb
@@ -1,10 +1,10 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestThreadSafety < Test::Unit::TestCase
   def setup
-    set_file_paths
+    clone_working_repo
   end
 
   def test_git_init_bare

--- a/tests/units/test_tree_ops.rb
+++ b/tests/units/test_tree_ops.rb
@@ -1,128 +1,117 @@
 #!/usr/bin/env ruby
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 class TestTreeOps < Test::Unit::TestCase
 
-  def setup
-    set_file_paths
-    @git = Git.open(@wdir)
-  end
-  
   def test_read_tree
-    
-    in_temp_dir do
-      g = Git.clone(@wbare, 'test')
+    in_bare_repo_clone do |g|
+      g.branch('testbranch1').in_branch('tb commit 1') do
+        new_file('test-file1', 'blahblahblah2')
+        g.add
+        true
+      end
 
-      g.chdir do
-        g.branch('testbranch1').in_branch('tb commit 1') do
-          new_file('test-file1', 'blahblahblah2')
-          g.add
-          true          
-        end
+      g.branch('testbranch2').in_branch('tb commit 2') do
+        new_file('test-file2', 'blahblahblah3')
+        g.add
+        true
+      end
 
-        g.branch('testbranch2').in_branch('tb commit 2') do
-          new_file('test-file2', 'blahblahblah3')
-          g.add
-          true          
-        end
+      g.branch('testbranch3').in_branch('tb commit 3') do
+        new_file('test-file3', 'blahblahblah4')
+        g.add
+        true
+      end
 
-        g.branch('testbranch3').in_branch('tb commit 3') do
-          new_file('test-file3', 'blahblahblah4')
-          g.add
-          true          
-        end
-    
-        # test some read-trees
+      # test some read-trees
+      tr = g.with_temp_index do
+        g.read_tree('testbranch1')
+        g.read_tree('testbranch2', :prefix => 'b2/')
+        g.read_tree('testbranch3', :prefix => 'b2/b3/')
+        index = g.ls_files
+        assert(index['b2/test-file2'])
+        assert(index['b2/b3/test-file3'])
+        g.write_tree
+      end
+
+      assert_equal('2423ef1b38b3a140bbebf625ba024189c872e08b', tr)
+
+      # only prefixed read-trees
+      tr = g.with_temp_index do
+        g.add  # add whats in our working tree
+        g.read_tree('testbranch1', :prefix => 'b1/')
+        g.read_tree('testbranch3', :prefix => 'b2/b3/')
+        index = g.ls_files
+        assert(index['example.txt'])
+        assert(index['b1/test-file1'])
+        assert(!index['b2/test-file2'])
+        assert(index['b2/b3/test-file3'])
+        g.write_tree
+      end
+
+      assert_equal('aa7349e1cdaf4b85cc6a6a0cf4f9b3f24879fa42', tr)
+
+      # new working directory too
+      tr = nil
+      g.with_temp_working do
         tr = g.with_temp_index do
-          g.read_tree('testbranch1')
-          g.read_tree('testbranch2', :prefix => 'b2/')
-          g.read_tree('testbranch3', :prefix => 'b2/b3/')
-          index = g.ls_files
-          assert(index['b2/test-file2'])
-          assert(index['b2/b3/test-file3'])
-          g.write_tree
-        end
-
-        assert_equal('2423ef1b38b3a140bbebf625ba024189c872e08b', tr)
-              
-        # only prefixed read-trees
-        tr = g.with_temp_index do
-          g.add  # add whats in our working tree
+          begin
+            g.add
+          rescue Exception => e
+            # Adding nothig is now validd on Git 1.7.x
+            # If an error ocurres (Git 1.6.x) it MUST rise Git::GitExecuteError
+            assert_equal(e.class, Git::GitExecuteError)
+          end
           g.read_tree('testbranch1', :prefix => 'b1/')
-          g.read_tree('testbranch3', :prefix => 'b2/b3/')
+          g.read_tree('testbranch3', :prefix => 'b1/b3/')
           index = g.ls_files
-          assert(index['example.txt'])
+          assert(!index['example.txt'])
           assert(index['b1/test-file1'])
           assert(!index['b2/test-file2'])
-          assert(index['b2/b3/test-file3'])
+          assert(index['b1/b3/test-file3'])
           g.write_tree
         end
-
-        assert_equal('aa7349e1cdaf4b85cc6a6a0cf4f9b3f24879fa42', tr)
-        
-        # new working directory too
-        tr = nil
-        g.with_temp_working do
-          tr = g.with_temp_index do
-            begin 
-              g.add
-            rescue Exception => e
-              # Adding nothig is now validd on Git 1.7.x
-              # If an error ocurres (Git 1.6.x) it MUST rise Git::GitExecuteError
-              assert_equal(e.class, Git::GitExecuteError)
-            end
-            g.read_tree('testbranch1', :prefix => 'b1/')
-            g.read_tree('testbranch3', :prefix => 'b1/b3/')
-            index = g.ls_files
-            assert(!index['example.txt'])
-            assert(index['b1/test-file1'])
-            assert(!index['b2/test-file2'])
-            assert(index['b1/b3/test-file3'])
-            g.write_tree
-          end
-          assert_equal('b40f7a9072cdec637725700668f8fdebe39e6d38', tr)
-        end
-        
-        c = g.commit_tree(tr, :parents => 'HEAD')
-        assert(c.commit?)
-        assert_equal('b40f7a9072cdec637725700668f8fdebe39e6d38', c.gtree.sha)
-        
-        tmp = Tempfile.new('tesxt')
-        tmppath = tmp.path
-        tmp.close
-        tmp.unlink
-        
-        g.with_index(tmppath) do
-          g.read_tree('testbranch1', :prefix => 'b1/')
-          g.read_tree('testbranch3', :prefix => 'b3/')
-          index = g.ls_files
-          assert(!index['b2/test-file2'])
-          assert(index['b3/test-file3'])
-          g.commit('hi')
-        end
-
-        assert(c.commit?)
-
-        files = g.ls_files
-        assert(!files['b1/example.txt'])
-        
-        g.branch('newbranch').update_ref(c)        
-        g.checkout('newbranch')
-        assert(!files['b1/example.txt'])
-        
-        assert_equal('b40f7a9072cdec637725700668f8fdebe39e6d38', c.gtree.sha)
-        
-        g.with_temp_working do 
-          assert(!File.directory?('b1'))
-          g.checkout_index
-          assert(!File.directory?('b1'))
-          g.checkout_index(:all => true)
-          assert(File.directory?('b1'))
-        end
-        
+        assert_equal('b40f7a9072cdec637725700668f8fdebe39e6d38', tr)
       end
+
+      c = g.commit_tree(tr, :parents => 'HEAD')
+      assert(c.commit?)
+      assert_equal('b40f7a9072cdec637725700668f8fdebe39e6d38', c.gtree.sha)
+
+      tmp = Tempfile.new('tesxt')
+      tmppath = tmp.path
+      tmp.close
+      tmp.unlink
+
+      g.with_index(tmppath) do
+        g.read_tree('testbranch1', :prefix => 'b1/')
+        g.read_tree('testbranch3', :prefix => 'b3/')
+        index = g.ls_files
+        assert(!index['b2/test-file2'])
+        assert(index['b3/test-file3'])
+        g.commit('hi')
+      end
+
+      assert(c.commit?)
+
+      files = g.ls_files
+      assert(!files['b1/example.txt'])
+
+      g.branch('newbranch').update_ref(c)
+      g.checkout('newbranch')
+      assert(!files['b1/example.txt'])
+
+      assert_equal('b40f7a9072cdec637725700668f8fdebe39e6d38', c.gtree.sha)
+
+      g.with_temp_working do
+        assert(!File.directory?('b1'))
+        g.checkout_index
+        assert(!File.directory?('b1'))
+        g.checkout_index(:all => true)
+        assert(File.directory?('b1'))
+      end
+
     end
   end
-
 end

--- a/tests/units/test_windows_cmd_escaping.rb
+++ b/tests/units/test_windows_cmd_escaping.rb
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # encoding: utf-8
 
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 # Test diff when the file path has to be quoted according to core.quotePath
 # See https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath

--- a/tests/units/test_worktree.rb
+++ b/tests/units/test_worktree.rb
@@ -1,34 +1,13 @@
 #!/usr/bin/env ruby
 require 'fileutils'
 require 'pathname'
-require File.dirname(__FILE__) + '/../test_helper'
+require 'test_helper'
 
 SAMPLE_LAST_COMMIT = '5e53019b3238362144c2766f02a2c00d91fcc023'
 
 class TestWorktree < Test::Unit::TestCase
   def git_working_dir
-    cwd = FileUtils.pwd
-    if File.directory?(File.join(cwd, 'files'))
-      test_dir = File.join(cwd, 'files')
-    elsif File.directory?(File.join(cwd, '..', 'files'))
-      test_dir = File.join(cwd, '..', 'files')
-    elsif File.directory?(File.join(cwd, 'tests', 'files'))
-      test_dir = File.join(cwd, 'tests', 'files')
-    end
-
-    create_temp_repo(File.expand_path(File.join(test_dir, 'worktree')))
-  end
-
-  def create_temp_repo(clone_path)
-    filename = 'git_test' + Time.now.to_i.to_s + rand(300).to_s.rjust(3, '0')
-    @tmp_path = File.join("/tmp/", filename)
-    FileUtils.mkdir_p(@tmp_path)
-    FileUtils.cp_r(clone_path, @tmp_path)
-    tmp_path = File.join(@tmp_path, File.basename(clone_path))
-    Dir.chdir(tmp_path) do
-      FileUtils.mv('dot_git', '.git')
-    end
-    tmp_path
+    create_temp_repo('worktree')
   end
 
   def setup


### PR DESCRIPTION
### Your checklist for this pull request

🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description

Loading files for tests currently involves a lot of manually-constructed relative requires, as well as a `Dir.chdir` in the `tests/all_tests.rb` file which adjusts where requires need to be relative from.

Apart from some boilerplate, the main effect of this is that it's hard to run a single test file from the command line, as you need to edit the `all_tests.rb` file.

This makes things a bit simpler by:

* Adding the `tests` directory to the load path for the `rake test` task
* Removing the `chdir` from `all_tests.rb` to avboid a bunch of path complexity
* Replacing all relative requires with direct ones.

You can now run a single test file from the root directory of the project in a fairly standard way:

    $ ruby -Ilib:tests tests/units/test_object.rb

### Feedback

These changes seem simpler to me, but I haven't made a huge effort to investigate why the loading was the way it was. Are there any ways of running or writing tests that my changes would obstruct?