### PR TITLE
Refactor Git::Lib#rev_parse(revision) and sanitize its input

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,7 +277,7 @@ tree.blobs
 tree.subtrees
 tree.children # blobs and subtrees
 
-g.revparse('v2.5:Makefile')
+g.rev_parse('v2.0.0:README.md')
 
 g.branches # returns Git::Branch objects
 g.branches.local

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -634,13 +634,16 @@ module Git
     # runs git rev-parse to convert the objectish to a full sha
     #
     # @example
-    #   git.revparse("HEAD^^")
-    #   git.revparse('v2.4^{tree}')
-    #   git.revparse('v2.4:/doc/index.html')
+    #   git.rev_parse("HEAD^^")
+    #   git.rev_parse('v2.4^{tree}')
+    #   git.rev_parse('v2.4:/doc/index.html')
     #
-    def revparse(objectish)
-      self.lib.revparse(objectish)
+    def rev_parse(objectish)
+      self.lib.rev_parse(objectish)
     end
+
+    # For backwards compatibility
+    alias revparse rev_parse
 
     def ls_tree(objectish, opts = {})
       self.lib.ls_tree(objectish, opts)

--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -23,7 +23,7 @@ module Git
       end
 
       def sha
-        @sha ||= @base.lib.revparse(@objectish)
+        @sha ||= @base.lib.rev_parse(@objectish)
       end
 
       def size

--- a/tests/units/test_branch.rb
+++ b/tests/units/test_branch.rb
@@ -160,11 +160,11 @@ class TestBranch < Test::Unit::TestCase
       File.write('foo','rev 2')
       git.add('foo')
       git.commit('rev 2')
-      git.branch('testing').update_ref(git.revparse('HEAD'))
+      git.branch('testing').update_ref(git.rev_parse('HEAD'))
 
       # Expect the call to Branch#update_ref to pass the full ref name for the
       # of the testing branch to Lib#update_ref
-      assert_equal(git.revparse('HEAD'), git.revparse('refs/heads/testing'))
+      assert_equal(git.rev_parse('HEAD'), git.rev_parse('refs/heads/testing'))
     end
   end
 end

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -174,10 +174,28 @@ class TestLib < Test::Unit::TestCase
     Git::Base.config.git_ssh = saved_git_ssh
   end
 
-  def test_revparse
-    assert_equal('1cc8667014381e2788a94777532a788307f38d26', @lib.revparse('1cc8667014381')) # commit
-    assert_equal('94c827875e2cadb8bc8d4cdd900f19aa9e8634c7', @lib.revparse('1cc8667014381^{tree}')) #tree
-    assert_equal('ba492c62b6227d7f3507b4dcc6e6d5f13790eabf', @lib.revparse('v2.5:example.txt')) #blob
+  def test_rev_parse_commit
+    assert_equal('1cc8667014381e2788a94777532a788307f38d26', @lib.rev_parse('1cc8667014381')) # commit
+  end
+
+  def test_rev_parse_tree
+    assert_equal('94c827875e2cadb8bc8d4cdd900f19aa9e8634c7', @lib.rev_parse('1cc8667014381^{tree}')) #tree
+  end
+
+  def test_rev_parse_blob
+    assert_equal('ba492c62b6227d7f3507b4dcc6e6d5f13790eabf', @lib.rev_parse('v2.5:example.txt')) #blob
+  end
+
+  def test_rev_parse_with_bad_revision
+    assert_raise(ArgumentError) do
+      @lib.rev_parse('--all')
+    end
+  end
+
+  def test_rev_parse_with_unknown_revision
+    assert_raise(Git::FailedError) do
+      @lib.rev_parse('NOTFOUND')
+    end
   end
 
   def test_object_type

--- a/tests/units/test_object.rb
+++ b/tests/units/test_object.rb
@@ -120,8 +120,8 @@ class TestObject < Test::Unit::TestCase
     assert(block_called)
   end
 
-  def test_revparse
-    sha = @git.revparse('v2.6:example.txt')
+  def test_rev_parse
+    sha = @git.rev_parse('v2.6:example.txt')
     assert_equal('1f09f2edb9c0d9275d15960771b363ca6940fbe3', sha)
   end
 


### PR DESCRIPTION
Make the following changes to Git::Lib#rev_parse:

* Remove optimizations that try to calculate the resulting SHA instead of calling `git rev-parse`. This library should not reimplement git functionality if possible. Git could change and then the assumptions in these optimizations would no longer be valid (e.g. SHAs are 40 digit hex numbers).

  There is a chance that this could break existing uses if the optimization implementation is already different than the implementation of `git rev-parse`

* Validate that the reference passed in does not look like a command-line option (i.e. starts with a hyphen).