### PR TITLE
Remove the DCO requirement for commits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,9 +1,9 @@
-### Your checklist for this pull request
-🚨Please review the [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository.
+[Guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository
 
-- [ ] Ensure all commits include DCO sign-off.
-- [ ] Ensure that your contributions pass unit testing.
-- [ ] Ensure that your contributions contain documentation if applicable.
+A good start is to:
 
-### Description
-Please describe your pull request.
+* Ensure that your changes pass CI tests by running `rake` before pushing
+* Ensure that your changes are documented in the README.md and in YARD documentation
+
+# Description
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,10 +40,6 @@ There is three step process for code or documentation changes:
 
 Make your changes in a fork of the ruby-git repository.
 
-Each commit must include a [DCO sign-off](#developer-certificate-of-origin-dco)
-by adding the line `Signed-off-by: Name <email>` to the end of the commit
-message.
-
 ### Create a pull request
 
 See [this article](https://help.github.com/articles/about-pull-requests/) if you
@@ -71,15 +67,18 @@ request meets [the project's coding standards](#coding-standards).
 In order to ensure high quality, all pull requests must meet these requirements:
 
 ### 1 PR = 1 Commit
-  * All commits for a PR must be squashed into one commit
-  * To avoid an extra merge commit, the PR must be able to be merged as [a fast forward merge](https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging)
-  * The easiest way to ensure a fast forward merge is to rebase your local branch
-    to the ruby-git master branch
+
+* All commits for a PR must be squashed into one commit
+* To avoid an extra merge commit, the PR must be able to be merged as [a fast forward
+  merge](https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging)
+* The easiest way to ensure a fast forward merge is to rebase your local branch to
+ the ruby-git master branch
 
 ### Unit tests
-  * All changes must be accompanied by new or modified unit tests
-  * The entire test suite must pass when `bundle exec rake default` is run from the
-    project's local working copy.
+
+* All changes must be accompanied by new or modified unit tests
+* The entire test suite must pass when `bundle exec rake default` is run from the
+  project's local working copy.
 
 While working on specific features you can run individual test files or
 a group of tests using `bin/test`:
@@ -94,20 +93,21 @@ a group of tests using `bin/test`:
     $ bin/test
 
 ### Continuous integration
-  * All tests must pass in the project's [GitHub Continuous Integration build](https://github.com/ruby-git/ruby-git/actions?query=workflow%3ACI)
-    before the pull request will be merged.
-  * The [Continuous Integration workflow](https://github.com/ruby-git/ruby-git/blob/master/.github/workflows/continuous_integration.yml)
-    runs both `bundle exec rake default` and `bundle exec rake test:gem` from the project's [Rakefile](https://github.com/ruby-git/ruby-git/blob/master/Rakefile).
+
+* All tests must pass in the project's [GitHub Continuous Integration
+  build](https://github.com/ruby-git/ruby-git/actions?query=workflow%3ACI) before the
+  pull request will be merged.
+* The [Continuous Integration
+  workflow](https://github.com/ruby-git/ruby-git/blob/master/.github/workflows/continuous_integration.yml)
+  runs both `bundle exec rake default` and `bundle exec rake test:gem` from the
+  project's [Rakefile](https://github.com/ruby-git/ruby-git/blob/master/Rakefile).
 
 ### Documentation
-  * New and updated public methods must have [YARD](https://yardoc.org/)
-    documentation added to them
-  * New and updated public facing features should be documented in the project's
-    [README.md](README.md)
 
-### Licensing sign-off
-  * Each commit must contain [the DCO sign-off](#developer-certificate-of-origin-dco)
-    in the form:  `Signed-off-by: Name <email>`
+* New and updated public methods must have [YARD](https://yardoc.org/) documentation
+  added to them
+* New and updated public facing features should be documented in the project's
+  [README.md](README.md)
 
 ## Licensing
 
@@ -116,48 +116,3 @@ declared in the [LICENSE](LICENSE) file.
 
 Licensing is very important to open source projects. It helps ensure the
 software continues to be available under the terms that the author desired.
-
-### Developer Certificate of Origin (DCO)
-
-This project requires that authors have permission to submit their contributions
-under the MIT license. To make a good faith effort to ensure this, ruby-git
-requires the [Developer Certificate of Origin (DCO)](https://elinux.org/Developer_Certificate_Of_Origin)
-process be followed.
-
-This process requires that each commit include a `Signed-off-by` line that
-indicates the author accepts the DCO.  Here is an example DCO sign-off line:
-
-```
-Signed-off-by: John Doe <john.doe@hisdomain.com>
-```
-
-The full text of the DCO version 1.1 is below or at <http://developercertificate.org/>.
-
-```
-Developer's Certificate of Origin 1.1
-
-By making a contribution to this project, I certify that:
-
-(a) The contribution was created in whole or in part by me and I
-    have the right to submit it under the open source license
-    indicated in the file; or
-
-(b) The contribution is based upon previous work that, to the
-    best of my knowledge, is covered under an appropriate open
-    source license and I have the right under that license to
-    submit that work with modifications, whether created in whole
-    or in part by me, under the same open source license (unless
-    I am permitted to submit under a different license), as
-    Indicated in the file; or
-
-(c) The contribution was provided directly to me by some other
-    person who certified (a), (b) or (c) and I have not modified
-    it.
-
-(d) I understand and agree that this project and the contribution
-    are public and that a record of the contribution (including
-    all personal information I submit with it, including my
-    sign-off) is maintained indefinitely and may be redistributed
-    consistent with this project or the open source license(s)
-    involved.
-```


### PR DESCRIPTION
Remove the requirement for DCO sign-off. 

This project has implemented an automated check for the presence of a sign-off but nothing to check it's authenticity or the contributor's understanding. In order to provide the intended robust legal protection, a mechanism would have to be put into place to track that contributors have understood what putting the sign-off in the commit message and add them to a "committer whitelist".

[Truffle Ruby](https://github.com/oracle/truffleruby), for example, requires that all contributors sign an [Oracle Contributor Agreement](https://oca.opensource.oracle.com) before they are allowed to contribute to their repository.

Rather than implement a more formalized and heavier process to track these attestations, DCO shall be removed from this project.

In my experience, this is the way that most OpenSource Ruby project operate.