### PR TITLE
test: add `#run_command` for tests to use instead of backticks

### DIFF
--- a/tests/units/test_branch.rb
+++ b/tests/units/test_branch.rb
@@ -50,6 +50,26 @@ class TestBranch < Test::Unit::TestCase
     end
   end
 
+  test 'Git::Base#branches when checked out branch is a remote branch' do
+    in_temp_dir do
+      Dir.mkdir('remote_git')
+      Dir.chdir('remote_git') do
+        run_command 'git', 'init', '--initial-branch=main'
+        File.write('file1.txt', 'This is file1')
+        run_command 'git', 'add', 'file1.txt'
+        run_command 'git', 'commit', '-m', 'Add file1.txt'
+      end
+
+      run_command 'git', 'clone', File.join('remote_git', '.git'), 'local_git'
+
+      Dir.chdir('local_git') do
+        run_command 'git', 'checkout', 'origin/main'
+        git = Git.open('.')
+        assert_nothing_raised { git.branches }
+      end
+    end
+  end
+
   # Git::Lib#current_branch_state
 
   test 'Git::Lib#current_branch_state -- empty repository' do


### PR DESCRIPTION
Add the method `#run_command` to `tests/test_helper.rb` so it is available to all tests.

This method is to be used in tests in place of using backticks for running shell commands (like git). This method has the following advantages:

* shell quoting and escaping is not necessary as it is with backticks - this is particularly bothersome to get right in a cross platform way)
* a timeout can be specified (by passing `timeout: value`)
* both stdout and stderr are captured and returned along with the process status in a `CommandResult` object (see below)
* by default an error is raised when the command returns a non-zero exit code (this can be turned off by passing `raise_errors: false`) - to eliminate silent errors because the backtick exit status was not checked.

This method returns a `CommandResult` which is a wrapper around [ProcessExecuter::Status](https://rubydoc.info/gems/process_executer/ProcessExecuter/Status) which is a wrapper around [Process::Status](https://ruby-doc.org/3.3.6/Process/Status.html). This object includes the following methods:

* out [String] the stdout output from the process
* err [String] the stderr output from the process
* timeout? [Boolean] true if the process took longer than the given timeout (from [ProcessExecuter::Status](https://rubydoc.info/gems/process_executer/ProcessExecuter/Status))
* All the methods defined in [Process::Status](https://ruby-doc.org/3.3.6/Process/Status.html)