### PR TITLE
Add target_oid and upstream attributes to BranchInfo

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -838,9 +838,11 @@ module Git
     def branch(branch_name = current_branch)
       branch_info = Git::BranchInfo.new(
         refname: branch_name,
+        target_oid: nil,
         current: false,
         worktree: false,
-        symref: nil
+        symref: nil,
+        upstream: nil
       )
       Git::Branch.new(self, branch_info)
     end

--- a/lib/git/branch_info.rb
+++ b/lib/git/branch_info.rb
@@ -41,9 +41,11 @@ module Git
   # @example Creating from git branch output
   #   info = Git::BranchInfo.new(
   #     refname: 'main',
+  #     target_oid: 'abc123def456789012345678901234567890abcd',
   #     current: true,
   #     worktree: false,
-  #     symref: nil
+  #     symref: nil,
+  #     upstream: nil
   #   )
   #   info.current?     #=> true
   #   info.remote?      #=> false
@@ -52,20 +54,82 @@ module Git
   # @example Remote branch
   #   info = Git::BranchInfo.new(
   #     refname: 'remotes/origin/main',
+  #     target_oid: 'abc123def456789012345678901234567890abcd',
   #     current: false,
   #     worktree: false,
-  #     symref: nil
+  #     symref: nil,
+  #     upstream: nil
   #   )
   #   info.remote?      #=> true
   #   info.remote_name  #=> 'origin'
   #   info.short_name   #=> 'main'
+  #
+  # @example Local branch with upstream tracking
+  #   upstream_info = Git::BranchInfo.new(
+  #     refname: 'remotes/origin/main',
+  #     target_oid: 'abc123def456789012345678901234567890abcd',
+  #     current: false,
+  #     worktree: false,
+  #     symref: nil,
+  #     upstream: nil
+  #   )
+  #   info = Git::BranchInfo.new(
+  #     refname: 'main',
+  #     target_oid: 'abc123def456789012345678901234567890abcd',
+  #     current: true,
+  #     worktree: false,
+  #     symref: nil,
+  #     upstream: upstream_info
+  #   )
+  #   info.upstream.remote_name  #=> 'origin'
   #
   # @see Git::Branch for the full-featured branch object with operations
   # @see Git::Commands::Branch::List for the command that produces these
   #
   # @api public
   #
-  BranchInfo = Data.define(:refname, :current, :worktree, :symref) do
+  # @!attribute [r] refname
+  #
+  #   The full reference name of the branch
+  #
+  #   @return [String] the branch refname (e.g., 'main', 'remotes/origin/main')
+  #
+  # @!attribute [r] target_oid
+  #
+  #   The commit object ID (SHA) that this branch points to
+  #
+  #   @return [String, nil] the full 40-character object ID, or nil if unavailable
+  #
+  # @!attribute [r] current
+  #
+  #   Whether this branch is currently checked out in the current worktree
+  #
+  #   @return [Boolean] true if this is the current branch
+  #
+  # @!attribute [r] worktree
+  #
+  #   Whether this branch is checked out in another linked worktree
+  #
+  #   @return [Boolean] true if checked out in a different worktree
+  #
+  # @!attribute [r] symref
+  #
+  #   The target reference if this is a symbolic reference
+  #
+  #   @return [String, nil] the target ref (e.g., 'refs/heads/main'), or nil if not a symref
+  #
+  # @!attribute [r] upstream
+  #
+  #   The configured upstream/tracking branch
+  #
+  #   @return [Git::BranchInfo, nil] the upstream branch info, or nil if no upstream is configured
+  #
+  #   @note Remote-tracking branches (e.g., 'origin/main') have upstream: nil
+  #
+  #   @note When upstream exists but the remote-tracking branch hasn't been fetched,
+  #     the upstream's target_oid may be nil
+  #
+  BranchInfo = Data.define(:refname, :target_oid, :current, :worktree, :symref, :upstream) do
     # @return [Boolean] true if this is the currently checked out branch
     def current? = current
 

--- a/lib/git/remote.rb
+++ b/lib/git/remote.rb
@@ -27,9 +27,11 @@ module Git
       remote_tracking_branch = "#{@name}/#{branch}"
       branch_info = Git::BranchInfo.new(
         refname: remote_tracking_branch,
+        target_oid: nil,
         current: false,
         worktree: false,
-        symref: nil
+        symref: nil,
+        upstream: nil
       )
       Git::Branch.new(@base, branch_info)
     end

--- a/spec/integration/git/commands/branch/list_spec.rb
+++ b/spec/integration/git/commands/branch/list_spec.rb
@@ -33,6 +33,30 @@ RSpec.describe Git::Commands::Branch::List, :integration do
         result = command.call
         expect(result.find(&:current).refname).to eq('main')
       end
