### PR TITLE
Fix windows CI build

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -357,12 +357,13 @@ module Git
     #
     # @see https://git-scm.com/docs/git-cat-file git-cat-file
     #
-    # @param object [String] the object whose contents to return
-    # @param opts [Hash] the options for this command
-    # @option opts [Boolean] :tag
-    # @option opts [Boolean] :size
-    # @option opts
+    # @example Get the contents of a file without a block
+    #   lib.cat_file_contents('README.md') # => "This is a README file\n"
     #
+    # @example Get the contents of a file with a block
+    #  lib.cat_file_contents('README.md') { |f| f.read } # => "This is a README file\n"
+    #  
+    # @param object [String] the object whose contents to return
     #
     # @return [String] the object contents
     #

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -424,7 +424,7 @@ class TestLib < Test::Unit::TestCase
 
     in_temp_repo('working') do
       # Creeate an annotated tag:
-      `git tag -a annotated_tag -m 'Creating an annotated tag'`
+      `git tag -a annotated_tag -m "Creating an annotated tag"`
 
       git = Git.open('.')
       cat_file_tag = git.lib.cat_file_tag('annotated_tag')

--- a/tests/units/test_logger.rb
+++ b/tests/units/test_logger.rb
@@ -17,39 +17,40 @@ class TestLogger < Test::Unit::TestCase
   end
 
   def test_logger
-    log = Tempfile.new('logfile')
-    log.close
+    in_temp_dir do |path|
+      log_path = 'logfile.log'
 
-    logger = Logger.new(log.path)
-    logger.level = Logger::DEBUG
+      logger = Logger.new(log_path, level: Logger::DEBUG)
 
-    @git = Git.open(@wdir, :log => logger)
-    @git.branches.size
+      @git = Git.open(@wdir, :log => logger)
+      @git.branches.size
 
-    logc = File.read(log.path)
+      logc = File.read(log_path)
 
-    expected_log_entry = /INFO -- : \["git", "(?<global_options>.*?)", "branch", "-a"/
-    assert_match(expected_log_entry, logc, missing_log_entry)
+      expected_log_entry = /INFO -- : \["git", "(?<global_options>.*?)", "branch", "-a"/
+      assert_match(expected_log_entry, logc, missing_log_entry)
 
-    expected_log_entry = /DEBUG -- : stdout:\n"  cherry/
-    assert_match(expected_log_entry, logc, missing_log_entry)
+      expected_log_entry = /DEBUG -- : stdout:\n"  cherry/
+      assert_match(expected_log_entry, logc, missing_log_entry)
+    end
   end
 
   def test_logging_at_info_level_should_not_show_debug_messages
-    log = Tempfile.new('logfile')
-    log.close
-    logger = Logger.new(log.path)
-    logger.level = Logger::INFO
+    in_temp_dir do |path|
+      log_path = 'logfile.log'
 
-    @git = Git.open(@wdir, :log => logger)
-    @git.branches.size
+      logger = Logger.new(log_path, level: Logger::INFO)
 
-    logc = File.read(log.path)
+      @git = Git.open(@wdir, :log => logger)
+      @git.branches.size
 
-    expected_log_entry = /INFO -- : \["git", "(?<global_options>.*?)", "branch", "-a"/
-    assert_match(expected_log_entry, logc, missing_log_entry)
+      logc = File.read(log_path)
 
-    expected_log_entry = /DEBUG -- : stdout:\n"  cherry/
-    assert_not_match(expected_log_entry, logc, unexpected_log_entry)
+      expected_log_entry = /INFO -- : \["git", "(?<global_options>.*?)", "branch", "-a"/
+      assert_match(expected_log_entry, logc, missing_log_entry)
+
+      expected_log_entry = /DEBUG -- : stdout:\n"  cherry/
+      assert_not_match(expected_log_entry, logc, unexpected_log_entry)
+    end
   end
 end


### PR DESCRIPTION
Adjust the quoting in a shell command in a test that made the windows build fail.

Ignore error on windows where the test finalizer fails to remove files that were already removed.

Fix a Yardoc error.