### PR TITLE
refactor(commands): fix command classes and standardize signatures

### DIFF
--- a/lib/git/commands/branch/create.rb
+++ b/lib/git/commands/branch/create.rb
@@ -59,29 +59,58 @@ module Git
 
         # Execute the git branch command to create a new branch
         #
-        # @overload call(branch_name, start_point = nil, force: nil, create_reflog: nil,
-        #   recurse_submodules: nil, track: nil)
+        # @overload call(branch_name, **options)
         #
-        #   @param branch_name [String] The name of the branch to create. Must pass all checks
-        #     defined by git-check-ref-format.
+        #   Create a new branch from the current HEAD
         #
-        #   @param start_point [String, nil] The commit, branch, or tag to start the new branch from.
-        #     If omitted, defaults to HEAD. Can also use `<rev-A>...<rev-B>` syntax for merge base.
+        #   @param branch_name [String] The name of the branch to create
         #
-        #   @param force [Boolean] Reset the branch to `start_point` even if it already exists.
+        #   @param options [Hash] command options
+        #
+        #   @option options [Boolean] :force (nil) Reset the branch to `start_point` even if it already exists.
         #     Without this, git branch refuses to change an existing branch.
         #     Adds `--force` flag.
         #
-        #   @param create_reflog [Boolean] Create the branch's reflog, enabling date-based sha1
+        #   @option options [Boolean] :create_reflog (nil) Create the branch's reflog, enabling date-based sha1
         #     expressions such as `branch@{yesterday}`. Note that in non-bare repositories,
         #     reflogs are usually enabled by default via `core.logAllRefUpdates`.
         #     Adds `--create-reflog` flag.
         #
-        #   @param recurse_submodules [Boolean] Create the branch in the superproject and all
+        #   @option options [Boolean] :recurse_submodules (nil) Create the branch in the superproject and all
         #     submodules. This is an experimental feature.
         #     Adds `--recurse-submodules` flag.
         #
-        #   @param track [Boolean, String, false] Configure upstream tracking for the new branch.
+        #   @option options [Boolean, String, false] :track (nil) Configure upstream tracking for the new branch.
+        #     - `true`: Set up tracking using the start-point branch itself (`--track`)
+        #     - `false`: Do not set up tracking even if `branch.autoSetupMerge` is set (`--no-track`)
+        #     - `'direct'`: Same as `true`, explicitly use start-point as upstream (`--track=direct`)
+        #     - `'inherit'`: Copy upstream configuration from start-point branch (`--track=inherit`)
+        #
+        # @overload call(branch_name, start_point, **options)
+        #
+        #   Create a new branch from the specified start point
+        #
+        #   @param branch_name [String] The name of the branch to create
+        #
+        #   @param start_point [String, nil] The commit, branch, or tag to start the new branch from.
+        #     Can also use `<rev-A>...<rev-B>` syntax for merge base.
+        #
+        #   @param options [Hash] command options
+        #
+        #   @option options [Boolean] :force (nil) Reset the branch to `start_point` even if it already exists.
+        #     Without this, git branch refuses to change an existing branch.
+        #     Adds `--force` flag.
+        #
+        #   @option options [Boolean] :create_reflog (nil) Create the branch's reflog, enabling date-based sha1
+        #     expressions such as `branch@{yesterday}`. Note that in non-bare repositories,
+        #     reflogs are usually enabled by default via `core.logAllRefUpdates`.
+        #     Adds `--create-reflog` flag.
+        #
+        #   @option options [Boolean] :recurse_submodules (nil) Create the branch in the superproject and all
+        #     submodules. This is an experimental feature.
+        #     Adds `--recurse-submodules` flag.
+        #
+        #   @option options [Boolean, String, false] :track (nil) Configure upstream tracking for the new branch.
         #     - `true`: Set up tracking using the start-point branch itself (`--track`)
         #     - `false`: Do not set up tracking even if `branch.autoSetupMerge` is set (`--no-track`)
         #     - `'direct'`: Same as `true`, explicitly use start-point as upstream (`--track=direct`)
