### PR TITLE
Rename FsckObject sha to oid

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -689,7 +689,7 @@ module Git
     #
     #   @example Check repository integrity
     #     result = git.fsck
-    #     result.dangling.each { |obj| puts "#{obj.type}: #{obj.sha}" }
+    #     result.dangling.each { |obj| puts "#{obj.type}: #{obj.oid}" }
     #
     #   @example Check with strict mode and suppress dangling output
     #     result = git.fsck(strict: true, dangling: false)
@@ -700,7 +700,7 @@ module Git
     #
     #   @example List root commits
     #     result = git.fsck(root: true)
-    #     result.root.each { |obj| puts obj.sha }
+    #     result.root.each { |obj| puts obj.oid }
     #
     #   @example Check specific objects
     #     result = git.fsck('abc1234', 'def5678')

--- a/lib/git/commands/fsck.rb
+++ b/lib/git/commands/fsck.rb
@@ -146,7 +146,7 @@ module Git
       def parse_object_line(line, result)
         return unless (match = OBJECT_PATTERN.match(line))
 
-        result[match[1].to_sym] << Git::FsckObject.new(type: match[2].to_sym, sha: match[3], name: match[4])
+        result[match[1].to_sym] << Git::FsckObject.new(type: match[2].to_sym, oid: match[3], name: match[4])
       end
 
       # Parse a warning line
@@ -158,7 +158,7 @@ module Git
       def parse_warning_line(line, result)
         return unless (match = WARNING_PATTERN.match(line))
 
-        result[:warnings] << Git::FsckObject.new(type: match[1].to_sym, sha: match[2], message: match[3])
+        result[:warnings] << Git::FsckObject.new(type: match[1].to_sym, oid: match[2], message: match[3])
       end
 
       # Parse a root line
@@ -170,7 +170,7 @@ module Git
       def parse_root_line(line, result)
         return unless (match = ROOT_PATTERN.match(line))
 
-        result[:root] << Git::FsckObject.new(type: :commit, sha: match[1])
+        result[:root] << Git::FsckObject.new(type: :commit, oid: match[1])
       end
 
       # Parse a tagged line
@@ -182,7 +182,7 @@ module Git
       def parse_tagged_line(line, result)
         return unless (match = TAGGED_PATTERN.match(line))
 
-        result[:tagged] << Git::FsckObject.new(type: match[1].to_sym, sha: match[2], name: match[3])
+        result[:tagged] << Git::FsckObject.new(type: match[1].to_sym, oid: match[2], name: match[3])
       end
     end
   end

--- a/lib/git/fsck_object.rb
+++ b/lib/git/fsck_object.rb
@@ -13,9 +13,9 @@ module Git
     # @return [Symbol] one of :commit, :tree, :blob, or :tag
     attr_reader :type
 
-    # The SHA-1 hash of the object
-    # @return [String] the 40-character SHA-1 hash
-    attr_reader :sha
+    # The object identifier (OID) of the object
+    # @return [String] the 40-character object identifier
+    attr_reader :oid
 
     # A warning or error message associated with this object
     # @return [String, nil] the message, or nil if no message
@@ -28,21 +28,21 @@ module Git
     # Create a new FsckObject
     #
     # @param type [Symbol] the object type (:commit, :tree, :blob, or :tag)
-    # @param sha [String] the 40-character SHA-1 hash
+    # @param oid [String] the 40-character object identifier
     # @param message [String, nil] optional warning/error message
     # @param name [String, nil] optional name from --name-objects (e.g., "HEAD~2^2:src/")
     #
-    def initialize(type:, sha:, message: nil, name: nil)
+    def initialize(type:, oid:, message: nil, name: nil)
       @type = type
-      @sha = sha
+      @oid = oid
       @message = message
       @name = name
     end
 
-    # Returns the SHA as the string representation
-    # @return [String] the SHA-1 hash
+    # Returns the OID as the string representation
+    # @return [String] the object identifier
     def to_s
-      sha
+      oid
     end
   end
 end

--- a/lib/git/fsck_result.rb
+++ b/lib/git/fsck_result.rb
@@ -85,7 +85,7 @@ module Git
     #
     # @example
     #   result = git.fsck
-    #   result.all_objects.each { |obj| puts obj.sha }
+    #   result.all_objects.each { |obj| puts obj.oid }
     #
     def all_objects
       dangling + missing + unreachable + warnings

