### PR TITLE
Add frozen_string_literal: true magic comment to files

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         # Only the latest versions of JRuby and TruffleRuby are tested
-        ruby: ["3.0", "3.1", "3.2", "3.3", "truffleruby-24.0.0", "jruby-9.4.5.0"]
+        ruby: ["3.0", "3.1", "3.2", "3.3", "truffleruby-24.1.2", "jruby-9.4.12.0"]
         operating-system: [ubuntu-latest]
         experimental: [No]
         include:

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'active_support'
 require 'active_support/deprecation'
 

--- a/lib/git/author.rb
+++ b/lib/git/author.rb
@@ -1,7 +1,9 @@
+# frozen_string_literal: true
+
 module Git
   class Author
     attr_accessor :name, :email, :date
-    
+
     def initialize(author_string)
       if m = /(.*?) <(.*?)> (\d+) (.*)/.match(author_string)
         @name = m[1]
@@ -9,6 +11,5 @@ module Git
         @date = Time.at(m[3].to_i)
       end
     end
-    
   end
 end

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'logger'
 require 'open3'
 

--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'git/path'
 
 module Git

--- a/lib/git/branches.rb
+++ b/lib/git/branches.rb
@@ -1,15 +1,17 @@
+# frozen_string_literal: true
+
 module Git
-  
+
   # object that holds all the available branches
   class Branches
 
     include Enumerable
-    
+
     def initialize(base)
       @branches = {}
-      
+
       @base = base
-            
+
       @base.lib.branches_all.each do |b|
         @branches[b[0]] = Git::Branch.new(@base, b[0])
       end
@@ -18,21 +20,21 @@ module Git
     def local
       self.select { |b| !b.remote }
     end
-    
+
     def remote
       self.select { |b| b.remote }
     end
-    
+
     # array like methods
 
     def size
       @branches.size
-    end    
-    
+    end
+
     def each(&block)
       @branches.values.each(&block)
     end
-    
+
     # Returns the target branch
     #
     # Example:
@@ -50,14 +52,14 @@ module Git
       @branches.values.inject(@branches) do |branches, branch|
         branches[branch.full] ||= branch
 
-        # This is how Git (version 1.7.9.5) works. 
-        # Lets you ignore the 'remotes' if its at the beginning of the branch full name (even if is not a real remote branch). 
+        # This is how Git (version 1.7.9.5) works.
+        # Lets you ignore the 'remotes' if its at the beginning of the branch full name (even if is not a real remote branch).
         branches[branch.full.sub('remotes/', '')] ||= branch if branch.full =~ /^remotes\/.+/
-        
+
         branches
       end[branch_name.to_s]
     end
-    
+
     def to_s
       out = ''
       @branches.each do |k, b|
@@ -65,7 +67,6 @@ module Git
       end
       out
     end
-    
   end
 
 end

--- a/lib/git/config.rb
+++ b/lib/git/config.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Git
 
   class Config

--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Git
 
   # object that holds the last X commits on given branch

--- a/lib/git/index.rb
+++ b/lib/git/index.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
+
 module Git
   class Index < Git::Path
-    
   end
 end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'git/command_line'
 require 'git/errors'
 require 'logger'
@@ -570,7 +572,7 @@ module Git
         case key
           when 'commit'
             hsh_array << hsh if hsh
-            hsh = {'sha' => value, 'message' => '', 'parent' => []}
+            hsh = {'sha' => value, 'message' => +'', 'parent' => []}
           when 'parent'
             hsh['parent'] << value
           else

--- a/lib/git/log.rb
+++ b/lib/git/log.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Git
 
   # Return the last n commits that match the specified criteria

--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'git/author'
 require 'git/diff'
 require 'git/errors'

--- a/lib/git/path.rb
+++ b/lib/git/path.rb
@@ -1,19 +1,21 @@
+# frozen_string_literal: true
+
 module Git
- 
+
  class Path
-    
+
     attr_accessor :path