@@ -91,8 +120,8 @@ module Git
         #
         # @raise [ArgumentError] if unsupported options are provided
         #
-        def call(branch_name, start_point = nil, **)
-          args = ARGS.build(branch_name, start_point, **)
+        def call(*, **)
+          args = ARGS.build(*, **)
           @execution_context.command('branch', *args)
         end
       end

--- a/lib/git/commands/branch/set_upstream.rb
+++ b/lib/git/commands/branch/set_upstream.rb
@@ -30,7 +30,7 @@ module Git
         # The set_upstream_to keyword is required by the Ruby method signature, not the DSL.
         #
         ARGS = Arguments.define do
-          inline_value :set_upstream_to
+          inline_value :set_upstream_to, required: true, allow_nil: false
           positional :branch_name
         end.freeze
 
@@ -44,14 +44,23 @@ module Git
 
         # Execute the git branch --set-upstream-to command
         #
-        # @overload call(set_upstream_to:)
-        #   Set upstream for the current branch
-        #   @param set_upstream_to [String] The upstream branch (e.g., 'origin/main')
+        # @overload call(**options)
         #
-        # @overload call(branch_name, set_upstream_to:)
-        #   Set upstream for a specific branch
-        #   @param branch_name [String] The branch to configure
-        #   @param set_upstream_to [String] The upstream branch (e.g., 'origin/main')
+        #   Sets upstream for the current branch
+        #
+        #   @param options [Hash] command options
+        #
+        #   @option options [String] :set_upstream_to (required) the upstream branch (e.g., 'origin/main')
+        #
+        # @overload call(branch_name, **options)
+        #
+        #    Set upstream for the specified branch
+        #
+        #   @param branch_name [String] the branch to set upstream for
+        #
+        #   @param options [Hash] command options
+        #
+        #   @option options [String] :set_upstream_to (required) the upstream branch (e.g., 'origin/main')
         #
         # @return [String] the command output
         #
@@ -59,8 +68,8 @@ module Git
         # @raise [ArgumentError] if unsupported options are provided
         # @raise [Git::FailedError] if the branch or upstream doesn't exist
         #
-        def call(branch_name = nil, set_upstream_to:)
-          args = ARGS.build(branch_name, set_upstream_to: set_upstream_to)
+        def call(*, **)
+          args = ARGS.build(*, **)
           @execution_context.command('branch', *args)
         end
       end

--- a/lib/git/commands/branch/unset_upstream.rb
+++ b/lib/git/commands/branch/unset_upstream.rb
@@ -43,20 +43,19 @@ module Git
 
         # Execute the git branch --unset-upstream command
         #
-        # @overload call
-        #   Unset upstream for the current branch
+        # @overload call(branch_name = nil, **options)
         #
-        # @overload call(branch_name)
-        #   Unset upstream for a specific branch
-        #   @param branch_name [String] The branch to configure
+        #   @param branch_name [String, nil] The branch to configure (defaults to current branch if nil)
+        #
+        #   @param options [Hash] command options (none currently supported)
         #
         # @return [String] the command output
         #
         # @raise [ArgumentError] if unsupported options are provided
         # @raise [Git::FailedError] if the branch doesn't exist or has no upstream
         #
-        def call(branch_name = nil, **)
-          args = ARGS.build(branch_name, **)
+        def call(*, **)
+          args = ARGS.build(*, **)
           @execution_context.command('branch', *args)
         end
       end

--- a/lib/git/commands/commit.rb
+++ b/lib/git/commands/commit.rb
@@ -54,32 +54,32 @@ module Git
 
       # Execute the git commit command
       #
-      # @overload call(message: nil, all: nil, add_all: nil, allow_empty: nil,
-      #   allow_empty_message: nil, amend: nil, author: nil, date: nil,
-      #   no_verify: nil, gpg_sign: nil)
+      # @overload call(**options)
       #
