### PR TITLE
Make Git::Base#ls_tree handle commit objects

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -338,7 +338,7 @@ module Git
     end
 
     def ls_tree(sha)
-      data = {'blob' => {}, 'tree' => {}}
+      data = { 'blob' => {}, 'tree' => {}, 'commit' => {} }
 
       command_lines('ls-tree', sha).each do |line|
         (info, filenm) = line.split("\t")

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -170,4 +170,9 @@ class Test::Unit::TestCase
 
     assert_equal(expected_command_line, actual_command_line)
   end
+
+  def assert_child_process_success(&block)
+    yield
+    assert_equal 0, $CHILD_STATUS.exitstatus, "Child process failed with exitstatus #{$CHILD_STATUS.exitstatus}"
+  end
 end

--- a/tests/units/test_ls_tree.rb
+++ b/tests/units/test_ls_tree.rb
@@ -1,0 +1,31 @@
+require 'test_helper'
+
+class TestLsTree < Test::Unit::TestCase
+  def test_ls_tree_with_submodules
+    in_temp_dir do
+      submodule = Git.init('submodule', initial_branch: 'main')
+      File.write('submodule/README.md', '# Submodule')
+      submodule.add('README.md')
+      submodule.commit('Add README.md')
+
+      repo = Git.init('repo', initial_branch: 'main')
+      File.write('repo/README.md', '# Main Repository')
+      repo.add('README.md')
+      repo.commit('Add README.md')
+
+      Dir.chdir('repo') do
+        assert_child_process_success { `git -c protocol.file.allow=always submodule add ../submodule submodule 2>&1` }
+        assert_child_process_success { `git commit -am "Add submodule" 2>&1` }
+      end
+
+      expected_submodule_sha = submodule.object('HEAD').sha
+
+      # Make sure the ls_tree command can handle submodules (which show up as a commit object in the tree)
+      tree = assert_nothing_raised { repo.ls_tree('HEAD') }
+      actual_submodule_sha = tree.dig('commit', 'submodule', :sha)
+
+      # Make sure the submodule commit was parsed correctly
+      assert_equal(expected_submodule_sha, actual_submodule_sha, 'Submodule SHA was not returned')
+    end
+  end
+end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

Fixes #475

[git-ls-tree](https://git-scm.com/docs/git-ls-tree) returns three types of objects: `commits`, `blobs` and `trees`. `git ls-tree` returns a commit in place of a submodule tree to indicate the commit SHA in the submodule's repository that is linked into the containing repository.

The implementation of `Git::Lib#ls_tree` raised an error when `git ls-tree` returns a `commit`. This PR changes the implementation so that the commit is returned in the Hash returned (from the test case):

```ruby
{
  "blob" => {
    ".gitmodules" =>{ mode: "100644", sha: "caff6b7d44973f53e3e0cf31d0d695188b19aec6" },
    "README.md" => { mode: "100644", sha: "ab1bc6e140b700e97253b02e4ca117abe068a73f" }
    },
  "tree" => { },
  "commit" => {
    "submodule" => { mode: "160000", sha: "31b05441cda227c0531d659a13b7e10ce3ba8754" }
  }
}
```