### PR TITLE
fix: raise a Git::FailedError if depth < 0 is passed to Git.clone

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ rdoc
 Gemfile.lock
 node_modules
 package-lock.json
+ai-prompt.erb

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -126,7 +126,7 @@ module Git
       arr_opts = []
       arr_opts << '--bare' if opts[:bare]
       arr_opts << '--branch' << opts[:branch] if opts[:branch]
-      arr_opts << '--depth' << opts[:depth].to_i if opts[:depth] && opts[:depth].to_i > 0
+      arr_opts << '--depth' << opts[:depth].to_i if opts[:depth]
       arr_opts << '--filter' << opts[:filter] if opts[:filter]
       Array(opts[:config]).each { |c| arr_opts << '--config' << c }
       arr_opts << '--origin' << opts[:remote] || opts[:origin] if opts[:remote] || opts[:origin]

--- a/tests/units/test_git_clone.rb
+++ b/tests/units/test_git_clone.rb
@@ -159,4 +159,49 @@ class TestGitClone < Test::Unit::TestCase
 
     assert_equal(expected_command_line, actual_command_line)
   end
+
+  test 'clone with negative depth' do
+    repository_url = 'https://github.com/ruby-git/ruby-git.git'
+    destination = 'ruby-git'
+
+    actual_command_line = nil
+
+    in_temp_dir do |path|
+      # Give a bare repository with a single commit
+      repository_path = File.join(path, 'repository.git')
+      Git.init(repository_path, :bare => true)
+      worktree_path = File.join(path, 'repository')
+      worktree = Git.clone(repository_path, worktree_path)
+      File.write(File.join(worktree_path, 'test.txt'), 'test')
+      worktree.add('test.txt')
+      worktree.commit('Initial commit')
+      worktree.push
+      FileUtils.rm_rf(worktree_path)
+
+      # When I clone it with a negative depth with
+      error = assert_raises(Git::FailedError) do
+        Git.clone(repository_path, worktree, depth: -1)
+      end
+
+      assert_match(/depth/, error.result.stderr)
+    end
+
+    #   git = Git.init('.')
+
+    #   # Mock the Git::Lib#command method to capture the actual command line args
+    #   git.lib.define_singleton_method(:command) do |cmd, *opts, &block|
+    #     actual_command_line = [cmd, *opts.flatten]
+    #   end
+
+    #   git.lib.clone(repository_url, destination, depth: -1)
+    # end
+
+    # expected_command_line = [
+    #   'clone',
+    #   '--depth', '-1',
+    #   '--', repository_url, destination, {timeout: nil}
+    # ]
+
+    # assert_equal(expected_command_line, actual_command_line)
+  end
 end


### PR DESCRIPTION

Fixes #805

Currently, `Git.clone(repository_url, dir, depth: -1)` silently does not pass the depth option to the git command.

This change passes it through to the git command line which then return an error causing the `Git.clone` method to raise a Git::FailedError which is the desired behavior.
