### PR TITLE
Make it easier to run test files from the command line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,11 +84,11 @@ In order to ensure high quality, all pull requests must meet these requirements:
 While working on specific features you can run individual test files or
 a group of tests using `bin/test`:
 
-    # run a single file:
-    $ bin/test tests/units/test_object.rb
+    # run a single file (from tests/units):
+    $ bin/test test_object
 
     # run multiple files:
-    $ bin/test tests/units/test_object.rb tests/units/test_archive.rb
+    $ bin/test test_object test_archive
 
     # run all unit tests:
     $ bin/test

--- a/bin/test
+++ b/bin/test
@@ -11,10 +11,11 @@ project_root = File.expand_path(File.join(__dir__, '..'))
 
 $LOAD_PATH.unshift(File.join(project_root, 'tests'))
 
-if ARGV.empty?
-  paths = Dir.glob(File.join(project_root, 'tests/**/test_*.rb'))
-else
-  paths = ARGV.map { |p| File.join(project_root, p) }
-end
+paths =
+  if ARGV.empty?
+    Dir.glob('tests/units/test_*.rb').map { |p| File.basename(p) }
+  else
+    ARGV
+  end.map { |p| File.join(project_root, 'tests/units', p) }
 
 paths.each { |p| require p }


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
Building upon #615, make it so that tests can be run without specifying the directory:

```shell
# Run a single test file tests/units/test_archive.rb:
$ bin/test test_archive
...
# Run a multiple test files tests/units/test_archive.rb and tests/units/test_object.rb:
$ bin/test test_archive test_object
...
# Run all tests:
$ bin/test
...
```
