### PR TITLE
fix: render arguments in definition order instead of grouped by type

### DIFF
--- a/lib/git/commands/branch/delete.rb
+++ b/lib/git/commands/branch/delete.rb
@@ -37,10 +37,6 @@ module Git
       #
       class Delete
         # Arguments DSL for building command-line arguments
-        #
-        # NOTE: Static flags are always output first regardless of definition order,
-        # so we define them first for readability.
-        #
         ARGS = Arguments.define do
           static '--delete'
           flag %i[force f], args: '--force'

--- a/lib/git/commands/tag/delete.rb
+++ b/lib/git/commands/tag/delete.rb
@@ -23,9 +23,6 @@ module Git
       #
       class Delete
         # Arguments DSL for building command-line arguments
-        #
-        # NOTE: Static flags are always output first regardless of definition order.
-        #
         ARGS = Arguments.define do
           static '-d'
           positional :tag_names, variadic: true, required: true

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -384,27 +384,30 @@ future work:
    Review the command class's `#call` signature when writing the adapter to ensure
    no arguments are lost in translation.
 
-8. **Static flags are always output first—define them first for readability**
+8. **Arguments are rendered in definition order**
 
-   The Arguments DSL outputs arguments in this order: static flags → dynamic flags
-   (in definition order) → positionals. For readability, define `static` flags first
-   to match the actual output order:
+   The Arguments DSL outputs arguments in the exact order they are defined,
+   regardless of type. This allows precise control over argument positioning,
+   which is important for commands like `git checkout` where `--` must appear
+   between options and pathspecs:
 
    ```ruby
-   # ✅ Preferred: static first matches output order
+   # Arguments render in definition order
    ARGS = Arguments.define do
-     static '--delete'                    # Always first in output
-     flag %i[force f], args: '--force'
-     flag %i[remotes r], args: '--remotes'
-     positional :branch_names, variadic: true, required: true
+     flag :force
+     positional :tree_ish
+     static '--'
+     positional :paths, variadic: true
    end
+   # build('HEAD', 'file.txt', force: true) => ['--force', 'HEAD', '--', 'file.txt']
 
-   # ❌ Less clear: static at end is misleading
+   # Common pattern: static flags first for subcommands like branch --delete
    ARGS = Arguments.define do
+     static '--delete'
      flag %i[force f], args: '--force'
-     static '--delete'                    # Still output first, but confusing
      positional :branch_names, variadic: true, required: true
    end
+   # build('feature', force: true) => ['--delete', '--force', 'feature']
    ```
 
 9. **Use `%i[long short]` array syntax for flag aliases**


### PR DESCRIPTION
## Summary

Fixes #948

Previously, `Arguments.build` rendered arguments in a fixed order: static flags → dynamic options → positionals. This was problematic for git commands where argument position matters, such as `git checkout` where `--` must appear between tree-ish and pathspecs.

Now arguments are rendered in the exact order they are defined in the DSL block, giving full control over argument positioning.

## Example

```ruby
ARGS = Arguments.define do
  flag :force
  positional :tree_ish
  static '--'
  positional :paths, variadic: true
end

ARGS.build('HEAD', 'file.txt', force: true)
# => ['--force', 'HEAD', '--', 'file.txt']
```

## Changes

### Core Implementation (`lib/git/commands/arguments.rb`)
- Add `@ordered_definitions` instance variable to track all definitions in order
- Update `#static` to append `{ kind: :static, flag: flag_string }` to ordered list
- Update `#positional` to append `{ kind: :positional, name: name }` to ordered list  
- Update `#register_option` to append `{ kind: :option, name: primary }` to ordered list
- Refactor `#build` to use new `#build_ordered_arguments` method that iterates in definition order
- Extract `#build_entry` helper method (for RuboCop method length compliance)
- Enhance `#static` method YARD documentation with ordering examples

### Tests (`spec/git/commands/arguments_spec.rb`)
- Add 18 new tests in "argument ordering" describe block covering:
  - Interleaved options and positionals
  - Static flags in definition position (not grouped first)
  - Complex patterns like `git checkout [tree-ish] -- paths`
  - Complex patterns like `git diff commit1 commit2 -- paths`
  - Multiple static flags in different positions
  - Valued and inline-valued options
  - Custom options
  - Negatable flags

### Documentation Updates
- Remove outdated comment in `lib/git/commands/branch/delete.rb` about static flags being output first
- Remove outdated comment in `lib/git/commands/tag/delete.rb` about static flags being output first
- Update architectural insight #8 in `redesign/3_architecture_implementation.md` from "Static flags are always output first" to "Arguments are rendered in definition order"

## Testing

All tests pass:
- 919 RSpec examples (including 18 new ordering tests)
- 530 TestUnit tests
- RuboCop: no offenses
- YARD: 76.9% coverage (meets threshold)