-      #   @param message [String] The commit message
+      #   @param options [Hash] command options
       #
-      #   @param all [Boolean] Automatically stage all modified and deleted files
+      #   @option options [String] :message (nil) The commit message
+      #
+      #   @option options [Boolean] :all (nil) Automatically stage all modified and deleted files
       #     before committing (alias: add_all)
       #
-      #   @param add_all [Boolean] Alias for :all
+      #   @option options [Boolean] :add_all (nil) Alias for :all
       #
-      #   @param allow_empty [Boolean] Allow creating a commit with no changes
+      #   @option options [Boolean] :allow_empty (nil) Allow creating a commit with no changes
       #
-      #   @param allow_empty_message [Boolean] Allow creating a commit with an empty message
+      #   @option options [Boolean] :allow_empty_message (nil) Allow creating a commit with an empty message
       #
-      #   @param amend [Boolean] Amend the previous commit instead of creating a new one.
+      #   @option options [Boolean] :amend (nil) Amend the previous commit instead of creating a new one.
       #     When true, --no-edit is also added to prevent opening an editor.
       #
-      #   @param author [String] Override the commit author in the format 'Name <email>'
+      #   @option options [String] :author (nil) Override the commit author in the format 'Name <email>'
       #
-      #   @param date [String] Override the author date. Must be a string in a format
+      #   @option options [String] :date (nil) Override the author date. Must be a string in a format
       #     that git understands (e.g., '2023-01-15T10:30:00', 'now', 'yesterday')
       #
-      #   @param no_verify [Boolean] Bypass the pre-commit and commit-msg hooks
+      #   @option options [Boolean] :no_verify (nil) Bypass the pre-commit and commit-msg hooks
       #
-      #   @param gpg_sign [Boolean, String, false] GPG-sign the commit. When true, uses the
+      #   @option options [Boolean, String, false] :gpg_sign (nil) GPG-sign the commit. When true, uses the
       #     default key. When a string, uses the specified key ID. When false, adds --no-gpg-sign
       #     to override any commit.gpgsign configuration.
       #
@@ -88,8 +88,8 @@ module Git
       # @raise [ArgumentError] if unsupported options are provided
       # @raise [ArgumentError] if :date is not a String
       #
-      def call(**)
-        args = ARGS.build(**)
+      def call(*, **)
+        args = ARGS.build(*, **)
         @execution_context.command('commit', *args)
       end
     end

--- a/lib/git/commands/merge/resolve.rb
+++ b/lib/git/commands/merge/resolve.rb
@@ -49,7 +49,7 @@ module Git
 
         # Execute the git merge state management command
         #
-        # @overload call(options = {})
+        # @overload call(**options)
         #
         #   @param options [Hash] command options (exactly one must be true)
         #
@@ -69,8 +69,8 @@ module Git
         # @raise [Git::FailedError] if the command fails (e.g., no merge in progress,
         #   unresolved conflicts for continue)
         #
-        def call(**)
-          args = ARGS.build(**)
+        def call(*, **)
+          args = ARGS.build(*, **)
           @execution_context.command('merge', *args)
         end
       end

--- a/lib/git/commands/mv.rb
+++ b/lib/git/commands/mv.rb
@@ -28,8 +28,8 @@ module Git
         flag :dry_run, args: '--dry-run'
         flag :verbose, args: '--verbose'
         flag :skip_errors, args: '-k'
-        positional :source, variadic: true, separator: '--'
-        positional :destination
+        positional :source, variadic: true, required: true, separator: '--'
+        positional :destination, required: true
       end.freeze
 
       # Initialize the Mv command
@@ -42,7 +42,7 @@ module Git
 
       # Execute the git mv command
       #
-      # @overload call(source, destination, options = {})
+      # @overload call(*source, destination, **options)
       #
       #   @param source [Array<String>] one or more source file(s) or directories to move
       #
@@ -50,18 +50,18 @@ module Git
       #
       #   @param options [Hash] command options
       #
