### PR TITLE
Migrate reset command to Git::Commands::Reset (8/~50 commands)

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -402,7 +402,14 @@ module Git
     end
 
     # resets the working directory to the commitish with '--hard'
+    #
+    # @deprecated Use {#reset} with `hard: true` instead.
+    #
     def reset_hard(commitish = nil, opts = {})
+      Git::Deprecation.warn(
+        'Git::Base#reset_hard is deprecated and will be removed in a future version. ' \
+        'Use Git::Base#reset(commitish, hard: true) instead.'
+      )
       opts = { hard: true }.merge(opts)
       lib.reset(commitish, opts)
     end

--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -42,7 +42,7 @@ module Git
       if yield
         @base.commit_all(message)
       else
-        @base.reset_hard
+        @base.reset(nil, hard: true)
       end
       @base.checkout(old_current)
     end

--- a/lib/git/commands/reset.rb
+++ b/lib/git/commands/reset.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+
+module Git
+  module Commands
+    # Implements the `git reset` command
+    #
+    # This command resets the current HEAD to the specified state. It can be used to
+    # unstage files, move the HEAD pointer, or reset the working directory.
+    #
+    # @api private
+    #
+    # @example Reset to HEAD (default)
+    #   reset = Git::Commands::Reset.new(execution_context)
+    #   reset.call
+    #
+    # @example Reset to a specific commit
+    #   reset.call('HEAD~1')
+    #   reset.call('abc123def')
+    #
+    # @example Hard reset (resets index and working directory)
+    #   reset.call('HEAD~1', hard: true)
+    #
+    # @example Soft reset (keeps changes staged)
+    #   reset.call('HEAD~1', soft: true)
+    #
+    # @example Mixed reset (keeps changes unstaged)
+    #   reset.call('HEAD~1', mixed: true)
+    #
+    class Reset
+      # Arguments DSL for building command-line arguments
+      ARGS = Arguments.define do
+        flag :hard
+        flag :soft
+        flag :mixed
+        conflicts :hard, :soft, :mixed
+        positional :commit, required: false
+      end.freeze
+
+      # Initialize the Reset command
+      #
+      # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
+      #
+      def initialize(execution_context)
+        @execution_context = execution_context
+      end
+
+      # Execute the git reset command
+      #
+      # @overload call(commit = nil, hard: nil, soft: nil, mixed: nil)
+      #
+      #   @param commit [String, nil] the commit to reset to (defaults to HEAD if not specified)
+      #
+      #   @param hard [Boolean] reset the index and working tree. Any changes to tracked
+      #     files in the working tree since the commit are discarded
+      #
+      #   @param soft [Boolean] does not touch the index file or the working tree at all,
+      #     but resets the head to the commit
+      #
+      #   @param mixed [Boolean] resets the index but not the working tree (i.e., the
+      #     changed files are preserved but not marked for commit)
+      #
+      # @raise [ArgumentError] if more than one of :hard, :soft, or :mixed is specified
+      #
+      # @return [String] the command output (typically empty on success)
+      #
+      def call(commit = nil, **)
+        args = ARGS.build(commit, **)
+        @execution_context.command('reset', *args)
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -7,6 +7,7 @@ require_relative 'commands/commit'
 require_relative 'commands/fsck'
 require_relative 'commands/init'
 require_relative 'commands/mv'
+require_relative 'commands/reset'
 require_relative 'commands/rm'
 
 require 'git/command_line'
@@ -1152,14 +1153,8 @@ module Git
       Git::Commands::Commit.new(self).call(**opts)
     end
 
-    RESET_OPTION_MAP = [
-      { keys: [:hard], flag: '--hard', type: :boolean }
-    ].freeze
-
-    def reset(commit, opts = {})
-      args = build_args(opts, RESET_OPTION_MAP)
-      args << commit if commit
-      command('reset', *args)
+    def reset(commit = nil, opts = {})
+      Git::Commands::Reset.new(self).call(commit, **opts)
     end
 
     CLEAN_OPTION_MAP = [

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,24 +22,24 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (7/~50 commands migrated) |
+| Phase 2 | 🔄 In Progress | Migrating commands (8/~50 commands migrated) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate the `reset` command** → `Git::Commands::Reset`
+**Migrate the `clean` command** → `Git::Commands::Clean`
 
 #### Workflow
 
 1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def
-   reset`). Understand all options and edge cases.
+   clean`). Understand all options and edge cases.
 
