### PR TITLE
Release v2.0.0.pre2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@
 
 # Change Log
 
+## v2.0.0.pre2 (2024-02-24)
+
+[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v2.0.0.pre1..v2.0.0.pre2)
+
+Changes since v2.0.0.pre1:
+
+* 023017b Add a timeout for git commands (#692)
+* 8286ceb Refactor the Error heriarchy (#693)
+
 ## v2.0.0.pre1 (2024-01-15)
 
 [Full Changelog](https://github.com/ruby-git/ruby-git/compare/v1.19.1..v2.0.0.pre1)

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -1,5 +1,5 @@
 module Git
   # The current gem version
   # @return [String] the current gem version.
-  VERSION='2.0.0.pre1'
+  VERSION='2.0.0.pre2'
 end


### PR DESCRIPTION
# Release PR

## v2.0.0.pre2 (2024-02-24)

[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v2.0.0.pre1..v2.0.0.pre2)

Changes since v2.0.0.pre2:

* 023017b Add a timeout for git commands (#692)
* 8286ceb Refactor the Error heriarchy (#693)
