### PR TITLE
Simplify how temp files are used when testing Git::Base#archive

### DIFF
--- a/tests/units/test_archive.rb
+++ b/tests/units/test_archive.rb
@@ -3,61 +3,88 @@
 require 'test_helper'
 
 class TestArchive < Test::Unit::TestCase
-
   def setup
     clone_working_repo
     @git = Git.open(@wdir)
-    @tempfiles = []
-  end
-
-  def teardown
-    @tempfiles.clear
   end
 
   def tempfile
-    tempfile_object = Tempfile.new('archive-test')
-    @tempfiles << tempfile_object # prevent deletion until teardown
-    tempfile_object.close # close to avoid locking from git processes
-    tempfile_object.path
+    Dir::Tmpname.create('test-archive') { }
   end
 
   def test_archive
     f = @git.archive('v2.6', tempfile)
     assert(File.exist?(f))
+    File.delete(f)
+  end
 
+  def test_archive_object
     f = @git.object('v2.6').archive(tempfile)  # writes to given file
     assert(File.exist?(f))
+    File.delete(f)
+  end
 
+  def test_archive_object_with_no_filename
     f = @git.object('v2.6').archive # returns path to temp file
     assert(File.exist?(f))
+    File.delete(f)
+  end
 
+  def test_archive_to_tar
     f = @git.object('v2.6').archive(nil, :format => 'tar') # returns path to temp file
     assert(File.exist?(f))
 
-    lines = Minitar::Input.open(f).each.to_a.map(&:full_name)
+    lines = []
+    Minitar::Input.open(f) do |tar_reader|
+      lines = tar_reader.to_a.map(&:full_name)
+    end
+    File.delete(f)
+
     assert_match(%r{ex_dir/}, lines[1])
     assert_match(/ex_dir\/ex\.txt/, lines[2])
     assert_match(/example\.txt/, lines[3])
+  end
 
+  def test_archive_to_zip
     f = @git.object('v2.6').archive(tempfile, :format => 'zip')
     assert(File.file?(f))
+    File.delete(f)
+  end
 
+  def test_archive_to_tgz
     f = @git.object('v2.6').archive(tempfile, :format => 'tgz', :prefix => 'test/')
     assert(File.exist?(f))
 
-    lines = Minitar::Input.open(Zlib::GzipReader.new(File.open(f, 'rb'))).each.to_a.map(&:full_name)
+    lines = []
+    File.open(f, 'rb') do |file_reader|
+      Zlib::GzipReader.open(file_reader) do |gz_reader|
+        Minitar::Input.open(gz_reader) do |tar_reader|
+          lines = tar_reader.to_a.map(&:full_name)
+        end
+      end
+    end
+    File.delete(f)
+
     assert_match(%r{test/}, lines[1])
     assert_match(%r{test/ex_dir/ex\.txt}, lines[3])
+  end
 
+  def test_archive_with_prefix_and_path
     f = @git.object('v2.6').archive(tempfile, :format => 'tar', :prefix => 'test/', :path => 'ex_dir/')
     assert(File.exist?(f))
 
-    lines = Minitar::Input.open(f).each.to_a.map(&:full_name)
+    tar_file = Minitar::Input.open(f)
+    lines = tar_file.each.to_a.map(&:full_name)
+    tar_file.close
+    File.delete(f)
+
     assert_match(%r{test/}, lines[1])
     assert_match(%r{test/ex_dir/ex\.txt}, lines[3])
-
-    f = @git.remote('working').branch('master').archive(tempfile, :format => 'tgz')
-    assert(File.exist?(f))
   end
 
+  def test_archive_branch
+    f = @git.remote('working').branch('master').archive(tempfile, :format => 'tgz')
+    assert(File.exist?(f))
+    File.delete(f)
+  end
 end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
Use `Dir::Tmpname.create` to get a name of a temporary file instead of creating the file with `Tempfile.new`. 

Also, each test should clean up manually after itself rather than having the complexity of keeping track of temp files and deleting them in the `#cleanup` method.
