### PR TITLE
Add Git::Commands::Branch::List command

### DIFF
--- a/lib/git/commands/branch/list.rb
+++ b/lib/git/commands/branch/list.rb
@@ -1,0 +1,223 @@
+# frozen_string_literal: true
+
+require 'git/branch_info'
+require 'git/commands/arguments'
+
+module Git
+  module Commands
+    module Branch
+      # Implements the `git branch --list` command
+      #
+      # This command lists existing branches with optional filtering and formatting.
+      #
+      # @see https://git-scm.com/docs/git-branch git-branch
+      #
+      # @api private
+      #
+      # @example Basic branch listing
+      #   list = Git::Commands::Branch::List.new(execution_context)
+      #   branches = list.call
+      #
+      # @example List all branches (local and remote)
+      #   list = Git::Commands::Branch::List.new(execution_context)
+      #   all_branches = list.call(all: true)
+      #
+      # @example List branches containing a commit
+      #   list = Git::Commands::Branch::List.new(execution_context)
+      #   branches = list.call(contains: 'abc123')
+      #
+      # @example List branches with patterns
+      #   list = Git::Commands::Branch::List.new(execution_context)
+      #   feature_branches = list.call(patterns: 'feature/*')
+      #
+      class List
+        # Arguments DSL for building command-line arguments
+        #
+        # NOTE: The order of definitions here determines the order of arguments
+        # in the final command line.
+        #
+        ARGS = Arguments.define do
+          flag :all, args: '-a'
+          flag :remotes, args: '-r'
+          inline_value :sort, multi_valued: true
+          value :contains
+          value :no_contains
+          value :merged
+          value :no_merged
+          value :points_at
+          custom(:patterns) do |patterns|
+            next [] if patterns.nil?
+
+            patterns_array = Array(patterns)
+            ['--list', *patterns_array]
+          end
+        end.freeze
+
+        # Regular expression for parsing git branch output
+        #
+        # Matches the format of each line in `git branch` output, capturing:
+        # - The prefix indicating branch state (current, checked out in worktree, or neither)
+        # - The branch reference name
+        # - Optional symbolic reference target
+        #
+        BRANCH_LINE_REGEXP = /
+          ^
+            # Prefix indicates if this branch is checked out. The prefix is one of:
+            (?:
+              (?<current>\*[[:blank:]]) |  # Current branch (checked out in the current worktree)
+              (?<worktree>\+[[:blank:]]) | # Branch checked out in a different worktree
+              [[:blank:]]{2}               # Branch not checked out
+            )
+
+            # The branch's full refname
+            (?:
+              (?<not_a_branch>\(not[[:blank:]]a[[:blank:]]branch\)) |
+               (?:\(HEAD[[:blank:]]detached[[:blank:]]at[[:blank:]](?<detached_ref>[^)]+)\)) |
+              (?<refname>[^[[:blank:]]]+)
+            )
+
+            # Optional symref
+            # If this ref is a symbolic reference, this is the ref referenced
+            (?:
+              [[:blank:]]->[[:blank:]](?<symref>.*)
+            )?
+          $
+        /x
+
+        # Initialize the List command
+        #
+        # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
+        #
+        def initialize(execution_context)
+          @execution_context = execution_context
+        end
+
+        # Execute the git branch --list command
+        #
+        # @overload call(all: nil, remotes: nil, sort: nil,
+        #   contains: nil, no_contains: nil, merged: nil, no_merged: nil,
+        #   points_at: nil, patterns: nil)
+        #
+        #   @param all [Boolean] List both local and remote branches (adds -a flag)
+        #
+        #   @param remotes [Boolean] List only remote-tracking branches (adds -r flag)
+        #
+        #   @param sort [String, Array<String>] Sort branches by the specified key(s)
+        #     Single value adds --sort=<key>
+        #     Array adds multiple --sort=<key> (e.g., ['refname', '-committerdate'])
+        #     Common keys: 'refname', '-refname', 'committerdate', '-committerdate'
+        #
+        #   @param contains [String] List only branches that contain the specified commit
+        #     Adds --contains <commit>
+        #
+        #   @param no_contains [String] List only branches that don't contain the specified commit
+        #     Adds --no-contains <commit>
+        #
+        #   @param merged [String] List only branches merged into the specified commit
+        #     Adds --merged <commit>
+        #
+        #   @param no_merged [String] List only branches not merged into the specified commit
+        #     Adds --no-merged <commit>
+        #
+        #   @param points_at [String] List only branches that point at the specified object
+        #     Adds --points-at <object>
+        #
+        #   @param patterns [String, Array<String>] Shell wildcard patterns to filter branches
+        #     Automatically adds --list flag when patterns are provided
+        #
+        # @return [Array<Git::BranchInfo>] array of branch info objects
+        #
+        # @raise [ArgumentError] if unsupported options are provided
+        # @raise [Git::UnexpectedResultError] if git output format is unexpected
+        #
+        def call(**)
+          args = ARGS.build(**)
+          lines = @execution_context.command_lines('branch', *args)
+          parse_branches(lines, args)
+        end
+
+        private
+
+        # Parse the output lines from git branch
+        #
+        # @param lines [Array<String>] output lines from git branch command
+        # @param args [Array<String>] the arguments passed to git branch
+        # @return [Array<Array>] parsed branch data
+        #
+        def parse_branches(lines, args)
+          lines.each_with_index.filter_map do |line, index|
+            parse_branch_line(line, index, lines, args)
+          end
+        end
+
+        # Parse a single branch line
+        #
+        # @param line [String] the line to parse
+        # @param index [Integer] the line index (for error messages)
+        # @param all_lines [Array<String>] all output lines (for error messages)
+        # @param args [Array<String>] the arguments passed to git branch
+        # @return [Array, nil] parsed branch data or nil if line should be filtered
+        #
+        def parse_branch_line(line, index, all_lines, args)
+          match_data = match_branch_line(line, index, all_lines, args)
+
+          # Filter out non-branch lines (detached HEAD, etc.)
+          return nil if match_data[:not_a_branch] || match_data[:detached_ref]
+
+          format_branch_data(match_data)
+        end
+
+        # Match a branch line against the expected format
+        #
+        # @param line [String] the line to match
+        # @param index [Integer] the line index (for error messages)
+        # @param all_lines [Array<String>] all output lines (for error messages)
+        # @param args [Array<String>] the arguments passed to git branch
+        # @return [MatchData] the match data
+        # @raise [Git::UnexpectedResultError] if line doesn't match expected format
+        #
+        def match_branch_line(line, index, all_lines, args)
+          match_data = line.match(BRANCH_LINE_REGEXP)
+          raise Git::UnexpectedResultError, unexpected_branch_line_error(all_lines, line, index, args) unless match_data
+
+          match_data
+        end
+
+        # Format match data into BranchInfo object
+        #
+        # @param match_data [MatchData] the regex match data
+        # @return [Git::BranchInfo] branch info object
+        #
+        def format_branch_data(match_data)
+          Git::BranchInfo.new(
+            refname: match_data[:refname],
+            current: !match_data[:current].nil?,
+            worktree: !match_data[:worktree].nil?,
+            symref: match_data[:symref]
+          )
+        end
+
+        # Generate error message for unexpected branch line format
+        #
+        # @param lines [Array<String>] all output lines
+        # @param line [String] the problematic line
+        # @param index [Integer] the line index
+        # @param args [Array<String>] the arguments passed to git branch
+        # @return [String] formatted error message
+        #
+        def unexpected_branch_line_error(lines, line, index, args)
+          command_str = "git branch #{args.join(' ')}".strip
+          <<~ERROR
+            Unexpected line in output from `#{command_str}`, line #{index + 1}
+
+            Full output:
+              #{lines.join("\n  ")}
+
+            Line #{index + 1}:
+              "#{line}"
+          ERROR
+        end
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -2,6 +2,7 @@
 
 require_relative 'args_builder'
 require_relative 'commands/add'
