### PR TITLE
refactor: enhance Arguments DSL with new features

### DIFF
--- a/lib/git/commands/arguments.rb
+++ b/lib/git/commands/arguments.rb
@@ -5,6 +5,8 @@ module Git
     # Git::Commands::Arguments provides a DSL for defining command-line arguments
     # (both options and positional arguments) for Git commands.
     #
+    # @api private
+    #
     # @example Defining arguments for a command
     #   ARGS = Git::Commands::Arguments.define do
     #     flag :force
@@ -15,6 +17,26 @@ module Git
     # @example Building command-line arguments
     #   ARGS.build('https://github.com/user/repo', force: true, branch: 'main')
     #   # => ['--force', '--branch', 'main', 'https://github.com/user/repo']
+    #
+    # == Type Validation
+    #
+    # The `type:` parameter provides declarative type validation for option values.
+    # When validation fails, an ArgumentError is raised with a descriptive message.
+    #
+    # @example Single type validation
+    #   inline_value :date, type: String
+    #   # Valid: date: "2024-01-01"
+    #   # Invalid: date: 12345
+    #   #   => ArgumentError: The :date option must be a String, but was a Integer
+    #
+    # @example Multiple type validation (allows any of the specified types)
+    #   inline_value :timeout, type: [Integer, Float]
+    #   # Valid: timeout: 30 or timeout: 30.5
+    #   # Invalid: timeout: "30"
+    #   #   => ArgumentError: The :timeout option must be a Integer or Float, but was a String
+    #
+    # @note The `type:` parameter cannot be combined with a custom `validator:` parameter.
+    #   Attempting to use both will raise an ArgumentError during definition.
     #
     class Arguments
       # Define a new Arguments instance using the DSL
@@ -38,57 +60,148 @@ module Git
         @alias_map = {} # Maps alias keys to primary keys
         @static_flags = []
         @positional_definitions = []
+        @conflicts = [] # Array of conflicting option pairs/groups
       end
 
       # Define a boolean flag option (--flag when true)
       #
       # @param names [Symbol, Array<Symbol>] the option name(s), first is primary
-      # @param flag [String, nil] custom flag string (e.g., '-r' instead of '--recursive')
+      # @param args [String, Array<String>, nil] custom argument(s) to output (e.g., '-r' or ['--amend', '--no-edit'])
+      # @param type [Class, Array<Class>, nil] expected type(s) for validation. Raises ArgumentError with
+      #   descriptive message if value doesn't match. Cannot be combined with validator:.
       # @return [void]
       #
-      def flag(names, flag: nil)
-        register_option(names, type: :flag, flag: flag)
+      # @example With type validation
+      #   flag :force, type: [TrueClass, FalseClass]
+      #
+      def flag(names, args: nil, type: nil)
+        register_option(names, type: :flag, args: args, expected_type: type)
       end
 
       # Define a negatable boolean flag option (--flag when true, --no-flag when false)
       #
       # @param names [Symbol, Array<Symbol>] the option name(s), first is primary
-      # @param flag [String, nil] custom flag string
-      # @param validator [Proc, nil] optional validator proc that receives the value and returns true if valid
+      # @param args [String, Array<String>, nil] custom argument(s) to output (arrays only for flag types)
+      # @param type [Class, Array<Class>, nil] expected type(s) for validation. Raises ArgumentError with
+      #   descriptive message if value doesn't match. Cannot be combined with validator:.
+      # @param validator [Proc, nil] optional validator block (cannot be combined with type:)
       # @return [void]
       #
-      def negatable_flag(names, flag: nil, validator: nil)
-        register_option(names, type: :negatable_flag, flag: flag, validator: validator)
+      def negatable_flag(names, args: nil, type: nil, validator: nil)
+        register_option(names, type: :negatable_flag, args: args, expected_type: type, validator: validator)
       end
 
       # Define a valued option (--flag value as separate arguments)
       #
       # @param names [Symbol, Array<Symbol>] the option name(s), first is primary
-      # @param flag [String, nil] custom flag string
+      # @param args [String, nil] custom flag string (arrays not supported for value types)
+      # @param type [Class, Array<Class>, nil] expected type(s) for validation. Raises ArgumentError with
+      #   descriptive message if value doesn't match. Cannot be combined with validator:.
+      # @param allow_empty [Boolean] whether to include the flag even when value is an empty string.
+      #   When false (default), empty strings are skipped entirely. When true, the flag and empty
+      #   value are included in the output.
       # @return [void]
       #
