### PR TITLE
Enforce conventional commit messages with GitHub Action

### DIFF
--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -1,0 +1,28 @@
+---
+name: Conventional Commits
+
+permissions:
+  contents: read
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  commit-lint:
+    name: Verify Conventional Commits
+
+    # Skip this job if this is a release PR
+    if: (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - name: Check Commit Messages
+        uses: wagoid/commitlint-github-action@v6
+        with: { configFile: .commitlintrc.yml }


### PR DESCRIPTION
- Add a GitHub Actions workflow to enforce conventional commits
- Add commitlint configuration based on my specific preferences

Partially addresses issue #791