### PR TITLE
Migrate init command to new architecture

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -73,30 +73,6 @@ module Git
       version_parts.fill(0, version_parts.length...3)
     end
 
-    # (see Git.init)
-    def self.init(directory = '.', options = {})
-      bare = options[:bare]
-      paths = resolve_paths(
-        working_directory: directory,
-        repository: options[:repository],
-        bare: bare
-      )
-
-      create_and_init_repository(paths, options)
-    end
-
-    private_class_method def self.create_and_init_repository(paths, options)
-      bare = options[:bare]
-      target_directory = bare ? paths[:repository] : paths[:working_directory]
-      FileUtils.mkdir_p(target_directory)
-
-      # Create the Git::Base instance first, then initialize the repository.
-      # This avoids creating a temporary Git::Lib just for the init command.
-      new(options.merge(paths)).tap do |base|
-        base.lib.init(bare: bare, initial_branch: options[:initial_branch])
-      end
-    end
-
     def self.root_of_worktree(working_dir)
       raise ArgumentError, "'#{working_dir}' does not exist" unless Dir.exist?(working_dir)
 

--- a/lib/git/commands/init.rb
+++ b/lib/git/commands/init.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'git/commands/options'
+
+module Git
+  module Commands
+    # Implements the `git init` command
+    #
+    # This command creates an empty Git repository or reinitializes an existing one.
+    #
+    # @api private
+    #
+    # @example Basic usage
+    #   init = Git::Commands::Init.new(execution_context)
+    #   init.call
+    #
+    # @example Create a bare repository
+    #   init = Git::Commands::Init.new(execution_context)
+    #   init.call('my-repo.git', bare: true)
+    #
+    # @example Specify the initial branch name
+    #   init = Git::Commands::Init.new(execution_context)
+    #   init.call('my-repo', initial_branch: 'main')
+    #
+    class Init
+      # Options DSL for building command-line arguments
+      OPTIONS = Options.define do
+        flag :bare
+        inline_value :initial_branch
+        inline_value :repository, flag: '--separate-git-dir'
+        positional :directory, default: '.'
+      end.freeze
+
+      # Initialize the Init command
+      #
+      # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
+      #
+      def initialize(execution_context)
+        @execution_context = execution_context
+      end
+
+      # Execute the git init command
+      #
+      # @param directory [String] the directory to initialize (default: '.')
+      #   If :bare is false, creates the repository in +<directory>/.git+.
+      #   If :bare is true, creates a bare repository in +<directory>+.
+      #
+      # @param options [Hash] command options
+      #
+      # @option options [Boolean] :bare Create a bare repository
+      # @option options [String] :initial_branch Use the specified name for the initial branch
+      # @option options [String] :repository Path to put the .git directory (uses --separate-git-dir)
+      #
+      # @return [void]
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      def call(directory = '.', options = {})
+        path = File.expand_path(directory)
+        args = OPTIONS.build(path, **options)
+        @execution_context.command('init', *args)
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -4,6 +4,7 @@ require_relative 'args_builder'
 require_relative 'commands/add'
 require_relative 'commands/clone'
 require_relative 'commands/fsck'
+require_relative 'commands/init'
 
 require 'git/command_line'
 require 'git/errors'
@@ -78,20 +79,22 @@ module Git
       end
     end
 
-    INIT_OPTION_MAP = [
-      { keys: [:bare], flag: '--bare', type: :boolean },
-      { keys: [:initial_branch], flag: '--initial-branch', type: :valued_equals }
-    ].freeze
-
-    # creates or reinitializes the repository
+    # creates or reinitializes the repository in the current directory
     #
-    # options:
-    #   :bare
-    #   :working_directory
-    #   :initial_branch
+    # This is a low-level method that just runs `git init` with the given options.
+    # For full repository initialization including directory creation and path
+    # resolution, use Git.init instead.
+    #
+    # @param opts [Hash] command options
+    # @option opts [Boolean] :bare Create a bare repository
+    # @option opts [String] :initial_branch Use the specified name for the initial branch
+    #
+    # @return [String] the command output
     #
     def init(opts = {})
