### PR TITLE
Move experimental builds out of the CI workflow and into their own workflow

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -32,7 +32,7 @@ jobs:
             operating-system: windows-latest
 
           - # Since JRuby on Windows is known to not work, consider this experimental
-            ruby: jruby-9.4.5.0
+            ruby: jruby-head
             operating-system: windows-latest
             experimental: Yes
 

--- a/.github/workflows/experimental_continuous_integration.yml
+++ b/.github/workflows/experimental_continuous_integration.yml
@@ -1,9 +1,7 @@
-name: CI
+name: CI Experimental
 
 on:
   push:
-    branches: [master,v1]
-  pull_request:
     branches: [master,v1]
   workflow_dispatch:
 
@@ -11,20 +9,22 @@ jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
     runs-on: ${{ matrix.operating-system }}
-    continue-on-error: ${{ matrix.experimental == 'Yes' }}
+    continue-on-error: true
     env: { JAVA_OPTS: -Djdk.io.File.enableADS=true }
 
     strategy:
       fail-fast: false
       matrix:
-        # Only the latest versions of JRuby and TruffleRuby are tested
-        ruby: ["3.0", "3.1", "3.2", "3.3", "truffleruby-24.0.0", "jruby-9.4.5.0"]
-        operating-system: [ubuntu-latest]
-        experimental: [No]
         include:
-          - # Only test with minimal Ruby version on Windows
-            ruby: 3.0
+          - # Building against head version of Ruby is considered experimental
+            ruby: head
+            operating-system: ubuntu-latest
+            experimental: Yes
+
+          - # Since JRuby on Windows is known to not work, consider this experimental
+            ruby: jruby-head
             operating-system: windows-latest
+            experimental: Yes
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description

The following builds are considered experimental:

* jruby-head on Windows (until jruby/jruby#7515 is fixed)
* ruby-head

Remove them from the main CI workflow so that PRs show that 100% of builds passed. Make experimental builds only run when something is merged to master (or the experimental workflow is run manually).