+
+      it 'returns BranchInfo objects with all expected attributes' do
+        result = command.call
+        main_branch = result.find { |b| b.refname == 'main' }
+
+        # Verify all BranchInfo attributes are present
+        expect(main_branch).to respond_to(:refname)
+        expect(main_branch).to respond_to(:target_oid)
+        expect(main_branch).to respond_to(:current)
+        expect(main_branch).to respond_to(:worktree)
+        expect(main_branch).to respond_to(:symref)
+        expect(main_branch).to respond_to(:upstream)
+
+        # Verify current values
+        expect(main_branch.current).to be true
+        expect(main_branch.worktree).to be false
+        expect(main_branch.symref).to be_nil
+
+        # target_oid is populated from format output
+        expect(main_branch.target_oid).to match(/\A[0-9a-f]{40}\z/)
+
+        # upstream is nil because no upstream is configured in this test
+        expect(main_branch.upstream).to be_nil
+      end
     end
 
     context 'with branch names containing special characters' do
@@ -52,6 +76,64 @@ RSpec.describe Git::Commands::Branch::List, :integration do
       it 'parses branch names with unicode' do
         result = command.call
         expect(result.map(&:refname)).to include('feature/日本語')
+      end
+    end
+
+    context 'with upstream tracking' do
+      let(:bare_dir) { Dir.mktmpdir('bare_repo') }
+
+      after do
+        FileUtils.rm_rf(bare_dir)
+      end
+
+      before do
+        # Create initial content in the test repo
+        write_file('file.txt')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+
+        # Create a bare repo and add as remote
+        Git.init(bare_dir, bare: true)
+        repo.add_remote('origin', bare_dir)
+        repo.push('origin', 'main')
+
+        # Set upstream tracking
+        repo.lib.command('branch', '-u', 'origin/main', 'main')
+      end
+
+      it 'populates upstream as BranchInfo with refname' do
+        result = command.call
+        main_branch = result.find { |b| b.refname == 'main' }
+
+        expect(main_branch.upstream).to be_a(Git::BranchInfo)
+        expect(main_branch.upstream.refname).to eq('remotes/origin/main')
+        expect(main_branch.upstream.target_oid).to be_nil # Upstream OID not available from format
+        expect(main_branch.upstream.current).to be false
+        expect(main_branch.upstream.worktree).to be false
+      end
+    end
+
+    context 'with detached HEAD' do
+      before do
+        write_file('file.txt')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+        repo.add_tag('v1.0.0')
+        write_file('file2.txt')
+        repo.add('file2.txt')
+        repo.commit('Second commit')
+
+        # Detach HEAD by checking out the tag
+        repo.checkout('v1.0.0')
+      end
+
+      it 'filters out detached HEAD entry and only returns real branches' do
+        result = command.call
+
+        # Should only have the main branch, not the detached HEAD
+        expect(result.size).to eq(1)
+        expect(result.first.refname).to eq('main')
+        expect(result.none? { |b| b.refname.include?('detached') }).to be true
       end
     end
   end

--- a/spec/unit/git/branch_info_spec.rb
+++ b/spec/unit/git/branch_info_spec.rb
@@ -5,7 +5,14 @@ require 'spec_helper'
 RSpec.describe Git::BranchInfo do
   describe 'attributes' do
     subject(:branch_info) do
-      described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+      described_class.new(
+        refname: 'main',
+        target_oid: 'abc123def456789012345678901234567890abcd',
+        current: true,
+        worktree: false,
+        symref: nil,
+        upstream: nil
+      )
     end
 
     it 'exposes refname' do
@@ -23,40 +30,61 @@ RSpec.describe Git::BranchInfo do
     it 'exposes symref' do
       expect(branch_info.symref).to be_nil
     end
+
+    it 'exposes target_oid' do
+      expect(branch_info.target_oid).to eq('abc123def456789012345678901234567890abcd')
+    end
+
+    it 'exposes upstream' do
+      expect(branch_info.upstream).to be_nil
+    end
   end
 
   describe '#current?' do
     it 'returns true when current is true' do
-      branch_info = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+      branch_info = described_class.new(
+        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+      )
       expect(branch_info.current?).to be true
     end
 
     it 'returns false when current is false' do
-      branch_info = described_class.new(refname: 'main', current: false, worktree: false, symref: nil)
+      branch_info = described_class.new(
+        refname: 'main', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+      )
       expect(branch_info.current?).to be false
     end
   end
 
   describe '#worktree?' do
     it 'returns true when worktree is true' do
-      branch_info = described_class.new(refname: 'feature', current: false, worktree: true, symref: nil)
+      branch_info = described_class.new(
+        refname: 'feature', target_oid: 'abc123', current: false, worktree: true, symref: nil, upstream: nil
+      )
       expect(branch_info.worktree?).to be true
     end
 
     it 'returns false when worktree is false' do
-      branch_info = described_class.new(refname: 'feature', current: false, worktree: false, symref: nil)
+      branch_info = described_class.new(
+        refname: 'feature', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+      )
       expect(branch_info.worktree?).to be false
     end
   end
 
   describe '#symref?' do
     it 'returns true when symref is present' do