-      args = build_args(opts, INIT_OPTION_MAP)
+      args = []
+      args << '--bare' if opts[:bare]
+      args << "--initial-branch=#{opts[:initial_branch]}" if opts[:initial_branch]
       command('init', *args)
     end
 

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,24 +22,24 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (3/~50 commands migrated) |
+| Phase 2 | 🔄 In Progress | Migrating commands (4/~50 commands migrated) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate the `init` command** → `Git::Commands::Init`
+**Migrate the `rm` command** → `Git::Commands::Rm`
 
 #### Workflow
 
 1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def
-   init`). Understand all options and edge cases.
+   remove`). Understand all options and edge cases.
 
-2. **Design**: Create `lib/git/commands/init.rb` with a `Git::Commands::Init` class
+2. **Design**: Create `lib/git/commands/rm.rb` with a `Git::Commands::Rm` class
    following the pattern in `lib/git/commands/add.rb`. The interface for
-   `Git::Commands::Init#call` should match the public interface for `Git::Base.init`
+   `Git::Commands::Rm#call` should match the public interface for `Git::Base#remove`
 
-3. **TDD**: Write `spec/git/commands/init_spec.rb` *before* implementing:
+3. **TDD**: Write `spec/git/commands/rm_spec.rb` *before* implementing:
    - Test every option using separate `context` blocks
    - Mock the execution context with `double('ExecutionContext')`
    - Verify argument building matches expected git CLI args
@@ -50,16 +50,16 @@ risk and allows for a gradual, controlled migration to the new architecture.
      tags
    - Mark class with `@api private`
 
-5. **Delegate**: Update `Git::Lib#init` to delegate to the new class:
+5. **Delegate**: Update `Git::Lib#remove` to delegate to the new class:
 
    ```ruby
-   def init(options = {})
-     Git::Commands::Init.new(self).call(options)
+   def remove(path = '.', options = {})
+     Git::Commands::Rm.new(self).call(path, options)
    end
    ```
 
 6. **Verify**:
-   - `bundle exec rspec spec/git/commands/init_spec.rb` — new tests pass
+   - `bundle exec rspec spec/git/commands/rm_spec.rb` — new tests pass
    - `bundle exec rspec` — all RSpec tests pass
    - `bundle exec rake test` — legacy TestUnit tests pass
    - `bundle exec rubocop` — no lint errors
@@ -68,9 +68,9 @@ risk and allows for a gradual, controlled migration to the new architecture.
    To run a single legacy test: `bundle exec bin/test test_<name>` (e.g., `bundle
    exec bin/test test_archive`)
 
-7. **Update Checklist**: Move `init` from "Commands To Migrate" to "Migrated
+7. **Update Checklist**: Move `rm` from "Commands To Migrate" to "Migrated
    Commands" table in this document, and update the "Next Task" section to point to
-   `rm`.
+   `mv`.
 
 #### Reference Files
 
@@ -212,15 +212,12 @@ The following tracks the migration status of commands from `Git::Lib` to
 | `add` | `Git::Commands::Add` | `spec/git/commands/add_spec.rb` | `git add` |
 | `clone` | `Git::Commands::Clone` | `spec/git/commands/clone_spec.rb` | `git clone` |
 | `fsck` | `Git::Commands::Fsck` | `spec/git/commands/fsck_spec.rb` | `git fsck` |
+| `init` | `Git::Commands::Init` | `spec/git/commands/init_spec.rb` | `git init` |
 
 #### ⏳ Commands To Migrate
 
 Commands are listed in recommended migration order within each group. Migrate in
 order: Basic Snapshotting → Branching & Merging → etc.
-
-**Setup & Init** (migrate these first):
-
-- [ ] `init` → `Git::Commands::Init` — `git init`
 
 **Basic Snapshotting**:
 

