### PR TITLE
Add Git::BranchInfo value object

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -10,6 +10,7 @@ end
 require 'git/author'
 require 'git/base'
 require 'git/branch'
+require 'git/branch_info'
 require 'git/branches'
 require 'git/command_line_result'
 require 'git/command_line'

--- a/lib/git/branch_info.rb
+++ b/lib/git/branch_info.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+module Git
+  # Regular expression for parsing branch refnames
+  #
+  # Captures:
+  #   - remote_name: the remote name (e.g., 'origin') for remote branches, nil for local
+  #   - branch_name: the branch name without the remote prefix
+  #
+  # @note This regex is similar to Git::Branch::BRANCH_NAME_REGEXP but uses \A/\z anchors
+  #   instead of ^/$ for stricter matching. As part of the architectural redesign,
+  #   Git::Branch will eventually be refactored to use BranchInfo internally, at which
+  #   point this will become the single source of truth for branch name parsing.
+  #
+  # @note This regex assumes remote names do not contain '/'. If a remote name
+  #   contains '/', parsing will be incorrect. For example, 'remotes/team/upstream/main'
+  #   would parse as remote_name='team' instead of 'team/upstream'. This is an inherent
+  #   ambiguity in git refnames that can only be resolved with knowledge of configured
+  #   remotes. See: https://github.com/ruby-git/ruby-git/issues/919
+  #
+  # @example
+  #   'main' => { remote_name: nil, branch_name: 'main' }
+  #   'remotes/origin/main' => { remote_name: 'origin', branch_name: 'main' }
+  #   'feature/foo' => { remote_name: nil, branch_name: 'feature/foo' }
+  #   'remotes/origin/feature/bar' => { remote_name: 'origin', branch_name: 'feature/bar' }
+  #
+  # @api private
+  BRANCH_REFNAME_REGEXP = %r{
+    \A                              # start of string
+    (?:(?:refs/)?remotes/(?<remote_name>[^/]+)/)? # optional 'refs?/remotes/<remote_name>/'
+    (?<branch_name>.+)                   # branch name (everything else)
+    \z                              # end of string
+  }x
+
+  # Value object representing branch metadata from git branch output
+  #
+  # This is a lightweight, immutable data structure returned by branch listing
+  # commands. It contains only the data parsed from git output without any
+  # repository context or operations.
+  #
+  # @example Creating from git branch output
+  #   info = Git::BranchInfo.new(
+  #     refname: 'main',
+  #     current: true,
+  #     worktree: false,
+  #     symref: nil
+  #   )
+  #   info.current?     #=> true
+  #   info.remote?      #=> false
+  #   info.short_name   #=> 'main'
+  #
+  # @example Remote branch
+  #   info = Git::BranchInfo.new(
+  #     refname: 'remotes/origin/main',
+  #     current: false,
+  #     worktree: false,
+  #     symref: nil
+  #   )
+  #   info.remote?      #=> true
+  #   info.remote_name  #=> 'origin'
+  #   info.short_name   #=> 'main'
+  #
+  # @see Git::Branch for the full-featured branch object with operations
+  # @see Git::Commands::Branch::List for the command that produces these
+  #
+  # @api public
+  #
+  BranchInfo = Data.define(:refname, :current, :worktree, :symref) do
+    # @return [Boolean] true if this is the currently checked out branch
+    def current? = current
+
+    # @return [Boolean] true if this branch is checked out in another worktree
+    def worktree? = worktree
+
+    # @return [Boolean] true if this is a symbolic reference
+    def symref? = !symref.nil?
+
+    # @return [Boolean] true if this is a remote-tracking branch
+    def remote? = !remote_name.nil?
+
+    # @return [String, nil] the name of the remote (e.g., 'origin'), or nil for local branches
+    def remote_name
+      parse_refname[:remote_name]
+    end
+
+    # @return [String] the branch name without remote prefix (e.g., 'main' or 'feature/foo')
+    def short_name
+      parse_refname[:branch_name]
+    end
+
+    # @return [String] string representation (the full refname)
+    def to_s = refname
+
+    private
+
+    # Parse the refname and return match data
+    #
+    # The regex is guaranteed to match any non-empty string due to the `.+` pattern,
+    # so we don't need nil checking. If refname is empty/nil, this would fail at
+    # object creation time since refname is a required attribute.
+    #
+    # @return [MatchData] the match result
+    def parse_refname
+      refname.match(Git::BRANCH_REFNAME_REGEXP)
+    end
+  end
+end

