### PR TITLE
Fix Rubocop Metrics/AbcSize offense

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,9 +3,14 @@ inherit_from: .rubocop_todo.yml
 inherit_gem:
   main_branch_shared_rubocop_config: config/rubocop.yml
 
-# Don't care about complexity in TestUnit tests
-# This should go away when we switch to RSpec
+# Don't care about CyclomaticComplexity or AbcSize in TestUnit tests This should go
+# away when we switch to RSpec.
 Metrics/CyclomaticComplexity:
+  Exclude:
+    - "tests/test_helper.rb"
+    - "tests/units/**/*"
+
+Metrics/AbcSize:
   Exclude:
     - "tests/test_helper.rb"
     - "tests/units/**/*"

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -6,11 +6,6 @@
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
 
-# Offense count: 50
-# Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
-Metrics/AbcSize:
-  Max: 109
-
 # Offense count: 21
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:


### PR DESCRIPTION
Most of these offenses were fixed by excluding tests from this metric. This is fine since I plan on moving tests to RSpec in the near future.

The other few instances were fixed by refactoring the methods.