--- a/spec/git/commands/init_spec.rb
+++ b/spec/git/commands/init_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::Commands::Init do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with default arguments' do
+      it 'runs git init in the current directory' do
+        current_dir = File.expand_path('.')
+        expect(execution_context).to receive(:command).with('init', current_dir)
+
+        command.call
+      end
+    end
+
+    context 'with a directory argument' do
+      it 'initializes in the specified directory' do
+        dir = File.expand_path('my-repo')
+        expect(execution_context).to receive(:command).with('init', dir)
+
+        command.call('my-repo')
+      end
+    end
+
+    context 'with the :bare option' do
+      it 'includes the --bare flag when true' do
+        dir = File.expand_path('my-repo.git')
+        expect(execution_context).to receive(:command).with('init', '--bare', dir)
+
+        command.call('my-repo.git', bare: true)
+      end
+
+      it 'does not include the flag when false' do
+        dir = File.expand_path('my-repo')
+        expect(execution_context).to receive(:command).with('init', dir)
+
+        command.call('my-repo', bare: false)
+      end
+    end
+
+    context 'with the :initial_branch option' do
+      it 'includes the --initial-branch flag with the specified value' do
+        dir = File.expand_path('my-repo')
+        expect(execution_context).to receive(:command).with('init', '--initial-branch=main', dir)
+
+        command.call('my-repo', initial_branch: 'main')
+      end
+
+      it 'handles branch names with special characters' do
+        dir = File.expand_path('my-repo')
+        expect(execution_context).to receive(:command).with('init', '--initial-branch=feature/my-branch', dir)
+
+        command.call('my-repo', initial_branch: 'feature/my-branch')
+      end
+    end
+
+    context 'with the :repository option' do
+      it 'uses --separate-git-dir for the repository path' do
+        work_dir = File.expand_path('work')
+        # The repository path is passed through as-is (not expanded by the command)
+        expect(execution_context).to receive(:command).with('init', '--separate-git-dir=repo.git', work_dir)
+
+        command.call('work', repository: 'repo.git')
+      end
+    end
+
+    context 'with multiple options combined' do
+      it 'includes all specified flags' do
+        dir = File.expand_path('bare.git')
+        expect(execution_context).to receive(:command).with('init', '--bare', '--initial-branch=develop', dir)
+
+        command.call('bare.git', bare: true, initial_branch: 'develop')
+      end
+    end
+
+    context 'with unsupported options' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('my-repo', invalid_option: true) }.to(
+          raise_error(ArgumentError, /Unsupported options: :invalid_option/)
+        )
+      end
+
+      it 'raises ArgumentError for :log (handled by Git.init)' do
+        expect { command.call('my-repo', log: double('Logger')) }.to(
+          raise_error(ArgumentError, /Unsupported options: :log/)
+        )
+      end
+
+      it 'raises ArgumentError for :git_ssh (handled by Git.init)' do
+        expect { command.call('my-repo', git_ssh: '/path/to/ssh') }.to(
+          raise_error(ArgumentError, /Unsupported options: :git_ssh/)
+        )
+      end
+    end
+  end
+end

