### PR TITLE
ci: add Ruby 4.0 to continuous integration test matrix

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ The git gem wraps system calls to the `git` command line and provides an API to:
 - Handle complex interactions including branching, merging, and patch generation
 
 **Current Status:** Stable project supporting Ruby 3.2.0+ minimum and Git 2.28.0+.
-Compatible with MRI Ruby on Mac, Linux, and Windows.
+Compatible with MRI Ruby 3.2+ on Mac, Linux, and Windows.
 
 ## Architecture & Module Organization
 
@@ -434,7 +434,7 @@ open coverage/index.html
 
 - Minimum Ruby: 3.2.0
 - Minimum Git: 2.28.0 or greater
-- Actively tested on: MRI Ruby 3.2+
+- Actively tested on: MRI Ruby 3.2, 3.4, and 4.0
 - Platforms: Mac, Linux, Windows
 - CI tests on multiple Ruby versions and platforms
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         # Only the latest versions of JRuby and TruffleRuby are tested
-        ruby: ["3.2", "3.3", "3.4", "truffleruby-24.2.1", "jruby-10.0.0.1"]
+        ruby: ["3.2", "3.4", "4.0", "truffleruby-24.2.1", "jruby-10.0.0.1"]
         operating-system: [ubuntu-latest]
         experimental: [No]
         java_version: [""]

--- a/git.gemspec
+++ b/git.gemspec
@@ -44,6 +44,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'test-unit', '~> 3.6'
 
   unless RUBY_PLATFORM == 'java'
+    spec.add_development_dependency 'irb', '~> 1.6'
     spec.add_development_dependency 'redcarpet', '~> 3.6'
     spec.add_development_dependency 'yard', '~> 0.9', '>= 0.9.28'
     spec.add_development_dependency 'yardstick', '~> 0.9'


### PR DESCRIPTION
## Description

This PR updates the CI workflow and documentation to added Ruby 4.0 support and remove Ruby 3.3.

## Changes

- **CI Workflow**: Remove Ruby 3.3 and add Ruby 4.0 in the test matrix
- **README.md**: 
  - Fix typo: "Linus" → "Linux"

## Rationale

We are adding Ruby 4.0 to the test matrix to ensure we test against the latest Ruby versions. The documentation now explicitly lists the supported versions for clarity.

## Testing

The CI workflow will automatically test against the updated Ruby versions once this PR is merged.