--- a/spec/git/branch_info_spec.rb
+++ b/spec/git/branch_info_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::BranchInfo do
+  describe 'attributes' do
+    subject(:branch_info) do
+      described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+    end
+
+    it 'exposes refname' do
+      expect(branch_info.refname).to eq('main')
+    end
+
+    it 'exposes current' do
+      expect(branch_info.current).to be true
+    end
+
+    it 'exposes worktree' do
+      expect(branch_info.worktree).to be false
+    end
+
+    it 'exposes symref' do
+      expect(branch_info.symref).to be_nil
+    end
+  end
+
+  describe '#current?' do
+    it 'returns true when current is true' do
+      branch_info = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+      expect(branch_info.current?).to be true
+    end
+
+    it 'returns false when current is false' do
+      branch_info = described_class.new(refname: 'main', current: false, worktree: false, symref: nil)
+      expect(branch_info.current?).to be false
+    end
+  end
+
+  describe '#worktree?' do
+    it 'returns true when worktree is true' do
+      branch_info = described_class.new(refname: 'feature', current: false, worktree: true, symref: nil)
+      expect(branch_info.worktree?).to be true
+    end
+
+    it 'returns false when worktree is false' do
+      branch_info = described_class.new(refname: 'feature', current: false, worktree: false, symref: nil)
+      expect(branch_info.worktree?).to be false
+    end
+  end
+
+  describe '#symref?' do
+    it 'returns true when symref is present' do
+      branch_info = described_class.new(refname: 'HEAD', current: false, worktree: false, symref: 'refs/heads/main')
+      expect(branch_info.symref?).to be true
+    end
+
+    it 'returns false when symref is nil' do
+      branch_info = described_class.new(refname: 'main', current: false, worktree: false, symref: nil)
+      expect(branch_info.symref?).to be false
+    end
+  end
+
+  describe '#remote?' do
+    context 'with local branch' do
+      it 'returns false for simple branch name' do
+        branch_info = described_class.new(refname: 'main', current: false, worktree: false, symref: nil)
+        expect(branch_info.remote?).to be false
+      end
+
+      it 'returns false for branch with slashes' do
+        branch_info = described_class.new(refname: 'feature/my-feature', current: false, worktree: false, symref: nil)
+        expect(branch_info.remote?).to be false
+      end
+    end
+
+    context 'with remote-tracking branch' do
+      it 'returns true for remotes/origin/main' do
+        branch_info = described_class.new(refname: 'remotes/origin/main', current: false, worktree: false, symref: nil)
+        expect(branch_info.remote?).to be true
+      end
+
+      it 'returns true for refs/remotes/origin/main' do
+        branch_info = described_class.new(
+          refname: 'refs/remotes/origin/main', current: false, worktree: false, symref: nil
+        )
+        expect(branch_info.remote?).to be true
+      end
+    end
+  end
+
+  describe '#remote_name' do
+    context 'with local branch' do
+      it 'returns nil for simple branch name' do
+        branch_info = described_class.new(refname: 'main', current: false, worktree: false, symref: nil)
+        expect(branch_info.remote_name).to be_nil
+      end
+
+      it 'returns nil for branch with slashes' do
+        branch_info = described_class.new(refname: 'feature/my-feature', current: false, worktree: false, symref: nil)
+        expect(branch_info.remote_name).to be_nil
+      end
+    end
+
+    context 'with remote-tracking branch' do
+      it 'extracts remote name from remotes/origin/main' do
+        branch_info = described_class.new(refname: 'remotes/origin/main', current: false, worktree: false, symref: nil)
+        expect(branch_info.remote_name).to eq('origin')
+      end
+
+      it 'extracts remote name from refs/remotes/origin/main' do
+        branch_info = described_class.new(
+          refname: 'refs/remotes/origin/main', current: false, worktree: false, symref: nil
+        )
+        expect(branch_info.remote_name).to eq('origin')
+      end
+
+      it 'extracts remote name from remotes/upstream/feature' do
+        branch_info = described_class.new(
+          refname: 'remotes/upstream/feature', current: false, worktree: false, symref: nil
+        )
+        expect(branch_info.remote_name).to eq('upstream')
+      end
+    end
+  end
+
+  describe '#short_name' do
+    context 'with local branch' do
+      it 'returns the branch name for simple branch' do
+        branch_info = described_class.new(refname: 'main', current: false, worktree: false, symref: nil)
+        expect(branch_info.short_name).to eq('main')
+      end
+
+      it 'returns the full name for branch with slashes' do
+        branch_info = described_class.new(refname: 'feature/my-feature', current: false, worktree: false, symref: nil)
+        expect(branch_info.short_name).to eq('feature/my-feature')
+      end
+
+      it 'returns the full name for deeply nested branch' do
+        branch_info = described_class.new(
+          refname: 'feature/team/project/task', current: false, worktree: false, symref: nil
+        )
+        expect(branch_info.short_name).to eq('feature/team/project/task')
+      end
+    end
+
+    context 'with remote-tracking branch' do
+      it 'extracts branch name from remotes/origin/main' do
+        branch_info = described_class.new(refname: 'remotes/origin/main', current: false, worktree: false, symref: nil)
+        expect(branch_info.short_name).to eq('main')
+      end
+
+      it 'extracts branch name from refs/remotes/origin/main' do
+        branch_info = described_class.new(
+          refname: 'refs/remotes/origin/main', current: false, worktree: false, symref: nil
+        )
+        expect(branch_info.short_name).to eq('main')
+      end
+
+      it 'preserves slashes in remote branch name' do
+        branch_info = described_class.new(
+          refname: 'remotes/origin/feature/my-feature', current: false, worktree: false, symref: nil
+        )
+        expect(branch_info.short_name).to eq('feature/my-feature')
+      end
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns the refname' do
+      branch_info = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+      expect(branch_info.to_s).to eq('main')
+    end
+
+    it 'returns full refname for remote branches' do
+      branch_info = described_class.new(refname: 'remotes/origin/main', current: false, worktree: false, symref: nil)
+      expect(branch_info.to_s).to eq('remotes/origin/main')
+    end
+  end
+
+  describe 'immutability' do
+    it 'is frozen' do
+      branch_info = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+      expect(branch_info).to be_frozen
+    end
+  end
+
+  describe 'equality' do
+    it 'is equal to another BranchInfo with same attributes' do
+      info1 = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+      info2 = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+      expect(info1).to eq(info2)
+    end
+
+    it 'is not equal when refname differs' do
+      info1 = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+      info2 = described_class.new(refname: 'develop', current: true, worktree: false, symref: nil)
+      expect(info1).not_to eq(info2)
+    end
+
+    it 'is not equal when current differs' do
+      info1 = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+      info2 = described_class.new(refname: 'main', current: false, worktree: false, symref: nil)
+      expect(info1).not_to eq(info2)
+    end
+  end
+
+  describe 'pattern matching' do
+    it 'supports pattern matching on attributes' do
+      branch_info = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+
+      result = case branch_info
+               in { refname: 'main', current: true }
+                 :matched
+               else
+                 :not_matched
+               end
+
+      expect(result).to eq(:matched)
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Introduce an immutable value object for representing branch metadata from git branch output. `BranchInfo` is a pure data structure with no repository context, created using Ruby's `Data.define`.

