### PR TITLE
Add --filter to Git.clone for partial clones

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ g.dir #=> /tmp/clone/ruby-git-clean
 g.config('user.name', 'Scott Chacon')
 g.config('user.email', 'email@email.com')
 
+# Clone can take a filter to tell the serve to send a partial clone
+g = Git.clone(git_url, name, :path => path, :filter => 'tree:0')
+
 # Clone can take an optional logger
 logger = Logger.new
 g = Git.clone(git_url, NAME, :log => logger)

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -139,6 +139,9 @@ module Git
   # @option options [Integer] :depth Create a shallow clone with a history
   #   truncated to the specified number of commits.
   #
+  # @option options [String] :filter Request that the server send a partial
+  #   clone according to the given filter
+  #
   # @option options [Logger] :log A logger to use for Git operations.  Git
   #   commands are logged at the `:info` level.  Additional logging is done
   #   at the `:debug` level.

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -102,7 +102,7 @@ module Git
       arr_opts << '--bare' if opts[:bare]
       arr_opts << '--branch' << opts[:branch] if opts[:branch]
       arr_opts << '--depth' << opts[:depth].to_i if opts[:depth] && opts[:depth].to_i > 0
-      arr_opts << "--filter=#{opts[:filter]}" if opts[:filter]
+      arr_opts << '--filter' << opts[:filter] if opts[:filter]
       Array(opts[:config]).each { |c| arr_opts << '--config' << c }
       arr_opts << '--origin' << opts[:remote] || opts[:origin] if opts[:remote] || opts[:origin]
       arr_opts << '--recursive' if opts[:recursive]

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -84,6 +84,7 @@ module Git
     #  :bare::      no working directory
     #  :branch::    name of branch to track (rather than 'master')
     #  :depth::     the number of commits back to pull
+    #  :filter::    specify partial clone
     #  :origin::    name of remote (same as remote)
     #  :path::      directory where the repo will be cloned
     #  :remote::    name of remote (rather than 'origin')
@@ -101,6 +102,7 @@ module Git
       arr_opts << '--bare' if opts[:bare]
       arr_opts << '--branch' << opts[:branch] if opts[:branch]
       arr_opts << '--depth' << opts[:depth].to_i if opts[:depth] && opts[:depth].to_i > 0
+      arr_opts << "--filter=#{opts[:filter]}" if opts[:filter]
       Array(opts[:config]).each { |c| arr_opts << '--config' << c }
       arr_opts << '--origin' << opts[:remote] || opts[:origin] if opts[:remote] || opts[:origin]
       arr_opts << '--recursive' if opts[:recursive]

--- a/tests/units/test_git_clone.rb
+++ b/tests/units/test_git_clone.rb
@@ -83,4 +83,29 @@ class TestGitClone < Test::Unit::TestCase
     assert_equal(expected_command_line, actual_command_line)
   end
 
+  test 'clone with a filter' do
+    repository_url = 'https://github.com/ruby-git/ruby-git.git'
+    destination = 'ruby-git'
+
+    actual_command_line = nil
+
+    in_temp_dir do |path|
+      git = Git.init('.')
+
+      # Mock the Git::Lib#command method to capture the actual command line args
+      git.lib.define_singleton_method(:command) do |cmd, *opts, &block|
+        actual_command_line = [cmd, *opts.flatten]
+      end
+
+      git.lib.clone(repository_url, destination, filter: 'tree:0')
+    end
+
+    expected_command_line = [
+      'clone',
+      '--filter', 'tree:0',
+      '--', repository_url, destination
+    ]
+
+    assert_equal(expected_command_line, actual_command_line)
+  end
 end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description

Add in support for `git clone --filter` option so you can do partial clones with. For example, `Git.clone(..., filter: 'tree:0')` would result in `git clone ... --filter=tree:0`
