### PR TITLE
Implement Branch::SetUpstream and Branch::UnsetUpstream commands

### DIFF
--- a/lib/git/commands/branch/set_upstream.rb
+++ b/lib/git/commands/branch/set_upstream.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+
+module Git
+  module Commands
+    module Branch
+      # Implements the `git branch --set-upstream-to` command for configuring upstream tracking
+      #
+      # This command sets up tracking information so the specified upstream branch is considered
+      # the upstream for the given branch (or current branch if not specified).
+      #
+      # @see https://git-scm.com/docs/git-branch git-branch
+      #
+      # @api private
+      #
+      # @example Set upstream for current branch
+      #   set_upstream = Git::Commands::Branch::SetUpstream.new(execution_context)
+      #   set_upstream.call(set_upstream_to: 'origin/main')
+      #
+      # @example Set upstream for a specific branch
+      #   set_upstream = Git::Commands::Branch::SetUpstream.new(execution_context)
+      #   set_upstream.call('feature', set_upstream_to: 'origin/main')
+      #
+      class SetUpstream
+        # Arguments DSL for building command-line arguments
+        #
+        # NOTE: The set_upstream_to option maps to git's --set-upstream-to=<upstream> syntax.
+        # The branch_name positional is optional; if omitted, git uses the current branch.
+        # The set_upstream_to keyword is required by the Ruby method signature, not the DSL.
+        #
+        ARGS = Arguments.define do
+          inline_value :set_upstream_to
+          positional :branch_name
+        end.freeze
+
+        # Initialize the SetUpstream command
+        #
+        # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
+        #
+        def initialize(execution_context)
+          @execution_context = execution_context
+        end
+
+        # Execute the git branch --set-upstream-to command
+        #
+        # @overload call(set_upstream_to:)
+        #   Set upstream for the current branch
+        #   @param set_upstream_to [String] The upstream branch (e.g., 'origin/main')
+        #
+        # @overload call(branch_name, set_upstream_to:)
+        #   Set upstream for a specific branch
+        #   @param branch_name [String] The branch to configure
+        #   @param set_upstream_to [String] The upstream branch (e.g., 'origin/main')
+        #
+        # @return [String] the command output
+        #
+        # @raise [ArgumentError] if set_upstream_to is not provided
+        # @raise [ArgumentError] if unsupported options are provided
+        # @raise [Git::FailedError] if the branch or upstream doesn't exist
+        #
+        def call(branch_name = nil, set_upstream_to:)
+          args = ARGS.build(branch_name, set_upstream_to: set_upstream_to)
+          @execution_context.command('branch', *args)
+        end
+      end
+    end
+  end
+end

--- a/lib/git/commands/branch/unset_upstream.rb
+++ b/lib/git/commands/branch/unset_upstream.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+
+module Git
+  module Commands
+    module Branch
+      # Implements the `git branch --unset-upstream` command for removing upstream tracking
+      #
+      # This command removes the upstream tracking information for the given branch
+      # (or current branch if not specified).
+      #
+      # @see https://git-scm.com/docs/git-branch git-branch
+      #
+      # @api private
+      #
+      # @example Unset upstream for current branch
+      #   unset_upstream = Git::Commands::Branch::UnsetUpstream.new(execution_context)
+      #   unset_upstream.call
+      #
+      # @example Unset upstream for a specific branch
+      #   unset_upstream = Git::Commands::Branch::UnsetUpstream.new(execution_context)
+      #   unset_upstream.call('feature')
+      #
+      class UnsetUpstream
+        # Arguments DSL for building command-line arguments
+        #
+        # NOTE: The --unset-upstream flag is always present.
+        # The branch_name positional is optional; if omitted, git uses the current branch.
+        #
+        ARGS = Arguments.define do
+          static '--unset-upstream'
+          positional :branch_name
+        end.freeze
+
+        # Initialize the UnsetUpstream command
+        #
+        # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
+        #
+        def initialize(execution_context)
+          @execution_context = execution_context
+        end
+
+        # Execute the git branch --unset-upstream command
+        #
+        # @overload call
+        #   Unset upstream for the current branch
+        #
+        # @overload call(branch_name)
+        #   Unset upstream for a specific branch
+        #   @param branch_name [String] The branch to configure
+        #
+        # @return [String] the command output
+        #
+        # @raise [ArgumentError] if unsupported options are provided
+        # @raise [Git::FailedError] if the branch doesn't exist or has no upstream
+        #
+        def call(branch_name = nil, **)
+          args = ARGS.build(branch_name, **)
+          @execution_context.command('branch', *args)
+        end
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -7,6 +7,8 @@ require_relative 'commands/branch/create'
 require_relative 'commands/branch/delete'
 require_relative 'commands/branch/list'
 require_relative 'commands/branch/move'
+require_relative 'commands/branch/set_upstream'
+require_relative 'commands/branch/unset_upstream'
 require_relative 'commands/clean'
 require_relative 'commands/clone'
 require_relative 'commands/commit'
@@ -1266,6 +1268,27 @@ module Git
     #
     def branch_copy(*, **)
       Git::Commands::Branch::Copy.new(self).call(*, **)
