### PR TITLE
Update Git::Branch to accept BranchInfo

### DIFF
--- a/spec/git/branch_spec.rb
+++ b/spec/git/branch_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::Branch do
+  let(:lib) { instance_double(Git::Lib) }
+  let(:base) { instance_double(Git::Base, lib: lib) }
+
+  describe '#initialize' do
+    context 'with a BranchInfo object for a local branch' do
+      let(:branch_info) do
+        Git::BranchInfo.new(
+          refname: 'feature/my-feature',
+          current: true,
+          worktree: false,
+          symref: nil
+        )
+      end
+
+      subject(:branch) { described_class.new(base, branch_info) }
+
+      it 'sets the full refname' do
+        expect(branch.full).to eq('feature/my-feature')
+      end
+
+      it 'sets the short name' do
+        expect(branch.name).to eq('feature/my-feature')
+      end
+
+      it 'has no remote' do
+        expect(branch.remote).to be_nil
+      end
+    end
+
+    context 'with a BranchInfo object for a remote branch' do
+      let(:branch_info) do
+        Git::BranchInfo.new(
+          refname: 'remotes/origin/main',
+          current: false,
+          worktree: false,
+          symref: nil
+        )
+      end
+
+      let(:remote_config) { { 'url' => 'https://github.com/test/repo.git' } }
+
+      subject(:branch) { described_class.new(base, branch_info) }
+
+      before do
+        allow(lib).to receive(:config_remote).with('origin').and_return(remote_config)
+      end
+
+      it 'sets the full refname' do
+        expect(branch.full).to eq('remotes/origin/main')
+      end
+
+      it 'sets the short name without remote prefix' do
+        expect(branch.name).to eq('main')
+      end
+
+      it 'creates a remote object' do
+        expect(branch.remote).to be_a(Git::Remote)
+        expect(branch.remote.name).to eq('origin')
+      end
+    end
+
+    context 'with a String (legacy path)' do
+      let(:remote_config) { { 'url' => 'https://github.com/test/repo.git' } }
+
+      subject(:branch) { described_class.new(base, 'remotes/origin/develop') }
+
+      before do
+        allow(lib).to receive(:config_remote).with('origin').and_return(remote_config)
+      end
+
+      it 'sets the full refname' do
+        expect(branch.full).to eq('remotes/origin/develop')
+      end
+
+      it 'sets the short name without remote prefix' do
+        expect(branch.name).to eq('develop')
+      end
+
+      it 'creates a remote object' do
+        expect(branch.remote).to be_a(Git::Remote)
+        expect(branch.remote.name).to eq('origin')
+      end
+    end
+
+    context 'equivalence between BranchInfo and String initialization' do
+      let(:refname) { 'remotes/upstream/feature/test' }
+      let(:remote_config) { { 'url' => 'https://github.com/test/repo.git' } }
+
+      let(:branch_info) do
+        Git::BranchInfo.new(
+          refname: refname,
+          current: false,
+          worktree: false,
+          symref: nil
+        )
+      end
+
+      let(:branch_from_info) { described_class.new(base, branch_info) }
+      let(:branch_from_string) { described_class.new(base, refname) }
+
+      before do
+        allow(lib).to receive(:config_remote).with('upstream').and_return(remote_config)
+      end
+
+      it 'produces equivalent full refname' do
+        expect(branch_from_info.full).to eq(branch_from_string.full)
+      end
+
+      it 'produces equivalent short name' do
+        expect(branch_from_info.name).to eq(branch_from_string.name)
+      end
+
+      it 'produces equivalent remote name' do
+        if branch_from_info.remote
+          expect(branch_from_info.remote.name).to eq(branch_from_string.remote.name)
+        else
+          expect(branch_from_string.remote).to be_nil
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Update `Git::Branch` constructor to accept either a `Git::BranchInfo` object or a string name, maintaining full backward compatibility while enabling callers to transition to using `BranchInfo`.

## Changes

- Add dual-mode constructor supporting `BranchInfo` and `String`
- Extract initialization logic into private helper methods:
  - `initialize_from_argument` - dispatcher
  - `initialize_from_branch_info` - new preferred path
  - `initialize_from_name` - legacy string path
- Add comprehensive class and method documentation
- Add `require_relative 'branch_info'` for type checking

## Behavior

**When passed a `BranchInfo`:**
- Uses `refname`, `short_name`, and `remote_name` directly
- Avoids redundant parsing of the branch name

**When passed a `String` (backward compatible):**
- Uses existing `parse_name` logic
- No deprecation warning yet (will be added in future PR after consumers are updated)

## Why No Deprecation Warning?

The internal consumers (`Git::Branches`, `Git::Base#branch`, `Git::Remote#branch`) still pass strings because `branches_all` returns the legacy array format. Adding a deprecation warning now would cause test failures.

The deprecation warning will be added in a future PR after:
1. PR #5 updates consumers to use `BranchInfo`
2. `branches_all` returns `BranchInfo` objects directly

## Dependencies

- Requires PR #918 (Git::BranchInfo) - ✅ Merged
- Requires PR #920 (Git::Commands::Branch::List) - ✅ Merged
- Requires PR #921 (Integrate Branch::List in Lib) - ✅ Merged

## Testing

```bash
bundle exec rake test
# 530 tests, 1805 assertions, 0 failures, 0 errors
```

All existing tests pass without modification.