### PR TITLE
Update instructions for building a specific version of Git

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,12 @@
   * [Unit tests](#unit-tests)
   * [Continuous integration](#continuous-integration)
   * [Documentation](#documentation)
+* [Building a specific version of the Git command-line](#building-a-specific-version-of-the-git-command-line)
+  * [Install pre-requisites](#install-pre-requisites)
+  * [Obtain Git source code](#obtain-git-source-code)
+  * [Build git](#build-git)
+  * [Use the new Git version](#use-the-new-git-version)
 * [Licensing](#licensing)
-* [Building a specific version of the git command-line](#building-a-specific-version-of-the-git-command-line)
 
 ## Summary
 
@@ -182,72 +186,93 @@ $ GIT_PATH=/Users/james/Downloads/git-2.30.2/bin-wrappers bin/test
 
 ### Continuous integration
 
-All tests must pass in the project's [GitHub Continuous Integration build](https://github.com/ruby-git/ruby-git/actions?query=workflow%3ACI) before the pull request will be merged.
+All tests must pass in the project's [GitHub Continuous Integration
+build](https://github.com/ruby-git/ruby-git/actions?query=workflow%3ACI) before the
+pull request will be merged.
 
-The [Continuous Integration workflow](https://github.com/ruby-git/ruby-git/blob/master/.github/workflows/continuous_integration.yml) runs both `bundle exec rake default` and `bundle exec rake test:gem` from the project's [Rakefile](https://github.com/ruby-git/ruby-git/blob/master/Rakefile).
+The [Continuous Integration
+workflow](https://github.com/ruby-git/ruby-git/blob/master/.github/workflows/continuous_integration.yml)
+runs both `bundle exec rake default` and `bundle exec rake test:gem` from the
+project's [Rakefile](https://github.com/ruby-git/ruby-git/blob/master/Rakefile).
 
 ### Documentation
 
-New and updated public methods must include [YARD](https://yardoc.org/) documentation.
+New and updated public methods must include [YARD](https://yardoc.org/)
+documentation.
 
-New and updated public-facing features should be documented in the project's [README.md](README.md).
+New and updated public-facing features should be documented in the project's
+[README.md](README.md).
+
+## Building a specific version of the Git command-line
+
+To test with a specific version of the Git command-line, you may need to build that
+version from source code. The following instructions are adapted from Atlassian’s
+[How to install Git](https://www.atlassian.com/git/tutorials/install-git) page for
+building Git on macOS.
+
+### Install pre-requisites
+
+Prerequisites only need to be installed if they are not already present.
+
+From your terminal, install Xcode’s Command Line Tools:
+
+```shell
+xcode-select --install
+```
+
+Install [Homebrew](http://brew.sh/) by following the instructions on the Homebrew
+page.
+
+Using Homebrew, install OpenSSL:
+
+```shell
+brew install openssl
+```
+
+### Obtain Git source code
+
+Download and extract the source tarball for the desired Git version from [this source
+code mirror](https://mirrors.edge.kernel.org/pub/software/scm/git/).
+
+### Build git
+
+From your terminal, change to the root directory of the extracted source code and run
+the build with following command:
+
+```shell
+NO_GETTEXT=1 make CFLAGS="-I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/opt/openssl/lib"
+```
+
+The build script will place the newly compiled Git executables in the `bin-wrappers`
+directory (e.g., `bin-wrappers/git`).
+
+### Use the new Git version
+
+To configure programs that use the Git gem to utilize the newly built version, do the
+following:
+
+```ruby
+require 'git'
+
+# Set the binary path
+Git.configure { |c| c.binary_path = '/Users/james/Downloads/git-2.30.2/bin-wrappers/git' }
+
+# Validate the version (if desired)
+assert_equal([2, 30, 2], Git.binary_version)
+```
+
+Tests can be run using the newly built Git version as follows:
+
+```shell
+GIT_PATH=/Users/james/Downloads/git-2.30.2/bin-wrappers bin/test
+```
+
+Note: `GIT_PATH` refers to the directory containing the `git` executable.
 
 ## Licensing
 
-`ruby-git` uses [the MIT license](https://choosealicense.com/licenses/mit/) as declared in the [LICENSE](LICENSE) file.
+`ruby-git` uses [the MIT license](https://choosealicense.com/licenses/mit/) as
+declared in the [LICENSE](LICENSE) file.
 
-Licensing is critical to open-source projects as it ensures the software remains available under the terms desired by the author.
-
-## Building a specific version of the git command-line
-
-For testing, it is helpful to be able to build and use a specific version of the git
-command-line with the git gem.
-
-Instructions to do this can be found on the page [How to install
-Git](https://www.atlassian.com/git/tutorials/install-git) from Atlassian.
-
-I have successfully used the instructions in the section "Build Git from source on OS
-X" on MacOS 15. I have copied the following instructions from the Atlassian page.
-
-1. From your terminal install XCode's Command Line Tools:
-
-   ```shell
-   xcode-select --install
-   ```
-
-2. Install [Homebrew](http://brew.sh/)
-
-3. Using Homebrew, install openssl:
-
-   ```shell
-   brew install openssl
-   ```
-
-4. Download the source tarball for the desired version from
-   [here](https://mirrors.edge.kernel.org/pub/software/scm/git/) and extract it
-
-5. Build Git run make with the following command:
-
-   ```shell
-   NO_GETTEXT=1 make CFLAGS="-I/usr/local/opt/openssl/include" LDFLAGS="-L/usr/local/opt/openssl/lib"
-   ```
-
-6. The newly built git command will be found at `bin-wrappers/git`
-
-7. Use the new git command-line version
-
-   Configure the git gem to use the newly built version:
-
-   ```ruby
-   require 'git'
-   # set the binary path
-   Git.configure { |config| config.binary_path = '/Users/james/Downloads/git-2.30.2/bin-wrappers/git' }
-   # validate the version
-   assert_equal([2, 30, 2], Git.binary_version)
-   ```
-
-   or run tests using the newly built version:
-
-   ```shell
-   GIT_PATH=/Users/james/Downloads/git-2.30.2/bin-wrappers bin/test
-   ```
+Licensing is critical to open-source projects as it ensures the software remains
+available under the terms desired by the author.


### PR DESCRIPTION
The instructions were re-written for clarity.