### PR TITLE
Improved error message of rev_parse

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -333,7 +333,7 @@ module Git
     def rev_parse(revision)
       assert_args_are_not_options('rev', revision)
 
-      command('rev-parse', revision)
+      command('rev-parse', '--revs-only', '--end-of-options', revision, '--')
     end
 
     # For backwards compatibility with the old method name

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -199,7 +199,7 @@ class TestLib < Test::Unit::TestCase
   end
 
   def test_rev_parse_with_unknown_revision
-    assert_raise(Git::FailedError) do
+    assert_raise_with_message(Git::FailedError, /exit 128, stderr: "fatal: bad revision 'NOTFOUND'"/) do
       @lib.rev_parse('NOTFOUND')
     end
   end


### PR DESCRIPTION
# Description

Improved error message of rev_parse

As described by git-rev-parse:
```
  Many Git porcelainish commands take mixture of flags (i.e. parameters
  that begin with a dash -) and parameters meant for the underlying git
  rev-list command they use internally and flags and parameters for the
  other commands they use downstream of git rev-list. This command is
  used to distinguish between them.
```

Using the `--` to separate revisions from paths is at the core of git. I do not think this behavior will ever change.

The message without the extra parameters:
```
  fatal: ambiguous argument 'v3': unknown revision or path not in the
  working tree.
  Use '--' to separate paths from revisions, like this:
  'git <command> [<revision>...] -- [<file>...]'
```

The message with new parameters:
```
  fatal: bad revision 'NOTFOUND'
```

I think it's way more descriptive.

