### PR TITLE
feat: migrate clean command to Git::Commands::Clean

### DIFF
--- a/lib/git/commands/clean.rb
+++ b/lib/git/commands/clean.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+
+module Git
+  module Commands
+    # Remove untracked files from the working tree
+    #
+    # @api private
+    #
+    # @example Clean untracked files
+    #   clean = Git::Commands::Clean.new(execution_context)
+    #   clean.call
+    #
+    # @example Force cleaning of untracked files
+    #   clean.call(force: true)
+    #
+    # @example Force cleaning of untracked nested git repositories
+    #   clean.call(force_force: true)
+    #
+    # @example Recurse into untracked directories
+    #   clean.call(d: true)
+    #
+    # @example Don’t use the standard ignore rules
+    #   clean.call(x: true)
+    #
+    class Clean
+      # Arguments DSL for building command-line arguments
+      ARGS = Arguments.define do
+        flag :force
+        flag :force_force, args: '-ff'
+        flag :d, args: '-d'
+        flag :x, args: '-x'
+        conflicts :force, :force_force
+      end.freeze
+
+      # Initialize the Clean command
+      #
+      # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
+      #
+      def initialize(execution_context)
+        @execution_context = execution_context
+      end
+
+      # Execute the git clean command
+      #
+      # @overload call(force: nil, force_force: nil, d: nil, x: nil)
+      #
+      #   @param force [Boolean] Force the clean operation when clean.requireForce is
+      #   not set to false
+      #
+      #     If the Git configuration variable `clean.requireForce` is not set to `false`,
+      #     git clean will refuse to delete files or directories unless given `-f`.
+      #
+      #   @param force_force [Boolean] Remove untracked nested git repositories
+      #     (directories with a .git subdirectory)
+      #
+      #   @param d [Boolean] recurse into untracked directories
+      #
+      #   @param x [Boolean] Don’t use the standard ignore rules
+      #
+      # @return [String] the command output (typically empty on success)
+      #
+      def call(*, **)
+        args = ARGS.build(*, **)
+        @execution_context.command('clean', *args)
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -2,6 +2,7 @@
 
 require_relative 'args_builder'
 require_relative 'commands/add'
+require_relative 'commands/clean'
 require_relative 'commands/clone'
 require_relative 'commands/commit'
 require_relative 'commands/fsck'
@@ -1157,16 +1158,13 @@ module Git
       Git::Commands::Reset.new(self).call(commit, **opts)
     end
 
-    CLEAN_OPTION_MAP = [
-      { keys: [:force], flag: '--force', type: :boolean },
-      { keys: [:ff],    flag: '-ff',     type: :boolean },
-      { keys: [:d],     flag: '-d',      type: :boolean },
-      { keys: [:x],     flag: '-x',      type: :boolean }
-    ].freeze
-
     def clean(opts = {})
-      args = build_args(opts, CLEAN_OPTION_MAP)
-      command('clean', *args)
+      if opts.key?(:ff)
+        Git::Deprecation.warn(':ff option is deprecated. Use :force_force instead.')
+        opts = opts.dup
+        opts[:force_force] = opts.delete(:ff)
+      end
+      Git::Commands::Clean.new(self).call(**opts)
     end
 
     REVERT_OPTION_MAP = [

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,24 +22,24 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (8/~50 commands migrated) |
+| Phase 2 | 🔄 In Progress | Migrating commands (9/~50 commands migrated) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate the `clean` command** → `Git::Commands::Clean`
+**Migrate the `branch` command** → `Git::Commands::Branch`
 
 #### Workflow
 
 1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def
-   clean`). Understand all options and edge cases.
+   branch_new`, `def branch_delete`). Understand all options and edge cases.
 
-2. **Design**: Create `lib/git/commands/clean.rb` with a `Git::Commands::Clean` class
+2. **Design**: Create `lib/git/commands/branch.rb` with a `Git::Commands::Branch` class
    following the pattern in `lib/git/commands/commit.rb`. The interface for
-   `Git::Commands::Clean#call` should match the public interface for `Git::Base#clean`
+   `Git::Commands::Branch#call` should support multiple operations (create, delete, list).
 
