### PR TITLE
Do not change global env

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -69,8 +69,10 @@ module Git
       status = nil
 
       git_cmd = "#{Git::Base.config.binary_path} -c core.quotePath=true -c color.ui=false rev-parse --show-toplevel 2>&1"
-      result, status = Open3.capture2(git_cmd, chdir: File.expand_path(working_dir))
-      result = result.chomp
+      IO.popen(git_cmd, :chdir => working_dir) do |io|
+        status = Process.wait2(io.pid).last
+        result = io.read.chomp
+      end
 
       raise ArgumentError, "'#{working_dir}' is not in a git working tree" unless status.success?
       result

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -69,10 +69,25 @@ module Git
       status = nil
 
       git_cmd = "#{Git::Base.config.binary_path} -c core.quotePath=true -c color.ui=false rev-parse --show-toplevel 2>&1"
-      IO.popen(git_cmd, :chdir => working_dir) do |io|
-        status = Process.wait2(io.pid).last
-        result = io.read.chomp
+
+      # Option 1 using IO.popen
+      #
+      # IO.popen(git_cmd, :chdir => working_dir) do |io|
+      #   status = Process.wait2(io.pid).last
+      #   result = io.read.chomp
+      # end
+
+      # Option 2 using Open3.popen2
+      #
+      Open3.popen2(git_cmd, chdir: working_dir) do |stdin, stdout, wait_thr|
+        status = wait_thr.value
+        result = stdout.chomp
       end
+
+      # Option 3 using Open3.capture3
+      #
+      # stdout_s, stderr_s, status = Open3.capture3(custom_git_env_variables, git_cmd, opts)
+      # result = status_s
 
       raise ArgumentError, "'#{working_dir}' is not in a git working tree" unless status.success?
       result

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -72,24 +72,25 @@ module Git
 
       # Option 1 using IO.popen
       #
-      # IO.popen(git_cmd, :chdir => working_dir) do |io|
+      # IO.popen(git_cmd, chdir: working_dir) do |io|
       #   status = Process.wait2(io.pid).last
       #   result = io.read.chomp
       # end
 
       # Option 2 using Open3.popen2
       #
-      Open3.popen2(git_cmd, chdir: working_dir) do |stdin, stdout, wait_thr|
-        status = wait_thr.value
-        result = stdout.chomp
-      end
+      # Open3.popen2(git_cmd, chdir: working_dir) do |stdin, stdout, wait_thr|
+      #   status = wait_thr.value
+      #   result = stdout.read.chomp
+      # end
 
       # Option 3 using Open3.capture3
       #
-      # stdout_s, stderr_s, status = Open3.capture3(custom_git_env_variables, git_cmd, opts)
-      # result = status_s
+      stdout_s, stderr_s, status = Open3.capture3(git_cmd, chdir: working_dir)
+      result = stdout_s.chomp
 
       raise ArgumentError, "'#{working_dir}' is not in a git working tree" unless status.success?
+
       result
     end
 

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1255,7 +1255,20 @@ module Git
       opts = {}
       opts[:chdir] = File.expand_path(chdir) if chdir
 
-      [IO.popen(custom_git_env_variables, git_cmd, opts, &block), $?]
+      # Option 1 using IO.popen
+      #
+      # [IO.popen(custom_git_env_variables, git_cmd, opts, &block), $?]
+
+      # Option 2 using Open3.popen2
+      #
+      Open3.popen2(custom_git_env_variables, git_cmd, opts) do |stdin, stdout, wait_thr|
+        [block.call(stdout), wait_thr.value]
+      end
+
+      # Option 3 using Open3.capture3
+      #
+      # stdout_s, stderr_s, status = Open3.capture3(custom_git_env_variables, git_cmd, opts)
+      # [block.call(StringIO.new(stdout_s)), status]
     end
 
     def escape(s)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -3,6 +3,7 @@ require 'logger'
 require 'tempfile'
 require 'zlib'
 require 'open3'
+require 'stringio'
 
 module Git
   class Lib
@@ -1261,14 +1262,14 @@ module Git
 
       # Option 2 using Open3.popen2
       #
-      Open3.popen2(custom_git_env_variables, git_cmd, opts) do |stdin, stdout, wait_thr|
-        [block.call(stdout), wait_thr.value]
-      end
+      # Open3.popen2(custom_git_env_variables, git_cmd, opts) do |stdin, stdout, wait_thr|
+      #   [block.call(stdout), wait_thr.value]
+      # end
 
       # Option 3 using Open3.capture3
       #
-      # stdout_s, stderr_s, status = Open3.capture3(custom_git_env_variables, git_cmd, opts)
-      # [block.call(StringIO.new(stdout_s)), status]
+      stdout_s, stderr_s, status = Open3.capture3(custom_git_env_variables, git_cmd, opts)
+      [block.call(StringIO.new(stdout_s)), status]
     end
 
     def escape(s)


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description
Do not change ENV variables of a current process. Instead pass relevant environment to the actual shell command being run.

this PR is built on top of #673 

