### PR TITLE
Explicitly name remote tracking branch in test

### DIFF
--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -223,7 +223,7 @@ class TestRemotes < Test::Unit::TestCase
       assert(!rem.status['test-file1'])
       assert(!rem.status['test-file3'])
 
-      loc.push('testrem')
+      loc.push('testrem', 'master')
 
       assert(rem.status['test-file1'])
       assert(!rem.status['test-file3'])


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
`TestRemotes#test_push` fails depending on the git configuration `push.default` if an explicit remote branch name is not given. In particular, values of `upstream` or `tracking` values would make the test fail.

In order not to depend on this setting, explicitly name the remote branch to push to. This is not relevant to the test.