### PR TITLE
Support for git log --merges option

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -294,6 +294,7 @@ module Git
     #   * 'tree' [String] the tree sha
     #   * 'author' [String] the author of the commit and timestamp of when the changes were created
     #   * 'committer' [String] the committer of the commit and timestamp of when the commit was applied
+    #   * 'merges' [Boolean] if truthy, only include merge commits (aka commits with 2 or more parents)
     #
     # @raise [ArgumentError] if the revision range (specified with :between or :object) is a string starting with a hyphen
     #
@@ -305,6 +306,7 @@ module Git
 
       arr_opts << '--pretty=raw'
       arr_opts << "--skip=#{opts[:skip]}" if opts[:skip]
+      arr_opts << '--merges' if opts[:merges]
 
       arr_opts += log_path_options(opts)
 

--- a/lib/git/log.rb
+++ b/lib/git/log.rb
@@ -133,10 +133,15 @@ module Git
       return self
     end
 
+    def merges
+      dirty_log
+      @merges = true
+      return self
+    end
+
     def to_s
       self.map { |c| c.to_s }.join("\n")
     end
-
 
     # forces git log to run
 
@@ -184,7 +189,7 @@ module Git
         log = @base.lib.full_log_commits(
           count: @max_count, all: @all, object: @object, path_limiter: @path, since: @since,
           author: @author, grep: @grep, skip: @skip, until: @until, between: @between,
-          cherry: @cherry
+          cherry: @cherry, merges: @merges
         )
         @commits = log.map { |c| Git::Object::Commit.new(@base, c['sha'], c) }
       end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -131,7 +131,7 @@ class Test::Unit::TestCase
   #
   # @return [void]
   #
-  def assert_command_line_eq(expected_command_line, method: :command, mocked_output: nil, include_env: false)
+  def assert_command_line_eq(expected_command_line, method: :command, mocked_output: '', include_env: false)
     actual_command_line = nil
 
     command_output = ''

--- a/tests/units/test_log.rb
+++ b/tests/units/test_log.rb
@@ -128,4 +128,9 @@ class TestLog < Test::Unit::TestCase
     l = @git.log.between( 'master', 'cherry').cherry
     assert_equal( 1, l.size )
   end
+
+  def test_log_merges
+    expected_command_line = ['log', '--max-count=30', '--no-color', '--pretty=raw', '--merges', {:chdir=>nil}]
+    assert_command_line_eq(expected_command_line) { |git| git.log.merges.size }
+  end
 end


### PR DESCRIPTION
Introduce the ability to filter commits to only include merge commits when using Git::Base#log. 

Example:

```Ruby
log = git.log
  .max_count(:all)
  .merges
```

This enhancement adds a new method to the Git::Log class to enable this functionality and updates the relevant log commands accordingly.

Since the `--merges` option to `git log` only filters the results, I thought it was sufficient to just test that the option was added to the git log command when appropriate.

Fixes #788