### PR TITLE
Set the locale when running git commands to en_US.UTF-8

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1548,6 +1548,7 @@ module Git
         'GIT_WORK_TREE' => @git_work_dir,
         'GIT_INDEX_FILE' => @git_index_file,
         'GIT_SSH' => Git::Base.config.git_ssh,
+        'LC_ALL' => 'en_US.UTF-8'
       }
     end
 

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1547,7 +1547,7 @@ module Git
         'GIT_DIR' => @git_dir,
         'GIT_WORK_TREE' => @git_work_dir,
         'GIT_INDEX_FILE' => @git_index_file,
-        'GIT_SSH' => Git::Base.config.git_ssh
+        'GIT_SSH' => Git::Base.config.git_ssh,
       }
     end
 

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -131,7 +131,7 @@ class Test::Unit::TestCase
   #
   # @return [void]
   #
-  def assert_command_line_eq(expected_command_line, method: :command, mocked_output: nil)
+  def assert_command_line_eq(expected_command_line, method: :command, mocked_output: nil, include_env: false)
     actual_command_line = nil
 
     command_output = ''
@@ -140,7 +140,11 @@ class Test::Unit::TestCase
       git = Git.init('test_project')
 
       git.lib.define_singleton_method(method) do |*cmd, **opts, &block|
-        actual_command_line = [*cmd, opts]
+        if include_env
+          actual_command_line = [env_overrides, *cmd, opts]
+        else
+          actual_command_line = [*cmd, opts]
+        end
         mocked_output
       end
 
@@ -148,6 +152,8 @@ class Test::Unit::TestCase
         yield(git) if block_given?
       end
     end
+
+    expected_command_line = expected_command_line.call if expected_command_line.is_a?(Proc)
 
     assert_equal(expected_command_line, actual_command_line)
 

--- a/tests/units/test_command_line_env_overrides.rb
+++ b/tests/units/test_command_line_env_overrides.rb
@@ -1,0 +1,48 @@
+
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TestCommandLineEnvOverrides < Test::Unit::TestCase
+  test 'it should set the expected environment variables' do
+    expected_command_line = nil
+    expected_command_line_proc = ->{ expected_command_line }
+    assert_command_line_eq(expected_command_line_proc, include_env: true) do |git|
+      expected_env = {
+        'GIT_DIR' => git.lib.git_dir,
+        'GIT_INDEX_FILE' => git.lib.git_index_file,
+        'GIT_SSH' => nil,
+        'GIT_WORK_TREE' => git.lib.git_work_dir
+      }
+      expected_command_line = [expected_env, 'checkout', {}]
+
+      git.checkout
+    end
+  end
+
+  test 'it should set the GIT_SSH environment variable from Git::Base.config.git_ssh' do
+    expected_command_line = nil
+    expected_command_line_proc = ->{ expected_command_line }
+
+    saved_git_ssh = Git::Base.config.git_ssh
+    begin
+      Git::Base.config.git_ssh = 'ssh -i /path/to/key'
+
+      assert_command_line_eq(expected_command_line_proc, include_env: true) do |git|
+        # Set the expected command line
+
+        expected_env = {
+          'GIT_DIR' => git.lib.git_dir,
+          'GIT_INDEX_FILE' => git.lib.git_index_file,
+          'GIT_SSH' => 'ssh -i /path/to/key',
+          'GIT_WORK_TREE' => git.lib.git_work_dir
+        }
+
+        expected_command_line = [expected_env, 'checkout', {}]
+        git.checkout
+      end
+    ensure
+      Git::Base.config.git_ssh = saved_git_ssh
+    end
+  end
+end

--- a/tests/units/test_command_line_env_overrides.rb
+++ b/tests/units/test_command_line_env_overrides.rb
@@ -12,7 +12,8 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
         'GIT_DIR' => git.lib.git_dir,
         'GIT_INDEX_FILE' => git.lib.git_index_file,
         'GIT_SSH' => nil,
-        'GIT_WORK_TREE' => git.lib.git_work_dir
+        'GIT_WORK_TREE' => git.lib.git_work_dir,
+        'LC_ALL' => 'en_US.UTF-8'
       }
       expected_command_line = [expected_env, 'checkout', {}]
 
@@ -29,16 +30,15 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
       Git::Base.config.git_ssh = 'ssh -i /path/to/key'
 
       assert_command_line_eq(expected_command_line_proc, include_env: true) do |git|
-        # Set the expected command line
-
         expected_env = {
           'GIT_DIR' => git.lib.git_dir,
           'GIT_INDEX_FILE' => git.lib.git_index_file,
           'GIT_SSH' => 'ssh -i /path/to/key',
-          'GIT_WORK_TREE' => git.lib.git_work_dir
+          'GIT_WORK_TREE' => git.lib.git_work_dir,
+          'LC_ALL' => 'en_US.UTF-8'
         }
-
         expected_command_line = [expected_env, 'checkout', {}]
+
         git.checkout
       end
     ensure


### PR DESCRIPTION
Set the locale when running git commands to en_US.UTF-8 to ensure that git output is untranslated (aka English). This ensures that the git command output can consistently be parsed by this gem.

A test was added to verify that command line environment variables are set correctly when executing commands. This includes enhancements to the assert_command_line_eq method to accommodate environment variable checks.

Fixes #753