-2. **Design**: Create `lib/git/commands/reset.rb` with a `Git::Commands::Reset` class
+2. **Design**: Create `lib/git/commands/clean.rb` with a `Git::Commands::Clean` class
    following the pattern in `lib/git/commands/commit.rb`. The interface for
-   `Git::Commands::Reset#call` should match the public interface for `Git::Base#reset`
+   `Git::Commands::Clean#call` should match the public interface for `Git::Base#clean`
 
-3. **TDD**: Write `spec/git/commands/reset_spec.rb` *before* implementing:
+3. **TDD**: Write `spec/git/commands/clean_spec.rb` *before* implementing:
    - Test every option using separate `context` blocks
    - Mock the execution context with `double('ExecutionContext')`
    - Verify argument building matches expected git CLI args
@@ -50,11 +50,11 @@ risk and allows for a gradual, controlled migration to the new architecture.
      tags
    - Mark class with `@api private`
 
-5. **Delegate**: Update `Git::Lib#mv` to delegate to the new class:
+5. **Delegate**: Update `Git::Lib#clean` to delegate to the new class:
 
    ```ruby
-   def mv(source, destination, options = {})
-     Git::Commands::Mv.new(self).call(*Array(source), destination, **options)
+   def clean(options = {})
+     Git::Commands::Clean.new(self).call(**options)
    end
    ```
 
@@ -63,7 +63,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
    using `**options`.
 
 6. **Verify**:
-   - `bundle exec rspec spec/git/commands/mv_spec.rb` — new tests pass
+   - `bundle exec rspec spec/git/commands/clean_spec.rb` — new tests pass
    - `bundle exec rspec` — all RSpec tests pass
    - `bundle exec rake test` — legacy TestUnit tests pass
    - `bundle exec rubocop` — no lint errors
@@ -72,7 +72,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
    To run a single legacy test: `bundle exec bin/test test_<name>` (e.g., `bundle
    exec bin/test test_archive`)
 
-7. **Update Checklist**: Move `reset` from "Commands To Migrate" to "Migrated
+7. **Update Checklist**: Move `clean` from "Commands To Migrate" to "Migrated
    Commands" table in this document, and update the "Next Task" section to point to
    the next command in the list.
 
@@ -307,6 +307,7 @@ The following tracks the migration status of commands from `Git::Lib` to
 | `fsck` | `Git::Commands::Fsck` | `spec/git/commands/fsck_spec.rb` | `git fsck` |
 | `init` | `Git::Commands::Init` | `spec/git/commands/init_spec.rb` | `git init` |
 | `mv` | `Git::Commands::Mv` | `spec/git/commands/mv_spec.rb` | `git mv` |
+| `reset` | `Git::Commands::Reset` | `spec/git/commands/reset_spec.rb` | `git reset` |
 | `rm` | `Git::Commands::Rm` | `spec/git/commands/rm_spec.rb` | `git rm` |
 
 #### ⏳ Commands To Migrate
@@ -319,7 +320,7 @@ order: Basic Snapshotting → Branching & Merging → etc.
 - [x] `rm` → `Git::Commands::Rm` — `git rm`
 - [x] `mv` → `Git::Commands::Mv` — `git mv`
 - [x] `commit` → `Git::Commands::Commit` — `git commit`
-- [ ] `reset` → `Git::Commands::Reset` — `git reset`
+- [x] `reset` → `Git::Commands::Reset` — `git reset`
 - [ ] `clean` → `Git::Commands::Clean` — `git clean`
 
 **Branching & Merging:**

