### PR TITLE
#checkout without args should do same as `git checkout` with no args

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -350,8 +350,8 @@ module Git
     end
 
     # checks out a branch as the new git working directory
-    def checkout(branch = 'master', opts = {})
-      self.lib.checkout(branch, opts)
+    def checkout(*args, **options)
+      self.lib.checkout(*args, **options)
     end
 
     # checks out an old version of a file

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -772,11 +772,16 @@ module Git
     #
     # @param [String] branch
     # @param [Hash] opts
-    def checkout(branch, opts = {})
+    def checkout(branch = nil, opts = {})
+      if branch.is_a?(Hash) && opts == {}
+        opts = branch
+        branch = nil
+      end
+
       arr_opts = []
       arr_opts << '-b' if opts[:new_branch] || opts[:b]
       arr_opts << '--force' if opts[:force] || opts[:f]
-      arr_opts << branch
+      arr_opts << branch if branch
       arr_opts << opts[:start_point] if opts[:start_point] && arr_opts.include?('-b')
 
       command('checkout', *arr_opts)

--- a/tests/units/test_checkout.rb
+++ b/tests/units/test_checkout.rb
@@ -1,0 +1,82 @@
+require 'test_helper'
+
+    # Runs checkout command to checkout or create branch
+    #
+    # accepts options:
+    #  :new_branch
+    #  :force
+    #  :start_point
+    #
+    # @param [String] branch
+    # @param [Hash] opts
+    # def checkout(branch, opts = {})
+
+class TestCheckout < Test::Unit::TestCase
+  test 'checkout with no args' do
+    expected_command_line = ['checkout']
+    git_cmd = :checkout
+    git_cmd_args = []
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
+  test 'checkout with no args and options' do
+    expected_command_line = ['checkout', '--force']
+    git_cmd = :checkout
+    git_cmd_args = [force: true]
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
+  test 'checkout with branch' do
+    expected_command_line = ['checkout', 'feature1']
+    git_cmd = :checkout
+    git_cmd_args = ['feature1']
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
+  test 'checkout with branch and options' do
+    expected_command_line = ['checkout', '--force', 'feature1']
+    git_cmd = :checkout
+    git_cmd_args = ['feature1', force: true]
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
+  test 'checkout with branch name and new_branch: true' do
+    expected_command_line = ['checkout', '-b', 'feature1']
+    git_cmd = :checkout
+    git_cmd_args = ['feature1', new_branch: true]
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
+  test 'checkout with force: true' do
+    expected_command_line = ['checkout', '--force', 'feature1']
+    git_cmd = :checkout
+    git_cmd_args = ['feature1', force: true]
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
+  test 'checkout with branch name and new_branch: true and start_point: "sha"' do
+    expected_command_line = ['checkout', '-b', 'feature1', 'sha']
+    git_cmd = :checkout
+    git_cmd_args = ['feature1', new_branch: true, start_point: 'sha']
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
+
+  test 'when checkout succeeds an error should not be raised' do
+    in_temp_dir do
+      git = Git.init('.', initial_branch: 'master')
+      File.write('file1.txt', 'file1')
+      git.add('file1.txt')
+      git.commit('commit1')
+      assert_nothing_raised { git.checkout('master') }
+    end
+  end
+
+  test 'when checkout fails a Git::FailedError should be raised' do
+    in_temp_dir do
+      git = Git.init('.', initial_branch: 'master')
+      # fails because there are no commits
+      assert_raises(Git::FailedError) { git.checkout('master') }
+    end
+  end
+end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
`Git::Lib#checkout` with no args currently performs `git checkout master`. The branch name default is 'master' even if there is no branch named 'master'.  This probably isn't what the user expects and can cause errors or undesired results.

`git checkout` with no args checks out the current branch which is "a glorified no-op" according to the git-checkout documentation.. `Git::Lib#checkout` should have the same behavior.