### PR TITLE
Add support for `--update-head-ok` to `fetch`

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,6 +311,7 @@ g.fetch
 g.fetch(g.remotes.first)
 g.fetch('origin', {:ref => 'some/ref/head'} )
 g.fetch(all: true, force: true, depth: 2)
+g.fetch('origin', {:'update-head-ok' => true})
 
 g.pull
 g.pull(Git::Repo, Git::Branch) # fetch and a merge

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -951,6 +951,7 @@ module Git
       arr_opts << '--prune' if opts[:p] || opts[:prune]
       arr_opts << '--prune-tags' if opts[:P] || opts[:'prune-tags']
       arr_opts << '--force' if opts[:f] || opts[:force]
+      arr_opts << '--update-head-ok' if opts[:u] || opts[:'update-head-ok']
       arr_opts << '--unshallow' if opts[:unshallow]
       arr_opts << '--depth' << opts[:depth] if opts[:depth]
       arr_opts << '--' if remote || opts[:ref]

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -147,6 +147,13 @@ class TestRemotes < Test::Unit::TestCase
     assert_command_line(expected_command_line, git_cmd, git_cmd_args)
   end
 
+  def test_fetch_cmd_with_update_head_ok
+    expected_command_line = ['fetch', '--update-head-ok']
+    git_cmd = :fetch
+    git_cmd_args = [:'update-head-ok' => true]
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
   def test_fetch_command_injection
     test_file = 'VULNERABILITY_EXISTS'
     vulnerability_exists = false


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
Hey! Thanks for maintaining this awesome gem. This is my PR here, it's to add support for the [`--update-head-ok` (or `-u`) option](https://git-scm.com/docs/git-fetch#Documentation/git-fetch.txt--u) to '#fetch`. Looking forward to (hopefully) getting this shipped! 🚢 
