### PR TITLE
docs: add git version support policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - [Deprecations](#deprecations)
 - [Examples](#examples)
 - [Ruby version support policy](#ruby-version-support-policy)
+- [Git version support policy](#git-version-support-policy)
 - [License](#license)
 - [📢 Project Announcements 📢](#-project-announcements-)
   - [2025-07-09: Architectural Redesign](#2025-07-09-architectural-redesign)
@@ -535,6 +536,25 @@ It is this project's intent to support the latest version of JRuby on Windows
 once the following JRuby bug is fixed:
 
 jruby/jruby#7515
+
+## Git version support policy
+
+This gem requires git version 2.28.0 or greater as specified in the gemspec. This
+requirement reflects:
+
+- The minimum git version necessary to support all features provided by this gem
+- A reasonable balance between supporting older systems and leveraging modern git
+  capabilities
+- The practical limitations of testing across multiple git versions in CI
+
+Git 2.28.0 was released on July 27, 2020. While this gem may work with earlier
+versions of git, compatibility with versions prior to 2.28.0 is not tested or
+guaranteed. Users on older git versions should upgrade to at least 2.28.0.
+
+The supported git version may be increased in future major or minor releases of this
+gem as new git features are adopted or as maintaining backward compatibility becomes
+impractical. Such changes will be clearly documented in the CHANGELOG and release
+notes.
 
 ## License
 


### PR DESCRIPTION
Closes #551

This PR documents the git version support policy in the README.md file.

## Changes

- Added a new "Git version support policy" section to the README
- Documents that git 2.28.0 or greater is required (as specified in git.gemspec)
- Explains the rationale for the requirement
- Defines the policy for future version requirement changes

## Addresses Issue #551

The issue asked for:
1. **What version of git SHOULD we claim to support?** → git 2.28.0+ (released July 27, 2020)
2. **Going forward, what is the policy for how the supported version of git changes?** → May be increased in major or minor releases with clear documentation in CHANGELOG
3. **What responsibility does that imply?** → Compatibility with versions prior to 2.28.0 is not tested or guaranteed

The documentation follows the same style as the existing "Ruby version support policy" section.