### PR TITLE
ls-tree optional recursion into subtrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,9 @@ g.index.writable?
 g.repo
 g.dir
 
+# ls-tree with recursion into subtrees (list files)
+g.ls_tree("head", recursive: true)
+
 # log - returns a Git::Log object, which is an Enumerator of Git::Commit objects
 # default configuration returns a max of 30 commits
 g.log

--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ g.repo
 g.dir
 
 # ls-tree with recursion into subtrees (list files)
-g.ls_tree("head", recursive: true)
+g.ls_tree("HEAD", recursive: true)
 
 # log - returns a Git::Log object, which is an Enumerator of Git::Commit objects
 # default configuration returns a max of 30 commits

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -642,8 +642,8 @@ module Git
       self.lib.revparse(objectish)
     end
 
-    def ls_tree(objectish)
-      self.lib.ls_tree(objectish)
+    def ls_tree(objectish, opts = {})
+      self.lib.ls_tree(objectish, opts)
     end
 
     def cat_file(objectish)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -374,10 +374,15 @@ module Git
       end
     end
 
-    def ls_tree(sha)
+    def ls_tree(sha, opts = {})
       data = { 'blob' => {}, 'tree' => {}, 'commit' => {} }
 
-      command_lines('ls-tree', sha).each do |line|
+      ls_tree_opts = []
+      ls_tree_opts << '-r' if opts[:recursive]
+      # path must be last arg
+      ls_tree_opts << opts[:path] if opts[:path]
+
+      command_lines('ls-tree', sha, *ls_tree_opts).each do |line|
         (info, filenm) = line.split("\t")
         (mode, type, sha) = info.split
         data[type][filenm] = {:mode => mode, :sha => sha}


### PR DESCRIPTION
Enables `git ls-tree -r head` which lists the contents of a tree object, recursively.

`git ls-files` isn't appropriate since it includes files in the index and the working tree.