### PR TITLE
Avoid deprecated dsa for tests keys

### DIFF
--- a/tests/units/test_signed_commits.rb
+++ b/tests/units/test_signed_commits.rb
@@ -14,7 +14,7 @@ class TestSignedCommits < Test::Unit::TestCase
     in_temp_dir do |path|
       `git init`
       ssh_key_file = File.expand_path(File.join('.git', 'test-key'))
-      `ssh-keygen -t dsa -N "" -C "test key" -f "#{ssh_key_file}"`
+      `ssh-keygen -t ed25519 -N "" -C "test key" -f "#{ssh_key_file}"`
       `git config --local gpg.format ssh`
       `git config --local user.signingkey #{ssh_key_file}.pub`
 


### PR DESCRIPTION
# Description

Running tests on a very modern system results in 

```
ssh-keygen -t dsa
unknown key type dsa
```
with OpenSSH_9.9p1