+require_relative 'commands/branch/list'
 require_relative 'commands/clean'
 require_relative 'commands/clone'
 require_relative 'commands/commit'
@@ -1919,6 +1920,9 @@ module Git
            end
       op.split("\n")
     end
+
+    # Make command_lines public for use by Git::Commands classes
+    public :command_lines
 
     # Returns a hash of environment variable overrides for git commands
     #

--- a/spec/git/commands/branch/list_spec.rb
+++ b/spec/git/commands/branch/list_spec.rb
@@ -1,0 +1,224 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/branch/list'
+
+RSpec.describe Git::Commands::Branch::List do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with no options (basic list)' do
+      it 'calls git branch with no additional arguments' do
+        expect(execution_context).to receive(:command_lines).with('branch').and_return([])
+        command.call
+      end
+    end
+
+    context 'with :all option' do
+      it 'adds -a flag' do
+        expect(execution_context).to receive(:command_lines).with('branch', '-a').and_return([])
+        command.call(all: true)
+      end
+    end
+
+    context 'with :remotes option' do
+      it 'adds -r flag' do
+        expect(execution_context).to receive(:command_lines).with('branch', '-r').and_return([])
+        command.call(remotes: true)
+      end
+    end
+
+    context 'with :sort option' do
+      it 'adds --sort=<key> with single value' do
+        expect(execution_context).to receive(:command_lines).with('branch', '--sort=refname').and_return([])
+        command.call(sort: 'refname')
+      end
+
+      it 'adds multiple --sort=<key> with array of values' do
+        expect(execution_context).to receive(:command_lines).with('branch', '--sort=refname',
+                                                                  '--sort=-committerdate').and_return([])
+        command.call(sort: ['refname', '-committerdate'])
+      end
+    end
+
+    context 'with :contains option' do
+      it 'adds --contains <commit>' do
+        expect(execution_context).to receive(:command_lines).with('branch', '--contains', 'abc123').and_return([])
+        command.call(contains: 'abc123')
+      end
+    end
+
+    context 'with :no_contains option' do
+      it 'adds --no-contains <commit>' do
+        expect(execution_context).to receive(:command_lines).with('branch', '--no-contains', 'abc123').and_return([])
+        command.call(no_contains: 'abc123')
+      end
+    end
+
+    context 'with :merged option' do
+      it 'adds --merged <commit>' do
+        expect(execution_context).to receive(:command_lines).with('branch', '--merged', 'main').and_return([])
+        command.call(merged: 'main')
+      end
+    end
+
+    context 'with :no_merged option' do
+      it 'adds --no-merged <commit>' do
+        expect(execution_context).to receive(:command_lines).with('branch', '--no-merged', 'main').and_return([])
+        command.call(no_merged: 'main')
+      end
+    end
+
+    context 'with :points_at option' do
+      it 'adds --points-at <object>' do
+        expect(execution_context).to receive(:command_lines).with('branch', '--points-at', 'v1.0').and_return([])
+        command.call(points_at: 'v1.0')
+      end
+    end
+
+    context 'with patterns' do
+      it 'adds pattern arguments' do
+        expect(execution_context).to receive(:command_lines).with('branch', '--list', 'feature/*').and_return([])
+        command.call(patterns: 'feature/*')
+      end
+
+      it 'adds multiple pattern arguments' do
+        expect(execution_context).to receive(:command_lines).with('branch', '--list', 'feature/*',
+                                                                  'bugfix/*').and_return([])
+        command.call(patterns: ['feature/*', 'bugfix/*'])
+      end
+    end
+
+    context 'with multiple options' do
+      it 'combines flags correctly' do
+        expect(execution_context).to receive(:command_lines).with(
+          'branch', '-a', '--sort=refname', '--contains', 'abc123'
+        ).and_return([])
+        command.call(all: true, sort: 'refname', contains: 'abc123')
+      end
+    end
+
+    context 'when parsing branch output' do
+      let(:branch_output) do
+        [
+          '* main',
+          '  feature-branch',
+          '  remotes/origin/main',
+          '  remotes/origin/feature-branch'
+        ]
+      end
+
+      it 'returns parsed branch data as array of BranchInfo objects' do
+        expect(execution_context).to receive(:command_lines).with('branch').and_return(branch_output)
+        result = command.call
+        expect(result).to be_an(Array)
+        expect(result.size).to eq(4)
+        expect(result).to all(be_a(Git::BranchInfo))
+      end
+
+      it 'marks current branch correctly' do
+        expect(execution_context).to receive(:command_lines).with('branch').and_return(branch_output)
+        result = command.call
+        expect(result[0]).to have_attributes(refname: 'main', current: true, worktree: false, symref: nil)
+        expect(result[1]).to have_attributes(refname: 'feature-branch', current: false, worktree: false, symref: nil)
+      end
+
+      it 'parses remote branch names' do
+        expect(execution_context).to receive(:command_lines).with('branch').and_return(branch_output)
+        result = command.call
+        expect(result[2].refname).to eq('remotes/origin/main')
+        expect(result[3].refname).to eq('remotes/origin/feature-branch')
+      end
+    end
+
+    context 'with worktree branch' do
+      let(:worktree_output) do
+        [
+          '* main',
+          '+ feature-in-worktree',
+          '  other-branch'
+        ]
+      end
+
+      it 'marks worktree branch correctly' do
+        expect(execution_context).to receive(:command_lines).with('branch').and_return(worktree_output)
+        result = command.call
+        expect(result[0]).to have_attributes(refname: 'main', current: true, worktree: false, symref: nil)
+        expect(result[1]).to have_attributes(
+          refname: 'feature-in-worktree', current: false, worktree: true, symref: nil
+        )
+        expect(result[2]).to have_attributes(refname: 'other-branch', current: false, worktree: false, symref: nil)
+      end
+    end
+
+    context 'with detached HEAD state' do
+      let(:detached_output) do
+        [
+          '* (HEAD detached at v1.0)',
+          '  main',
+          '  feature-branch'
+        ]
+      end
+
+      it 'filters out detached HEAD lines' do
+        expect(execution_context).to receive(:command_lines).with('branch').and_return(detached_output)
+        result = command.call
+        expect(result.size).to eq(2)
+        expect(result.map(&:refname)).to eq(%w[main feature-branch])
+      end
+    end
+
+    context 'with (not a branch) line' do
+      let(:not_a_branch_output) do
+        [
+          '* (not a branch)',
+          '  main',
+          '  feature-branch'
+        ]
+      end
+
+      it 'filters out (not a branch) lines' do
+        expect(execution_context).to receive(:command_lines).with('branch').and_return(not_a_branch_output)
+        result = command.call
+        expect(result.size).to eq(2)
+        expect(result.map(&:refname)).to eq(%w[main feature-branch])
+      end
+    end
+
+    context 'with symbolic reference' do
+      let(:symref_output) do
+        [
+          '  main -> origin/main',
+          '  feature-branch'
+        ]
+      end
+
+      it 'includes symbolic reference information' do
+        expect(execution_context).to receive(:command_lines).with('branch').and_return(symref_output)
+        result = command.call
+        expect(result[0].symref).to eq('origin/main')
+      end
+    end
+
+    context 'with unsupported options' do
+      it 'raises ArgumentError' do
+        expect { command.call(invalid_option: true) }.to raise_error(ArgumentError, /unsupported/i)
+      end
+    end
+
+    context 'with unexpected git output format' do
+      let(:malformed_output) do
+        [
+          'malformed line without proper prefix',
+          '  valid-branch'
+        ]
+      end
+
+      it 'raises Git::UnexpectedResultError' do
+        expect(execution_context).to receive(:command_lines).with('branch').and_return(malformed_output)
+        expect { command.call }.to raise_error(Git::UnexpectedResultError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add a new `Git::Commands::Branch::List` command class for listing branches, following the architectural redesign pattern established in previous PRs.

## Changes

- **Add `Git::Commands::Branch::List` command** with full option support
- **Add comprehensive RSpec tests** (22 test cases)
- **Make `command_lines` public** in `Git::Lib` for use by Command classes

## Features

The command supports all `git branch --list` options:
- `all`/`remotes` flags for filtering local vs remote branches
- `sort` - single or multiple sort keys
- `contains`/`no_contains` - filter by commit containment
- `merged`/`no_merged` - filter by merge status
- `points_at` - filter by object reference
- `patterns` - shell wildcard patterns for branch name filtering

## Return Type

Returns `Array<Git::BranchInfo>` with parsed branch metadata including:
- `refname` - the full branch reference name
- `current` - whether this is the current branch
- `worktree` - whether checked out in another worktree
- `symref` - symbolic reference target (if applicable)

## Dependencies

- Requires PR #918 (Git::BranchInfo value object) - ✅ Merged

## Testing

```bash
bundle exec rspec spec/git/commands/branch/list_spec.rb
# 22 examples, 0 failures
```

## Part of Architectural Redesign

This PR is part of the ongoing architectural redesign to separate concerns:
- Command classes handle argument building and output parsing
- Value objects (`BranchInfo`) provide clean data structures
- `Git::Lib` will delegate to these commands (in future PR)