### PR TITLE
refactor: migrate commit command to Git::Commands::Commit

### DIFF
--- a/lib/git/commands/commit.rb
+++ b/lib/git/commands/commit.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+
+module Git
+  module Commands
+    # Implements the `git commit` command
+    #
+    # This command records changes to the repository by creating a new commit
+    # with the staged changes.
+    #
+    # @see https://git-scm.com/docs/git-commit git-commit
+    #
+    # @api private
+    #
+    # @example Basic usage
+    #   commit = Git::Commands::Commit.new(execution_context)
+    #   commit.call(message: 'Initial commit')
+    #
+    # @example With options
+    #   commit = Git::Commands::Commit.new(execution_context)
+    #   commit.call(message: 'Add feature', all: true, author: 'Jane <jane@example.com>')
+    #
+    # @example Amending the previous commit
+    #   commit = Git::Commands::Commit.new(execution_context)
+    #   commit.call(amend: true)
+    #
+    class Commit
+      # Arguments DSL for building command-line arguments
+      #
+      # NOTE: The order of definitions here determines the order of arguments
+      # in the final command line. This order matches the original COMMIT_OPTION_MAP
+      # for backward compatibility with existing tests.
+      #
+      ARGS = Arguments.define do
+        flag %i[all add_all]
+        flag :allow_empty
+        flag :no_verify
+        flag :allow_empty_message
+        inline_value :author
+        inline_value :message, allow_empty: true
+        inline_value :date, type: String
+        flag :amend, args: ['--amend', '--no-edit']
+        negatable_flag_or_inline_value :gpg_sign
+      end.freeze
+
+      # Initialize the Commit command
+      #
+      # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
+      #
+      def initialize(execution_context)
+        @execution_context = execution_context
+      end
+
+      # Execute the git commit command
+      #
+      # @overload call(message: nil, all: nil, add_all: nil, allow_empty: nil,
+      #   allow_empty_message: nil, amend: nil, author: nil, date: nil,
+      #   no_verify: nil, gpg_sign: nil)
+      #
+      #   @param message [String] The commit message
+      #
+      #   @param all [Boolean] Automatically stage all modified and deleted files
+      #     before committing (alias: add_all)
+      #
+      #   @param add_all [Boolean] Alias for :all
+      #
+      #   @param allow_empty [Boolean] Allow creating a commit with no changes
+      #
+      #   @param allow_empty_message [Boolean] Allow creating a commit with an empty message
+      #
+      #   @param amend [Boolean] Amend the previous commit instead of creating a new one.
+      #     When true, --no-edit is also added to prevent opening an editor.
+      #
+      #   @param author [String] Override the commit author in the format 'Name <email>'
+      #
+      #   @param date [String] Override the author date. Must be a string in a format
+      #     that git understands (e.g., '2023-01-15T10:30:00', 'now', 'yesterday')
+      #
+      #   @param no_verify [Boolean] Bypass the pre-commit and commit-msg hooks
+      #
+      #   @param gpg_sign [Boolean, String, false] GPG-sign the commit. When true, uses the
+      #     default key. When a string, uses the specified key ID. When false, adds --no-gpg-sign
+      #     to override any commit.gpgsign configuration.
+      #
+      # @return [String] the command output
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      # @raise [ArgumentError] if :date is not a String
+      #
+      def call(**)
+        args = ARGS.build(**)
+        @execution_context.command('commit', *args)
+      end
+    end
+  end
+end

--- a/redesign/2_architecture_redesign.md
+++ b/redesign/2_architecture_redesign.md
@@ -117,6 +117,30 @@ into three distinct layers: a Facade, an Execution Context, and Command Objects.
        `ExecutionContext#command` and converting it into rich, structured Ruby
        objects.
 
