### PR TITLE
Populate TagInfo with rich metadata using git tag --format

### DIFF
--- a/spec/integration/git/commands/tag/list_spec.rb
+++ b/spec/integration/git/commands/tag/list_spec.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/tag/list'
+
+RSpec.describe Git::Commands::Tag::List, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when there are no tags' do
+      it 'returns an empty array' do
+        result = command.call
+        expect(result).to eq([])
+      end
+    end
+
+    context 'with lightweight tags' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+        repo.add_tag('v1.0.0')
+      end
+
+      it 'returns tag with populated metadata' do
+        result = command.call
+        expect(result.size).to eq(1)
+        tag = result.first
+        expect(tag.name).to eq('v1.0.0')
+        expect(tag.sha).to match(/^[0-9a-f]{40}$/)
+        expect(tag.objecttype).to eq('commit')
+      end
+
+      it 'identifies lightweight tags correctly' do
+        result = command.call
+        expect(result.first.lightweight?).to be true
+        expect(result.first.annotated?).to be false
+      end
+
+      it 'has nil tagger fields for lightweight tags' do
+        result = command.call
+        tag = result.first
+        expect(tag.tagger_name).to be_nil
+        expect(tag.tagger_email).to be_nil
+        expect(tag.tagger_date).to be_nil
+        expect(tag.message).to be_nil
+      end
+    end
+
+    context 'with annotated tags' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+        repo.add_tag('v2.0.0', annotate: true, message: 'Release version 2.0.0')
+      end
+
+      it 'returns tag with populated metadata' do
+        result = command.call
+        expect(result.size).to eq(1)
+        tag = result.first
+        expect(tag.name).to eq('v2.0.0')
+        expect(tag.sha).to match(/^[0-9a-f]{40}$/)
+        expect(tag.objecttype).to eq('tag')
+      end
+
+      it 'identifies annotated tags correctly' do
+        result = command.call
+        expect(result.first.annotated?).to be true
+        expect(result.first.lightweight?).to be false
+      end
+
+      it 'has tagger fields populated for annotated tags' do
+        result = command.call
+        tag = result.first
+        expect(tag.tagger_name).not_to be_nil
+        expect(tag.tagger_email).not_to be_nil
+        # iso8601-strict format: YYYY-MM-DDTHH:MM:SS±HH:MM or YYYY-MM-DDTHH:MM:SSZ
+        expect(tag.tagger_date).to match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([-+]\d{2}:\d{2}|Z)$/)
+        expect(tag.message).to eq('Release version 2.0.0')
+      end
+    end
+
+    context 'with multiple tags' do
+      before do
+        write_file('file1.txt', 'content1')
+        repo.add('file1.txt')
+        repo.commit('First commit')
+        repo.add_tag('v1.0.0')
+
+        write_file('file2.txt', 'content2')
+        repo.add('file2.txt')
+        repo.commit('Second commit')
+        repo.add_tag('v1.1.0', annotate: true, message: 'Version 1.1.0')
+
+        write_file('file3.txt', 'content3')
+        repo.add('file3.txt')
+        repo.commit('Third commit')
+        repo.add_tag('v2.0.0')
+      end
+
+      it 'returns all tags' do
+        result = command.call
+        expect(result.size).to eq(3)
+        expect(result.map(&:name)).to contain_exactly('v1.0.0', 'v1.1.0', 'v2.0.0')
+      end
+
+      it 'correctly identifies tag types' do
+        result = command.call
+        v1_tag = result.find { |t| t.name == 'v1.0.0' }
+        v1_1_tag = result.find { |t| t.name == 'v1.1.0' }
+        v2_tag = result.find { |t| t.name == 'v2.0.0' }
+
+        expect(v1_tag.lightweight?).to be true
+        expect(v1_1_tag.annotated?).to be true
+        expect(v2_tag.lightweight?).to be true
+      end
+    end
+
+    context 'with pattern filtering' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+        repo.add_tag('v1.0.0')
+        repo.add_tag('v1.1.0')
+        repo.add_tag('v2.0.0')
+        repo.add_tag('release-1.0')
+      end
+
+      it 'filters tags by pattern' do
+        result = command.call('v1.*')
+        expect(result.map(&:name)).to contain_exactly('v1.0.0', 'v1.1.0')
+      end
+
+      it 'filters tags by multiple patterns' do
+        result = command.call('v1.*', 'release-*')
+        expect(result.map(&:name)).to contain_exactly('v1.0.0', 'v1.1.0', 'release-1.0')
+      end
+    end
+
+    context 'with special characters in tag names' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+        repo.add_tag('release/v1.0')
+        repo.add_tag('feature-branch-tag')
+      end
+
+      it 'handles tags with slashes' do
+        result = command.call
+        expect(result.map(&:name)).to include('release/v1.0')
+      end
+
+      it 'handles tags with hyphens' do
+        result = command.call
+        expect(result.map(&:name)).to include('feature-branch-tag')
+      end
+    end
+
+    context 'with sorting' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+        repo.add_tag('v1.10.0')
+        repo.add_tag('v1.2.0')
+        repo.add_tag('v1.20.0')
+      end
+
+      it 'sorts tags by refname' do
+        result = command.call(sort: 'refname')
+        expect(result.map(&:name)).to eq(['v1.10.0', 'v1.2.0', 'v1.20.0'])
+      end
+
+      it 'sorts tags by version' do
+        result = command.call(sort: 'version:refname')
+        expect(result.map(&:name)).to eq(['v1.2.0', 'v1.10.0', 'v1.20.0'])
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/tag/list_spec.rb
+++ b/spec/unit/git/commands/tag/list_spec.rb
@@ -8,41 +8,45 @@ RSpec.describe Git::Commands::Tag::List do
   let(:command) { described_class.new(execution_context) }
 
   describe '#call' do
