### PR TITLE
Fix Git::Status#untracked when run from worktree subdir

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -600,6 +600,9 @@ module Git
       command_lines('ls-files', '--others', '-i', '--exclude-standard')
     end
 
+    def untracked_files
+      command_lines('ls-files', '--others', '--exclude-standard', chdir: @git_work_dir)
+    end
 
     def config_remote(name)
       hsh = {}

--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -170,13 +170,7 @@ module Git
     end
 
     def fetch_untracked
-      ignore = @base.lib.ignored_files
-
-      root_dir = @base.dir.path
-      Dir.glob('**/*', File::FNM_DOTMATCH, base: root_dir) do |file|
-        next if @files[file] || File.directory?(File.join(root_dir, file)) ||
-                ignore.include?(file) || file =~ %r{^.git\/.+}
-
+      @base.lib.untracked_files.each do |file|
         @files[file] = { path: file, untracked: true }
       end
     end

--- a/tests/units/test_status.rb
+++ b/tests/units/test_status.rb
@@ -87,6 +87,56 @@ class TestStatus < Test::Unit::TestCase
     end
   end
 
+  def test_untracked
+    in_temp_dir do |path|
+      `git init`
+      File.write('file1', 'contents1')
+      File.write('file2', 'contents2')
+      Dir.mkdir('subdir')
+      File.write('subdir/file3', 'contents3')
+      File.write('subdir/file4', 'contents4')
+      `git add file1 subdir/file3`
+      `git commit -m "my message"`
+
+      git = Git.open('.')
+      assert_equal(2, git.status.untracked.size)
+      assert_equal(['file2', 'subdir/file4'], git.status.untracked.keys)
+    end
+  end
+
+  def test_untracked_no_untracked_files
+    in_temp_dir do |path|
+      `git init`
+      File.write('file1', 'contents1')
+      Dir.mkdir('subdir')
+      File.write('subdir/file3', 'contents3')
+      `git add file1 subdir/file3`
+      `git commit -m "my message"`
+
+      git = Git.open('.')
+      assert_equal(0, git.status.untracked.size)
+    end
+  end
+
+  def test_untracked_from_subdir
+    in_temp_dir do |path|
+      `git init`
+      File.write('file1', 'contents1')
+      File.write('file2', 'contents2')
+      Dir.mkdir('subdir')
+      File.write('subdir/file3', 'contents3')
+      File.write('subdir/file4', 'contents4')
+      `git add file1 subdir/file3`
+      `git commit -m "my message"`
+
+      Dir.chdir('subdir') do
+        git = Git.open('..')
+        assert_equal(2, git.status.untracked.size)
+        assert_equal(['file2', 'subdir/file4'], git.status.untracked.keys)
+      end
+    end
+  end
+
   def test_untracked_boolean
     in_temp_dir do |path|
       git = Git.clone(@wdir, 'test_dot_files_status')


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository. A good start is to:

* Write tests for your changes
* Run `rake` before pushing
* Include / update docs in the README.md and in YARD documentation

# Description

Fixes #422

The original implementation was needed for older versions of Git. Now that we are supporting newer versions, we can use the following method to get untracked files which changes the directory to the worktree root directory:

`command_lines('ls-files', '--others', '--exclude-standard', chdir: @git_work_dir)`