--- a/spec/integration/git/commands/fsck/fsck_spec.rb
+++ b/spec/integration/git/commands/fsck/fsck_spec.rb
@@ -1,0 +1,439 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/fsck'
+
+RSpec.describe Git::Commands::Fsck, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when repository is clean' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+      end
+
+      it 'returns an empty result' do
+        result = command.call
+        expect(result.empty?).to be true
+        expect(result.any_issues?).to be false
+      end
+
+      it 'returns FsckResult with all empty arrays' do
+        result = command.call
+        expect(result.dangling).to eq([])
+        expect(result.missing).to eq([])
+        expect(result.unreachable).to eq([])
+        expect(result.warnings).to eq([])
+      end
+    end
+
+    context 'with dangling objects' do
+      # OID for blob with content 'orphaned content' (no trailing newline)
+      # Can be generated via: echo -n 'orphaned content' | git hash-object --stdin
+      let(:expected_blob_oid) { 'cf3f826230a67eac544a2ce2912965f004e94bd7' }
+
+      before do
+        write_file('file.txt', 'original content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+
+        # Create an orphaned blob by writing content then resetting
+        write_file('orphan.txt', 'orphaned content')
+        repo.add('orphan.txt')
+        # Don't commit - just add to index, then reset
+        # This creates a blob object that isn't referenced by any commit
+        repo.reset('HEAD', hard: true)
+      end
+
+      it 'detects dangling blobs' do
+        result = command.call
+        expect(result.dangling.any? { |obj| obj.type == :blob }).to be true
+      end
+
+      it 'returns FsckObject with the expected oid' do
+        result = command.call
+        dangling_blob = result.dangling.find { |obj| obj.type == :blob }
+        expect(dangling_blob.oid).to eq(expected_blob_oid)
+      end
+
+      it 'sets correct type on dangling objects' do
+        result = command.call
+        result.dangling.each do |obj|
+          expect(obj.type).to eq(:blob)
+        end
+      end
+    end
+
+    context 'with :root option' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('First root commit')
+
+        # Create another root commit by creating an orphan branch
+        repo.branch('orphan-branch').checkout
+        # Create the orphan via low-level git command
+        `cd #{repo_dir} && git checkout --orphan another-root && git commit --allow-empty -m "Another root"`
+      end
+
+      it 'reports root commits' do
+        result = command.call(root: true)
+        expect(result.root).not_to be_empty
+      end
+
+      it 'returns root commits as FsckObject with :commit type' do
+        result = command.call(root: true)
+        result.root.each do |obj|
+          expect(obj.type).to eq(:commit)
+          expect(obj.oid).to match(/^[0-9a-f]{40}$/)
+        end
+      end
+    end
+
+    context 'with :tags option' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+        repo.add_tag('v1.0.0', annotate: true, message: 'Version 1.0.0')
+      end
+
+      it 'reports tagged objects' do
+        result = command.call(tags: true)
+        expect(result.tagged).not_to be_empty
+      end
+
+      it 'returns tagged objects with tag name' do
+        result = command.call(tags: true)
+        tag_obj = result.tagged.find { |t| t.name == 'v1.0.0' }
+        expect(tag_obj).not_to be_nil
+        expect(tag_obj.oid).to match(/^[0-9a-f]{40}$/)
+      end
+    end
+
+    context 'with :strict option' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+      end
+
+      it 'runs with strict checking enabled' do
+        result = command.call(strict: true)
+        expect(result).to be_a(Git::FsckResult)
+      end
+    end
+
+    context 'with :connectivity_only option' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+      end
+
+      it 'runs connectivity-only check' do
+        result = command.call(connectivity_only: true)
+        expect(result).to be_a(Git::FsckResult)
+      end
+    end
+
+    context 'with :dangling option set to false' do
+      before do
+        write_file('file.txt', 'original content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+        write_file('orphan.txt', 'orphaned content')
+        repo.add('orphan.txt')
+        repo.reset('HEAD', hard: true)
+      end
+
+      it 'suppresses dangling object output' do
+        result = command.call(dangling: false)
+        # With dangling: false, git doesn't report dangling objects
+        expect(result.dangling).to be_empty
+      end
+    end
+
+    context 'with :unreachable option' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+
+        # Create an unreachable commit
+        write_file('file2.txt', 'more content')
+        repo.add('file2.txt')
+        repo.commit('Second commit')
+
+        # Reset back, making the second commit unreachable
+        repo.reset('HEAD~1', hard: true)
+        # Run git gc to potentially make objects unreachable
+        # Note: git keeps reflog entries, so this may still be reachable via reflog
+        `cd #{repo_dir} && git reflog expire --expire=now --all`
+      end
+
+      it 'reports unreachable objects when requested' do
+        result = command.call(unreachable: true)
+        # The commit may be unreachable after expiring reflog
+        expect(result).to be_a(Git::FsckResult)
+      end
+    end
+
+    context 'with combined options' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+        repo.add_tag('v1.0.0', annotate: true, message: 'Release')
+      end
+
+      it 'accepts multiple options' do
+        result = command.call(root: true, tags: true, strict: true)
+        expect(result).to be_a(Git::FsckResult)
+        expect(result.root).not_to be_empty
+        expect(result.tagged).not_to be_empty
+      end
+    end
+
+    context 'FsckObject attributes' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+
+        # Create a dangling blob
+        write_file('temp.txt', 'temporary')
+        repo.add('temp.txt')
+        repo.reset('HEAD', hard: true)
+      end
+
+      it 'has oid attribute accessible' do
+        result = command.call
+        dangling_obj = result.dangling.first
+        next if dangling_obj.nil?
+
+        expect(dangling_obj).to respond_to(:oid)
+        expect(dangling_obj.oid).to be_a(String)
+        expect(dangling_obj.oid.length).to eq(40)
+      end
+
+      it 'has type attribute accessible' do
+        result = command.call
+        dangling_obj = result.dangling.first
+        next if dangling_obj.nil?
+
+        expect(dangling_obj).to respond_to(:type)
+        expect(dangling_obj.type).to be_a(Symbol)
+      end
+
+      it 'returns oid from to_s' do
+        result = command.call
+        dangling_obj = result.dangling.first
+        next if dangling_obj.nil?
+
+        expect(dangling_obj.to_s).to eq(dangling_obj.oid)
+      end
+    end
+
+    context 'FsckResult methods' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+      end
+
+      it 'count returns correct total' do
+        result = command.call
+        expect(result.count).to eq(result.all_objects.size)
+      end
+
+      it 'to_h returns hash with all keys' do
+        result = command.call
+        hash = result.to_h
+        expect(hash).to have_key(:dangling)
+        expect(hash).to have_key(:missing)
+        expect(hash).to have_key(:unreachable)
+        expect(hash).to have_key(:warnings)
+        expect(hash).to have_key(:root)
+        expect(hash).to have_key(:tagged)
+      end
+    end
+
+    context 'with :name_objects option' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+        repo.add_tag('v1.0.0', annotate: true, message: 'Release')
+      end
+
+      it 'can include name information for objects' do
+        result = command.call(tags: true, name_objects: true)
+        # name_objects adds ref names to output when available
+        expect(result).to be_a(Git::FsckResult)
+      end
+    end
+
+    context 'with :cache option' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+      end
+
+      it 'considers index objects as head nodes' do
+        write_file('staged.txt', 'staged content')
+        repo.add('staged.txt')
+
+        result = command.call(cache: true)
+        expect(result).to be_a(Git::FsckResult)
+      end
+    end
+
+    context 'with :no_reflogs option' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+      end
+
+      it 'excludes reflog entries from reachability trace' do
+        result = command.call(no_reflogs: true)
+        expect(result).to be_a(Git::FsckResult)
+      end
+    end
+
+    context 'with :lost_found option' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+
+        # Create dangling content
+        write_file('orphan.txt', 'orphaned')
+        repo.add('orphan.txt')
+        repo.reset('HEAD', hard: true)
+      end
+
+      it 'writes dangling objects to lost-found directory' do
+        result = command.call(lost_found: true)
+        expect(result).to be_a(Git::FsckResult)
+        # The lost-found directory may or may not be created depending on whether there are
+        # dangling objects. We just verify the command ran successfully.
+      end
+    end
+
+    context 'with :full option' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+      end
+
+      it 'performs full object check' do
+        result = command.call(full: true)
+        expect(result).to be_a(Git::FsckResult)
+      end
+
+      it 'can disable full check' do
+        result = command.call(full: false)
+        expect(result).to be_a(Git::FsckResult)
+      end
+    end
+
+    context 'with :references option' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+      end
+
+      it 'can enable references check' do
+        result = command.call(references: true)
+        expect(result).to be_a(Git::FsckResult)
+      end
+
+      it 'can disable references check' do
+        result = command.call(references: false)
+        expect(result).to be_a(Git::FsckResult)
+      end
+    end
+
+    context 'with specific objects' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+      end
+
+      it 'checks specific objects by oid' do
+        # Get the HEAD commit SHA
+        head_sha = `cd #{repo_dir} && git rev-parse HEAD`.strip
+
+        result = command.call(head_sha)
+        expect(result).to be_a(Git::FsckResult)
+      end
+    end
+
+    context 'edge cases' do
+      it 'handles empty repository' do
+        # No commits at all
+        result = command.call
+        expect(result).to be_a(Git::FsckResult)
+        expect(result.empty?).to be true
+      end
+
+      context 'with multiple dangling objects' do
+        before do
+          write_file('file.txt', 'content')
+          repo.add('file.txt')
+          repo.commit('Initial commit')
+
+          # Create multiple dangling blobs
+          write_file('orphan1.txt', 'orphaned content 1')
+          repo.add('orphan1.txt')
+          repo.reset('HEAD', hard: true)
+
+          write_file('orphan2.txt', 'orphaned content 2')
+          repo.add('orphan2.txt')
+          repo.reset('HEAD', hard: true)
+        end
+
+        it 'returns all dangling objects' do
+          result = command.call
+          # We created at least 2 dangling blobs
+          expect(result.dangling.length).to be >= 2
+        end
+
+        it 'each dangling object has unique oid' do
+          result = command.call
+          oids = result.dangling.map(&:oid)
+          expect(oids.uniq.length).to eq(oids.length)
+        end
+      end
+
+      context 'with various object types' do
+        before do
+          # Create initial commit with tree structure
+          create_directory('lib')
+          write_file('lib/file.rb', 'ruby code')
+          write_file('README.md', '# Title')
+          repo.add(all: true)
+          repo.commit('Initial commit with tree structure')
+          repo.add_tag('v1.0.0', annotate: true, message: 'First release')
+        end
+
+        it 'handles commits, trees, blobs and tags' do
+          result = command.call(root: true, tags: true)
+          expect(result).to be_a(Git::FsckResult)
+          expect(result.root.first.type).to eq(:commit)
+          expect(result.tagged).not_to be_empty
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/fsck_spec.rb
+++ b/spec/unit/git/commands/fsck_spec.rb
@@ -217,7 +217,7 @@ RSpec.describe Git::Commands::Fsck do
 
           expect(result.dangling.size).to eq(1)
           expect(result.dangling.first.type).to eq(:blob)
-          expect(result.dangling.first.sha).to eq('1234567890abcdef1234567890abcdef12345678')
+          expect(result.dangling.first.oid).to eq('1234567890abcdef1234567890abcdef12345678')
         end
 
         it 'parses dangling objects with names' do
@@ -239,7 +239,7 @@ RSpec.describe Git::Commands::Fsck do
 
           expect(result.missing.size).to eq(1)
           expect(result.missing.first.type).to eq(:tree)
-          expect(result.missing.first.sha).to eq('abcdef1234567890abcdef1234567890abcdef12')
+          expect(result.missing.first.oid).to eq('abcdef1234567890abcdef1234567890abcdef12')
         end
       end
 
@@ -252,7 +252,7 @@ RSpec.describe Git::Commands::Fsck do
 
           expect(result.unreachable.size).to eq(1)
           expect(result.unreachable.first.type).to eq(:commit)
-          expect(result.unreachable.first.sha).to eq('fedcba0987654321fedcba0987654321fedcba09')
+          expect(result.unreachable.first.oid).to eq('fedcba0987654321fedcba0987654321fedcba09')
         end
       end
 
@@ -265,7 +265,7 @@ RSpec.describe Git::Commands::Fsck do
 
           expect(result.warnings.size).to eq(1)
           expect(result.warnings.first.type).to eq(:commit)
-          expect(result.warnings.first.sha).to eq('1234567890abcdef1234567890abcdef12345678')
+          expect(result.warnings.first.oid).to eq('1234567890abcdef1234567890abcdef12345678')
           expect(result.warnings.first.message).to eq('invalid author/committer')
         end
       end
@@ -279,7 +279,7 @@ RSpec.describe Git::Commands::Fsck do
 
           expect(result.root.size).to eq(1)
           expect(result.root.first.type).to eq(:commit)
-          expect(result.root.first.sha).to eq('1234567890abcdef1234567890abcdef12345678')
+          expect(result.root.first.oid).to eq('1234567890abcdef1234567890abcdef12345678')
         end
       end
 
@@ -293,7 +293,7 @@ RSpec.describe Git::Commands::Fsck do
 
           expect(result.tagged.size).to eq(1)
           expect(result.tagged.first.type).to eq(:commit)
-          expect(result.tagged.first.sha).to eq('abcdef1234567890abcdef1234567890abcdef12')
+          expect(result.tagged.first.oid).to eq('abcdef1234567890abcdef1234567890abcdef12')
           expect(result.tagged.first.name).to eq('v1.0.0')
         end
       end

--- a/tests/units/test_fsck.rb
+++ b/tests/units/test_fsck.rb
@@ -173,7 +173,7 @@ class TestFsck < Test::Unit::TestCase
       result.dangling.each do |obj|
         assert_instance_of(Git::FsckObject, obj)
         assert_includes(%i[commit tree blob tag], obj.type)
-        assert_match(/\A[0-9a-f]{40}\z/, obj.sha)
+        assert_match(/\A[0-9a-f]{40}\z/, obj.oid)
       end
     end
   end
@@ -200,7 +200,7 @@ class TestFsck < Test::Unit::TestCase
 
         assert_equal(1, result.dangling.size)
         assert_equal(:commit, result.dangling.first.type)
-        assert_match(/\A[0-9a-f]{40}\z/, result.dangling.first.sha)
+        assert_match(/\A[0-9a-f]{40}\z/, result.dangling.first.oid)
         assert(result.any_issues?)
         assert_equal(false, result.empty?)
       end
@@ -223,7 +223,7 @@ class TestFsck < Test::Unit::TestCase
         result = git.fsck
 
         assert(result.dangling.any? { |obj| obj.type == :blob })
-        dangling_blob = result.dangling.find { |obj| obj.sha == blob_sha }
+        dangling_blob = result.dangling.find { |obj| obj.oid == blob_sha }
         assert_not_nil(dangling_blob)
         assert_equal(:blob, dangling_blob.type)
       end
@@ -268,7 +268,7 @@ class TestFsck < Test::Unit::TestCase
         # Should have exactly one root commit (the initial commit)
         assert_equal(1, result.root.size)
         assert_equal(:commit, result.root.first.type)
-        assert_match(/\A[0-9a-f]{40}\z/, result.root.first.sha)
+        assert_match(/\A[0-9a-f]{40}\z/, result.root.first.oid)
 
         # root commits are not considered "issues"
         assert_equal(false, result.any_issues?) if result.dangling.empty? && result.missing.empty?
@@ -297,7 +297,7 @@ class TestFsck < Test::Unit::TestCase
         assert_equal(2, result.root.size)
         result.root.each do |obj|
           assert_equal(:commit, obj.type)
-          assert_match(/\A[0-9a-f]{40}\z/, obj.sha)
+          assert_match(/\A[0-9a-f]{40}\z/, obj.oid)
         end
       end
     end
@@ -320,7 +320,7 @@ class TestFsck < Test::Unit::TestCase
         assert(result.tagged.size >= 1)
         tagged_obj = result.tagged.first
         assert_equal(:commit, tagged_obj.type)
-        assert_match(/\A[0-9a-f]{40}\z/, tagged_obj.sha)
+        assert_match(/\A[0-9a-f]{40}\z/, tagged_obj.oid)
         assert_equal('v1.0.0', tagged_obj.name)
       end
     end
@@ -349,7 +349,7 @@ class TestFsck < Test::Unit::TestCase
         result = git.fsck
 
         assert(result.missing.size >= 1)
-        missing_obj = result.missing.find { |obj| obj.sha == blob_sha }
+        missing_obj = result.missing.find { |obj| obj.oid == blob_sha }
         assert_not_nil(missing_obj)
         assert_equal(:blob, missing_obj.type)
         assert(result.any_issues?)
@@ -381,7 +381,7 @@ class TestFsck < Test::Unit::TestCase
         # but the parsing should work either way
         dangling = result.dangling.first
         assert_equal(:commit, dangling.type)
-        assert_match(/\A[0-9a-f]{40}\z/, dangling.sha)
+        assert_match(/\A[0-9a-f]{40}\z/, dangling.oid)
       end
     end
   end

--- a/tests/units/test_fsck_object.rb
+++ b/tests/units/test_fsck_object.rb
@@ -4,28 +4,28 @@ require 'test_helper'
 
 class TestFsckObject < Test::Unit::TestCase
   def test_attributes
-    obj = Git::FsckObject.new(type: :commit, sha: 'abc123', message: 'test message', name: 'HEAD~2')
+    obj = Git::FsckObject.new(type: :commit, oid: 'abc123', message: 'test message', name: 'HEAD~2')
 
     assert_equal(:commit, obj.type)
-    assert_equal('abc123', obj.sha)
+    assert_equal('abc123', obj.oid)
     assert_equal('test message', obj.message)
     assert_equal('HEAD~2', obj.name)
   end
 
   def test_message_defaults_to_nil
-    obj = Git::FsckObject.new(type: :tree, sha: 'def456')
+    obj = Git::FsckObject.new(type: :tree, oid: 'def456')
 
     assert_nil(obj.message)
   end
 
   def test_name_defaults_to_nil
-    obj = Git::FsckObject.new(type: :tree, sha: 'def456')
+    obj = Git::FsckObject.new(type: :tree, oid: 'def456')
 
     assert_nil(obj.name)
   end
 
-  def test_to_s_returns_sha
-    obj = Git::FsckObject.new(type: :blob, sha: 'abc123def456')
+  def test_to_s_returns_oid
+    obj = Git::FsckObject.new(type: :blob, oid: 'abc123def456')
 
     assert_equal('abc123def456', obj.to_s)
   end

--- a/tests/units/test_fsck_result.rb
+++ b/tests/units/test_fsck_result.rb
@@ -15,10 +15,10 @@ class TestFsckResult < Test::Unit::TestCase
   end
 
   test 'initialize with provided arrays' do
-    dangling = [Git::FsckObject.new(type: :commit, sha: 'a' * 40)]
-    missing = [Git::FsckObject.new(type: :blob, sha: 'b' * 40)]
-    unreachable = [Git::FsckObject.new(type: :tree, sha: 'c' * 40)]
-    warnings = [Git::FsckObject.new(type: :commit, sha: 'd' * 40, message: 'badTimezone')]
+    dangling = [Git::FsckObject.new(type: :commit, oid: 'a' * 40)]
+    missing = [Git::FsckObject.new(type: :blob, oid: 'b' * 40)]
+    unreachable = [Git::FsckObject.new(type: :tree, oid: 'c' * 40)]
+    warnings = [Git::FsckObject.new(type: :commit, oid: 'd' * 40, message: 'badTimezone')]
 
     result = Git::FsckResult.new(
       dangling: dangling,
@@ -40,7 +40,7 @@ class TestFsckResult < Test::Unit::TestCase
   end
 
   test 'empty? returns false when dangling is not empty' do
-    dangling = [Git::FsckObject.new(type: :commit, sha: 'a' * 40)]
+    dangling = [Git::FsckObject.new(type: :commit, oid: 'a' * 40)]
     result = Git::FsckResult.new(dangling: dangling)
 
     assert_equal(false, result.empty?)
@@ -53,17 +53,17 @@ class TestFsckResult < Test::Unit::TestCase
   end
 
   test 'any_issues? returns true when missing is not empty' do
-    missing = [Git::FsckObject.new(type: :blob, sha: 'b' * 40)]
+    missing = [Git::FsckObject.new(type: :blob, oid: 'b' * 40)]
     result = Git::FsckResult.new(missing: missing)
 
     assert(result.any_issues?)
   end
 
   test 'all_objects returns combined array' do
-    obj1 = Git::FsckObject.new(type: :commit, sha: 'a' * 40)
-    obj2 = Git::FsckObject.new(type: :blob, sha: 'b' * 40)
-    obj3 = Git::FsckObject.new(type: :tree, sha: 'c' * 40)
-    obj4 = Git::FsckObject.new(type: :tag, sha: 'd' * 40, message: 'badTimezone')
+    obj1 = Git::FsckObject.new(type: :commit, oid: 'a' * 40)
+    obj2 = Git::FsckObject.new(type: :blob, oid: 'b' * 40)
+    obj3 = Git::FsckObject.new(type: :tree, oid: 'c' * 40)
+    obj4 = Git::FsckObject.new(type: :tag, oid: 'd' * 40, message: 'badTimezone')
 
     result = Git::FsckResult.new(
       dangling: [obj1],
@@ -82,12 +82,12 @@ class TestFsckResult < Test::Unit::TestCase
 
   test 'count returns total number of objects' do
     result = Git::FsckResult.new(
-      dangling: [Git::FsckObject.new(type: :commit, sha: 'a' * 40)],
-      missing: [Git::FsckObject.new(type: :blob, sha: 'b' * 40)],
+      dangling: [Git::FsckObject.new(type: :commit, oid: 'a' * 40)],
+      missing: [Git::FsckObject.new(type: :blob, oid: 'b' * 40)],
       unreachable: [],
       warnings: [
-        Git::FsckObject.new(type: :commit, sha: 'c' * 40, message: 'msg1'),
-        Git::FsckObject.new(type: :commit, sha: 'd' * 40, message: 'msg2')
+        Git::FsckObject.new(type: :commit, oid: 'c' * 40, message: 'msg1'),
+        Git::FsckObject.new(type: :commit, oid: 'd' * 40, message: 'msg2')
       ]
     )
 
@@ -95,8 +95,8 @@ class TestFsckResult < Test::Unit::TestCase
   end
 
   test 'to_h returns hash representation' do
-    dangling = [Git::FsckObject.new(type: :commit, sha: 'a' * 40)]
-    missing = [Git::FsckObject.new(type: :blob, sha: 'b' * 40)]
+    dangling = [Git::FsckObject.new(type: :commit, oid: 'a' * 40)]
+    missing = [Git::FsckObject.new(type: :blob, oid: 'b' * 40)]
 
     result = Git::FsckResult.new(dangling: dangling, missing: missing)
     hash = result.to_h
@@ -111,8 +111,8 @@ class TestFsckResult < Test::Unit::TestCase
   end
 
   test 'empty? returns true even when root and tagged have items' do
-    root = [Git::FsckObject.new(type: :commit, sha: 'a' * 40)]
-    tagged = [Git::FsckObject.new(type: :commit, sha: 'b' * 40, name: 'v1.0.0')]
+    root = [Git::FsckObject.new(type: :commit, oid: 'a' * 40)]
+    tagged = [Git::FsckObject.new(type: :commit, oid: 'b' * 40, name: 'v1.0.0')]
 
     result = Git::FsckResult.new(root: root, tagged: tagged)
 


### PR DESCRIPTION
# Description

Rename the `sha` attribute in `FsckObject` to `oid` for consistency with the naming conventions established in `TagInfo`, `BranchInfo`, and `StashInfo`.

## Background

Git's internal terminology uses "OID" (Object ID) as the abstract identifier, while SHA-1/SHA-256 refers to the hash algorithm. The newer data classes in this codebase use `oid`:
- `TagInfo`: uses `oid`, `target_oid`
- `BranchInfo`: uses `target_oid`

`FsckObject` should follow this convention.

## Breaking Change

⚠️ This is a breaking API change for users accessing `fsck_object.sha`. They should use `fsck_object.oid` instead.

## Changes

### lib/git/fsck_object.rb
- Rename `attr_reader :sha` → `attr_reader :oid`
- Update `initialize` parameter: `sha:` → `oid:`
- Update instance variable: `@sha` → `@oid`
- Update `to_s` method to return `oid` instead of `sha`
- Update YARD documentation

### lib/git/commands/fsck.rb
- Update all `Git::FsckObject.new` calls: `sha:` → `oid:`

### lib/git/fsck_result.rb
- Update YARD example comments: `obj.sha` → `obj.oid`

### lib/git/base.rb
- Update YARD example comments: `obj.sha` → `obj.oid`

### Tests Updated
- tests/units/test_fsck_object.rb
- tests/units/test_fsck_result.rb
- tests/units/test_fsck.rb
- spec/unit/git/commands/fsck_spec.rb

### New Integration Tests
Added comprehensive integration tests in `spec/integration/git/commands/fsck/fsck_spec.rb` covering:
- Clean repository checks
- Dangling objects detection
- Root commit reporting (`--root`)
- Tagged objects reporting (`--tags`)
- Unreachable objects (`--unreachable`)
- Various options: `--strict`, `--connectivity-only`, `--dangling`, `--full`, `--name-objects`, `--cache`, `--no-reflogs`, `--lost-found`, `--references`
- Multiple dangling objects with unique OIDs
- Empty repository edge case
- Combined options usage

Fixes #967

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).