### PR TITLE
feat: add deprecation warning for .path accessor

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -195,7 +195,7 @@ module Git
     #   :fetch => true
     #   :track => <branch_name>
     def add_remote(name, url, opts = {})
-      url = url.repo.path if url.is_a?(Git::Base)
+      url = url.repo.to_s if url.is_a?(Git::Base)
       lib.remote_add(name, url, opts)
       Git::Remote.new(self, name)
     end
@@ -210,8 +210,8 @@ module Git
     #    @git.commit('message')
     #  end
     def chdir # :yields: the Git::Path
-      Dir.chdir(dir.path) do
-        yield dir.path
+      Dir.chdir(dir.to_s) do
+        yield dir.to_s
       end
     end
 
@@ -558,7 +558,7 @@ module Git
     #  @git.set_remote_url('scotts_git', 'git://repo.or.cz/rubygit.git')
     #
     def set_remote_url(name, url)
-      url = url.repo.path if url.is_a?(Git::Base)
+      url = url.repo.to_s if url.is_a?(Git::Base)
       lib.remote_set_url(name, url)
       Git::Remote.new(self, name)
     end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1709,9 +1709,9 @@ module Git
     end
 
     def initialize_from_base(base_object)
-      @git_dir = base_object.repo.path
-      @git_index_file = base_object.index&.path
-      @git_work_dir = base_object.dir&.path
+      @git_dir = base_object.repo.to_s
+      @git_index_file = base_object.index&.to_s
+      @git_work_dir = base_object.dir&.to_s
       @git_ssh = base_object.git_ssh
     end
 

--- a/lib/git/path.rb
+++ b/lib/git/path.rb
@@ -7,7 +7,13 @@ module Git
   # directory or index file.
   #
   class Path
-    attr_accessor :path
+    def path
+      Git::Deprecation.warn(
+        'The .path accessor is deprecated and will be removed in v5.0. ' \
+        'Use .to_s instead.'
+      )
+      @path
+    end
 
     def initialize(path, must_exist: true)
       path = File.expand_path(path)

--- a/tests/units/test_deprecations.rb
+++ b/tests/units/test_deprecations.rb
@@ -69,7 +69,7 @@ class TestDeprecations < Test::Unit::TestCase
       )
 
       @git.set_working(dir, false, must_exist: true)
-      assert_equal(dir, @git.dir.path)
+      assert_equal(dir, @git.dir.to_s)
     end
   end
 
@@ -183,5 +183,34 @@ class TestDeprecations < Test::Unit::TestCase
     )
 
     assert_equal(true, Git::Lib.warn_if_old_command(@git.lib))
+  end
+
+  # --- Git::Path deprecations ---
+
+  def test_working_directory_path_accessor_deprecation
+    Git::Deprecation.expects(:warn).with(
+      'The .path accessor is deprecated and will be removed in v5.0. ' \
+      'Use .to_s instead.'
+    )
+
+    @git.dir.path
+  end
+
+  def test_index_path_accessor_deprecation
+    Git::Deprecation.expects(:warn).with(
+      'The .path accessor is deprecated and will be removed in v5.0. ' \
+      'Use .to_s instead.'
+    )
+
+    @git.index.path
+  end
+
+  def test_repository_path_accessor_deprecation
+    Git::Deprecation.expects(:warn).with(
+      'The .path accessor is deprecated and will be removed in v5.0. ' \
+      'Use .to_s instead.'
+    )
+
+    @git.repo.path
   end
 end

--- a/tests/units/test_git_dir.rb
+++ b/tests/units/test_git_dir.rb
@@ -8,14 +8,14 @@ class TestGitDir < Test::Unit::TestCase
       Dir.mktmpdir do |git_dir|
         git = Git.open(work_tree, repository: git_dir)
 
-        assert_equal(work_tree, git.dir.path)
-        assert_equal(git_dir, git.repo.path)
+        assert_equal(work_tree, git.dir.to_s)
+        assert_equal(git_dir, git.repo.to_s)
 
         # Since :index was not given in the options to Git#open, index should
         # be defined automatically based on the git_dir.
         #
         index = File.join(git_dir, 'index')
-        assert_equal(index, git.index.path)
+        assert_equal(index, git.index.to_s)
       end
     end
   end
@@ -31,8 +31,8 @@ class TestGitDir < Test::Unit::TestCase
         FileUtils.cp_r(Dir["#{source_git_dir}/*"], git_dir, preserve: true)
         git = Git.open(work_tree, repository: git_dir)
 
-        assert_equal(work_tree, git.dir.path)
-        assert_equal(git_dir, git.repo.path)
+        assert_equal(work_tree, git.dir.to_s)
+        assert_equal(git_dir, git.repo.to_s)
 
         # Reconstitute the work tree from the bare repository
         #

--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -8,9 +8,9 @@ class TestInit < Test::Unit::TestCase
   def test_open_simple
     clone_working_repo
     g = Git.open(@wdir)
