### PR TITLE
Refactor env_overrides to use keyword arguments and merge

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -9,4 +9,4 @@
 # Offense count: 2
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 1500
+  Max: 1150

--- a/tests/units/test_command_line_env_overrides.rb
+++ b/tests/units/test_command_line_env_overrides.rb
@@ -44,4 +44,112 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
       Git::Base.config.git_ssh = saved_git_ssh
     end
   end
+
+  test 'env_overrides should return default environment variables' do
+    in_temp_dir do |_path|
+      git = Git.init('test_project')
+
+      env = git.lib.send(:env_overrides)
+
+      assert_equal git.lib.git_dir, env['GIT_DIR']
+      assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
+      assert_equal git.lib.git_index_file, env['GIT_INDEX_FILE']
+      assert_equal 'en_US.UTF-8', env['LC_ALL']
+      assert_equal Git::Base.config.git_ssh, env['GIT_SSH']
+    end
+  end
+
+  test 'env_overrides should allow adding additional environment variables' do
+    in_temp_dir do |_path|
+      git = Git.init('test_project')
+
+      env = git.lib.send(:env_overrides, 'GIT_TRACE' => '1', 'GIT_CURL_VERBOSE' => '1')
+
+      # Original variables should still be present
+      assert_equal git.lib.git_dir, env['GIT_DIR']
+      assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
+      assert_equal git.lib.git_index_file, env['GIT_INDEX_FILE']
+
+      # Additional variables should be present
+      assert_equal '1', env['GIT_TRACE']
+      assert_equal '1', env['GIT_CURL_VERBOSE']
+    end
+  end
+
+  test 'env_overrides should allow overriding existing environment variables' do
+    in_temp_dir do |_path|
+      git = Git.init('test_project')
+
+      env = git.lib.send(:env_overrides, 'LC_ALL' => 'C', 'GIT_SSH' => '/custom/ssh')
+
+      # Overridden variables should have new values
+      assert_equal 'C', env['LC_ALL']
+      assert_equal '/custom/ssh', env['GIT_SSH']
+
+      # Other variables should remain unchanged
+      assert_equal git.lib.git_dir, env['GIT_DIR']
+      assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
+    end
+  end
+
+  test 'env_overrides should allow excluding environment variables by setting to nil' do
+    in_temp_dir do |_path|
+      git = Git.init('test_project')
+
+      env = git.lib.send(:env_overrides, 'GIT_INDEX_FILE' => nil, 'GIT_SSH' => nil)
+
+      # Excluded variables should be set to nil
+      assert_nil env['GIT_INDEX_FILE']
+      assert_nil env['GIT_SSH']
+
+      # Other variables should remain unchanged
+      assert_equal git.lib.git_dir, env['GIT_DIR']
+      assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
+      assert_equal 'en_US.UTF-8', env['LC_ALL']
+    end
+  end
+
+  test 'worktree_command_line should exclude GIT_INDEX_FILE from environment' do
+    in_temp_dir do |_path|
+      git = Git.init('test_project')
+
+      # Get the worktree command line instance
+      worktree_cmd_line = git.lib.send(:worktree_command_line)
+
+      # Extract the env_overrides from the command line instance
+      env = worktree_cmd_line.instance_variable_get(:@env)
+
+      # GIT_INDEX_FILE should be set to nil (will be unset per Process.spawn semantics)
+      assert_nil env['GIT_INDEX_FILE']
+
+      # Other environment variables should still be present
+      assert_equal git.lib.git_dir, env['GIT_DIR']
+      assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
+      assert_equal 'en_US.UTF-8', env['LC_ALL']
+    end
+  end
+
+  test 'env_overrides should allow both adding and excluding variables simultaneously' do
+    in_temp_dir do |_path|
+      git = Git.init('test_project')
+
+      env = git.lib.send(:env_overrides,
+                         'GIT_TRACE' => '1',           # Add new variable
+                         'GIT_INDEX_FILE' => nil,      # Exclude existing variable
+                         'LC_ALL' => 'C')              # Override existing variable
+
+      # Added variable should be present
+      assert_equal '1', env['GIT_TRACE']
+
+      # Excluded variable should be nil
+      assert_nil env['GIT_INDEX_FILE']
+
+      # Overridden variable should have new value
+      assert_equal 'C', env['LC_ALL']
+
+      # Unchanged variables should remain
+      assert_equal git.lib.git_dir, env['GIT_DIR']
+      assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
+    end
+  end
 end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

* Write tests for your changes
* Run `rake` before pushing
* Include / update docs in the README.md and in YARD documentation

# Description

This PR refactors the `env_overrides` method to use a more idiomatic Ruby approach:

- **Before**: Used an `exclude` array parameter to remove specific keys after building the hash
- **After**: Uses keyword arguments (`**additional_overrides`) and merges them, allowing individual keys to be set to `nil` to exclude them

## Changes

- Changed `env_overrides(exclude: [])` to `env_overrides(**additional_overrides)`
- Removed the `exclude.each { |key| env.delete(key) }` logic
- Now uses `.merge(additional_overrides)` to combine environment overrides
- Updated `worktree_command_line` to pass `'GIT_INDEX_FILE' => nil` instead of `exclude: ['GIT_INDEX_FILE']`
- Added comprehensive YARD documentation explaining the method's purpose and the `nil` semantics

## Benefits

- More idiomatic Ruby code
- Clearer intent: setting a key to `nil` explicitly shows what's being excluded
- More flexible: can both exclude keys (by setting to `nil`) and add/override values in a single call
- Simpler implementation without mutation
- Well-documented with examples showing the Process.spawn semantics

## Related Issue

Fixes #665