### PR TITLE
ci: enable releases from 4.x maintenance branch

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2540,21 +2540,49 @@ automated releases based on conventional commits.
 
 **Branch Strategy:**
 
+This project maintains two active branches:
+
+- **`main`**: Active development for the next major version (v5.0.0+). May contain
+  breaking changes.
+- **`4.x`**: Maintenance branch for the v4.x release series. Bug fixes and
+  backward-compatible improvements only.
+
+**Important:** Never commit directly to `main` or `4.x`. All changes must be
+submitted via pull requests from feature branches. This ensures proper code review,
+CI validation, and maintains a clean commit history.
+
+**For new features and breaking changes (target `main`):**
+
 1. Ensure local main is up-to-date: `git fetch origin main`
 2. Create a new branch from origin/main: `git checkout -b feature/your-feature
    origin/main`
 3. Make your changes following TDD
 4. Ensure all tests pass and code quality checks pass
-5. Push the branch and create a PR
+5. Push the branch and create a PR targeting `main`
+
+**For bug fixes (target `main`, maintainers backport to `4.x` if applicable):**
+
+1. Ensure local main is up-to-date: `git fetch origin main`
+2. Create a new branch from origin/main: `git checkout -b fix/your-fix origin/main`
+3. Make your changes following TDD
+4. Push the branch and create a PR targeting `main`
+
+**For security fixes or 4.x-only changes (target `4.x`):**
+
+1. Ensure local 4.x is up-to-date: `git fetch origin 4.x`
+2. Create a new branch from origin/4.x: `git checkout -b fix/your-fix origin/4.x`
+3. Make your changes following TDD
+4. Push the branch and create a PR targeting `4.x`
 
 **When Submitting Existing Changes:**
 
-- Ensure changes are on a feature branch (not `main`), following the naming
+- Ensure changes are on a feature branch (not `main` or `4.x`), following the naming
   convention `<type>/<short-description>`
-- If changes are on the wrong branch, offer to create a new branch from
-  `origin/main` and relocate the user's existing work (commits or uncommitted
-  changes) onto that new branch, choosing an appropriate Git approach (for
-  example, cherry-pick, rebase, or recommitting) based on the situation
+- If changes are on the wrong branch, offer to create a new branch from the
+  appropriate base branch (`origin/main` or `origin/4.x`) and relocate the user's
+  existing work (commits or uncommitted changes) onto that new branch, choosing an
+  appropriate Git approach (for example, cherry-pick, rebase, or recommitting) based
+  on the situation
 
 **PR Creation Automation:**
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, 4.x]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -8,6 +8,7 @@ on:
   pull_request:
     branches:
       - main
+      - 4.x
 
 jobs:
   commit-lint:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ description: |
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main", "4.x"]
 
   workflow_dispatch:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@
   - [Commit your changes to a fork of `ruby-git`](#commit-your-changes-to-a-fork-of-ruby-git)
   - [Create a pull request](#create-a-pull-request)
   - [Get your pull request reviewed](#get-your-pull-request-reviewed)
+- [Branch strategy](#branch-strategy)
 - [AI-assisted contributions](#ai-assisted-contributions)
 - [Design philosophy](#design-philosophy)
   - [Direct mapping to git commands](#direct-mapping-to-git-commands)
@@ -97,12 +98,31 @@ Once your pull request is ready for review, request a review from at least one
 [maintainer](MAINTAINERS.md) and any other contributors you deem necessary.
 
 During the review process, you may need to make additional commits, which should be
-squashed. Additionally, you may need to rebase your branch to the latest `master`
-branch if other changes have been merged.
+squashed. Additionally, you will need to rebase your branch to the latest version of
+the target branch (e.g., `main` or `4.x`) before merging.
 
 At least one approval from a project maintainer is required before your pull request
 can be merged. The maintainer is responsible for ensuring that the pull request meets
 [the project's coding standards](#coding-standards).
+
+## Branch strategy
+
+This project maintains two active branches:
+
+- **`main`**: Active development for the next major version (v5.0.0+). This branch
+  may contain breaking changes.
+- **`4.x`**: Maintenance branch for the v4.x release series. This branch receives
+  bug fixes and backward-compatible improvements only.
+
+**Important:** Never commit directly to `main` or `4.x`. All changes must be
+submitted via pull requests from feature branches. This ensures proper code review,
+CI validation, and maintains a clean commit history.
+
+When submitting a pull request:
+
+- **New features and breaking changes**: Target the `main` branch
+- **Bug fixes**: Target `main`, and maintainers will backport to `4.x` if applicable
+- **Security fixes**: Target both branches or `4.x` if the issue only affects v4.x
 
 ## AI-assisted contributions
 


### PR DESCRIPTION
## Summary

Work is beginning on the 5.0 release which will have breaking changes. 

Since we will need to add deprecation warnings to the 4.x versions of the gem (and critical fixes or security issues), we will need to add a release-line branch for 4.x versions of this gem.

Add 4.x branch to workflow triggers to support parallel development of v5.0 (main) and v4.x maintenance releases.

## Changes

- **GitHub Actions workflows**: Add `4.x` branch to trigger releases from maintenance branch
- **CONTRIBUTING.md** and **copilot-instructions.md**: Document the branch strategy

## Branch Strategy

- **`main`**: Active development for v5.0.0+ (may contain breaking changes)
- **`4.x`**: Maintenance branch for v4.x releases (bug fixes and backward-compatible improvements)

## Next Steps

After this PR is merged:
1. Create `4.x` branch from the commit of these changes
2. Push `4.x` branch to origin
3. Continue v5.0 development on `main`