### PR TITLE
Update test of 'git worktree add' with no commits

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1108,6 +1108,22 @@ module Git
       version_parts.fill(0, version_parts.length...3)
     end
 
+    # Returns current_command_version <=> other_version
+    #
+    # @example
+    #   lib.current_command_version #=> [2, 42, 0]
+    #
+    #   lib.compare_version_to(2, 41, 0) #=> 1 
+    #   lib.compare_version_to(2, 42, 0) #=> 0
+    #   lib.compare_version_to(2, 43, 0) #=> -1
+    #
+    # @param other_version [Array<Object>] the other version to compare to
+    # @return [Integer] -1 if this version is less than other_version, 0 if equal, or 1 if greater than
+    #
+    def compare_version_to(*other_version)
+      current_command_version <=> other_version
+    end
+
     def required_command_version
       [1, 6]
     end

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -325,4 +325,15 @@ class TestLib < Test::Unit::TestCase
     assert(@lib.show('gitsearch1', 'scott/text.txt') == "hello\nthis is\na file\nthat is\nput here\nto search one\nto search two\nnothing!\n")
   end
 
+  def test_compare_version_to
+    lib = Git::Lib.new(nil, nil)
+    current_version = [2, 42, 0]
+    lib.define_singleton_method(:current_command_version) { current_version }
+    assert lib.compare_version_to(0, 43, 9) == 1
+    assert lib.compare_version_to(2, 41, 0) == 1
+    assert lib.compare_version_to(2, 42, 0) == 0
+    assert lib.compare_version_to(2, 42, 1) == -1
+    assert lib.compare_version_to(2, 43, 0) == -1
+    assert lib.compare_version_to(3, 0, 0) == -1
+  end
 end

--- a/tests/units/test_repack.rb
+++ b/tests/units/test_repack.rb
@@ -3,20 +3,18 @@
 require 'test_helper'
 
 class TestRepack < Test::Unit::TestCase
-  def test_repack
+  test 'should be able to call repack with the right args' do
     in_bare_repo_clone do |r1|
       new_file('new_file', 'new content')
-
       r1.add
       r1.commit('my commit')
 
-      # see how big the repo is
-      size1 = r1.repo_size
+      # assert_nothing_raised { r1.repack }
 
-      r1.repack
-
-      # see how big the repo is now, should be smaller
-      assert(size1 > r1.repo_size)
+      expected_command_line = ['repack', '-a', '-d']
+      git_cmd = :repack
+      git_cmd_args = []
+      assert_command_line(expected_command_line, git_cmd, git_cmd_args)
     end
   end
 end

--- a/tests/units/test_worktree.rb
+++ b/tests/units/test_worktree.rb
@@ -31,6 +31,8 @@ class TestWorktree < Test::Unit::TestCase
   end
 
   test 'adding a worktree when there are no commits should fail' do
+    omit('Omitted since git version is >= 2.42.0') if Git::Lib.new(nil, nil).compare_version_to(2, 42, 0) >= 0
+
     in_temp_dir do |path|
       Dir.mkdir('main_worktree')
       Dir.chdir('main_worktree') do
@@ -43,6 +45,33 @@ class TestWorktree < Test::Unit::TestCase
 
       assert_raises(Git::FailedError) do
         git.worktree('feature1').add
+      end
+    end
+  end
+
+  test 'adding a worktree when there are no commits should succeed' do
+    omit('Omitted since git version is < 2.42.0') if Git::Lib.new(nil, nil).compare_version_to(2, 42, 0) < 0
+
+    in_temp_dir do |path|
+      Dir.mkdir('main_worktree')
+      Dir.chdir('main_worktree') do
+        `git init`
+        # `git commit --allow-empty -m "first commit"`
+      end
+
+      git = Git.open('main_worktree')
+
+      assert_nothing_raised do
+        git.worktree('feature1').add
+      end
+
+      assert_equal(2, git.worktrees.size)
+
+      expected_worktree_dirs = [
+        File.join(path, 'main_worktree'),
+        File.join(path, 'feature1')
+      ].each_with_index do |expected_worktree_dir, i|
+        assert_equal(expected_worktree_dir, git.worktrees.to_a[i].dir)
       end
     end
   end


### PR DESCRIPTION
- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
git-2.42.0 changes the behavior of `git worktree add` when there are no commits in the repository. Prior to 2.42.0, an error would result with creating a new worktree. Starting wtih 2.42.0, git will create an orphan branch for the worktree.

#### Other Changes

This PR also adds `Git::Lib#compare_version_to(other_version)` which return -1 if the git command version is less than the other_version, 0 if equal, and 1 if greater than.

This PR rewrites tests/units/test_repack.rb to make sure that the correct git command was called without error when Git::Lib#repack is called. Prior to this change, the test actually checked to see if the size of the repository was less after calling repack which was not always the case in the tests.