-      branch_info = described_class.new(refname: 'HEAD', current: false, worktree: false, symref: 'refs/heads/main')
+      branch_info = described_class.new(
+        refname: 'HEAD', target_oid: 'abc123', current: false, worktree: false,
+        symref: 'refs/heads/main', upstream: nil
+      )
       expect(branch_info.symref?).to be true
     end
 
     it 'returns false when symref is nil' do
-      branch_info = described_class.new(refname: 'main', current: false, worktree: false, symref: nil)
+      branch_info = described_class.new(
+        refname: 'main', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+      )
       expect(branch_info.symref?).to be false
     end
   end
@@ -64,25 +92,34 @@ RSpec.describe Git::BranchInfo do
   describe '#remote?' do
     context 'with local branch' do
       it 'returns false for simple branch name' do
-        branch_info = described_class.new(refname: 'main', current: false, worktree: false, symref: nil)
+        branch_info = described_class.new(
+          refname: 'main', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+        )
         expect(branch_info.remote?).to be false
       end
 
       it 'returns false for branch with slashes' do
-        branch_info = described_class.new(refname: 'feature/my-feature', current: false, worktree: false, symref: nil)
+        branch_info = described_class.new(
+          refname: 'feature/my-feature', target_oid: 'abc123', current: false, worktree: false,
+          symref: nil, upstream: nil
+        )
         expect(branch_info.remote?).to be false
       end
     end
 
     context 'with remote-tracking branch' do
       it 'returns true for remotes/origin/main' do
-        branch_info = described_class.new(refname: 'remotes/origin/main', current: false, worktree: false, symref: nil)
+        branch_info = described_class.new(
+          refname: 'remotes/origin/main', target_oid: 'abc123', current: false, worktree: false,
+          symref: nil, upstream: nil
+        )
         expect(branch_info.remote?).to be true
       end
 
       it 'returns true for refs/remotes/origin/main' do
         branch_info = described_class.new(
-          refname: 'refs/remotes/origin/main', current: false, worktree: false, symref: nil
+          refname: 'refs/remotes/origin/main', target_oid: 'abc123', current: false, worktree: false,
+          symref: nil, upstream: nil
         )
         expect(branch_info.remote?).to be true
       end
@@ -92,32 +129,42 @@ RSpec.describe Git::BranchInfo do
   describe '#remote_name' do
     context 'with local branch' do
       it 'returns nil for simple branch name' do
-        branch_info = described_class.new(refname: 'main', current: false, worktree: false, symref: nil)
+        branch_info = described_class.new(
+          refname: 'main', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+        )
         expect(branch_info.remote_name).to be_nil
       end
 
       it 'returns nil for branch with slashes' do
-        branch_info = described_class.new(refname: 'feature/my-feature', current: false, worktree: false, symref: nil)
+        branch_info = described_class.new(
+          refname: 'feature/my-feature', target_oid: 'abc123', current: false, worktree: false,
+          symref: nil, upstream: nil
+        )
         expect(branch_info.remote_name).to be_nil
       end
     end
 
     context 'with remote-tracking branch' do
       it 'extracts remote name from remotes/origin/main' do
-        branch_info = described_class.new(refname: 'remotes/origin/main', current: false, worktree: false, symref: nil)
+        branch_info = described_class.new(
+          refname: 'remotes/origin/main', target_oid: 'abc123', current: false, worktree: false,
+          symref: nil, upstream: nil
+        )
         expect(branch_info.remote_name).to eq('origin')
       end
 
       it 'extracts remote name from refs/remotes/origin/main' do
         branch_info = described_class.new(
-          refname: 'refs/remotes/origin/main', current: false, worktree: false, symref: nil
+          refname: 'refs/remotes/origin/main', target_oid: 'abc123', current: false, worktree: false,
+          symref: nil, upstream: nil
         )
         expect(branch_info.remote_name).to eq('origin')
       end
 
       it 'extracts remote name from remotes/upstream/feature' do
         branch_info = described_class.new(
-          refname: 'remotes/upstream/feature', current: false, worktree: false, symref: nil
+          refname: 'remotes/upstream/feature', target_oid: 'abc123', current: false, worktree: false,
+          symref: nil, upstream: nil
         )
         expect(branch_info.remote_name).to eq('upstream')
       end
@@ -127,18 +174,24 @@ RSpec.describe Git::BranchInfo do
   describe '#short_name' do
     context 'with local branch' do
       it 'returns the branch name for simple branch' do
-        branch_info = described_class.new(refname: 'main', current: false, worktree: false, symref: nil)
+        branch_info = described_class.new(
+          refname: 'main', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+        )
         expect(branch_info.short_name).to eq('main')
       end
 
       it 'returns the full name for branch with slashes' do
-        branch_info = described_class.new(refname: 'feature/my-feature', current: false, worktree: false, symref: nil)
+        branch_info = described_class.new(
+          refname: 'feature/my-feature', target_oid: 'abc123', current: false, worktree: false,
+          symref: nil, upstream: nil
+        )
         expect(branch_info.short_name).to eq('feature/my-feature')
       end
 
       it 'returns the full name for deeply nested branch' do
         branch_info = described_class.new(
-          refname: 'feature/team/project/task', current: false, worktree: false, symref: nil
+          refname: 'feature/team/project/task', target_oid: 'abc123', current: false, worktree: false,
+          symref: nil, upstream: nil
         )
         expect(branch_info.short_name).to eq('feature/team/project/task')
       end
