### PR TITLE
Fix error when calling `Git::Lib#remove` with `recursive` or `cached` options

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -272,9 +272,11 @@ module Git
     end
 
     # removes file(s) from the git repository
-    def remove(path = '.', opts = {})
-      self.lib.remove(path, opts)
+    def rm(path = '.', opts = {})
+      self.lib.rm(path, opts)
     end
+
+    alias remove rm
 
     # resets the working directory to the provided commitish
     def reset(commitish = nil, opts = {})

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -630,8 +630,8 @@ module Git
 
     def remove(path = '.', opts = {})
       arr_opts = ['-f']  # overrides the up-to-date check by default
-      arr_opts << ['-r'] if opts[:recursive]
-      arr_opts << ['--cached'] if opts[:cached]
+      arr_opts << '-r' if opts[:recursive]
+      arr_opts << '--cached' if opts[:cached]
       arr_opts << '--'
       if path.is_a?(Array)
         arr_opts += path

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -628,16 +628,12 @@ module Git
       command('add', *arr_opts)
     end
 
-    def remove(path = '.', opts = {})
+    def rm(path = '.', opts = {})
       arr_opts = ['-f']  # overrides the up-to-date check by default
       arr_opts << '-r' if opts[:recursive]
       arr_opts << '--cached' if opts[:cached]
       arr_opts << '--'
-      if path.is_a?(Array)
-        arr_opts += path
-      else
-        arr_opts << path
-      end
+      arr_opts += Array(path)
 
       command('rm', *arr_opts)
     end

--- a/tests/units/test_rm.rb
+++ b/tests/units/test_rm.rb
@@ -1,0 +1,76 @@
+#!/usr/bin/env ruby
+
+require 'test_helper'
+
+# tests all the low level git communication
+#
+# this will be helpful if we ever figure out how
+# to either build these in pure ruby or get git bindings working
+# because right now it forks for every call
+
+class TestRm < Test::Unit::TestCase
+  test 'rm with no options should specific "." for the pathspec' do
+    expected_command_line = ['rm', '-f', '--', '.']
+    git_cmd = :rm
+    git_cmd_args = []
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
+  test 'rm with one pathspec' do
+    expected_command_line = ['rm', '-f', '--', 'pathspec']
+    git_cmd = :rm
+    git_cmd_args = ['pathspec']
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
+  test 'rm with multiple pathspecs' do
+    expected_command_line = ['rm', '-f', '--', 'pathspec1', 'pathspec2']
+    git_cmd = :rm
+    git_cmd_args = [['pathspec1', 'pathspec2']]
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
+  test 'rm with the recursive option' do
+    expected_command_line = ['rm', '-f', '-r', '--', 'pathspec']
+    git_cmd = :rm
+    git_cmd_args = ['pathspec', recursive: true]
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
+  test 'rm with the cached option' do
+    expected_command_line = ['rm', '-f', '--cached', '--', 'pathspec']
+    git_cmd = :rm
+    git_cmd_args = ['pathspec', cached: true]
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
+  test 'when rm succeeds an error should not be raised' do
+    in_temp_dir do
+      git = Git.init
+      File.write('README.txt', 'hello world')
+      git.add('README.txt')
+      git.commit('Initial commit')
+
+      assert(File.exist?('README.txt'))
+
+      assert_nothing_raised do
+        git.rm('README.txt')
+      end
+
+      assert(!File.exist?('README.txt'))
+    end
+  end
+
+  test 'when rm fails a Git::FailedError error should be raised' do
+    in_temp_dir do
+      git = Git.init
+      File.write('README.txt', 'hello world')
+      git.add('README.txt')
+      git.commit('Initial commit')
+
+      assert_raises(Git::FailedError) do
+        git.rm('Bogus.txt')
+      end
+    end
+  end
+end

--- a/tests/units/test_rm.rb
+++ b/tests/units/test_rm.rb
@@ -61,6 +61,23 @@ class TestRm < Test::Unit::TestCase
     end
   end
 
+  test '#rm should be aliased to #remove' do
+    in_temp_dir do
+      git = Git.init
+      File.write('README.txt', 'hello world')
+      git.add('README.txt')
+      git.commit('Initial commit')
+
+      assert(File.exist?('README.txt'))
+
+      assert_nothing_raised do
+        git.remove('README.txt')
+      end
+
+      assert(!File.exist?('README.txt'))
+    end
+  end
+
   test 'when rm fails a Git::FailedError error should be raised' do
     in_temp_dir do
       git = Git.init


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description

Calling `Git::Lib#remove` with `recursive` or `cached` option causes nested array assignment to `cmd` argument of `Git::Lib#command` and throws exception.
It is caused by passing an array to `Array#<<`.

fix #631