### PR TITLE
Remove calls to Dir.chdir

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -244,7 +244,7 @@ module Git
     options.delete(:remote)
     repo = clone(repository, name, {:depth => 1}.merge(options))
     repo.checkout("origin/#{options[:branch]}") if options[:branch]
-    Dir.chdir(repo.dir.to_s) { FileUtils.rm_r '.git' }
+    FileUtils.rm_r File.join(repo.dir.to_s, '.git')
   end
 
   # Same as g.config, but forces it to be at the global level

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1,5 +1,6 @@
 require 'git/base/factory'
 require 'logger'
+require 'open3'
 
 module Git
   # Git::Base is the main public interface for interacting with Git commands.
@@ -66,11 +67,11 @@ module Git
     def self.root_of_worktree(working_dir)
       result = working_dir
       status = nil
-      Dir.chdir(working_dir) do
-        git_cmd = "#{Git::Base.config.binary_path} -c core.quotePath=true -c color.ui=false rev-parse --show-toplevel 2>&1"
-        result = `#{git_cmd}`.chomp
-        status = $?
-      end
+
+      git_cmd = "#{Git::Base.config.binary_path} -c core.quotePath=true -c color.ui=false rev-parse --show-toplevel 2>&1"
+      result, status = Open3.capture2(git_cmd, chdir: File.expand_path(working_dir))
+      result = result.chomp
+
       raise ArgumentError, "'#{working_dir}' is not in a git working tree" unless status.success?
       result
     end

--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -172,13 +172,12 @@ module Git
     def fetch_untracked
       ignore = @base.lib.ignored_files
 
-      Dir.chdir(@base.dir.path) do
-        Dir.glob('**/*', File::FNM_DOTMATCH) do |file|
-          next if @files[file] || File.directory?(file) ||
-                  ignore.include?(file) || file =~ %r{^.git\/.+}
+      root_dir = @base.dir.path
+      Dir.glob('**/*', File::FNM_DOTMATCH, base: root_dir) do |file|
+        next if @files[file] || File.directory?(File.join(root_dir, file)) ||
+                ignore.include?(file) || file =~ %r{^.git\/.+}
 
-          @files[file] = { path: file, untracked: true }
-        end
+        @files[file] = { path: file, untracked: true }
       end
     end
 

--- a/tests/units/test_commit_with_gpg.rb
+++ b/tests/units/test_commit_with_gpg.rb
@@ -11,9 +11,9 @@ class TestCommitWithGPG < Test::Unit::TestCase
     Dir.mktmpdir do |dir|
       git = Git.init(dir)
       actual_cmd = nil
-      git.lib.define_singleton_method(:run_command) do |git_cmd, &block|
+      git.lib.define_singleton_method(:run_command) do |git_cmd, chdir, &block|
         actual_cmd = git_cmd
-        `true`
+        [`true`, $?]
       end
       message = 'My commit message'
       git.commit(message, gpg_sign: true)
@@ -25,9 +25,9 @@ class TestCommitWithGPG < Test::Unit::TestCase
     Dir.mktmpdir do |dir|
       git = Git.init(dir)
       actual_cmd = nil
-      git.lib.define_singleton_method(:run_command) do |git_cmd, &block|
+      git.lib.define_singleton_method(:run_command) do |git_cmd, chdir, &block|
         actual_cmd = git_cmd
-        `true`
+        [`true`, $?]
       end
       message = 'My commit message'
       git.commit(message, gpg_sign: 'keykeykey')
@@ -39,9 +39,9 @@ class TestCommitWithGPG < Test::Unit::TestCase
     Dir.mktmpdir do |dir|
       git = Git.init(dir)
       actual_cmd = nil
-      git.lib.define_singleton_method(:run_command) do |git_cmd, &block|
+      git.lib.define_singleton_method(:run_command) do |git_cmd, chdir, &block|
         actual_cmd = git_cmd
-        `true`
+        [`true`, $?]
       end
       message = 'My commit message'
       git.commit(message, no_gpg_sign: true)

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -91,7 +91,7 @@ class TestLib < Test::Unit::TestCase
     assert(@lib.reset(nil, hard: true)) # to get around worktree status on windows
 
     actual_cmd = nil
-    @lib.define_singleton_method(:run_command) do |git_cmd, &block|
+    @lib.define_singleton_method(:run_command) do |git_cmd, chdir, &block|
       actual_cmd = git_cmd
       super(git_cmd, &block)
     end


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
In multithreaded environment Dir.chdir changes current directory of all process' threads, so other threads might misbehave.

Base#chdir, Base#with_working and Base#with_temp_working were left intact, cause they are not used internally, so it's an explicit user decision to use them.

Fixes https://github.com/ruby-git/ruby-git/issues/355