+    let(:format_arg) { "--format=#{described_class::FORMAT_STRING}" }
+
     context 'with no options (basic list)' do
-      it 'calls git tag --list with no additional arguments' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list').and_return([])
+      it 'calls git tag --list with format string' do
+        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return([])
         command.call
       end
     end
 
     context 'with patterns' do
       it 'adds a single pattern argument' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', 'v1.*').and_return([])
+        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg, 'v1.*').and_return([])
         command.call('v1.*')
       end
 
       it 'adds multiple pattern arguments' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', 'v1.*', 'v2.*').and_return([])
+        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg, 'v1.*',
+                                                                  'v2.*').and_return([])
         command.call('v1.*', 'v2.*')
       end
     end
 
     context 'with :sort option' do
       it 'adds --sort=<key> with single value' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', '--sort=refname').and_return([])
+        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg,
+                                                                  '--sort=refname').and_return([])
         command.call(sort: 'refname')
       end
 
       it 'adds multiple --sort=<key> with array of values' do
         expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', '--sort=refname', '--sort=-creatordate'
+          'tag', '--list', format_arg, '--sort=refname', '--sort=-creatordate'
         ).and_return([])
         command.call(sort: ['refname', '-creatordate'])
       end
 
       it 'supports version:refname sort key' do
         expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', '--sort=version:refname'
+          'tag', '--list', format_arg, '--sort=version:refname'
         ).and_return([])
         command.call(sort: 'version:refname')
       end
@@ -51,7 +55,7 @@ RSpec.describe Git::Commands::Tag::List do
     context 'with :contains option' do
       it 'adds --contains <commit>' do
         expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', '--contains', 'abc123'
+          'tag', '--list', format_arg, '--contains', 'abc123'
         ).and_return([])
         command.call(contains: 'abc123')
       end
@@ -60,7 +64,7 @@ RSpec.describe Git::Commands::Tag::List do
     context 'with :no_contains option' do
       it 'adds --no-contains <commit>' do
         expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', '--no-contains', 'abc123'
+          'tag', '--list', format_arg, '--no-contains', 'abc123'
         ).and_return([])
         command.call(no_contains: 'abc123')
       end
