### PR TITLE
Implement Ruby-style positional argument mapping in Arguments DSL

### DIFF
--- a/spec/git/commands/rm_spec.rb
+++ b/spec/git/commands/rm_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Git::Commands::Rm do
 
   describe '#call' do
     context 'when no paths are provided' do
-      it 'raises ArgumentError for nil' do
-        expect { command.call(nil) }.to raise_error(ArgumentError, /nil values are not allowed/)
+      it 'raises ArgumentError for nil (treated as not provided)' do
+        expect { command.call(nil) }.to raise_error(ArgumentError, /at least one value is required/)
       end
 
       it 'raises ArgumentError for empty array' do


### PR DESCRIPTION
## Summary

This PR implements proper positional argument allocation in the Arguments DSL following Ruby method signature semantics. This enables patterns like `git mv` where a variadic positional can be followed by required positionals.

## Changes

### Ruby-style Positional Allocation

Positional arguments are now mapped following Ruby method signature rules:

1. Required positionals before variadic are filled first (left to right)
2. Required positionals after variadic are filled from the end
3. Optional positionals (with defaults) are filled with remaining args
4. Variadic positional gets whatever is left in the middle

### Now-Supported Patterns

```ruby
# git mv pattern: def mv(*sources, destination)
positional :sources, variadic: true, required: true
positional :destination, required: true
# build('src1', 'src2', 'dest') => ['src1', 'src2', 'dest']

# Variadic in the middle: def foo(a, *middle, b)
positional :a, required: true
positional :middle, variadic: true
positional :b, required: true
# build('first', 'mid1', 'mid2', 'last') => ['first', 'mid1', 'mid2', 'last']

# Complex patterns: def foo(a, b, *rest, c, d)
positional :a, required: true
positional :b, required: true
positional :rest, variadic: true
positional :c, required: true
positional :d, required: true
# build('1', '2', 'm1', 'm2', '3', '4') => ['1', '2', 'm1', 'm2', '3', '4']
```

### Additional Improvements

- **Unexpected positional validation**: Raises `ArgumentError` with clear message when extra positionals are provided
- **Comprehensive YARD documentation**: Added detailed examples for all positional patterns
- **Nil handling**: Properly documents that nil means "not provided" for non-variadic positionals

## Tests

Added 50+ new tests covering:
- All positional mapping patterns (single, multiple, variadic, mixed)
- Ruby-style allocation with variadic before required
- Nil handling for positionals
- Unexpected positional argument detection
- Default values with various patterns

## Context

This is part of the Phase 2 architectural redesign, providing the infrastructure needed for commands like `git mv` that have variadic sources followed by a required destination.

This is an internal API (`@api private`) used by `Git::Commands::*` classes.