### PR TITLE
Add test to ensure that `Git.open` works for submodules

### DIFF
--- a/tests/units/test_submodule.rb
+++ b/tests/units/test_submodule.rb
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+
+require 'test_helper'
+
+class TestSubmodule < Test::Unit::TestCase
+  test 'Git.open should be able to open a submodule' do
+    in_temp_dir do
+      submodule = Git.init('submodule', initial_branch: 'main')
+      File.write('submodule/README.md', '# Submodule')
+      submodule.add('README.md')
+      submodule.commit('Add README.md')
+
+      repo = Git.init('repo', initial_branch: 'main')
+      File.write('repo/README.md', '# Main Repository')
+      repo.add('README.md')
+      repo.commit('Add README.md')
+
+      Dir.chdir('repo') do
+        assert_child_process_success { `git -c protocol.file.allow=always submodule add ../submodule submodule 2>&1` }
+        assert_child_process_success { `git commit -am "Add submodule" 2>&1` }
+      end
+
+      submodule_repo = assert_nothing_raised { Git.open('repo/submodule') }
+
+      assert_equal(submodule.object('HEAD').sha, submodule_repo.object('HEAD').sha)
+    end
+  end
+
+  test 'Git.open should be able to open a submodule from a subdirectory within the submodule' do
+    in_temp_dir do
+      submodule = Git.init('submodule', initial_branch: 'main')
+      Dir.mkdir('submodule/subdir')
+      File.write('submodule/subdir/README.md', '# Submodule')
+      submodule.add('subdir/README.md')
+      submodule.commit('Add README.md')
+
+      repo = Git.init('repo', initial_branch: 'main')
+      File.write('repo/README.md', '# Main Repository')
+      repo.add('README.md')
+      repo.commit('Add README.md')
+
+      Dir.chdir('repo') do
+        assert_child_process_success { `git -c protocol.file.allow=always submodule add ../submodule submodule 2>&1` }
+        assert_child_process_success { `git commit -am "Add submodule" 2>&1` }
+      end
+
+      submodule_repo = assert_nothing_raised { Git.open('repo/submodule/subdir') }
+
+      repo_files = submodule_repo.ls_files
+      assert(repo_files.include?('subdir/README.md'))
+    end
+  end
+end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

There was no test that ensured that `Git.open` works for submodules. This PR adds two tests:
* test that a submodule can be opened from its root directory
* test that a submodule can be opened from a subdirectory within the submodule

This supersedes #488 