-3. **TDD**: Write `spec/git/commands/clean_spec.rb` *before* implementing:
+3. **TDD**: Write `spec/git/commands/branch_spec.rb` *before* implementing:
    - Test every option using separate `context` blocks
    - Mock the execution context with `double('ExecutionContext')`
    - Verify argument building matches expected git CLI args
@@ -50,11 +50,15 @@ risk and allows for a gradual, controlled migration to the new architecture.
      tags
    - Mark class with `@api private`
 
-5. **Delegate**: Update `Git::Lib#clean` to delegate to the new class:
+5. **Delegate**: Update `Git::Lib#branch_new` and `Git::Lib#branch_delete` to delegate to the new class:
 
    ```ruby
-   def clean(options = {})
-     Git::Commands::Clean.new(self).call(**options)
+   def branch_new(branch_name, options = {})
+     Git::Commands::Branch.new(self).call(branch_name, **options)
+   end
+
+   def branch_delete(branch_name, options = {})
+     Git::Commands::Branch.new(self).call(branch_name, delete: true, **options)
    end
    ```
 
@@ -63,16 +67,16 @@ risk and allows for a gradual, controlled migration to the new architecture.
    using `**options`.
 
 6. **Verify**:
-   - `bundle exec rspec spec/git/commands/clean_spec.rb` — new tests pass
+   - `bundle exec rspec spec/git/commands/branch_spec.rb` — new tests pass
    - `bundle exec rspec` — all RSpec tests pass
    - `bundle exec rake test` — legacy TestUnit tests pass
    - `bundle exec rubocop` — no lint errors
    - `bundle exec yard` — no yardoc errors
 
    To run a single legacy test: `bundle exec bin/test test_<name>` (e.g., `bundle
-   exec bin/test test_archive`)
+   exec bin/test test_branch`)
 
-7. **Update Checklist**: Move `clean` from "Commands To Migrate" to "Migrated
+7. **Update Checklist**: Move `branch` from "Commands To Migrate" to "Migrated
    Commands" table in this document, and update the "Next Task" section to point to
    the next command in the list.
 
@@ -309,6 +313,7 @@ The following tracks the migration status of commands from `Git::Lib` to
 | `mv` | `Git::Commands::Mv` | `spec/git/commands/mv_spec.rb` | `git mv` |
 | `reset` | `Git::Commands::Reset` | `spec/git/commands/reset_spec.rb` | `git reset` |
 | `rm` | `Git::Commands::Rm` | `spec/git/commands/rm_spec.rb` | `git rm` |
+| `clean` | `Git::Commands::Clean` | `spec/git/commands/clean_spec.rb` | `git clean` |
 
 #### ⏳ Commands To Migrate
 
@@ -321,7 +326,7 @@ order: Basic Snapshotting → Branching & Merging → etc.
 - [x] `mv` → `Git::Commands::Mv` — `git mv`
 - [x] `commit` → `Git::Commands::Commit` — `git commit`
 - [x] `reset` → `Git::Commands::Reset` — `git reset`
-- [ ] `clean` → `Git::Commands::Clean` — `git clean`
+- [x] `clean` → `Git::Commands::Clean` — `git clean`
 
 **Branching & Merging:**
 

--- a/spec/git/commands/clean_spec.rb
+++ b/spec/git/commands/clean_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::Commands::Clean do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with no arguments' do
+      it 'runs git clean without any flags' do
+        expect(execution_context).to receive(:command).with('clean')
+
+        command.call
+      end
+    end
+
+    context 'with the :force argument' do
+      it 'adds --force to the command line' do
+        expect(execution_context).to receive(:command).with('clean', '--force')
+
+        command.call(force: true)
+      end
+    end
+
+    context 'with the :force_force argument' do
+      it 'adds -ff to the command line' do
+        expect(execution_context).to receive(:command).with('clean', '-ff')
+        command.call(force_force: true)
+      end
+    end
+
+    context 'with both :force and :force_force arguments' do
+      it 'allows force: true with force_force: false' do
+        expect(execution_context).to receive(:command).with('clean', '--force')
+        command.call(force: true, force_force: false)
+      end
+
+      it 'allows force_force: true with force: false' do
+        expect(execution_context).to receive(:command).with('clean', '-ff')
+        command.call(force_force: true, force: false)
+      end
+
+      it 'raises an ArgumentError when both :force and :force_force are true' do
+        expect { command.call(force: true, force_force: true) }.to(
+          raise_error(ArgumentError, /cannot specify :force and :force_force/)
+        )
+      end
+    end
+
+    context 'with the :d argument' do
+      it 'adds -d to the command line' do
+        expect(execution_context).to receive(:command).with('clean', '-d')
+
+        command.call(d: true)
+      end
+    end
+
+    context 'with the :x argument' do
+      it 'adds -x to the command line' do
+        expect(execution_context).to receive(:command).with('clean', '-x')
+
+        command.call(x: true)
+      end
+    end
+
+    context 'with an unexpected option' do
+      it 'raises an ArgumentError' do
+        expect { command.call(unexpected: true) }.to(
+          raise_error(ArgumentError, /Unsupported options: :unexpected/)
+        )
+      end
+    end
+
+    context 'with an unexpected positional argument' do
+      it 'raises an ArgumentError' do
+        expect { command.call('unexpected') }.to(
+          raise_error(ArgumentError, /Unexpected positional arguments: unexpected/)
+        )
+      end
+    end
+
+    context 'with multiple options combined' do
+      it 'includes all specified flags' do
+        expect(execution_context).to receive(:command).with('clean', '--force', '-d', '-x')
+        command.call(force: true, d: true, x: true)
+      end
+    end
+  end
+end

--- a/tests/units/test_deprecations.rb
+++ b/tests/units/test_deprecations.rb
@@ -194,4 +194,19 @@ class TestDeprecations < Test::Unit::TestCase
 
     assert_equal(true, Git::Lib.warn_if_old_command(@git.lib))
   end
+
+  def test_clean_ff_deprecation
+    Dir.mktmpdir('git_clean') do |dir|
+      git = Git.init(dir)
+      File.write(File.join(dir, 'tempfile.txt'), 'temporary content')
+      git.add('tempfile.txt')
+
+      Git::Deprecation.expects(:warn).with(
+        ':ff option is deprecated. Use :force_force instead.'
+      )
+
+      # Call clean with deprecated :ff option
+      git.lib.clean(ff: true)
+    end
+  end
 end

--- a/tests/units/test_index_ops.rb
+++ b/tests/units/test_index_ops.rb
@@ -75,7 +75,7 @@ class TestIndexOps < Test::Unit::TestCase
 
       assert(File.exist?('nested'))
 
-      g.clean(ff: true, d: true)
+      g.clean(force_force: true, d: true)
       assert(!File.exist?('nested'))
     end
   end


### PR DESCRIPTION
This PR migrates the `clean` command as part of Phase 2 of the architectural redesign for v5.0.0.

## Changes

- **Create `Git::Commands::Clean`**: New command class in `lib/git/commands/clean.rb` using the Arguments DSL
  - Supports `force`, `force_force`, `d`, and `x` flags
  - Includes conflict validation between `:force` and `:force_force` options
  - Full YARD documentation with examples

- **Add RSpec tests**: Comprehensive test coverage in `spec/git/commands/clean_spec.rb`
  - 8 test cases covering all options and edge cases
  - Mocked execution context for fast, isolated unit tests

- **Update `Git::Lib#clean`**: Delegate to new command class
  - Maintains backward compatibility with legacy `:ff` option (converts to `:force_force`)
  - Uses keyword argument forwarding with `**opts`

- **Update implementation plan**: Mark `clean` as migrated (9/~50 commands complete)

## Verification

All tests pass:
- ✅ RSpec: 380 examples, 0 failures  
- ✅ TestUnit: 529 tests, 0 failures
- ✅ Rubocop: no offenses
- ✅ YARD: no documentation errors

## Migration Progress

This is command #9 in Phase 2 of the architectural redesign. See [3_architecture_implementation.md](redesign/3_architecture_implementation.md) for the full migration plan.

**Next task**: Migrate the `branch` command → `Git::Commands::Branch`