@@ -146,20 +199,25 @@ RSpec.describe Git::BranchInfo do
 
     context 'with remote-tracking branch' do
       it 'extracts branch name from remotes/origin/main' do
-        branch_info = described_class.new(refname: 'remotes/origin/main', current: false, worktree: false, symref: nil)
+        branch_info = described_class.new(
+          refname: 'remotes/origin/main', target_oid: 'abc123', current: false, worktree: false,
+          symref: nil, upstream: nil
+        )
         expect(branch_info.short_name).to eq('main')
       end
 
       it 'extracts branch name from refs/remotes/origin/main' do
         branch_info = described_class.new(
-          refname: 'refs/remotes/origin/main', current: false, worktree: false, symref: nil
+          refname: 'refs/remotes/origin/main', target_oid: 'abc123', current: false, worktree: false,
+          symref: nil, upstream: nil
         )
         expect(branch_info.short_name).to eq('main')
       end
 
       it 'preserves slashes in remote branch name' do
         branch_info = described_class.new(
-          refname: 'remotes/origin/feature/my-feature', current: false, worktree: false, symref: nil
+          refname: 'remotes/origin/feature/my-feature', target_oid: 'abc123', current: false,
+          worktree: false, symref: nil, upstream: nil
         )
         expect(branch_info.short_name).to eq('feature/my-feature')
       end
@@ -168,46 +226,67 @@ RSpec.describe Git::BranchInfo do
 
   describe '#to_s' do
     it 'returns the refname' do
-      branch_info = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+      branch_info = described_class.new(
+        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+      )
       expect(branch_info.to_s).to eq('main')
     end
 
     it 'returns full refname for remote branches' do
-      branch_info = described_class.new(refname: 'remotes/origin/main', current: false, worktree: false, symref: nil)
+      branch_info = described_class.new(
+        refname: 'remotes/origin/main', target_oid: 'abc123', current: false, worktree: false,
+        symref: nil, upstream: nil
+      )
       expect(branch_info.to_s).to eq('remotes/origin/main')
     end
   end
 
   describe 'immutability' do
     it 'is frozen' do
-      branch_info = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+      branch_info = described_class.new(
+        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+      )
       expect(branch_info).to be_frozen
     end
   end
 
   describe 'equality' do
     it 'is equal to another BranchInfo with same attributes' do
-      info1 = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
-      info2 = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+      info1 = described_class.new(
+        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+      )
+      info2 = described_class.new(
+        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+      )
       expect(info1).to eq(info2)
     end
 
     it 'is not equal when refname differs' do
-      info1 = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
-      info2 = described_class.new(refname: 'develop', current: true, worktree: false, symref: nil)
+      info1 = described_class.new(
+        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+      )
+      info2 = described_class.new(
+        refname: 'develop', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+      )
       expect(info1).not_to eq(info2)
     end
 
     it 'is not equal when current differs' do
-      info1 = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
-      info2 = described_class.new(refname: 'main', current: false, worktree: false, symref: nil)
+      info1 = described_class.new(
+        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+      )
+      info2 = described_class.new(
+        refname: 'main', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+      )
       expect(info1).not_to eq(info2)
     end
   end
 
   describe 'pattern matching' do
     it 'supports pattern matching on attributes' do
-      branch_info = described_class.new(refname: 'main', current: true, worktree: false, symref: nil)
+      branch_info = described_class.new(
+        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+      )
 
       result = case branch_info
                in { refname: 'main', current: true }
@@ -217,6 +296,134 @@ RSpec.describe Git::BranchInfo do
                end
 
       expect(result).to eq(:matched)
