### PR TITLE
Sanatize object ref sent to cat-file command

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -650,7 +650,7 @@ module Git
     end
 
     def cat_file(objectish)
-      self.lib.object_contents(objectish)
+      self.lib.cat_file(objectish)
     end
 
     # The name of the branch HEAD refers to or 'HEAD' if detached

--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -27,7 +27,7 @@ module Git
       end
 
       def size
-        @size ||= @base.lib.object_size(@objectish)
+        @size ||= @base.lib.cat_file_size(@objectish)
       end
 
       # Get the object's contents.
@@ -38,9 +38,9 @@ module Git
       # Use this for large files so that they are not held in memory.
       def contents(&block)
         if block_given?
-          @base.lib.object_contents(@objectish, &block)
+          @base.lib.cat_file_contents(@objectish, &block)
         else
-          @contents ||= @base.lib.object_contents(@objectish)
+          @contents ||= @base.lib.cat_file_contents(@objectish)
         end
       end
 
@@ -237,7 +237,7 @@ module Git
         def check_commit
           return if @tree
 
-          data = @base.lib.commit_data(@objectish)
+          data = @base.lib.cat_file_commit(@objectish)
           set_commit(data)
         end
 
@@ -254,7 +254,7 @@ module Git
       end
 
       def annotated?
-        @annotated ||= (@base.lib.object_type(self.name) == 'tag')
+        @annotated ||= (@base.lib.cat_file_type(self.name) == 'tag')
       end
 
       def message
@@ -279,7 +279,7 @@ module Git
         if !self.annotated?
           @message = @tagger = nil
         else
-          tdata = @base.lib.tag_data(@name)
+          tdata = @base.lib.cat_file_tag(@name)
           @message = tdata['message'].chomp
           @tagger = Git::Author.new(tdata['tagger'])
         end
@@ -300,7 +300,7 @@ module Git
         return Git::Object::Tag.new(base, sha, objectish)
       end
 
-      type ||= base.lib.object_type(objectish)
+      type ||= base.lib.cat_file_type(objectish)
       klass =
         case type
         when /blob/   then Blob

--- a/tests/units/test_object.rb
+++ b/tests/units/test_object.rb
@@ -62,7 +62,7 @@ class TestObject < Test::Unit::TestCase
     assert_equal('ba492c62b6227d7f3507b4dcc6e6d5f13790eabf', @blob.sha)
   end
 
-  def test_object_size
+  def test_cat_file_size
     assert_equal(265, @commit.size)
     assert_equal(72, @tree.size)
     assert_equal(128, @blob.size)

--- a/tests/units/test_signed_commits.rb
+++ b/tests/units/test_signed_commits.rb
@@ -24,7 +24,7 @@ class TestSignedCommits < Test::Unit::TestCase
     end
   end
 
-  def test_commit_data
+  def test_cat_file_commit
     # Signed commits should work on windows, but this test is omitted until the setup
     # on windows can be figured out
     omit('Omit testing of signed commits on Windows') if windows_platform?
@@ -34,7 +34,7 @@ class TestSignedCommits < Test::Unit::TestCase
       `git add README.md`
       `git commit -S -m "Signed, sealed, delivered"`
 
-      data = Git.open('.').lib.commit_data('HEAD')
+      data = Git.open('.').lib.cat_file_commit('HEAD')
 
       assert_match(SSH_SIGNATURE_REGEXP, data['gpgsig'])
       assert_equal("Signed, sealed, delivered\n", data['message'])


### PR DESCRIPTION
Sanitize the object reference sent to the cat-file command.

Make sure the object reference sent to cat-file commands do not start with a hyphen so they are not mistaken for command line options.

Also normalize the cat-file commands in accordance with [this project's design philosophy](https://github.com/ruby-git/ruby-git/blob/master/CONTRIBUTING.md#design-philosophy). This includes adding the following commands (and aliases):

* #cat_file_contents was aliased to #object_contents
* #cat_file_type was aliased to #object_type
* #cat_file_size was aliased to #object_size
* #cat_file_commit was aliased to #commit_data
* #cat_file_tag was aliased to #tag_data