### PR TITLE
Supply all of the _specific_ color options too

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1223,6 +1223,14 @@ module Git
         global_opts << "--work-tree=#{@git_work_dir}" if !@git_work_dir.nil?
         global_opts << '-c' << 'core.quotePath=true'
         global_opts << '-c' << 'color.ui=false'
+        global_opts << '-c' << 'color.advice=false'
+        global_opts << '-c' << 'color.diff=false'
+        global_opts << '-c' << 'color.grep=false'
+        global_opts << '-c' << 'color.push=false'
+        global_opts << '-c' << 'color.remote=false'
+        global_opts << '-c' << 'color.showBranch=false'
+        global_opts << '-c' << 'color.status=false'
+        global_opts << '-c' << 'color.transport=false'
       end
     end
 

--- a/tests/files/working/dot_git/config
+++ b/tests/files/working/dot_git/config
@@ -13,3 +13,12 @@
 [remote "working"]
 	url = ../working.git
 	fetch = +refs/heads/*:refs/remotes/working/*
+[color]
+  diff = always
+  showBranch = always
+  grep = always
+  advice = always
+  push = always
+  remote = always
+  transport = always
+  status = always


### PR DESCRIPTION
Previously, we were supplying `color.ui=false`, but if the local gitconfig specified any of the more specific options (like `color.diff`), those would take precedence. This updates our command-runner to always supply all of the specific color options as false as well, so that we definitely get a color-free output suitable for parsing.

Updating the fixture causes several of the existing specs to fail without the code changes (especially the `diff` tests), which is probably an appropriate level of testing - I doubt all of these config options are actually necessary, but I don't see any harm in including them.

This should replace #723, since that won't be necessary anymore. We don't currently have any tests checking the actual contents of the commands being run, but I _could_ rig up a test that supplies a `.git/config`.