### PR TITLE
Correctly report command output when there is an error

### DIFF
--- a/lib/git/failed_error.rb
+++ b/lib/git/failed_error.rb
@@ -14,18 +14,20 @@ module Git
   class FailedError < Git::GitExecuteError
     # Create a FailedError object
     #
+    # Since this gem redirects stderr to stdout, the stdout of the process is used.
+    #
     # @example
     #   `exit 1` # set $? appropriately for this example
-    #   result = Git::CommandLineResult.new(%w[git status], $?, '', "failed")
+    #   result = Git::CommandLineResult.new(%w[git status], $?, 'stdout', 'stderr')
     #   error = Git::FailedError.new(result)
     #   error.message #=>
-    #     "[\"git\", \"status\"]\nstatus: pid 89784 exit 1\nstderr: \"failed\""
+    #     "[\"git\", \"status\"]\nstatus: pid 89784 exit 1\noutput: \"stdout\""
     #
     # @param result [Git::CommandLineResult] the result of the git command including
     #   the git command, status, stdout, and stderr
     #
     def initialize(result)
-      super("#{result.git_cmd}\nstatus: #{result.status}\nstderr: #{result.stderr.inspect}")
+      super("#{result.git_cmd}\nstatus: #{result.status}\noutput: #{result.stdout.inspect}")
       @result = result
     end
 
@@ -35,14 +37,14 @@ module Git
     #
     # @example
     #   `exit 1` # set $? appropriately for this example
-    #   result = Git::CommandLineResult.new(%w[git status], $?, '', "failed")
+    #   result = Git::CommandLineResult.new(%w[git status], $?, 'stdout', 'stderr')
     #   error = Git::FailedError.new(result)
     #   error.result #=>
     #     #<Git::CommandLineResult:0x00000001046bd488
     #       @git_cmd=["git", "status"],
     #       @status=#<Process::Status: pid 89784 exit 1>,
-    #       @stderr="failed",
-    #       @stdout="">
+    #       @stderr="stderr",
+    #       @stdout="stdout">
     #
     # @return [Git::CommandLineResult]
     #

--- a/tests/units/test_failed_error.rb
+++ b/tests/units/test_failed_error.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class TestFailedError < Test::Unit::TestCase
   def test_initializer
     status = Struct.new(:to_s).new('pid 89784 exit 1')
-    result = Git::CommandLineResult.new(%w[git status], status, '', "failed")
+    result = Git::CommandLineResult.new(%w[git status], status, 'stdout', 'stderr')
 
     error = Git::FailedError.new(result)
 
@@ -13,11 +13,11 @@ class TestFailedError < Test::Unit::TestCase
 
   def test_message
     status = Struct.new(:to_s).new('pid 89784 exit 1')
-    result = Git::CommandLineResult.new(%w[git status], status, '', "failed")
+    result = Git::CommandLineResult.new(%w[git status], status, 'stdout', 'stderr')
 
     error = Git::FailedError.new(result)
 
-    expected_message = "[\"git\", \"status\"]\nstatus: pid 89784 exit 1\nstderr: \"failed\""
+    expected_message = "[\"git\", \"status\"]\nstatus: pid 89784 exit 1\noutput: \"stdout\""
     assert_equal(expected_message, error.message)
   end
 end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

Include command line output in command result instead of just stderr. This gem currently redirects stderr to stdout so the reported error message was always blank.

Thanks @alexjfisher