+    **Migration Strategy: Git::Lib as Adapter Layer**
+
+    During the migration to this architecture, `Git::Lib` methods serve as **adapters**
+    between the legacy public interface and the new `Git::Commands::*` classes. This
+    separation ensures backward compatibility while enabling incremental migration:
+
+    - **Legacy Interface Acceptance**: `Git::Lib` methods continue to accept the
+      historical interface—positional arguments, deprecated options, and quirky
+      parameter names.
+
+    - **Interface Translation**: The adapter converts legacy patterns to the clean
+      `Git::Commands::*` API (e.g., positional `message` → `:message` keyword,
+      `:no_gpg_sign => true` → `:gpg_sign => false`).
+
+    - **Deprecation Handling**: Warnings about deprecated options are issued in the
+      adapter layer before delegating, ensuring users are informed even if they make
+      other errors.
+
+    - **Clean Command Classes**: `Git::Commands::*` classes remain free of legacy
+      baggage with a consistent, modern API.
+
+    Once all commands are migrated and deprecation periods end, the adapter logic can
+    be simplified or moved to the new facade layer (`Git::Repository`).
+
     **Arguments DSL**: To standardize argument building across commands, a declarative
     `Git::Commands::Arguments` DSL is provided. This allows each command to define its
     accepted arguments in a clear, self-documenting way:

--- a/spec/git/commands/commit_spec.rb
+++ b/spec/git/commands/commit_spec.rb
@@ -1,0 +1,171 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::Commands::Commit do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with a simple message' do
+      it 'commits with the given message' do
+        expect(execution_context).to receive(:command).with('commit', '--message=Initial commit')
+
+        command.call(message: 'Initial commit')
+      end
+    end
+
+    context 'with the :all option' do
+      it 'includes the --all flag' do
+        expect(execution_context).to receive(:command).with('commit', '--all', '--message=Add all changes')
+
+        command.call(message: 'Add all changes', all: true)
+      end
+
+      it 'also accepts :add_all as an alias' do
+        expect(execution_context).to receive(:command).with('commit', '--all', '--message=Add all changes')
+
+        command.call(message: 'Add all changes', add_all: true)
+      end
+
+      it 'does not include the flag when false' do
+        expect(execution_context).to receive(:command).with('commit', '--message=Message')
+
+        command.call(message: 'Message', all: false)
+      end
+    end
+
+    context 'with the :allow_empty option' do
+      it 'includes the --allow-empty flag' do
+        expect(execution_context).to receive(:command).with('commit', '--allow-empty', '--message=Empty commit')
+
+        command.call(message: 'Empty commit', allow_empty: true)
+      end
+    end
+
+    context 'with the :allow_empty_message option' do
+      it 'includes the --allow-empty-message flag without a message' do
+        expect(execution_context).to receive(:command).with('commit', '--allow-empty-message')
+
+        command.call(allow_empty_message: true)
+      end
+    end
+
+    context 'with the :no_verify option' do
+      it 'includes the --no-verify flag' do
+        expect(execution_context).to receive(:command).with('commit', '--no-verify', '--message=Skip hooks')
+
+        command.call(message: 'Skip hooks', no_verify: true)
+      end
+    end
+
+    context 'with the :author option' do
+      it 'includes the --author flag with the specified value' do
+        expect(execution_context).to receive(:command).with(
+          'commit',
+          '--author=John Doe <john@example.com>',
+          '--message=Authored commit'
+        )
+
+        command.call(message: 'Authored commit', author: 'John Doe <john@example.com>')
+      end
+    end
+
+    context 'with the :date option' do
+      it 'includes the --date flag with the specified value' do
+        expect(execution_context).to receive(:command).with(
+          'commit',
+          '--message=Dated commit',
+          '--date=2023-01-15T10:30:00'
+        )
+
+        command.call(message: 'Dated commit', date: '2023-01-15T10:30:00')
+      end
+
+      it 'raises an error when date is not a string' do
+        expect { command.call(message: 'Commit', date: Time.now) }.to(
+          raise_error(ArgumentError, /The :date option must be a String, but was a Time/)
+        )
+      end
+    end
+
+    context 'with the :amend option' do
+      it 'includes --amend and --no-edit flags' do
+        expect(execution_context).to receive(:command).with('commit', '--amend', '--no-edit')
+
+        command.call(amend: true)
+      end
+
+      it 'does not include the flags when false' do
+        expect(execution_context).to receive(:command).with('commit', '--message=Normal commit')
+
+        command.call(message: 'Normal commit', amend: false)
+      end
+    end
+
+    context 'with GPG signing options' do
+      context 'when :gpg_sign is true' do
+        it 'includes --gpg-sign flag' do
+          expect(execution_context).to receive(:command).with('commit', '--message=Signed commit', '--gpg-sign')
+
+          command.call(message: 'Signed commit', gpg_sign: true)
+        end
+      end
+
+      context 'when :gpg_sign is a key ID' do
+        it 'includes --gpg-sign with the key ID' do
+          expect(execution_context).to receive(:command).with(
+            'commit',
+            '--message=Signed commit',
+            '--gpg-sign=ABCD1234'
+          )
+
+          command.call(message: 'Signed commit', gpg_sign: 'ABCD1234')
+        end
+      end
+
+      context 'when :gpg_sign is false' do
+        it 'includes --no-gpg-sign flag' do
+          expect(execution_context).to receive(:command).with('commit', '--message=Unsigned commit', '--no-gpg-sign')
+
+          command.call(message: 'Unsigned commit', gpg_sign: false)
+        end
+      end
+    end
+
+    context 'with multiple options combined' do
+      it 'includes all specified flags' do
+        expect(execution_context).to receive(:command).with(
+          'commit',
+          '--all',
+          '--no-verify',
+          '--author=Jane <jane@example.com>',
+          '--message=Combined options'
+        )
+
+        command.call(
+          message: 'Combined options',
+          all: true,
+          no_verify: true,
+          author: 'Jane <jane@example.com>'
+        )
+      end
+    end
+
+    context 'with unsupported options' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(message: 'Commit', invalid_option: true) }.to(
+          raise_error(ArgumentError, /Unsupported options: :invalid_option/)
+        )
+      end
+    end
+
+    context 'with conflicting aliases' do
+      it 'raises ArgumentError when both :all and :add_all are provided' do
+        expect { command.call(message: 'Commit', all: true, add_all: true) }.to(
+          raise_error(ArgumentError, /Conflicting options/)
+        )
+      end
+    end
+  end
+end

