### PR TITLE
Handle ignored files with quoted (non-ASCII) filenames

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -309,6 +309,13 @@ module Git
       self.object('HEAD').grep(string, path_limiter, opts)
     end
 
+    # List the files in the worktree that are ignored by git
+    # @return [Array<String>] the list of ignored files relative to teh root of the worktree
+    #
+    def ignored_files
+      self.lib.ignored_files
+    end
+
     # removes file(s) from the git repository
     def rm(path = '.', opts = {})
       self.lib.rm(path, opts)

--- a/lib/git/escaped_path.rb
+++ b/lib/git/escaped_path.rb
@@ -3,7 +3,7 @@
 module Git
   # Represents an escaped Git path string
   #
-  # Git commands that output paths (e.g. ls-files, diff), will escape usual
+  # Git commands that output paths (e.g. ls-files, diff), will escape unusual
   # characters in the path with backslashes in the same way C escapes control
   # characters (e.g. \t for TAB, \n for LF, \\ for backslash) or bytes with values
   # larger than 0x80 (e.g. octal \302\265 for "micro" in UTF-8).

--- a/tests/units/test_ignored_files_with_escaped_path.rb
+++ b/tests/units/test_ignored_files_with_escaped_path.rb
@@ -1,0 +1,23 @@
+#!/usr/bin/env ruby
+# encoding: utf-8
+
+require 'test_helper'
+
+# Test diff when the file path has to be quoted according to core.quotePath
+# See https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath
+#
+class TestIgnoredFilesWithEscapedPath < Test::Unit::TestCase
+  def test_ignored_files_with_non_ascii_filename
+    in_temp_dir do |path|
+      create_file('README.md', '# My Project')
+      `git init`
+      `git add .`
+      `git config --local core.safecrlf false` if Gem.win_platform?
+      `git commit -m "First Commit"`
+      create_file('my_other_file_☠', "First Line\n")
+      create_file(".gitignore", "my_other_file_☠")
+      files = Git.open('.').ignored_files
+      assert_equal(['my_other_file_☠'].sort, files)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #694

This is a bug fix: if a repository contains ignored files with non-ASCII or otherwise “unusual” characters that trigger [quotePath](https://git-scm.com/docs/git-config#Documentation/git-config.txt-corequotePath), then Git.open(…).lib.ignored_files currently returns the git-quoted paths, not the proper filenames.

This PR properly unescapes the paths returned from `git ls-files` called from Git::Lib#ignore_files.