@@ -69,7 +73,7 @@ RSpec.describe Git::Commands::Tag::List do
     context 'with :merged option' do
       it 'adds --merged <commit>' do
         expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', '--merged', 'main'
+          'tag', '--list', format_arg, '--merged', 'main'
         ).and_return([])
         command.call(merged: 'main')
       end
@@ -78,7 +82,7 @@ RSpec.describe Git::Commands::Tag::List do
     context 'with :no_merged option' do
       it 'adds --no-merged <commit>' do
         expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', '--no-merged', 'main'
+          'tag', '--list', format_arg, '--no-merged', 'main'
         ).and_return([])
         command.call(no_merged: 'main')
       end
@@ -87,7 +91,7 @@ RSpec.describe Git::Commands::Tag::List do
     context 'with :points_at option' do
       it 'adds --points-at <object>' do
         expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', '--points-at', 'HEAD'
+          'tag', '--list', format_arg, '--points-at', 'HEAD'
         ).and_return([])
         command.call(points_at: 'HEAD')
       end
@@ -96,14 +100,14 @@ RSpec.describe Git::Commands::Tag::List do
     context 'with multiple options combined' do
       it 'combines flags correctly' do
         expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', '--sort=refname', '--contains', 'abc123', 'v1.*'
+          'tag', '--list', format_arg, '--sort=refname', '--contains', 'abc123', 'v1.*'
         ).and_return([])
         command.call('v1.*', sort: 'refname', contains: 'abc123')
       end
 
       it 'combines multiple patterns with options' do
         expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', '--merged', 'main', 'release-*', 'v*'
+          'tag', '--list', format_arg, '--merged', 'main', 'release-*', 'v*'
         ).and_return([])
         command.call('release-*', 'v*', merged: 'main')
       end
@@ -112,14 +116,16 @@ RSpec.describe Git::Commands::Tag::List do
     context 'when parsing tag output' do
       let(:tag_output) do
         [
-          'v1.0.0',
-          'v1.1.0',
-          'v2.0.0-beta'
+          "v1.0.0\x1fabc123def456\x1ftag\x1fJohn Doe\x1f<john@example.com>\x1f" \
+          "2024-01-15T10:30:00-08:00\x1fRelease version 1.0.0",
+          "v1.1.0\x1fdef456abc123\x1fcommit\x1f\x1f\x1f\x1f",
+          "v2.0.0-beta\x1f789abc456def\x1ftag\x1fJane Smith\x1f<jane@example.com>\x1f" \
+          "2024-02-20T14:00:00-05:00\x1fBeta release"
         ]
       end
 
       it 'returns parsed tag data as array of TagInfo objects' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list').and_return(tag_output)
+        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
         result = command.call
         expect(result).to be_an(Array)
         expect(result.size).to eq(3)
@@ -127,29 +133,143 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'extracts tag names correctly' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list').and_return(tag_output)
+        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
         result = command.call
         expect(result.map(&:name)).to eq(%w[v1.0.0 v1.1.0 v2.0.0-beta])
+      end
+
+      it 'extracts SHA correctly' do
+        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
+        result = command.call
+        expect(result[0].sha).to eq('abc123def456')
+        expect(result[1].sha).to eq('def456abc123')
+        expect(result[2].sha).to eq('789abc456def')
+      end
+
+      it 'extracts object type correctly' do
+        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
+        result = command.call
+        expect(result[0].objecttype).to eq('tag')
+        expect(result[1].objecttype).to eq('commit')
+        expect(result[2].objecttype).to eq('tag')
+      end
+
+      it 'identifies annotated tags' do
+        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
+        result = command.call
+        expect(result[0].annotated?).to be true
+        expect(result[1].annotated?).to be false
+        expect(result[2].annotated?).to be true
+      end
+
+      it 'identifies lightweight tags' do
+        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
+        result = command.call
+        expect(result[0].lightweight?).to be false
+        expect(result[1].lightweight?).to be true
+        expect(result[2].lightweight?).to be false
       end
     end
 
     context 'with annotated tags' do