--- a/spec/git/init_spec.rb
+++ b/spec/git/init_spec.rb
@@ -1,0 +1,114 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git do
+  describe '.init' do
+    let(:logger) { instance_double(Logger) }
+    let(:git_base) { instance_double(Git::Base) }
+
+    before do
+      # Mock Git::Commands::Init to avoid actual git execution
+      command = instance_double(Git::Commands::Init)
+      allow(Git::Commands::Init).to receive(:new).and_return(command)
+      allow(command).to receive(:call)
+    end
+
+    context 'with bare: false (non-bare repository)' do
+      it 'forwards correct options to Git.open' do
+        expect(Git).to receive(:open).with(
+          'my-repo',
+          { log: logger, git_ssh: 'custom-ssh', index: 'my-index', repository: 'repo.git' }
+        ).and_return(git_base)
+
+        Git.init(
+          'my-repo',
+          bare: false,
+          log: logger,
+          git_ssh: 'custom-ssh',
+          index: 'my-index',
+          repository: 'repo.git'
+        )
+      end
+
+      it 'does not forward :bare or :initial_branch to Git.open' do
+        expect(Git).to receive(:open).with(
+          'my-repo',
+          { log: logger }
+        ).and_return(git_base)
+
+        Git.init('my-repo', bare: false, initial_branch: 'main', log: logger)
+      end
+
+      it 'consolidates :separate_git_dir to :repository' do
+        expect(Git).to receive(:open).with(
+          'my-repo',
+          { repository: 'repo.git' }
+        ).and_return(git_base)
+
+        Git.init('my-repo', separate_git_dir: 'repo.git')
+      end
+
+      it 'prefers :repository over :separate_git_dir when both provided' do
+        expect(Git).to receive(:open).with(
+          'my-repo',
+          { repository: 'repo.git' }
+        ).and_return(git_base)
+
+        Git.init('my-repo', repository: 'repo.git', separate_git_dir: 'other.git')
+      end
+    end
+
+    context 'with bare: true (bare repository)' do
+      it 'forwards correct options to Git.bare (excluding :index and :repository)' do
+        expect(Git).to receive(:bare).with(
+          'my-repo.git',
+          { log: logger, git_ssh: 'custom-ssh' }
+        ).and_return(git_base)
+
+        Git.init(
+          'my-repo.git',
+          bare: true,
+          log: logger,
+          git_ssh: 'custom-ssh',
+          index: 'my-index'
+        )
+      end
+
+      it 'uses :repository path as the bare repository location' do
+        expect(Git).to receive(:bare).with(
+          'repo.git',
+          { log: logger }
+        ).and_return(git_base)
+
+        Git.init('work', bare: true, repository: 'repo.git', log: logger)
+      end
+
+      it 'uses directory when :repository not provided' do
+        expect(Git).to receive(:bare).with(
+          'my-repo.git',
+          {}
+        ).and_return(git_base)
+
+        Git.init('my-repo.git', bare: true)
+      end
+
+      it 'does not forward :initial_branch to Git.bare' do
+        expect(Git).to receive(:bare).with(
+          'my-repo.git',
+          {}
+        ).and_return(git_base)
+
+        Git.init('my-repo.git', bare: true, initial_branch: 'main')
+      end
+    end
+
+    context 'with minimal options' do
+      it 'calls Git.open with directory and empty options when bare not specified' do
+        expect(Git).to receive(:open).with('.', {}).and_return(git_base)
+
+        Git.init
+      end
+    end
+  end
+end

--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -77,6 +77,17 @@ class TestInit < Test::Unit::TestCase
     end
   end
 
+  def test_git_init_separate_git_dir
+    in_temp_dir do |dir|
+      assert(!File.exist?(File.join(dir, 'config')))
+
+      in_temp_dir do |path|
+        Git.init(path, separate_git_dir: dir)
+        assert(File.exist?(File.join(dir, 'config')))
+      end
+    end
+  end
+
   def test_git_init_initial_branch
     in_temp_dir do |path|
       repo = Git.init(path, initial_branch: 'main')


### PR DESCRIPTION
Migrates the `git init` command to the new command class architecture using the Options DSL.

## Changes

- **New `Git::Commands::Init`** - Self-contained command class with full Options DSL support
- **Simplified `Git.init`** - Now delegates directly to the new command class
- **Removed `Git::Base.init`** - Was redundant; `Git.init` is the public entry point
- **New `:separate_git_dir` option** - Maps to `--separate-git-dir` flag, with `:repository` as an alias

## Notes

- No breaking changes to the public `Git.init` API
- `Git::Base.init` removal may affect users who called it directly (unlikely, was undocumented)