### PR TITLE
Don't trigger our own deprecation warning

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -14,9 +14,9 @@ task :test do
   # You can run individual test files (or multiple files) from the command
   # line with:
   #
-  # $ bin/test tests/units/test_archive.rb
+  # $ bin/test test_archive.rb
   #
-  # $ bin/test tests/units/test_archive.rb tests/units/test_object.rb
+  # $ bin/test test_archive.rb test_object.rb
 end
 default_tasks << :test
 

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -851,7 +851,7 @@ module Git
     def initialize_components(options)
       @working_directory = Git::WorkingDirectory.new(options[:working_directory]) if options[:working_directory]
       @repository = Git::Repository.new(options[:repository]) if options[:repository]
-      @index = Git::Index.new(options[:index], false) if options[:index]
+      @index = Git::Index.new(options[:index], must_exist: false) if options[:index]
     end
 
     # Normalize options before they are sent to Git::Base.new


### PR DESCRIPTION
# Description
I was getting a lot of deprecation warnings from inside this gem, but when I tracked them down, they were actually just an internal call, and also deprecated internally. Easy fix :-)

`Git.open(".")` can reproduce the issue on 4.0.1:

* `Git.open` calls `Git::Base.open`
* which calls the initializer (on line 129)
* which calls `initialize_components` (line 157)
* which calls `Git::Index.new` with a second positional parameter
* but `Git::Index` is a straight subclass of `Git::Path`, which warns us about the positional parameter

I started to open an issue, and then decided that was silly - this is a trivial fix. (Though I guess I'll need to wait for a gem release to escape the cli noise)

While exercising it, I also noticed that the comments in Rakefile describing how to run individual tests (`bin/test tests/units/test_archive.rb`) were also outdated, and corrected them.