-      #   @option options [Boolean] :force Force renaming or moving even if the destination exists
+      #   @option options [Boolean] :force (nil) Force renaming or moving even if the destination exists
       #
-      #   @option options [Boolean] :dry_run Do nothing; only show what would happen
+      #   @option options [Boolean] :dry_run (nil) Do nothing; only show what would happen
       #
-      #   @option options [Boolean] :verbose Report the names of files as they are moved
+      #   @option options [Boolean] :verbose (nil) Report the names of files as they are moved
       #
-      #   @option options [Boolean] :skip_errors Skip move or rename actions which would lead to an error
+      #   @option options [Boolean] :skip_errors (nil) Skip move or rename actions which would lead to an error
       #
       # @return [String] the command output
       #
-      def call(*source, destination, **)
-        args = ARGS.build(*source, destination, **)
+      def call(*, **)
+        args = ARGS.build(*, **)
         @execution_context.command('mv', *args)
       end
     end

--- a/spec/git/commands/branch/list_spec.rb
+++ b/spec/git/commands/branch/list_spec.rb
@@ -9,34 +9,34 @@ RSpec.describe Git::Commands::Branch::List do
 
   describe '#call' do
     context 'with no options (basic list)' do
-      it 'calls git branch with no additional arguments' do
-        expect(execution_context).to receive(:command_lines).with('branch').and_return([])
+      it 'calls git branch --list with no additional arguments' do
+        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return([])
         command.call
       end
     end
 
     context 'with :all option' do
       it 'adds -a flag' do
-        expect(execution_context).to receive(:command_lines).with('branch', '-a').and_return([])
+        expect(execution_context).to receive(:command_lines).with('branch', '--list', '-a').and_return([])
         command.call(all: true)
       end
     end
 
     context 'with :remotes option' do
       it 'adds -r flag' do
-        expect(execution_context).to receive(:command_lines).with('branch', '-r').and_return([])
+        expect(execution_context).to receive(:command_lines).with('branch', '--list', '-r').and_return([])
         command.call(remotes: true)
       end
     end
 
     context 'with :sort option' do
       it 'adds --sort=<key> with single value' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--sort=refname').and_return([])
+        expect(execution_context).to receive(:command_lines).with('branch', '--list', '--sort=refname').and_return([])
         command.call(sort: 'refname')
       end
 
       it 'adds multiple --sort=<key> with array of values' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--sort=refname',
+        expect(execution_context).to receive(:command_lines).with('branch', '--list', '--sort=refname',
                                                                   '--sort=-committerdate').and_return([])
         command.call(sort: ['refname', '-committerdate'])
       end
@@ -44,35 +44,39 @@ RSpec.describe Git::Commands::Branch::List do
 
     context 'with :contains option' do
       it 'adds --contains <commit>' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--contains', 'abc123').and_return([])
+        expect(execution_context).to receive(:command_lines).with('branch', '--list', '--contains',
+                                                                  'abc123').and_return([])
         command.call(contains: 'abc123')
       end
     end
 
     context 'with :no_contains option' do
       it 'adds --no-contains <commit>' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--no-contains', 'abc123').and_return([])
+        expect(execution_context).to receive(:command_lines).with('branch', '--list', '--no-contains',
+                                                                  'abc123').and_return([])
         command.call(no_contains: 'abc123')
       end
     end
 
     context 'with :merged option' do
       it 'adds --merged <commit>' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--merged', 'main').and_return([])
+        expect(execution_context).to receive(:command_lines).with('branch', '--list', '--merged', 'main').and_return([])
         command.call(merged: 'main')
       end
     end
 
     context 'with :no_merged option' do
       it 'adds --no-merged <commit>' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--no-merged', 'main').and_return([])
+        expect(execution_context).to receive(:command_lines).with('branch', '--list', '--no-merged',
+                                                                  'main').and_return([])
         command.call(no_merged: 'main')
       end
     end
 
     context 'with :points_at option' do
       it 'adds --points-at <object>' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--points-at', 'v1.0').and_return([])
