### PR TITLE
Releases from the main branch should be prerelease

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
           token: ${{ secrets.AUTO_RELEASE_TOKEN }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          prerelease: true
 
       - name: Setup ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
## Summary
- set release-please prerelease flag to true in the release workflow
- allows main (5.x) to ship pre-releases for testing before 5.0.0

## Testing
- not run (workflow change only)
