### PR TITLE
refactor: update branch consumers to use BranchInfo

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -834,7 +834,13 @@ module Git
 
     # @return [Git::Branch] an object for branch_name
     def branch(branch_name = current_branch)
-      Git::Branch.new(self, branch_name)
+      branch_info = Git::BranchInfo.new(
+        refname: branch_name,
+        current: false,
+        worktree: false,
+        symref: nil
+      )
+      Git::Branch.new(self, branch_info)
     end
 
     # @return [Git::Branches] a collection of all the branches in the repository.

--- a/lib/git/branches.rb
+++ b/lib/git/branches.rb
@@ -10,8 +10,8 @@ module Git
 
       @base = base
 
-      @base.lib.branches_all.each do |b|
-        @branches[b[0]] = Git::Branch.new(@base, b[0])
+      @base.lib.branches_all.each do |branch_info|
+        @branches[branch_info.refname] = Git::Branch.new(@base, branch_info)
       end
     end
 

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -662,9 +662,7 @@ module Git
     end
 
     def branches_all
-      Git::Commands::Branch::List.new(self).call(all: true).map do |branch_info|
-        [branch_info.refname, branch_info.current, branch_info.worktree, branch_info.symref]
-      end
+      Git::Commands::Branch::List.new(self).call(all: true)
     end
 
     def worktrees_all

--- a/lib/git/remote.rb
+++ b/lib/git/remote.rb
@@ -25,7 +25,13 @@ module Git
 
     def branch(branch = @base.current_branch)
       remote_tracking_branch = "#{@name}/#{branch}"
-      Git::Branch.new(@base, remote_tracking_branch)
+      branch_info = Git::BranchInfo.new(
+        refname: remote_tracking_branch,
+        current: false,
+        worktree: false,
+        symref: nil
+      )
+      Git::Branch.new(@base, branch_info)
     end
 
     def remove

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -289,14 +289,15 @@ class TestLib < Test::Unit::TestCase
     end
   end
 
-  # returns Git::Branch object array
+  # returns Git::BranchInfo object array
   def test_branches_all
     branches = @lib.branches_all
     assert(branches.size.positive?)
-    assert(branches.select { |b| b[1] }.size.positive?) # has a current branch
-    assert(branches.select { |b| %r{/}.match(b[0]) }.size.positive?) # has a remote branch
-    assert(branches.reject { |b| %r{/}.match(b[0]) }.size.positive?) # has a local branch
-    assert(branches.select { |b| /master/.match(b[0]) }.size.positive?) # has a master branch
+    assert(branches.all? { |b| b.is_a?(Git::BranchInfo) }) # all are BranchInfo objects
+    assert(branches.select(&:current).size.positive?) # has a current branch
+    assert(branches.select { |b| %r{/}.match(b.refname) }.size.positive?) # has a remote branch
+    assert(branches.reject { |b| %r{/}.match(b.refname) }.size.positive?) # has a local branch
+    assert(branches.select { |b| /master/.match(b.refname) }.size.positive?) # has a master branch
   end
 
   test 'Git::Lib#branches_all with unexpected output from git branches -a' do


### PR DESCRIPTION
## Summary

Update `Git::Lib#branches_all` to return `BranchInfo` objects directly and update all consumers to use the new API.

## Motivation

This is PR 4 of 5 for the Branch::List migration. It completes the integration of the `Branch::List` command by updating all internal consumers to use `BranchInfo` objects instead of array access patterns.

## Changes

### `lib/git/lib.rb`
- `branches_all` now returns `Array<BranchInfo>` directly instead of converting to arrays

### `lib/git/branches.rb`
- Uses `branch_info.refname` instead of `branch[0]`

### `lib/git/base.rb`
- `#branch` method creates `BranchInfo` when constructing `Git::Branch`

### `lib/git/remote.rb`
- `#branch` method creates `BranchInfo` when constructing `Git::Branch`

### `tests/units/test_lib.rb`
- Updated `test_branches_all` to use `BranchInfo` properties:
  - `b[1]` → `b.current`
  - `b[0]` → `b.refname`
  - Added assertion that all results are `BranchInfo` objects

## Testing

- ✅ All 530 unit tests pass (100%)
- ✅ No Rubocop offenses
- ✅ All internal callers now pass `BranchInfo`, eliminating internal deprecation warnings

## Related PRs

This is PR 4 of 5 for the Branch::List migration:
1. ✅ Add Git::BranchInfo value object
2. ✅ Add Git::Commands::Branch::List command
3. ✅ Update Git::Branch to accept BranchInfo
4. **Update branch consumers to use BranchInfo** ← this PR
5. Documentation updates