-      def value(names, flag: nil)
-        register_option(names, type: :value, flag: flag)
+      # @example With type validation
+      #   value :branch, type: String
+      #
+      # @example With allow_empty
+      #   value :message, allow_empty: true
+      #   # message: ""     => ['--message', '']
+      #   # message: "text" => ['--message', 'text']
+      #
+      #   value :message  # allow_empty defaults to false
+      #   # message: ""     => [] (skipped)
+      #   # message: "text" => ['--message', 'text']
+      #
+      def value(names, args: nil, type: nil, allow_empty: false)
+        register_option(names, type: :value, args: args, expected_type: type, allow_empty: allow_empty)
       end
 
       # Define an inline valued option (--flag=value as single argument)
       #
       # @param names [Symbol, Array<Symbol>] the option name(s), first is primary
-      # @param flag [String, nil] custom flag string
+      # @param args [String, nil] custom flag string (arrays not supported for value types)
+      # @param type [Class, Array<Class>, nil] expected type(s) for validation. Raises ArgumentError with
+      #   descriptive message if value doesn't match. Cannot be combined with validator:.
+      # @param allow_empty [Boolean] whether to include the flag even when value is an empty string.
+      #   When false (default), empty strings are skipped entirely. When true, the flag with empty
+      #   value is included in the output (e.g., --message=).
       # @return [void]
       #
-      def inline_value(names, flag: nil)
-        register_option(names, type: :inline_value, flag: flag)
+      # @example With type validation
+      #   inline_value :date, type: String
+      #   inline_value :timeout, type: [Integer, Float]
+      #
+      # @example With allow_empty
+      #   inline_value :message, allow_empty: true
+      #   # message: ""     => ['--message=']
+      #   # message: "text" => ['--message=text']
+      #
+      #   inline_value :message  # allow_empty defaults to false
+      #   # message: ""     => [] (skipped)
+      #   # message: "text" => ['--message=text']
+      #
+      def inline_value(names, args: nil, type: nil, allow_empty: false)
+        register_option(names, type: :inline_value, args: args, expected_type: type, allow_empty: allow_empty)
       end
 
       # Define a multi-value option (--flag value repeated for each value)
       #
       # @param names [Symbol, Array<Symbol>] the option name(s), first is primary
-      # @param flag [String, nil] custom flag string
+      # @param args [String, nil] custom flag string (arrays not supported for value types)
+      # @param type [Class, Array<Class>, nil] expected type(s) for validation. Raises ArgumentError with
+      #   descriptive message if value doesn't match. Cannot be combined with validator:.
       # @return [void]
       #
-      def multi_value(names, flag: nil)
-        register_option(names, type: :multi_value, flag: flag)
+      def multi_value(names, args: nil, type: nil)
+        register_option(names, type: :multi_value, args: args, expected_type: type)
+      end
+
+      # Define a flag or inline value option (--flag when true, --flag=value when string)
+      #
+      # When the value is true, outputs just the flag (e.g., --gpg-sign)
+      # When the value is a string, outputs flag with inline value (e.g., --gpg-sign=<key-id>)
+      # When the value is nil/false, outputs nothing
+      #
+      # @param names [Symbol, Array<Symbol>] the option name(s), first is primary
+      # @param args [String, nil] custom flag string (arrays not supported for value types)
+      # @param type [Class, Array<Class>, nil] expected type(s) for validation. Raises ArgumentError with
+      #   descriptive message if value doesn't match. Cannot be combined with validator:.
+      # @return [void]
+      #
+      # @example
+      #   flag_or_inline_value :gpg_sign
+      #   # true  => --gpg-sign
+      #   # "KEY" => --gpg-sign=KEY
+      #   # nil   => (nothing)
+      #
+      def flag_or_inline_value(names, args: nil, type: nil)
+        register_option(names, type: :flag_or_inline_value, args: args, expected_type: type)
+      end
+
+      # Define a negatable flag or inline value option
+      #
+      # When the value is true, outputs just the flag (e.g., --gpg-sign)
+      # When the value is false, outputs negated flag (e.g., --no-gpg-sign)
+      # When the value is a string, outputs flag with inline value (e.g., --gpg-sign=<key-id>)
+      # When the value is nil, outputs nothing
+      #
+      # @param names [Symbol, Array<Symbol>] the option name(s), first is primary
+      # @param args [String, nil] custom flag string (arrays not supported for value types)
+      # @param type [Class, Array<Class>, nil] expected type(s) for validation. Raises ArgumentError with
+      #   descriptive message if value doesn't match. Cannot be combined with validator:.
+      # @return [void]
+      #
+      # @example
+      #   negatable_flag_or_inline_value :gpg_sign
+      #   # true  => --gpg-sign
+      #   # false => --no-gpg-sign
+      #   # "KEY" => --gpg-sign=KEY
+      #   # nil   => (nothing)
+      #
+      def negatable_flag_or_inline_value(names, args: nil, type: nil)
+        register_option(names, type: :negatable_flag_or_inline_value, args: args, expected_type: type)
       end
 
       # Define a static flag that is always included
