### PR TITLE
fix(commands): add required validation for variadic positionals

### DIFF
--- a/lib/git/commands/options.rb
+++ b/lib/git/commands/options.rb
@@ -122,7 +122,7 @@ module Git
       # Define a positional argument
       #
       # @param name [Symbol] the positional argument name
-      # @param required [Boolean] whether the argument is required
+      # @param required [Boolean] whether the argument is required (for variadic, requires at least one value)
       # @param variadic [Boolean] whether the argument accepts multiple values
       # @param default [Object] the default value if not provided
       # @param separator [String, nil] separator to insert before this positional (e.g., '--')
@@ -241,6 +241,8 @@ module Git
       def validate_required_positional(value, definition)
         return unless definition[:required]
         return unless value_empty?(value)
+
+        raise ArgumentError, "at least one value is required for #{definition[:name]}" if definition[:variadic]
 
         raise ArgumentError, "#{definition[:name]} is required"
       end

--- a/lib/git/commands/rm.rb
+++ b/lib/git/commands/rm.rb
@@ -33,7 +33,7 @@ module Git
         flag :force, flag: '-f'
         flag :recursive, flag: '-r'
         flag :cached
-        positional :paths, variadic: true, separator: '--'
+        positional :paths, variadic: true, required: true, separator: '--'
       end.freeze
 
       # Initialize the Rm command

--- a/spec/git/commands/options_spec.rb
+++ b/spec/git/commands/options_spec.rb
@@ -236,6 +236,30 @@ RSpec.describe Git::Commands::Options do
       end
     end
 
+    context 'with required variadic positional arguments' do
+      let(:options) do
+        described_class.define do
+          positional :paths, variadic: true, required: true
+        end
+      end
+
+      it 'accepts multiple positional arguments' do
+        expect(options.build('file1.rb', 'file2.rb')).to eq(%w[file1.rb file2.rb])
+      end
+
+      it 'accepts single positional argument' do
+        expect(options.build('file.rb')).to eq(['file.rb'])
+      end
+
+      it 'raises ArgumentError when no paths provided' do
+        expect { options.build }.to raise_error(ArgumentError, /at least one value is required for paths/)
+      end
+
+      it 'raises ArgumentError when empty array provided' do
+        expect { options.build([]) }.to raise_error(ArgumentError, /at least one value is required for paths/)
+      end
+    end
+
     context 'with positional arguments with default values' do
       let(:options) do
         described_class.define do

--- a/spec/git/commands/rm_spec.rb
+++ b/spec/git/commands/rm_spec.rb
@@ -12,16 +12,12 @@ RSpec.describe Git::Commands::Rm do
         expect { command.call(nil) }.to raise_error(ArgumentError, /nil values are not allowed/)
       end
 
-      it 'raises Git::FailedError for empty array' do
-        result_double = double('Result',
-                               status: double('Status', exitstatus: 128),
-                               stdout: '',
-                               stderr: 'fatal: No pathspec was given. Which files should I remove?',
-                               git_cmd: 'git rm')
-        failed_error = Git::FailedError.new(result_double)
-        allow(execution_context).to receive(:command).and_raise(failed_error)
+      it 'raises ArgumentError for empty array' do
+        expect { command.call([]) }.to raise_error(ArgumentError, /at least one value is required for paths/)
+      end
 
-        expect { command.call([]) }.to raise_error(Git::FailedError)
+      it 'raises ArgumentError for no arguments' do
+        expect { command.call }.to raise_error(ArgumentError, /at least one value is required for paths/)
       end
     end
 


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

This PR adds support for `required: true` on variadic positional arguments in the `Git::Commands::Options` DSL to enforce that at least one value is provided.

## Problem

The `Git::Commands::Rm` command documentation states that "at least one path is required", but the implementation didn't enforce this constraint. Previously, calling `rm.call()` or `rm.call([])` would fail with a confusing Git error message rather than a clear Ruby validation error.

## Solution

- Added support for `required: true` on variadic positionals in the Options DSL
- Enhanced `validate_required_positional` to provide clearer error messages for variadic positionals ("at least one value is required for {name}")
- Applied `required: true` to the `paths` positional in `Git::Commands::Rm`
- Added comprehensive tests for required variadic positionals

## Breaking Changes

None. This is an additive change that doesn't affect existing code.

## Testing

- Added tests for required variadic positionals in `spec/git/commands/options_spec.rb`
- Updated tests in `spec/git/commands/rm_spec.rb` to verify the new validation behavior
- All existing tests pass (`bundle exec rake`)

## Platform Considerations

This change is platform-agnostic and works across all supported platforms (macOS, Linux, Windows).

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).
