### PR TITLE
Release v2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@
 
 # Change Log
 
+## v2.0.1 (2024-05-21)
+
+[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v2.0.0..v2.0.1)
+
+Changes since v2.0.0:
+
+* da435b1 Document and add tests for Git::Status
+* c8a77db Fix Git::Base#status on an empty repo
+* 712fdad Fix Git::Status#untracked when run from worktree subdir
+* 6a59bc8 Remove the Git::Base::Factory module
+
 ## v2.0.0 (2024-05-10)
 
 [Full Changelog](https://github.com/ruby-git/ruby-git/compare/v2.0.0.pre4..v2.0.0)

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -1,5 +1,5 @@
 module Git
   # The current gem version
   # @return [String] the current gem version.
-  VERSION='2.0.0'
+  VERSION='2.0.1'
 end


### PR DESCRIPTION
# Release PR

## v2.0.1 (2024-05-21)

[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v2.0.0..v2.0.1)

Changes since v2.0.0:

* da435b1 Document and add tests for Git::Status
* c8a77db Fix Git::Base#status on an empty repo
* 712fdad Fix Git::Status#untracked when run from worktree subdir
* 6a59bc8 Remove the Git::Base::Factory module