+    end
+  end
+
+  describe 'upstream tracking' do
+    context 'local branch tracking a remote-tracking branch' do
+      let(:upstream_info) do
+        described_class.new(
+          refname: 'remotes/origin/main',
+          target_oid: 'abc123def456789012345678901234567890abcd',
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      subject(:branch_info) do
+        described_class.new(
+          refname: 'main',
+          target_oid: 'abc123def456789012345678901234567890abcd',
+          current: true,
+          worktree: false,
+          symref: nil,
+          upstream: upstream_info
+        )
+      end
+
+      it 'has an upstream' do
+        expect(branch_info.upstream).not_to be_nil
+      end
+
+      it 'upstream is a BranchInfo' do
+        expect(branch_info.upstream).to be_a(Git::BranchInfo)
+      end
+
+      it 'upstream has no upstream of its own' do
+        expect(branch_info.upstream.upstream).to be_nil
+      end
+
+      it 'allows accessing upstream properties' do
+        expect(branch_info.upstream.remote_name).to eq('origin')
+        expect(branch_info.upstream.short_name).to eq('main')
+      end
+    end
+
+    context 'local branch tracking another local branch' do
+      let(:upstream_local) do
+        described_class.new(
+          refname: 'main',
+          target_oid: 'abc123def456789012345678901234567890abcd',
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      subject(:branch_info) do
+        described_class.new(
+          refname: 'feature',
+          target_oid: 'def456789012345678901234567890abcdef12',
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: upstream_local
+        )
+      end
+
+      it 'has a local branch as upstream' do
+        expect(branch_info.upstream.remote?).to be false
+      end
+
+      it 'upstream refname is the local branch name' do
+        expect(branch_info.upstream.refname).to eq('main')
+      end
+    end
+
+    context 'branch with no upstream' do
+      subject(:branch_info) do
+        described_class.new(
+          refname: 'orphan-branch',
+          target_oid: 'ghi789012345678901234567890abcdef123456',
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      it 'has nil upstream' do
+        expect(branch_info.upstream).to be_nil
+      end
+    end
+  end
+
+  describe 'target_oid scenarios' do
+    context 'when target_oid is present' do
+      subject(:branch_info) do
+        described_class.new(
+          refname: 'main',
+          target_oid: 'abc123def456789012345678901234567890abcd',
+          current: true,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      it 'returns the commit SHA' do
+        expect(branch_info.target_oid).to eq('abc123def456789012345678901234567890abcd')
+      end
+    end
+
+    context 'when target_oid is nil (e.g., unborn branch)' do
+      subject(:branch_info) do
+        described_class.new(
+          refname: 'unborn',
+          target_oid: nil,
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      it 'returns nil' do
+        expect(branch_info.target_oid).to be_nil
+      end
     end
   end
 end

--- a/spec/unit/git/branch_spec.rb
+++ b/spec/unit/git/branch_spec.rb
@@ -11,9 +11,11 @@ RSpec.describe Git::Branch do
       let(:branch_info) do
         Git::BranchInfo.new(
           refname: 'feature/my-feature',
+          target_oid: 'abc123',
           current: true,
           worktree: false,
-          symref: nil
+          symref: nil,
+          upstream: nil
         )
       end
 
@@ -36,9 +38,11 @@ RSpec.describe Git::Branch do
       let(:branch_info) do
         Git::BranchInfo.new(
           refname: 'remotes/origin/main',
+          target_oid: 'abc123',
           current: false,
           worktree: false,
-          symref: nil
+          symref: nil,
+          upstream: nil
         )
       end
 
@@ -94,9 +98,11 @@ RSpec.describe Git::Branch do
       let(:branch_info) do
         Git::BranchInfo.new(
           refname: refname,
+          target_oid: 'abc123',
           current: false,
           worktree: false,
-          symref: nil
+          symref: nil,
+          upstream: nil
         )
       end
 

--- a/spec/unit/git/commands/branch/create_spec.rb
+++ b/spec/unit/git/commands/branch/create_spec.rb
@@ -10,7 +10,14 @@ RSpec.describe Git::Commands::Branch::Create do
 
   # Create a BranchInfo for testing
   def build_branch_info(branch_name)
-    Git::BranchInfo.new(refname: branch_name, current: false, worktree: false, symref: nil)
+    Git::BranchInfo.new(
+      refname: branch_name,
+      target_oid: nil,
+      current: false,
+      worktree: false,
+      symref: nil,
+      upstream: nil
+    )
   end
 
   # Set up mock for Branch::List command

--- a/spec/unit/git/commands/branch/list_spec.rb
+++ b/spec/unit/git/commands/branch/list_spec.rb
@@ -7,89 +7,98 @@ RSpec.describe Git::Commands::Branch::List do
   let(:execution_context) { double('ExecutionContext') }
   let(:command) { described_class.new(execution_context) }
 
+  # Format string used by the command
+  let(:format_string) { described_class::FORMAT_STRING }
+
+  # Helper to build expected command arguments
+  def expected_args(*extra_args)
+    ['branch', '--list', "--format=#{format_string}", *extra_args]
+  end
+
   describe '#call' do
     context 'with no options (basic list)' do
-      it 'calls git branch --list with no additional arguments' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return([])
+      it 'calls git branch --list with format string' do
+        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return([])
         command.call
       end
     end
 
     context 'with :all option' do
       it 'adds -a flag' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list', '-a').and_return([])
+        expect(execution_context).to receive(:command_lines).with(*expected_args('-a')).and_return([])
         command.call(all: true)
       end
     end
 
     context 'with :remotes option' do
       it 'adds -r flag' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list', '-r').and_return([])
+        expect(execution_context).to receive(:command_lines).with(*expected_args('-r')).and_return([])
         command.call(remotes: true)
       end
     end
 
     context 'with :sort option' do
       it 'adds --sort=<key> with single value' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list', '--sort=refname').and_return([])
+        expect(execution_context).to receive(:command_lines).with(*expected_args('--sort=refname')).and_return([])
         command.call(sort: 'refname')
       end
 
       it 'adds multiple --sort=<key> with array of values' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list', '--sort=refname',
-                                                                  '--sort=-committerdate').and_return([])
+        expect(execution_context).to receive(:command_lines).with(
+          *expected_args('--sort=refname', '--sort=-committerdate')
+        ).and_return([])
         command.call(sort: ['refname', '-committerdate'])
       end
     end
 
     context 'with :contains option' do
       it 'adds --contains <commit>' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list', '--contains',
-                                                                  'abc123').and_return([])
+        expect(execution_context).to receive(:command_lines).with(
+          *expected_args('--contains', 'abc123')
+        ).and_return([])
         command.call(contains: 'abc123')
       end
     end
 
     context 'with :no_contains option' do
       it 'adds --no-contains <commit>' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list', '--no-contains',
-                                                                  'abc123').and_return([])
+        expect(execution_context).to receive(:command_lines).with(
+          *expected_args('--no-contains', 'abc123')
+        ).and_return([])
         command.call(no_contains: 'abc123')
       end
     end
 
     context 'with :merged option' do
       it 'adds --merged <commit>' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list', '--merged', 'main').and_return([])
+        expect(execution_context).to receive(:command_lines).with(*expected_args('--merged', 'main')).and_return([])
         command.call(merged: 'main')
       end
     end
 
     context 'with :no_merged option' do
       it 'adds --no-merged <commit>' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list', '--no-merged',
-                                                                  'main').and_return([])
+        expect(execution_context).to receive(:command_lines).with(*expected_args('--no-merged', 'main')).and_return([])
         command.call(no_merged: 'main')
       end
     end
 
     context 'with :points_at option' do
       it 'adds --points-at <object>' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list', '--points-at',
-                                                                  'v1.0').and_return([])
+        expect(execution_context).to receive(:command_lines).with(*expected_args('--points-at', 'v1.0')).and_return([])
         command.call(points_at: 'v1.0')
       end
     end
 
     context 'with patterns' do
       it 'adds pattern arguments' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list', 'feature/*').and_return([])
+        expect(execution_context).to receive(:command_lines).with(*expected_args('feature/*')).and_return([])
         command.call('feature/*')
       end
 
       it 'adds multiple pattern arguments' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list', 'feature/*',
-                                                                  'bugfix/*').and_return([])
+        expected = expected_args('feature/*', 'bugfix/*')
+        expect(execution_context).to receive(:command_lines).with(*expected).and_return([])
         command.call('feature/*', 'bugfix/*')
       end
     end
@@ -97,111 +106,101 @@ RSpec.describe Git::Commands::Branch::List do
     context 'with multiple options' do
       it 'combines flags correctly' do
         expect(execution_context).to receive(:command_lines).with(
-          'branch', '--list', '-a', '--sort=refname', '--contains', 'abc123'
+          *expected_args('-a', '--sort=refname', '--contains', 'abc123')
         ).and_return([])
         command.call(all: true, sort: 'refname', contains: 'abc123')
       end
     end
 
-    context 'when parsing branch output' do
-      let(:branch_output) do
+    context 'when parsing formatted branch output' do
+      # Format: refname|objectname|HEAD|worktreepath|symref|upstream
+      let(:format_output) do
         [
-          '* main',
-          '  feature-branch',
-          '  remotes/origin/main',
-          '  remotes/origin/feature-branch'
+          'refs/heads/main|abc123def456789012345678901234567890abcd|*|||refs/remotes/origin/main',
+          'refs/heads/feature-branch|def456789012345678901234567890abcdef12||||',
+          'refs/remotes/origin/main|abc123def456789012345678901234567890abcd||||',
+          'refs/remotes/origin/feature|ghi789012345678901234567890abcdef123456||||'
         ]
       end
 
       it 'returns parsed branch data as array of BranchInfo objects' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(branch_output)
+        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(format_output)
         result = command.call
         expect(result).to be_an(Array)
         expect(result.size).to eq(4)
         expect(result).to all(be_a(Git::BranchInfo))
       end
 
-      it 'marks current branch correctly' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(branch_output)
+      it 'parses target_oid from objectname' do
+        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(format_output)
         result = command.call
-        expect(result[0]).to have_attributes(refname: 'main', current: true, worktree: false, symref: nil)
-        expect(result[1]).to have_attributes(refname: 'feature-branch', current: false, worktree: false, symref: nil)
+        expect(result[0].target_oid).to eq('abc123def456789012345678901234567890abcd')
+        expect(result[1].target_oid).to eq('def456789012345678901234567890abcdef12')
+      end
+
+      it 'marks current branch correctly from HEAD field' do
+        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(format_output)
+        result = command.call
+        expect(result[0]).to have_attributes(refname: 'main', current: true)
+        expect(result[1]).to have_attributes(refname: 'feature-branch', current: false)
+      end
+
+      it 'parses upstream as BranchInfo' do
+        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(format_output)
+        result = command.call
+        main_branch = result[0]
+
+        expect(main_branch.upstream).to be_a(Git::BranchInfo)
+        expect(main_branch.upstream.refname).to eq('remotes/origin/main')
+        expect(main_branch.upstream.upstream).to be_nil
+      end
+
+      it 'sets upstream to nil when not configured' do
+        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(format_output)
+        result = command.call
+        expect(result[1].upstream).to be_nil  # feature-branch has no upstream
+        expect(result[2].upstream).to be_nil  # remote-tracking branches don't have upstreams
       end
 
       it 'parses remote branch names' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(branch_output)
+        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(format_output)
         result = command.call
         expect(result[2].refname).to eq('remotes/origin/main')
-        expect(result[3].refname).to eq('remotes/origin/feature-branch')
+        expect(result[3].refname).to eq('remotes/origin/feature')
       end
     end
 
     context 'with worktree branch' do
       let(:worktree_output) do
         [
-          '* main',
-          '+ feature-in-worktree',
-          '  other-branch'
+          'refs/heads/main|abc123def456789012345678901234567890abcd|*|||',
+          'refs/heads/feature-in-worktree|def456789012345678901234567890abcdef12||/path/to/worktree||',
+          'refs/heads/other-branch|ghi789012345678901234567890abcdef123456||||'
         ]
       end
 
-      it 'marks worktree branch correctly' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(worktree_output)
+      it 'marks worktree branch correctly from worktreepath field' do
+        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(worktree_output)
         result = command.call
-        expect(result[0]).to have_attributes(refname: 'main', current: true, worktree: false, symref: nil)
-        expect(result[1]).to have_attributes(
-          refname: 'feature-in-worktree', current: false, worktree: true, symref: nil
-        )
-        expect(result[2]).to have_attributes(refname: 'other-branch', current: false, worktree: false, symref: nil)
-      end
-    end
-
-    context 'with detached HEAD state' do
-      let(:detached_output) do
-        [
-          '* (HEAD detached at v1.0)',
-          '  main',
-          '  feature-branch'
-        ]
-      end
-
-      it 'filters out detached HEAD lines' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(detached_output)
-        result = command.call
-        expect(result.size).to eq(2)
-        expect(result.map(&:refname)).to eq(%w[main feature-branch])
-      end
-    end
-
-    context 'with (not a branch) line' do
-      let(:not_a_branch_output) do
-        [
-          '* (not a branch)',
-          '  main',
-          '  feature-branch'
-        ]
-      end
-
-      it 'filters out (not a branch) lines' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(not_a_branch_output)
-        result = command.call
-        expect(result.size).to eq(2)
-        expect(result.map(&:refname)).to eq(%w[main feature-branch])
+        expect(result[0]).to have_attributes(refname: 'main', current: true, worktree: false)
+        expect(result[1]).to have_attributes(refname: 'feature-in-worktree', current: false, worktree: true)
+        expect(result[2]).to have_attributes(refname: 'other-branch', current: false, worktree: false)
       end
     end
 
     context 'with symbolic reference' do
       let(:symref_output) do
         [
-          '  main -> origin/main',
-          '  feature-branch'
+          'refs/heads/HEAD|abc123def456789012345678901234567890abcd|||refs/heads/main|',
+          'refs/heads/main|abc123def456789012345678901234567890abcd|*|||'
         ]
       end
 
       it 'includes symbolic reference information' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(symref_output)
+        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(symref_output)
         result = command.call
-        expect(result[0].symref).to eq('origin/main')
+        expect(result[0].symref).to eq('refs/heads/main')
+        expect(result[1].symref).to be_nil
       end
     end
 
@@ -211,17 +210,61 @@ RSpec.describe Git::Commands::Branch::List do
       end
     end
 
-    context 'with unexpected git output format' do
-      let(:malformed_output) do
+    context 'with empty fields in output' do
+      let(:empty_fields_output) do
         [
-          'malformed line without proper prefix',
-          '  valid-branch'
+          'refs/heads/main|abc123def456789012345678901234567890abcd||||'
         ]
       end
 
-      it 'raises Git::UnexpectedResultError' do
-        expect(execution_context).to receive(:command_lines).with('branch', '--list').and_return(malformed_output)
-        expect { command.call }.to raise_error(Git::UnexpectedResultError)
+      it 'handles empty fields gracefully' do
+        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(empty_fields_output)
+        result = command.call
+        expect(result[0]).to have_attributes(
+          refname: 'main',
+          target_oid: 'abc123def456789012345678901234567890abcd',
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+    end
+
+    context 'with detached HEAD in output' do
+      let(:detached_head_output) do
+        [
+          '(HEAD detached at v1.0.0)|abc123def456789012345678901234567890abcd|*|||',
+          'refs/heads/master|def456789012345678901234567890abcdef12||||',
+          'refs/remotes/origin/master|ghi789012345678901234567890abcdef123456||||'
+        ]
+      end
+
+      it 'filters out detached HEAD entries' do
+        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(detached_head_output)
+        result = command.call
+
+        expect(result.size).to eq(2)
+        expect(result.map(&:refname)).to contain_exactly('master', 'remotes/origin/master')
+        expect(result.none? { |b| b.refname.include?('detached') }).to be true
+      end
+    end
+
+    context 'with (not a branch) in output' do
+      let(:not_a_branch_output) do
+        [
+          '(not a branch)|abc123def456789012345678901234567890abcd|*|||',
+          'refs/heads/master|def456789012345678901234567890abcdef12||||'
+        ]
+      end
+
+      it 'filters out (not a branch) entries' do
+        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(not_a_branch_output)
+        result = command.call
+
+        expect(result.size).to eq(1)
+        expect(result.first.refname).to eq('master')
+        expect(result.none? { |b| b.refname.include?('not a branch') }).to be true
       end
     end
   end

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -300,39 +300,6 @@ class TestLib < Test::Unit::TestCase
     assert(branches.select { |b| /master/.match(b.refname) }.size.positive?) # has a master branch
   end
 
-  test 'Git::Lib#branches_all with unexpected output from git branches -a' do
-    # Mock command lines to return unexpected branch data
-    def @lib.command_lines(*_command)
-      <<~COMMAND_LINES.split("\n")
-        * (HEAD detached at origin/master)
-          this line should result in a Git::UnexpectedResultError
-          master
-          remotes/origin/HEAD -> origin/master
-          remotes/origin/master
-      COMMAND_LINES
-    end
-
-    begin
-      @lib.branches_all
-    rescue Git::UnexpectedResultError => e
-      assert_equal(<<~MESSAGE, e.message)
-        Unexpected line in output from `git branch --list -a`, line 2
-
-        Full output:
-          * (HEAD detached at origin/master)
-            this line should result in a Git::UnexpectedResultError
-            master
-            remotes/origin/HEAD -> origin/master
-            remotes/origin/master
-
-        Line 2:
-          "  this line should result in a Git::UnexpectedResultError"
-      MESSAGE
-    else
-      raise 'Expected Git::UnexpectedResultError'
-    end
-  end
-
   def test_config_remote
     config = @lib.config_remote('working')
     assert_equal('../working.git', config['url'])

--- a/tests/units/test_logger.rb
+++ b/tests/units/test_logger.rb
@@ -27,10 +27,10 @@ class TestLogger < Test::Unit::TestCase
 
       logc = File.read(log_path)
 
-      expected_log_entry = /INFO -- : \[\{[^}]+}, "git", "(?<global_options>.*?)", "branch", "--list", "-a"/
+      expected_log_entry = /INFO -- : \[\{[^}]+}, "git", "(?<global_options>.*?)", "branch", "--list", "--format=[^"]+", "-a"/
       assert_match(expected_log_entry, logc, missing_log_entry)
 
-      expected_log_entry = /DEBUG -- : stdout:\n"  cherry/
+      expected_log_entry = /DEBUG -- : stdout:\n"/
       assert_match(expected_log_entry, logc, missing_log_entry)
     end
   end
@@ -46,10 +46,10 @@ class TestLogger < Test::Unit::TestCase
 
       logc = File.read(log_path)
 
-      expected_log_entry = /INFO -- : \[\{[^}]+}, "git", "(?<global_options>.*?)", "branch", "--list", "-a"/
+      expected_log_entry = /INFO -- : \[\{[^}]+}, "git", "(?<global_options>.*?)", "branch", "--list", "--format=[^"]+", "-a"/
       assert_match(expected_log_entry, logc, missing_log_entry)
 
-      expected_log_entry = /DEBUG -- : stdout:\n"  cherry/
+      expected_log_entry = /DEBUG -- : stdout:\n"/
       assert_not_match(expected_log_entry, logc, unexpected_log_entry)
     end
   end


### PR DESCRIPTION
## Summary

Implements #962 by adding `target_oid` and `upstream` attributes to `BranchInfo`.

## Changes

### BranchInfo Data Structure
- Added `target_oid` attribute - the full SHA of the commit the branch points to
- Added `upstream` attribute - a `BranchInfo` object for the upstream tracking branch
- Added YARD documentation for all attributes

### Branch::List Command
- Added `FORMAT_STRING` constant using `git branch --format` placeholders
- Format: `%(refname:short)|%(objectname)|%(HEAD)|%(worktreepath)|%(symref)|%(upstream)`
- Replaced regex-based parsing with format-based parsing
- `target_oid` is now populated from `%(objectname)`
- `upstream` is now populated as a `BranchInfo` from `%(upstream)`

### Call Sites Updated
- `lib/git/base.rb` - Updated `BranchInfo.new` call
- `lib/git/remote.rb` - Updated `BranchInfo.new` call
- `lib/git/commands/branch/create.rb` - Returns nil for `target_oid` and `upstream` (newly created branches)

### Tests
- Unit tests for BranchInfo with new attributes
- Unit tests for Branch::List format parsing
- Integration test for upstream tracking with a real remote

## Note on `%(upstream:objectname)`

The issue originally suggested using `%(upstream:objectname)` to get the upstream's commit SHA. However, this placeholder is not supported in git. The `upstream.target_oid` will be `nil` - users who need the upstream's OID can look up the upstream branch separately.

Closes #962