### PR TITLE
Update minimum required version of Ruby and Git

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,11 +18,11 @@ jobs:
         include:
           - ruby: head
             operating-system: ubuntu-latest
-          - ruby: truffleruby-latest
+          - ruby: truffleruby-23.1.1
             operating-system: ubuntu-latest
           - ruby: 3.0
             operating-system: windows-latest
-          - ruby: jruby-latest
+          - ruby: jruby-9.4.5.0
             operating-system: windows-latest
 
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -13,16 +13,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: [2.7, 3.0, 3.1, 3.2]
+        ruby: [3.0, 3.1, 3.2, 3.3]
         operating-system: [ubuntu-latest]
         include:
           - ruby: head
             operating-system: ubuntu-latest
-          - ruby: truffleruby-head
+          - ruby: truffleruby-latest
             operating-system: ubuntu-latest
-          - ruby: 2.7
+          - ruby: 3.0
             operating-system: windows-latest
-          - ruby: jruby-head
+          - ruby: jruby-latest
             operating-system: windows-latest
 
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ command line. The API can be used for working with Git in complex interactions
 including branching and merging, object inspection and manipulation, history, patch
 generation and more.
 
+Get started by obtaining a repository object by:
+
+* opening an existing working copy with [Git.open](https://rubydoc.info/gems/git/Git#open-class_method)
+* initializing a new repository with [Git.init](https://rubydoc.info/gems/git/Git#init-class_method)
+* cloning a repository with [Git.clone](https://rubydoc.info/gems/git/Git#clone-class_method)
+
+Methods that can be called on a repository object are documented in [Git::Base](https://rubydoc.info/gems/git/Git/Base)
+
 ## v2.0.0 pre-release
 
 git 2.0.0 is available as a pre-release version for testing! Please give it a try.
@@ -41,36 +49,19 @@ the feedback received during the pre-release period.
 The `master` branch will be used for `2.x` development. If needed, fixes for `1.x`
 version will be done on the `v1` branch.
 
-## Homepage
-
-The project source code is at:
-
-http://github.com/ruby-git/ruby-git
-
-## Documentation
-
-Detailed documentation can be found at:
-
-https://rubydoc.info/gems/git/Git.html
-
-Get started by obtaining a repository object by:
-
-* opening an existing working copy with [Git.open](https://rubydoc.info/gems/git/Git#open-class_method)
-* initializing a new repository with [Git.init](https://rubydoc.info/gems/git/Git#init-class_method)
-* cloning a repository with [Git.clone](https://rubydoc.info/gems/git/Git#clone-class_method)
-
-Methods that can be called on a repository object are documented in [Git::Base](https://rubydoc.info/gems/git/Git/Base)
-
 ## Install
 
-You can install Ruby/Git like this:
+Install the gem and add to the application's Gemfile by executing:
 
+```shell
+bundle add git
 ```
-sudo gem install git
+
+If bundler is not being used to manage dependencies, install the gem by executing:
+
+```shell
+gem install git
 ```
-
-## Code Status
-
 
 ## Major Objects
 
@@ -102,12 +93,6 @@ Pass the `--all` option to `git log` as follows:
 ## Examples
 
 Here are a bunch of examples of how to use the Ruby/Git package.
-
-Ruby < 1.9 will require rubygems to be loaded.
-
-```ruby
-require 'rubygems'
-```
 
 Require the 'git' gem.
 ```ruby
@@ -421,6 +406,14 @@ g.with_temp_working(dir) do
   g.commit # commits to index
 end
 ```
+
+## Ruby version support policy
+
+This gem will be expected to function correctly on:
+
+* All non-EOL versions of the MRI Ruby on Mac, Linux, and Windows
+* The latest version of JRuby on Linux and Windows
+* The latest version of Truffle Ruby on Linus
 
 ## License
 

--- a/git.gemspec
+++ b/git.gemspec
@@ -24,22 +24,19 @@ Gem::Specification.new do |s|
   s.metadata['documentation_uri'] = "https://rubydoc.info/gems/#{s.name}/#{s.version}"
 
   s.require_paths = ['lib']
-  s.required_ruby_version = '>= 2.3'
-  s.required_rubygems_version = Gem::Requirement.new('>= 0') if s.respond_to?(:required_rubygems_version=)
-  s.requirements = ['git 1.6.0.0, or greater']
+  s.required_ruby_version = '>= 3.0.0'
+  s.requirements = ['git 2.28.0 or greater']
 
   s.add_runtime_dependency 'addressable', '~> 2.8'
   s.add_runtime_dependency 'rchardet', '~> 1.8'
 
-  s.add_development_dependency 'bump', '~> 0.10'
-  s.add_development_dependency 'create_github_release', '~> 0.2'
   s.add_development_dependency 'minitar', '~> 0.9'
   s.add_development_dependency 'mocha', '~> 2.1'
-  s.add_development_dependency 'rake', '~> 13.0'
-  s.add_development_dependency 'test-unit', '~> 3.3'
+  s.add_development_dependency 'rake', '~> 13.1'
+  s.add_development_dependency 'test-unit', '~> 3.6'
 
   unless RUBY_PLATFORM == 'java'
-    s.add_development_dependency 'redcarpet', '~> 3.5'
+    s.add_development_dependency 'redcarpet', '~> 3.6'
     s.add_development_dependency 'yard', '~> 0.9', '>= 0.9.28'
     s.add_development_dependency 'yardstick', '~> 0.9'
   end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1115,7 +1115,7 @@ module Git
     end
 
     def required_command_version
-      [1, 6]
+      [2, 28]
     end
 
     def meets_required_version?


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

The following changes were made in this PR:

* Update min supported Ruby version to 3.0.0
* Update min supported Git CLI version to 2.28.0
* Document supported Ruby policy in the README
* Update dependencies to latest versions
* Make a few tweaks to the README