### PR TITLE
Release v1.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 # Change Log
 
+## v1.17.0 (2023-03-05)
+
+[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v1.16.0..v1.17.0)
+
+Changes since v1.16.0:
+
+* 1311 Add deprecation mechanism (introduces runtime dependency on ActiveSupport) (#645)
+* 50b8 Add the push_option option for Git::Lib#push (#644)
+* a799 Make Git::Base#ls_tree handle commit objects (#643)
+* 6db3 Implememt Git.default_branch (#571)
+
 ## v1.16.0 (2023-03-03)
 
 [Full Changelog](https://github.com/ruby-git/ruby-git/compare/v1.15.0..v1.16.0)

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -1,5 +1,5 @@
 module Git
   # The current gem version
   # @return [String] the current gem version.
-  VERSION='1.16.0'
+  VERSION='1.17.0'
 end


### PR DESCRIPTION
# Release PR

## v1.17.0 (2023-03-05)

[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v1.16.0..v1.17.0)

Changes since v1.16.0:

* 1311 Add deprecation mechanism (introduces runtime dependency on ActiveSupport) (#645)
* 50b8 Add the push_option option for Git::Lib#push (#644)
* a799 Make Git::Base#ls_tree handle commit objects (#643)
* 6db3 Implememt Git.default_branch (#571)
