### PR TITLE
docs: add Quick Start section and reorganize README for new users

### DIFF
--- a/lib/git/log.rb
+++ b/lib/git/log.rb
@@ -1,9 +1,14 @@
 # frozen_string_literal: true
 
 module Git
-  # Builds and executes a `git log` query.
+  # Builds and executes a `git log` query
   #
   # This class provides a fluent interface for building complex `git log` queries.
+  #
+  # Queries default to returning 30 commits; call {#max_count} with `:all` to
+  # return every matching commit. Calling {#all} adds the `--all` flag to include
+  # all refs in the search but does not change the number of commits returned.
+  #
   # The query is lazily executed when results are requested either via the modern
   # `#execute` method or the deprecated Enumerable methods.
   #


### PR DESCRIPTION
## Description

This PR reorganizes the README documentation to make it more approachable for new users. The main change is replacing the abstract "Major Objects" section with a practical "Quick Start" section that shows working code immediately.

### What problem does this solve?

The previous README started with descriptions of internal objects (Git::Base, Git::Object, Git::Diff, etc.) which required users to understand the gem's architecture before seeing any working code. New users had to scroll through a lot of content before finding practical examples.

### What approach was taken?

1. **Added Quick Start section** with three copy-paste-ready examples:
   - Clone a repo, check status, view log
   - Open an existing repo, add/commit/push
   - Initialize a new repo, make first commit

2. **Reorganized Examples section** into logical subsections:
   - Configuration (moved from Quick Start)
   - Read Operations
   - Write Operations
   - Index and Tree Operations

3. **Code quality improvements**:
   - Renamed variable `g` to `repo` throughout for clarity
   - Fixed broken examples

4. **Documentation relocation**:
   - Moved detailed `Git::Log` API documentation from the README to `lib/git/log.rb` source file where it belongs (discoverable via RubyDoc)

### Any breaking changes?

No breaking changes. This is documentation only.

### Testing performed

- Verified all code examples are syntactically correct
- Reviewed section organization and flow

### Related issues/PRs

None

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).