-    
+
     def initialize(path, check_path=true)
       path = File.expand_path(path)
-      
+
       if check_path && !File.exist?(path)
         raise ArgumentError, 'path does not exist', [path]
       end
-      
+
       @path = path
     end
-    
+
     def readable?
       File.readable?(@path)
     end
@@ -21,11 +23,10 @@ module Git
     def writable?
       File.writable?(@path)
     end
-    
+
     def to_s
       @path
     end
-    
  end
 
 end

--- a/lib/git/remote.rb
+++ b/lib/git/remote.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Git
   class Remote < Path
 

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Git
 
   class Repository < Path

--- a/lib/git/stash.rb
+++ b/lib/git/stash.rb
@@ -1,27 +1,28 @@
+# frozen_string_literal: true
+
 module Git
   class Stash
-    
+
     def initialize(base, message, existing=false)
       @base = base
       @message = message
       save unless existing
     end
-    
+
     def save
       @saved = @base.lib.stash_save(@message)
     end
-    
+
     def saved?
       @saved
     end
-    
+
     def message
       @message
     end
-    
+
     def to_s
       message
     end
-    
   end
 end

--- a/lib/git/stashes.rb
+++ b/lib/git/stashes.rb
@@ -1,14 +1,16 @@
+# frozen_string_literal: true
+
 module Git
-  
+
   # object that holds all the available stashes
   class Stashes
     include Enumerable
-    
+
     def initialize(base)
       @stashes = []
-      
+
       @base = base
-            
+
       @base.lib.stashes_all.each do |id, message|
         @stashes.unshift(Git::Stash.new(@base, message, true))
       end
@@ -24,16 +26,16 @@ module Git
     def all
       @base.lib.stashes_all
     end
-    
+
     def save(message)
       s = Git::Stash.new(@base, message)
       @stashes.unshift(s) if s.saved?
     end
-    
+
     def apply(index=nil)
       @base.lib.stash_apply(index)
     end
-    
+
     def clear
       @base.lib.stash_clear
       @stashes = []
@@ -42,14 +44,13 @@ module Git
     def size
       @stashes.size
     end
-    
+
     def each(&block)
       @stashes.each(&block)
     end
-    
+
     def [](index)
       @stashes[index.to_i]
     end
-    
   end
 end

--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Git
   # The status class gets the status of a git repository
   #
@@ -100,7 +102,7 @@ module Git
     end
 
     def pretty
-      out = ''
+      out = +''
       each do |file|
         out << pretty_file(file)
       end

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Git
   # The current gem version
   # @return [String] the current gem version.

--- a/lib/git/working_directory.rb
+++ b/lib/git/working_directory.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Git
   class WorkingDirectory < Git::Path
   end

--- a/lib/git/worktree.rb
+++ b/lib/git/worktree.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'git/path'
 
 module Git

--- a/lib/git/worktrees.rb
+++ b/lib/git/worktrees.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Git
   # object that holds all the available worktrees
   class Worktrees

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'date'
 require 'fileutils'
 require 'minitar'

--- a/tests/units/test_archive.rb
+++ b/tests/units/test_archive.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_bare.rb
+++ b/tests/units/test_bare.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_base.rb
+++ b/tests/units/test_base.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 
@@ -11,7 +11,7 @@ class TestBase < Test::Unit::TestCase
   def test_add
     in_temp_dir do |path|
       git = Git.clone(@wdir, 'test_add')
-      
+
       create_file('test_add/test_file_1', 'content tets_file_1')
       create_file('test_add/test_file_2', 'content test_file_2')
       create_file('test_add/test_file_3', 'content test_file_3')
@@ -19,7 +19,7 @@ class TestBase < Test::Unit::TestCase
       create_file('test_add/test file with \' quote', 'content test_file_4')
 
       assert(!git.status.added.assoc('test_file_1'))
-      
+
       # Adding a single file, usign String
       git.add('test_file_1')
 
