### PR TITLE
Release v2.0.0.pre1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,9 @@
 
 # Change Log
 
-## v2.0.0-pre.1 (2024-01-15)
+## v2.0.0.pre1 (2024-01-15)
 
-[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v1.19.1..v2.0.0-pre.1)
+[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v1.19.1..v2.0.0.pre1)
 
 Changes since v1.19.1:
 

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -1,5 +1,5 @@
 module Git
   # The current gem version
   # @return [String] the current gem version.
-  VERSION='2.0.0-pre.1'
+  VERSION='2.0.0.pre1'
 end


### PR DESCRIPTION
# Release PR

## v2.0.0.pre1 (2024-01-15)

[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v1.19.1..v2.0.0.pre1)

Changes since v1.19.1:

* 7585c39 Change how the git CLI subprocess is executed (#684)
* f93e042 Update instructions for releasing a new version of the git gem (#686)
* f48930d Update minimum required version of Ruby and Git (#685)