--- a/tests/units/test_commit_with_gpg.rb
+++ b/tests/units/test_commit_with_gpg.rb
@@ -21,12 +21,16 @@ class TestCommitWithGPG < Test::Unit::TestCase
   end
 
   def test_disabling_gpg_sign
+    Git::Deprecation.expects(:warn).with(':no_gpg_sign option is deprecated. Use :gpg_sign => false instead.')
+
     message = 'My commit message'
     expected_command_line = ['commit', "--message=#{message}", '--no-gpg-sign', {}]
     assert_command_line_eq(expected_command_line) { |g| g.commit(message, no_gpg_sign: true) }
   end
 
   def test_conflicting_gpg_sign_options
+    Git::Deprecation.expects(:warn).with(':no_gpg_sign option is deprecated. Use :gpg_sign => false instead.')
+
     Dir.mktmpdir do |dir|
       git = Git.init(dir)
       message = 'My commit message'


### PR DESCRIPTION
## Summary

Migrate the `commit` command from the ArgsBuilder pattern to the new `Git::Commands::*` architecture using the Arguments DSL.

This is part of Phase 2 of the architectural redesign documented in `redesign/`.

## Changes

- **Add `lib/git/commands/commit.rb`**: New commit command implementation using Arguments DSL
- **Add `spec/git/commands/commit_spec.rb`**: Comprehensive RSpec tests (18 examples)
- **Update `lib/git/lib.rb`**: Delegate to new command class with backward compatibility
- **Update `redesign/3_architecture_implementation.md`**: Mark commit as migrated

## Arguments DSL Features Used

This migration demonstrates several Arguments DSL features:

| Feature | Usage |
|---------|-------|
| `flag` with aliases | `:all` / `:add_all` |
| `inline_value` with `allow_empty: true` | `:message` (supports empty commit messages) |
| `inline_value` with `type: String` | `:date` (validates date is a string) |
| `flag` with `args:` array | `:amend` (outputs `--amend --no-edit`) |
| `negatable_flag_or_inline_value` | `:gpg_sign` (handles `true`, `false`, and key IDs) |

## Backward Compatibility

The `:no_gpg_sign` option is preserved for backward compatibility:
- `no_gpg_sign: true` is converted to `gpg_sign: false`
- Using both `:gpg_sign` and `:no_gpg_sign` raises an error (original behavior)

## Test Results

- ✅ 528 legacy tests pass
- ✅ 276 RSpec examples pass (including 18 new commit tests)
- ✅ RuboCop: No offenses
- ✅ YARD: No warnings