### PR TITLE
Add the push_option option for Git::Lib#push

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -374,10 +374,23 @@ module Git
       self.lib.fetch(remote, opts)
     end
 
-    # pushes changes to a remote repository - easiest if this is a cloned repository,
-    # otherwise you may have to run something like this first to setup the push parameters:
+    # Push changes to a remote repository
     #
-    #  @git.config('remote.remote-name.push', 'refs/heads/master:refs/heads/master')
+    # @overload push(remote = nil, branch = nil, options = {})
+    #   @param remote [String] the remote repository to push to
+    #   @param branch [String] the branch to push
+    #   @param options [Hash] options to pass to the push command
+    #
+    #   @option opts [Boolean] :mirror (false) Push all refs under refs/heads/, refs/tags/ and refs/remotes/
+    #   @option opts [Boolean] :delete (false) Delete refs that don't exist on the remote
+    #   @option opts [Boolean] :force (false) Force updates
+    #   @option opts [Boolean] :tags (false) Push all refs under refs/tags/
+    #   @option opts [Array, String] :push_options (nil) Push options to transmit
+    #
+    #   @return [Void]
+    #
+    #   @raise [Git::FailedError] if the push fails
+    #   @raise [ArgumentError] if a branch is given without a remote
     #
     def push(*args, **options)
       self.lib.push(*args, **options)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -982,6 +982,7 @@ module Git
       arr_opts << '--mirror'  if opts[:mirror]
       arr_opts << '--delete'  if opts[:delete]
       arr_opts << '--force'  if opts[:force] || opts[:f]
+      Array(opts[:push_option]).each { |o| arr_opts << '--push-option' << o } if opts[:push_option]
       arr_opts << remote if remote
       arr_opts_with_branch = arr_opts.dup
       arr_opts_with_branch << branch if branch

--- a/tests/units/test_push.rb
+++ b/tests/units/test_push.rb
@@ -22,6 +22,20 @@ class TestPush < Test::Unit::TestCase
     assert_command_line(expected_command_line, git_cmd, git_cmd_args)
   end
 
+  test 'push with a single push option' do
+    expected_command_line = ['push', '--push-option', 'foo']
+    git_cmd = :push
+    git_cmd_args = [push_option: 'foo']
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
+  test 'push with an array of push options' do
+    expected_command_line = ['push', '--push-option', 'foo', '--push-option', 'bar', '--push-option', 'baz']
+    git_cmd = :push
+    git_cmd_args = [push_option: ['foo', 'bar', 'baz']]
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
   test 'push with only a remote name and options' do
     expected_command_line = ['push', '--force', 'origin']
     git_cmd = :push


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

Add the ability to specify `--push-option` args to the `git push` command (see [git-push](https://git-scm.com/docs/git-push) for details).

Either a string or an array may be passed:

```ruby
# pass a single push-option
# results in `git push --push-option foo`
git.push(push_option: 'foo') 


# pass one or more push-options:
# results in `git push --push-option foo --push-option bar --push-option baz`
git.push(push_option: ['foo', 'bar', 'baz'])
```