### PR TITLE
Skip experimental build workflow for release PRs

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,16 +1,15 @@
 name: CI
 
 on:
-  push:
-    branches: [master,v1]
   pull_request:
-    branches: [master,v1]
+    branches: [master]
   workflow_dispatch:
 
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
 
+    # Skip this job if triggered by a release PR
     if: >-
       github.event_name == 'workflow_dispatch' ||
       (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))

--- a/.github/workflows/experimental_continuous_integration.yml
+++ b/.github/workflows/experimental_continuous_integration.yml
@@ -2,12 +2,19 @@ name: CI Experimental
 
 on:
   push:
-    branches: [master,v1]
+    branches: [master]
+
   workflow_dispatch:
 
 jobs:
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+
+    # Skip this job if triggered by pushing a release commit
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'push' && !startsWith(github.event.head_commit.message, 'chore: release '))
+
     runs-on: ${{ matrix.operating-system }}
     continue-on-error: true
     env: { JAVA_OPTS: -Djdk.io.File.enableADS=true }


### PR DESCRIPTION
Modify the CI configuration to skip the experimental build workflow when a release commit is pushed to the master branch. This change streamlines the build process by avoiding unnecessary builds for release-related commits.