### PR TITLE
Release v2.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 
 # Change Log
 
+## v2.3.3 (2024-12-04)
+
+[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v2.3.2..v2.3.3)
+
+Changes since v2.3.2:
+
+* c25e5e0 test: add tests for spaces in the git binary path or the working dir
+* 5f43a1a fix: open3 errors on binary paths with spaces
+* 60b58ba test: add #run_command for tests to use instead of backticks
+
 ## v2.3.2 (2024-11-19)
 
 [Full Changelog](https://github.com/ruby-git/ruby-git/compare/v2.3.1..v2.3.2)

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -1,5 +1,5 @@
 module Git
   # The current gem version
   # @return [String] the current gem version.
-  VERSION='2.3.2'
+  VERSION='2.3.3'
 end


### PR DESCRIPTION
# Release PR

## v2.3.3 (2024-12-04)

[Full Changelog](https://github.com/ruby-git/ruby-git/compare/v2.3.2..v2.3.3)

Changes since v2.3.2:

* c25e5e0 test: add tests for spaces in the git binary path or the working dir
* 5f43a1a fix: open3 errors on binary paths with spaces
* 60b58ba test: add #run_command for tests to use instead of backticks
