### PR TITLE
Add multi_valued option to value and inline_value types in Arguments DSL

### DIFF
--- a/lib/git/commands/clone.rb
+++ b/lib/git/commands/clone.rb
@@ -28,7 +28,7 @@ module Git
         value :branch
         value :filter
         value %i[origin remote]
-        multi_value :config
+        value :config, multi_valued: true
         negatable_flag :single_branch, validator: ->(v) { [nil, true, false].include?(v) }
         custom(:depth) { |v| ['--depth', v.to_i] }
         # Options handled by the command itself, not passed to git


### PR DESCRIPTION
## Summary

This refactoring simplifies the internal Arguments DSL by replacing the separate `multi_value` method with a `multi_valued:` parameter on the existing `value` and `inline_value` methods.

## Changes

- Add `multi_valued:` parameter to `value()` and `inline_value()` methods
- When `multi_valued: true`, the option accepts arrays and repeats the flag for each value:
  - `value :config, multi_valued: true` → `--config a --config b`
  - `inline_value :sort, multi_valued: true` → `--sort=a --sort=b`
- Single values and nil are still accepted when `multi_valued: true`
- Remove the standalone `multi_value()` method
- Update `clone.rb` to use `value :config, multi_valued: true`
- Add tests for the new `multi_valued:` parameter

## Rationale

This provides a more consistent API where:
- The **format** (separate args vs equals) is determined by the method (`value` vs `inline_value`)
- The **cardinality** is controlled by the `multi_valued:` flag

Previously, there was no way to get multi-valued inline format (`--sort=a --sort=b`), which is needed for options like `git branch --sort`.

## Type of Change

- [x] Refactoring (internal change, no external API impact)

## Testing

- All existing tests pass
- Added new tests for `value` with `multi_valued: true`
- Added new tests for `inline_value` with `multi_valued: true`