--- a/spec/git/commands/reset_spec.rb
+++ b/spec/git/commands/reset_spec.rb
@@ -1,0 +1,132 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::Commands::Reset do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with no arguments' do
+      it 'runs git reset without a commit' do
+        expect(execution_context).to receive(:command).with('reset')
+
+        command.call
+      end
+    end
+
+    context 'with a commit argument' do
+      it 'resets to the specified commit' do
+        expect(execution_context).to receive(:command).with('reset', 'HEAD~1')
+
+        command.call('HEAD~1')
+      end
+
+      it 'resets to a SHA' do
+        expect(execution_context).to receive(:command).with('reset', 'abc123')
+
+        command.call('abc123')
+      end
+
+      it 'accepts nil as the commit' do
+        expect(execution_context).to receive(:command).with('reset')
+
+        command.call(nil)
+      end
+    end
+
+    context 'with the :hard option' do
+      it 'includes the --hard flag when true' do
+        expect(execution_context).to receive(:command).with('reset', '--hard')
+
+        command.call(hard: true)
+      end
+
+      it 'includes --hard with a commit' do
+        expect(execution_context).to receive(:command).with('reset', '--hard', 'HEAD~1')
+
+        command.call('HEAD~1', hard: true)
+      end
+
+      it 'does not include the flag when false' do
+        expect(execution_context).to receive(:command).with('reset')
+
+        command.call(hard: false)
+      end
+    end
+
+    context 'with the :soft option' do
+      it 'includes the --soft flag when true' do
+        expect(execution_context).to receive(:command).with('reset', '--soft')
+
+        command.call(soft: true)
+      end
+
+      it 'includes --soft with a commit' do
+        expect(execution_context).to receive(:command).with('reset', '--soft', 'HEAD~1')
+
+        command.call('HEAD~1', soft: true)
+      end
+
+      it 'does not include the flag when false' do
+        expect(execution_context).to receive(:command).with('reset')
+
+        command.call(soft: false)
+      end
+    end
+
+    context 'with the :mixed option' do
+      it 'includes the --mixed flag when true' do
+        expect(execution_context).to receive(:command).with('reset', '--mixed')
+
+        command.call(mixed: true)
+      end
+
+      it 'includes --mixed with a commit' do
+        expect(execution_context).to receive(:command).with('reset', '--mixed', 'HEAD~1')
+
+        command.call('HEAD~1', mixed: true)
+      end
+
+      it 'does not include the flag when false' do
+        expect(execution_context).to receive(:command).with('reset')
+
+        command.call(mixed: false)
+      end
+    end
+
+    context 'with multiple mode options' do
+      it 'raises an error when both hard and soft are true' do
+        expect { command.call(hard: true, soft: true) }.to(
+          raise_error(ArgumentError, /cannot specify :hard and :soft/)
+        )
+      end
+
+      it 'raises an error when both hard and mixed are true' do
+        expect { command.call(hard: true, mixed: true) }.to(
+          raise_error(ArgumentError, /cannot specify :hard and :mixed/)
+        )
+      end
+
+      it 'raises an error when both soft and mixed are true' do
+        expect { command.call(soft: true, mixed: true) }.to(
+          raise_error(ArgumentError, /cannot specify :soft and :mixed/)
+        )
+      end
+
+      it 'raises an error when all three are true' do
+        expect { command.call(hard: true, soft: true, mixed: true) }.to(
+          raise_error(ArgumentError, /cannot specify/)
+        )
+      end
+    end
+
+    context 'with unsupported options' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('HEAD', invalid_option: true) }.to(
+          raise_error(ArgumentError, /Unsupported options: :invalid_option/)
+        )
+      end
+    end
+  end
+end

--- a/tests/units/test_deprecations.rb
+++ b/tests/units/test_deprecations.rb
@@ -73,6 +73,16 @@ class TestDeprecations < Test::Unit::TestCase
     end
   end
 
+  def test_base_reset_hard_deprecation
+    Git::Deprecation.expects(:warn).with(
+      'Git::Base#reset_hard is deprecated and will be removed in a future version. ' \
+      'Use Git::Base#reset(commitish, hard: true) instead.'
+    )
+
+    # Call reset_hard - it should work but emit deprecation warning
+    @git.reset_hard
+  end
+
   # --- Git::Log deprecations ---
 
   def test_log_each_deprecation

--- a/tests/units/test_fsck.rb
+++ b/tests/units/test_fsck.rb
@@ -193,7 +193,7 @@ class TestFsck < Test::Unit::TestCase
         git.commit('Second commit')
 
         # Create a dangling commit by resetting and expiring reflogs
-        git.reset_hard('HEAD~1')
+        git.reset('HEAD~1', hard: true)
         `git reflog expire --expire=now --all 2>&1`
 
         result = git.fsck
@@ -243,7 +243,7 @@ class TestFsck < Test::Unit::TestCase
         git.commit('Second commit')
 
         # Create unreachable commit and expire reflogs
-        git.reset_hard('HEAD~1')
+        git.reset('HEAD~1', hard: true)
         `git reflog expire --expire=now --all 2>&1`
 
         result = git.fsck(unreachable: true, dangling: false)
