### PR TITLE
Release v1.17.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 
 # Change Log
 
+## v1.17.1 (2023-03-06)
+
+[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v1.17.0..v1.17.1)
+
+Changes since v1.17.0:
+
+* 774e Revert introduction of ActiveSupport dependency (#649)
+
 ## v1.17.0 (2023-03-05)
 
 [Full Changelog](https://github.com/ruby-git/ruby-git/compare/v1.16.0..v1.17.0)

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -1,5 +1,5 @@
 module Git
   # The current gem version
   # @return [String] the current gem version.
-  VERSION='1.17.0'
+  VERSION='1.17.1'
 end


### PR DESCRIPTION
# Release PR

## v1.17.1 (2023-03-06)

[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v1.17.0..v1.17.1)

Changes since v1.17.0:

* 774e Revert introduction of ActiveSupport dependency (#649)