+        expect(execution_context).to receive(:command_lines).with('branch', '--list', '--points-at',
+                                                                  'v1.0').and_return([])
         command.call(points_at: 'v1.0')
       end
     end
@@ -80,20 +84,20 @@ RSpec.describe Git::Commands::Branch::List do
     context 'with patterns' do
       it 'adds pattern arguments' do
         expect(execution_context).to receive(:command_lines).with('branch', '--list', 'feature/*').and_return([])
-        command.call(patterns: 'feature/*')
+        command.call('feature/*')
       end
 
       it 'adds multiple pattern arguments' do
         expect(execution_context).to receive(:command_lines).with('branch', '--list', 'feature/*',
                                                                   'bugfix/*').and_return([])
-        command.call(patterns: ['feature/*', 'bugfix/*'])
+        command.call('feature/*', 'bugfix/*')
       end
     end
 
     context 'with multiple options' do
       it 'combines flags correctly' do
         expect(execution_context).to receive(:command_lines).with(
-          'branch', '-a', '--sort=refname', '--contains', 'abc123'
+          'branch', '--list', '-a', '--sort=refname', '--contains', 'abc123'
         ).and_return([])
         command.call(all: true, sort: 'refname', contains: 'abc123')
       end
@@ -110,7 +114,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'returns parsed branch data as array of BranchInfo objects' do
-        expect(execution_context).to receive(:command_lines).with('branch').and_return(branch_output)
+        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(branch_output)
         result = command.call
         expect(result).to be_an(Array)
         expect(result.size).to eq(4)
@@ -118,14 +122,14 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'marks current branch correctly' do
-        expect(execution_context).to receive(:command_lines).with('branch').and_return(branch_output)
+        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(branch_output)
         result = command.call
         expect(result[0]).to have_attributes(refname: 'main', current: true, worktree: false, symref: nil)
         expect(result[1]).to have_attributes(refname: 'feature-branch', current: false, worktree: false, symref: nil)
       end
 
       it 'parses remote branch names' do
-        expect(execution_context).to receive(:command_lines).with('branch').and_return(branch_output)
+        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(branch_output)
         result = command.call
         expect(result[2].refname).to eq('remotes/origin/main')
         expect(result[3].refname).to eq('remotes/origin/feature-branch')