@@ -39,11 +39,11 @@ class TestBase < Test::Unit::TestCase
       assert(git.status.added.assoc('test_file_3'))
       assert(git.status.added.assoc('test_file_4'))
       assert(git.status.added.assoc('test file with \' quote'))
-      
+
       git.commit('test_add commit #1')
 
       assert(git.status.added.empty?)
-       
+
       delete_file('test_add/test_file_3')
       update_file('test_add/test_file_4', 'content test_file_4 update #1')
       create_file('test_add/test_file_5', 'content test_file_5')
@@ -54,24 +54,24 @@ class TestBase < Test::Unit::TestCase
       assert(git.status.deleted.assoc('test_file_3'))
       assert(git.status.changed.assoc('test_file_4'))
       assert(git.status.added.assoc('test_file_5'))
-      
+
       git.commit('test_add commit #2')
-      
+
       assert(git.status.deleted.empty?)
       assert(git.status.changed.empty?)
       assert(git.status.added.empty?)
-      
+
       delete_file('test_add/test_file_4')
       update_file('test_add/test_file_5', 'content test_file_5 update #1')
       create_file('test_add/test_file_6', 'content test_fiile_6')
-      
+
       # Adding all files (new or updated), without params
       git.add
-      
+
       assert(git.status.deleted.assoc('test_file_4'))
       assert(git.status.changed.assoc('test_file_5'))
       assert(git.status.added.assoc('test_file_6'))
-      
+
       git.commit('test_add commit #3')
 
       assert(git.status.changed.empty?)
@@ -82,7 +82,7 @@ class TestBase < Test::Unit::TestCase
   def test_commit
     in_temp_dir do |path|
       git = Git.clone(@wdir, 'test_commit')
-      
+
       create_file('test_commit/test_file_1', 'content tets_file_1')
       create_file('test_commit/test_file_2', 'content test_file_2')
 
@@ -96,7 +96,7 @@ class TestBase < Test::Unit::TestCase
       original_commit_id = git.log[0].objectish
 
       create_file('test_commit/test_file_3', 'content test_file_3')
-      
+
       git.add('test_file_3')
 
       git.commit(nil, :amend => true)
@@ -105,5 +105,4 @@ class TestBase < Test::Unit::TestCase
       assert(git.log[1].objectish == base_commit_id)
     end
   end
-
 end

--- a/tests/units/test_branch.rb
+++ b/tests/units/test_branch.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_checkout.rb
+++ b/tests/units/test_checkout.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestCheckout < Test::Unit::TestCase

--- a/tests/units/test_command_line.rb
+++ b/tests/units/test_command_line.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 require 'tempfile'
 

--- a/tests/units/test_command_line_error.rb
+++ b/tests/units/test_command_line_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestCommandLineError < Test::Unit::TestCase

--- a/tests/units/test_command_line_result.rb
+++ b/tests/units/test_command_line_result.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestCommamndLineResult < Test::Unit::TestCase

--- a/tests/units/test_commit_with_empty_message.rb
+++ b/tests/units/test_commit_with_empty_message.rb
@@ -1,4 +1,5 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestCommitWithEmptyMessage < Test::Unit::TestCase

--- a/tests/units/test_commit_with_gpg.rb
+++ b/tests/units/test_commit_with_gpg.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_config.rb
+++ b/tests/units/test_config.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_config_module.rb
+++ b/tests/units/test_config_module.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_describe.rb
+++ b/tests/units/test_describe.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_diff.rb
+++ b/tests/units/test_diff.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_diff_non_default_encoding.rb
+++ b/tests/units/test_diff_non_default_encoding.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_diff_with_escaped_path.rb
+++ b/tests/units/test_diff_with_escaped_path.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 # encoding: utf-8
 
 require 'test_helper'

--- a/tests/units/test_each_conflict.rb
+++ b/tests/units/test_each_conflict.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_escaped_path.rb
+++ b/tests/units/test_escaped_path.rb
@@ -1,4 +1,3 @@
-#!/usr/bin/env ruby
 # frozen_string_literal: true
 
 require 'test_helper'

