### PR TITLE
Migrate merge commands to Commands layer

### DIFF
--- a/lib/git/commands/merge/resolve.rb
+++ b/lib/git/commands/merge/resolve.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+
+module Git
+  module Commands
+    module Merge
+      # Implements merge state management: abort, continue, or quit an in-progress merge
+      #
+      # This command handles the resolution of a merge that has stopped due to conflicts:
+      # - `--abort`: Abort the merge and restore pre-merge state
+      # - `--continue`: Complete the merge after conflicts are resolved
+      # - `--quit`: Forget about the merge, leaving working tree as-is
+      #
+      # @see https://git-scm.com/docs/git-merge git-merge
+      #
+      # @api private
+      #
+      # @example Abort a merge
+      #   resolve = Git::Commands::Merge::Resolve.new(execution_context)
+      #   resolve.call(abort: true)
+      #
+      # @example Continue after resolving conflicts
+      #   resolve.call(continue: true)
+      #
+      # @example Quit the merge, leaving working tree as-is
+      #   resolve.call(quit: true)
+      #
+      class Resolve
+        # Arguments DSL for building command-line arguments
+        #
+        # NOTE: Exactly one of abort, continue, or quit must be specified.
+        #
+        ARGS = Arguments.define do
+          flag :abort, args: '--abort'
+          flag :continue, args: '--continue'
+          flag :quit, args: '--quit'
+
+          conflicts :abort, :continue, :quit
+        end.freeze
+
+        # Initialize the Merge::Resolve command
+        #
+        # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
+        #
+        def initialize(execution_context)
+          @execution_context = execution_context
+        end
+
+        # Execute the git merge state management command
+        #
+        # @overload call(options = {})
+        #
+        #   @param options [Hash] command options (exactly one must be true)
+        #
+        #   @option options [Boolean] :abort (nil) Abort the current merge and
+        #     restore the pre-merge state. If an autostash entry is present,
+        #     apply it to the worktree.
+        #
+        #   @option options [Boolean] :continue (nil) Complete the merge after
+        #     conflicts have been resolved and staged.
+        #
+        #   @option options [Boolean] :quit (nil) Forget about the current merge
+        #     in progress. Leave the index and working tree as-is. If an
+        #     autostash entry is present, save it to the stash list.
+        #
+        # @return [String] the command output
+        #
+        # @raise [Git::FailedError] if the command fails (e.g., no merge in progress,
+        #   unresolved conflicts for continue)
+        #
+        def call(**)
+          args = ARGS.build(**)
+          @execution_context.command('merge', *args)
+        end
+      end
+    end
+  end
+end

--- a/lib/git/commands/merge_base.rb
+++ b/lib/git/commands/merge_base.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+
+module Git
+  module Commands
+    # Implements the `git merge-base` command to find common ancestors
+    #
+    # This command finds as good common ancestors as possible for a merge.
+    # Given two commits, it outputs a common ancestor that is reachable from
+    # both commits through the parent relationship.
+    #
+    # @see https://git-scm.com/docs/git-merge-base git-merge-base
+    #
+    # @api private
+    #
+    # @example Find merge base of two branches
+    #   merge_base = Git::Commands::MergeBase.new(execution_context)
+    #   shas = merge_base.call('main', 'feature')
+    #   # => ['abc123def456...']
+    #
+    # @example Find all common ancestors
+    #   shas = merge_base.call('main', 'feature', all: true)
+    #   # => ['sha1', 'sha2']
+    #
+    # @example Find merge base for octopus merge
+    #   shas = merge_base.call('main', 'branch1', 'branch2', octopus: true)
+    #
+    # @example Find fork point
+    #   shas = merge_base.call('main', 'feature', fork_point: true)
+    #
+    class MergeBase
+      # Arguments DSL for building command-line arguments
+      #
+      # NOTE: The order of definitions determines the order of arguments
+      # in the final command line.
+      #
+      ARGS = Arguments.define do
+        flag :octopus, args: '--octopus'
+        flag :independent, args: '--independent'
+        flag :fork_point, args: '--fork-point'
+        flag :all, args: '--all'
+
+        # Positional: commits to find common ancestor(s) of
+        positional :commits, variadic: true, required: true
+      end.freeze
+
+      # Initialize the MergeBase command
+      #
+      # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
+      #
+      def initialize(execution_context)
+        @execution_context = execution_context
+      end
+
+      # Execute the git merge-base command
+      #
+      # @overload call(*commits, options = {})
+      #
+      #   @param commits [Array<String>] Two or more commit SHAs, branch names,
+      #     or refs to find common ancestor(s) of
+      #
+      #   @param options [Hash] command options
+      #
+      #   @option options [Boolean] :octopus (nil) Compute best common ancestor
+      #     for an n-way merge (intersection of all merge bases)
+      #
+      #   @option options [Boolean] :independent (nil) List commits not reachable
+      #     from any other (useful for finding branch tips)
+      #
+      #   @option options [Boolean] :fork_point (nil) Find the fork point where
+      #     a branch diverged from another
+      #
+      #   @option options [Boolean] :all (nil) Output all merge bases instead of
+      #     just one (when multiple equally good bases exist)
+      #
+      # @return [Array<String>] array of commit SHA strings (common ancestors)
+      #
+      # @raise [Git::FailedError] if the command fails
+      #
+      def call(*, **)
+        args = ARGS.build(*, **)
+        output = @execution_context.command('merge-base', *args)
+        parse_output(output)
+      end
+
+      private
+
+      # Parse the command output into an array of SHAs
+      #
+      # @param output [String] the raw command output
+      # @return [Array<String>] array of commit SHAs
+      #
+      def parse_output(output)
+        output.lines.map(&:strip).reject(&:empty?)
+      end
+    end
+  end
+end

