### PR TITLE
When core.ignorecase, check Status for files case-insensitively

### DIFF
--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -108,7 +108,11 @@ module Git
     #     untracked?('lib/git.rb')
     # @return [Boolean]
     def untracked?(file)
-      untracked.member?(file)
+      if ignore_case?
+        untracked.keys.map(&:downcase).include?(file.downcase)
+      else
+        untracked.member?(file)
+      end
     end
 
     def pretty

--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -34,7 +34,11 @@ module Git
     #     changed?('lib/git.rb')
     # @return [Boolean]
     def changed?(file)
-      changed.member?(file)
+      if ignore_case?
+        changed.keys.map(&:downcase).include?(file.downcase)
+      else
+        changed.member?(file)
+      end
     end
 
     # Returns an Enumerable containing files that have been added.
@@ -263,6 +267,16 @@ module Git
           @files[path] ? @files[path].merge!(data) : @files[path] = data
         end
       end
+    end
+
+    # It's worth noting that (like git itself) this gem will not behave well if
+    # ignoreCase is set inconsistently with the file-system itself. For details:
+    # https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreignoreCase
+    def ignore_case?
+      return @_ignore_case if defined?(@_ignore_case)
+      @_ignore_case = @base.config('core.ignoreCase') == 'true'
+    rescue Git::FailedError
+      @_ignore_case = false
     end
   end
 end

--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -83,7 +83,11 @@ module Git
     #     deleted?('lib/git.rb')
     # @return [Boolean]
     def deleted?(file)
-      deleted.member?(file)
+      if ignore_case?
+        deleted.keys.map(&:downcase).include?(file.downcase)
+      else
+        deleted.member?(file)
+      end
     end
 
     #

--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -58,7 +58,11 @@ module Git
     #     added?('lib/git.rb')
     # @return [Boolean]
     def added?(file)
-      added.member?(file)
+      if ignore_case?
+        added.keys.map(&:downcase).include?(file.downcase)
+      else
+        added.member?(file)
+      end
     end
 
     #

--- a/tests/units/test_status.rb
+++ b/tests/units/test_status.rb
@@ -136,6 +136,7 @@ class TestStatus < Test::Unit::TestCase
   def test_deleted_boolean
     in_temp_dir do |path|
       git = Git.clone(@wdir, 'test_dot_files_status')
+      git.config('core.ignorecase', 'false')
 
       create_file('test_dot_files_status/test_file_1', 'content tets_file_1')
       create_file('test_dot_files_status/test_file_2', 'content tets_file_2')
@@ -146,6 +147,10 @@ class TestStatus < Test::Unit::TestCase
 
       assert(git.status.deleted?('test_file_1'))
       assert(!git.status.deleted?('test_file_2'))
+      assert(!git.status.deleted?('TEST_FILE_1'))
+
+      git.config('core.ignorecase', 'true')
+      assert(git.status.deleted?('TEST_FILE_1'))
     end
   end
 

--- a/tests/units/test_status.rb
+++ b/tests/units/test_status.rb
@@ -92,6 +92,7 @@ class TestStatus < Test::Unit::TestCase
   def test_added_boolean
     in_temp_dir do |path|
       git = Git.clone(@wdir, 'test_dot_files_status')
+      git.config('core.ignorecase', 'false')
 
       create_file('test_dot_files_status/test_file_1', 'content tets_file_1')
       create_file('test_dot_files_status/test_file_2', 'content tets_file_2')
@@ -100,6 +101,10 @@ class TestStatus < Test::Unit::TestCase
 
       assert(git.status.added?('test_file_1'))
       assert(!git.status.added?('test_file_2'))
+      assert(!git.status.added?('TEST_FILE_1'))
+
+      git.config('core.ignorecase', 'true')
+      assert(git.status.added?('TEST_FILE_1'))
     end
   end
 

--- a/tests/units/test_status.rb
+++ b/tests/units/test_status.rb
@@ -207,6 +207,7 @@ class TestStatus < Test::Unit::TestCase
   def test_untracked_boolean
     in_temp_dir do |path|
       git = Git.clone(@wdir, 'test_dot_files_status')
+      git.config('core.ignorecase', 'false')
 
       create_file('test_dot_files_status/test_file_1', 'content tets_file_1')
       create_file('test_dot_files_status/test_file_2', 'content tets_file_2')
@@ -214,6 +215,10 @@ class TestStatus < Test::Unit::TestCase
 
       assert(git.status.untracked?('test_file_1'))
       assert(!git.status.untracked?('test_file_2'))
+      assert(!git.status.untracked?('TEST_FILE_1'))
+
+      git.config('core.ignorecase', 'true')
+      assert(git.status.untracked?('TEST_FILE_1'))
     end
   end
 

--- a/tests/units/test_status.rb
+++ b/tests/units/test_status.rb
@@ -106,6 +106,7 @@ class TestStatus < Test::Unit::TestCase
   def test_changed_boolean
     in_temp_dir do |path|
       git = Git.clone(@wdir, 'test_dot_files_status')
+      git.config('core.ignorecase', 'false')
 
       create_file('test_dot_files_status/test_file_1', 'content tets_file_1')
       create_file('test_dot_files_status/test_file_2', 'content tets_file_2')
@@ -117,6 +118,13 @@ class TestStatus < Test::Unit::TestCase
 
       assert(git.status.changed?('test_file_1'))
       assert(!git.status.changed?('test_file_2'))
+
+      update_file('test_dot_files_status/scott/text.txt', 'definitely different')
+      assert(git.status.changed?('scott/text.txt'))
+      assert(!git.status.changed?('scott/TEXT.txt'))
+
+      git.config('core.ignorecase', 'true')
+      assert(git.status.changed?('scott/TEXT.txt'))
     end
   end
 


### PR DESCRIPTION
Fixes #586 by making `Status#changed?` case-insensitive when `core.ignoreCase` is set. Also solve the matching unreported issues for `Status#added`, `Status#deleted`, and `Status#untracked`.

I did run into a bit of an issue trying to write thorough tests for these, because it turns out that _git itself_ doesn't support setting `core.ignoreCase` to a value that doesn't match the behavior of the file-system; [that option](https://git-scm.com/docs/git-config#Documentation/git-config.txt-coreignoreCase) is provided so you can tell git how the file-system is going to act, not so you can control git's behavior! In the tests here, I do break that guideline, but because I don't actually rename any files, `git` doesn't have trouble - just don't try to make it test the case that was actually _reported_, because that will not work.