### PR TITLE
fix(test): use larger timeout values on JRuby to prevent flaky tests

### DIFF
--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -189,6 +189,10 @@ module Test
         RUBY_PLATFORM =~ win_platform_regex || RUBY_DESCRIPTION =~ win_platform_regex
       end
 
+      def jruby_platform?
+        RUBY_PLATFORM == 'java'
+      end
+
       # Run a command and return the status including stdout and stderr output
       #
       # @example

--- a/tests/units/test_git_clone.rb
+++ b/tests/units/test_git_clone.rb
@@ -11,7 +11,8 @@ class TestGitClone < Test::Unit::TestCase
 
       in_temp_dir do |_path|
         setup_repo
-        Git.config.timeout = 0.00001
+        # Use larger timeout on JRuby due to subprocess timing differences
+        Git.config.timeout = jruby_platform? ? 0.001 : 0.00001
 
         error = assert_raise Git::TimeoutError do
           Git.clone('repository.git', 'temp2', timeout: nil)
@@ -29,7 +30,8 @@ class TestGitClone < Test::Unit::TestCase
 
         in_temp_dir do |_path|
           setup_repo
-          Git.config.timeout = 0.00001
+          # Use larger timeout on JRuby due to subprocess timing differences
+          Git.config.timeout = jruby_platform? ? 0.001 : 0.00001
 
           assert_nothing_raised do
             Git.clone('repository.git', 'temp2', timeout: 10)
@@ -44,8 +46,10 @@ class TestGitClone < Test::Unit::TestCase
       in_temp_dir do |_path|
         setup_repo
 
+        # Use larger timeout on JRuby due to subprocess timing differences
+        timeout_value = jruby_platform? ? 0.001 : 0.00001
         error = assert_raise Git::TimeoutError do
-          Git.clone('repository.git', 'temp2', timeout: 0.00001)
+          Git.clone('repository.git', 'temp2', timeout: timeout_value)
         end
 
         assert_equal(true, error.result.status.timeout?)


### PR DESCRIPTION
Fixes #847

## Summary
This PR addresses the intermittent test failures on JRuby by using platform-specific timeout values in the timeout tests.

## Problem
The test `test: global timmeout(TestGitClone::Git.clone with timeouts)` in `tests/units/test_git_clone.rb` fails intermittently on JRuby due to different subprocess handling and timing characteristics. The extremely small timeout value (10 microseconds) creates race conditions in JRuby's process execution.

## Solution
- Added `jruby_platform?` helper method in test_helper.rb (following the same pattern as `windows_platform?`)
- Updated three timeout tests to use 1ms timeout on JRuby (100x larger) while maintaining the original 10μs timeout on MRI
- This approach maintains test coverage across all platforms while accounting for JRuby's timing characteristics

## Testing
- All 437 tests pass with 0 failures
- RuboCop passes with no offenses
- YARD coverage: 70.7% (above 50% threshold)

## Note
There is a possibility that this larger timeout may not fully resolve the intermittent failures on JRuby. If the problem persists, we should consider omitting these tests when running on JRuby using the `omit()` method, similar to other platform-specific test handling in the codebase (e.g., `test_git_base_root_of_worktree.rb`, `test_signed_commits.rb`).