### PR TITLE
Upgrade to ProcessExecuter 4.x

### DIFF
--- a/git.gemspec
+++ b/git.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'activesupport', '>= 5.0'
   s.add_runtime_dependency 'addressable', '~> 2.8'
-  s.add_runtime_dependency 'process_executer', '~> 1.3'
+  s.add_runtime_dependency 'process_executer', '~> 4.0'
   s.add_runtime_dependency 'rchardet', '~> 1.9'
 
   s.add_development_dependency 'create_github_release', '~> 2.1'

--- a/lib/git/command_line_result.rb
+++ b/lib/git/command_line_result.rb
@@ -19,15 +19,21 @@ module Git
     #   result = Git::CommandLineResult.new(git_cmd, status, stdout, stderr)
     #
     # @param git_cmd [Array<String>] the git command that was executed
-    # @param status [Process::Status] the status of the process
-    # @param stdout [String] the output of the process
-    # @param stderr [String] the error output of the process
+    # @param status [ProcessExecuter::ResultWithCapture] the status of the process
+    # @param stdout [String] the processed stdout of the process
+    # @param stderr [String] the processed stderr of the process
     #
     def initialize(git_cmd, status, stdout, stderr)
       @git_cmd = git_cmd
       @status = status
       @stdout = stdout
       @stderr = stderr
+
+      # ProcessExecuter::ResultWithCapture changed the timeout? method to timed_out?
+      # in version 4.x. This is a compatibility layer to maintain the old method name
+      # for backward compatibility.
+      #
+      status.define_singleton_method(:timeout?) { timed_out? }
     end
 
     # @attribute [r] git_cmd

--- a/tests/units/test_command_line.rb
+++ b/tests/units/test_command_line.rb
@@ -61,7 +61,7 @@ class TestCommamndLine < Test::Unit::TestCase
       command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
       args = []
       error = assert_raise ArgumentError do
-        command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge, timeout: 'not a number')
+        command_line.run(*args, normalize: normalize, chomp: chomp, timeout_after: 'not a number')
       end
     end
 
@@ -97,7 +97,6 @@ class TestCommamndLine < Test::Unit::TestCase
     assert_equal([{}, 'ruby', 'bin/command_line_test', '--stdout=stdout output', '--stderr=stderr output'], result.git_cmd)
     assert_equal('stdout output', result.stdout.chomp)
     assert_equal('stderr output', result.stderr.chomp)
-    assert(result.status.is_a? ProcessExecuter::Command::Result)
     assert_equal(0, result.status.exitstatus)
   end
 
@@ -239,10 +238,8 @@ class TestCommamndLine < Test::Unit::TestCase
     command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
     args = ['--stderr=ERROR: fatal error', '--stdout=STARTING PROCESS']
     Tempfile.create do |f|
-      err_writer = f
-      result = command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
-      f.rewind
-      assert_equal('ERROR: fatal error', f.read.chomp)
+      result = command_line.run(*args, normalize: normalize, chomp: chomp, merge: merge)
+      assert_equal('ERROR: fatal error', result.stderr.chomp)
     end
   end
 


### PR DESCRIPTION
Update the dependency to ProcessExecuter 4.x and modify the code to accommodate changes in the API, ensuring backward compatibility where necessary.