### PR TITLE
Show log(x).since combination in README (1.x)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,9 +112,12 @@ g.index.writable?
 g.repo
 g.dir
 
-g.log   # returns a Git::Log object, which is an Enumerator of Git::Commit objects
-g.log(200)
-g.log.since('2 weeks ago')
+# log - returns a Git::Log object, which is an Enumerator of Git::Commit objects
+# default configuration returns a max of 30 commits
+g.log
+g.log(200) # 200 most recent commits
+g.log.since('2 weeks ago') # default count of commits since 2 weeks ago.
+g.log(200).since('2 weeks ago') # commits since 2 weeks ago, limited to 200.
 g.log.between('v2.5', 'v2.6')
 g.log.each {|l| puts l.sha }
 g.gblob('v2.5:Makefile').log.since('2 weeks ago')


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
- Adds some more detail to the README for the log function, specifically around combining with other filters.

`.log.since` respects the default count configuration which makes sense but isn't clear in the examples or the docs. 
Perhaps naively I expected `g.log.since('1 month ago')` to return a whole month's worth of commits. Instead it consistently returned 30 which is the default for the `count` param.  To return a whole month you have to also specify a greater maximum i.e. `g.log(1000).since('1 month ago')` depending on the amount of activity in the repository.