### PR TITLE
Rename StashInfo sha/short_sha to oid/short_oid

### DIFF
--- a/lib/git/commands/stash/list.rb
+++ b/lib/git/commands/stash/list.rb
@@ -19,7 +19,7 @@ module Git
       # @example List all stashes
       #   stashes = Git::Commands::Stash::List.new(execution_context).call
       #   stashes.each do |s|
-      #     puts "#{s.short_sha} #{s.name}: #{s.message} (#{s.author_name})"
+      #     puts "#{s.short_oid} #{s.name}: #{s.message} (#{s.author_name})"
       #   end
       #
       class List
@@ -67,8 +67,8 @@ module Git
 
         # Field indices for parsed output
         module Fields
-          SHA = 0
-          SHORT_SHA = 1
+          OID = 0
+          SHORT_OID = 1
           REFLOG = 2
           MESSAGE = 3
           AUTHOR_NAME = 4
@@ -143,8 +143,8 @@ module Git
           {
             index: index,
             name: parts[Fields::REFLOG],
-            sha: parts[Fields::SHA],
-            short_sha: parts[Fields::SHORT_SHA],
+            oid: parts[Fields::OID],
+            short_oid: parts[Fields::SHORT_OID],
             branch: extract_branch(parts[Fields::MESSAGE]),
             message: parts[Fields::MESSAGE],
             author_name: parts[Fields::AUTHOR_NAME],

--- a/lib/git/stash_info.rb
+++ b/lib/git/stash_info.rb
@@ -14,8 +14,8 @@ module Git
   #   info = Git::StashInfo.new(
   #     index: 0,
   #     name: 'stash@{0}',
-  #     sha: 'abc123def456789...',
-  #     short_sha: 'abc123d',
+  #     oid: 'abc123def456789...',
+  #     short_oid: 'abc123d',
   #     branch: 'main',
   #     message: 'WIP on main: abc123 Initial commit',
   #     author_name: 'Jane Doe',
@@ -28,8 +28,8 @@ module Git
   #
   #   info.index           # => 0
   #   info.name            # => 'stash@{0}'
-  #   info.sha             # => 'abc123def456789...'
-  #   info.short_sha       # => 'abc123d'
+  #   info.oid             # => 'abc123def456789...'
+  #   info.short_oid       # => 'abc123d'
   #   info.branch          # => 'main'
   #   info.message         # => 'WIP on main: abc123 Initial commit'
   #   info.author_name     # => 'Jane Doe'
@@ -45,11 +45,11 @@ module Git
   # @!attribute [r] name
   #   @return [String] the stash reference name (e.g., 'stash@\\{0\\}')
   #
-  # @!attribute [r] sha
-  #   @return [String] the full 40-character commit SHA of the stash
+  # @!attribute [r] oid
+  #   @return [String] the full 40-character object identifier of the stash
   #
-  # @!attribute [r] short_sha
-  #   @return [String] the abbreviated commit SHA (typically 7 characters)
+  # @!attribute [r] short_oid
+  #   @return [String] the abbreviated object identifier (typically 7 characters)
   #
   # @!attribute [r] branch
   #   @return [String, nil] the branch name where the stash was created,
@@ -79,8 +79,8 @@ module Git
   StashInfo = Data.define(
     :index,
     :name,
-    :sha,
-    :short_sha,
+    :oid,
+    :short_oid,
     :branch,
     :message,
     :author_name,

--- a/lib/git/stashes.rb
+++ b/lib/git/stashes.rb
@@ -23,7 +23,7 @@ module Git
     #
     # @example Listing stashes with metadata
     #   git.stashes.all.each do |info|
-    #     puts "#{info.short_sha} #{info.name}: #{info.message}"
+    #     puts "#{info.short_oid} #{info.name}: #{info.message}"
     #   end
     #
     # @return [Array<Git::StashInfo>] array of stash info objects

--- a/spec/unit/git/commands/stash/apply_spec.rb
+++ b/spec/unit/git/commands/stash/apply_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Apply do
   let(:command) { described_class.new(execution_context) }
   let(:first_stash_info) do
     Git::StashInfo.new(
-      index: 0, name: 'stash@{0}', sha: 'abc123', short_sha: 'abc123',
+      index: 0, name: 'stash@{0}', oid: 'abc123', short_oid: 'abc123',
       branch: 'main', message: 'WIP on main: test',
       author_name: 'Test', author_email: 'test@example.com', author_date: '2024-01-01',
       committer_name: 'Test', committer_email: 'test@example.com', committer_date: '2024-01-01'
@@ -18,7 +18,7 @@ RSpec.describe Git::Commands::Stash::Apply do
   end
   let(:second_stash_info) do
     Git::StashInfo.new(
-      index: 1, name: 'stash@{1}', sha: 'def456', short_sha: 'def456',
+      index: 1, name: 'stash@{1}', oid: 'def456', short_oid: 'def456',
       branch: 'main', message: 'WIP on main: other',
       author_name: 'Test', author_email: 'test@example.com', author_date: '2024-01-01',
       committer_name: 'Test', committer_email: 'test@example.com', committer_date: '2024-01-01'
@@ -26,7 +26,7 @@ RSpec.describe Git::Commands::Stash::Apply do
   end
   let(:third_stash_info) do
     Git::StashInfo.new(
-      index: 2, name: 'stash@{2}', sha: 'ghi789', short_sha: 'ghi789',
+      index: 2, name: 'stash@{2}', oid: 'ghi789', short_oid: 'ghi789',
       branch: 'main', message: 'WIP on main: third',
       author_name: 'Test', author_email: 'test@example.com', author_date: '2024-01-01',
       committer_name: 'Test', committer_email: 'test@example.com', committer_date: '2024-01-01'

--- a/spec/unit/git/commands/stash/drop_spec.rb
+++ b/spec/unit/git/commands/stash/drop_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Drop do
   let(:command) { described_class.new(execution_context) }
   let(:first_stash_info) do
     Git::StashInfo.new(
-      index: 0, name: 'stash@{0}', sha: 'abc123', short_sha: 'abc123',
+      index: 0, name: 'stash@{0}', oid: 'abc123', short_oid: 'abc123',
       branch: 'main', message: 'WIP on main: test',
       author_name: 'Test', author_email: 'test@example.com', author_date: '2024-01-01',
       committer_name: 'Test', committer_email: 'test@example.com', committer_date: '2024-01-01'
@@ -18,7 +18,7 @@ RSpec.describe Git::Commands::Stash::Drop do
   end
   let(:second_stash_info) do
     Git::StashInfo.new(
-      index: 1, name: 'stash@{1}', sha: 'def456', short_sha: 'def456',
+      index: 1, name: 'stash@{1}', oid: 'def456', short_oid: 'def456',
       branch: 'main', message: 'WIP on main: other',
       author_name: 'Test', author_email: 'test@example.com', author_date: '2024-01-01',
       committer_name: 'Test', committer_email: 'test@example.com', committer_date: '2024-01-01'
@@ -26,7 +26,7 @@ RSpec.describe Git::Commands::Stash::Drop do
   end
   let(:third_stash_info) do
     Git::StashInfo.new(
-      index: 2, name: 'stash@{2}', sha: 'ghi789', short_sha: 'ghi789',
+      index: 2, name: 'stash@{2}', oid: 'ghi789', short_oid: 'ghi789',
       branch: 'main', message: 'WIP on main: third',
       author_name: 'Test', author_email: 'test@example.com', author_date: '2024-01-01',
       committer_name: 'Test', committer_email: 'test@example.com', committer_date: '2024-01-01'

--- a/spec/unit/git/commands/stash/list_spec.rb
+++ b/spec/unit/git/commands/stash/list_spec.rb
@@ -10,8 +10,8 @@ RSpec.describe Git::Commands::Stash::List do
   # Default stash line attributes for building test data
   let(:default_stash_attrs) do
     {
-      sha: 'abc1234567890abcdef1234567890abcdef123456',
-      short_sha: 'abc1234',
+      oid: 'abc1234567890abcdef1234567890abcdef123456',
+      short_oid: 'abc1234',
       reflog: 'stash@{0}',
       message: 'WIP on main: abc1234 Initial commit',
       author_name: 'Test Author',
@@ -26,7 +26,7 @@ RSpec.describe Git::Commands::Stash::List do
   # Helper to build stash format line with unit separator (0x1F)
   def stash_line(attrs)
     [
-      attrs[:sha], attrs[:short_sha], attrs[:reflog], attrs[:message],
+      attrs[:oid], attrs[:short_oid], attrs[:reflog], attrs[:message],
       attrs[:author_name], attrs[:author_email], attrs[:author_date],
       attrs[:committer_name], attrs[:committer_email], attrs[:committer_date]
     ].join("\x1f")
@@ -48,20 +48,20 @@ RSpec.describe Git::Commands::Stash::List do
       let(:stash_output) do
         [
           stash_line(default_stash_attrs.merge(
-                       sha: 'abc1234567890abcdef1234567890abcdef123456',
-                       short_sha: 'abc1234',
+                       oid: 'abc1234567890abcdef1234567890abcdef123456',
+                       short_oid: 'abc1234',
                        reflog: 'stash@{0}',
                        message: 'WIP on main: abc1234 Initial commit'
                      )),
           stash_line(default_stash_attrs.merge(
-                       sha: 'def5678901234567890abcdef1234567890abcdef',
-                       short_sha: 'def5678',
+                       oid: 'def5678901234567890abcdef1234567890abcdef',
+                       short_oid: 'def5678',
                        reflog: 'stash@{1}',
                        message: 'On feature: def5678 Add feature'
                      )),
           stash_line(default_stash_attrs.merge(
-                       sha: '9876543210abcdef1234567890abcdef12345678',
-                       short_sha: '9876543',
+                       oid: '9876543210abcdef1234567890abcdef12345678',
+                       short_oid: '9876543',
                        reflog: 'stash@{2}',
                        message: 'WIP on bugfix: 9876543 Fix bug'
                      ))
@@ -103,10 +103,10 @@ RSpec.describe Git::Commands::Stash::List do
           .with('stash', 'list', format_arg).and_return(stash_output)
         result = command.call
 
-        expect(result[0].sha).to eq('abc1234567890abcdef1234567890abcdef123456')
-        expect(result[0].short_sha).to eq('abc1234')
-        expect(result[1].sha).to eq('def5678901234567890abcdef1234567890abcdef')
-        expect(result[1].short_sha).to eq('def5678')
+        expect(result[0].oid).to eq('abc1234567890abcdef1234567890abcdef123456')
+        expect(result[0].short_oid).to eq('abc1234')
+        expect(result[1].oid).to eq('def5678901234567890abcdef1234567890abcdef')
+        expect(result[1].short_oid).to eq('def5678')
       end
 
       it 'parses branch name correctly' do
@@ -265,7 +265,7 @@ RSpec.describe Git::Commands::Stash::List do
     context 'with unexpected output format' do
       it 'raises UnexpectedResultError when field count is wrong' do
         # Malformed line with only 5 fields instead of 10
-        malformed_line = %w[sha short_sha reflog message author_name].join("\x1f")
+        malformed_line = %w[oid short_oid reflog message author_name].join("\x1f")
         expect(execution_context).to receive(:command_lines)
           .with('stash', 'list', format_arg).and_return([malformed_line])
 

--- a/spec/unit/git/commands/stash/pop_spec.rb
+++ b/spec/unit/git/commands/stash/pop_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Pop do
   let(:command) { described_class.new(execution_context) }
   let(:first_stash_info) do
     Git::StashInfo.new(
-      index: 0, name: 'stash@{0}', sha: 'abc123', short_sha: 'abc123',
+      index: 0, name: 'stash@{0}', oid: 'abc123', short_oid: 'abc123',
       branch: 'main', message: 'WIP on main: test',
       author_name: 'Test', author_email: 'test@example.com', author_date: '2024-01-01',
       committer_name: 'Test', committer_email: 'test@example.com', committer_date: '2024-01-01'
@@ -18,7 +18,7 @@ RSpec.describe Git::Commands::Stash::Pop do
   end
   let(:second_stash_info) do
     Git::StashInfo.new(
-      index: 1, name: 'stash@{1}', sha: 'def456', short_sha: 'def456',
+      index: 1, name: 'stash@{1}', oid: 'def456', short_oid: 'def456',
       branch: 'main', message: 'WIP on main: other',
       author_name: 'Test', author_email: 'test@example.com', author_date: '2024-01-01',
       committer_name: 'Test', committer_email: 'test@example.com', committer_date: '2024-01-01'
@@ -26,7 +26,7 @@ RSpec.describe Git::Commands::Stash::Pop do
   end
   let(:third_stash_info) do
     Git::StashInfo.new(
-      index: 2, name: 'stash@{2}', sha: 'ghi789', short_sha: 'ghi789',
+      index: 2, name: 'stash@{2}', oid: 'ghi789', short_oid: 'ghi789',
       branch: 'main', message: 'WIP on main: third',
       author_name: 'Test', author_email: 'test@example.com', author_date: '2024-01-01',
       committer_name: 'Test', committer_email: 'test@example.com', committer_date: '2024-01-01'

--- a/spec/unit/git/commands/stash/push_spec.rb
+++ b/spec/unit/git/commands/stash/push_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Push do
   let(:command) { described_class.new(execution_context) }
   let(:stash_info) do
     Git::StashInfo.new(
-      index: 0, name: 'stash@{0}', sha: 'abc123', short_sha: 'abc123',
+      index: 0, name: 'stash@{0}', oid: 'abc123', short_oid: 'abc123',
       branch: 'main', message: 'WIP on main: test',
       author_name: 'Test', author_email: 'test@example.com', author_date: '2024-01-01',
       committer_name: 'Test', committer_email: 'test@example.com', committer_date: '2024-01-01'

--- a/spec/unit/git/stash_info_spec.rb
+++ b/spec/unit/git/stash_info_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Git::StashInfo do
     {
       index: 0,
       name: 'stash@{0}',
-      sha: 'abc1234567890abcdef1234567890abcdef123456',
-      short_sha: 'abc1234',
+      oid: 'abc1234567890abcdef1234567890abcdef123456',
+      short_oid: 'abc1234',
       branch: 'main',
       message: 'WIP on main: abc123 Initial commit',
       author_name: 'Test Author',
@@ -28,8 +28,8 @@ RSpec.describe Git::StashInfo do
 
       expect(info.index).to eq(0)
       expect(info.name).to eq('stash@{0}')
-      expect(info.sha).to eq('abc1234567890abcdef1234567890abcdef123456')
-      expect(info.short_sha).to eq('abc1234')
+      expect(info.oid).to eq('abc1234567890abcdef1234567890abcdef123456')
+      expect(info.short_oid).to eq('abc1234')
       expect(info.branch).to eq('main')
       expect(info.message).to eq('WIP on main: abc123 Initial commit')
       expect(info.author_name).to eq('Test Author')
@@ -90,11 +90,11 @@ RSpec.describe Git::StashInfo do
 
     it 'supports Ruby pattern matching with all attributes' do
       case info
-      in [idx, name, sha, short_sha, branch, message, *rest]
+      in [idx, name, oid, short_oid, branch, message, *rest]
         expect(idx).to eq(0)
         expect(name).to eq('stash@{0}')
-        expect(sha).to eq('abc1234567890abcdef1234567890abcdef123456')
-        expect(short_sha).to eq('abc1234')
+        expect(oid).to eq('abc1234567890abcdef1234567890abcdef123456')
+        expect(short_oid).to eq('abc1234')
         expect(branch).to eq('main')
         expect(message).to eq('WIP on main: abc123 Initial commit')
         expect(rest.length).to eq(6) # remaining author/committer fields


### PR DESCRIPTION
## Summary

Rename `sha` and `short_sha` attributes in `StashInfo` to `oid` and `short_oid` for consistency with the naming conventions established in `TagInfo` and `BranchInfo`, aligning with Git's internal terminology.

**Note:** This is not a breaking change as the `StashInfo` class has not been released yet.

**Changes:**
- `StashInfo#sha` → `StashInfo#oid`
- `StashInfo#short_sha` → `StashInfo#short_oid`

## Background

Git's internal terminology uses "OID" (Object ID) as the abstract identifier, while SHA-1/SHA-256 refers to the hash algorithm. The codebase is moving toward `oid` naming:
- `TagInfo`: uses `oid`, `target_oid`
- `BranchInfo`: uses `target_oid`
- `StashInfo`: previously used `sha`, `short_sha` ← now fixed

## Files Modified

### Production Code
- `lib/git/stash_info.rb`: Renamed attributes and updated YARD documentation
- `lib/git/commands/stash/list.rb`: Renamed `Fields::SHA`/`Fields::SHORT_SHA` to `Fields::OID`/`Fields::SHORT_OID`
- `lib/git/stashes.rb`: Updated YARD example

### Test Files
- `spec/unit/git/stash_info_spec.rb`
- `spec/unit/git/commands/stash/list_spec.rb`
- `spec/unit/git/commands/stash/push_spec.rb`
- `spec/unit/git/commands/stash/pop_spec.rb`
- `spec/unit/git/commands/stash/drop_spec.rb`
- `spec/unit/git/commands/stash/apply_spec.rb`

## Acceptance Criteria

- [x] All `sha` references in `StashInfo` renamed to `oid`
- [x] All `short_sha` references renamed to `short_oid`
- [x] YARD documentation updated with correct attribute names
- [x] All unit tests pass
- [x] All integration tests pass
- [x] `rake` (full CI) passes

Closes #966