### PR TITLE
Update Git.clone to set multiple config variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,18 @@ end
 g.config('user.name')  # returns 'Scott Chacon'
 g.config # returns whole config hash
 
+# Configuration can be set when cloning using the :config option.
+# This option can be an single configuration String or an Array
+# if multiple config items need to be set.
+#
+g = Git.clone(
+  git_uri, destination_path,
+  :config => [
+    'core.sshCommand=ssh -i /home/user/.ssh/id_rsa',
+    'submodule.recurse=true'
+  ]
+)
+
 g.tags # returns array of Git::Tag objects
 
 g.show()

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -133,6 +133,9 @@ module Git
   # @option options [String] :branch The name of a branch or tag to checkout
   #   instead of the default branch.
   #
+  # @option options [Array, String] :config A list of configuration options to
+  #  set on the newly created repository.
+  #
   # @option options [Integer] :depth Create a shallow clone with a history
   #   truncated to the specified number of commits.
   #
@@ -165,6 +168,18 @@ module Git
   #
   # @example Create a bare repository in the directory `ruby-git.git`
   #   git = Git.clone('https://github.com/ruby-git/ruby-git.git', bare: true)
+  #
+  # @example Clone a repository and set a single config option
+  #   git = Git.clone(
+  #     'https://github.com/ruby-git/ruby-git.git',
+  #     config: 'submodule.recurse=true'
+  #   )
+  #
+  # @example Clone a repository and set multiple config options
+  #   git = Git.clone(
+  #     'https://github.com/ruby-git/ruby-git.git',
+  #     config: ['user.name=John Doe', 'user.email=john@doe.com']
+  #   )
   #
   # @return [Git::Base] an object that can execute git commands in the context
   #   of the cloned local working copy or cloned repository.

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -101,7 +101,7 @@ module Git
       arr_opts << '--bare' if opts[:bare]
       arr_opts << '--branch' << opts[:branch] if opts[:branch]
       arr_opts << '--depth' << opts[:depth].to_i if opts[:depth] && opts[:depth].to_i > 0
-      arr_opts << '--config' << opts[:config] if opts[:config]
+      Array(opts[:config]).each { |c| arr_opts << '--config' << c }
       arr_opts << '--origin' << opts[:remote] || opts[:origin] if opts[:remote] || opts[:origin]
       arr_opts << '--recursive' if opts[:recursive]
       arr_opts << '--mirror' if opts[:mirror]

--- a/tests/units/test_git_clone.rb
+++ b/tests/units/test_git_clone.rb
@@ -33,4 +33,54 @@ class TestGitClone < Test::Unit::TestCase
       assert_equal(expected_dir, git.dir.to_s)
     end
   end
+
+  test 'clone with single config option' do
+    repository_url = 'https://github.com/ruby-git/ruby-git.git'
+    destination = 'ruby-git'
+
+    actual_command_line = nil
+
+    in_temp_dir do |path|
+      git = Git.init('.')
+
+      # Mock the Git::Lib#command method to capture the actual command line args
+      git.lib.define_singleton_method(:command) do |cmd, *opts, &block|
+        actual_command_line = [cmd, *opts.flatten]
+      end
+
+      git.lib.clone(repository_url, destination, { config: 'user.name=John Doe' })
+    end
+
+    expected_command_line = ['clone', '--config', 'user.name=John Doe', '--', repository_url, destination]
+
+    assert_equal(expected_command_line, actual_command_line)
+  end
+
+  test 'clone with multiple config options' do
+    repository_url = 'https://github.com/ruby-git/ruby-git.git'
+    destination = 'ruby-git'
+
+    actual_command_line = nil
+
+    in_temp_dir do |path|
+      git = Git.init('.')
+
+      # Mock the Git::Lib#command method to capture the actual command line args
+      git.lib.define_singleton_method(:command) do |cmd, *opts, &block|
+        actual_command_line = [cmd, *opts.flatten]
+      end
+
+      git.lib.clone(repository_url, destination, { config: ['user.name=John Doe', 'user.email=john@doe.com'] })
+    end
+
+    expected_command_line = [
+      'clone',
+      '--config', 'user.name=John Doe',
+      '--config', 'user.email=john@doe.com',
+      '--', repository_url, destination
+    ]
+
+    assert_equal(expected_command_line, actual_command_line)
+  end
+
 end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

Currently, `Git.clone` only allows setting a single config variable via the `:config` option. This option is given as a string as follows:

```ruby
Git.clone(uri, destination, { config: 'submodule.recurse=true' }
```

This PR allows an Array to be given for `:config` (in addition to still supporting the single String value):

```ruby
g = Git.clone(
  uri, destination,
  :config => [
    'core.sshCommand=ssh -i /home/user/.ssh/id_rsa',
    'submodule.recurse=true'
  ]
)

See [git-clone --config](https://git-scm.com/docs/git-clone#Documentation/git-clone.txt--cltkeygtltvaluegt) for more details.