### PR TITLE
Remove unneeded explicit return statements

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -65,7 +65,7 @@ module Git
   end
 
   def self.config
-    return Base.config
+    Base.config
   end
 
   def global_config(name = nil, value = nil)

--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -24,7 +24,7 @@ module Git
 
     def path(path)
       @path = path
-      return self
+      self
     end
 
     def size

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -217,7 +217,7 @@ module Git
 
       arr_opts << commit_ish if commit_ish
 
-      return command('describe', *arr_opts)
+      command('describe', *arr_opts)
     end
 
     # Return the commits that are within the given revision range
@@ -472,7 +472,7 @@ module Git
 
       hsh['message'] = data.join("\n") + "\n"
 
-      return hsh
+      hsh
     end
 
     CAT_FILE_HEADER_LINE = /\A(?<key>\w+) (?<value>.*)\z/
@@ -543,7 +543,7 @@ module Git
 
       hsh['message'] = data.join("\n") + "\n"
 
-      return hsh
+      hsh
     end
 
     def process_commit_log_data(data)
@@ -584,7 +584,7 @@ module Git
 
       hsh_array << hsh if hsh
 
-      return hsh_array
+      hsh_array
     end
 
     def ls_tree(sha, opts = {})
@@ -758,7 +758,7 @@ module Git
           :unborn
         end
 
-      return HeadState.new(state, branch_name)
+      HeadState.new(state, branch_name)
     end
 
     def branch_current
@@ -1488,7 +1488,7 @@ module Git
           gz.write(file_content)
         end
       end
-      return file
+      file
     end
 
     # returns the current version of git, as an Array of Fixnums.

--- a/lib/git/log.rb
+++ b/lib/git/log.rb
@@ -82,61 +82,61 @@ module Git
     def object(objectish)
       dirty_log
       @object = objectish
-      return self
+      self
     end
 
     def author(regex)
       dirty_log
       @author = regex
-      return self
+      self
     end
 
     def grep(regex)
       dirty_log
       @grep = regex
-      return self
+      self
     end
 
     def path(path)
       dirty_log
       @path = path
-      return self
+      self
     end
 
     def skip(num)
       dirty_log
       @skip = num
-      return self
+      self
     end
 
     def since(date)
       dirty_log
       @since = date
-      return self
+      self
     end
 
     def until(date)
       dirty_log
       @until = date
-      return self
+      self
     end
 
     def between(sha1, sha2 = nil)
       dirty_log
       @between = [sha1, sha2]
-      return self
+      self
     end
 
     def cherry
       dirty_log
       @cherry = true
-      return self
+      self
     end
 
     def merges
       dirty_log
       @merges = true
-      return self
+      self
     end
 
     def to_s


### PR DESCRIPTION
Eliminate unnecessary explicit return statements in various methods to streamline the code.