### PR TITLE
docs: move inactive maintainers to Emeritus per governance policy

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,14 +11,14 @@ See [GOVERNANCE.md](GOVERNANCE.md) for a definition of the Maintainer role.
 
 - [James Couball](https://github.com/jcouball) (Project Lead)
 - [Frank Throckmorton](https://github.com/frankthrock)
-- [Per Lundberg](https://github.com/perlun)
 
 ## Maintainers Emeritus (Alumni)
 
 **Maintainers Emeritus** are former maintainers who are no longer active. We honor
 their past contributions.
 
+- [Per Lundberg](https://github.com/perlun)
 - [Vern Burton](https://github.com/tarcinil)
 - [Daniel Perez](https://github.com/dpmex4527)
 - [Richard Vodden](https://github.com/rvodden)
-- [Scott Chacon](https://github.com/schacon)
+- [Scott Chacon](https://github.com/schacon) (original creator)


### PR DESCRIPTION
## Description

This PR updates the MAINTAINERS.md file in accordance with our [GOVERNANCE.md](GOVERNANCE.md) policy on maintainer access.

### What problem does this solve?

Per our governance policy, elevated access should be kept only while actively needed ("least privilege" principle). This PR reflects the current state of maintainer activity.

### Changes

1. **Moved Per Lundberg to Maintainers Emeritus** - Last contribution was January 2020
2. **Added "original creator" designation for Scott Chacon** - Honors his foundational role in creating the ruby-git gem

### Context

All affected maintainers are being notified via email about this change and the associated access updates. Per our governance policy:
- Emeritus maintainers remain listed to honor their contributions
- Emeritus maintainers can be re-added quickly after renewed participation

### Any breaking changes?

No breaking changes. This is documentation only.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).