@@ -142,7 +146,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'marks worktree branch correctly' do
-        expect(execution_context).to receive(:command_lines).with('branch').and_return(worktree_output)
+        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(worktree_output)
         result = command.call
         expect(result[0]).to have_attributes(refname: 'main', current: true, worktree: false, symref: nil)
         expect(result[1]).to have_attributes(
@@ -162,7 +166,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'filters out detached HEAD lines' do
-        expect(execution_context).to receive(:command_lines).with('branch').and_return(detached_output)
+        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(detached_output)
         result = command.call
         expect(result.size).to eq(2)
         expect(result.map(&:refname)).to eq(%w[main feature-branch])
@@ -179,7 +183,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'filters out (not a branch) lines' do
-        expect(execution_context).to receive(:command_lines).with('branch').and_return(not_a_branch_output)
+        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(not_a_branch_output)
         result = command.call
         expect(result.size).to eq(2)
         expect(result.map(&:refname)).to eq(%w[main feature-branch])
@@ -195,7 +199,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'includes symbolic reference information' do
-        expect(execution_context).to receive(:command_lines).with('branch').and_return(symref_output)
+        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(symref_output)
         result = command.call
         expect(result[0].symref).to eq('origin/main')
       end
@@ -216,7 +220,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'raises Git::UnexpectedResultError' do
-        expect(execution_context).to receive(:command_lines).with('branch').and_return(malformed_output)
+        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(malformed_output)
         expect { command.call }.to raise_error(Git::UnexpectedResultError)
       end
     end

--- a/spec/git/commands/mv_spec.rb
+++ b/spec/git/commands/mv_spec.rb
@@ -138,7 +138,13 @@ RSpec.describe Git::Commands::Mv do
     context 'with missing arguments' do
       it 'raises ArgumentError when no arguments provided' do
         expect { command.call }.to(
-          raise_error(ArgumentError, /wrong number of arguments/)
+          raise_error(ArgumentError, /at least one value is required for source/)
+        )
+      end
+
+      it 'raises ArgumentError when only destination provided (no source)' do
+        expect { command.call('dest.rb') }.to(
+          raise_error(ArgumentError, /at least one value is required for source/)
         )
       end
     end

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -316,7 +316,7 @@ class TestLib < Test::Unit::TestCase
       @lib.branches_all
     rescue Git::UnexpectedResultError => e
       assert_equal(<<~MESSAGE, e.message)
-        Unexpected line in output from `git branch -a`, line 2
+        Unexpected line in output from `git branch --list -a`, line 2
 
         Full output:
           * (HEAD detached at origin/master)

--- a/tests/units/test_logger.rb
+++ b/tests/units/test_logger.rb
@@ -27,7 +27,7 @@ class TestLogger < Test::Unit::TestCase
 
       logc = File.read(log_path)
 
-      expected_log_entry = /INFO -- : \[\{[^}]+}, "git", "(?<global_options>.*?)", "branch", "-a"/
+      expected_log_entry = /INFO -- : \[\{[^}]+}, "git", "(?<global_options>.*?)", "branch", "--list", "-a"/
       assert_match(expected_log_entry, logc, missing_log_entry)
 
       expected_log_entry = /DEBUG -- : stdout:\n"  cherry/
@@ -46,7 +46,7 @@ class TestLogger < Test::Unit::TestCase
 
       logc = File.read(log_path)
 
-      expected_log_entry = /INFO -- : \[\{[^}]+}, "git", "(?<global_options>.*?)", "branch", "-a"/
+      expected_log_entry = /INFO -- : \[\{[^}]+}, "git", "(?<global_options>.*?)", "branch", "--list", "-a"/
       assert_match(expected_log_entry, logc, missing_log_entry)
 
       expected_log_entry = /DEBUG -- : stdout:\n"  cherry/


### PR DESCRIPTION
## Summary

Fix several command classes and standardize method signatures to use `call(*, **)` pattern, letting the Arguments DSL handle parameter validation.

## Changes

### Branch::List
- **Breaking Change:** Add `static '--list'` flag (always include in command)
- **Breaking Change:** Change `patterns` from keyword to positional argument
- API change: `call('feature/*')` instead of `call(patterns: 'feature/*')`

### Branch::SetUpstream
- Add `required: true, allow_nil: false` to `set_upstream_to` option to enforce required parameter
- Standardize method signature to `call(*, **)`

### Branch::Create, Branch::UnsetUpstream, Commit, Merge::Resolve
- Standardize method signatures to use `call(*, **)` pattern
- Let Arguments DSL handle parameter validation instead of explicit method params

### Mv
- Add `required: true` to source and destination positionals for better error messages
- Standardize method signature to `call(*, **)`

### Documentation
- Update Yardoc to use `@param options [Hash]` + `@option` pattern for all changed files

## Files Changed

**Command Classes:**
- lib/git/commands/branch/create.rb
- lib/git/commands/branch/list.rb
- lib/git/commands/branch/set_upstream.rb
- lib/git/commands/branch/unset_upstream.rb
- lib/git/commands/commit.rb
- lib/git/commands/merge/resolve.rb
- lib/git/commands/mv.rb

**Tests:**
- spec/git/commands/branch/list_spec.rb
- spec/git/commands/mv_spec.rb
- tests/units/test_lib.rb
- tests/units/test_logger.rb

## Testing

- All 530 unit tests pass
- All 812 RSpec examples pass  
- RuboCop passes with no offenses

## Related

Depends on: None (independent of #944)
