### PR TITLE
Extract branch creation to Git::Commands::Branch::Create

### DIFF
--- a/lib/git/commands/branch/create.rb
+++ b/lib/git/commands/branch/create.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+
+module Git
+  module Commands
+    module Branch
+      # Implements the `git branch` command for creating new branches
+      #
+      # This command creates a new branch head pointing to the current HEAD
+      # or a specified start point.
+      #
+      # @see https://git-scm.com/docs/git-branch git-branch
+      #
+      # @api private
+      #
+      # @example Basic branch creation
+      #   create = Git::Commands::Branch::Create.new(execution_context)
+      #   create.call('feature-branch')
+      #
+      # @example Create branch from a specific start point
+      #   create = Git::Commands::Branch::Create.new(execution_context)
+      #   create.call('feature-branch', 'main')
+      #
+      # @example Force create (reset existing branch)
+      #   create = Git::Commands::Branch::Create.new(execution_context)
+      #   create.call('feature-branch', 'main', force: true)
+      #
+      # @example Create with upstream tracking
+      #   create = Git::Commands::Branch::Create.new(execution_context)
+      #   create.call('feature-branch', 'origin/main', track: true)
+      #
+      # @example Create with inherited tracking configuration
+      #   create = Git::Commands::Branch::Create.new(execution_context)
+      #   create.call('feature-branch', 'origin/main', track: 'inherit')
+      #
+      class Create
+        # Arguments DSL for building command-line arguments
+        #
+        # NOTE: The order of definitions here determines the order of arguments
+        # in the final command line.
+        #
+        ARGS = Arguments.define do
+          flag :force
+          flag :create_reflog
+          flag :recurse_submodules
+          negatable_flag_or_inline_value :track
+          positional :branch_name, required: true
+          positional :start_point
+        end.freeze
+
+        # Initialize the Create command
+        #
+        # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
+        #
+        def initialize(execution_context)
+          @execution_context = execution_context
+        end
+
+        # Execute the git branch command to create a new branch
+        #
+        # @overload call(branch_name, start_point = nil, force: nil, create_reflog: nil,
+        #   recurse_submodules: nil, track: nil)
+        #
+        #   @param branch_name [String] The name of the branch to create. Must pass all checks
+        #     defined by git-check-ref-format.
+        #
+        #   @param start_point [String, nil] The commit, branch, or tag to start the new branch from.
+        #     If omitted, defaults to HEAD. Can also use `<rev-A>...<rev-B>` syntax for merge base.
+        #
+        #   @param force [Boolean] Reset the branch to `start_point` even if it already exists.
+        #     Without this, git branch refuses to change an existing branch.
+        #     Adds `--force` flag.
+        #
+        #   @param create_reflog [Boolean] Create the branch's reflog, enabling date-based sha1
+        #     expressions such as `branch@{yesterday}`. Note that in non-bare repositories,
+        #     reflogs are usually enabled by default via `core.logAllRefUpdates`.
+        #     Adds `--create-reflog` flag.
+        #
+        #   @param recurse_submodules [Boolean] Create the branch in the superproject and all
+        #     submodules. This is an experimental feature.
+        #     Adds `--recurse-submodules` flag.
+        #
+        #   @param track [Boolean, String, false] Configure upstream tracking for the new branch.
+        #     - `true`: Set up tracking using the start-point branch itself (`--track`)
+        #     - `false`: Do not set up tracking even if `branch.autoSetupMerge` is set (`--no-track`)
+        #     - `'direct'`: Same as `true`, explicitly use start-point as upstream (`--track=direct`)
+        #     - `'inherit'`: Copy upstream configuration from start-point branch (`--track=inherit`)
+        #
+        # @return [String] the command output
+        #
+        # @raise [ArgumentError] if unsupported options are provided
+        #
+        def call(branch_name, start_point = nil, **)
+          args = ARGS.build(branch_name, start_point, **)
+          @execution_context.command('branch', *args)
+        end
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -2,6 +2,7 @@
 
 require_relative 'args_builder'
 require_relative 'commands/add'
