### PR TITLE
#pull with no options should do the same thing as `git pull` with no options

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -399,7 +399,7 @@ module Git
     #  @git.pull('upstream')              # pulls from upstream/master
     #  @git.pull('upstream', 'develope')  # pulls from upstream/develop
     #
-    def pull(remote='origin', branch='master')
+    def pull(remote = nil, branch = nil)
       self.lib.pull(remote, branch)
     end
 

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -926,8 +926,13 @@ module Git
       end
     end
 
-    def pull(remote='origin', branch='master')
-      command('pull', remote, branch)
+    def pull(remote = nil, branch = nil)
+      raise ArgumentError, "You must specify a remote if a branch is specified" if remote.nil? && !branch.nil?
+
+      arr_opts = []
+      arr_opts << remote if remote
+      arr_opts << branch if branch
+      command('pull', *arr_opts)
     end
 
     def tag_sha(tag_name)

--- a/tests/units/test_pull.rb
+++ b/tests/units/test_pull.rb
@@ -1,0 +1,112 @@
+require 'test_helper'
+
+class TestPull < Test::Unit::TestCase
+
+  test 'pull with branch only should raise an ArgumentError' do
+    in_temp_dir do |path|
+      Dir.mkdir('remote')
+
+      Dir.chdir('remote') do
+        `git init --initial-branch=branch1`
+        File.write('README.md', 'Line 1')
+        `git add README.md`
+        `git commit -m "Initial commit"`
+      end
+
+      `git clone remote/.git local 2>&1`
+
+      Dir.chdir('local') do
+        git = Git.open('.')
+        assert_raises(ArgumentError) { git.pull(nil, 'branch1') }
+      end
+    end
+  end
+
+  test 'pull with no args should use the default remote and current branch name' do
+    in_temp_dir do |path|
+      Dir.mkdir('remote')
+
+      Dir.chdir('remote') do
+        `git init --initial-branch=branch1`
+        File.write('README.md', 'Line 1')
+        `git add README.md`
+        `git commit -m "Initial commit"`
+      end
+
+      `git clone remote/.git local 2>&1`
+
+      Dir.chdir('remote') do
+        File.open('README.md', 'a') { |f| f.write('Line 2') }
+        `git add README.md`
+        `git commit -m "Initial commit"`
+      end
+
+      Dir.chdir('local') do
+        git = Git.open('.')
+        assert_equal(1, git.log.size)
+        assert_nothing_raised { git.pull }
+        assert_equal(2, git.log.size)
+      end
+    end
+  end
+
+  test 'pull with one arg should use arg as remote and the current branch name' do
+    in_temp_dir do |path|
+      Dir.mkdir('remote')
+
+      Dir.chdir('remote') do
+        `git init --initial-branch=branch1`
+        File.write('README.md', 'Line 1')
+        `git add README.md`
+        `git commit -m "Initial commit"`
+      end
+
+      `git clone remote/.git local 2>&1`
+
+      Dir.chdir('remote') do
+        File.open('README.md', 'a') { |f| f.write('Line 2') }
+        `git add README.md`
+        `git commit -m "Initial commit"`
+      end
+
+      Dir.chdir('local') do
+        git = Git.open('.')
+        assert_equal(1, git.log.size)
+        assert_nothing_raised { git.pull('origin') }
+        assert_equal(2, git.log.size)
+      end
+    end
+  end
+
+  test 'pull with both remote and branch should use both' do
+    in_temp_dir do |path|
+      Dir.mkdir('remote')
+
+      Dir.chdir('remote') do
+        `git init --initial-branch=master`
+        File.write('README.md', 'Line 1')
+        `git add README.md`
+        `git commit -m "Initial commit"`
+      end
+
+      `git clone remote/.git local 2>&1`
+
+      Dir.chdir('remote') do
+        `git checkout -b feature1 2>&1`
+        File.write('feature1.md', 'Line 1')
+        `git add feature1.md`
+        `git commit -m "Implement feature 1"`
+        File.open('feature1.md', 'a') { |f| f.write('Line 2') }
+        `git add feature1.md`
+        `git commit -m "Implement feature 1, line 2"`
+      end
+
+      Dir.chdir('local') do
+        git = Git.open('.')
+        assert_equal(1, git.log.size)
+        assert_nothing_raised { git.pull('origin', 'feature1') }
+        assert_equal(3, git.log.size)
+      end
+    end
+  end
+end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

Fixes #423 

`Git::Lib#pull` with no args currently performs `git pull origin master`. It sets the remote name to 'origin' and the branch to pull to 'master'.  This probably isn't what the user expects and can cause errors or undesired results.

`git pull` with no args figures out defaults for the remote name and branch name to use. `Git::Lib#pull` should have the same effect.