@@ -370,7 +370,7 @@ class TestFsck < Test::Unit::TestCase
         git.commit('Second commit')
 
         # Create dangling commit and expire reflogs
-        git.reset_hard('HEAD~1')
+        git.reset('HEAD~1', hard: true)
         `git reflog expire --expire=now --all 2>&1`
 
         result = git.fsck(name_objects: true)

--- a/tests/units/test_merge_base.rb
+++ b/tests/units/test_merge_base.rb
@@ -38,7 +38,7 @@ class TestMergeBase < Test::Unit::TestCase
 
       add_commit(repo, 'new_branch')
 
-      repo.reset_hard(repo.gcommit('HEAD^'))
+      repo.reset(repo.gcommit('HEAD^'), hard: true)
 
       add_commit(repo, 'master')
 


### PR DESCRIPTION
## Summary

Migrates the `reset` command from `Git::Lib` to `Git::Commands::Reset` as part of the v5.0.0 architectural redesign ([Phase 2](https://github.com/ruby-git/ruby-git/blob/main/redesign/3_architecture_implementation.md#phase-2-the-strangler-fig-pattern---migrating-commands)).

This is the **8th of ~50 commands** being migrated using the Strangler Fig pattern.

## Changes

### New Files
- **lib/git/commands/reset.rb** - New command class implementing `git reset`
  - Supports `--hard`, `--soft`, and `--mixed` modes using Arguments DSL
  - Uses `conflicts :hard, :soft, :mixed` for mutual exclusion validation
  - Makes commit parameter optional (defaults to HEAD)
  
- **spec/git/commands/reset_spec.rb** - Comprehensive unit tests
  - 18 test examples covering all modes and edge cases
  - Tests conflict validation between mutually exclusive options

### Modified Files
- **lib/git/lib.rb**
  - Updated `reset(commit, opts)` → `reset(commit = nil, opts = {})`
  - Delegates to `Git::Commands::Reset.new(self).call(commit, **opts)`
  - Removed obsolete `RESET_OPTION_MAP` constant

- **lib/git/base.rb**
  - Added deprecation warning to `reset_hard` method
  - Added `@deprecated` YARD tag

- **lib/git/branch.rb**
  - Updated `@base.reset_hard` → `@base.reset(nil, hard: true)` in `in_branch` method

- **tests/units/test_deprecations.rb**
  - Added `test_base_reset_hard_deprecation` test

- **tests/units/test_fsck.rb** and **test_merge_base.rb**
  - Updated 4 instances of `reset_hard` calls to use new API

- **redesign/3_architecture_implementation.md**
  - Updated progress: 8/~50 commands migrated
  - Moved `reset` to "Migrated Commands" table
  - Updated "Next Task" to `clean` command

## Enhanced Functionality

The new implementation adds support for `--soft` and `--mixed` modes, which git supports but were not previously exposed by the ruby-git API:

```ruby
# New capabilities (previously unavailable)
git.reset('HEAD~1', soft: true)   # Keep changes staged
git.reset('HEAD~1', mixed: true)  # Keep changes unstaged
```

## Backward Compatibility

✅ **Fully backward compatible**
- Existing `reset(commit, hard: true)` calls continue to work
- `reset_hard` method deprecated with clear migration path
- All internal gem code updated to use new API
- All 529 TestUnit + 294 RSpec tests pass

## Testing

- ✅ 18 new unit tests (all passing)
- ✅ 294 RSpec tests pass
- ✅ 529 TestUnit tests pass (100% pass rate)
- ✅ No RuboCop violations
- ✅ No YARD documentation errors

## Edge Cases Covered

| Scenario | Test Coverage |
|----------|---------------|
| No arguments (reset to HEAD) | ✅ |
| Reset to specific commit | ✅ |
| Reset with SHA | ✅ |
| Hard mode | ✅ |
| Soft mode | ✅ |
| Mixed mode | ✅ |
| Mode conflict validation | ✅ |
| Unsupported options | ✅ |

## Deprecation Path

`Git::Base#reset_hard` is now deprecated and will emit a warning:
```
Git::Base#reset_hard is deprecated and will be removed in a future version. 
Use Git::Base#reset(commitish, hard: true) instead.
```

## Related

Part of the architectural redesign tracked in [3_architecture_implementation.md](https://github.com/ruby-git/ruby-git/blob/main/redesign/3_architecture_implementation.md).

Next command to migrate: `clean` → `Git::Commands::Clean`