### PR TITLE
Fix Git::Branch#update_ref

### DIFF
--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -78,7 +78,11 @@ module Git
     end
     
     def update_ref(commit)
-      @base.lib.update_ref(@full, commit)
+      if @remote
+        @base.lib.update_ref("refs/remotes/#{@remote.name}/#{@name}", commit)
+      else
+        @base.lib.update_ref("refs/heads/#{@name}", commit)
+      end
     end
     
     def to_a
@@ -114,7 +118,7 @@ module Git
       # param [String] name branch full name.
       # return [<Git::Remote,NilClass,String>] an Array containing the remote and branch names. 
       def parse_name(name)
-        if name.match(/^(?:remotes)?\/([^\/]+)\/(.+)/)
+        if name.match(/^(?:remotes\/)?([^\/]+)\/(.+)/)
           return [Git::Remote.new(@base, $1), $2]
         end
 

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -974,8 +974,8 @@ module Git
       command('commit-tree', *arr_opts, redirect: "< #{escape t.path}")
     end
 
-    def update_ref(branch, commit)
-      command('update-ref', branch, commit)
+    def update_ref(ref, commit)
+      command('update-ref', ref, commit)
     end
 
     def checkout_index(opts = {})

--- a/tests/units/test_branch.rb
+++ b/tests/units/test_branch.rb
@@ -98,4 +98,22 @@ class TestBranch < Test::Unit::TestCase
       assert(git.branch('other_branch').current)
     end
   end
+
+  def test_branch_update_ref
+    in_temp_dir do |path|
+      git = Git.init
+      File.write('foo','rev 1')
+      git.add('foo')
+      git.commit('rev 1')
+      git.branch('testing').create
+      File.write('foo','rev 2')
+      git.add('foo')
+      git.commit('rev 2')
+      git.branch('testing').update_ref(git.revparse('HEAD'))
+
+      # Expect the call to Branch#update_ref to pass the full ref name for the
+      # of the testing branch to Lib#update_ref
+      assert_equal(git.revparse('HEAD'), git.revparse('refs/heads/testing'))
+    end
+  end
 end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

Fixes #599
Fixes #600 

`Git::Branch#update_ref` creates the wrong ref name, resulting in "refname is ambiguous" warnings. For instance, when updating an existing branch named 'testing' with the following code:

```Ruby
git.branch('testing').update_ref(git.revparse('HEAD'))
```

Creates a new file `.git/testing` instead of updating the file `.git/refs/heads/testing`.