-    assert_match(/^C?:?#{@wdir}$/, g.dir.path)
-    assert_match(/^C?:?#{File.join(@wdir, '.git')}$/, g.repo.path)
-    assert_match(/^C?:?#{File.join(@wdir, '.git', 'index')}$/, g.index.path)
+    assert_match(/^C?:?#{@wdir}$/, g.dir.to_s)
+    assert_match(/^C?:?#{File.join(@wdir, '.git')}$/, g.repo.to_s)
+    assert_match(/^C?:?#{File.join(@wdir, '.git', 'index')}$/, g.index.to_s)
   end
 
   def test_open_from_non_root_dir
@@ -31,13 +31,13 @@ class TestInit < Test::Unit::TestCase
     clone_working_repo
     index = File.join(TEST_FIXTURES, 'index')
     g = Git.open @wdir, repository: BARE_REPO_PATH, index: index
-    assert_equal(g.repo.path, BARE_REPO_PATH)
-    assert_equal(g.index.path, index)
+    assert_equal(g.repo.to_s, BARE_REPO_PATH)
+    assert_equal(g.index.to_s, index)
   end
 
   def test_git_bare
     g = Git.bare BARE_REPO_PATH
-    assert_equal(g.repo.path, BARE_REPO_PATH)
+    assert_equal(g.repo.to_s, BARE_REPO_PATH)
   end
 
   # g = Git.init
@@ -90,7 +90,7 @@ class TestInit < Test::Unit::TestCase
   def test_git_clone
     in_temp_dir do |_path|
       g = Git.clone(BARE_REPO_PATH, 'bare-co')
-      assert(File.exist?(File.join(g.repo.path, 'config')))
+      assert(File.exist?(File.join(g.repo.to_s, 'config')))
       assert(g.dir)
     end
   end
@@ -105,7 +105,7 @@ class TestInit < Test::Unit::TestCase
   def test_git_clone_bare
     in_temp_dir do |_path|
       g = Git.clone(BARE_REPO_PATH, 'bare.git', bare: true)
-      assert(File.exist?(File.join(g.repo.path, 'config')))
+      assert(File.exist?(File.join(g.repo.to_s, 'config')))
       assert_nil(g.dir)
     end
   end
@@ -113,7 +113,7 @@ class TestInit < Test::Unit::TestCase
   def test_git_clone_mirror
     in_temp_dir do |_path|
       g = Git.clone(BARE_REPO_PATH, 'bare.git', mirror: true)
-      assert(File.exist?(File.join(g.repo.path, 'config')))
+      assert(File.exist?(File.join(g.repo.to_s, 'config')))
       assert_nil(g.dir)
     end
   end
@@ -122,7 +122,7 @@ class TestInit < Test::Unit::TestCase
     in_temp_dir do |_path|
       g = Git.clone(BARE_REPO_PATH, 'config.git', config: 'receive.denyCurrentBranch=ignore')
       assert_equal('ignore', g.config['receive.denycurrentbranch'])
-      assert(File.exist?(File.join(g.repo.path, 'config')))
+      assert(File.exist?(File.join(g.repo.to_s, 'config')))
       assert(g.dir)
     end
   end

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -54,8 +54,8 @@ class TestRemotes < Test::Unit::TestCase
       local.set_remote_url('testremote', remote2)
 
       assert(local.remotes.map(&:name).include?('testremote'))
-      assert(local.remote('testremote').url != remote1.repo.path)
-      assert(local.remote('testremote').url == remote2.repo.path)
+      assert(local.remote('testremote').url != remote1.repo.to_s)
+      assert(local.remote('testremote').url == remote2.repo.to_s)
     end
   end
 
@@ -114,7 +114,7 @@ class TestRemotes < Test::Unit::TestCase
         upstream.checkout(default_branch)
       end
 
-      local = Git.clone(upstream.dir.path, 'local', branch: upstream.current_branch, single_branch: true)
+      local = Git.clone(upstream.dir.to_s, 'local', branch: upstream.current_branch, single_branch: true)
       fetch_refspec = "+refs/heads/#{upstream.current_branch}:refs/remotes/origin/#{upstream.current_branch}"
       local.config('remote.origin.fetch', fetch_refspec)
 
@@ -142,7 +142,7 @@ class TestRemotes < Test::Unit::TestCase
         upstream.checkout(default_branch)
       end
 
-      local = Git.clone(upstream.dir.path, 'local', branch: upstream.current_branch, single_branch: true)
+      local = Git.clone(upstream.dir.to_s, 'local', branch: upstream.current_branch, single_branch: true)
 
       # create multiple fetch refspecs to ensure a replace operation is observable
       local.remote_set_branches('origin', upstream.current_branch, add: true)

--- a/tests/units/test_set_index.rb
+++ b/tests/units/test_set_index.rb
@@ -46,20 +46,20 @@ class SetIndexTest < Test::Unit::TestCase
     repo.set_index(custom_index_path, must_exist: false)
 
     # Verification: The repo object should now point to the new index path.
-    assert_equal(custom_index_path, repo.index.path, 'Index path should be updated to the custom path.')
+    assert_equal(custom_index_path, repo.index.to_s, 'Index path should be updated to the custom path.')
   end
 
   # Tests that `set_index` successfully points to an existing index file
   # when `must_exist: true` is specified.
   def test_set_index_with_must_exist_true_for_existing_path
-    original_index_path = repo.index.path
+    original_index_path = repo.index.to_s
     assert(File.exist?(original_index_path), 'Precondition: Original index file should exist.')
 
     # Action: Set the index to the same, existing path, explicitly requiring it to exist.
     repo.set_index(original_index_path, must_exist: true)
 
     # Verification: The index path should remain unchanged.
-    assert_equal(original_index_path, repo.index.path, 'Index path should still be the original path.')
+    assert_equal(original_index_path, repo.index.to_s, 'Index path should still be the original path.')
   end
 
   # Tests that `set_index` raises an ArgumentError when trying to point to a
@@ -90,7 +90,7 @@ class SetIndexTest < Test::Unit::TestCase
     repo.set_index(custom_index_path, false)
 
     # Verification: The repo object should still point to the new index path.
-    assert_equal(custom_index_path, repo.index.path, 'Index path should be updated even with deprecated argument.')
+    assert_equal(custom_index_path, repo.index.to_s, 'Index path should be updated even with deprecated argument.')
     # Mocha automatically verifies the expectation at the end of the test.
   end
 
@@ -110,7 +110,7 @@ class SetIndexTest < Test::Unit::TestCase
     # 3. Point the git object to use our custom index file.
     #    Since the file doesn't exist yet, we must pass `must_exist: false`.
     repo.set_index(custom_index_path, must_exist: false)
-    assert_equal(custom_index_path, repo.index.path, 'The git object should now be using the custom index.')
+    assert_equal(custom_index_path, repo.index.to_s, 'The git object should now be using the custom index.')
 
     # 4. Populate the new index by reading the tree from our initial commit into it.
     #    This stages all the files from the 'main' commit in our custom index.

--- a/tests/units/test_set_working.rb
+++ b/tests/units/test_set_working.rb
@@ -33,20 +33,20 @@ class SetWorkingTest < Test::Unit::TestCase
     repo.set_working(custom_working_path, must_exist: false)
 
     # Verification: The repo object should now point to the new working directory path.
-    assert_equal(custom_working_path, repo.dir.path, 'Working directory path should be updated to the custom path.')
+    assert_equal(custom_working_path, repo.dir.to_s, 'Working directory path should be updated to the custom path.')
   end
 
   # Tests that `set_working` successfully points to an existing directory
   # when `must_exist: true` is specified.
   def test_set_working_with_must_exist_true_for_existing_path
-    original_working_path = repo.dir.path
+    original_working_path = repo.dir.to_s
     assert(File.exist?(original_working_path), 'Precondition: Original working directory should exist.')
 
     # Action: Set the working directory to the same, existing path, explicitly requiring it to exist.
     repo.set_working(original_working_path, must_exist: true)
 
     # Verification: The working directory path should remain unchanged.
-    assert_equal(original_working_path, repo.dir.path, 'Working directory path should still be the original path.')
+    assert_equal(original_working_path, repo.dir.to_s, 'Working directory path should still be the original path.')
   end
 
   # Tests that `set_working` raises an ArgumentError when trying to point to a
@@ -77,7 +77,7 @@ class SetWorkingTest < Test::Unit::TestCase
     repo.set_working(custom_working_path, false)
 
     # Verification: The repo object should still point to the new working directory path.
-    assert_equal(custom_working_path, repo.dir.path, 'Working directory path should be updated even with deprecated argument.')
+    assert_equal(custom_working_path, repo.dir.to_s, 'Working directory path should be updated even with deprecated argument.')
     # Mocha automatically verifies the expectation at the end of the test.
   end
 end


### PR DESCRIPTION
## Summary

This PR adds deprecation warnings for the `.path` accessor on `Git::Path`, `Git::WorkingDirectory`, `Git::Index`, and `Git::Repository` (the path class) to prepare users for the breaking change in v5.0 where these classes will be replaced with Ruby's `Pathname`.

## Deprecation Details

Users should migrate from `.path` to `.to_s`:

```ruby
# Before (v4.x - deprecated but still works)
repo.dir.path      # ⚠️ Deprecation warning
repo.index.path    # ⚠️ Deprecation warning
repo.repo.path     # ⚠️ Deprecation warning

# After (v4.x forward-compatible)
repo.dir.to_s      # ✅ No warning
repo.index.to_s    # ✅ No warning
repo.repo.to_s     # ✅ No warning
```

The `.path` accessor will be removed in v5.0 when these path classes are replaced with `Pathname`.

## What Still Works

The `readable?` and `writable?` methods continue to work as before and will continue to work in v5.0 (since `Pathname` provides these methods natively).

## Implementation

Following TDD practices:
1. ✅ Added tests for the deprecation warnings (RED)
2. ✅ Implemented the deprecation warnings (GREEN)
3. ✅ Updated all internal usage to use `.to_s` instead of `.path`
4. ✅ All 481 tests pass
5. ✅ RuboCop passes with no offenses

## Related

This deprecation prepares users for PR #879 which eliminates these custom path wrapper classes and uses Ruby's stdlib `Pathname` instead.