### PR TITLE
Add push option to push all branches to a remote repository at one time

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,6 +345,9 @@ g.push(g.remote('name'))
 # delete remote branch
 g.push('origin', 'remote_branch_name', force: true, delete: true)
 
+# push all branches to remote at one time
+g.push('origin', all: true)
+
 g.worktree('/tmp/new_worktree').add
 g.worktree('/tmp/new_worktree', 'branch1').add
 g.worktree('/tmp/new_worktree').remove

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -984,7 +984,9 @@ module Git
       arr_opts = []
       arr_opts << '--mirror'  if opts[:mirror]
       arr_opts << '--delete'  if opts[:delete]
-      arr_opts << '--force'  if opts[:force] || opts[:f]
+      arr_opts << '--force'   if opts[:force] || opts[:f]
+      arr_opts << '--all'     if opts[:all] && remote
+
       Array(opts[:push_option]).each { |o| arr_opts << '--push-option' << o } if opts[:push_option]
       arr_opts << remote if remote
       arr_opts_with_branch = arr_opts.dup

--- a/tests/units/test_push.rb
+++ b/tests/units/test_push.rb
@@ -96,6 +96,13 @@ class TestPush < Test::Unit::TestCase
     assert_command_line(expected_command_line, git_cmd, git_cmd_args)
   end
 
+  test 'push with all: true' do
+    expected_command_line = ['push', '--all', 'origin']
+    git_cmd = :push
+    git_cmd_args = ['origin', all: true]
+    assert_command_line(expected_command_line, git_cmd, git_cmd_args)
+  end
+
   test 'when push succeeds an error should not be raised' do
     in_temp_dir do
       Git.init('remote.git', initial_branch: 'master', bare: true)


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [x] Ensure all commits include DCO sign-off.
- [x] Ensure that your contributions pass unit testing.
- [x] Ensure that your contributions contain documentation if applicable.

### Description

Add the ability to specify `all: true` to push all local branches to a specific remote repository at one time.

```ruby
# $ git push --all origin
git.push('origin', all: true)
``` 