### PR TITLE
Omit testing of Git::Lib#commit_data to retrieve gpg sig of signed commits on Windows

### DIFF
--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -45,7 +45,7 @@ class Test::Unit::TestCase
   def create_temp_repo(clone_name)
     clone_path = File.join(TEST_FIXTURES, clone_name)
     filename = 'git_test' + Time.now.to_i.to_s + rand(300).to_s.rjust(3, '0')
-    path = File.expand_path(File.join("/tmp/", filename))
+    path = File.expand_path(File.join(Dir.tmpdir, filename))
     FileUtils.mkdir_p(path)
     @tmp_path = File.realpath(path)
     FileUtils.cp_r(clone_path, @tmp_path)

--- a/tests/units/test_signed_commits.rb
+++ b/tests/units/test_signed_commits.rb
@@ -13,15 +13,22 @@ class TestSignedCommits < Test::Unit::TestCase
   def in_repo_with_signing_config(&block)
     in_temp_dir do |path|
       `git init`
-      `ssh-keygen -t dsa -N "" -C "test key" -f .git/test-key`
+      ssh_key_file = File.expand_path(File.join('.git', 'test-key'))
+      `ssh-keygen -t dsa -N "" -C "test key" -f "#{ssh_key_file}"`
       `git config --local gpg.format ssh`
-      `git config --local user.signingkey .git/test-key`
+      `git config --local user.signingkey #{ssh_key_file}.pub`
+
+      raise "ERROR: No .git/test-key file" unless File.exist?("#{ssh_key_file}.pub")
 
       yield
     end
   end
 
   def test_commit_data
+    # Signed commits should work on windows, but this test is omitted until the setup
+    # on windows can be figured out
+    omit('Omit testing of signed commits on Windows') if windows_platform?
+
     in_repo_with_signing_config do
       create_file('README.md', '# My Project')
       `git add README.md`


### PR DESCRIPTION
During the Windows MRI Ruby 3.0 build, the following error occurs:

```text
error: Couldn't load public key D:/a/_temp/d20240826-5256-oy57bv/.git/test-key.pub: No such file or directory?

fatal: failed to write commit object
```

This is due to signed commits not being setup correctly in the Windows testing. This is not an issue with the git gem, but an issue with how the test sets up commit signing on Windows.

This test is about how the output from `git cat-file` is handled by the git gem. If this functionality works on Linux, it should work on Windows.