### PR TITLE
Support `no_color: true` on diff commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,11 +281,12 @@ g.describe('HEAD', {:all => true, :tags => true})
 g.diff(commit1, commit2).size
 g.diff(commit1, commit2).stats
 g.diff(commit1, commit2).name_status
+g.diff(commit1, commit2, no_color: true).patch
 g.gtree('v2.5').diff('v2.6').insertions
 g.diff('gitsearch1', 'v2.5').path('lib/')
 g.diff('gitsearch1', @git.gtree('v2.5'))
 g.diff('gitsearch1', 'v2.5').path('docs/').patch
-g.gtree('v2.5').diff('v2.6').patch
+g.gtree('v2.5').diff('v2.6', no_color: true).patch
 
 g.gtree('v2.5').diff('v2.6').each do |file_diff|
   puts file_diff.path

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -675,9 +675,10 @@ module Git
       Git::Object::Commit.new(self, self.lib.commit_tree(tree, opts))
     end
 
+    # @param [Boolean] no_color Prevent git from colorizing diff output
     # @return [Git::Diff] a Git::Diff object
-    def diff(objectish = 'HEAD', obj2 = nil)
-      Git::Diff.new(self, objectish, obj2)
+    def diff(objectish = 'HEAD', obj2 = nil, no_color: false)
+      Git::Diff.new(self, objectish, obj2, no_color: no_color)
     end
 
     # @return [Git::Object] a Git object

--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -4,10 +4,11 @@ module Git
   class Diff
     include Enumerable
 
-    def initialize(base, from = nil, to = nil)
+    def initialize(base, from = nil, to = nil, no_color: nil)
       @base = base
       @from = from && from.to_s
       @to = to && to.to_s
+      @no_color = no_color
 
       @path = nil
       @full_diff = nil
@@ -101,7 +102,7 @@ module Git
     private
 
       def cache_full
-        @full_diff ||= @base.lib.diff_full(@from, @to, {:path_limiter => @path})
+        @full_diff ||= @base.lib.diff_full(@from, @to, {:path_limiter => @path, :no_color => @no_color})
       end
 
       def process_full

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -523,6 +523,7 @@ module Git
 
     def diff_full(obj1 = 'HEAD', obj2 = nil, opts = {})
       diff_opts = ['-p']
+      diff_opts << "--no-color" if opts[:no_color]
       diff_opts << obj1
       diff_opts << obj2 if obj2.is_a?(String)
       diff_opts << '--' << opts[:path_limiter] if opts[:path_limiter].is_a? String

--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -57,8 +57,8 @@ module Git
         @base.lib.grep(string, opts)
       end
 
-      def diff(objectish)
-        Git::Diff.new(@base, @objectish, objectish)
+      def diff(objectish, no_color: false)
+        Git::Diff.new(@base, @objectish, objectish, no_color: no_color)
       end
 
       def log(count = 30)


### PR DESCRIPTION
We ran into an issue when combining the diff output from this gem with several of the diff-parsers, that only turned up for users that had `color.diff=always` set. Most likely because they liked still having diff colors after piping their diffs through grep/etc, but for _our_ purposes (the `quiet_quality` gem, which uses the fairly old `git_diff_parser` gem), it just broke change-detection whenever that setting was enabled, because the color escapes break the parsing.

This change allows us to supply an extra option `no_color: true` (it defaults to the current behavior) like this:

    git.diff(no_color: true).patch
    git.diff(base, sha, no_color: true).patch

and get un-colorized output more appropriate for parsing, even if the git-configuration has `color.diff=always`

Note - I looked for tests on the equivalent existing feature (the `color.ui` override) and didn't find any, but if you'd like _this_ feature to have tests, I'm happy to add some. I just wasn't sure what layer to test at - I've pretty much only worked in rspec thus far, and could use some guidance :-) (I'd normally test this sort of thing by mocking the Git::CommandLine instantiation, but that doesn't look like that preferred approach here)

Likewise, I think the `Git::Object::AbstractObject#diff` method qualifies as a 'public' method (it is mentioned in the readme examples), but none of the methods in that file had yard documentation yet, and I wasn't sure if I should start adding it for just the one method? Happy to iterate as much as is helpful!