### PR TITLE
`Remote#branch` and `#merge` should default to current branch instead of `master`

### DIFF
--- a/lib/git/remote.rb
+++ b/lib/git/remote.rb
@@ -1,8 +1,8 @@
 module Git
   class Remote < Path
-    
+
     attr_accessor :name, :url, :fetch_opts
-    
+
     def initialize(base, name)
       @base = base
       config = @base.lib.config_remote(name)
@@ -10,27 +10,29 @@ module Git
       @url = config['url']
       @fetch_opts = config['fetch']
     end
-    
+
     def fetch(opts={})
       @base.fetch(@name, opts)
     end
-    
+
     # merge this remote locally
-    def merge(branch = 'master')
-      @base.merge("#{@name}/#{branch}")
+    def merge(branch = @base.current_branch)
+      remote_tracking_branch = "#{@name}/#{branch}"
+      @base.merge(remote_tracking_branch)
     end
-    
-    def branch(branch = 'master')
-      Git::Branch.new(@base, "#{@name}/#{branch}")
+
+    def branch(branch = @base.current_branch)
+      remote_tracking_branch = "#{@name}/#{branch}"
+      Git::Branch.new(@base, remote_tracking_branch)
     end
-    
+
     def remove
-      @base.lib.remote_remove(@name)     
+      @base.lib.remote_remove(@name)
     end
-    
+
     def to_s
       @name
     end
-    
+
   end
 end

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -232,4 +232,53 @@ class TestRemotes < Test::Unit::TestCase
       assert(rem.tag('test-tag'))
     end
   end
+
+  test 'Remote#branch with no args' do
+    in_temp_dir do
+      Dir.mkdir 'git'
+      Git.init('git', initial_branch: 'first', bare: true)
+      r1 = Git.clone('git', 'r1')
+      File.write('r1/file1.txt', 'hello world')
+      r1.add('file1.txt')
+      r1.commit('first commit')
+      r1.push
+
+      r2 = Git.clone('git', 'r2')
+
+      File.write('r1/file2.txt', 'hello world')
+      r1.add('file2.txt')
+      r1.commit('second commit')
+      r1.push
+
+      branch = r2.remote('origin').branch
+
+      assert_equal('origin/first', branch.full)
+    end
+  end
+
+  test 'Remote#merge with no args' do
+    in_temp_dir do
+      Dir.mkdir 'git'
+      Git.init('git', initial_branch: 'first', bare: true)
+      r1 = Git.clone('git', 'r1')
+      File.write('r1/file1.txt', 'hello world')
+      r1.add('file1.txt')
+      r1.commit('first commit')
+      r1.push
+
+      r2 = Git.clone('git', 'r2')
+
+      File.write('r1/file2.txt', 'hello world')
+      r1.add('file2.txt')
+      r1.commit('second commit')
+      r1.push
+
+      remote = r2.remote('origin')
+
+      remote.fetch
+      remote.merge
+
+      assert(File.exist?('r2/file2.txt'))
+    end
+  end
 end


### PR DESCRIPTION
### Your checklist for this pull request

🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

This PR makes two changes:
1. `Remote#branch` when not given a branch name will create a Branch object representing the remote tracking branch with the same name as the current branch. Originally, the default was `master` even if a branch of that name did not exist.
2. `Remote#merge` when not given a branch name will merge from the remote tracking branch with the same name as the current branch. Before this PR, merge would try to merge from the remote `master` branch even if that branch did not exist.