### PR TITLE
Update create_github_release dependency so pre-releases can be made

### DIFF
--- a/git.gemspec
+++ b/git.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'process_executer', '~> 1.1'
   s.add_runtime_dependency 'rchardet', '~> 1.8'
 
-  s.add_development_dependency 'create_github_release', '~> 1.3'
+  s.add_development_dependency 'create_github_release', '~> 1.4'
   s.add_development_dependency 'minitar', '~> 0.9'
   s.add_development_dependency 'mocha', '~> 2.1'
   s.add_development_dependency 'rake', '~> 13.1'


### PR DESCRIPTION
Signed-off-by: James Couball <jcouball@yahoo.com>

### Your checklist for this pull request
🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.

- [X] Ensure all commits include DCO sign-off.
- [X] Ensure that your contributions pass unit testing.
- [X] Ensure that your contributions contain documentation if applicable.

### Description
Update create_github_release dependency so pre-releases can be made. Prior to 1.4.0, there was a bug when using prerelease versions.