### PR TITLE
Document and add tests for Git::Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,8 @@
 
 ## Summary
 
-The [git gem](https://rubygems.org/gems/git) provides an API that can be used to
-create, read, and manipulate Git repositories by wrapping system calls to the `git`
-command line. The API can be used for working with Git in complex interactions
-including branching and merging, object inspection and manipulation, history, patch
-generation and more.
+The [git gem](https://rubygems.org/gems/git) provides a Ruby interface to the `git`
+command line.
 
 Get started by obtaining a repository object by:
 
@@ -41,8 +38,7 @@ Methods that can be called on a repository object are documented in [Git::Base](
 
 git 2.0.0 has recently been released. Please give it a try.
 
-
-**If you have problems with the 2.x release, open an issue and use the 1.9.1 version
+**If you have problems with the 2.x release, open an issue and use the 1.x version
 instead.** We will do our best to fix your issues in a timely fashion.
 
 **JRuby on Windows is not yet supported by the 2.x release line. Users running JRuby

--- a/tests/units/test_status.rb
+++ b/tests/units/test_status.rb
@@ -35,6 +35,45 @@ class TestStatus < Test::Unit::TestCase
     end
   end
 
+  def test_added
+    in_temp_dir do |path|
+      `git init`
+      File.write('file1', 'contents1')
+      File.write('file2', 'contents2')
+      `git add file1 file2`
+      `git commit -m "my message"`
+
+      File.write('file2', 'contents2B')
+      File.write('file3', 'contents3')
+
+      `git add file2 file3`
+
+      git = Git.open('.')
+      status = assert_nothing_raised do
+        git.status
+      end
+
+      assert_equal(1, status.added.size)
+      assert_equal(['file3'], status.added.keys)
+    end
+  end
+
+  def test_added_on_empty_repo
+    in_temp_dir do |path|
+      `git init`
+      File.write('file1', 'contents1')
+      File.write('file2', 'contents2')
+      `git add file1 file2`
+
+      git = Git.open('.')
+      status = assert_nothing_raised do
+        git.status
+      end
+
+      assert_equal(0, status.added.size)
+    end
+  end
+
   def test_dot_files_status
     in_temp_dir do |path|
       git = Git.clone(@wdir, 'test_dot_files_status')

--- a/tests/units/test_status_object.rb
+++ b/tests/units/test_status_object.rb
@@ -1,0 +1,615 @@
+require 'rbconfig'
+require 'securerandom'
+require 'test_helper'
+
+module Git
+  # Add methods to the Status class to make it easier to test
+  class Status
+    def size
+      @files.size
+    end
+
+    alias count size
+
+    def files
+      @files
+    end
+  end
+end
+
+# A suite of tests for the Status class for the following scenarios
+#
+# For all tests, the initial state of the repo is one commit with the following
+# files:
+#
+# * { path: 'file1', content: 'contents1', mode: '100644' }
+# * { path: 'file2', content: 'contents2', mode: '100755' }
+#
+# Assume the repo is cloned to a temporary directory (`worktree_path`) and the
+# index and worktree are in a clean state before each test.
+#
+# Assume the Status object is initialized with `base` which is a Git object created
+# via `Git.open(worktree_path)`.
+#
+# Test that the status object returns the expected #files
+#
+class TestStatusObject < Test::Unit::TestCase
+  def logger
+    # Change log level to Logger::DEBUG to see the log entries
+    @logger ||= Logger.new(STDOUT, level: Logger::ERROR)
+  end
+
+  def test_no_changes
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid (initial)
+      # # branch.head main
+      # 1 A. N... 000000 100644 100644 0000000000000000000000000000000000000000 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec file1
+      # 1 A. N... 000000 100755 100755 0000000000000000000000000000000000000000 c061beb85924d309fde78d996a7602544e4f69a5 file2
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      expected_status_files = [
+        {
+          path: 'file1', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_delete_file1_from_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.delete('file1')
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid 1d5ec91c189281dbbd97a00451815c8ae288c512
+      # # branch.head main
+      # 1 .D N... 100644 100644 000000 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec file1
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # ERROR: mode_index and sha_indes for file1 is not returned
+
+      expected_status_files = [
+        {
+          path: 'file1', type: 'D', stage: '0', untracked: nil,
+          mode_index: '000000', sha_index: '0000000000000000000000000000000000000000',
+          mode_repo: expect_read_write_mode, sha_repo: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec'
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_delete_file1_from_index
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      `git rm file1`
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid 9a6c20a5ca26595796ff5c2ef6e6a806ae4427f3
+      # # branch.head main
+      # 1 D. N... 100644 000000 000000 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec 0000000000000000000000000000000000000000 file1
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      expected_status_files = [
+        {
+          path: 'file1', type: 'D', stage: nil, untracked: nil,
+          mode_index: '000000', sha_index: '0000000000000000000000000000000000000000',
+          mode_repo: expect_read_write_mode, sha_repo: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec'
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_delete_file1_from_index_and_recreate_in_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      `git rm file1`
+      File.open('file1', 'w', 0o644) { |f| f.write('does_not_matter') }
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid 9a6c20a5ca26595796ff5c2ef6e6a806ae4427f3
+      # # branch.head main
+      # 1 D. N... 100644 000000 000000 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec 0000000000000000000000000000000000000000 file1
+      # ? file1
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      expected_status_files = [
+        {
+          path: 'file1', type: 'D', stage: nil, untracked: true,
+          mode_index: '000000', sha_index: '0000000000000000000000000000000000000000',
+          mode_repo: expect_read_write_mode, sha_repo: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec'
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_modify_file1_in_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file1', 'w', 0o644) { |f| f.write('updated_content') }
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid 1d5ec91c189281dbbd97a00451815c8ae288c512
+      # # branch.head main
+      # 1 .M N... 100644 100644 100644 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec file1
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # ERROR: sha_index for file1 is not returned
+
+      expected_status_files = [
+        {
+          path: 'file1', type: 'M', stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '0000000000000000000000000000000000000000',
+          mode_repo: expect_read_write_mode, sha_repo: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec'
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_modify_file1_in_worktree_and_add_to_index
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file1', 'w', 0o644) { |f| f.write('updated_content') }
+      `git add file1`
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid 1d5ec91c189281dbbd97a00451815c8ae288c512
+      # # branch.head main
+      # 1 M. N... 100644 100644 100644 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec c6190329af2f07c1a949128b8e962c06eb23cfa4 file1
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      expected_status_files = [
+        {
+          path: 'file1', type: 'M', stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: 'c6190329af2f07c1a949128b8e962c06eb23cfa4',
+          mode_repo: expect_read_write_mode, sha_repo: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec'
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_modify_file1_in_worktree_and_add_to_index_and_modify_in_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file1', 'w', 0o644) { |f| f.write('updated_content1') }
+      `git add file1`
+      File.open('file1', 'w', 0o644) { |f| f.write('updated_content2') }
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid 1d5ec91c189281dbbd97a00451815c8ae288c512
+      # # branch.head main
+      # 1 MM N... 100644 100644 100644 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec a9114691c7e7d6139fa9558897eeda2c8cb2cd81 file1
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # ERROR: there shouldn't be a mode_repo or sha_repo for file1
+
+      expected_status_files = [
+        {
+          path: 'file1', type: 'M', stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '0000000000000000000000000000000000000000',
+          mode_repo: expect_read_write_mode, sha_repo: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec'
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_modify_file1_in_worktree_and_add_to_index_and_delete_in_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file1', 'w', 0o644) { |f| f.write('updated_content1') }
+      `git add file1`
+      File.delete('file1')
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid 1d5ec91c189281dbbd97a00451815c8ae288c512
+      # # branch.head main
+      # 1 MD N... 100644 100644 000000 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec a9114691c7e7d6139fa9558897eeda2c8cb2cd81 file1
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # ERROR: Impossible to tell that a change to file1 was already staged and the delete happened in the worktree
+
+      expected_status_files = [
+        {
+          path: 'file1', type: 'D', stage: '0', untracked: nil,
+          mode_index: '000000', sha_index: '0000000000000000000000000000000000000000',
+          mode_repo: expect_read_write_mode, sha_repo: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec'
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_add_file3_to_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file3', 'w', 0o644) { |f| f.write('content3') }
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid 9a6c20a5ca26595796ff5c2ef6e6a806ae4427f3
+      # # branch.head main
+      # ? file3
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      expected_status_files = [
+        {
+          path: 'file1', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file3', type: nil, stage: nil, untracked: true,
+          mode_index: nil, sha_index: nil,
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_add_file3_to_worktree_and_index
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file3', 'w', 0o644) { |f| f.write('content3') }
+      `git add file3`
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid 9a6c20a5ca26595796ff5c2ef6e6a806ae4427f3
+      # # branch.head main
+      # 1 A. N... 000000 100644 100644 0000000000000000000000000000000000000000 a2b32293aab475bf50798c7642f0fe0593c167f6 file3
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      expected_status_files = [
+        {
+          path: 'file1', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file3', type: 'A', stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: 'a2b32293aab475bf50798c7642f0fe0593c167f6',
+          mode_repo: '000000', sha_repo: '0000000000000000000000000000000000000000'
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_add_file3_to_worktree_and_index_and_modify_in_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file3', 'w', 0o644) { |f| f.write('content3') }
+      `git add file3`
+      File.open('file3', 'w', 0o644) { |f| f.write('updated_content3') }
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid 9a6c20a5ca26595796ff5c2ef6e6a806ae4427f3
+      # # branch.head main
+      # 1 AM N... 000000 100644 100644 0000000000000000000000000000000000000000 a2b32293aab475bf50798c7642f0fe0593c167f6 file3
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # ERROR: the sha_mode and sha_index for file3 is not correct below
+
+      # ERROR: impossible to tell that file3 was modified in the worktree
+
+      expected_status_files = [
+        {
+          path: 'file1', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file3', type: 'A', stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '0000000000000000000000000000000000000000',
+          mode_repo: '000000', sha_repo: '0000000000000000000000000000000000000000'
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  # * Add { path: 'file3', content: 'content3', mode: expect_read_write_mode } to the worktree, add
+  #   file3 to the index, delete file3 in the worktree [DONE]
+  def test_add_file3_to_worktree_and_index_and_delete_in_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file3', 'w', 0o644) { |f| f.write('content3') }
+      `git add file3`
+      File.delete('file3')
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid 9a6c20a5ca26595796ff5c2ef6e6a806ae4427f3
+      # # branch.head main
+      # 1 AD N... 000000 100644 000000 0000000000000000000000000000000000000000 a2b32293aab475bf50798c7642f0fe0593c167f6 file3
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      expected_status_files = [
+        {
+          path: 'file1', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file3', type: 'D', stage: '0', untracked: nil,
+          mode_index: '000000', sha_index: '0000000000000000000000000000000000000000',
+          mode_repo: expect_read_write_mode, sha_repo: 'a2b32293aab475bf50798c7642f0fe0593c167f6'
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  private
+
+  def setup_worktree(worktree_path)
+    `git init`
+    File.open('file1', 'w', 0o644) { |f| f.write('contents1') }
+    File.open('file2', 'w', 0o755) { |f| f.write('contents2') }
+    `git add file1 file2`
+    `git commit -m "Initial commit"`
+  end
+
+  # Generate a unique string to use as file content
+  def random_content
+    SecureRandom.uuid
+  end
+
+  def assert_has_attributes(expected_attrs, object)
+    expected_attrs.each do |expected_attr, expected_value|
+      assert_equal(expected_value, object.send(expected_attr), "The #{expected_attr} attribute does not match")
+    end
+  end
+
+  def assert_has_status_files(expected_status_files, status_files)
+    assert_equal(expected_status_files.count, status_files.count)
+
+    expected_status_files.each do |expected_status_file|
+      status_file = status_files[expected_status_file[:path]]
+      assert_not_nil(status_file, "Status for file #{expected_status_file[:path]} not found")
+      assert_has_attributes(expected_status_file, status_file)
+    end
+  end
+
+  def log_git_status
+    logger.debug do
+      <<~LOG_ENTRY
+
+        ==========
+        #{self.class.name}
+        #{caller[3][/`([^']*)'/, 1].split.last}
+        ----------
+              # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+              #
+        #{`git status --porcelain=v2 --untracked-files=all --branch`.split("\n").map { |line| "      # #{line}" }.join("\n")}
+        ==========
+
+      LOG_ENTRY
+    end
+  end
+
+  def expect_read_write_mode
+    '100644'
+  end
+
+  def expect_execute_mode
+    windows? ? expect_read_write_mode : '100755'
+  end
+
+  def windows?
+    RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+  end
+end

--- a/tests/units/test_status_object_empty_repo.rb
+++ b/tests/units/test_status_object_empty_repo.rb
@@ -1,0 +1,629 @@
+require 'rbconfig'
+require 'securerandom'
+require 'test_helper'
+
+module Git
+  # Add methods to the Status class to make it easier to test
+  class Status
+    def size
+      @files.size
+    end
+
+    alias count size
+
+    def files
+      @files
+    end
+  end
+end
+
+# This is the same suite of tests as TestStatusObject, but the repo has no commits.
+# The worktree and index are setup with the same files as TestStatusObject, but the
+# repo is in a clean state with no commits.
+#
+class TestStatusObjectEmptyRepo < Test::Unit::TestCase
+  def logger
+    # Change log level to Logger::DEBUG to see the log entries
+    @logger ||= Logger.new(STDOUT, level: Logger::ERROR)
+  end
+
+  def test_no_changes
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid 45bcb25ceb9c69b66337d63e2c1c5b520d8a003d
+      # # branch.head main
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      expected_status_files = [
+        {
+          path: 'file1', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_delete_file1_from_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.delete('file1')
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid (initial)
+      # # branch.head main
+      # 1 AD N... 000000 100644 000000 0000000000000000000000000000000000000000 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec file1
+      # 1 A. N... 000000 100755 100755 0000000000000000000000000000000000000000 c061beb85924d309fde78d996a7602544e4f69a5 file2
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # ERROR: mode_index/shw_index are switched with mod_repo/sha_repo
+
+      expected_status_files = [
+        {
+          path: 'file1', type: 'D', stage: '0', untracked: nil,
+          mode_index: '000000', sha_index: '0000000000000000000000000000000000000000',
+          mode_repo: expect_read_write_mode, sha_repo: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec'
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_delete_file1_from_index
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      `git rm -f file1`
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid (initial)
+      # # branch.head main
+      # 1 A. N... 000000 100755 100755 0000000000000000000000000000000000000000 c061beb85924d309fde78d996a7602544e4f69a5 file2
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # ERROR: file2 type should be 'A'
+
+      expected_status_files = [
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_delete_file1_from_index_and_recreate_in_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      `git rm -f file1`
+      File.open('file1', 'w', 0o644) { |f| f.write('does_not_matter') }
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid (initial)
+      # # branch.head main
+      # 1 A. N... 000000 100755 100755 0000000000000000000000000000000000000000 c061beb85924d309fde78d996a7602544e4f69a5 file2
+      # ? file1
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # ERROR: file2 type should be 'A'
+
+      expected_status_files = [
+        {
+          path: 'file1', type: nil, stage: nil, untracked: true,
+          mode_index: nil, sha_index: nil,
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_modify_file1_in_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file1', 'w', 0o644) { |f| f.write('updated_content') }
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid (initial)
+      # # branch.head main
+      # 1 AM N... 000000 100644 100644 0000000000000000000000000000000000000000 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec file1
+      # 1 A. N... 000000 100755 100755 0000000000000000000000000000000000000000 c061beb85924d309fde78d996a7602544e4f69a5 file2
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # ERROR: file1 sha_index is not returned as sha_repo
+      # ERROR: file1 sha_repo/sha_index should be zeros
+
+      expected_status_files = [
+        {
+          path: 'file1', type: 'M', stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '0000000000000000000000000000000000000000',
+          mode_repo: expect_read_write_mode, sha_repo: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec'
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_modify_file1_in_worktree_and_add_to_index
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file1', 'w', 0o644) { |f| f.write('updated_content') }
+      `git add file1`
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid (initial)
+      # # branch.head main
+      # 1 A. N... 000000 100644 100644 0000000000000000000000000000000000000000 c6190329af2f07c1a949128b8e962c06eb23cfa4 file1
+      # 1 A. N... 000000 100755 100755 0000000000000000000000000000000000000000 c061beb85924d309fde78d996a7602544e4f69a5 file2
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # ERROR: file1 type should be 'A'
+      # ERROR: file2 type should be 'A'
+      # ERROR: file1 and file2 mode_repo/show_repo should be zeros instead of nil
+
+      expected_status_files = [
+        {
+          path: 'file1', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: 'c6190329af2f07c1a949128b8e962c06eb23cfa4',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_modify_file1_in_worktree_and_add_to_index_and_modify_in_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file1', 'w', 0o644) { |f| f.write('updated_content1') }
+      `git add file1`
+      File.open('file1', 'w', 0o644) { |f| f.write('updated_content2') }
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid (initial)
+      # # branch.head main
+      # 1 AM N... 000000 100644 100644 0000000000000000000000000000000000000000 a9114691c7e7d6139fa9558897eeda2c8cb2cd81 file1
+      # 1 A. N... 000000 100755 100755 0000000000000000000000000000000000000000 c061beb85924d309fde78d996a7602544e4f69a5 file2
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # ERROR: file1 mode_repo and sha_repo should be zeros
+      # ERROR: file1 sha_index is not set to the actual sha
+      # ERROR: impossible to tell that file1 was added to the index and modified in the worktree
+      # ERROR: file2 type should be 'A'
+
+      expected_status_files = [
+        {
+          path: 'file1', type: 'M', stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '0000000000000000000000000000000000000000',
+          mode_repo: expect_read_write_mode, sha_repo: 'a9114691c7e7d6139fa9558897eeda2c8cb2cd81'
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_modify_file1_in_worktree_and_add_to_index_and_delete_in_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file1', 'w', 0o644) { |f| f.write('updated_content1') }
+      `git add file1`
+      File.delete('file1')
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid (initial)
+      # # branch.head main
+      # 1 AD N... 000000 100644 000000 0000000000000000000000000000000000000000 a9114691c7e7d6139fa9558897eeda2c8cb2cd81 file1
+      # 1 A. N... 000000 100755 100755 0000000000000000000000000000000000000000 c061beb85924d309fde78d996a7602544e4f69a5 file2
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # ERROR: impossible to tell that file1 was added to the index
+      # ERROR: file1 sha_index/sha_repo are swapped
+      # ERROR: file1 mode_repo should be all zeros
+      # ERROR: impossible to tell that file1 or file2 was added to the index and are not in the repo
+      # ERROR: inconsistent use of all zeros (in file1) and nils (in file2)
+
+      expected_status_files = [
+        {
+          path: 'file1', type: 'D', stage: '0', untracked: nil,
+          mode_index: '000000', sha_index: '0000000000000000000000000000000000000000',
+          mode_repo: expect_read_write_mode, sha_repo: 'a9114691c7e7d6139fa9558897eeda2c8cb2cd81'
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_add_file3_to_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file3', 'w', 0o644) { |f| f.write('content3') }
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid (initial)
+      # # branch.head main
+      # 1 A. N... 000000 100644 100644 0000000000000000000000000000000000000000 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec file1
+      # 1 A. N... 000000 100755 100755 0000000000000000000000000000000000000000 c061beb85924d309fde78d996a7602544e4f69a5 file2
+      # ? file3
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # ERROR: hard to tell that file1 and file2 were aded to the index but are not in the repo
+
+      expected_status_files = [
+        {
+          path: 'file1', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file3', type: nil, stage: nil, untracked: true,
+          mode_index: nil, sha_index: nil,
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_add_file3_to_worktree_and_index
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file3', 'w', 0o644) { |f| f.write('content3') }
+      `git add file3`
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid (initial)
+      # # branch.head main
+      # 1 A. N... 000000 100644 100644 0000000000000000000000000000000000000000 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec file1
+      # 1 A. N... 000000 100755 100755 0000000000000000000000000000000000000000 c061beb85924d309fde78d996a7602544e4f69a5 file2
+      # 1 A. N... 000000 100644 100644 0000000000000000000000000000000000000000 a2b32293aab475bf50798c7642f0fe0593c167f6 file3
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # WARNING: hard to tell that file1/file2/file3 were added to the index but are not in the repo
+
+      expected_status_files = [
+        {
+          path: 'file1', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file3', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: 'a2b32293aab475bf50798c7642f0fe0593c167f6',
+          mode_repo: nil, sha_repo: nil
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_add_file3_to_worktree_and_index_and_modify_in_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file3', 'w', 0o644) { |f| f.write('content3') }
+      `git add file3`
+      File.open('file3', 'w', 0o644) { |f| f.write('updated_content3') }
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid (initial)
+      # # branch.head main
+      # 1 A. N... 000000 100644 100644 0000000000000000000000000000000000000000 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec file1
+      # 1 A. N... 000000 100755 100755 0000000000000000000000000000000000000000 c061beb85924d309fde78d996a7602544e4f69a5 file2
+      # 1 AM N... 000000 100644 100644 0000000000000000000000000000000000000000 a2b32293aab475bf50798c7642f0fe0593c167f6 file3
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # WARNING: hard to tell that file3 was added to the index and is not in the repo
+      # ERROR: sha_index/sha_repo are swapped
+      # ERROR: mode_repo should be all zeros
+
+      expected_status_files = [
+        {
+          path: 'file1', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file3', type: 'M', stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '0000000000000000000000000000000000000000',
+          mode_repo: expect_read_write_mode, sha_repo: 'a2b32293aab475bf50798c7642f0fe0593c167f6'
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  def test_add_file3_to_worktree_and_index_and_delete_in_worktree
+    in_temp_dir do |worktree_path|
+
+      # Given
+
+      setup_worktree(worktree_path)
+      File.open('file3', 'w', 0o644) { |f| f.write('content3') }
+      `git add file3`
+      File.delete('file3')
+      git = Git.open(worktree_path)
+
+      log_git_status
+      # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+      #
+      # # branch.oid (initial)
+      # # branch.head main
+      # 1 A. N... 000000 100644 100644 0000000000000000000000000000000000000000 146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec file1
+      # 1 A. N... 000000 100755 100755 0000000000000000000000000000000000000000 c061beb85924d309fde78d996a7602544e4f69a5 file2
+      # 1 AD N... 000000 100644 000000 0000000000000000000000000000000000000000 a2b32293aab475bf50798c7642f0fe0593c167f6 file3
+
+      # When
+
+      status = git.status
+
+      # Then
+
+      # ERROR: mode_index/sha_index are switched with mod_repo/sha_repo
+      # WARNING: hard to tell that file3 was added to the index and deleted in the worktree
+
+      expected_status_files = [
+        {
+          path: 'file1', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_read_write_mode, sha_index: '146edcbe0a35a475bd97aa6fbf83ecf8b21cfeec',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file2', type: nil, stage: '0', untracked: nil,
+          mode_index: expect_execute_mode, sha_index: 'c061beb85924d309fde78d996a7602544e4f69a5',
+          mode_repo: nil, sha_repo: nil
+        },
+        {
+          path: 'file3', type: 'D', stage: '0', untracked: nil,
+          mode_index: '000000', sha_index: '0000000000000000000000000000000000000000',
+          mode_repo: expect_read_write_mode, sha_repo: 'a2b32293aab475bf50798c7642f0fe0593c167f6'
+        }
+      ]
+
+      assert_has_status_files(expected_status_files, status.files)
+    end
+  end
+
+  private
+
+  def setup_worktree(worktree_path)
+    `git init`
+    File.open('file1', 'w', 0o644) { |f| f.write('contents1') }
+    File.open('file2', 'w', 0o755) { |f| f.write('contents2') }
+    `git add file1 file2`
+  end
+
+  # Generate a unique string to use as file content
+  def random_content
+    SecureRandom.uuid
+  end
+
+  def assert_has_attributes(expected_attrs, object)
+    expected_attrs.each do |expected_attr, expected_value|
+      assert_equal(expected_value, object.send(expected_attr), "The #{expected_attr} attribute does not match")
+    end
+  end
+
+  def assert_has_status_files(expected_status_files, status_files)
+    assert_equal(expected_status_files.count, status_files.count)
+
+    expected_status_files.each do |expected_status_file|
+      status_file = status_files[expected_status_file[:path]]
+      assert_not_nil(status_file, "Status for file #{expected_status_file[:path]} not found")
+      assert_has_attributes(expected_status_file, status_file)
+    end
+  end
+
+  def log_git_status
+    logger.debug do
+      <<~LOG_ENTRY
+
+        ==========
+        #{self.class.name}
+        #{caller[3][/`([^']*)'/, 1].split.last}
+        ----------
+              # Output of `git status --porcelain=v2 --untracked-files=all --branch`:
+              #
+        #{`git status --porcelain=v2 --untracked-files=all --branch`.split("\n").map { |line| "      # #{line}" }.join("\n")}
+        ==========
+
+      LOG_ENTRY
+    end
+  end
+
+  def expect_read_write_mode
+    '100644'
+  end
+
+  def expect_execute_mode
+    windows? ? expect_read_write_mode : '100755'
+  end
+
+  def windows?
+    RbConfig::CONFIG['host_os'] =~ /mswin|mingw|cygwin/
+  end
+end


### PR DESCRIPTION
## Description

This PR codifies what the Git::Status class does via unit test assertions to see what is returned for different states of the repository, index, and worktree. In addition to documenting what Git::Status actually does, I have noted in each test what the `git status` command line would return in the same scenario and where I think Git::Status is wrong (search for ERROR: in the test files).

This PR does not change the implementation of Git::Status.

## Background

The Git::Status class tries to add functionality over the top of the `git status` command and returns surprising and often incorrect results. However, it was not obvious what is **SHOULD** return even upon inspecting the code. 

If I had to try summarize it: Git::Status tries to merge the functionality of `git ls-files` (which lists ALL files in the index and worktree), `git diff-files` (which identifies changes between the index vs. the worktree), and `git diff-index HEAD` (which identifies changes between the repo HEAD vs. the worktree).

I believe where this implementation goes really wrong is the way it tries to merge this information and that it only has one "change type" flag (this is the flag that can be M for modified, A for added, and D for deleted).

My conclusion is that Git::Status is broken and probably needs to be completely reimplemented to be exactly what `git status` returns.