### PR TITLE
Fix Git::Base#status on an empty repo

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -707,6 +707,19 @@ module Git
       command('rm', *arr_opts)
     end
 
+    # Returns true if the repository is empty (meaning it has no commits)
+    #
+    # @return [Boolean]
+    #
+    def empty?
+      command('rev-parse', '--verify', 'HEAD')
+      false
+    rescue Git::FailedError => e
+      raise unless e.result.status.exitstatus == 128 &&
+        e.result.stderr == 'fatal: Needed a single revision'
+      true
+    end
+
     # Takes the commit message with the options and executes the commit command
     #
     # accepts options:

--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -183,9 +183,11 @@ module Git
     end
 
     def fetch_added
-      # find added but not committed - new files
-      @base.lib.diff_index('HEAD').each do |path, data|
-        @files[path] ? @files[path].merge!(data) : @files[path] = data
+      unless @base.lib.empty?
+        # find added but not committed - new files
+        @base.lib.diff_index('HEAD').each do |path, data|
+          @files[path] ? @files[path].merge!(data) : @files[path] = data
+        end
       end
     end
   end

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -318,4 +318,25 @@ class TestLib < Test::Unit::TestCase
     assert lib.compare_version_to(2, 43, 0) == -1
     assert lib.compare_version_to(3, 0, 0) == -1
   end
+
+  def test_empty_when_not_empty
+    in_temp_dir do |path|
+      `git init`
+      `touch file1`
+      `git add file1`
+      `git commit -m "my commit message"`
+
+      git = Git.open('.')
+      assert_false(git.lib.empty?)
+    end
+  end
+
+  def test_empty_when_empty
+    in_temp_dir do |path|
+      `git init`
+
+      git = Git.open('.')
+      assert_true(git.lib.empty?)
+    end
+  end
 end

--- a/tests/units/test_status.rb
+++ b/tests/units/test_status.rb
@@ -25,6 +25,16 @@ class TestStatus < Test::Unit::TestCase
     end
   end
 
+  def test_on_empty_repo
+    in_temp_dir do |path|
+      `git init`
+      git = Git.open('.')
+      assert_nothing_raised do
+        git.status
+      end
+    end
+  end
+
   def test_dot_files_status
     in_temp_dir do |path|
       git = Git.clone(@wdir, 'test_dot_files_status')


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md) to this repository. A good start is to:

* Write tests for your changes
* Run `rake` before pushing
* Include / update docs in the README.md and in YARD documentation

# Description

Git::Base#status on an empty repo throws an exception. To determine the files that were added, a diff is done between the index and HEAD revision. However, in an empty repository, HEAD does not exist and diffing returns an error.

This PR makes a change to check if the repository is empty before trying to do the diff. Git::Lib#empty? is introduced to determine if the repository is empty (i.e. it has no commits).

Fixes #422 