### PR TITLE
Add move command class for branch renaming

### DIFF
--- a/lib/git/commands/branch/move.rb
+++ b/lib/git/commands/branch/move.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+
+module Git
+  module Commands
+    module Branch
+      # Implements the `git branch --move` command for renaming branches
+      #
+      # This command moves/renames a branch, together with its config and reflog.
+      # If the old branch name is omitted, renames the current branch.
+      #
+      # @see https://git-scm.com/docs/git-branch git-branch
+      #
+      # @api private
+      #
+      # @example Rename the current branch
+      #   move = Git::Commands::Branch::Move.new(execution_context)
+      #   move.call('new-branch-name')
+      #
+      # @example Rename a specific branch
+      #   move = Git::Commands::Branch::Move.new(execution_context)
+      #   move.call('old-branch-name', 'new-branch-name')
+      #
+      # @example Force rename (overwrite existing branch)
+      #   move = Git::Commands::Branch::Move.new(execution_context)
+      #   move.call('old-branch', 'existing-branch', force: true)
+      #
+      class Move
+        # Arguments DSL for building command-line arguments
+        #
+        # NOTE: The positional arguments follow Ruby semantics:
+        # - When one positional is provided, it fills new_branch (required)
+        # - When two positionals are provided, they fill old_branch and new_branch
+        #
+        # This matches the git CLI: `git branch -m [<old-branch>] <new-branch>`
+        #
+        ARGS = Arguments.define do
+          static '--move'
+          flag :force
+          positional :old_branch
+          positional :new_branch, required: true
+        end.freeze
+
+        # Initialize the Move command
+        #
+        # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
+        #
+        def initialize(execution_context)
+          @execution_context = execution_context
+        end
+
+        # Execute the git branch --move command to rename a branch
+        #
+        # @overload call(new_branch, force: nil)
+        #   Rename the current branch
+        #   @param new_branch [String] The new name for the current branch
+        #   @param force [Boolean] Allow renaming even if new_branch already exists
+        #
+        # @overload call(old_branch, new_branch, force: nil)
+        #   Rename a specific branch
+        #   @param old_branch [String] The name of the branch to rename
+        #   @param new_branch [String] The new name for the branch
+        #   @param force [Boolean] Allow renaming even if new_branch already exists
+        #
+        # @return [String] the command output
+        #
+        # @raise [ArgumentError] if unsupported options are provided
+        # @raise [Git::FailedError] if the branch doesn't exist or target exists (without force)
+        #
+        def call(*, **)
+          args = ARGS.build(*, **)
+          @execution_context.command('branch', *args)
+        end
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -5,6 +5,7 @@ require_relative 'commands/add'
 require_relative 'commands/branch/create'
 require_relative 'commands/branch/delete'
 require_relative 'commands/branch/list'
+require_relative 'commands/branch/move'
 require_relative 'commands/clean'
 require_relative 'commands/clone'
 require_relative 'commands/commit'
@@ -1222,6 +1223,27 @@ module Git
     def branch_delete(*branches, **options)
       options = { force: true }.merge(options)
       Git::Commands::Branch::Delete.new(self).call(*branches, **options)
+    end
+
+    # Move/rename a branch
+    #
+    # @overload branch_move(new_branch, options = {})
+    #   Rename the current branch
+    #   @param new_branch [String] the new name for the current branch
+    #   @param options [Hash] command options
+    #
+    # @overload branch_move(old_branch, new_branch, options = {})
+    #   Rename a specific branch
+    #   @param old_branch [String] the branch to rename
+    #   @param new_branch [String] the new name for the branch
+    #   @param options [Hash] command options
+    #
+    # @option options [Boolean] :force allow renaming even if new_branch already exists
+    #
+    # @note This method delegates to {Git::Commands::Branch::Move}
+    #
+    def branch_move(*, **)
+      Git::Commands::Branch::Move.new(self).call(*, **)
     end
 
     CHECKOUT_OPTION_MAP = [

--- a/spec/git/commands/branch/move_spec.rb
+++ b/spec/git/commands/branch/move_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/branch/move'
+
+RSpec.describe Git::Commands::Branch::Move do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with only new_branch (rename current branch)' do
+      it 'calls git branch --move with only the new branch name' do
+        expect(execution_context).to receive(:command).with('branch', '--move', 'new-name')
+        command.call('new-name')
+      end
+    end
+
+    context 'with old_branch and new_branch' do
+      it 'calls git branch --move with both branch names' do
+        expect(execution_context).to receive(:command).with('branch', '--move', 'old-name', 'new-name')
+        command.call('old-name', 'new-name')
+      end
+    end
+
+    context 'with :force option' do
+      it 'adds --force flag when renaming current branch' do
+        expect(execution_context).to receive(:command).with('branch', '--move', '--force', 'new-name')
+        command.call('new-name', force: true)
+      end
+
+      it 'adds --force flag when renaming specific branch' do
+        expect(execution_context).to receive(:command).with('branch', '--move', '--force', 'old-name', 'new-name')
+        command.call('old-name', 'new-name', force: true)
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('branch', '--move', 'new-name')
+        command.call('new-name', force: false)
+      end
+    end
+
+    context 'with unsupported options' do
+      it 'raises ArgumentError for unknown options' do
+        expect { command.call('new-name', unknown: true) }.to raise_error(ArgumentError, /unknown/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements `Git::Commands::Branch::Move` following the command pattern established by Create, Delete, and List commands.

## Features

- **Rename current branch**: `move.call('new-name')`
- **Rename specific branch**: `move.call('old-name', 'new-name')`  
- **Force rename**: `move.call('new-name', force: true)`

## Implementation Details

The command uses the Arguments DSL with Ruby-like positional semantics where the required `new_branch` parameter is filled before the optional `old_branch` parameter.

```ruby
ARGS = Arguments.define do
  static '--move'
  flag :force
  positional :old_branch
  positional :new_branch, required: true
end.freeze
```

This matches the git CLI pattern: `git branch -m [<old-branch>] <new-branch>`

## Changes

- `lib/git/commands/branch/move.rb` - New command class
- `spec/git/commands/branch/move_spec.rb` - Tests for all options
- `lib/git/lib.rb` - Adds `branch_move` delegation method

## Testing

- All 6 move_spec.rb tests pass
- All 517 RSpec tests pass
- All 530 legacy TestUnit tests pass
- RuboCop: no offenses
- YARD: no errors