--- a/spec/git/commands/merge/resolve_spec.rb
+++ b/spec/git/commands/merge/resolve_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/merge/resolve'
+
+RSpec.describe Git::Commands::Merge::Resolve do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with :abort option' do
+      it 'calls git merge --abort' do
+        expect(execution_context).to receive(:command).with('merge', '--abort')
+        command.call(abort: true)
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('merge')
+        command.call(abort: false)
+      end
+    end
+
+    context 'with :continue option' do
+      it 'calls git merge --continue' do
+        expect(execution_context).to receive(:command).with('merge', '--continue')
+        command.call(continue: true)
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('merge')
+        command.call(continue: false)
+      end
+    end
+
+    context 'with :quit option' do
+      it 'calls git merge --quit' do
+        expect(execution_context).to receive(:command).with('merge', '--quit')
+        command.call(quit: true)
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('merge')
+        command.call(quit: false)
+      end
+    end
+
+    context 'with conflicting options' do
+      it 'raises error when abort and continue are both true' do
+        expect { command.call(abort: true, continue: true) }.to raise_error(ArgumentError, /cannot specify/)
+      end
+
+      it 'raises error when abort and quit are both true' do
+        expect { command.call(abort: true, quit: true) }.to raise_error(ArgumentError, /cannot specify/)
+      end
+
+      it 'raises error when continue and quit are both true' do
+        expect { command.call(continue: true, quit: true) }.to raise_error(ArgumentError, /cannot specify/)
+      end
+
+      it 'raises error when all three are true' do
+        expect { command.call(abort: true, continue: true, quit: true) }.to raise_error(ArgumentError, /cannot specify/)
+      end
+    end
+
+    context 'with no options' do
+      it 'calls git merge with no flags' do
+        expect(execution_context).to receive(:command).with('merge')
+        command.call
+      end
+    end
+  end
+end

