### PR TITLE
Fix commit tree with multiple parents

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1040,10 +1040,19 @@ module Git
       t.write(opts[:message])
       t.close
 
+      # Adapted from activesupport Array.wrap
+      parents = if opts[:parents].nil?
+        []
+      elsif opts[:parents].respond_to?(:to_ary)
+        opts[:parents].to_ary || [opts[:parents]]
+      else
+        [opts[:parents]]
+      end
+      parents << opts[:parent] if opts[:parent]
+
       arr_opts = []
       arr_opts << tree
-      arr_opts << '-p' << opts[:parent] if opts[:parent]
-      arr_opts += [opts[:parents]].map { |p| ['-p', p] }.flatten if opts[:parents]
+      arr_opts += parents.map { |p| ['-p', p] }.flatten
       command('commit-tree', *arr_opts, redirect: "< #{escape t.path}")
     end
 

--- a/tests/units/test_tree_ops.rb
+++ b/tests/units/test_tree_ops.rb
@@ -79,6 +79,14 @@ class TestTreeOps < Test::Unit::TestCase
       assert(c.commit?)
       assert_equal('b40f7a9072cdec637725700668f8fdebe39e6d38', c.gtree.sha)
 
+      c = g.commit_tree(tr, :parent => 'HEAD')
+      assert(c.commit?)
+      assert_equal('b40f7a9072cdec637725700668f8fdebe39e6d38', c.gtree.sha)
+
+      c = g.commit_tree(tr, :parents => ['HEAD', 'testbranch1'])
+      assert(c.commit?)
+      assert_equal('b40f7a9072cdec637725700668f8fdebe39e6d38', c.gtree.sha)
+
       tmp = Tempfile.new('tesxt')
       tmppath = tmp.path
       tmp.close


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
This change fixes commit_tree to actually pass through multiple parents
correctly, while preserving backwards-compatibility by still handling
single commits passed into the `parents` field.
