### PR TITLE
Do not generate yard documentation when building in TruffleRuby

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -18,7 +18,7 @@ task :test do
 end
 default_tasks << :test
 
-unless RUBY_PLATFORM == 'java'
+unless RUBY_PLATFORM == 'java' || RUBY_ENGINE == 'truffleruby'
   #
   # YARD documentation for this project can NOT be built with JRuby.
   # This project uses the redcarpet gem which can not be installed on JRuby.


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

When building YARD documentation using TruffleRuby-head, the following error occurs which fails the build:

```shell
[warn]: Syntax error in `lib/git/lib.rb`:(695,11): _1 is reserved for numbered parameter
[20](https://github.com/ruby-git/ruby-git/actions/runs/4380304214/jobs/7667220593#step:4:21)
[warn]: ParserSyntaxError: syntax error in `lib/git/lib.rb`:(695,11): _1 is reserved for numbered parameter
[21](https://github.com/ruby-git/ruby-git/actions/runs/4380304214/jobs/7667220593#step:4:22)
[warn]: Stack trace:
[22](https://github.com/ruby-git/ruby-git/actions/runs/4380304214/jobs/7667220593#step:4:23)
	/home/runner/work/ruby-git/ruby-git/vendor/bundle/truffleruby/3.1.3.3/gems/yard-0.9.28/lib/yard/parser/ruby/ruby_parser.rb:601:in `on_parse_error'
[23](https://github.com/ruby-git/ruby-git/actions/runs/4380304214/jobs/7667220593#step:4:24)
	/home/runner/.rubies/truffleruby-head/lib/truffle/truffle/cext.rb:919:in `rb_funcall'
[24](https://github.com/ruby-git/ruby-git/actions/runs/4380304214/jobs/7667220593#step:4:25)
	ripper.y:13755:in `ripper_compile_error'
[25](https://github.com/ruby-git/ruby-git/actions/runs/4380304214/jobs/7667220593#step:4:26)
	ripper.y:12686:in `numparam_name'
[26](https://github.com/ruby-git/ruby-git/actions/runs/4380304214/jobs/7667220593#step:4:27)
	ripper.y:1808:in `ripper_yyparse'
[27](https://github.com/ruby-git/ruby-git/actions/runs/4380304214/jobs/7667220593#step:4:28)
	ripper.y:13844:in `ripper_parse0'
[28](https://github.com/ruby-git/ruby-git/actions/runs/4380304214/jobs/7667220593#step:4:29)
```

For this project, YARD docs do not need to be built using TruffleRuby so I am disabling this for now.