--- a/spec/git/commands/merge/start_spec.rb
+++ b/spec/git/commands/merge/start_spec.rb
@@ -1,0 +1,324 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/merge/start'
+
+RSpec.describe Git::Commands::Merge::Start do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with single branch to merge' do
+      it 'calls git merge with --no-edit and the branch name' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', 'feature')
+        command.call('feature')
+      end
+    end
+
+    context 'with multiple branches (octopus merge)' do
+      it 'merges multiple branches' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', 'branch1', 'branch2')
+        command.call('branch1', 'branch2')
+      end
+
+      it 'merges three branches' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', 'a', 'b', 'c')
+        command.call('a', 'b', 'c')
+      end
+    end
+
+    context 'with :commit option' do
+      context 'when true' do
+        it 'adds --commit flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--commit', 'feature')
+          command.call('feature', commit: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-commit flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--no-commit', 'feature')
+          command.call('feature', commit: false)
+        end
+      end
+    end
+
+    context 'with :squash option' do
+      it 'adds --squash flag' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', '--squash', 'feature')
+        command.call('feature', squash: true)
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', 'feature')
+        command.call('feature', squash: false)
+      end
+    end
+
+    context 'with :ff option (fast-forward)' do
+      context 'when true' do
+        it 'adds --ff flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--ff', 'feature')
+          command.call('feature', ff: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-ff flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--no-ff', 'feature')
+          command.call('feature', ff: false)
+        end
+      end
+    end
+
+    context 'with :ff_only option' do
+      it 'adds --ff-only flag' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', '--ff-only', 'feature')
+        command.call('feature', ff_only: true)
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', 'feature')
+        command.call('feature', ff_only: false)
+      end
+    end
+
+    context 'with :message option' do
+      it 'adds -m flag with message' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', '-m', 'Merge feature', 'feature')
+        command.call('feature', message: 'Merge feature')
+      end
+
+      it 'works with :m alias' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', '-m', 'My message', 'feature')
+        command.call('feature', m: 'My message')
+      end
+    end
+
+    context 'with :file option' do
+      it 'adds -F flag with file path' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', '-F', '/path/to/msg.txt', 'feature')
+        command.call('feature', file: '/path/to/msg.txt')
+      end
+
+      it 'works with :F alias' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', '-F', 'msg.txt', 'feature')
+        command.call('feature', F: 'msg.txt')
+      end
+    end
+
+    context 'with :into_name option' do
+      it 'adds --into-name flag with value' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', '--into-name=main', 'feature')
+        command.call('feature', into_name: 'main')
+      end
+    end
+
+    context 'with :strategy option' do
+      it 'adds -s flag with strategy name' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', '-s', 'ours', 'feature')
+        command.call('feature', strategy: 'ours')
+      end
+
+      it 'works with :s alias' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', '-s', 'recursive', 'feature')
+        command.call('feature', s: 'recursive')
+      end
+    end
+
+    context 'with :strategy_option option' do
+      it 'adds -X flag with strategy option' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', '-X', 'ours', 'feature')
+        command.call('feature', strategy_option: 'ours')
+      end
+
+      it 'works with :X alias' do
+        expect(execution_context).to receive(:command).with('merge', '--no-edit', '-X', 'theirs', 'feature')
+        command.call('feature', X: 'theirs')
+      end
+
+      it 'supports multiple strategy options' do
+        expect(execution_context).to receive(:command).with(
+          'merge', '--no-edit', '-X', 'ours', '-X', 'patience', 'feature'
+        )
+        command.call('feature', strategy_option: %w[ours patience])
+      end
+    end
+
+    context 'with :verify option' do
+      context 'when true' do
+        it 'adds --verify flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--verify', 'feature')
+          command.call('feature', verify: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-verify flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--no-verify', 'feature')
+          command.call('feature', verify: false)
+        end
+      end
+    end
+
+    context 'with :verify_signatures option' do
+      context 'when true' do
+        it 'adds --verify-signatures flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--verify-signatures', 'feature')
+          command.call('feature', verify_signatures: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-verify-signatures flag' do
+          expect(execution_context).to receive(:command).with(
+            'merge', '--no-edit', '--no-verify-signatures', 'feature'
+          )
+          command.call('feature', verify_signatures: false)
+        end
+      end
+    end
+
+    context 'with :gpg_sign option' do
+      context 'when true' do
+        it 'adds --gpg-sign flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--gpg-sign', 'feature')
+          command.call('feature', gpg_sign: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-gpg-sign flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--no-gpg-sign', 'feature')
+          command.call('feature', gpg_sign: false)
+        end
+      end
+    end
+
+    context 'with :allow_unrelated_histories option' do
+      context 'when true' do
+        it 'adds --allow-unrelated-histories flag' do
+          expect(execution_context).to receive(:command).with(
+            'merge', '--no-edit', '--allow-unrelated-histories', 'feature'
+          )
+          command.call('feature', allow_unrelated_histories: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-allow-unrelated-histories flag' do
+          expect(execution_context).to receive(:command).with(
+            'merge', '--no-edit', '--no-allow-unrelated-histories', 'feature'
+          )
+          command.call('feature', allow_unrelated_histories: false)
+        end
+      end
+    end
+
+    context 'with :rerere_autoupdate option' do
+      context 'when true' do
+        it 'adds --rerere-autoupdate flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--rerere-autoupdate', 'feature')
+          command.call('feature', rerere_autoupdate: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-rerere-autoupdate flag' do
+          expect(execution_context).to receive(:command).with(
+            'merge', '--no-edit', '--no-rerere-autoupdate', 'feature'
+          )
+          command.call('feature', rerere_autoupdate: false)
+        end
+      end
+    end
+
+    context 'with :autostash option' do
+      context 'when true' do
+        it 'adds --autostash flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--autostash', 'feature')
+          command.call('feature', autostash: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-autostash flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--no-autostash', 'feature')
+          command.call('feature', autostash: false)
+        end
+      end
+    end
+
+    context 'with :signoff option' do
+      context 'when true' do
+        it 'adds --signoff flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--signoff', 'feature')
+          command.call('feature', signoff: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-signoff flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--no-signoff', 'feature')
+          command.call('feature', signoff: false)
+        end
+      end
+    end
+
+    context 'with :log option' do
+      context 'when true' do
+        it 'adds --log flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--log', 'feature')
+          command.call('feature', log: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-log flag' do
+          expect(execution_context).to receive(:command).with('merge', '--no-edit', '--no-log', 'feature')
+          command.call('feature', log: false)
+        end
+      end
+    end
+
+    context 'with multiple options combined' do
+      it 'includes all specified flags in correct order' do
+        expect(execution_context).to receive(:command).with(
+          'merge', '--no-edit', '--no-commit', '--no-ff',
+          '-m', 'Merge feature branch',
+          '-s', 'ort',
+          '-X', 'theirs',
+          'feature'
+        )
+        command.call(
+          'feature',
+          commit: false,
+          ff: false,
+          message: 'Merge feature branch',
+          strategy: 'ort',
+          strategy_option: 'theirs'
+        )
+      end
+
+      it 'combines squash with no-commit behavior' do
+        expect(execution_context).to receive(:command).with(
+          'merge', '--no-edit', '--squash', 'feature'
+        )
+        command.call('feature', squash: true)
+      end
+
+      it 'combines ff_only with allow_unrelated_histories' do
+        expect(execution_context).to receive(:command).with(
+          'merge', '--no-edit', '--ff-only', '--allow-unrelated-histories', 'feature'
+        )
+        command.call('feature', ff_only: true, allow_unrelated_histories: true)
+      end
+    end
+
+    context 'with no commits provided' do
+      it 'raises an error' do
+        expect { command.call }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end

--- a/spec/git/commands/merge_base_spec.rb
+++ b/spec/git/commands/merge_base_spec.rb
@@ -1,0 +1,122 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/merge_base'
+
+RSpec.describe Git::Commands::MergeBase do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with two commits' do
+      it 'calls git merge-base with both commits' do
+        expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature').and_return("abc123\n")
+        result = command.call('main', 'feature')
+        expect(result).to eq(['abc123'])
+      end
+    end
+
+    context 'with multiple commits' do
+      it 'calls git merge-base with all commits' do
+        expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature1',
+                                                            'feature2').and_return("abc123\n")
+        result = command.call('main', 'feature1', 'feature2')
+        expect(result).to eq(['abc123'])
+      end
+    end
+
+    context 'with :octopus option' do
+      it 'adds --octopus flag' do
+        expect(execution_context).to receive(:command).with('merge-base', '--octopus', 'main', 'b1',
+                                                            'b2').and_return("abc123\n")
+        result = command.call('main', 'b1', 'b2', octopus: true)
+        expect(result).to eq(['abc123'])
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature').and_return("abc123\n")
+        command.call('main', 'feature', octopus: false)
+      end
+    end
+
+    context 'with :independent option' do
+      it 'adds --independent flag' do
+        expect(execution_context).to receive(:command).with('merge-base', '--independent', 'a', 'b',
+                                                            'c').and_return("sha1\nsha2\n")
+        result = command.call('a', 'b', 'c', independent: true)
+        expect(result).to eq(%w[sha1 sha2])
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature').and_return("abc123\n")
+        command.call('main', 'feature', independent: false)
+      end
+    end
+
+    context 'with :fork_point option' do
+      it 'adds --fork-point flag' do
+        expect(execution_context).to receive(:command).with('merge-base', '--fork-point', 'main',
+                                                            'feature').and_return("abc123\n")
+        result = command.call('main', 'feature', fork_point: true)
+        expect(result).to eq(['abc123'])
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature').and_return("abc123\n")
+        command.call('main', 'feature', fork_point: false)
+      end
+    end
+
+    context 'with :all option' do
+      it 'adds --all flag' do
+        expect(execution_context).to receive(:command).with('merge-base', '--all', 'main',
+                                                            'feature').and_return("sha1\nsha2\n")
+        result = command.call('main', 'feature', all: true)
+        expect(result).to eq(%w[sha1 sha2])
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature').and_return("abc123\n")
+        command.call('main', 'feature', all: false)
+      end
+    end
+
+    context 'with multiple options combined' do
+      it 'includes all specified flags in correct order' do
+        expect(execution_context).to receive(:command).with(
+          'merge-base', '--octopus', '--all', 'main', 'b1', 'b2'
+        ).and_return("sha1\nsha2\n")
+        result = command.call('main', 'b1', 'b2', octopus: true, all: true)
+        expect(result).to eq(%w[sha1 sha2])
+      end
+    end
+
+    context 'with no commits provided' do
+      it 'raises an error' do
+        expect { command.call }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'return value parsing' do
+      it 'returns empty array when no output' do
+        expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature').and_return('')
+        result = command.call('main', 'feature')
+        expect(result).to eq([])
+      end
+
+      it 'strips whitespace from each SHA' do
+        expect(execution_context).to receive(:command).with('merge-base', '--all', 'main',
+                                                            'feature').and_return("  sha1  \n  sha2  \n")
+        result = command.call('main', 'feature', all: true)
+        expect(result).to eq(%w[sha1 sha2])
+      end
+
+      it 'filters out empty lines' do
+        expect(execution_context).to receive(:command).with('merge-base', 'main',
+                                                            'feature').and_return("sha1\n\nsha2\n\n")
+        result = command.call('main', 'feature')
+        expect(result).to eq(%w[sha1 sha2])
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Migrates `git merge`, `git merge-base`, and merge state management (`--abort`/`--continue`/`--quit`) to the new `Git::Commands::*` architecture following the Strangler Fig pattern.

## New Command Classes

| Class | Purpose |
|-------|---------|
| `Git::Commands::Merge::Start` | Initiates merge operations (`git merge <branches>`) |
| `Git::Commands::Merge::Resolve` | Handles abort/continue/quit for in-progress merges |
| `Git::Commands::MergeBase` | Finds common ancestor commits (`git merge-base`) |

## Key Design Decisions

### Naming: `Start` instead of `Commit`
- Avoids confusion with `git commit` (there will be a `Git::Commands::Commit`)
- More accurate since `--no-commit` merges don't create commits
- Pairs naturally with `Resolve`: you **start** a merge, then **resolve** it if conflicts arise

### Combined `Resolve` class
- `--abort`, `--continue`, and `--quit` share the same purpose: resolving merge state
- Uses mutually exclusive flags with `conflicts :abort, :continue, :quit`
- Cleaner than three separate single-method classes

### Non-interactive design
- Uses `static '--no-edit'` to suppress editor (appropriate for programmatic use)
- Omits `--quiet`/`--verbose` as output formatting options

## Backward Compatibility

`Git::Lib` adapter methods preserve the existing interface:

```ruby
# Legacy options still work
merge('feature', no_commit: true)  # translates to commit: false
merge('feature', no_ff: true)      # translates to ff: false  
merge('feature', m: 'message')     # translates to message: 'message'

# New methods added
merge_abort
merge_continue
merge_quit
```

## Test Coverage

- ✅ 67 new RSpec examples for command classes
- ✅ All 530 existing tests pass
- ✅ Rubocop clean
- ✅ YARD documentation complete