### PR TITLE
Enable option validation in Add and Fsck commands

### DIFF
--- a/lib/git/commands/add.rb
+++ b/lib/git/commands/add.rb
@@ -61,7 +61,7 @@ module Git
       # @return [Array<String>] the command-line arguments
       #
       def build_args(options)
-        Git::ArgsBuilder.new(options, OPTION_MAP).build
+        Git::ArgsBuilder.build(options, OPTION_MAP)
       end
     end
   end

--- a/lib/git/commands/fsck.rb
+++ b/lib/git/commands/fsck.rb
@@ -106,7 +106,7 @@ module Git
       # @return [Array<String>] the command-line arguments
       #
       def build_args(options)
-        Git::ArgsBuilder.new(options, OPTION_MAP).build
+        Git::ArgsBuilder.build(options, OPTION_MAP)
       end
 
       # Parse the output from git fsck into a structured result

--- a/spec/git/commands/add_spec.rb
+++ b/spec/git/commands/add_spec.rb
@@ -80,5 +80,13 @@ RSpec.describe Git::Commands::Add do
         command.call('path/to/файл.rb')
       end
     end
+
+    context 'with unsupported options' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('.', invalid_option: true) }.to(
+          raise_error(ArgumentError, /Unsupported options: :invalid_option/)
+        )
+      end
+    end
   end
 end

--- a/spec/git/commands/fsck_spec.rb
+++ b/spec/git/commands/fsck_spec.rb
@@ -384,5 +384,13 @@ RSpec.describe Git::Commands::Fsck do
         expect { command.call }.to raise_error(Git::FailedError)
       end
     end
+
+    context 'with unsupported options' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(invalid_option: true) }.to(
+          raise_error(ArgumentError, /Unsupported options: :invalid_option/)
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

This PR updates the `Add` and `Fsck` command classes to use `ArgsBuilder.build()` class method instead of `ArgsBuilder.new().build()` instance method pattern. This enables option validation, improving consistency with other command classes like `Clone`.

## Changes

- **lib/git/commands/add.rb**: Changed `build_args` to use `ArgsBuilder.build(options, OPTION_MAP)`
- **lib/git/commands/fsck.rb**: Changed `build_args` to use `ArgsBuilder.build(options, OPTION_MAP)`
- **spec/git/commands/add_spec.rb**: Added test to verify validation of unsupported options
- **spec/git/commands/fsck_spec.rb**: Added test to verify validation of unsupported options

## Benefits

1. **Consistency**: Aligns with the pattern used in `Git::Commands::Clone` and other modernized commands
2. **Validation**: Provides early error detection for invalid options, improving developer experience
3. **Error Messages**: Users get clear `ArgumentError` messages for unsupported options instead of silent failures

## Testing

```
87 examples, 0 failures (RSpec)
526 tests, 3072 assertions, 0 failures, 0 errors, 1 omissions (TestUnit)
```

New validation tests verify that both commands properly reject unsupported options.

## Related Work

Part of the v5.0.0 architecture redesign. Related to #896 which implemented the Clone command using this validated approach.