### PR TITLE
Support Ruby 3.4 and drop Ruby 3.0 support

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -18,12 +18,12 @@ jobs:
       fail-fast: false
       matrix:
         # Only the latest versions of JRuby and TruffleRuby are tested
-        ruby: ["3.0", "3.1", "3.2", "3.3", "truffleruby-24.0.0", "jruby-9.4.5.0"]
+        ruby: ["3.1", "3.2", "3.3", "3.4", "truffleruby-24.0.0", "jruby-9.4.5.0"]
         operating-system: [ubuntu-latest]
         experimental: [No]
         include:
           - # Only test with minimal Ruby version on Windows
-            ruby: 3.0
+            ruby: 3.1
             operating-system: windows-latest
 
     steps:


### PR DESCRIPTION
Introduce support for Ruby 3.4 while removing support for Ruby 3.0 in the continuous integration testing matrix.