### PR TITLE
Git.open(work_dir) should use the top-level directory of the working tree containing work_dir

### DIFF
--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -22,6 +22,19 @@ class TestInit < Test::Unit::TestCase
     assert_equal(expected_index_path, actual_index_path)
   end
 
+  def test_open_from_child_dir
+    in_temp_dir do |path|
+      git = Git.init
+      Dir.mkdir('child')
+      File.write('child/foo.txt','rev 1')
+      git.add('child/foo.txt')
+      git.commit('rev 1')
+      Dir.chdir('child') do
+        assert_nothing_raised { Git.open(Dir.pwd) }
+      end
+    end
+  end
+
   def test_open_opts
     clone_working_repo
     index = File.join(TEST_FIXTURES, 'index')

--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -8,9 +8,18 @@ class TestInit < Test::Unit::TestCase
   def test_open_simple
     clone_working_repo
     g = Git.open(@wdir)
-    assert_match(/^C?:?#{@wdir}$/, g.dir.path)
-    assert_match(/^C?:?#{File.join(@wdir, '.git')}$/, g.repo.path)
-    assert_match(/^C?:?#{File.join(@wdir, '.git', 'index')}$/, g.index.path)
+
+    expected_working_dir = File.realpath(@wdir)
+    actual_working_dir = File.realpath(g.dir.path)
+    assert_equal(expected_working_dir, actual_working_dir)
+
+    expected_repo_path = File.join(expected_working_dir, '.git')
+    actual_repo_path = File.realpath(g.repo.path)
+    assert_equal(expected_repo_path, actual_repo_path)
+
+    expected_index_path = File.join(expected_repo_path, 'index')
+    actual_index_path = File.realpath(g.index.path)
+    assert_equal(expected_index_path, actual_index_path)
   end
 
   def test_open_opts


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

Fixes #596 

When opening a working directory via `Git.open`, find and use the repository root directory. 