### PR TITLE
Add Git.binary_version to return the version of the git command line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,9 @@
 # @title How To Contribute
 -->
 
+# Contributing to the git gem
+
+* [Summary](#summary)
 * [How to contribute](#how-to-contribute)
 * [How to report an issue or request a feature](#how-to-report-an-issue-or-request-a-feature)
 * [How to submit a code or documentation change](#how-to-submit-a-code-or-documentation-change)
@@ -19,9 +22,9 @@
   * [Continuous integration](#continuous-integration)
   * [Documentation](#documentation)
 * [Licensing](#licensing)
+* [Building a specific version of the git command-line](#building-a-specific-version-of-the-git-command-line)
 
-
-# Contributing to the git gem
+## Summary
 
 Thank you for your interest in contributing to the `ruby-git` project.
 
@@ -172,6 +175,9 @@ $ bin/test test_object test_archive
 
 # run all unit tests:
 $ bin/test
+
+# run unit tests with a different version of the git command line:
+$ GIT_PATH=/Users/james/Downloads/git-2.30.2/bin-wrappers bin/test
 ```
 
 ### Continuous integration
@@ -191,3 +197,57 @@ New and updated public-facing features should be documented in the project's [RE
 `ruby-git` uses [the MIT license](https://choosealicense.com/licenses/mit/) as declared in the [LICENSE](LICENSE) file.
 
 Licensing is critical to open-source projects as it ensures the software remains available under the terms desired by the author.
+
+## Building a specific version of the git command-line
+
+For testing, it is helpful to be able to build and use a specific version of the git
+command-line with the git gem.
+
+Instructions to do this can be found on the page [How to install
+Git](https://www.atlassian.com/git/tutorials/install-git) from Atlassian.
+
+I have successfully used the instructions in the section "Build Git from source on OS
+X" on MacOS 15. I have copied the following instructions from the Atlassian page.
+
+1. From your terminal install XCode's Command Line Tools:
+
+   ```shell
+   xcode-select --install
+   ```
+
+2. Install [Homebrew](http://brew.sh/)
+
+3. Using Homebrew, install openssl:
+
+   ```shell
+   brew install openssl
+   ```
+
+4. Download the source tarball for the desired version from
+   [here](https://mirrors.edge.kernel.org/pub/software/scm/git/) and extract it
+
+5. Build Git run make with the following command:
+
+   ```shell
+   NO_GETTEXT=1 make CFLAGS="-I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/opt/openssl/lib"
+   ```
+
+6. The newly built git command will be found at `bin-wrappers/git`
+
+7. Use the new git command-line version
+
+   Configure the git gem to use the newly built version:
+
+   ```ruby
+   require 'git'
+   # set the binary path
+   Git.configure { |config| config.binary_path = '/Users/james/Downloads/git-2.30.2/bin-wrappers/git' }
+   # validate the version
+   assert_equal([2, 30, 2], Git.binary_version)
+   ```
+
+   or run tests using the newly built version:
+
+   ```shell
+   GIT_PATH=/Users/james/Downloads/git-2.30.2/bin-wrappers bin/test
+   ```

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -381,4 +381,15 @@ module Git
   def self.open(working_dir, options = {})
     Base.open(working_dir, options)
   end
+
+  # Return the version of the git binary
+  #
+  # @example
+  #  Git.binary_version # => [2, 46, 0]
+  #
+  # @return [Array<Integer>] the version of the git binary
+  #
+  def self.binary_version(binary_path = Git::Base.config.binary_path)
+    Base.binary_version(binary_path)
+  end
 end

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -36,6 +36,20 @@ module Git
       @@config ||= Config.new
     end
 
+    def self.binary_version(binary_path)
+      git_cmd = "#{binary_path} -c core.quotePath=true -c color.ui=false version 2>&1"
+      result, status = Open3.capture2(git_cmd)
+      result = result.chomp
+
+      if status.success?
+        version = result[/\d+(\.\d+)+/]
+        version_parts = version.split('.').collect { |i| i.to_i }
+        version_parts.fill(0, version_parts.length...3)
+      else
+        raise RuntimeError, "Failed to get git version: #{status}\n#{result}"
+      end
+    end
+
     # (see Git.init)
     def self.init(directory = '.', options = {})
       normalize_paths(options, default_working_directory: directory, default_repository: directory, bare: options[:bare])

--- a/tests/units/test_git_binary_version.rb
+++ b/tests/units/test_git_binary_version.rb
@@ -1,0 +1,54 @@
+require 'test_helper'
+
+class TestGitBinaryVersion < Test::Unit::TestCase
+  def windows_mocked_git_binary = <<~GIT_SCRIPT
+    @echo off
+    # Loop through the arguments and check for the version command
+    for %%a in (%*) do (
+      if "%%a" == "version" (
+        echo git version 1.2.3
+        exit /b 0
+      )
+    )
+    exit /b 1
+  GIT_SCRIPT
+
+  def linux_mocked_git_binary = <<~GIT_SCRIPT
+    #!/bin/sh
+    # Loop through the arguments and check for the version command
+    for arg in "$@"; do
+      if [ "$arg" = "version" ]; then
+        echo "git version 1.2.3"
+        exit 0
+      fi
+    done
+    exit 1
+  GIT_SCRIPT
+
+  def test_binary_version_windows
+    omit('Only implemented for Windows') unless windows_platform?
+
+    in_temp_dir do |path|
+      git_binary_path = File.join(path, 'my_git.bat')
+      File.write(git_binary_path, windows_mocked_git_binary)
+      assert_equal([1, 2, 3], Git.binary_version(git_binary_path))
+    end
+  end
+
+  def test_binary_version_linux
+    omit('Only implemented for Linux') if windows_platform?
+
+    in_temp_dir do |path|
+      git_binary_path = File.join(path, 'my_git.bat')
+      File.write(git_binary_path, linux_mocked_git_binary)
+      File.chmod(0755, git_binary_path)
+      assert_equal([1, 2, 3], Git.binary_version(git_binary_path))
+    end
+  end
+
+  def test_binary_version_bad_binary_path
+    assert_raise RuntimeError do
+      Git.binary_version('/path/to/nonexistent/git')
+    end
+  end
+end


### PR DESCRIPTION
Add Git.binary_version to get the version of the git command line without having to open a repository.