### PR TITLE
Allow a repo to be opened by giving a non-root repo directory

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -58,9 +58,26 @@ module Git
       self.new(options)
     end
 
+    def self.root_of_worktree(working_dir)
+      result = working_dir
+      status = nil
+      Dir.chdir(working_dir) do
+        git_cmd = "#{Git::Base.config.binary_path} -c core.quotePath=true -c color.ui=false rev-parse --show-toplevel 2>&1"
+        result = `#{git_cmd}`.chomp
+        status = $?
+      end
+      raise ArgumentError, "'#{working_dir}' is not in a git working tree" unless status.success?
+      result
+    end
+
     # (see Git.open)
     def self.open(working_dir, options = {})
+      raise ArgumentError, "'#{working_dir}' is not a directory" unless Dir.exist?(working_dir)
+
+      working_dir = root_of_worktree(working_dir) unless options[:repository]
+
       normalize_paths(options, default_working_directory: working_dir)
+
       self.new(options)
     end
 

--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -13,6 +13,20 @@ class TestInit < Test::Unit::TestCase
     assert_match(/^C?:?#{File.join(@wdir, '.git', 'index')}$/, g.index.path)
   end
 
+  def test_open_from_non_root_dir
+    in_temp_dir do |path|
+      `git init`
+      File.write('file.txt', 'test')
+      `git add file.txt`
+      `git commit -m "initial commit "`
+      Dir.mkdir('subdir')
+      Dir.chdir('subdir') do
+        g = Git.open('.')
+        assert_equal(path, g.dir.to_s)
+      end
+    end
+  end
+
   def test_open_opts
     clone_working_repo
     index = File.join(TEST_FIXTURES, 'index')


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

This change allows giving `Git.open(path)` a path that isn't the root repository directory. `Git.open` will use the top-level directory of the working tree containing `path`.

Fixes #596.