### PR TITLE
Configure beta prerelease releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,8 @@ jobs:
         id: release
         with:
           token: ${{ secrets.AUTO_RELEASE_TOKEN }}
-          config-file: release-please-config.json
+          config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
-          prerelease: true
 
       - name: Setup ruby
         uses: ruby/setup-ruby@v1

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,7 +9,9 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
-      "prerelease": false,
+      "prerelease": true,
+      "versioning-strategy": "prerelease",
+      "prerelease-type": "beta",
       "include-component-in-tag": false,
       "pull-request-title-pattern": "chore: release v${version}",
       "changelog-sections": [


### PR DESCRIPTION
## Summary
- switch workflow to use dotfile config and remove unsupported prerelease input
- configure release-please for prerelease strategy with beta suffix
- delete legacy release-please-config.json in favor of .release-please-config.json

## Testing
- npx release-please release-pr --dry-run (configuration validation)