### PR TITLE
Create a null logger if a logger is not provided

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1,4 +1,5 @@
 require 'git/base/factory'
+require 'logger'
 
 module Git
   # Git::Base is the main public interface for interacting with Git commands.
@@ -90,12 +91,8 @@ module Git
         options[:repository] ||= File.join(working_dir, '.git')
         options[:index] ||= File.join(options[:repository], 'index')
       end
-      if options[:log]
-        @logger = options[:log]
-        @logger.info("Starting Git")
-      else
-        @logger = nil
-      end
+      @logger = (options[:log] || Logger.new(nil))
+      @logger.info("Starting Git")
 
       @working_directory = options[:working_directory] ? Git::WorkingDirectory.new(options[:working_directory]) : nil
       @repository = options[:repository] ? Git::Repository.new(options[:repository]) : nil

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1,3 +1,4 @@
+require 'logger'
 require 'tempfile'
 require 'zlib'
 
@@ -52,6 +53,7 @@ module Git
       @git_index_file = nil
       @git_work_dir = nil
       @path = nil
+      @logger = logger || Logger.new(nil)
 
       if base.is_a?(Git::Base)
         @git_dir = base.repo.path
@@ -62,7 +64,6 @@ module Git
         @git_index_file = base[:index]
         @git_work_dir = base[:working_directory]
       end
-      @logger = logger
     end
 
     # creates or reinitializes the repository
@@ -1137,10 +1138,8 @@ module Git
         command_thread.join
       end
 
-      if @logger
-        @logger.info(git_cmd)
-        @logger.debug(output)
-      end
+      @logger.info(git_cmd)
+      @logger.debug(output)
 
       raise Git::GitExecuteError, "#{git_cmd}:#{output}" if
         exitstatus > 1 || (exitstatus == 1 && output != '')

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -1,6 +1,5 @@
 require 'date'
 require 'fileutils'
-require 'logger'
 require 'minitar'
 require 'test/unit'
 

--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -113,14 +113,13 @@ class TestInit < Test::Unit::TestCase
     end
   end
 
-  # If the :log option is not passed to Git.clone, the result should not
-  # have a logger
+  # If the :log option is not passed to Git.clone, a Logger will be created
   #
   def test_git_clone_without_log
     in_temp_dir do |path|
       g = Git.clone(BARE_REPO_PATH, 'bare-co')
       actual_logger = g.instance_variable_get(:@logger)
-      assert_equal(nil, actual_logger)
+      assert_equal(Logger, actual_logger.class)
     end
   end
 


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
Rather than allow the logger to be nil which requires special casing it use, create a null logger with `Logger.new(nil)` which gives a functional logger object that does not log anything.

This should make the code a little less complex.
