### PR TITLE
Update documentation for new timeout functionality

### DIFF
--- a/bin/command_line_test
+++ b/bin/command_line_test
@@ -12,6 +12,7 @@ require 'optparse'
 # --stderr: string to output to stderr
 # --exitstatus: exit status to return (default is zero)
 # --signal: uncaught signal to raise (default is not to signal)
+# --duration: number of seconds to sleep before exiting (default is zero)
 #
 # Both --stdout and --stderr can be given.
 #
@@ -31,7 +32,13 @@ require 'optparse'
 #   $ bin/command_line_test --stdout="Hello, world!" --stderr="ERROR: timeout"
 #
 
-
+# The command line parser for this script
+#
+# @example
+#   parser = CommandLineParser.new
+#   options = parser.parse(['--exitstatus', '1', '--stderr', 'ERROR: timeout', '--duration', '5'])
+#
+# @api private
 class CommandLineParser
   def initialize
     @option_parser = OptionParser.new

--- a/lib/git/command_line.rb
+++ b/lib/git/command_line.rb
@@ -114,7 +114,6 @@ module Git
     # the normalize option will be ignored.
     #
     # @example Run a command and return the output
-    #
     #   cli.run('version') #=> "git version 2.39.1\n"
     #
     # @example The args array should be splatted into the parameter list
@@ -162,14 +161,18 @@ module Git
     #   `stderr_writer.string` will be merged into the output returned by this method.
     #
     # @param normalize [Boolean] whether to normalize the output to a valid encoding
+    #
     # @param chomp [Boolean] whether to chomp the output
+    #
     # @param merge [Boolean] whether to merge stdout and stderr in the string returned
+    #
     # @param chdir [String] the directory to run the command in
     #
     # @param timeout [Numeric, nil] the maximum seconds to wait for the command to complete
     #
-    #   If timeout is zero or nil, the command will not time out. If the command
-    #   times out, it is killed via a SIGKILL signal and `Git::TimeoutError` is raised.
+    #   If timeout is zero, the timeout will not be enforced.
+    #
+    #   If the command times out, it is killed via a `SIGKILL` signal and `Git::TimeoutError` is raised.
     #
     #   If the command does not respond to SIGKILL, it will hang this method.
     #
@@ -178,9 +181,13 @@ module Git
     #   This result of running the command.
     #
     # @raise [ArgumentError] if `args` is not an array of strings
+    #
     # @raise [Git::SignaledError] if the command was terminated because of an uncaught signal
+    #
     # @raise [Git::FailedError] if the command returned a non-zero exitstatus
+    #
     # @raise [Git::GitExecuteError] if an exception was raised while collecting subprocess output
+    #
     # @raise [Git::TimeoutError] if the command times out
     #
     def run(*args, out:, err:, normalize:, chomp:, merge:, chdir: nil, timeout: nil)
@@ -267,7 +274,7 @@ module Git
     #
     # @param cmd [Array<String>] the git command to execute
     # @param chdir [String] the directory to run the command in
-    # @param timeout [Float, Integer, nil] the maximum seconds to wait for the command to complete
+    # @param timeout [Numeric, nil] the maximum seconds to wait for the command to complete
     #
     #   If timeout is zero of nil, the command will not time out. If the command
     #   times out, it is killed via a SIGKILL signal and `Git::TimeoutError` is raised.
@@ -321,6 +328,7 @@ module Git
     # @param err [#write] the object that stderr was written to
     # @param normalize [Boolean] whether to normalize the output of each writer
     # @param chomp [Boolean] whether to chomp the output of each writer
+    # @param timeout [Numeric, nil] the maximum seconds to wait for the command to complete
     #
     # @return [Git::CommandLineResult] the result of the command to return to the caller
     #
@@ -346,7 +354,7 @@ module Git
     # @param out [#write] the object to write stdout to
     # @param err [#write] the object to write stderr to
     # @param chdir [String] the directory to run the command in
-    # @param timeout [Float, Integer, nil] the maximum seconds to wait for the command to complete
+    # @param timeout [Numeric, nil] the maximum seconds to wait for the command to complete
     #
     #   If timeout is zero of nil, the command will not time out. If the command
     #   times out, it is killed via a SIGKILL signal and `Git::TimeoutError` is raised.

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -80,21 +80,33 @@ module Git
       command('init', *arr_opts)
     end
 
-    # tries to clone the given repo
+    # Clones a repository into a newly created directory
     #
-    # accepts options:
-    #  :bare::      no working directory
-    #  :branch::    name of branch to track (rather than 'master')
-    #  :depth::     the number of commits back to pull
-    #  :filter::    specify partial clone
-    #  :origin::    name of remote (same as remote)
-    #  :path::      directory where the repo will be cloned
-    #  :remote::    name of remote (rather than 'origin')
-    #  :recursive:: after the clone is created, initialize all submodules within, using their default settings.
+    # @param [String] repository_url the URL of the repository to clone
+    # @param [String, nil] directory the directory to clone into
     #
-    # TODO - make this work with SSH password or auth_key
+    #   If nil, the repository is cloned into a directory with the same name as
+    #   the repository.
+    #
+    # @param [Hash] opts the options for this command
+    #
+    # @option opts [Boolean] :bare (false) if true, clone as a bare repository
+    # @option opts [String] :branch the branch to checkout
+    # @option opts [String, Array] :config one or more configuration options to set
+    # @option opts [Integer] :depth the number of commits back to pull
+    # @option opts [String] :filter specify partial clone
+    # @option opts [String] :mirror set up a mirror of the source repository
+    # @option opts [String] :origin the name of the remote
+    # @option opts [String] :path an optional prefix for the directory parameter
+    # @option opts [String] :remote the name of the remote
+    # @option opts [Boolean] :recursive after the clone is created, initialize all submodules within, using their default settings
+    # @option opts [Numeric, nil] :timeout the number of seconds to wait for the command to complete
+    #
+    #   See {Git::Lib#command} for more information about :timeout
     #
     # @return [Hash] the options to pass to {Git::Base.new}
+    #
+    # @todo make this work with SSH password or auth_key
     #
     def clone(repository_url, directory, opts = {})
       @path = opts[:path] || '.'
@@ -1215,8 +1227,15 @@ module Git
     #
     # @param chdir [String, nil] the directory to run the command in
     #
-    # @param timeout [Numeric, nil] the maximum time to wait for the command to
-    # complete
+    # @param timeout [Numeric, nil] the maximum seconds to wait for the command to complete
+    #
+    #   If timeout is nil, the global timeout from {Git::Config} is used.
+    #
+    #   If timeout is zero, the timeout will not be enforced.
+    #
+    #   If the command times out, it is killed via a `SIGKILL` signal and `Git::TimeoutError` is raised.
+    #
+    #   If the command does not respond to SIGKILL, it will hang this method.
     #
     # @see Git::CommandLine#run
     #


### PR DESCRIPTION
### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
Updates are to documentation only. No code was changed.
* More precisely described when timeouts can be specified and what impact they have: the git command is killed and a Git::TimeoutError is raised.
* Describe the global timeout vs. method timeouts
* Update `bin/command_line_test` to be able to sleep for a specific number of seconds to test timeouts.
* Update YARD doc to indicate that the timeout value is a Numeric or nil.
* Update Git.clone YARD doc
