### PR TITLE
Enforce conventional commit messages with husky and commitlint

### DIFF
--- a/.commitlintrc.yml
+++ b/.commitlintrc.yml
@@ -1,0 +1,38 @@
+---
+extends: '@commitlint/config-conventional'
+
+rules:
+  # See: https://commitlint.js.org/reference/rules.html
+  #
+  # Rules are made up by a name and a configuration array. The configuration
+  # array contains:
+  #
+  # * Severity [0..2]: 0 disable rule, 1 warning if violated, or 2 error if
+  #   violated
+  # * Applicability [always|never]: never inverts the rule
+  # * Value: value to use for this rule (if applicable)
+  #
+  # Run `npx commitlint --print-config` to see the current setting for all
+  # rules.
+  #
+  header-max-length:      [2, always, 100]        # Header can not exceed 100 chars
+
+  type-case:              [2, always, lower-case] # Type must be lower case
+  type-empty:             [2, never]              # Type must not be empty
+
+  # Supported conventional commit types
+  type-enum:              [2, always, [build, ci, chore, docs, feat, fix, perf, refactor, revert, style, test]]
+
+  scope-case:             [2, always, lower-case] # Scope must be lower case
+
+  # Error if subject is one of these cases (encourages lower-case)
+  subject-case:           [2, never, [sentence-case, start-case, pascal-case, upper-case]]
+  subject-empty:          [2, never]              # Subject must not be empty
+  subject-full-stop:      [2, never, "."]         # Subject must not end with a period
+
+  body-leading-blank:     [2, always]             # Body must have a blank line before it
+  body-max-line-length:   [2, always, 100]        # Body lines can not exceed 100 chars
+
+  footer-leading-blank:   [2, always]             # Footer must have a blank line before it
+  footer-max-line-length: [2, always, 100]        # Footer lines can not exceed 100 chars
+  

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ doc
 pkg
 rdoc
 Gemfile.lock
+node_modules
+package-lock.json

--- a/.husky/commit-msg
+++ b/.husky/commit-msg
@@ -1,0 +1,1 @@
+npx --no-install commitlint --edit "$1"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,28 +5,28 @@
 
 # Contributing to the git gem
 
-* [Summary](#summary)
-* [How to contribute](#how-to-contribute)
-* [How to report an issue or request a feature](#how-to-report-an-issue-or-request-a-feature)
-* [How to submit a code or documentation change](#how-to-submit-a-code-or-documentation-change)
-  * [Commit your changes to a fork of `ruby-git`](#commit-your-changes-to-a-fork-of-ruby-git)
-  * [Create a pull request](#create-a-pull-request)
-  * [Get your pull request reviewed](#get-your-pull-request-reviewed)
-* [Design philosophy](#design-philosophy)
-  * [Direct mapping to git commands](#direct-mapping-to-git-commands)
-  * [Parameter naming](#parameter-naming)
-  * [Output processing](#output-processing)
-* [Coding standards](#coding-standards)
-  * [1 PR = 1 Commit](#1-pr--1-commit)
-  * [Unit tests](#unit-tests)
-  * [Continuous integration](#continuous-integration)
-  * [Documentation](#documentation)
-* [Building a specific version of the Git command-line](#building-a-specific-version-of-the-git-command-line)
-  * [Install pre-requisites](#install-pre-requisites)
-  * [Obtain Git source code](#obtain-git-source-code)
-  * [Build git](#build-git)
-  * [Use the new Git version](#use-the-new-git-version)
-* [Licensing](#licensing)
+- [Summary](#summary)
+- [How to contribute](#how-to-contribute)
+- [How to report an issue or request a feature](#how-to-report-an-issue-or-request-a-feature)
+- [How to submit a code or documentation change](#how-to-submit-a-code-or-documentation-change)
+  - [Commit your changes to a fork of `ruby-git`](#commit-your-changes-to-a-fork-of-ruby-git)
+  - [Create a pull request](#create-a-pull-request)
+  - [Get your pull request reviewed](#get-your-pull-request-reviewed)
+- [Design philosophy](#design-philosophy)
+  - [Direct mapping to git commands](#direct-mapping-to-git-commands)
+  - [Parameter naming](#parameter-naming)
+  - [Output processing](#output-processing)
+- [Coding standards](#coding-standards)
+  - [Commit message guidelines](#commit-message-guidelines)
+  - [Unit tests](#unit-tests)
+  - [Continuous integration](#continuous-integration)
+  - [Documentation](#documentation)
+- [Building a specific version of the Git command-line](#building-a-specific-version-of-the-git-command-line)
+  - [Install pre-requisites](#install-pre-requisites)
+  - [Obtain Git source code](#obtain-git-source-code)
+  - [Build git](#build-git)
+  - [Use the new Git version](#use-the-new-git-version)
+- [Licensing](#licensing)
 
 ## Summary
 
@@ -153,18 +153,30 @@ behavior.
 To ensure high-quality contributions, all pull requests must meet the following
 requirements:
 
-### 1 PR = 1 Commit
+### Commit message guidelines
 
-* All commits for a PR must be squashed into a single commit.
-* To avoid an extra merge commit, the PR must be able to be merged as [a fast-forward
-  merge](https://git-scm.com/book/en/v2/Git-Branching-Basic-Branching-and-Merging).
-* The easiest way to ensure a fast-forward merge is to rebase your local branch to
-  the `ruby-git` master branch.
+All commit messages must follow the [Conventional Commits
+standard](https://www.conventionalcommits.org/en/v1.0.0/). This helps us maintain a
+clear and structured commit history, automate versioning, and generate changelogs
+effectively.
+
+To ensure compliance, this project includes:
+
+- A git commit-msg hook that validates your commit messages before they are accepted.
+
+  To activate the hook, you must have node installed and run `bin/setup` or
+  `npm install`.
+
+- A GitHub Actions workflow that will enforce the Conventional Commit standard as
+  part of the continuous integration pipeline.
+
+  Any commit message that does not conform to the Conventional Commits standard will
+  cause the workflow to fail and not allow the PR to be merged.
 
 ### Unit tests
 
-* All changes must be accompanied by new or modified unit tests.
-* The entire test suite must pass when `bundle exec rake default` is run from the
+- All changes must be accompanied by new or modified unit tests.
+- The entire test suite must pass when `bundle exec rake default` is run from the
   project's local working copy.
 
 While working on specific features, you can run individual test files or a group of

--- a/bin/setup
+++ b/bin/setup
@@ -5,4 +5,9 @@ set -vx
 
 bundle install
 
-# Do any other automated setup that you need to do here
+if [ -x "$(command -v npm)" ]; then
+  npm install
+else
+  echo "npm is not installed"
+  echo "Install npm then re-run this script to enable the conventional commit git hook."
+fi

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "devDependencies": {
+    "@commitlint/cli": "^19.8.0",
+    "@commitlint/config-conventional": "^19.8.0",
+    "husky": "^9.1.7"
+  },
+  "scripts": {
+    "prepare": "husky"
+  }
+}


### PR DESCRIPTION
- Add steps to bin/setup to install husky and the commitlint npm packages
- Configure husky to run commitlint via the commit-msg hook
- Add commitlint configuration based on my specific preferences
- Add npm specific files (node_modules/, package-lock.json) to .gitignore

This partially addresses issue #791.