### PR TITLE
Sanitize non-option arguments passed to `git name-rev`

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -337,9 +337,21 @@ module Git
     # For backwards compatibility with the old method name
     alias :revparse :rev_parse
 
-    def namerev(string)
-      command('name-rev', string).split[1]
+    # Find the first symbolic name for given commit_ish
+    #
+    # @param commit_ish [String] the commit_ish to find the symbolic name of
+    #
+    # @return [String, nil] the first symbolic name or nil if the commit_ish isn't found
+    #
+    # @raise [ArgumentError] if the commit_ish is a string starting with a hyphen
+    #
+    def name_rev(commit_ish)
+      assert_args_are_not_options('commit_ish', commit_ish)
+
+      command('name-rev', commit_ish).split[1]
     end
+
+    alias :namerev :name_rev
 
     def object_type(sha)
       command('cat-file', '-t', sha)

--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -175,7 +175,7 @@ module Git
       end
 
       def name
-        @base.lib.namerev(sha)
+        @base.lib.name_rev(sha)
       end
 
       def gtree

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -198,6 +198,16 @@ class TestLib < Test::Unit::TestCase
     end
   end
 
+  def test_name_rev
+    assert_equal('tags/v2.5~5', @lib.name_rev('00ea60e'))
+  end
+
+  def test_name_rev_with_invalid_commit_ish
+    assert_raise(ArgumentError) do
+      @lib.name_rev('-1cc8667014381')
+    end
+  end
+
   def test_object_type
     assert_equal('commit', @lib.object_type('1cc8667014381')) # commit
     assert_equal('tree', @lib.object_type('1cc8667014381^{tree}')) #tree


### PR DESCRIPTION
Sanitize the commit_ish argument passed to Git::Lib#name_rev.

Before this change, the following method call:

```
lib.name_rev('--all')
```

would result in `git name-rev --all` which is not the intention.

After this change, passing a commit-ish that looks like a command-line option (aka starts with a hyphen) will cause an ArgumentError to be raised.