### PR TITLE
[WIP] Handle ignored files with quoted (non-ASCII) filenames

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -559,9 +559,7 @@ module Git
       command_lines('ls-files', '--stage', location).each do |line|
         (info, file) = line.split("\t")
         (mode, sha, stage) = info.split
-        if file.start_with?('"') && file.end_with?('"')
-          file = Git::EscapedPath.new(file[1..-2]).unescape
-        end
+        file = unescape_if_quoted(file)
         hsh[file] = {:path => file, :mode_index => mode, :sha_index => sha, :stage => stage}
       end
       hsh
@@ -586,6 +584,15 @@ module Git
 
     def ignored_files
       command_lines('ls-files', '--others', '-i', '--exclude-standard')
+        .map { |f| unescape_if_quoted(f) }
+    end
+
+    def unescape_if_quoted(file)
+      if file.start_with?('"') && file.end_with?('"')
+        Git::EscapedPath.new(file[1..-2]).unescape
+      else
+        file
+      end
     end
 
 


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [ ] Ensure all commits include DCO sign-off.
- [ ] Ensure that your contributions pass unit testing.
- [ ] Ensure that your contributions contain documentation if applicable.

### Description

This is a bug fix: if a repository contains ignored files with non-ASCII or otherwise “unusual” characters that trigger [`quotePath`](https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath), then `Git.open(…).lib.ignored_files` currently returns the git-quoted paths, not the proper filenames.

Some pre-review questions before I add the DCO sign-off:

- It seems like this should be tested, but there are apparently no tests for `ignored_files`. Should I add some? If so, where?
- Is `ignored_files` the only place this unescaping behavior is missing? Does it apply only to paths, or can (for example) branches and remotes also end up quoted? Should this unescaping live in `Lib#command_lines`, applying to _all_ command outputs? (Probably not, but….)