### PR TITLE
Add Git::Log#all option

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ like:
 
  `@git.log(20).object("some_file").since("2 weeks ago").between('v2.6', 'v2.7').each { |commit| [block] }`
 
+Pass the `--all` option to `git log` as follows:
+
+ `@git.log.all.each { |commit| [block] }`
+
  **Git::Worktrees** - Enumerable object that holds `Git::Worktree objects`.
 
 ## Examples

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1182,7 +1182,12 @@ module Git
     def log_common_options(opts)
       arr_opts = []
 
-      arr_opts << "-#{opts[:count]}" if opts[:count]
+      if opts[:count] && !opts[:count].is_a?(Integer)
+        raise ArgumentError, "The log count option must be an Integer but was #{opts[:count].inspect}"
+      end
+
+      arr_opts << "--max-count=#{opts[:count]}" if opts[:count]
+      arr_opts << "--all" if opts[:all]
       arr_opts << "--no-color"
       arr_opts << "--cherry" if opts[:cherry]
       arr_opts << "--since=#{opts[:since]}" if opts[:since].is_a? String

--- a/lib/git/log.rb
+++ b/lib/git/log.rb
@@ -1,24 +1,19 @@
 module Git
-  
+
   # object that holds the last X commits on given branch
   class Log
     include Enumerable
-    
+
     def initialize(base, count = 30)
       dirty_log
       @base = base
       @count = count
- 
-      @commits = nil
-      @author = nil
-      @grep = nil
-      @object = nil
-      @path = nil
-      @since = nil
-      @skip = nil
-      @until = nil
-      @between = nil
-      @cherry = nil
+    end
+
+    def all
+      dirty_log
+      @all = true
+      self
     end
 
     def object(objectish)
@@ -32,37 +27,37 @@ module Git
       @author = regex
       return self
     end
-        
+
     def grep(regex)
       dirty_log
       @grep = regex
       return self
     end
-    
+
     def path(path)
       dirty_log
       @path = path
       return self
     end
-    
+
     def skip(num)
       dirty_log
       @skip = num
       return self
     end
-    
+
     def since(date)
       dirty_log
       @since = date
       return self
     end
-    
+
     def until(date)
       dirty_log
       @until = date
       return self
     end
-    
+
     def between(sha1, sha2 = nil)
       dirty_log
       @between = [sha1, sha2]
@@ -74,24 +69,24 @@ module Git
       @cherry = true
       return self
     end
-    
+
     def to_s
       self.map { |c| c.to_s }.join("\n")
     end
-    
+
 
     # forces git log to run
-    
+
     def size
       check_log
       @commits.size rescue nil
     end
-    
+
     def each(&block)
       check_log
       @commits.each(&block)
     end
-    
+
     def first
       check_log
       @commits.first rescue nil
@@ -107,29 +102,30 @@ module Git
       @commits[index] rescue nil
     end
 
-    
-    private 
-    
+
+    private
+
       def dirty_log
         @dirty_flag = true
       end
-      
+
       def check_log
         if @dirty_flag
           run_log
           @dirty_flag = false
         end
       end
-      
+
       # actually run the 'git log' command
-      def run_log      
-        log = @base.lib.full_log_commits(:count => @count, :object => @object, 
-                                    :path_limiter => @path, :since => @since, 
-                                    :author => @author, :grep => @grep, :skip => @skip,
-                                    :until => @until, :between => @between, :cherry => @cherry)
+      def run_log
+        log = @base.lib.full_log_commits(
+          count: @count, all: @all, object: @object, path_limiter: @path, since: @since,
+          author: @author, grep: @grep, skip: @skip, until: @until, between: @between,
+          cherry: @cherry
+        )
         @commits = log.map { |c| Git::Object::Commit.new(@base, c['sha'], c) }
       end
-      
+
   end
-  
+
 end

--- a/tests/units/test_log.rb
+++ b/tests/units/test_log.rb
@@ -9,7 +9,16 @@ class TestLog < Test::Unit::TestCase
     @git = Git.open(@wdir)
   end
 
-  def test_get_fisrt_and_last_entries
+  def test_log_all
+    assert_equal(72, @git.log(100).size)
+    assert_equal(76, @git.log(100).all.size)
+  end
+
+  def test_log_non_integer_count
+    assert_raises(ArgumentError) { @git.log('foo').size }
+  end
+
+  def test_get_first_and_last_entries
     log = @git.log
     assert(log.first.is_a?(Git::Object::Commit))
     assert_equal('46abbf07e3c564c723c7c039a43ab3a39e5d02dd', log.first.objectish)
@@ -96,5 +105,4 @@ class TestLog < Test::Unit::TestCase
     l = @git.log.between( 'master', 'cherry').cherry
     assert_equal( 1, l.size )
   end
-
 end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

Fixes #466 

Add ability to pass the `--all` option to `git log` as follows:

```ruby
git.log.all
```

Passing a non-integer value as the `count` parameter to `Git::Base#log` will raise a `ArgumentError` when the log is run:

```ruby
git = Git.open('.')
max_count = 'a'
git.log(max_count).size
lib/git/lib.rb:1186:in `log_common_options': The log count option must be an Integer but was "a" (ArgumentError)
```