### PR TITLE
grep: Allow the use of an array of path limiters and extended_regexp as an available option.

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -209,6 +209,15 @@ module Git
     #     end
     #   end
     #
+    # @param string [String] the string to search for
+    # @param path_limiter [String, Array] a path or array of paths to limit the search to or nil for no limit
+    # @param opts [Hash] options to pass to the underlying `git grep` command
+    #
+    # @option opts [Boolean] :ignore_case (false) ignore case when matching
+    # @option opts [Boolean] :invert_match (false) select non-matching lines
+    # @option opts [Boolean] :extended_regexp (false) use extended regular expressions
+    # @option opts [String] :object (HEAD) the object to search from
+    #
     # @return [Hash<String, Array>] a hash of arrays
     #   ```Ruby
     #   {

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -413,10 +413,12 @@ module Git
       grep_opts = ['-n']
       grep_opts << '-i' if opts[:ignore_case]
       grep_opts << '-v' if opts[:invert_match]
+      grep_opts << '-E' if opts[:extended_regexp]
       grep_opts << '-e'
       grep_opts << string
       grep_opts << opts[:object] if opts[:object].is_a?(String)
-      grep_opts << '--' << opts[:path_limiter] if opts[:path_limiter].is_a? String
+      grep_opts.push('--', opts[:path_limiter]) if opts[:path_limiter].is_a?(String)
+      grep_opts.push('--', *opts[:path_limiter]) if opts[:path_limiter].is_a?(Array)
 
       hsh = {}
       command_lines('grep', *grep_opts).each do |line|

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -291,6 +291,12 @@ class TestLib < Test::Unit::TestCase
     assert_equal("you can't search me!", match["gitsearch1:scott/newfile"].first[1])
     assert_equal(1, match.size)
 
+    match = @lib.grep('search', :object => 'gitsearch1', :path_limiter => ['scott/new*', 'scott/text.*'])
+    assert_equal("you can't search me!", match["gitsearch1:scott/newfile"].first[1])
+    assert_equal('to search one', match['gitsearch1:scott/text.txt'].assoc(6)[1])
+    assert_equal(2, match['gitsearch1:scott/text.txt'].size)
+    assert_equal(2, match.size)
+
     match = @lib.grep('SEARCH', :object => 'gitsearch1')
     assert_equal(0, match.size)
 
@@ -300,6 +306,11 @@ class TestLib < Test::Unit::TestCase
 
     match = @lib.grep('search', :object => 'gitsearch1', :invert_match => true)
     assert_equal(6, match['gitsearch1:scott/text.txt'].size)
+    assert_equal(2, match.size)
+
+    match = @lib.grep("you can't search me!|nothing!", :object => 'gitsearch1', :extended_regexp => true)
+    assert_equal("you can't search me!", match["gitsearch1:scott/newfile"].first[1])
+    assert_equal("nothing!", match["gitsearch1:scott/text.txt"].first[1])
     assert_equal(2, match.size)
 
     match = @lib.grep('Grep', :object => 'grep_colon_numbers')


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
This PR adds`extended_regexp` as a passable option, and allows multiple path limiters to be used. I think the additions are fairly self-explanatory, but happy to answer questions if need be.
