### PR TITLE
Fix branch name parsing to handle names that include slashes

### DIFF
--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -1,11 +1,9 @@
 require 'git/path'
 
 module Git
-
   class Branch < Path
-    
     attr_accessor :full, :remote, :name
-    
+
     def initialize(base, name)
       @full = name
       @base = base
@@ -13,25 +11,25 @@ module Git
       @stashes = nil
       @remote, @name = parse_name(name)
     end
-    
+
     def gcommit
       @gcommit ||= @base.gcommit(@full)
       @gcommit
     end
-    
+
     def stashes
       @stashes ||= Git::Stashes.new(@base)
     end
-    
+
     def checkout
       check_if_create
       @base.checkout(@full)
     end
-    
+
     def archive(file, opts = {})
       @base.lib.archive(@full, file, opts)
     end
-    
+
     # g.branch('new_branch').in_branch do
     #   # create new file
     #   # do other stuff
@@ -47,26 +45,26 @@ module Git
       end
       @base.checkout(old_current)
     end
-    
+
     def create
       check_if_create
     end
-    
+
     def delete
       @base.lib.branch_delete(@name)
     end
-    
+
     def current
       determine_current
     end
-    
+
     def contains?(commit)
       !@base.lib.branch_contains(commit, self.name).empty?
     end
-    
+
     def merge(branch = nil, message = nil)
       if branch
-        in_branch do 
+        in_branch do
           @base.merge(branch, message)
           false
         end
@@ -76,7 +74,7 @@ module Git
         @base.merge(@name)
       end
     end
-    
+
     def update_ref(commit)
       if @remote
         @base.lib.update_ref("refs/remotes/#{@remote.name}/#{@name}", commit)
@@ -84,47 +82,62 @@ module Git
         @base.lib.update_ref("refs/heads/#{@name}", commit)
       end
     end
-    
+
     def to_a
       [@full]
     end
-    
+
     def to_s
       @full
     end
-    
-    private 
 
-      def check_if_create
-        @base.lib.branch_new(@name) rescue nil
-      end
-      
-      def determine_current
-        @base.lib.branch_current == @name
-      end
-    
-      # Given a full branch name return an Array containing the remote and branch names.
-      #
-      # Removes 'remotes' from the beggining of the name (if present).
-      # Takes the second part (splittign by '/') as the remote name.
-      # Takes the rest as the repo name (can also hold one or more '/').
-      #
-      # Example:
-      #   parse_name('master') #=> [nil, 'master']
-      #   parse_name('origin/master') #=> ['origin', 'master']
-      #   parse_name('remotes/origin/master') #=> ['origin', 'master']
-      #   parse_name('origin/master/v2') #=> ['origin', 'master/v2'] 
-      #
-      # param [String] name branch full name.
-      # return [<Git::Remote,NilClass,String>] an Array containing the remote and branch names. 
-      def parse_name(name)
-        if name.match(/^(?:remotes\/)?([^\/]+)\/(.+)/)
-          return [Git::Remote.new(@base, $1), $2]
-        end
+    private
 
-        return [nil, name]
-      end
-    
+    def check_if_create
+      @base.lib.branch_new(@name) rescue nil
+    end
+
+    def determine_current
+      @base.lib.branch_current == @name
+    end
+
+    BRANCH_NAME_REGEXP = %r{
+      ^
+        # Optional 'refs/remotes/' at the beggining to specify a remote tracking branch
+        # with a <remote_name>. <remote_name> is nil if not present.
+        (?:
+          (?:(?:refs/)?remotes/)(?<remote_name>[^/]+)/
+        )?
+        (?<branch_name>.*)
+      $
+    }x
+
+    # Given a full branch name return an Array containing the remote and branch names.
+    #
+    # Removes 'remotes' from the beggining of the name (if present).
+    # Takes the second part (splittign by '/') as the remote name.
+    # Takes the rest as the repo name (can also hold one or more '/').
+    #
+    # Example:
+    #   # local branches
+    #   parse_name('master') #=> [nil, 'master']
+    #   parse_name('origin/master') #=> [nil, 'origin/master']
+    #   parse_name('origin/master/v2') #=> [nil, 'origin/master']
+    #
+    #   # remote branches
+    #   parse_name('remotes/origin/master') #=> ['origin', 'master']
+    #   parse_name('remotes/origin/master/v2') #=> ['origin', 'master/v2']
+    #   parse_name('refs/remotes/origin/master') #=> ['origin', 'master']
+    #   parse_name('refs/remotes/origin/master/v2') #=> ['origin', 'master/v2']
+    #
+    # param [String] name branch full name.
+    # return [<Git::Remote,NilClass,String>] an Array containing the remote and branch names.
+    def parse_name(name)
+      # Expect this will always match
+      match = name.match(BRANCH_NAME_REGEXP)
+      remote = match[:remote_name] ? Git::Remote.new(@base, match[:remote_name]) : nil
+      branch_name = match[:branch_name]
+      [ remote, branch_name ]
+    end
   end
-  
 end

--- a/tests/units/test_checkout.rb
+++ b/tests/units/test_checkout.rb
@@ -79,4 +79,18 @@ class TestCheckout < Test::Unit::TestCase
       assert_raises(Git::FailedError) { git.checkout('master') }
     end
   end
+
+  test 'checking out to a branch whose name contains slashes' do
+    in_temp_dir do
+      git = Git.init('.', initial_branch: 'master')
+
+      File.write('file1.txt', 'file1')
+      git.add('file1.txt')
+      git.commit('commit1')
+
+      assert_nothing_raised { git.branch('foo/a_new_branch').checkout }
+
+      assert_equal('foo/a_new_branch', git.current_branch)
+    end
+  end
 end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

#626 made a change to branch names parsing that incorrectly handled branch names with slashes. This PR reverses that change, improves the implementation to make it more readable, and better documents what Git::Branch#parse_name does. 

That said, how branch names are dealt with by this gem need to be re-thought because it is not possible to correctly parse a non-full ref all the time. For instance, does `origin/master` refer to a remote tracking branch named `master` or to a local branch named `origin/master`? The only way to tell for sure is if you have the full ref: `refs/remotes/origin/master` is a remote tracking branch and `refs/heads/origin/master` is a local branch.

This change makes it so that any branch whose name (not full reference) begins with `refs/remotes/` or `remotes/` must be treated as a remote tracking branch. An example where this implementation would fail is if you has a local branch named `remotes/master/v2` whose full ref is `refs/heads/remotes/master/v2`.

Even though `refs/heads/remotes/master` is considered 