+    end
+
+    # Set upstream tracking information for a branch
+    #
+    # @param upstream [String] the upstream branch (e.g., 'origin/main')
+    # @param branch_name [String, nil] the branch to configure (defaults to current branch)
+    #
+    # @note This method delegates to {Git::Commands::Branch::SetUpstream}
+    #
+    def branch_set_upstream(upstream, branch_name = nil)
+      Git::Commands::Branch::SetUpstream.new(self).call(branch_name, set_upstream_to: upstream)
+    end
+
+    # Remove upstream tracking information for a branch
+    #
+    # @param branch_name [String, nil] the branch to configure (defaults to current branch)
+    #
+    # @note This method delegates to {Git::Commands::Branch::UnsetUpstream}
+    #
+    def branch_unset_upstream(branch_name = nil)
+      Git::Commands::Branch::UnsetUpstream.new(self).call(branch_name)
     end
 
     CHECKOUT_OPTION_MAP = [

--- a/spec/git/commands/branch/set_upstream_spec.rb
+++ b/spec/git/commands/branch/set_upstream_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/branch/set_upstream'
+
+RSpec.describe Git::Commands::Branch::SetUpstream do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with only set_upstream_to (set upstream for current branch)' do
+      it 'calls git branch --set-upstream-to=<upstream>' do
+        expect(execution_context).to receive(:command).with('branch', '--set-upstream-to=origin/main')
+        command.call(set_upstream_to: 'origin/main')
+      end
+    end
+
+    context 'with set_upstream_to and branch_name' do
+      it 'calls git branch --set-upstream-to=<upstream> <branch>' do
+        expect(execution_context).to receive(:command).with('branch', '--set-upstream-to=origin/main', 'feature')
+        command.call('feature', set_upstream_to: 'origin/main')
+      end
+    end
+
+    context 'with remote-tracking branch as upstream' do
+      it 'accepts various remote-tracking branch formats' do
+        expect(execution_context).to receive(:command).with('branch', '--set-upstream-to=upstream/develop')
+        command.call(set_upstream_to: 'upstream/develop')
+      end
+    end
+
+    context 'with missing set_upstream_to' do
+      it 'raises ArgumentError' do
+        expect { command.call }.to raise_error(ArgumentError)
+      end
+
+      it 'raises ArgumentError even when branch_name is provided' do
+        expect { command.call('feature') }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with unsupported options' do
+      it 'raises ArgumentError for unknown options' do
+        expect { command.call(set_upstream_to: 'origin/main', unknown: true) }.to raise_error(ArgumentError, /unknown/)
+      end
+    end
+  end
+end

--- a/spec/git/commands/branch/unset_upstream_spec.rb
+++ b/spec/git/commands/branch/unset_upstream_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/branch/unset_upstream'
+
+RSpec.describe Git::Commands::Branch::UnsetUpstream do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with no arguments (unset upstream for current branch)' do
+      it 'calls git branch --unset-upstream' do
+        expect(execution_context).to receive(:command).with('branch', '--unset-upstream')
+        command.call
+      end
+    end
+
+    context 'with branch_name' do
+      it 'calls git branch --unset-upstream <branch>' do
+        expect(execution_context).to receive(:command).with('branch', '--unset-upstream', 'feature')
+        command.call('feature')
+      end
+    end
+
+    context 'with nil branch_name' do
+      it 'calls git branch --unset-upstream (nil is treated as not provided)' do
+        expect(execution_context).to receive(:command).with('branch', '--unset-upstream')
+        command.call(nil)
+      end
+    end
+
+    context 'with unsupported options' do
+      it 'raises ArgumentError for unknown options' do
+        expect { command.call(unknown: true) }.to raise_error(ArgumentError, /unknown/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Add new command classes for `git branch --set-upstream-to` and `git branch --unset-upstream` following the established pattern for branch commands.

## Changes

- Add `Git::Commands::Branch::SetUpstream` for `git branch --set-upstream-to=<upstream> [<branch>]`
- Add `Git::Commands::Branch::UnsetUpstream` for `git branch --unset-upstream [<branch>]`
- Add comprehensive RSpec tests for both commands
- Add `Git::Lib#branch_set_upstream` and `#branch_unset_upstream` delegation methods

## Architectural Decision

**The Commands layer maps strictly to git CLI semantics, not ergonomics.**

`SetUpstream` uses a required keyword argument (`set_upstream_to:`) because in git's CLI, `<upstream>` is the value of an option (`--set-upstream-to=<upstream>`), not a positional argument. The only positional is `[<branch-name>]`.

The "nicer" Ruby API with `upstream` as the first positional argument lives in `Git::Lib`:

```ruby
# Git::Commands::Branch::SetUpstream - strict CLI mapping
def call(branch_name = nil, set_upstream_to:)

# Git::Lib - ergonomic Ruby API  
def branch_set_upstream(upstream, branch_name = nil)
  Git::Commands::Branch::SetUpstream.new(self).call(branch_name, set_upstream_to: upstream)
end
```

This maintains separation of concerns:
- **Commands layer**: Strict 1:1 mapping to git CLI
- **Lib layer**: Provides natural Ruby API transformations

## Testing

- [x] `bundle exec rspec spec/git/commands/branch/*_spec.rb` — new tests pass
- [x] `bundle exec rspec` — all RSpec tests pass (533 examples)
- [x] `bundle exec rake test` — legacy TestUnit tests pass (530 tests)
- [x] `bundle exec rubocop` — no lint errors
- [x] `bundle exec yard` — no yardoc errors