### PR TITLE
Change release workflow trigger branch to master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ description: |
 
 on:
   push:
-    branches: ["main"]
+    branches: ["master"]
 
   workflow_dispatch:
 


### PR DESCRIPTION
Update the release workflow to trigger on changes to the 'master' branch instead of 'main'.