### PR TITLE
Avoid stderr redirection so GIT_TRACE can be used

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -67,7 +67,7 @@ module Git
       result = working_dir
       status = nil
       Dir.chdir(working_dir) do
-        git_cmd = "#{Git::Base.config.binary_path} -c core.quotePath=true -c color.ui=false rev-parse --show-toplevel 2>&1"
+        git_cmd = "#{Git::Base.config.binary_path} -c core.quotePath=true -c color.ui=false rev-parse --show-toplevel"
         result = `#{git_cmd}`.chomp
         status = $?
       end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [ ] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
Redirecting stderr to stdout causes incompatibility while using `GIT_TRACE` env var.

### Example 1
```
$ gem list git | grep "git "
git (1.17.2)

$ cat test.rb
require 'git'

g = Git.open("/home/jon/src/git-gem/test_git_repo")

$ export GIT_TRACE=1
$ ruby test.rb
Traceback (most recent call last):
/home/jon/src/git-gem/12:48:53.007165 git.c:460               trace: built-in: git rev-parse --show-toplevel
/home/jon/src/git-gem/test_git_repo: path does not exist (ArgumentError)

$ echo $?
1

$ export GIT_TRACE=0
$ ruby test.rb
$ echo $?
0
```

### Example 2

```
$ export GIT_TRACE=0
$ git -C test_git_repo/ -c core.quotePath=true -c color.ui=false rev-parse --show-toplevel
/home/jon/src/git-gem/test_git_repo
$ echo $?
0

$ export GIT_TRACE=1
$ git -C test_git_repo/ -c core.quotePath=true -c color.ui=false rev-parse --show-toplevel
12:46:37.325649 git.c:460               trace: built-in: git rev-parse --show-toplevel
/home/jon/src/git-gem/test_git_repo
$ echo $?
0
```