@@ -117,6 +230,39 @@ module Git
       #
       def metadata(names)
         register_option(names, type: :metadata)
+      end
+
+      # Declare that options conflict with each other (mutually exclusive)
+      #
+      # Each call to {#conflicts} defines a separate group of mutually exclusive
+      # options. When arguments are built, if more than one option in the same
+      # conflict group is provided with a truthy value, an ArgumentError is
+      # raised. Options whose values are `nil` or `false` do not participate in
+      # conflict detection.
+      #
+      # The error message has the general form:
+      #
+      #   "cannot specify :option1 and :option2"
+      #
+      # where the option names correspond to the conflicting options that were
+      # given truthy values.
+      #
+      # @param option_names [Array<Symbol>] the option names that conflict within
+      #   this group
+      # @return [void]
+      #
+      # @raise [ArgumentError] if more than one option in the same conflict group
+      #   is provided with a truthy value when building arguments
+      #
+      # @example Simple conflict group
+      #   conflicts :gpg_sign, :no_gpg_sign
+      #
+      # @example Multiple independent conflict groups
+      #   conflicts :gpg_sign, :no_gpg_sign
+      #   conflicts :force, :no_force
+      #
+      def conflicts(*option_names)
+        @conflicts << option_names.map(&:to_sym)
       end
 
       # Define a positional argument
@@ -148,8 +294,27 @@ module Git
         keys = Array(names)
         primary = keys.first
         definition[:aliases] = keys
+        validate_args_parameter!(definition, primary)
+        apply_type_validator!(definition, primary)
         @option_definitions[primary] = definition
         keys.each { |key| @alias_map[key] = primary }
+      end
+
+      def apply_type_validator!(definition, option_name)
+        return unless definition[:expected_type]
+
+        raise ArgumentError, "cannot specify both type: and validator: for :#{option_name}" if definition[:validator]
+
+        definition[:validator] = create_type_validator(option_name, definition[:expected_type])
+      end
+
+      def validate_args_parameter!(definition, option_name)
+        return unless definition[:args].is_a?(Array)
+        return if %i[flag negatable_flag].include?(definition[:type])
+
+        type = definition[:type]
+        raise ArgumentError,
+              "arrays for args: parameter are only supported for flag types, not :#{type} (option :#{option_name})"
       end
 
       # Build command-line arguments from the given positionals and options
@@ -164,24 +329,64 @@ module Git
         validate_conflicting_aliases!(opts)
         normalized_opts = normalize_aliases(opts)
         validate_option_values!(normalized_opts)
+        validate_conflicts!(normalized_opts)
         args = @static_flags.dup
+        build_options(args, normalized_opts)
+        build_positionals(args, positionals)
+        args
+      end
+
+      def build_options(args, normalized_opts)
         @option_definitions.each do |name, definition|
           build_option(args, name, definition, normalized_opts[name])
         end
