### PR TITLE
Document guidelines for Conventional Commits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,8 @@
   - [Output processing](#output-processing)
 - [Coding standards](#coding-standards)
   - [Commit message guidelines](#commit-message-guidelines)
+    - [What does this mean for contributors?](#what-does-this-mean-for-contributors)
+    - [What to know about Conventional Commits](#what-to-know-about-conventional-commits)
   - [Unit tests](#unit-tests)
   - [Continuous integration](#continuous-integration)
   - [Documentation](#documentation)
@@ -63,7 +65,8 @@ thoroughly as possible to describe the issue or feature request.
 There is a three-step process for submitting code or documentation changes:
 
 1. [Commit your changes to a fork of
-   `ruby-git`](#commit-your-changes-to-a-fork-of-ruby-git)
+   `ruby-git`](#commit-your-changes-to-a-fork-of-ruby-git) using [Conventional
+   Commits](#commit-message-guidelines)
 2. [Create a pull request](#create-a-pull-request)
 3. [Get your pull request reviewed](#get-your-pull-request-reviewed)
 
@@ -155,23 +158,81 @@ requirements:
 
 ### Commit message guidelines
 
-All commit messages must follow the [Conventional Commits
-standard](https://www.conventionalcommits.org/en/v1.0.0/). This helps us maintain a
-clear and structured commit history, automate versioning, and generate changelogs
-effectively.
+To enhance our development workflow, enable automated changelog generation, and pave
+the way for Continuous Delivery, the `ruby-git` project has adopted the [Conventional
+Commits standard](https://www.conventionalcommits.org/en/v1.0.0/) for all commit
+messages.
 
-To ensure compliance, this project includes:
+This structured approach to commit messages allows us to:
 
-- A git commit-msg hook that validates your commit messages before they are accepted.
+- **Automate versioning and releases:** Tools can now automatically determine the
+  semantic version bump (patch, minor, major) based on the types of commits merged.
+- **Generate accurate changelogs:** We can automatically create and update a
+  `CHANGELOG.md` file, providing a clear history of changes for users and
+  contributors.
+- **Improve commit history readability:** A standardized format makes it easier for
+  everyone to understand the nature of changes at a glance.
 
-  To activate the hook, you must have node installed and run `bin/setup` or
-  `npm install`.
+#### What does this mean for contributors?
 
-- A GitHub Actions workflow that will enforce the Conventional Commit standard as
-  part of the continuous integration pipeline.
+Going forward, all commits to this repository **MUST** adhere to the [Conventional
+Commits standard](https://www.conventionalcommits.org/en/v1.0.0/). Commits not
+adhering to this standard will cause the CI build to fail. PRs will not be merged if
+they include non-conventional commits.
 
-  Any commit message that does not conform to the Conventional Commits standard will
-  cause the workflow to fail and not allow the PR to be merged.
+A git pre-commit hook may be installed to validate your conventional commit messages
+before pushing them to GitHub by running `bin/setup` in the project root.
+
+#### What to know about Conventional Commits
+
+The simplist conventional commit is in the form `type: description` where `type`
+indicates the type of change and `description` is your usual commit message (with
+some limitations).
+
+- Types include: `feat`, `fix`, `docs`, `test`, `refactor`, and `chore`. See the full
+  list of types supported in [.commitlintrc.yml](.commitlintrc.yml).
+- The description must (1) not start with an upper case letter, (2) be no more than
+  100 characters, and (3) not end with punctuation.
+
+Examples of valid commits:
+
+- `feat: add the --merges option to Git::Lib.log`
+- `fix: exception thrown by Git::Lib.log when repo has no commits`
+- `docs: add conventional commit announcement to README.md`
+
+Commits that include breaking changes must include an exclaimation mark before the
+colon:
+
+- `feat!: removed Git::Base.commit_force`
+
+The commit messages will drive how the version is incremented for each release:
+
+- a release containing a **breaking change** will do a **major** version increment
+- a release containing a **new feature** will do a **minor** increment
+- a release containing **neither a breaking change nor a new feature** will do a
+  **patch** version increment
+
+The full conventional commit format is:
+
+```text
+<type>[optional scope][!]: <description>
+
+[optional body]
+
+[optional footer(s)]
+```
+
+- `optional body` may include multiple lines of descriptive text limited to 100 chars
+  each
+- `optional footers` only uses `BREAKING CHANGE: <description>` where description
+  should describe the nature of the backward incompatibility.
+
+Use of the `BREAKING CHANGE:` footer flags a backward incompatible change even if it
+is not flagged with an exclaimation mark after the `type`. Other footers are allowed
+by not acted upon.
+
+See [the Conventional Commits
+specification](https://www.conventionalcommits.org/en/v1.0.0/) for more details.
 
 ### Unit tests
 

--- a/README.md
+++ b/README.md
@@ -9,17 +9,34 @@
 [![Documentation](https://img.shields.io/badge/Documentation-Latest-green)](https://rubydoc.info/gems/git/)
 [![Change Log](https://img.shields.io/badge/CHANGELOG-Latest-green)](https://rubydoc.info/gems/git/file/CHANGELOG.md)
 [![Build Status](https://github.com/ruby-git/ruby-git/workflows/CI/badge.svg?branch=master)](https://github.com/ruby-git/ruby-git/actions?query=workflow%3ACI)
-[![Code Climate](https://codeclimate.com/github/ruby-git/ruby-git.png)](https://codeclimate.com/github/ruby-git/ruby-git)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 
-* [Summary](#summary)
-* [v2.x Release](#v2x-release)
-* [Install](#install)
-* [Major Objects](#major-objects)
-* [Errors Raised By This Gem](#errors-raised-by-this-gem)
-* [Specifying And Handling Timeouts](#specifying-and-handling-timeouts)
-* [Examples](#examples)
-* [Ruby version support policy](#ruby-version-support-policy)
-* [License](#license)
+- [📢 We've Switched to Conventional Commits 📢](#-weve-switched-to-conventional-commits-)
+- [Summary](#summary)
+- [Install](#install)
+- [Major Objects](#major-objects)
+- [Errors Raised By This Gem](#errors-raised-by-this-gem)
+- [Specifying And Handling Timeouts](#specifying-and-handling-timeouts)
+- [Examples](#examples)
+- [Ruby version support policy](#ruby-version-support-policy)
+- [License](#license)
+
+## 📢 We've Switched to Conventional Commits 📢
+
+To enhance our development workflow, enable automated changelog generation, and pave
+the way for Continuous Delivery, the `ruby-git` project has adopted the [Conventional
+Commits standard](https://www.conventionalcommits.org/en/v1.0.0/) for all commit
+messages.
+
+Going forward, all commits to this repository **MUST** adhere to the Conventional
+Commits standard. Commits not adhering to this standard will cause the CI build to
+fail. PRs will not be merged if they include non-conventional commits.
+
+A git pre-commit hook may be installed to validate your conventional commit messages
+before pushing them to GitHub by running `bin/setup` in the project root.
+
+Read more about this change in the [Commit Message Guidelines section of
+CONTRIBUTING.md](CONTRIBUTING.md#commit-message-guidelines)
 
 ## Summary
 
@@ -33,31 +50,6 @@ Get started by obtaining a repository object by:
 * cloning a repository with [Git.clone](https://rubydoc.info/gems/git/Git#clone-class_method)
 
 Methods that can be called on a repository object are documented in [Git::Base](https://rubydoc.info/gems/git/Git/Base)
-
-## v2.x Release
-
-git 2.0.0 has recently been released. Please give it a try.
-
-**If you have problems with the 2.x release, open an issue and use the 1.x version
-instead.** We will do our best to fix your issues in a timely fashion.
-
-**JRuby on Windows is not yet supported by the 2.x release line. Users running JRuby
-on Windows should continue to use the 1.x release line.**
-
-The changes in this major release include:
-
-* Added a dependency on the activesupport gem to use the deprecation functionality
-* Create a policy of supported Ruby versions to support only non-EOL Ruby versions
-* Create a policy of supported Git CLI versions (released 2020-12-25)
-* Update the required Ruby version to at least 3.0 (released 2020-07-27)
-* Update the required Git command line version to at least 2.28
-* Update how CLI commands are called to use the [process_executer](https://github.com/main-branch/process_executer)
-  gem which is built on top of [Kernel.spawn](https://ruby-doc.org/3.3.0/Kernel.html#method-i-spawn).
-  See [PR #684](https://github.com/ruby-git/ruby-git/pull/684) for more details
-  on the motivation for this implementation.
-
-The `master` branch will be used for `2.x` development. If needed, fixes for `1.x`
-version will be done on the `v1` branch.
 
 ## Install
 


### PR DESCRIPTION
This PR introduces two changes:

- Announce the adoption of conventional commits in the README.md
- Document the project's use of conventional commits in CONTRIBUTING.md

This further refines issue #791