### PR TITLE
Extract branch delete to Git::Commands::Branch::Delete

### DIFF
--- a/lib/git/commands/branch/delete.rb
+++ b/lib/git/commands/branch/delete.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+
+module Git
+  module Commands
+    module Branch
+      # Implements the `git branch --delete` command for deleting branches
+      #
+      # This command deletes one or more branch heads. The branch must be fully
+      # merged in its upstream branch, or in HEAD if no upstream was set, unless
+      # the `:force` option is provided.
+      #
+      # @see https://git-scm.com/docs/git-branch git-branch
+      #
+      # @api private
+      #
+      # @example Basic branch deletion (safe - fails if not merged)
+      #   delete = Git::Commands::Branch::Delete.new(execution_context)
+      #   delete.call('feature-branch')
+      #
+      # @example Force delete (works even if not merged)
+      #   delete = Git::Commands::Branch::Delete.new(execution_context)
+      #   delete.call('feature-branch', force: true)
+      #
+      # @example Delete remote-tracking branch
+      #   delete = Git::Commands::Branch::Delete.new(execution_context)
+      #   delete.call('origin/feature', remotes: true)
+      #
+      # @example Delete multiple branches at once
+      #   delete = Git::Commands::Branch::Delete.new(execution_context)
+      #   delete.call('branch1', 'branch2', 'branch3')
+      #
+      # @example Force delete with quiet mode
+      #   delete = Git::Commands::Branch::Delete.new(execution_context)
+      #   delete.call('feature-branch', force: true, quiet: true)
+      #
+      class Delete
+        # Arguments DSL for building command-line arguments
+        #
+        # NOTE: Static flags are always output first regardless of definition order,
+        # so we define them first for readability.
+        #
+        ARGS = Arguments.define do
+          static '--delete'
+          flag %i[force f], args: '--force'
+          flag %i[remotes r], args: '--remotes'
+          flag %i[quiet q], args: '--quiet'
+          positional :branch_names, variadic: true, required: true
+        end.freeze
+
+        # Initialize the Delete command
+        #
+        # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
+        #
+        def initialize(execution_context)
+          @execution_context = execution_context
+        end
+
+        # Execute the git branch --delete command to delete branches
+        #
+        # @overload call(*branch_names, force: nil, remotes: nil, quiet: nil)
+        #
+        #   @param branch_names [Array<String>] One or more branch names to delete.
+        #     You may specify more than one branch for deletion.
+        #
+        #   @param force [Boolean] Allow deleting the branch irrespective of its merged
+        #     status, or whether it even points to a valid commit. This is equivalent
+        #     to the `-D` shortcut (`--delete --force`).
+        #     Adds `--force` flag.
+        #
+        #   @param remotes [Boolean] Delete remote-tracking branches. Use this together
+        #     with `--delete` to delete remote-tracking branches. Note that this only
+        #     makes sense if the remote-tracking branches no longer exist in the remote
+        #     repository or if `git fetch` was configured not to fetch them again.
+        #     Adds `--remotes` flag.
+        #
+        #   @param quiet [Boolean] Be more quiet when deleting a branch, suppressing
+        #     non-error messages.
+        #     Adds `--quiet` flag.
+        #
+        # @return [String] the command output
+        #
+        # @raise [ArgumentError] if unsupported options are provided
+        # @raise [Git::FailedError] if the branch is not fully merged (without force)
+        #
+        def call(*, **)
+          args = ARGS.build(*, **)
+          @execution_context.command('branch', *args)
+        end
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -3,6 +3,7 @@
 require_relative 'args_builder'
 require_relative 'commands/add'
 require_relative 'commands/branch/create'
+require_relative 'commands/branch/delete'
 require_relative 'commands/branch/list'
 require_relative 'commands/clean'
 require_relative 'commands/clone'
@@ -1207,8 +1208,20 @@ module Git
       Git::Commands::Branch::Create.new(self).call(branch, start_point, **options)
     end
 