--- a/tests/units/test_failed_error.rb
+++ b/tests/units/test_failed_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestFailedError < Test::Unit::TestCase

--- a/tests/units/test_git_alt_uri.rb
+++ b/tests/units/test_git_alt_uri.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test/unit'
 
 # Tests for the Git::GitAltURI class

--- a/tests/units/test_git_base_root_of_worktree.rb
+++ b/tests/units/test_git_base_root_of_worktree.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestGitBaseRootOfWorktree < Test::Unit::TestCase

--- a/tests/units/test_git_binary_version.rb
+++ b/tests/units/test_git_binary_version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestGitBinaryVersion < Test::Unit::TestCase

--- a/tests/units/test_git_default_branch.rb
+++ b/tests/units/test_git_default_branch.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require File.dirname(__FILE__) + '/../test_helper'
 

--- a/tests/units/test_git_dir.rb
+++ b/tests/units/test_git_dir.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_git_path.rb
+++ b/tests/units/test_git_path.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_ignored_files_with_escaped_path.rb
+++ b/tests/units/test_ignored_files_with_escaped_path.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 # encoding: utf-8
 
 require 'test_helper'

--- a/tests/units/test_index_ops.rb
+++ b/tests/units/test_index_ops.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 require 'stringio'

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 require "fileutils"
@@ -241,14 +241,14 @@ class TestLib < Test::Unit::TestCase
   end
 
   def test_cat_file_contents
-    commit =  "tree 94c827875e2cadb8bc8d4cdd900f19aa9e8634c7\n"
+    commit =  +"tree 94c827875e2cadb8bc8d4cdd900f19aa9e8634c7\n"
     commit << "parent 546bec6f8872efa41d5d97a369f669165ecda0de\n"
     commit << "author scott Chacon <schacon@agadorsparticus.corp.reactrix.com> 1194561188 -0800\n"
     commit << "committer scott Chacon <schacon@agadorsparticus.corp.reactrix.com> 1194561188 -0800\n"
     commit << "\ntest"
     assert_equal(commit, @lib.cat_file_contents('1cc8667014381')) # commit
 
-    tree =  "040000 tree 6b790ddc5eab30f18cabdd0513e8f8dac0d2d3ed\tex_dir\n"
+    tree =  +"040000 tree 6b790ddc5eab30f18cabdd0513e8f8dac0d2d3ed\tex_dir\n"
     tree << "100644 blob 3aac4b445017a8fc07502670ec2dbf744213dd48\texample.txt"
     assert_equal(tree, @lib.cat_file_contents('1cc8667014381^{tree}')) #tree
 
@@ -257,7 +257,7 @@ class TestLib < Test::Unit::TestCase
   end
 
   def test_cat_file_contents_with_block
-    commit =  "tree 94c827875e2cadb8bc8d4cdd900f19aa9e8634c7\n"
+    commit =  +"tree 94c827875e2cadb8bc8d4cdd900f19aa9e8634c7\n"
     commit << "parent 546bec6f8872efa41d5d97a369f669165ecda0de\n"
     commit << "author scott Chacon <schacon@agadorsparticus.corp.reactrix.com> 1194561188 -0800\n"
     commit << "committer scott Chacon <schacon@agadorsparticus.corp.reactrix.com> 1194561188 -0800\n"
@@ -269,7 +269,7 @@ class TestLib < Test::Unit::TestCase
 
      # commit
 
-    tree =  "040000 tree 6b790ddc5eab30f18cabdd0513e8f8dac0d2d3ed\tex_dir\n"
+    tree =  +"040000 tree 6b790ddc5eab30f18cabdd0513e8f8dac0d2d3ed\tex_dir\n"
     tree << "100644 blob 3aac4b445017a8fc07502670ec2dbf744213dd48\texample.txt"
 
     @lib.cat_file_contents('1cc8667014381^{tree}') do |f|

