### PR TITLE
ci: add TruffleRuby 25 to CI matrix

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -22,7 +22,7 @@ jobs:
       fail-fast: false
       matrix:
         # Only the latest versions of JRuby and TruffleRuby are tested
-        ruby: ["3.2", "3.4", "4.0", "truffleruby-24.2.1", "jruby-10.0.0.1"]
+        ruby: ["3.2", "3.4", "4.0", "truffleruby-24.2.1", "truffleruby-25", "jruby-10.0.0.1"]
         operating-system: [ubuntu-latest]
         experimental: [No]
         java_version: [""]


### PR DESCRIPTION
## Summary

Add TruffleRuby 25 to the CI matrix to test against the latest TruffleRuby release.

## Changes

- Add `truffleruby-25` to the Ruby version matrix in the continuous integration workflow

## Testing

CI will run automatically on this PR to verify TruffleRuby 25 compatibility.