### PR TITLE
Upgrade minimally supported Ruby to 3.2

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -22,13 +22,16 @@ jobs:
       fail-fast: false
       matrix:
         # Only the latest versions of JRuby and TruffleRuby are tested
-        ruby: ["3.1", "3.2", "3.3", "3.4", "truffleruby-24.1.2", "jruby-9.4.12.0"]
+        ruby: ["3.2", "3.3", "3.4", "truffleruby-24.2.1", "jruby-10.0.0.1"]
         operating-system: [ubuntu-latest]
         experimental: [No]
         include:
-          - # Only test with minimal Ruby version on Windows
-            ruby: 3.1
+          - ruby: 3.2
             operating-system: windows-latest
+            experimental: No
+          - ruby: jruby-10.0.0.1
+            operating-system: windows-latest
+            experimental: No
 
     steps:
       - name: Checkout Code

--- a/git.gemspec
+++ b/git.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.metadata['documentation_uri'] = "https://rubydoc.info/gems/#{s.name}/#{s.version}"
 
   s.require_paths = ['lib']
-  s.required_ruby_version = '>= 3.0.0'
+  s.required_ruby_version = '>= 3.2.0'
   s.requirements = ['git 2.28.0 or greater']
 
   s.add_runtime_dependency 'activesupport', '>= 5.0'


### PR DESCRIPTION
Update the CI builds to build with MRI Ruby 3.2, 3.3,
and 3.4; TruffleRuby 24.2.1; and JRuby 10.0.0.1.

BREAKING CHANGE: Users will need to be on Ruby 3.2 or greater