### PR TITLE
`#branch` name should default to current branch instead of `master`

### DIFF
--- a/lib/git/base/factory.rb
+++ b/lib/git/base/factory.rb
@@ -3,9 +3,8 @@ module Git
   class Base
 
     module Factory
-
       # @return [Git::Branch] an object for branch_name
-      def branch(branch_name = 'master')
+      def branch(branch_name = self.current_branch)
         Git::Branch.new(self, branch_name)
       end
 
@@ -93,7 +92,6 @@ module Git
         shas = self.lib.merge_base(*args)
         shas.map { |sha| gcommit(sha) }
       end
-
     end
 
   end

--- a/tests/units/test_branch.rb
+++ b/tests/units/test_branch.rb
@@ -14,6 +14,18 @@ class TestBranch < Test::Unit::TestCase
     @branches = @git.branches
   end
 
+  test 'Git::Lib#branch with no args should return current branch' do
+    in_temp_dir do
+      git = Git.init('.', initial_branch: 'my_branch')
+      File.write('file.txt', 'hello world')
+      git.add('file.txt')
+      git.commit('Initial commit')
+
+      b = git.branch
+      assert_equal('my_branch', b.name)
+    end
+  end
+
   def test_branches_all
     assert(@git.branches[:master].is_a?(Git::Branch))
     assert(@git.branches.size > 5)


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
Currently, when getting a branch, the default branch name returned is 'master' even if no branch of that name exists.

This PR changes the behavior of Git::Lib#branch to use the current branch name instead of 'master' as a default.