--- a/tests/units/test_lib_meets_required_version.rb
+++ b/tests/units/test_lib_meets_required_version.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_lib_repository_default_branch.rb
+++ b/tests/units/test_lib_repository_default_branch.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require File.dirname(__FILE__) + '/../test_helper'
 

--- a/tests/units/test_log.rb
+++ b/tests/units/test_log.rb
@@ -1,4 +1,5 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'logger'
 require 'test_helper'
 

--- a/tests/units/test_logger.rb
+++ b/tests/units/test_logger.rb
@@ -1,4 +1,5 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
+
 require 'logger'
 require 'test_helper'
 

--- a/tests/units/test_ls_files_with_escaped_path.rb
+++ b/tests/units/test_ls_files_with_escaped_path.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 # encoding: utf-8
 
 require 'test_helper'

--- a/tests/units/test_ls_tree.rb
+++ b/tests/units/test_ls_tree.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestLsTree < Test::Unit::TestCase

--- a/tests/units/test_merge.rb
+++ b/tests/units/test_merge.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_merge_base.rb
+++ b/tests/units/test_merge_base.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_object.rb
+++ b/tests/units/test_object.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_pull.rb
+++ b/tests/units/test_pull.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestPull < Test::Unit::TestCase

--- a/tests/units/test_push.rb
+++ b/tests/units/test_push.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestPush < Test::Unit::TestCase

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_repack.rb
+++ b/tests/units/test_repack.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_rm.rb
+++ b/tests/units/test_rm.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_show.rb
+++ b/tests/units/test_show.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_signaled_error.rb
+++ b/tests/units/test_signaled_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestSignaledError < Test::Unit::TestCase

--- a/tests/units/test_signed_commits.rb
+++ b/tests/units/test_signed_commits.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 require "fileutils"

--- a/tests/units/test_stashes.rb
+++ b/tests/units/test_stashes.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_status.rb
+++ b/tests/units/test_status.rb
@@ -1,5 +1,5 @@
 
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_status_object.rb
+++ b/tests/units/test_status_object.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rbconfig'
 require 'securerandom'
 require 'test_helper'

--- a/tests/units/test_status_object_empty_repo.rb
+++ b/tests/units/test_status_object_empty_repo.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rbconfig'
 require 'securerandom'
 require 'test_helper'

--- a/tests/units/test_submodule.rb
+++ b/tests/units/test_submodule.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_tags.rb
+++ b/tests/units/test_tags.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_thread_safety.rb
+++ b/tests/units/test_thread_safety.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_timeout_error.rb
+++ b/tests/units/test_timeout_error.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class TestTimeoutError < Test::Unit::TestCase

--- a/tests/units/test_tree_ops.rb
+++ b/tests/units/test_tree_ops.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 require 'test_helper'
 

--- a/tests/units/test_windows_cmd_escaping.rb
+++ b/tests/units/test_windows_cmd_escaping.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 # encoding: utf-8
 
 require 'test_helper'

--- a/tests/units/test_worktree.rb
+++ b/tests/units/test_worktree.rb
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+# frozen_string_literal: true
 
 # require 'fileutils'
 # require 'pathname'


### PR DESCRIPTION
Introduce the `# frozen_string_literal: true` magic comment so that (1) warning output about modifying string literals are supressed and (2) the code base is ready for Ruby 3.5 which will treat all string literals as frozen.

In addition to adding these comments to every file in lib/ and tests/, the following changes were made:

* Fix the few cases where a frozen string was being modified.
* Remove the hash bang `#!/usr/bin/env ruby` from all test .rb files since it doesn't seem to be use consistently anyway... use bin/test to run tests.
* Since all files were being touched, all my editor to remove tabs and spaces at the end of lines.

In addition, the CI build had to be updated because the versions of TruffleRuby and JRuby needed to be updated to a version supported by the ruby container setup.