-      it 'returns TagInfo with name populated (metadata fields are nil until format parsing is implemented)' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list').and_return(['v1.0.0'])
+      let(:annotated_tag_output) do
+        [
+          "v1.0.0\x1fabc123def456\x1ftag\x1fJohn Doe\x1f<john@example.com>\x1f" \
+          "2024-01-15T10:30:00-08:00\x1fRelease version 1.0.0"
+        ]
+      end
+
+      it 'returns TagInfo with all metadata fields populated' do
+        expect(execution_context).to receive(:command_lines).with('tag', '--list',
+                                                                  format_arg).and_return(annotated_tag_output)
         result = command.call
         tag = result.first
         expect(tag.name).to eq('v1.0.0')
-        # sha, objecttype, tagger_*, and message are nil for now
-        # Future enhancement: use --format to populate these fields
-        expect(tag.sha).to be_nil
+        expect(tag.sha).to eq('abc123def456')
+        expect(tag.objecttype).to eq('tag')
+        expect(tag.tagger_name).to eq('John Doe')
+        expect(tag.tagger_email).to eq('<john@example.com>')
+        expect(tag.tagger_date).to eq('2024-01-15T10:30:00-08:00')
+        expect(tag.message).to eq('Release version 1.0.0')
+      end
+    end
+
+    context 'with lightweight tags' do
+      let(:lightweight_tag_output) { ["v2.0.0\x1fdef456abc123\x1fcommit\x1f\x1f\x1f\x1f"] }
+
+      it 'returns TagInfo with tagger fields as nil' do
+        expect(execution_context).to receive(:command_lines).with('tag', '--list',
+                                                                  format_arg).and_return(lightweight_tag_output)
+        result = command.call
+        tag = result.first
+        expect(tag.name).to eq('v2.0.0')
+        expect(tag.sha).to eq('def456abc123')
+        expect(tag.objecttype).to eq('commit')
+        expect(tag.tagger_name).to be_nil
+        expect(tag.tagger_email).to be_nil
+        expect(tag.tagger_date).to be_nil
+        expect(tag.message).to be_nil
       end
     end
 
     context 'with empty result' do
       it 'returns an empty array' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list').and_return([])
+        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return([])
         result = command.call
         expect(result).to eq([])
+      end
+    end
+
+    context 'with special characters in tag names and messages' do
+      it 'handles unicode in tag names' do
+        unicode_output = [
+          "tag-with-emoji-🚀\x1fabc123\x1ftag\x1fDev\x1f<dev@example.com>\x1f" \
+          "2024-01-01T00:00:00Z\x1fTest"
+        ]
+        expect(execution_context).to receive(:command_lines).with('tag', '--list',
+                                                                  format_arg).and_return(unicode_output)
+        result = command.call
+        expect(result.first.name).to eq('tag-with-emoji-🚀')
+      end
+
+      it 'handles slashes in tag names' do
+        slash_output = ["release/v1.0\x1fabc123\x1fcommit\x1f\x1f\x1f\x1f"]
+        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(slash_output)
+        result = command.call
+        expect(result.first.name).to eq('release/v1.0')
+      end
+
+      it 'handles unicode in messages' do
+        unicode_message_output = [
+          "v1.0\x1fabc123\x1ftag\x1fDev\x1f<dev@example.com>\x1f" \
+          "2024-01-01T00:00:00Z\x1fRelease 🎉"
+        ]
+        expect(execution_context).to receive(:command_lines).with('tag', '--list',
+                                                                  format_arg).and_return(unicode_message_output)
+        result = command.call
+        expect(result.first.message).to eq('Release 🎉')
+      end
+
+      it 'handles empty message for annotated tags' do
+        no_message_output = ["v1.0\x1fabc123\x1ftag\x1fDev\x1f<dev@example.com>\x1f2024-01-01T00:00:00Z\x1f"]
+        expect(execution_context).to receive(:command_lines).with('tag', '--list',
+                                                                  format_arg).and_return(no_message_output)
+        result = command.call
+        expect(result.first.message).to be_nil
+      end
+    end
+
+    context 'with malformed output' do
+      it 'raises UnexpectedResultError with helpful message for wrong field count' do
+        bad_output = ["v1.0\x1fabc123\x1ftag"] # Only 3 fields instead of 7
+        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(bad_output)
+
+        expect { command.call }.to raise_error(Git::UnexpectedResultError) do |error|
+          expect(error.message).to include('Unexpected line')
+          expect(error.message).to include('at index 0')
+          expect(error.message).to include('Expected 7 fields')
+          expect(error.message).to include('got 3')
+        end
       end
     end
   end


