### PR TITLE
Set init.defaultBranch when running tests if it is not already set

### DIFF
--- a/bin/test
+++ b/bin/test
@@ -5,6 +5,7 @@ require 'bundler/setup'
 
 `git config --global user.email "git@example.com"` if `git config user.email`.empty?
 `git config --global user.name "GitExample"` if `git config user.name`.empty?
+`git config --global init.defaultBranch master` if `git config init.defaultBranch`.empty?
 
 project_root = File.expand_path(File.join(__dir__, '..'))
 


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
To avoid warnings about init.defaultBranch not being set when running tests, set the default to `master`.

The actual value does not matter for the tests, but something needs to be set to avoid the warning.