-        build_positionals(args, positionals)
-        args
       end
 
       private
 
       BUILDERS = {
-        flag: ->(args, flag_name, value, _) { args << flag_name if value },
-        negatable_flag: lambda do |args, flag_name, value, _|
-          args << (value ? flag_name : flag_name.sub(/\A--/, '--no-'))
+        flag: lambda do |args, arg_spec, value, _|
+          return unless value
+
+          arg_spec.is_a?(Array) ? args.concat(arg_spec) : args << arg_spec
         end,
-        value: ->(args, flag_name, value, _) { args << flag_name << value.to_s },
-        inline_value: ->(args, flag_name, value, _) { args << "#{flag_name}=#{value}" },
-        multi_value: ->(args, flag_name, value, _) { Array(value).each { |v| args << flag_name << v.to_s } },
+        negatable_flag: lambda do |args, arg_spec, value, _|
+          unless [true, false].include?(value)
+            raise ArgumentError,
+                  "negatable_flag expects a boolean value, got #{value.inspect} (#{value.class})"
+          end
+
+          if arg_spec.is_a?(Array)
+            arg_spec.each { |spec| args << (value ? spec : spec.sub(/\A--/, '--no-')) }
+          else
+            args << (value ? arg_spec : arg_spec.sub(/\A--/, '--no-'))
+          end
+        end,
+        value: ->(args, arg_spec, value, _) { args << arg_spec << value.to_s },
+        inline_value: ->(args, arg_spec, value, _) { args << "#{arg_spec}=#{value}" },
+        multi_value: ->(args, arg_spec, value, _) { Array(value).each { |v| args << arg_spec << v.to_s } },
+        flag_or_inline_value: lambda do |args, arg_spec, value, _|
+          unless value.is_a?(TrueClass) || value.is_a?(FalseClass) || value.is_a?(String)
+            raise ArgumentError,
+                  "Invalid value for flag_or_inline_value: #{value.inspect} (#{value.class}); " \
+                  'expected true, false, or a String'
+          end
+          return if value == false
+
+          args << (value == true ? arg_spec : "#{arg_spec}=#{value}")
+        end,
+        negatable_flag_or_inline_value: lambda do |args, arg_spec, value, _|
+          unless value.is_a?(TrueClass) || value.is_a?(FalseClass) || value.is_a?(String)
+            raise ArgumentError,
+                  "Invalid value for negatable_flag_or_inline_value: #{value.inspect} (#{value.class}); " \
+                  'expected true, false, or a String'
+          end
+          args << case value
+                  when true then arg_spec
+                  when false then arg_spec.sub(/\A--/, '--no-')
+                  else "#{arg_spec}=#{value}"
+                  end
+        end,
         custom: lambda do |args, _, value, definition|
           result = definition[:builder]&.call(value)
           result.is_a?(Array) ? args.concat(result) : (args << result if result)
@@ -191,10 +396,17 @@ module Git
       private_constant :BUILDERS
 
       def build_option(args, name, definition, value)
-        return if value.nil? || (value.respond_to?(:empty?) && value.empty?)
+        return if should_skip_option?(value, definition)
 
-        flag_name = definition[:flag] || "--#{name.to_s.tr('_', '-')}"
-        BUILDERS[definition[:type]]&.call(args, flag_name, value, definition)
+        arg_spec = definition[:args] || "--#{name.to_s.tr('_', '-')}"
+        BUILDERS[definition[:type]]&.call(args, arg_spec, value, definition)
+      end
+
+      def should_skip_option?(value, definition)
+        return true if value.nil?
+        return true if value == false && definition[:type] == :flag_or_inline_value
+
+        value.respond_to?(:empty?) && value.empty? && !definition[:allow_empty]
       end
 
       def build_positionals(args, positionals)
@@ -289,9 +501,39 @@ module Git
           validator = definition[:validator]
           next unless validator
           next unless opts.key?(name)
-          next if validator.call(opts[name])
 
-          raise ArgumentError, "Invalid value for option: #{name}"
+          value = opts[name]
+          result = validator.call(value)
+          next if result == true
+
+          # If validator returns a string, use it as the error message
+          # Otherwise, generate a generic error message
+          error_msg = result.is_a?(String) ? result : "Invalid value for option: #{name}"
+          raise ArgumentError, error_msg
+        end
+      end
+
+      def create_type_validator(option_name, expected_type)
+        types = Array(expected_type)
+
+        lambda do |value|
+          return true if value.nil? # nil values are universally skipped by should_skip_option?
+          return true if types.any? { |t| value.is_a?(t) }
+
+          # Generate a helpful error message
+          type_names = types.map(&:name).join(' or ')
+          actual_type = value.class.name
+          "The :#{option_name} option must be a #{type_names}, but was a #{actual_type}"
+        end
+      end
+
+      def validate_conflicts!(opts)
+        @conflicts.each do |conflict_group|
+          provided = conflict_group.select { |name| opts.key?(name) && opts[name] }
+          next if provided.size <= 1
+
+          formatted = provided.map { |name| ":#{name}" }.join(' and ')
+          raise ArgumentError, "cannot specify #{formatted}"
         end
       end
     end

--- a/lib/git/commands/init.rb
+++ b/lib/git/commands/init.rb
@@ -27,7 +27,7 @@ module Git
       ARGS = Arguments.define do
         flag :bare
         inline_value :initial_branch
-        inline_value :repository, flag: '--separate-git-dir'
+        inline_value :repository, args: '--separate-git-dir'
         positional :directory, default: '.'
       end.freeze
 

--- a/lib/git/commands/mv.rb
+++ b/lib/git/commands/mv.rb
@@ -24,10 +24,10 @@ module Git
     class Mv
       # Arguments DSL for building command-line arguments
       ARGS = Arguments.define do
-        flag :force, flag: '--force'
-        flag :dry_run, flag: '--dry-run'
-        flag :verbose, flag: '--verbose'
-        flag :skip_errors, flag: '-k'
+        flag :force, args: '--force'
+        flag :dry_run, args: '--dry-run'
+        flag :verbose, args: '--verbose'
+        flag :skip_errors, args: '-k'
         positional :source, variadic: true, separator: '--'
         positional :destination
       end.freeze

--- a/lib/git/commands/rm.rb
+++ b/lib/git/commands/rm.rb
@@ -30,8 +30,8 @@ module Git
     class Rm
       # Arguments DSL for building command-line arguments
       ARGS = Arguments.define do
-        flag :force, flag: '-f'
-        flag :recursive, flag: '-r'
+        flag :force, args: '-f'
+        flag :recursive, args: '-r'
         flag :cached
         positional :paths, variadic: true, required: true, separator: '--'
       end.freeze

--- a/spec/git/commands/arguments_spec.rb
+++ b/spec/git/commands/arguments_spec.rb
@@ -49,6 +49,13 @@ RSpec.describe Git::Commands::Arguments do
       it 'outputs nothing when option is not provided' do
         expect(args.build).to eq([])
       end
+
+      it 'raises an error when value is not a boolean' do
+        expect { args.build(full: 'true') }.to raise_error(
+          ArgumentError,
+          /negatable_flag expects a boolean value, got "true"/
+        )
+      end
     end
 
     context 'with value options' do
@@ -88,6 +95,68 @@ RSpec.describe Git::Commands::Arguments do
 
       it 'outputs nothing when option is not provided' do
         expect(args.build).to eq([])
+      end
+    end
+
+    context 'with flag_or_inline_value options' do
+      let(:args) do
+        described_class.define do
+          flag_or_inline_value :gpg_sign
+        end
+      end
+
+      it 'outputs --flag when value is true' do
+        expect(args.build(gpg_sign: true)).to eq(['--gpg-sign'])
+      end
+
+      it 'outputs nothing when value is false' do
+        expect(args.build(gpg_sign: false)).to eq([])
+      end
+
+      it 'outputs --flag=value when value is a string' do
+        expect(args.build(gpg_sign: 'key-id')).to eq(['--gpg-sign=key-id'])
+      end
+
+      it 'outputs nothing when option is not provided' do
+        expect(args.build).to eq([])
+      end
+
+      it 'raises an error when value is not true, false, or a String' do
+        expect { args.build(gpg_sign: 1) }.to raise_error(
+          ArgumentError,
+          /Invalid value for flag_or_inline_value: 1 \(Integer\); expected true, false, or a String/
+        )
+      end
+    end
+
+    context 'with negatable_flag_or_inline_value options' do
+      let(:args) do
+        described_class.define do
+          negatable_flag_or_inline_value :sign
+        end
+      end
+
+      it 'outputs --flag when value is true' do
+        expect(args.build(sign: true)).to eq(['--sign'])
+      end
+
+      it 'outputs --no-flag when value is false' do
+        expect(args.build(sign: false)).to eq(['--no-sign'])
+      end
+
+      it 'outputs --flag=value when value is a string' do
+        expect(args.build(sign: 'key-id')).to eq(['--sign=key-id'])
+      end
+
+      it 'outputs nothing when option is not provided' do
+        expect(args.build).to eq([])
+      end
+
+      it 'raises an error when value is not true, false, or a String' do
+        expect { args.build(sign: 1) }.to raise_error(
+          ArgumentError,
+          /Invalid value for negatable_flag_or_inline_value: 1 \(Integer\); expected true, false, or a String/
+        )
       end
     end
 
@@ -312,8 +381,8 @@ RSpec.describe Git::Commands::Arguments do
     context 'with custom flag names' do
       let(:args) do
         described_class.define do
-          flag :recursive, flag: '-r'
-          value :skip, flag: '--skip-worktree'
+          flag :recursive, args: '-r'
+          value :skip, args: '--skip-worktree'
         end
       end
 
@@ -410,7 +479,7 @@ RSpec.describe Git::Commands::Arguments do
       end
 
       it 'allows custom flag with aliases' do
-        args = described_class.define { flag %i[recursive r], flag: '-R' }
+        args = described_class.define { flag %i[recursive r], args: '-R' }
         expect(args.build(recursive: true)).to eq(['-R'])
         expect(args.build(r: true)).to eq(['-R'])
       end
@@ -443,6 +512,414 @@ RSpec.describe Git::Commands::Arguments do
 
       it 'accepts all valid values' do
         expect(args.build('file1.rb', 'file2.rb')).to eq(%w[file1.rb file2.rb])
+      end
+    end
+
+    context 'with args: parameter arrays' do
+      it 'supports arrays for flag type' do
+        args = described_class.define do
+          flag :amend, args: ['--amend', '--no-edit']
+        end
+        expect(args.build(amend: true)).to eq(['--amend', '--no-edit'])
+      end
+
+      it 'supports arrays for negatable_flag type' do
+        args = described_class.define do
+          negatable_flag :verbose, args: ['--verbose', '--all']
+        end
+        expect(args.build(verbose: true)).to eq(['--verbose', '--all'])
+        expect(args.build(verbose: false)).to eq(['--no-verbose', '--no-all'])
+      end
+
+      it 'rejects arrays for value type' do
+        expect do
+          described_class.define do
+            value :branch, args: ['--branch', '--set-upstream']
+          end
+        end.to raise_error(ArgumentError, /arrays for args: parameter are only supported for flag types/)
+      end
+
+      it 'rejects arrays for inline_value type' do
+        expect do
+          described_class.define do
+            inline_value :message, args: ['--message', '--edit']
+          end
+        end.to raise_error(ArgumentError, /arrays for args: parameter are only supported for flag types/)
+      end
+
+      it 'rejects arrays for multi_value type' do
+        expect do
+          described_class.define do
+            multi_value :config, args: ['--config', '--global']
+          end
+        end.to raise_error(ArgumentError, /arrays for args: parameter are only supported for flag types/)
+      end
+
+      it 'rejects arrays for flag_or_inline_value type' do
+        expect do
+          described_class.define do
+            flag_or_inline_value :gpg_sign, args: ['--gpg-sign', '--verify']
+          end
+        end.to raise_error(ArgumentError, /arrays for args: parameter are only supported for flag types/)
+      end
+
+      it 'rejects arrays for negatable_flag_or_inline_value type' do
+        expect do
+          described_class.define do
+            negatable_flag_or_inline_value :sign, args: ['--sign', '--verify']
+          end
+        end.to raise_error(ArgumentError, /arrays for args: parameter are only supported for flag types/)
+      end
+    end
+
+    context 'with allow_empty parameter' do
+      context 'for value types' do
+        let(:args_without_allow_empty) do
+          described_class.define do
+            value :message
+          end
+        end
+
+        let(:args_with_allow_empty) do
+          described_class.define do
+            value :message, allow_empty: true
+          end
+        end
+
+        it 'skips empty string by default' do
+          expect(args_without_allow_empty.build(message: '')).to eq([])
+        end
+
+        it 'includes empty string when allow_empty is true' do
+          expect(args_with_allow_empty.build(message: '')).to eq(['--message', ''])
+        end
+
+        it 'includes non-empty string regardless of allow_empty' do
+          expect(args_without_allow_empty.build(message: 'hello')).to eq(['--message', 'hello'])
+          expect(args_with_allow_empty.build(message: 'hello')).to eq(['--message', 'hello'])
+        end
+      end
+
+      context 'for inline_value types' do
+        let(:args_without_allow_empty) do
+          described_class.define do
+            inline_value :abbrev
+          end
+        end
+
+        let(:args_with_allow_empty) do
+          described_class.define do
+            inline_value :abbrev, allow_empty: true
+          end
+        end
+
+        it 'skips empty string by default' do
+          expect(args_without_allow_empty.build(abbrev: '')).to eq([])
+        end
+
+        it 'includes empty string when allow_empty is true' do
+          expect(args_with_allow_empty.build(abbrev: '')).to eq(['--abbrev='])
+        end
+
+        it 'includes non-empty string regardless of allow_empty' do
+          expect(args_without_allow_empty.build(abbrev: '7')).to eq(['--abbrev=7'])
+          expect(args_with_allow_empty.build(abbrev: '7')).to eq(['--abbrev=7'])
+        end
+      end
+
+      context 'for multi_value types' do
+        let(:args) do
+          described_class.define do
+            multi_value :config
+          end
+        end
+
+        it 'skips empty array' do
+          expect(args.build(config: [])).to eq([])
+        end
+
+        it 'includes empty strings in array (no filtering)' do
+          expect(args.build(config: ['', 'value'])).to eq(['--config', '', '--config', 'value'])
+        end
+
+        it 'processes all non-empty values' do
+          expect(args.build(config: %w[a b c])).to eq(['--config', 'a', '--config', 'b', '--config', 'c'])
+        end
+      end
+    end
+
+    context 'with type: parameter for validation' do
+      context 'with String type' do
+        let(:args) do
+          described_class.define do
+            value :message, type: String
+          end
+        end
+
+        it 'accepts String values' do
+          expect(args.build(message: 'hello')).to eq(['--message', 'hello'])
+        end
+
+        it 'accepts nil values (skips validation and output)' do
+          expect(args.build(message: nil)).to eq([])
+        end
+
+        it 'raises descriptive error for non-String values' do
+          expect { args.build(message: 123) }.to raise_error(
+            ArgumentError,
+            /The :message option must be a String, but was a Integer/
+          )
+        end
+      end
+
+      context 'with Integer type' do
+        let(:args) do
+          described_class.define do
+            value :depth, type: Integer
+          end
+        end
+
+        it 'accepts Integer values' do
+          expect(args.build(depth: 42)).to eq(['--depth', '42'])
+        end
+
+        it 'accepts nil values (skips validation and output)' do
+          expect(args.build(depth: nil)).to eq([])
+        end
+
+        it 'raises descriptive error for non-Integer values' do
+          expect { args.build(depth: 'not a number') }.to raise_error(
+            ArgumentError,
+            /The :depth option must be a Integer, but was a String/
+          )
+        end
+      end
+
+      context 'with Array type' do
+        let(:args) do
+          described_class.define do
+            multi_value :paths, type: Array
+          end
+        end
+
+        it 'accepts Array values' do
+          expect(args.build(paths: %w[a b])).to eq(['--paths', 'a', '--paths', 'b'])
+        end
+
+        it 'accepts nil values (skips validation and output)' do
+          expect(args.build(paths: nil)).to eq([])
+        end
+
+        it 'raises descriptive error for non-Array values' do
+          expect { args.build(paths: 'single') }.to raise_error(
+            ArgumentError,
+            /The :paths option must be a Array, but was a String/
+          )
+        end
+      end
+
+      context 'with multiple options having type validation' do
+        let(:args) do
+          described_class.define do
+            value :message, type: String
+            value :depth, type: Integer
+          end
+        end
+
+        it 'validates all typed options independently' do
+          expect(args.build(message: 'hello', depth: 5)).to eq(['--message', 'hello', '--depth', '5'])
+        end
+
+        it 'raises error for first invalid option encountered' do
+          expect { args.build(message: 123, depth: 'invalid') }.to raise_error(
+            ArgumentError,
+            /The :message option must be a String, but was a Integer/
+          )
+        end
+      end
+
+      context 'with multiple allowed types' do
+        let(:args) do
+          described_class.define do
+            value :timeout, type: [Integer, Float]
+          end
+        end
+
+        it 'accepts first type' do
+          expect(args.build(timeout: 30)).to eq(['--timeout', '30'])
+        end
+
+        it 'accepts second type' do
+          expect(args.build(timeout: 30.5)).to eq(['--timeout', '30.5'])
+        end
+
+        it 'raises descriptive error for invalid type' do
+          expect { args.build(timeout: 'thirty') }.to raise_error(
+            ArgumentError,
+            /The :timeout option must be a Integer or Float, but was a String/
+          )
+        end
+      end
+
+      context 'when type: and validator: are both specified' do
+        it 'raises an error at definition time' do
+          expect do
+            described_class.define do
+              negatable_flag :single_branch, type: String, validator: ->(v) { [true, false].include?(v) }
+            end
+          end.to raise_error(ArgumentError, /cannot specify both type: and validator: for :single_branch/)
+        end
+      end
+    end
+
+    context 'with conflicts method' do
+      context 'with two conflicting options' do
+        let(:args) do
+          described_class.define do
+            flag :patch
+            flag :stat
+            conflicts :patch, :stat
+          end
+        end
+
+        it 'allows using neither option' do
+          expect(args.build).to eq([])
+        end
+
+        it 'allows using only first option' do
+          expect(args.build(patch: true)).to eq(['--patch'])
+        end
+
+        it 'allows using only second option' do
+          expect(args.build(stat: true)).to eq(['--stat'])
+        end
+
+        it 'raises error when both options are provided' do
+          expect { args.build(patch: true, stat: true) }.to raise_error(
+            ArgumentError,
+            /cannot specify :patch and :stat/
+          )
+        end
+
+        it 'allows false values (does not trigger conflict)' do
+          expect(args.build(patch: true, stat: false)).to eq(['--patch'])
+          expect(args.build(patch: false, stat: true)).to eq(['--stat'])
+        end
+
+        it 'allows nil values (does not trigger conflict)' do
+          expect(args.build(patch: true, stat: nil)).to eq(['--patch'])
+        end
+      end
+
+      context 'with multiple conflicting options' do
+        let(:args) do
+          described_class.define do
+            flag :patch
+            flag :stat
+            flag :summary
+            conflicts :patch, :stat, :summary
+          end
+        end
+
+        it 'raises error when any two options are provided' do
+          expect { args.build(patch: true, stat: true) }.to raise_error(
+            ArgumentError,
+            /cannot specify :patch and :stat/
+          )
+          expect { args.build(patch: true, summary: true) }.to raise_error(
+            ArgumentError,
+            /cannot specify :patch and :summary/
+          )
+          expect { args.build(stat: true, summary: true) }.to raise_error(
+            ArgumentError,
+            /cannot specify :stat and :summary/
+          )
+        end
+
+        it 'raises error when all three options are provided' do
+          expect { args.build(patch: true, stat: true, summary: true) }.to raise_error(
+            ArgumentError,
+            /cannot specify :patch and :stat/
+          )
+        end
+      end
+
+      context 'with multiple conflict groups' do
+        let(:args) do
+          described_class.define do
+            flag :patch
+            flag :stat
+            flag :quiet
+            flag :verbose
+            conflicts :patch, :stat
+            conflicts :quiet, :verbose
+          end
+        end
+
+        it 'validates each conflict group independently' do
+          # Allowed: patch with verbose
+          expect(args.build(patch: true, verbose: true)).to eq(['--patch', '--verbose'])
+          # Allowed: stat with quiet
+          expect(args.build(stat: true, quiet: true)).to eq(['--stat', '--quiet'])
+        end
+
+        it 'raises error when first conflict group violated' do
+          expect { args.build(patch: true, stat: true, verbose: true) }.to raise_error(
+            ArgumentError,
+            /cannot specify :patch and :stat/
+          )
+        end
+
+        it 'raises error when second conflict group violated' do
+          expect { args.build(patch: true, quiet: true, verbose: true) }.to raise_error(
+            ArgumentError,
+            /cannot specify :quiet and :verbose/
+          )
+        end
+      end
+
+      context 'with conflicts on valued options' do
+        let(:args) do
+          described_class.define do
+            value :branch
+            value :tag
+            conflicts :branch, :tag
+          end
+        end
+
+        it 'raises error when both valued options provided' do
+          expect { args.build(branch: 'main', tag: 'v1.0') }.to raise_error(
+            ArgumentError,
+            /cannot specify :branch and :tag/
+          )
+        end
+
+        it 'allows one valued option' do
+          expect(args.build(branch: 'main')).to eq(['--branch', 'main'])
+          expect(args.build(tag: 'v1.0')).to eq(['--tag', 'v1.0'])
+        end
+      end
+
+      context 'with conflicts on mixed option types' do
+        let(:args) do
+          described_class.define do
+            flag :all
+            value :since
+            conflicts :all, :since
+          end
+        end
+
+        it 'raises error when flag and value both provided' do
+          expect { args.build(all: true, since: '2020-01-01') }.to raise_error(
+            ArgumentError,
+            /cannot specify :all and :since/
+          )
+        end
+
+        it 'allows either option alone' do
+          expect(args.build(all: true)).to eq(['--all'])
+          expect(args.build(since: '2020-01-01')).to eq(['--since', '2020-01-01'])
+        end
       end
     end
   end


### PR DESCRIPTION
## Description

This PR adds six major enhancements to the `Git::Commands::Arguments` DSL, making it more powerful and eliminating the need for custom validation blocks in command definitions.

## Changes

### 1. `allow_empty` parameter for value/inline_value types
Allows empty strings to be passed through (e.g., `--message=` for empty commit messages):
```ruby
inline_value :message, allow_empty: true
```

### 2. `conflicts` method for declarative conflict detection
Define mutually exclusive options directly in ARGS:
```ruby
conflicts :gpg_sign, :no_gpg_sign
```

### 3. `args:` parameter with array support
Renamed from `flag:` with added array support for multi-flag options:
```ruby
flag :amend, args: ['--amend', '--no-edit']
```

### 4. `flag_or_inline_value` type
Handles boolean-or-valued options:
- `true` → outputs `--flag`
- `String` → outputs `--flag=value`
- `false`/`nil` → outputs nothing

### 5. `type:` parameter for declarative validation
Type validation with descriptive errors:
```ruby
inline_value :date, type: String
# Error: "The :date option must be a String, but was a Integer"
```

### 6. `negatable_flag_or_inline_value` type
Tri-state options with negation:
- `true` → outputs `--flag`
- `false` → outputs `--no-flag`
- `String` → outputs `--flag=value`
- `nil` → outputs nothing

## Impact

These enhancements make command definitions:
- ✅ More declarative (no custom validation blocks needed)
- ✅ More maintainable (clearer intent)
- ✅ More consistent (uniform validation patterns)

## Updated Files

- `lib/git/commands/arguments.rb` - Core DSL enhancements
- `spec/git/commands/arguments_spec.rb` - Test coverage for new features
- `lib/git/commands/init.rb` - Updated to use `args:`
- `lib/git/commands/mv.rb` - Updated to use `args:`
- `lib/git/commands/rm.rb` - Updated to use `args:`

## Testing

All tests pass:
- ✅ 219 RSpec examples, 0 failures
- ✅ 528 legacy tests, 0 failures
- ✅ RuboCop clean