### PR TITLE
docs: add AI Policy and update documentation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,8 +1,17 @@
 Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:
 
-* Write tests for your changes
-* Run `rake` before pushing
-* Include / update docs in the README.md and in YARD documentation
+- Write tests for your changes
+- Run `rake` before pushing
+- Include / update docs in the README.md and in YARD documentation
 
 # Description
 
+\<your description here\>
+
+## Checklist
+
+- [ ] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
+  and verify any AI-assisted changes included in this PR and ensured they meet
+  quality, security, and licensing standards.
+- [ ] Tests added/updated as needed and `rake` passes locally.
+- [ ] Documentation updated where applicable (README and/or YARD).

--- a/AI_POLICY.md
+++ b/AI_POLICY.md
@@ -1,0 +1,19 @@
+# AI Policy
+
+AI assisted contributions are welcome in this project.
+
+Reviewing and maintaining code requires human insight. While AI tools can be helpful
+assistants, they are no substitute for human judgment and creativity.
+
+We value the unique perspectives and critical thinking that our contributors bring.
+If you use AI tools to assist your work:
+
+1. **You are responsible**: You must review and understand every line of code or text
+   you submit.
+2. **Focus on quality**: Ensure that AI-generated content meets our standards for
+   correctness, readability, and security, and respects all licensing requirements.
+3. **Be transparent**: We encourage you to disclose if significant portions of your
+   contribution were AI-generated.
+
+Ultimately, the quality of this project depends on *your* expertise. Use tools
+wisely, but lead with your own intelligence.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@
   - [Commit your changes to a fork of `ruby-git`](#commit-your-changes-to-a-fork-of-ruby-git)
   - [Create a pull request](#create-a-pull-request)
   - [Get your pull request reviewed](#get-your-pull-request-reviewed)
+- [AI-assisted contributions](#ai-assisted-contributions)
 - [Design philosophy](#design-philosophy)
   - [Direct mapping to git commands](#direct-mapping-to-git-commands)
   - [Parameter naming](#parameter-naming)
@@ -97,6 +98,13 @@ branch if other changes have been merged.
 At least one approval from a project maintainer is required before your pull request
 can be merged. The maintainer is responsible for ensuring that the pull request meets
 [the project's coding standards](#coding-standards).
+
+## AI-assisted contributions
+
+AI-assisted contributions are welcome. Please review and apply our [AI Policy](AI_POLICY.md)
+before submitting changes. You are responsible for understanding and verifying any
+AI-assisted work included in PRs and ensuring it meets our standards for quality,
+security, and licensing.
 
 ## Design philosophy
 

--- a/README.md
+++ b/README.md
@@ -10,8 +10,10 @@
 [![Change Log](https://img.shields.io/badge/CHANGELOG-Latest-green)](https://rubydoc.info/gems/git/file/CHANGELOG.md)
 [![Build Status](https://github.com/ruby-git/ruby-git/workflows/CI/badge.svg?branch=main)](https://github.com/ruby-git/ruby-git/actions?query=workflow%3ACI)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
+[![AI Policy](https://img.shields.io/badge/AI%20Policy-Required-blue)](AI_POLICY.md)
 
 - [Summary](#summary)
+- [AI Policy](#ai-policy)
 - [Install](#install)
 - [Major Objects](#major-objects)
 - [Errors Raised By This Gem](#errors-raised-by-this-gem)
@@ -22,6 +24,7 @@
 - [Git version support policy](#git-version-support-policy)
 - [License](#license)
 - [📢 Project Announcements 📢](#-project-announcements-)
+  - [2026-01-07: AI Policy Introduced](#2026-01-07-ai-policy-introduced)
   - [2025-07-09: Architectural Redesign](#2025-07-09-architectural-redesign)
   - [2025-07-07: We Now Use RuboCop](#2025-07-07-we-now-use-rubocop)
   - [2025-06-06: Default Branch Rename](#2025-06-06-default-branch-rename)
@@ -39,6 +42,15 @@ Get started by obtaining a repository object by:
 - cloning a repository with [Git.clone](https://rubydoc.info/gems/git/Git#clone-class_method)
 
 Methods that can be called on a repository object are documented in [Git::Base](https://rubydoc.info/gems/git/Git/Base)
+
+## AI Policy
+
+AI-assisted contributions are welcome on this project.
+
+We ask contributors to read, review, and apply our [AI Policy](AI_POLICY.md) before
+submitting changes. You are responsible for understanding and verifying any
+AI-assisted work you include in PRs, and contributions should meet our standards for
+quality, security, and licensing.
 
 ## Install
 
@@ -592,6 +604,17 @@ Licensed under MIT License Copyright (c) 2008  Scott Chacon. See LICENSE for fur
 details.
 
 ## 📢 Project Announcements 📢
+
+### 2026-01-07: AI Policy Introduced
+
+We have adopted a formal [AI Policy](AI_POLICY.md) to clarify expectations for
+AI-assisted contributions. Please review it before opening a PR to ensure your
+changes are fully understood, meet our quality bar, and respect licensing
+requirements.
+
+We chose a principles-based policy to respect contributors’ time and expertise. It’s
+quick to read, easy to remember, and avoids unnecessary policy overhead while still
+setting clear expectations.
 
 ### 2025-07-09: Architectural Redesign
 


### PR DESCRIPTION
Add a new AI Policy to the project to clarify expectations for AI-assisted contributions.

Changes include:
- New `AI_POLICY.md` file.
- `README.md`: Added badge, policy section, and announcement.
- `CONTRIBUTING.md`: Added policy section.
- `.github/pull_request_template.md`: Added checklist item.

> [!NOTE]
> This PR contains content that was drafted by Copilot.