-    def branch_delete(branch)
-      command('branch', '-D', branch)
+    # Delete one or more branches
+    #
+    # @param branches [Array<String>] the name(s) of the branch(es) to delete
+    # @param options [Hash] command options (see {Git::Commands::Branch::Delete#call})
+    # @option options [Boolean] :force allow deleting unmerged branches (default: true for backward compatibility)
+    # @option options [Boolean] :remotes delete remote-tracking branches
+    # @option options [Boolean] :quiet suppress non-error messages
+    #
+    # @note This method delegates to {Git::Commands::Branch::Delete}
+    # @note Default force: true preserves backward compatibility with original -D behavior
+    #
+    def branch_delete(*branches, **options)
+      options = { force: true }.merge(options)
+      Git::Commands::Branch::Delete.new(self).call(*branches, **options)
     end
 
     CHECKOUT_OPTION_MAP = [

--- a/spec/git/commands/branch/delete_spec.rb
+++ b/spec/git/commands/branch/delete_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/branch/delete'
+
+RSpec.describe Git::Commands::Branch::Delete do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with single branch name (basic deletion)' do
+      it 'calls git branch --delete with the branch name' do
+        expect(execution_context).to receive(:command).with('branch', '--delete', 'feature-branch')
+        command.call('feature-branch')
+      end
+    end
+
+    context 'with multiple branch names' do
+      it 'deletes all specified branches in one command' do
+        expect(execution_context).to receive(:command).with('branch', '--delete', 'branch1', 'branch2', 'branch3')
+        command.call('branch1', 'branch2', 'branch3')
+      end
+    end
+
+    context 'with :force option' do
+      it 'adds --force flag' do
+        expect(execution_context).to receive(:command).with('branch', '--delete', '--force', 'feature-branch')
+        command.call('feature-branch', force: true)
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('branch', '--delete', 'feature-branch')
+        command.call('feature-branch', force: false)
+      end
+
+      it 'accepts :f alias' do
+        expect(execution_context).to receive(:command).with('branch', '--delete', '--force', 'feature-branch')
+        command.call('feature-branch', f: true)
+      end
+    end
+
+    context 'with :remotes option' do
+      it 'adds --remotes flag for remote-tracking branches' do
+        expect(execution_context).to receive(:command).with('branch', '--delete', '--remotes', 'origin/feature')
+        command.call('origin/feature', remotes: true)
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('branch', '--delete', 'origin/feature')
+        command.call('origin/feature', remotes: false)
+      end
+
+      it 'accepts :r alias' do
+        expect(execution_context).to receive(:command).with('branch', '--delete', '--remotes', 'origin/feature')
+        command.call('origin/feature', r: true)
+      end
+    end
+
+    context 'with :quiet option' do
+      it 'adds --quiet flag' do
+        expect(execution_context).to receive(:command).with('branch', '--delete', '--quiet', 'feature-branch')
+        command.call('feature-branch', quiet: true)
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('branch', '--delete', 'feature-branch')
+        command.call('feature-branch', quiet: false)
+      end
+
+      it 'accepts :q alias' do
+        expect(execution_context).to receive(:command).with('branch', '--delete', '--quiet', 'feature-branch')
+        command.call('feature-branch', q: true)
+      end
+    end
+
+    context 'with multiple options combined' do
+      it 'includes all specified flags in correct order' do
+        expect(execution_context).to receive(:command).with(
+          'branch',
+          '--delete',
+          '--force',
+          '--remotes',
+          '--quiet',
+          'origin/feature'
+        )
+        command.call('origin/feature', force: true, remotes: true, quiet: true)
+      end
+
+      it 'combines force with multiple branches' do
+        expect(execution_context).to receive(:command).with(
+          'branch',
+          '--delete',
+          '--force',
+          'branch1',
+          'branch2'
+        )
+        command.call('branch1', 'branch2', force: true)
+      end
+
+      it 'combines remotes with multiple branches' do
+        expect(execution_context).to receive(:command).with(
+          'branch',
+          '--delete',
+          '--remotes',
+          'origin/branch1',
+          'origin/branch2'
+        )
+        command.call('origin/branch1', 'origin/branch2', remotes: true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Migrate the branch delete functionality from `Git::Lib` to a dedicated command class following the strangler fig migration pattern.

## Changes

- Add `Git::Commands::Branch::Delete` command class with Arguments DSL
- Support `--force`, `--remotes`, `--quiet` options with short aliases (`:f`, `:r`, `:q`)
- Support deleting multiple branches in one command
- Update `Git::Lib#branch_delete` to delegate to the new class
- Default `force: true` for backward compatibility (original implementation used `-D`)
- Add comprehensive RSpec tests for all options and combinations

## Interface

```ruby
delete = Git::Commands::Branch::Delete.new(execution_context)

# Basic delete (safe - fails if not merged)
delete.call('feature-branch')

# Force delete (works even if not merged)
delete.call('feature-branch', force: true)

# Delete remote-tracking branch
delete.call('origin/feature', remotes: true)

# Delete multiple branches at once
delete.call('branch1', 'branch2', 'branch3')

# Force delete with quiet mode
delete.call('feature-branch', force: true, quiet: true)
```

## Backward Compatibility

The `Git::Lib#branch_delete` method defaults to `force: true` to preserve the original `-D` behavior. Users can opt into safe deletion by explicitly passing `force: false`.

## Testing

- [x] `bundle exec rspec spec/git/commands/branch/*_spec.rb` — new tests pass
- [x] `bundle exec rspec` — all RSpec tests pass
- [x] `bundle exec rake test` — legacy TestUnit tests pass
- [x] `bundle exec rubocop` — no lint errors
- [x] `bundle exec yard` — no yardoc errors

Part of the ongoing command migration effort (Phase 2).