### PR TITLE
Skip CI for release PRs

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -10,6 +10,11 @@ on:
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))
+
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: ${{ matrix.experimental == 'Yes' }}
     env: { JAVA_OPTS: -Djdk.io.File.enableADS=true }


### PR DESCRIPTION
Modify the CI workflow to skip execution for pull requests that are based on release PRs created by the release-please-action.

CI for these changes were already run twice: once for the PR and once after being merged to master.