+require_relative 'commands/branch/create'
 require_relative 'commands/branch/list'
 require_relative 'commands/clean'
 require_relative 'commands/clone'
@@ -1194,8 +1195,16 @@ module Git
       command('stash', 'list')
     end
 
-    def branch_new(branch)
-      command('branch', branch)
+    # Create a new branch
+    #
+    # @param branch [String] the name of the branch to create
+    # @param start_point [String, nil] the commit, branch, or tag to start the new branch from
+    # @param options [Hash] command options (see {Git::Commands::Branch::Create#call})
+    #
+    # @note This method delegates to {Git::Commands::Branch::Create}
+    #
+    def branch_new(branch, start_point = nil, options = {})
+      Git::Commands::Branch::Create.new(self).call(branch, start_point, **options)
     end
 
     def branch_delete(branch)

--- a/spec/git/commands/branch/create_spec.rb
+++ b/spec/git/commands/branch/create_spec.rb
@@ -1,0 +1,152 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/branch/create'
+
+RSpec.describe Git::Commands::Branch::Create do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with branch name only (basic creation)' do
+      it 'calls git branch with the branch name' do
+        expect(execution_context).to receive(:command).with('branch', 'feature-branch')
+        command.call('feature-branch')
+      end
+    end
+
+    context 'with start_point' do
+      it 'adds the start point after the branch name' do
+        expect(execution_context).to receive(:command).with('branch', 'feature-branch', 'main')
+        command.call('feature-branch', 'main')
+      end
+
+      it 'accepts a commit SHA as start point' do
+        expect(execution_context).to receive(:command).with('branch', 'feature-branch', 'abc123')
+        command.call('feature-branch', 'abc123')
+      end
+
+      it 'accepts a tag as start point' do
+        expect(execution_context).to receive(:command).with('branch', 'feature-branch', 'v1.0.0')
+        command.call('feature-branch', 'v1.0.0')
+      end
+
+      it 'accepts a remote branch as start point' do
+        expect(execution_context).to receive(:command).with('branch', 'feature-branch', 'origin/main')
+        command.call('feature-branch', 'origin/main')
+      end
+    end
+
+    context 'with :force option' do
+      it 'adds --force flag' do
+        expect(execution_context).to receive(:command).with('branch', '--force', 'feature-branch')
+        command.call('feature-branch', force: true)
+      end
+
+      it 'allows resetting an existing branch to a new start point' do
+        expect(execution_context).to receive(:command).with('branch', '--force', 'feature-branch', 'main')
+        command.call('feature-branch', 'main', force: true)
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('branch', 'feature-branch')
+        command.call('feature-branch', force: false)
+      end
+    end
+
+    context 'with :create_reflog option' do
+      it 'adds --create-reflog flag' do
+        expect(execution_context).to receive(:command).with('branch', '--create-reflog', 'feature-branch')
+        command.call('feature-branch', create_reflog: true)
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('branch', 'feature-branch')
+        command.call('feature-branch', create_reflog: false)
+      end
+    end
+
+    context 'with :recurse_submodules option' do
+      it 'adds --recurse-submodules flag' do
+        expect(execution_context).to receive(:command).with('branch', '--recurse-submodules', 'feature-branch')
+        command.call('feature-branch', recurse_submodules: true)
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('branch', 'feature-branch')
+        command.call('feature-branch', recurse_submodules: false)
+      end
+    end
+
+    context 'with :track option' do
+      context 'when true' do
+        it 'adds --track flag' do
+          expect(execution_context).to receive(:command).with('branch', '--track', 'feature-branch', 'origin/main')
+          command.call('feature-branch', 'origin/main', track: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-track flag' do
+          expect(execution_context).to receive(:command).with('branch', '--no-track', 'feature-branch', 'origin/main')
+          command.call('feature-branch', 'origin/main', track: false)
+        end
+      end
+
+      context 'when "direct"' do
+        it 'adds --track=direct flag' do
+          expect(execution_context).to receive(:command).with(
+            'branch', '--track=direct', 'feature-branch', 'origin/main'
+          )
+          command.call('feature-branch', 'origin/main', track: 'direct')
+        end
+      end
+
+      context 'when "inherit"' do
+        it 'adds --track=inherit flag' do
+          expect(execution_context).to receive(:command).with(
+            'branch', '--track=inherit', 'feature-branch', 'origin/main'
+          )
+          command.call('feature-branch', 'origin/main', track: 'inherit')
+        end
+      end
+    end
+
+    context 'with multiple options combined' do
+      it 'includes all specified flags in correct order' do
+        expect(execution_context).to receive(:command).with(
+          'branch',
+          '--force',
+          '--create-reflog',
+          '--track',
+          'feature-branch',
+          'origin/main'
+        )
+        command.call('feature-branch', 'origin/main', force: true, create_reflog: true, track: true)
+      end
+
+      it 'combines force with no-track' do
+        expect(execution_context).to receive(:command).with(
+          'branch',
+          '--force',
+          '--no-track',
+          'feature-branch',
+          'main'
+        )
+        command.call('feature-branch', 'main', force: true, track: false)
+      end
+    end
+
+    context 'with nil start_point' do
+      it 'omits the start point from the command' do
+        expect(execution_context).to receive(:command).with('branch', 'feature-branch')
+        command.call('feature-branch', nil)
+      end
+
+      it 'omits the start point when options are provided' do
+        expect(execution_context).to receive(:command).with('branch', '--force', 'feature-branch')
+        command.call('feature-branch', nil, force: true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extract the branch creation logic from `Git::Lib#branch_new` into a dedicated `Git::Commands::Branch::Create` command class following the established command pattern.

## Changes

### New Files
- `lib/git/commands/branch/create.rb` - New command class implementing `git branch` for creating branches
- `spec/git/commands/branch/create_spec.rb` - Comprehensive test suite with 20 examples

### Modified Files
- `lib/git/lib.rb` - Updated `branch_new` to delegate to the new command class

## Features

The new `Git::Commands::Branch::Create` class supports the following options:

| Option | Flag | Description |
|--------|------|-------------|
| `force` | `--force` | Reset branch to start-point even if it exists |
| `create_reflog` | `--create-reflog` | Create the branch's reflog |
| `recurse_submodules` | `--recurse-submodules` | Create branch in submodules (experimental) |
| `track: true` | `--track` | Set up upstream tracking |
| `track: false` | `--no-track` | Disable upstream tracking |
| `track: 'direct'` | `--track=direct` | Explicit direct tracking |
| `track: 'inherit'` | `--track=inherit` | Copy upstream config from start-point |

## Usage Examples

```ruby
# Basic branch creation
create.call('feature-branch')
# => git branch feature-branch

# With start point
create.call('feature-branch', 'main')
# => git branch feature-branch main

# With force (reset existing branch)
create.call('feature-branch', 'main', force: true)
# => git branch --force feature-branch main

# With tracking
create.call('feature-branch', 'origin/main', track: true)
# => git branch --track feature-branch origin/main

create.call('feature-branch', 'origin/main', track: 'inherit')
# => git branch --track=inherit feature-branch origin/main
```

## Testing

- ✅ `bundle exec rspec spec/git/commands/branch/create_spec.rb` — 20 tests pass
- ✅ `bundle exec rspec` — All RSpec tests pass
- ✅ `bundle exec rake test` — All legacy TestUnit tests pass
- ✅ `bundle exec rubocop` — No lint errors
- ✅ `bundle exec yard` — No documentation errors

## Part of

This is part of the ongoing effort to implement the `git branch` interface as a suite of command classes.