## Motivation

This is the first PR in a series to migrate `git branch --list` to the new `Git::Commands::*` architecture. The value object pattern separates "data from git" from "operations on branches", enabling:

- Commands to return pure data without repository dependencies
- Clean, testable command classes
- Domain objects (`Git::Branch`) to wrap value objects when operations are needed

## Changes

### New: `Git::BranchInfo` (`lib/git/branch_info.rb`)

**Attributes:**
- `refname` - the full branch reference name
- `current` - whether this is the currently checked out branch  
- `worktree` - whether this branch is checked out in another worktree
- `symref` - the target of a symbolic reference (e.g., HEAD -> main)

**Derived methods:**
- `current?`, `worktree?`, `symref?`, `remote?`
- `remote_name` - extracts remote name from refname (e.g., 'origin')
- `short_name` - branch name without remote prefix

### Modified: `lib/git.rb`

Added `require 'git/branch_info'`.

## Testing

- All 530 existing tests pass
- No Rubocop offenses
- This PR adds no consumers yet—`BranchInfo` will be used by subsequent PRs

## Related PRs

This is PR 1 of 5 for the Branch::List migration:
1. **Add Git::BranchInfo value object** ← this PR
2. Add Git::Commands::Branch::List command
3. Update Git::Branch to accept BranchInfo
4. Integrate Branch::List and update consumers
5. Documentation updates