### PR TITLE
Verify that the commit(s) passed to git diff do not resemble a command-line option

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -526,7 +526,24 @@ module Git
       hsh
     end
 
+    # Validate that the given arguments cannot be mistaken for a command-line option
+    #
+    # @param arg_name [String] the name of the arguments to mention in the error message
+    # @param args [Array<String, nil>] the arguments to validate
+    #
+    # @raise [ArgumentError] if any of the parameters are a string starting with a hyphen
+    # @return [void]
+    #
+    def validate_no_options(arg_name, *args)
+      invalid_args = args.select { |arg| arg&.start_with?('-') }
+      if invalid_args.any?
+        raise ArgumentError, "Invalid #{arg_name}: '#{invalid_args.join("', '")}'"
+      end
+    end
+
     def diff_full(obj1 = 'HEAD', obj2 = nil, opts = {})
+      validate_no_options('commit or commit range', obj1, obj2)
+
       diff_opts = ['-p']
       diff_opts << obj1
       diff_opts << obj2 if obj2.is_a?(String)
@@ -536,6 +553,8 @@ module Git
     end
 
     def diff_stats(obj1 = 'HEAD', obj2 = nil, opts = {})
+      validate_no_options('commit or commit range', obj1, obj2)
+
       diff_opts = ['--numstat']
       diff_opts << obj1
       diff_opts << obj2 if obj2.is_a?(String)
@@ -556,6 +575,8 @@ module Git
     end
 
     def diff_name_status(reference1 = nil, reference2 = nil, opts = {})
+      validate_no_options('commit or commit range', reference1, reference2)
+
       opts_arr = ['--name-status']
       opts_arr << reference1 if reference1
       opts_arr << reference2 if reference2

--- a/tests/units/test_diff.rb
+++ b/tests/units/test_diff.rb
@@ -118,5 +118,25 @@ class TestDiff < Test::Unit::TestCase
     assert_equal(160, files['scott/newfile'].patch.size)
   end
 
+  def test_diff_patch_with_bad_commit
+    assert_raise(ArgumentError) do
+      @git.diff('-s').patch
+    end
 
+    assert_raise(ArgumentError) do
+      @git.diff('gitsearch1', '-s').patch
+    end
+  end
+
+  def test_diff_name_status_with_bad_commit
+    assert_raise(ArgumentError) do
+      @git.diff('-s').name_status
+    end
+  end
+
+  def test_diff_stats_with_bad_commit
+    assert_raise(ArgumentError) do
+      @git.diff('-s').stats
+    end
+  end
 end


### PR DESCRIPTION
Verify that the commit arguments to Git::Base#diff do not resemble command-line options. Passing a commit that begins with a hyphen will result in an ArgumentError being raised.

For instance:

```
git = Git.open('.')
commit = 'HEAD'
git.diff(commit)
```

Would execute:

```
git diff HEAD
```

However, if the commit is something that looks like a command line option, such as '-s', then the following command line would be executed:

```
git diff -s
```

Which probably isn't what was wanted/expected. After this change, the above statement would raise an ArgumentError.