### PR DESCRIPTION
## Summary

Implements #955 - `Git::Commands::Tag::List` now returns `TagInfo` objects with rich metadata populated from `git tag --format`.

## Changes

### Implementation
- **Updated `Tag::List` command** to use `git tag --format` with unit separator (`\x1f`) delimited fields for safe parsing
- **Added format string** with 7 fields: name, SHA, object type, tagger name, tagger email, tagger date (ISO 8601 strict), and message
- **Added field count validation** to raise `Git::UnexpectedResultError` with helpful error messages for unexpected output
- **Added parsing methods** (`parse_tag_line`, `build_tag_info`, `parse_optional_field`, `parse_message`) to parse formatted output and populate all `TagInfo` fields
- **Handles both tag types appropriately**:
  - **Annotated tags**: All fields populated (name, sha, objecttype='tag', tagger info, message)
  - **Lightweight tags**: Basic fields only (name, sha, objecttype=target object type), tagger fields and message set to nil

### Testing
- **Updated 26 unit tests** to verify formatted output parsing with unit separator delimiter
- **Added error handling test** for malformed output validation
- **Added comprehensive edge case tests** for unicode, special characters, empty messages
- **Created 15 integration tests** with real git commands to verify behavior

## Format String

The command uses a unit separator (`\x1f`) to safely delimit fields (avoiding conflicts with pipes in tag messages):

```
%(refname:short)<US>%(objectname)<US>%(objecttype)<US>%(taggername)<US>%(taggeremail)<US>%(taggerdate:iso8601-strict)<US>%(contents:subject)
```

Where `<US>` represents the unit separator character (`\x1f`).

## Example Output

**Annotated tag:**
```ruby
tag = TagInfo.new(
  name: 'v1.0.0',
  sha: 'abc123def456',
  objecttype: 'tag',
  tagger_name: 'John Doe',
  tagger_email: '<john@example.com>',
  tagger_date: '2024-01-15T10:30:00-08:00',
  message: 'Release version 1.0.0'
)
```

**Lightweight tag:**
```ruby
tag = TagInfo.new(
  name: 'v2.0.0',
  sha: 'def456abc123',
  objecttype: 'commit',  # or 'tree', 'blob', etc. depending on target
  tagger_name: nil,
  tagger_email: nil,
  tagger_date: nil,
  message: nil
)
```

## Backward Compatibility

✅ **Fully backward compatible** - return type remains `Array<TagInfo>`, just with more fields populated. Existing code using only `.name` continues to work without changes.

## Benefits

- **Better UX**: Callers can immediately access tag SHA, type, tagger information, and message
- **Consistency**: Matches the pattern of other `-Info` objects (BranchInfo, StashInfo) which use unit separator delimiter
- **Safety**: Unit separator delimiter prevents issues with pipes in tag messages or names
- **Robustness**: Field count validation provides clear error messages for unexpected output
- **Efficiency**: Single git command retrieves all metadata (no additional git calls needed)
- **Utility**: Enables filtering, sorting, and displaying tag information without extra overhead

## Test Results

- ✅ All 27 unit tests pass
- ✅ All 15 integration tests pass  
- ✅ All 949 RSpec examples pass
- ✅ RuboCop clean

Closes #955