### PR TITLE
Add branch copy command class for copying branches

### DIFF
--- a/lib/git/commands/branch/copy.rb
+++ b/lib/git/commands/branch/copy.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+
+module Git
+  module Commands
+    module Branch
+      # Implements the `git branch --copy` command for copying branches
+      #
+      # This command copies a branch, together with its config and reflog.
+      # If the old branch name is omitted, copies the current branch.
+      #
+      # @see https://git-scm.com/docs/git-branch git-branch
+      #
+      # @api private
+      #
+      # @example Copy the current branch
+      #   copy = Git::Commands::Branch::Copy.new(execution_context)
+      #   copy.call('new-branch-name')
+      #
+      # @example Copy a specific branch
+      #   copy = Git::Commands::Branch::Copy.new(execution_context)
+      #   copy.call('old-branch-name', 'new-branch-name')
+      #
+      # @example Force copy (overwrite existing branch)
+      #   copy = Git::Commands::Branch::Copy.new(execution_context)
+      #   copy.call('old-branch', 'existing-branch', force: true)
+      #
+      class Copy
+        # Arguments DSL for building command-line arguments
+        #
+        # NOTE: The positional arguments follow Ruby semantics:
+        # - When one positional is provided, it fills new_branch (required)
+        # - When two positionals are provided, they fill old_branch and new_branch
+        #
+        # This matches the git CLI: `git branch -c [<old-branch>] <new-branch>`
+        #
+        ARGS = Arguments.define do
+          static '--copy'
+          flag :force
+          positional :old_branch
+          positional :new_branch, required: true
+        end.freeze
+
+        # Initialize the Copy command
+        #
+        # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
+        #
+        def initialize(execution_context)
+          @execution_context = execution_context
+        end
+
+        # Execute the git branch --copy command to copy a branch
+        #
+        # @overload call(new_branch, force: nil)
+        #   Copy the current branch
+        #   @param new_branch [String] The new name for the copied branch
+        #   @param force [Boolean] Allow copying even if new_branch already exists
+        #
+        # @overload call(old_branch, new_branch, force: nil)
+        #   Copy a specific branch
+        #   @param old_branch [String] The name of the branch to copy
+        #   @param new_branch [String] The new name for the copied branch
+        #   @param force [Boolean] Allow copying even if new_branch already exists
+        #
+        # @return [String] the command output
+        #
+        # @raise [ArgumentError] if unsupported options are provided
+        # @raise [Git::FailedError] if the branch doesn't exist or target exists (without force)
+        #
+        def call(*, **)
+          args = ARGS.build(*, **)
+          @execution_context.command('branch', *args)
+        end
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -2,6 +2,7 @@
 
 require_relative 'args_builder'
 require_relative 'commands/add'
+require_relative 'commands/branch/copy'
 require_relative 'commands/branch/create'
 require_relative 'commands/branch/delete'
 require_relative 'commands/branch/list'
@@ -1244,6 +1245,27 @@ module Git
     #
     def branch_move(*, **)
       Git::Commands::Branch::Move.new(self).call(*, **)
+    end
+
+    # Copy a branch, along with its config and reflog
+    #
+    # @overload branch_copy(new_branch, options = {})
+    #   Copy the current branch
+    #   @param new_branch [String] the name for the new branch
+    #   @param options [Hash] command options
+    #
+    # @overload branch_copy(old_branch, new_branch, options = {})
+    #   Copy a specific branch
+    #   @param old_branch [String] the branch to copy
+    #   @param new_branch [String] the name for the new branch
+    #   @param options [Hash] command options
+    #
+    # @option options [Boolean] :force allow copying even if new_branch already exists
+    #
+    # @note This method delegates to {Git::Commands::Branch::Copy}
+    #
+    def branch_copy(*, **)
+      Git::Commands::Branch::Copy.new(self).call(*, **)
     end
 
     CHECKOUT_OPTION_MAP = [

--- a/spec/git/commands/branch/copy_spec.rb
+++ b/spec/git/commands/branch/copy_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/branch/copy'
+
+RSpec.describe Git::Commands::Branch::Copy do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with only new_branch (copy current branch)' do
+      it 'calls git branch --copy with only the new branch name' do
+        expect(execution_context).to receive(:command).with('branch', '--copy', 'new-name')
+        command.call('new-name')
+      end
+    end
+
+    context 'with old_branch and new_branch' do
+      it 'calls git branch --copy with both branch names' do
+        expect(execution_context).to receive(:command).with('branch', '--copy', 'old-name', 'new-name')
+        command.call('old-name', 'new-name')
+      end
+    end
+
+    context 'with :force option' do
+      it 'adds --force flag when copying current branch' do
+        expect(execution_context).to receive(:command).with('branch', '--copy', '--force', 'new-name')
+        command.call('new-name', force: true)
+      end
+
+      it 'adds --force flag when copying specific branch' do
+        expect(execution_context).to receive(:command).with('branch', '--copy', '--force', 'old-name', 'new-name')
+        command.call('old-name', 'new-name', force: true)
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('branch', '--copy', 'new-name')
+        command.call('new-name', force: false)
+      end
+    end
+
+    context 'with unsupported options' do
+      it 'raises ArgumentError for unknown options' do
+        expect { command.call('new-name', unknown: true) }.to raise_error(ArgumentError, /unknown/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implement `Git::Commands::Branch::Copy` following the established command class pattern. This provides a clean interface for the `git branch --copy` command.

## Features

- **Copy current branch**: `copy.call('new-branch')`
- **Copy specific branch**: `copy.call('old-branch', 'new-branch')`
- **Force option**: Overwrite existing branches with `force: true`

## Changes

- Add `lib/git/commands/branch/copy.rb` with Copy command class
- Add `spec/git/commands/branch/copy_spec.rb` with comprehensive tests
- Add `Git::Lib#branch_copy` method delegating to the new command class

## Implementation Notes

This follows the exact same pattern as the `Move` command (implemented in the previous PR), since `git branch --copy` and `git branch --move` have identical semantics—the only difference is that copy creates a new branch while preserving the original.

## Testing

- [x] `bundle exec rspec spec/git/commands/branch/*_spec.rb` — new tests pass
- [x] `bundle exec rspec` — all RSpec tests pass (523 examples)
- [x] `bundle exec rake test` — legacy TestUnit tests pass (530 tests)
- [x] `bundle exec rubocop` — no lint errors
- [x] `bundle exec yard` — no yardoc errors