### PR TITLE
refactor: unify command execution with raise_on_failure and env options

### DIFF
--- a/lib/git/command_line_result.rb
+++ b/lib/git/command_line_result.rb
@@ -28,12 +28,6 @@ module Git
       @status = status
       @stdout = stdout
       @stderr = stderr
-
-      # ProcessExecuter::ResultWithCapture changed the timeout? method to timed_out?
-      # in version 4.x. This is a compatibility layer to maintain the old method name
-      # for backward compatibility.
-      #
-      status.define_singleton_method(:timeout?) { timed_out? }
     end
 
     # @attribute [r] git_cmd

--- a/lib/git/commands/add.rb
+++ b/lib/git/commands/add.rb
@@ -47,7 +47,7 @@ module Git
       #
       #   @option options [Boolean] :force (nil) Allow adding otherwise ignored files
       #
-      # @return [String] the command output (typically empty on success)
+      # @return [Git::CommandLineResult] the result of the command
       #
       def call(*, **)
         args = ARGS.build(*, **)

--- a/lib/git/commands/branch/copy.rb
+++ b/lib/git/commands/branch/copy.rb
@@ -75,7 +75,7 @@ module Git
         #
         #   @option options [Boolean] :force (nil) Allow copying even if new_branch already exists
         #
-        # @return [String] the command output
+        # @return [Git::CommandLineResult] the result of the command
         #
         # @raise [ArgumentError] if unsupported options are provided
         # @raise [Git::FailedError] if the branch doesn't exist or target exists (without force)

--- a/lib/git/commands/branch/delete.rb
+++ b/lib/git/commands/branch/delete.rb
@@ -74,7 +74,7 @@ module Git
         #   @option options [Boolean] :quiet (nil) Be more quiet when deleting a branch, suppressing
         #     non-error messages.
         #
-        # @return [String] the command output
+        # @return [Git::CommandLineResult] the result of the command
         #
         # @raise [ArgumentError] if unsupported options are provided
         # @raise [Git::FailedError] if the branch is not fully merged (without force)

--- a/lib/git/commands/branch/list.rb
+++ b/lib/git/commands/branch/list.rb
@@ -120,7 +120,7 @@ module Git
         #
         def call(*, **)
           args = ARGS.build(*, format: FORMAT_STRING, **)
-          lines = @execution_context.command_lines(*args)
+          lines = @execution_context.command(*args, raise_on_failure: false).stdout.split("\n")
           parse_branches(lines)
         end
 

--- a/lib/git/commands/branch/move.rb
+++ b/lib/git/commands/branch/move.rb
@@ -75,7 +75,7 @@ module Git
         #
         #   @option options [Boolean] :force (nil) Allow renaming even if new_branch already exists
         #
-        # @return [String] the command output
+        # @return [Git::CommandLineResult] the result of the command
         #
         # @raise [ArgumentError] if unsupported options are provided
         # @raise [Git::FailedError] if the branch doesn't exist or target exists (without force)

--- a/lib/git/commands/branch/set_upstream.rb
+++ b/lib/git/commands/branch/set_upstream.rb
@@ -63,7 +63,7 @@ module Git
         #
         #   @option options [String] :set_upstream_to (required) the upstream branch (e.g., 'origin/main')
         #
-        # @return [String] the command output
+        # @return [Git::CommandLineResult] the result of the command
         #
         # @raise [ArgumentError] if set_upstream_to is not provided
         # @raise [ArgumentError] if unsupported options are provided

--- a/lib/git/commands/branch/unset_upstream.rb
+++ b/lib/git/commands/branch/unset_upstream.rb
@@ -50,7 +50,7 @@ module Git
         #
         #   @param options [Hash] command options (none currently supported)
         #
-        # @return [String] the command output
+        # @return [Git::CommandLineResult] the result of the command
         #
         # @raise [ArgumentError] if unsupported options are provided
         # @raise [Git::FailedError] if the branch doesn't exist or has no upstream

--- a/lib/git/commands/checkout/branch.rb
+++ b/lib/git/commands/checkout/branch.rb
@@ -110,7 +110,7 @@ module Git
         #   @option options [Boolean] :recurse_submodules (nil) Update submodules.
         #     true for --recurse-submodules, false for --no-recurse-submodules
         #
-        # @return [String] the command output (typically empty on success)
+        # @return [Git::CommandLineResult] the result of the command
         #
         # @raise [Git::FailedError] if the checkout fails
         #

--- a/lib/git/commands/checkout/files.rb
+++ b/lib/git/commands/checkout/files.rb
@@ -96,7 +96,7 @@ module Git
         #   @option options [Boolean] :pathspec_file_nul (nil) NUL-separated paths in
         #     pathspec file
         #
-        # @return [String] the command output (typically empty on success)
+        # @return [Git::CommandLineResult] the result of the command
         #
         # @raise [Git::FailedError] if the checkout fails
         #

--- a/lib/git/commands/clean.rb
+++ b/lib/git/commands/clean.rb
@@ -62,7 +62,7 @@ module Git
       #
       #   @option options [Boolean] :x (nil) Don't use the standard ignore rules
       #
-      # @return [String] the command output (typically empty on success)
+      # @return [Git::CommandLineResult] the result of the command
       #
       def call(*, **)
         args = ARGS.build(*, **)

--- a/lib/git/commands/commit.rb
+++ b/lib/git/commands/commit.rb
@@ -84,7 +84,7 @@ module Git
       #     default key. When a string, uses the specified key ID. When false, adds --no-gpg-sign
       #     to override any commit.gpgsign configuration.
       #
-      # @return [String] the command output
+      # @return [Git::CommandLineResult] the result of the command
       #
       # @raise [ArgumentError] if unsupported options are provided
       # @raise [ArgumentError] if :date is not a String

--- a/lib/git/commands/fsck.rb
+++ b/lib/git/commands/fsck.rb
@@ -96,19 +96,14 @@ module Git
       #
       def call(*, **)
         args = ARGS.build(*, **)
+        result = @execution_context.command(*args, raise_on_failure: false)
 
         # fsck returns non-zero exit status when issues are found:
         # 1 = errors found, 2 = missing objects, 4 = warnings
-        # We still want to parse the output in these cases
-        output = begin
-          @execution_context.command(*args)
-        rescue Git::FailedError => e
-          raise unless [1, 2, 4].include?(e.result.status.exitstatus)
+        # These are bit flags that can be combined (0-7 are valid)
+        raise Git::FailedError, result if result.status.exitstatus > 7
 
-          e.result.stdout
-        end
-
-        parse_output(output)
+        parse_output(result.stdout)
       end
 
       private

--- a/lib/git/commands/merge/resolve.rb
+++ b/lib/git/commands/merge/resolve.rb
@@ -65,7 +65,7 @@ module Git
         #     in progress. Leave the index and working tree as-is. If an
         #     autostash entry is present, save it to the stash list.
         #
-        # @return [String] the command output
+        # @return [Git::CommandLineResult] the result of the command
         #
         # @raise [Git::FailedError] if the command fails (e.g., no merge in progress,
         #   unresolved conflicts for continue)

--- a/lib/git/commands/merge/start.rb
+++ b/lib/git/commands/merge/start.rb
@@ -150,7 +150,7 @@ module Git
         #   @option options [Boolean] :log (nil) Include one-line descriptions
         #     from commits in merge message. true for --log, false for --no-log
         #
-        # @return [String] the command output
+        # @return [Git::CommandLineResult] the result of the command
         #
         # @raise [Git::FailedError] if the merge fails (e.g., conflicts)
         #

--- a/lib/git/commands/merge_base.rb
+++ b/lib/git/commands/merge_base.rb
@@ -81,7 +81,7 @@ module Git
       #
       def call(*, **)
         args = ARGS.build(*, **)
-        output = @execution_context.command(*args)
+        output = @execution_context.command(*args).stdout
         parse_output(output)
       end
 

--- a/lib/git/commands/mv.rb
+++ b/lib/git/commands/mv.rb
@@ -59,7 +59,7 @@ module Git
       #
       #   @option options [Boolean] :skip_errors (nil) Skip move or rename actions which would lead to an error
       #
-      # @return [String] the command output
+      # @return [Git::CommandLineResult] the result of the command
       #
       def call(*, **)
         args = ARGS.build(*, **)

--- a/lib/git/commands/reset.rb
+++ b/lib/git/commands/reset.rb
@@ -66,7 +66,7 @@ module Git
       #
       # @raise [ArgumentError] if more than one of :hard, :soft, or :mixed is specified
       #
-      # @return [String] the command output (typically empty on success)
+      # @return [Git::CommandLineResult] the result of the command
       #
       def call(*, **)
         args = ARGS.build(*, **)

--- a/lib/git/commands/rm.rb
+++ b/lib/git/commands/rm.rb
@@ -64,7 +64,7 @@ module Git
       #
       # @raise [Git::FailedError] if the git command fails (e.g., no paths provided)
       #
-      # @return [String] the command output (typically empty on success)
+      # @return [Git::CommandLineResult] the result of the command
       #
       def call(*, **)
         args = ARGS.build(*, **)

--- a/lib/git/commands/stash/clear.rb
+++ b/lib/git/commands/stash/clear.rb
@@ -32,7 +32,7 @@ module Git
 
         # Clear all stash entries
         #
-        # @return [String] the command output (empty on success)
+        # @return [Git::CommandLineResult] the result of the command
         #
         def call
           @execution_context.command(*ARGS.build)

--- a/lib/git/commands/stash/list.rb
+++ b/lib/git/commands/stash/list.rb
@@ -98,7 +98,7 @@ module Git
         # @raise [Git::UnexpectedResultError] if stash output cannot be parsed
         #
         def call
-          lines = @execution_context.command_lines(*ARGS.build(format: STASH_FORMAT))
+          lines = @execution_context.command(*ARGS.build(format: STASH_FORMAT)).stdout.split("\n")
           lines.each_with_index.map { |line, idx| parse_stash_line(line, idx, lines) }
         end
 

--- a/lib/git/commands/stash/push.rb
+++ b/lib/git/commands/stash/push.rb
@@ -85,10 +85,10 @@ module Git
         # @return [Git::StashInfo, nil] the newly created stash info, or nil if nothing was stashed
         #
         def call(*, **)
-          output = @execution_context.command(*ARGS.build(*, **))
+          result = @execution_context.command(*ARGS.build(*, **))
 
           # No stash created if there were no local changes
-          return nil if output&.include?('No local changes to save')
+          return nil if result.stdout.include?('No local changes to save')
 
           # New stash is always at index 0
           stash_list.first

--- a/lib/git/commands/tag/list.rb
+++ b/lib/git/commands/tag/list.rb
@@ -124,7 +124,7 @@ module Git
         #
         def call(*, **)
           args = ARGS.build(*, **)
-          lines = @execution_context.command_lines(*args)
+          lines = @execution_context.command(*args, raise_on_failure: false).stdout.split("\n")
           parse_tags(lines)
         end
 

--- a/lib/git/errors.rb
+++ b/lib/git/errors.rb
@@ -146,7 +146,7 @@ module Git
   # The git command executed, status, stdout, and stderr, and the timeout duration
   # are available from this object.
   #
-  # result.status.timeout? will be `true`
+  # result.status.timed_out? will be `true`
   #
   # @api public
   #

--- a/spec/integration/git/command_line_spec.rb
+++ b/spec/integration/git/command_line_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe 'CommandLine#run raise_on_failure integration' do
+  include_context 'in an empty repository'
+
+  let(:command_line) do
+    Git::CommandLine.new({}, 'git', [], Logger.new(nil))
+  end
+
+  describe 'raise_on_failure: false' do
+    it 'returns CommandLineResult without raising on non-zero exit' do
+      result = command_line.run('rev-parse', 'nonexistent-ref', chdir: repo_dir, raise_on_failure: false)
+
+      expect(result).to be_a(Git::CommandLineResult)
+      expect(result.status.success?).to be false
+      expect(result.stderr).to include('unknown revision')
+    end
+  end
+
+  describe 'raise_on_failure: true (default)' do
+    it 'raises FailedError on non-zero exit' do
+      expect do
+        command_line.run('rev-parse', 'nonexistent-ref', chdir: repo_dir)
+      end.to raise_error(Git::FailedError)
+    end
+  end
+end

--- a/spec/integration/git/commands/branch/create_spec.rb
+++ b/spec/integration/git/commands/branch/create_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Git::Commands::Branch::Create, :integration do
         write_file('file1.txt', 'content1')
         repo.add('file1.txt')
         repo.commit('First commit')
-        execution_context.command('rev-parse', 'HEAD').strip
+        execution_context.command('rev-parse', 'HEAD').stdout.strip
       end
 
       before do
@@ -73,7 +73,7 @@ RSpec.describe Git::Commands::Branch::Create, :integration do
         expect(result.refname).to eq('old-branch')
 
         # Verify the branch points to the first commit
-        branch_sha = execution_context.command('rev-parse', 'old-branch').strip
+        branch_sha = execution_context.command('rev-parse', 'old-branch').stdout.strip
         expect(branch_sha).to eq(first_commit_sha)
       end
 
@@ -113,7 +113,7 @@ RSpec.describe Git::Commands::Branch::Create, :integration do
         write_file('file1.txt', 'content1')
         repo.add('file1.txt')
         repo.commit('First commit')
-        execution_context.command('rev-parse', 'HEAD').strip
+        execution_context.command('rev-parse', 'HEAD').stdout.strip
       end
 
       before do
@@ -133,7 +133,7 @@ RSpec.describe Git::Commands::Branch::Create, :integration do
         expect(result.refname).to eq('existing-branch')
 
         # Verify the branch now points to the first commit
-        branch_sha = execution_context.command('rev-parse', 'existing-branch').strip
+        branch_sha = execution_context.command('rev-parse', 'existing-branch').stdout.strip
         expect(branch_sha).to eq(first_commit_sha)
       end
     end

--- a/spec/integration/git/commands/tag/create_spec.rb
+++ b/spec/integration/git/commands/tag/create_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Git::Commands::Tag::Create, :integration do
       end
 
       it 'tags the current HEAD by default' do
-        commit_sha = execution_context.command('rev-parse', 'HEAD').strip
+        commit_sha = execution_context.command('rev-parse', 'HEAD').stdout.strip
 
         result = command.call('v1.0.0')
 
@@ -114,7 +114,7 @@ RSpec.describe Git::Commands::Tag::Create, :integration do
         write_file('file1.txt', 'content1')
         repo.add('file1.txt')
         repo.commit('First commit')
-        execution_context.command('rev-parse', 'HEAD').strip
+        execution_context.command('rev-parse', 'HEAD').stdout.strip
       end
 
       before do
@@ -156,7 +156,7 @@ RSpec.describe Git::Commands::Tag::Create, :integration do
       end
 
       it 'replaces the existing tag' do
-        new_commit_sha = execution_context.command('rev-parse', 'HEAD').strip
+        new_commit_sha = execution_context.command('rev-parse', 'HEAD').stdout.strip
 
         result = command.call('v1.0.0', force: true)
 

--- a/spec/integration/git/commands/tag/delete_spec.rb
+++ b/spec/integration/git/commands/tag/delete_spec.rb
@@ -89,7 +89,8 @@ RSpec.describe Git::Commands::Tag::Delete, :integration do
         expect(result.deleted.map(&:name)).to contain_exactly('v1.0.0', 'v2.0.0')
         expect(result.not_deleted.size).to eq(1)
         expect(result.not_deleted.first.name).to eq('nonexistent')
-        expect(result.not_deleted.first.error_message).to include("tag 'nonexistent' not found")
+        expect(result.not_deleted.first.error_message)
+          .to match(/tag 'nonexistent'.*not found|tag 'nonexistent' could not be deleted/)
       end
 
       it 'removes only the existing tags' do
@@ -119,7 +120,8 @@ RSpec.describe Git::Commands::Tag::Delete, :integration do
         result = command.call('nonexistent1', 'nonexistent2')
 
         result.not_deleted.each do |failure|
-          expect(failure.error_message).to include("tag '#{failure.name}' not found")
+          expect(failure.error_message)
+            .to match(/tag '#{failure.name}'.*not found|tag '#{failure.name}' could not be deleted/)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -67,3 +67,14 @@ SimpleCov::RSpec.start(
 )
 
 require 'git'
+
+# Helper to create a mock CommandLineResult for use in specs
+#
+# @param stdout [String] the stdout to return
+# @param stderr [String] the stderr to return (default: '')
+# @param exitstatus [Integer] the exit status code (default: 0)
+# @return [Git::CommandLineResult] a CommandLineResult object
+def command_result(stdout = '', stderr: '', exitstatus: 0)
+  status = double('status', success?: exitstatus.zero?, exitstatus: exitstatus, signaled?: false)
+  Git::CommandLineResult.new(%w[git], status, stdout, stderr)
+end

--- a/spec/unit/git/command_line_spec.rb
+++ b/spec/unit/git/command_line_spec.rb
@@ -1,0 +1,93 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::CommandLine do
+  let(:env) { {} }
+  let(:binary_path) { 'git' }
+  let(:global_opts) { [] }
+  let(:logger) { Logger.new(nil) }
+
+  def mock_result(**overrides)
+    default_options = {
+      command: %w[git status],
+      stdout: '',
+      stderr: '',
+      success?: true,
+      signaled?: false,
+      timed_out?: false
+    }
+
+    double('ProcessExecuter::ResultWithCapture', default_options.merge(overrides))
+  end
+
+  subject(:command_line) do
+    described_class.new(env, binary_path, global_opts, logger)
+  end
+
+  describe '#run with raise_on_failure option' do
+    before do
+      mocked_result = mock_result(command: %w[git status], stderr: 'fatal: not a git repository', success?: false)
+      allow(ProcessExecuter).to receive(:run_with_capture).and_return(mocked_result)
+    end
+
+    context 'when raise_on_failure is true (default)' do
+      it 'raises FailedError on non-zero exit status' do
+        expect do
+          command_line.run('status')
+        end.to raise_error(Git::FailedError)
+      end
+    end
+
+    context 'when raise_on_failure is false' do
+      it 'returns CommandLineResult on non-zero exit status without raising' do
+        result = command_line.run('status', raise_on_failure: false)
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.success?).to be false
+      end
+
+      context 'when command succeeds' do
+        before do
+          mocked_result = mock_result(success?: true)
+          allow(ProcessExecuter).to receive(:run_with_capture).and_return(mocked_result)
+        end
+
+        it 'returns CommandLineResult on success' do
+          result = command_line.run('--version', raise_on_failure: false)
+
+          expect(result).to be_a(Git::CommandLineResult)
+          expect(result.status.success?).to be true
+        end
+      end
+    end
+
+    context 'timeout and signal errors are always raised' do
+      context 'when command times out' do
+        before do
+          mocked_result = mock_result(success?: false, timed_out?: true)
+          allow(ProcessExecuter).to receive(:run_with_capture).and_return(mocked_result)
+        end
+
+        it 'raises TimeoutError even with raise_on_failure: false' do
+          expect do
+            command_line.run('status', raise_on_failure: false, timeout: 1)
+          end.to raise_error(Git::TimeoutError)
+        end
+      end
+
+      context 'when command is signaled' do
+        before do
+          mocked_result = mock_result(success?: false, signaled?: true)
+          allow(ProcessExecuter).to receive(:run_with_capture).and_return(mocked_result)
+        end
+
+        it 'raises SignaledError even with raise_on_failure: false' do
+          expect do
+            command_line.run('status', raise_on_failure: false)
+          end.to raise_error(Git::SignaledError)
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/branch/list_spec.rb
+++ b/spec/unit/git/commands/branch/list_spec.rb
@@ -15,99 +15,100 @@ RSpec.describe Git::Commands::Branch::List do
     ['branch', '--list', "--format=#{format_string}", *extra_args]
   end
 
+  # Helper to expect command call - verifies the command is called with specific arguments
+  def expect_command(*args, stdout: '')
+    expect(execution_context).to receive(:command).with(*args, any_args).and_return(command_result(stdout))
+  end
+
+  # Helper to stub command call for parsing tests where other expectations do the verification
+  def allow_command(*args, stdout: '')
+    allow(execution_context).to receive(:command).with(*args, any_args).and_return(command_result(stdout))
+  end
+
   describe '#call' do
     context 'with no options (basic list)' do
       it 'calls git branch --list with format string' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return([])
+        expect_command(*expected_args)
         command.call
       end
     end
 
     context 'with :all option' do
       it 'adds -a flag' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args('-a')).and_return([])
+        expect_command(*expected_args('-a'))
         command.call(all: true)
       end
     end
 
     context 'with :remotes option' do
       it 'adds -r flag' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args('-r')).and_return([])
+        expect_command(*expected_args('-r'))
         command.call(remotes: true)
       end
     end
 
     context 'with :sort option' do
       it 'adds --sort=<key> with single value' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args('--sort=refname')).and_return([])
+        expect_command(*expected_args('--sort=refname'))
         command.call(sort: 'refname')
       end
 
       it 'adds multiple --sort=<key> with array of values' do
-        expect(execution_context).to receive(:command_lines).with(
-          *expected_args('--sort=refname', '--sort=-committerdate')
-        ).and_return([])
+        expect_command(*expected_args('--sort=refname', '--sort=-committerdate'))
         command.call(sort: ['refname', '-committerdate'])
       end
     end
 
     context 'with :contains option' do
       it 'adds --contains <commit>' do
-        expect(execution_context).to receive(:command_lines).with(
-          *expected_args('--contains', 'abc123')
-        ).and_return([])
+        expect_command(*expected_args('--contains', 'abc123'))
         command.call(contains: 'abc123')
       end
     end
 
     context 'with :no_contains option' do
       it 'adds --no-contains <commit>' do
-        expect(execution_context).to receive(:command_lines).with(
-          *expected_args('--no-contains', 'abc123')
-        ).and_return([])
+        expect_command(*expected_args('--no-contains', 'abc123'))
         command.call(no_contains: 'abc123')
       end
     end
 
     context 'with :merged option' do
       it 'adds --merged <commit>' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args('--merged', 'main')).and_return([])
+        expect_command(*expected_args('--merged', 'main'))
         command.call(merged: 'main')
       end
     end
 
     context 'with :no_merged option' do
       it 'adds --no-merged <commit>' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args('--no-merged', 'main')).and_return([])
+        expect_command(*expected_args('--no-merged', 'main'))
         command.call(no_merged: 'main')
       end
     end
 
     context 'with :points_at option' do
       it 'adds --points-at <object>' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args('--points-at', 'v1.0')).and_return([])
+        expect_command(*expected_args('--points-at', 'v1.0'))
         command.call(points_at: 'v1.0')
       end
     end
 
     context 'with patterns' do
       it 'adds pattern arguments' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args('feature/*')).and_return([])
+        expect_command(*expected_args('feature/*'))
         command.call('feature/*')
       end
 
       it 'adds multiple pattern arguments' do
-        expected = expected_args('feature/*', 'bugfix/*')
-        expect(execution_context).to receive(:command_lines).with(*expected).and_return([])
+        expect_command(*expected_args('feature/*', 'bugfix/*'))
         command.call('feature/*', 'bugfix/*')
       end
     end
 
     context 'with multiple options' do
       it 'combines flags correctly' do
-        expect(execution_context).to receive(:command_lines).with(
-          *expected_args('-a', '--sort=refname', '--contains', 'abc123')
-        ).and_return([])
+        expect_command(*expected_args('-a', '--sort=refname', '--contains', 'abc123'))
         command.call(all: true, sort: 'refname', contains: 'abc123')
       end
     end
@@ -120,11 +121,11 @@ RSpec.describe Git::Commands::Branch::List do
           'refs/heads/feature-branch|def456789012345678901234567890abcdef12||||',
           'refs/remotes/origin/main|abc123def456789012345678901234567890abcd||||',
           'refs/remotes/origin/feature|ghi789012345678901234567890abcdef123456||||'
-        ]
+        ].join("\n")
       end
 
       it 'returns parsed branch data as array of BranchInfo objects' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(format_output)
+        allow_command(*expected_args, stdout: format_output)
         result = command.call
         expect(result).to be_an(Array)
         expect(result.size).to eq(4)
@@ -132,21 +133,21 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'parses target_oid from objectname' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(format_output)
+        allow_command(*expected_args, stdout: format_output)
         result = command.call
         expect(result[0].target_oid).to eq('abc123def456789012345678901234567890abcd')
         expect(result[1].target_oid).to eq('def456789012345678901234567890abcdef12')
       end
 
       it 'marks current branch correctly from HEAD field' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(format_output)
+        allow_command(*expected_args, stdout: format_output)
         result = command.call
         expect(result[0]).to have_attributes(refname: 'main', current: true)
         expect(result[1]).to have_attributes(refname: 'feature-branch', current: false)
       end
 
       it 'parses upstream as BranchInfo' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(format_output)
+        allow_command(*expected_args, stdout: format_output)
         result = command.call
         main_branch = result[0]
 
@@ -156,14 +157,14 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'sets upstream to nil when not configured' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(format_output)
+        allow_command(*expected_args, stdout: format_output)
         result = command.call
         expect(result[1].upstream).to be_nil  # feature-branch has no upstream
         expect(result[2].upstream).to be_nil  # remote-tracking branches don't have upstreams
       end
 
       it 'parses remote branch names' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(format_output)
+        allow_command(*expected_args, stdout: format_output)
         result = command.call
         expect(result[2].refname).to eq('remotes/origin/main')
         expect(result[3].refname).to eq('remotes/origin/feature')
@@ -176,11 +177,11 @@ RSpec.describe Git::Commands::Branch::List do
           'refs/heads/main|abc123def456789012345678901234567890abcd|*|||',
           'refs/heads/feature-in-worktree|def456789012345678901234567890abcdef12||/path/to/worktree||',
           'refs/heads/other-branch|ghi789012345678901234567890abcdef123456||||'
-        ]
+        ].join("\n")
       end
 
       it 'marks worktree branch correctly from worktreepath field' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(worktree_output)
+        allow_command(*expected_args, stdout: worktree_output)
         result = command.call
         expect(result[0]).to have_attributes(refname: 'main', current: true, worktree: false)
         expect(result[1]).to have_attributes(refname: 'feature-in-worktree', current: false, worktree: true)
@@ -193,11 +194,11 @@ RSpec.describe Git::Commands::Branch::List do
         [
           'refs/heads/HEAD|abc123def456789012345678901234567890abcd|||refs/heads/main|',
           'refs/heads/main|abc123def456789012345678901234567890abcd|*|||'
-        ]
+        ].join("\n")
       end
 
       it 'includes symbolic reference information' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(symref_output)
+        allow_command(*expected_args, stdout: symref_output)
         result = command.call
         expect(result[0].symref).to eq('refs/heads/main')
         expect(result[1].symref).to be_nil
@@ -212,13 +213,11 @@ RSpec.describe Git::Commands::Branch::List do
 
     context 'with empty fields in output' do
       let(:empty_fields_output) do
-        [
-          'refs/heads/main|abc123def456789012345678901234567890abcd||||'
-        ]
+        'refs/heads/main|abc123def456789012345678901234567890abcd||||'
       end
 
       it 'handles empty fields gracefully' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(empty_fields_output)
+        allow_command(*expected_args, stdout: empty_fields_output)
         result = command.call
         expect(result[0]).to have_attributes(
           refname: 'main',
@@ -237,11 +236,11 @@ RSpec.describe Git::Commands::Branch::List do
           '(HEAD detached at v1.0.0)|abc123def456789012345678901234567890abcd|*|||',
           'refs/heads/master|def456789012345678901234567890abcdef12||||',
           'refs/remotes/origin/master|ghi789012345678901234567890abcdef123456||||'
-        ]
+        ].join("\n")
       end
 
       it 'filters out detached HEAD entries' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(detached_head_output)
+        allow_command(*expected_args, stdout: detached_head_output)
         result = command.call
 
         expect(result.size).to eq(2)
@@ -255,11 +254,11 @@ RSpec.describe Git::Commands::Branch::List do
         [
           '(not a branch)|abc123def456789012345678901234567890abcd|*|||',
           'refs/heads/master|def456789012345678901234567890abcdef12||||'
-        ]
+        ].join("\n")
       end
 
       it 'filters out (not a branch) entries' do
-        expect(execution_context).to receive(:command_lines).with(*expected_args).and_return(not_a_branch_output)
+        allow_command(*expected_args, stdout: not_a_branch_output)
         result = command.call
 
         expect(result.size).to eq(1)

--- a/spec/unit/git/commands/fsck_spec.rb
+++ b/spec/unit/git/commands/fsck_spec.rb
@@ -6,10 +6,24 @@ RSpec.describe Git::Commands::Fsck do
   let(:execution_context) { double('ExecutionContext') }
   let(:command) { described_class.new(execution_context) }
 
+  # Helper to mock command call - accepts any keyword arguments
+  def mock_command(*args, stdout: '', stderr: '', exitstatus: 0)
+    allow(execution_context).to receive(:command).with(*args, any_args)
+                                                 .and_return(command_result(stdout, stderr: stderr,
+                                                                                    exitstatus: exitstatus))
+  end
+
+  def expect_command(*args, stdout: '', stderr: '', exitstatus: 0)
+    expect(execution_context).to receive(:command).with(*args, any_args)
+                                                  .and_return(command_result(stdout, stderr: stderr,
+                                                                                     exitstatus: exitstatus))
+  end
+
   describe '#call' do
     context 'with default arguments' do
       it 'runs fsck with --no-progress' do
-        expect(execution_context).to receive(:command).with('fsck', '--no-progress').and_return('')
+        expect(execution_context).to receive(:command).with('fsck', '--no-progress',
+                                                            any_args).and_return(command_result(''))
 
         command.call
       end
@@ -18,8 +32,8 @@ RSpec.describe Git::Commands::Fsck do
     context 'with specific objects' do
       it 'includes the object identifiers' do
         expect(execution_context).to receive(:command)
-          .with('fsck', '--no-progress', 'abc1234', 'def5678')
-          .and_return('')
+          .with('fsck', '--no-progress', 'abc1234', 'def5678', any_args)
+          .and_return(command_result(''))
 
         command.call('abc1234', 'def5678')
       end
@@ -28,16 +42,16 @@ RSpec.describe Git::Commands::Fsck do
     context 'with the :unreachable option' do
       it 'includes the --unreachable flag' do
         expect(execution_context).to receive(:command)
-          .with('fsck', '--no-progress', '--unreachable')
-          .and_return('')
+          .with('fsck', '--no-progress', '--unreachable', any_args)
+          .and_return(command_result(''))
 
         command.call(unreachable: true)
       end
 
       it 'does not include the flag when false' do
         expect(execution_context).to receive(:command)
-          .with('fsck', '--no-progress')
-          .and_return('')
+          .with('fsck', '--no-progress', any_args)
+          .and_return(command_result(''))
 
         command.call(unreachable: false)
       end
@@ -46,8 +60,8 @@ RSpec.describe Git::Commands::Fsck do
     context 'with the :strict option' do
       it 'includes the --strict flag' do
         expect(execution_context).to receive(:command)
-          .with('fsck', '--no-progress', '--strict')
-          .and_return('')
+          .with('fsck', '--no-progress', '--strict', any_args)
+          .and_return(command_result(''))
 
         command.call(strict: true)
       end
@@ -56,8 +70,8 @@ RSpec.describe Git::Commands::Fsck do
     context 'with the :connectivity_only option' do
       it 'includes the --connectivity-only flag' do
         expect(execution_context).to receive(:command)
-          .with('fsck', '--no-progress', '--connectivity-only')
-          .and_return('')
+          .with('fsck', '--no-progress', '--connectivity-only', any_args)
+          .and_return(command_result(''))
 
         command.call(connectivity_only: true)
       end
@@ -66,8 +80,8 @@ RSpec.describe Git::Commands::Fsck do
     context 'with the :root option' do
       it 'includes the --root flag' do
         expect(execution_context).to receive(:command)
-          .with('fsck', '--no-progress', '--root')
-          .and_return('')
+          .with('fsck', '--no-progress', '--root', any_args)
+          .and_return(command_result(''))
 
         command.call(root: true)
       end
@@ -76,8 +90,8 @@ RSpec.describe Git::Commands::Fsck do
     context 'with the :tags option' do
       it 'includes the --tags flag' do
         expect(execution_context).to receive(:command)
-          .with('fsck', '--no-progress', '--tags')
-          .and_return('')
+          .with('fsck', '--no-progress', '--tags', any_args)
+          .and_return(command_result(''))
 
         command.call(tags: true)
       end
@@ -86,8 +100,8 @@ RSpec.describe Git::Commands::Fsck do
     context 'with the :cache option' do
       it 'includes the --cache flag' do
         expect(execution_context).to receive(:command)
-          .with('fsck', '--no-progress', '--cache')
-          .and_return('')
+          .with('fsck', '--no-progress', '--cache', any_args)
+          .and_return(command_result(''))
 
         command.call(cache: true)
       end
@@ -96,8 +110,8 @@ RSpec.describe Git::Commands::Fsck do
     context 'with the :no_reflogs option' do
       it 'includes the --no-reflogs flag' do
         expect(execution_context).to receive(:command)
-          .with('fsck', '--no-progress', '--no-reflogs')
-          .and_return('')
+          .with('fsck', '--no-progress', '--no-reflogs', any_args)
+          .and_return(command_result(''))
 
         command.call(no_reflogs: true)
       end
@@ -106,8 +120,8 @@ RSpec.describe Git::Commands::Fsck do
     context 'with the :lost_found option' do
       it 'includes the --lost-found flag' do
         expect(execution_context).to receive(:command)
-          .with('fsck', '--no-progress', '--lost-found')
-          .and_return('')
+          .with('fsck', '--no-progress', '--lost-found', any_args)
+          .and_return(command_result(''))
 
         command.call(lost_found: true)
       end
@@ -117,16 +131,16 @@ RSpec.describe Git::Commands::Fsck do
       context ':dangling' do
         it 'includes --dangling when true' do
           expect(execution_context).to receive(:command)
-            .with('fsck', '--no-progress', '--dangling')
-            .and_return('')
+            .with('fsck', '--no-progress', '--dangling', any_args)
+            .and_return(command_result(''))
 
           command.call(dangling: true)
         end
 
         it 'includes --no-dangling when false' do
           expect(execution_context).to receive(:command)
-            .with('fsck', '--no-progress', '--no-dangling')
-            .and_return('')
+            .with('fsck', '--no-progress', '--no-dangling', any_args)
+            .and_return(command_result(''))
 
           command.call(dangling: false)
         end
@@ -135,16 +149,16 @@ RSpec.describe Git::Commands::Fsck do
       context ':full' do
         it 'includes --full when true' do
           expect(execution_context).to receive(:command)
-            .with('fsck', '--no-progress', '--full')
-            .and_return('')
+            .with('fsck', '--no-progress', '--full', any_args)
+            .and_return(command_result(''))
 
           command.call(full: true)
         end
 
         it 'includes --no-full when false' do
           expect(execution_context).to receive(:command)
-            .with('fsck', '--no-progress', '--no-full')
-            .and_return('')
+            .with('fsck', '--no-progress', '--no-full', any_args)
+            .and_return(command_result(''))
 
           command.call(full: false)
         end
@@ -153,16 +167,16 @@ RSpec.describe Git::Commands::Fsck do
       context ':name_objects' do
         it 'includes --name-objects when true' do
           expect(execution_context).to receive(:command)
-            .with('fsck', '--no-progress', '--name-objects')
-            .and_return('')
+            .with('fsck', '--no-progress', '--name-objects', any_args)
+            .and_return(command_result(''))
 
           command.call(name_objects: true)
         end
 
         it 'includes --no-name-objects when false' do
           expect(execution_context).to receive(:command)
-            .with('fsck', '--no-progress', '--no-name-objects')
-            .and_return('')
+            .with('fsck', '--no-progress', '--no-name-objects', any_args)
+            .and_return(command_result(''))
 
           command.call(name_objects: false)
         end
@@ -171,16 +185,16 @@ RSpec.describe Git::Commands::Fsck do
       context ':references' do
         it 'includes --references when true' do
           expect(execution_context).to receive(:command)
-            .with('fsck', '--no-progress', '--references')
-            .and_return('')
+            .with('fsck', '--no-progress', '--references', any_args)
+            .and_return(command_result(''))
 
           command.call(references: true)
         end
 
         it 'includes --no-references when false' do
           expect(execution_context).to receive(:command)
-            .with('fsck', '--no-progress', '--no-references')
-            .and_return('')
+            .with('fsck', '--no-progress', '--no-references', any_args)
+            .and_return(command_result(''))
 
           command.call(references: false)
         end
@@ -190,8 +204,8 @@ RSpec.describe Git::Commands::Fsck do
     context 'with multiple options combined' do
       it 'includes all specified flags' do
         expect(execution_context).to receive(:command)
-          .with('fsck', '--no-progress', '--unreachable', '--strict', '--full')
-          .and_return('')
+          .with('fsck', '--no-progress', '--unreachable', '--strict', '--full', any_args)
+          .and_return(command_result(''))
 
         command.call(unreachable: true, strict: true, full: true)
       end
@@ -200,8 +214,8 @@ RSpec.describe Git::Commands::Fsck do
     context 'with objects and options combined' do
       it 'includes both objects and flags' do
         expect(execution_context).to receive(:command)
-          .with('fsck', '--no-progress', '--strict', 'abc1234')
-          .and_return('')
+          .with('fsck', '--no-progress', '--strict', 'abc1234', any_args)
+          .and_return(command_result(''))
 
         command.call('abc1234', strict: true)
       end
@@ -211,7 +225,7 @@ RSpec.describe Git::Commands::Fsck do
       context 'with dangling objects' do
         it 'parses dangling objects correctly' do
           output = "dangling blob 1234567890abcdef1234567890abcdef12345678\n"
-          expect(execution_context).to receive(:command).and_return(output)
+          expect(execution_context).to receive(:command).and_return(command_result(output))
 
           result = command.call
 
@@ -222,7 +236,7 @@ RSpec.describe Git::Commands::Fsck do
 
         it 'parses dangling objects with names' do
           output = "dangling blob 1234567890abcdef1234567890abcdef12345678 (HEAD~2:src/file.rb)\n"
-          expect(execution_context).to receive(:command).and_return(output)
+          expect(execution_context).to receive(:command).and_return(command_result(output))
 
           result = command.call
 
@@ -233,7 +247,7 @@ RSpec.describe Git::Commands::Fsck do
       context 'with missing objects' do
         it 'parses missing objects correctly' do
           output = "missing tree abcdef1234567890abcdef1234567890abcdef12\n"
-          expect(execution_context).to receive(:command).and_return(output)
+          expect(execution_context).to receive(:command).and_return(command_result(output))
 
           result = command.call
 
@@ -246,7 +260,7 @@ RSpec.describe Git::Commands::Fsck do
       context 'with unreachable objects' do
         it 'parses unreachable objects correctly' do
           output = "unreachable commit fedcba0987654321fedcba0987654321fedcba09\n"
-          expect(execution_context).to receive(:command).and_return(output)
+          expect(execution_context).to receive(:command).and_return(command_result(output))
 
           result = command.call
 
@@ -259,7 +273,7 @@ RSpec.describe Git::Commands::Fsck do
       context 'with warnings' do
         it 'parses warning lines correctly' do
           output = "warning in commit 1234567890abcdef1234567890abcdef12345678: invalid author/committer\n"
-          expect(execution_context).to receive(:command).and_return(output)
+          expect(execution_context).to receive(:command).and_return(command_result(output))
 
           result = command.call
 
@@ -273,7 +287,7 @@ RSpec.describe Git::Commands::Fsck do
       context 'with root nodes' do
         it 'parses root lines correctly' do
           output = "root 1234567890abcdef1234567890abcdef12345678\n"
-          expect(execution_context).to receive(:command).and_return(output)
+          expect(execution_context).to receive(:command).and_return(command_result(output))
 
           result = command.call
 
@@ -287,7 +301,7 @@ RSpec.describe Git::Commands::Fsck do
         it 'parses tagged lines correctly' do
           output = 'tagged commit abcdef1234567890abcdef1234567890abcdef12 (v1.0.0) in ' \
                    "fedcba0987654321fedcba0987654321fedcba09\n"
-          expect(execution_context).to receive(:command).and_return(output)
+          expect(execution_context).to receive(:command).and_return(command_result(output))
 
           result = command.call
 
@@ -306,7 +320,7 @@ RSpec.describe Git::Commands::Fsck do
             unreachable commit 3333333333333333333333333333333333333333
             warning in commit 4444444444444444444444444444444444444444: bad date
           OUTPUT
-          expect(execution_context).to receive(:command).and_return(output)
+          expect(execution_context).to receive(:command).and_return(command_result(output))
 
           result = command.call
 
@@ -319,7 +333,7 @@ RSpec.describe Git::Commands::Fsck do
 
       context 'with empty output' do
         it 'returns an empty result' do
-          expect(execution_context).to receive(:command).and_return('')
+          expect(execution_context).to receive(:command).and_return(command_result(''))
 
           result = command.call
 
@@ -330,57 +344,81 @@ RSpec.describe Git::Commands::Fsck do
     end
 
     context 'error handling' do
-      it 'handles non-zero exit codes for errors' do
-        result_double = double('Result',
-                               status: double('Status', exitstatus: 1),
-                               stdout: 'missing tree abc123',
-                               git_cmd: 'git fsck',
-                               stderr: '')
-        failed_error = Git::FailedError.new(result_double)
+      it 'handles exit code 0 (no issues)' do
+        mock_command('fsck', '--no-progress')
+        result = command.call
+        expect(result).to be_a(Git::FsckResult)
+        expect(result.empty?).to be true
+      end
 
-        expect(execution_context).to receive(:command).and_raise(failed_error)
+      it 'handles exit code 1 (errors found)' do
+        output = "missing tree 1234567890abcdef1234567890abcdef12345678\n"
+        mock_command('fsck', '--no-progress', stdout: output, exitstatus: 1)
+        result = command.call
+        expect(result).to be_a(Git::FsckResult)
+        expect(result.missing.size).to eq(1)
+      end
 
+      it 'handles exit code 2 (missing objects)' do
+        output = "missing blob abcdef1234567890abcdef1234567890abcdef12\n"
+        mock_command('fsck', '--no-progress', stdout: output, exitstatus: 2)
+        result = command.call
+        expect(result).to be_a(Git::FsckResult)
+        expect(result.missing.size).to eq(1)
+      end
+
+      it 'handles exit code 4 (warnings)' do
+        output = "warning in commit 1234567890abcdef1234567890abcdef12345678: bad date\n"
+        mock_command('fsck', '--no-progress', stdout: output, exitstatus: 4)
+        result = command.call
+        expect(result).to be_a(Git::FsckResult)
+        expect(result.warnings.size).to eq(1)
+      end
+
+      # Exit codes are bit flags that can be combined
+      it 'handles exit code 3 (errors + missing)' do
+        output = <<~OUTPUT
+          missing tree 1111111111111111111111111111111111111111
+          missing blob 2222222222222222222222222222222222222222
+        OUTPUT
+        mock_command('fsck', '--no-progress', stdout: output, exitstatus: 3)
         result = command.call
         expect(result).to be_a(Git::FsckResult)
       end
 
-      it 'handles exit code 2 for missing objects' do
-        result_double = double('Result',
-                               status: double('Status', exitstatus: 2),
-                               stdout: 'missing blob def456',
-                               git_cmd: 'git fsck',
-                               stderr: '')
-        failed_error = Git::FailedError.new(result_double)
-
-        expect(execution_context).to receive(:command).and_raise(failed_error)
-
+      it 'handles exit code 5 (errors + warnings)' do
+        output = <<~OUTPUT
+          missing tree 1111111111111111111111111111111111111111
+          warning in commit 2222222222222222222222222222222222222222: bad date
+        OUTPUT
+        mock_command('fsck', '--no-progress', stdout: output, exitstatus: 5)
         result = command.call
         expect(result).to be_a(Git::FsckResult)
       end
 
-      it 'handles exit code 4 for warnings' do
-        result_double = double('Result',
-                               status: double('Status', exitstatus: 4),
-                               stdout: 'warning in commit ghi789: bad date',
-                               git_cmd: 'git fsck',
-                               stderr: '')
-        failed_error = Git::FailedError.new(result_double)
-
-        expect(execution_context).to receive(:command).and_raise(failed_error)
-
+      it 'handles exit code 6 (missing + warnings)' do
+        output = <<~OUTPUT
+          missing blob 1111111111111111111111111111111111111111
+          warning in commit 2222222222222222222222222222222222222222: bad date
+        OUTPUT
+        mock_command('fsck', '--no-progress', stdout: output, exitstatus: 6)
         result = command.call
         expect(result).to be_a(Git::FsckResult)
       end
 
-      it 're-raises errors with unexpected exit codes' do
-        result_double = double('Result',
-                               status: double('Status', exitstatus: 128),
-                               git_cmd: 'git fsck',
-                               stderr: '')
-        failed_error = Git::FailedError.new(result_double)
+      it 'handles exit code 7 (errors + missing + warnings)' do
+        output = <<~OUTPUT
+          missing tree 1111111111111111111111111111111111111111
+          missing blob 2222222222222222222222222222222222222222
+          warning in commit 3333333333333333333333333333333333333333: bad date
+        OUTPUT
+        mock_command('fsck', '--no-progress', stdout: output, exitstatus: 7)
+        result = command.call
+        expect(result).to be_a(Git::FsckResult)
+      end
 
-        expect(execution_context).to receive(:command).and_raise(failed_error)
-
+      it 'raises for exit code > 7 (fatal errors)' do
+        mock_command('fsck', '--no-progress', stderr: 'fatal: not a git repository', exitstatus: 128)
         expect { command.call }.to raise_error(Git::FailedError)
       end
     end

--- a/spec/unit/git/commands/merge_base_spec.rb
+++ b/spec/unit/git/commands/merge_base_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe Git::Commands::MergeBase do
   describe '#call' do
     context 'with two commits' do
       it 'calls git merge-base with both commits' do
-        expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature').and_return("abc123\n")
+        expect(execution_context).to receive(:command).with('merge-base', 'main',
+                                                            'feature').and_return(command_result("abc123\n"))
         result = command.call('main', 'feature')
         expect(result).to eq(['abc123'])
       end
@@ -19,7 +20,7 @@ RSpec.describe Git::Commands::MergeBase do
     context 'with multiple commits' do
       it 'calls git merge-base with all commits' do
         expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature1',
-                                                            'feature2').and_return("abc123\n")
+                                                            'feature2').and_return(command_result("abc123\n"))
         result = command.call('main', 'feature1', 'feature2')
         expect(result).to eq(['abc123'])
       end
@@ -28,13 +29,14 @@ RSpec.describe Git::Commands::MergeBase do
     context 'with :octopus option' do
       it 'adds --octopus flag' do
         expect(execution_context).to receive(:command).with('merge-base', '--octopus', 'main', 'b1',
-                                                            'b2').and_return("abc123\n")
+                                                            'b2').and_return(command_result("abc123\n"))
         result = command.call('main', 'b1', 'b2', octopus: true)
         expect(result).to eq(['abc123'])
       end
 
       it 'does not add flag when false' do
-        expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature').and_return("abc123\n")
+        expect(execution_context).to receive(:command).with('merge-base', 'main',
+                                                            'feature').and_return(command_result("abc123\n"))
         command.call('main', 'feature', octopus: false)
       end
     end
@@ -42,13 +44,14 @@ RSpec.describe Git::Commands::MergeBase do
     context 'with :independent option' do
       it 'adds --independent flag' do
         expect(execution_context).to receive(:command).with('merge-base', '--independent', 'a', 'b',
-                                                            'c').and_return("sha1\nsha2\n")
+                                                            'c').and_return(command_result("sha1\nsha2\n"))
         result = command.call('a', 'b', 'c', independent: true)
         expect(result).to eq(%w[sha1 sha2])
       end
 
       it 'does not add flag when false' do
-        expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature').and_return("abc123\n")
+        expect(execution_context).to receive(:command).with('merge-base', 'main',
+                                                            'feature').and_return(command_result("abc123\n"))
         command.call('main', 'feature', independent: false)
       end
     end
@@ -56,13 +59,14 @@ RSpec.describe Git::Commands::MergeBase do
     context 'with :fork_point option' do
       it 'adds --fork-point flag' do
         expect(execution_context).to receive(:command).with('merge-base', '--fork-point', 'main',
-                                                            'feature').and_return("abc123\n")
+                                                            'feature').and_return(command_result("abc123\n"))
         result = command.call('main', 'feature', fork_point: true)
         expect(result).to eq(['abc123'])
       end
 
       it 'does not add flag when false' do
-        expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature').and_return("abc123\n")
+        expect(execution_context).to receive(:command).with('merge-base', 'main',
+                                                            'feature').and_return(command_result("abc123\n"))
         command.call('main', 'feature', fork_point: false)
       end
     end
@@ -70,13 +74,14 @@ RSpec.describe Git::Commands::MergeBase do
     context 'with :all option' do
       it 'adds --all flag' do
         expect(execution_context).to receive(:command).with('merge-base', '--all', 'main',
-                                                            'feature').and_return("sha1\nsha2\n")
+                                                            'feature').and_return(command_result("sha1\nsha2\n"))
         result = command.call('main', 'feature', all: true)
         expect(result).to eq(%w[sha1 sha2])
       end
 
       it 'does not add flag when false' do
-        expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature').and_return("abc123\n")
+        expect(execution_context).to receive(:command).with('merge-base', 'main',
+                                                            'feature').and_return(command_result("abc123\n"))
         command.call('main', 'feature', all: false)
       end
     end
@@ -85,7 +90,7 @@ RSpec.describe Git::Commands::MergeBase do
       it 'includes all specified flags in correct order' do
         expect(execution_context).to receive(:command).with(
           'merge-base', '--octopus', '--all', 'main', 'b1', 'b2'
-        ).and_return("sha1\nsha2\n")
+        ).and_return(command_result("sha1\nsha2\n"))
         result = command.call('main', 'b1', 'b2', octopus: true, all: true)
         expect(result).to eq(%w[sha1 sha2])
       end
@@ -99,21 +104,22 @@ RSpec.describe Git::Commands::MergeBase do
 
     context 'return value parsing' do
       it 'returns empty array when no output' do
-        expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature').and_return('')
+        expect(execution_context).to receive(:command).with('merge-base', 'main',
+                                                            'feature').and_return(command_result(''))
         result = command.call('main', 'feature')
         expect(result).to eq([])
       end
 
       it 'strips whitespace from each SHA' do
-        expect(execution_context).to receive(:command).with('merge-base', '--all', 'main',
-                                                            'feature').and_return("  sha1  \n  sha2  \n")
+        expect(execution_context).to receive(:command).with('merge-base', '--all', 'main', 'feature')
+                                                      .and_return(command_result("  sha1  \n  sha2  \n"))
         result = command.call('main', 'feature', all: true)
         expect(result).to eq(%w[sha1 sha2])
       end
 
       it 'filters out empty lines' do
         expect(execution_context).to receive(:command).with('merge-base', 'main',
-                                                            'feature').and_return("sha1\n\nsha2\n\n")
+                                                            'feature').and_return(command_result("sha1\n\nsha2\n\n"))
         result = command.call('main', 'feature')
         expect(result).to eq(%w[sha1 sha2])
       end

--- a/spec/unit/git/commands/stash/clear_spec.rb
+++ b/spec/unit/git/commands/stash/clear_spec.rb
@@ -13,10 +13,11 @@ RSpec.describe Git::Commands::Stash::Clear do
       command.call
     end
 
-    it 'returns the command output' do
-      expect(execution_context).to receive(:command).with('stash', 'clear').and_return('')
+    it 'returns the CommandLineResult' do
+      mock_result = command_result('')
+      expect(execution_context).to receive(:command).with('stash', 'clear').and_return(mock_result)
       result = command.call
-      expect(result).to eq('')
+      expect(result).to eq(mock_result)
     end
   end
 end

--- a/spec/unit/git/commands/stash/push_spec.rb
+++ b/spec/unit/git/commands/stash/push_spec.rb
@@ -26,107 +26,115 @@ RSpec.describe Git::Commands::Stash::Push do
   describe '#call' do
     context 'with no arguments' do
       it 'calls git stash push' do
-        expect(execution_context).to receive(:command).with('stash', 'push').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push').and_return(command_result(''))
         command.call
       end
 
       it 'returns the new StashInfo' do
-        allow(execution_context).to receive(:command).with('stash', 'push').and_return('')
+        allow(execution_context).to receive(:command).with('stash', 'push').and_return(command_result(''))
         expect(command.call).to eq(stash_info)
       end
     end
 
     context 'when nothing to stash' do
       it 'returns nil' do
-        allow(execution_context).to receive(:command).with('stash', 'push').and_return('No local changes to save')
+        allow(execution_context).to receive(:command).with('stash', 'push')
+                                                     .and_return(command_result('No local changes to save'))
         expect(command.call).to be_nil
       end
     end
 
     context 'with :message option' do
       it 'adds -m flag with message' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--message=WIP changes').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push',
+                                                            '--message=WIP changes').and_return(command_result(''))
         command.call(message: 'WIP changes')
       end
 
       it 'accepts :m alias' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--message=WIP').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push',
+                                                            '--message=WIP').and_return(command_result(''))
         command.call(m: 'WIP')
       end
 
       it 'handles message with special characters' do
         expect(execution_context).to receive(:command)
-          .with('stash', 'push', '--message=Fix "bug" in code').and_return('')
+          .with('stash', 'push', '--message=Fix "bug" in code').and_return(command_result(''))
         command.call(message: 'Fix "bug" in code')
       end
     end
 
     context 'with :patch option' do
       it 'adds -p flag for interactive selection' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--patch').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push', '--patch').and_return(command_result(''))
         command.call(patch: true)
       end
 
       it 'accepts :p alias' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--patch').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push', '--patch').and_return(command_result(''))
         command.call(p: true)
       end
 
       it 'does not add flag when false' do
-        expect(execution_context).to receive(:command).with('stash', 'push').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push').and_return(command_result(''))
         command.call(patch: false)
       end
     end
 
     context 'with :staged option' do
       it 'adds -S flag to stash only staged changes' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--staged').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push', '--staged').and_return(command_result(''))
         command.call(staged: true)
       end
 
       it 'accepts :S alias' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--staged').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push', '--staged').and_return(command_result(''))
         command.call(S: true)
       end
     end
 
     context 'with :keep_index option' do
       it 'adds --keep-index flag when true' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--keep-index').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push',
+                                                            '--keep-index').and_return(command_result(''))
         command.call(keep_index: true)
       end
 
       it 'adds --no-keep-index flag when false' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--no-keep-index').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push',
+                                                            '--no-keep-index').and_return(command_result(''))
         command.call(keep_index: false)
       end
 
       it 'accepts :k alias' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--keep-index').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push',
+                                                            '--keep-index').and_return(command_result(''))
         command.call(k: true)
       end
     end
 
     context 'with :include_untracked option' do
       it 'adds -u flag to include untracked files' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--include-untracked').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push',
+                                                            '--include-untracked').and_return(command_result(''))
         command.call(include_untracked: true)
       end
 
       it 'accepts :u alias' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--include-untracked').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push',
+                                                            '--include-untracked').and_return(command_result(''))
         command.call(u: true)
       end
     end
 
     context 'with :all option' do
       it 'adds -a flag to include ignored and untracked files' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--all').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push', '--all').and_return(command_result(''))
         command.call(all: true)
       end
 
       it 'accepts :a alias' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--all').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push', '--all').and_return(command_result(''))
         command.call(a: true)
       end
     end
@@ -134,13 +142,13 @@ RSpec.describe Git::Commands::Stash::Push do
     context 'with :pathspec_from_file option' do
       it 'adds --pathspec-from-file flag' do
         expect(execution_context).to receive(:command)
-          .with('stash', 'push', '--pathspec-from-file=paths.txt').and_return('')
+          .with('stash', 'push', '--pathspec-from-file=paths.txt').and_return(command_result(''))
         command.call(pathspec_from_file: 'paths.txt')
       end
 
       it 'supports reading from stdin with -' do
         expect(execution_context).to receive(:command)
-          .with('stash', 'push', '--pathspec-from-file=-').and_return('')
+          .with('stash', 'push', '--pathspec-from-file=-').and_return(command_result(''))
         command.call(pathspec_from_file: '-')
       end
     end
@@ -149,27 +157,28 @@ RSpec.describe Git::Commands::Stash::Push do
       it 'adds --pathspec-file-nul flag' do
         expect(execution_context).to receive(:command).with(
           'stash', 'push', '--pathspec-from-file=paths.txt', '--pathspec-file-nul'
-        ).and_return('')
+        ).and_return(command_result(''))
         command.call(pathspec_from_file: 'paths.txt', pathspec_file_nul: true)
       end
     end
 
     context 'with paths (pathspecs)' do
       it 'adds paths after -- separator' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--', 'file.txt').and_return('')
+        expect(execution_context).to receive(:command).with('stash', 'push', '--',
+                                                            'file.txt').and_return(command_result(''))
         command.call('file.txt')
       end
 
       it 'accepts multiple paths' do
         expect(execution_context).to receive(:command)
-          .with('stash', 'push', '--', 'file1.txt', 'file2.txt').and_return('')
+          .with('stash', 'push', '--', 'file1.txt', 'file2.txt').and_return(command_result(''))
         command.call('file1.txt', 'file2.txt')
       end
 
       it 'combines paths with options' do
         expect(execution_context).to receive(:command).with(
           'stash', 'push', '--message=Partial stash', '--', 'src/'
-        ).and_return('')
+        ).and_return(command_result(''))
         command.call('src/', message: 'Partial stash')
       end
     end
@@ -178,14 +187,14 @@ RSpec.describe Git::Commands::Stash::Push do
       it 'combines keep_index with message' do
         expect(execution_context).to receive(:command).with(
           'stash', 'push', '--keep-index', '--message=Testing'
-        ).and_return('')
+        ).and_return(command_result(''))
         command.call(keep_index: true, message: 'Testing')
       end
 
       it 'combines staged with paths' do
         expect(execution_context).to receive(:command).with(
           'stash', 'push', '--staged', '--', 'src/', 'lib/'
-        ).and_return('')
+        ).and_return(command_result(''))
         command.call('src/', 'lib/', staged: true)
       end
     end

--- a/spec/unit/git/commands/tag/list_spec.rb
+++ b/spec/unit/git/commands/tag/list_spec.rb
@@ -7,108 +7,98 @@ RSpec.describe Git::Commands::Tag::List do
   let(:execution_context) { double('ExecutionContext') }
   let(:command) { described_class.new(execution_context) }
 
+  # Helper to expect command call - verifies the command is called with specific arguments
+  def expect_command(*args, stdout: '')
+    expect(execution_context).to receive(:command).with(*args, any_args).and_return(command_result(stdout))
+  end
+
+  # Helper to stub command call for parsing tests where other expectations do the verification
+  def allow_command(*args, stdout: '')
+    allow(execution_context).to receive(:command).with(*args, any_args).and_return(command_result(stdout))
+  end
+
   describe '#call' do
     let(:format_arg) { "--format=#{described_class::FORMAT_STRING}" }
 
     context 'with no options (basic list)' do
       it 'calls git tag --list with format string' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return([])
+        expect_command('tag', '--list', format_arg)
         command.call
       end
     end
 
     context 'with patterns' do
       it 'adds a single pattern argument' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg, 'v1.*').and_return([])
+        expect_command('tag', '--list', format_arg, 'v1.*')
         command.call('v1.*')
       end
 
       it 'adds multiple pattern arguments' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg, 'v1.*',
-                                                                  'v2.*').and_return([])
+        expect_command('tag', '--list', format_arg, 'v1.*', 'v2.*')
         command.call('v1.*', 'v2.*')
       end
     end
 
     context 'with :sort option' do
       it 'adds --sort=<key> with single value' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg,
-                                                                  '--sort=refname').and_return([])
+        expect_command('tag', '--list', format_arg, '--sort=refname')
         command.call(sort: 'refname')
       end
 
       it 'adds multiple --sort=<key> with array of values' do
-        expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', format_arg, '--sort=refname', '--sort=-creatordate'
-        ).and_return([])
+        expect_command('tag', '--list', format_arg, '--sort=refname', '--sort=-creatordate')
         command.call(sort: ['refname', '-creatordate'])
       end
 
       it 'supports version:refname sort key' do
-        expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', format_arg, '--sort=version:refname'
-        ).and_return([])
+        expect_command('tag', '--list', format_arg, '--sort=version:refname')
         command.call(sort: 'version:refname')
       end
     end
 
     context 'with :contains option' do
       it 'adds --contains <commit>' do
-        expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', format_arg, '--contains', 'abc123'
-        ).and_return([])
+        expect_command('tag', '--list', format_arg, '--contains', 'abc123')
         command.call(contains: 'abc123')
       end
     end
 
     context 'with :no_contains option' do
       it 'adds --no-contains <commit>' do
-        expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', format_arg, '--no-contains', 'abc123'
-        ).and_return([])
+        expect_command('tag', '--list', format_arg, '--no-contains', 'abc123')
         command.call(no_contains: 'abc123')
       end
     end
 
     context 'with :merged option' do
       it 'adds --merged <commit>' do
-        expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', format_arg, '--merged', 'main'
-        ).and_return([])
+        expect_command('tag', '--list', format_arg, '--merged', 'main')
         command.call(merged: 'main')
       end
     end
 
     context 'with :no_merged option' do
       it 'adds --no-merged <commit>' do
-        expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', format_arg, '--no-merged', 'main'
-        ).and_return([])
+        expect_command('tag', '--list', format_arg, '--no-merged', 'main')
         command.call(no_merged: 'main')
       end
     end
 
     context 'with :points_at option' do
       it 'adds --points-at <object>' do
-        expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', format_arg, '--points-at', 'HEAD'
-        ).and_return([])
+        expect_command('tag', '--list', format_arg, '--points-at', 'HEAD')
         command.call(points_at: 'HEAD')
       end
     end
 
     context 'with multiple options combined' do
       it 'combines flags correctly' do
-        expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', format_arg, '--sort=refname', '--contains', 'abc123', 'v1.*'
-        ).and_return([])
+        expect_command('tag', '--list', format_arg, '--sort=refname', '--contains', 'abc123', 'v1.*')
         command.call('v1.*', sort: 'refname', contains: 'abc123')
       end
 
       it 'combines multiple patterns with options' do
-        expect(execution_context).to receive(:command_lines).with(
-          'tag', '--list', format_arg, '--merged', 'main', 'release-*', 'v*'
-        ).and_return([])
+        expect_command('tag', '--list', format_arg, '--merged', 'main', 'release-*', 'v*')
         command.call('release-*', 'v*', merged: 'main')
       end
     end
@@ -121,11 +111,11 @@ RSpec.describe Git::Commands::Tag::List do
           "v1.1.0\x1fdef456abc123\x1f\x1fcommit\x1f\x1f\x1f\x1f",
           "v2.0.0-beta\x1f789abc456def\x1f222222222222\x1ftag\x1fJane Smith\x1f<jane@example.com>\x1f" \
           "2024-02-20T14:00:00-05:00\x1fBeta release"
-        ]
+        ].join("\n")
       end
 
       it 'returns parsed tag data as array of TagInfo objects' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
+        allow_command('tag', '--list', format_arg, stdout: tag_output)
         result = command.call
         expect(result).to be_an(Array)
         expect(result.size).to eq(3)
@@ -133,39 +123,39 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'extracts tag names correctly' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
+        allow_command('tag', '--list', format_arg, stdout: tag_output)
         result = command.call
         expect(result.map(&:name)).to eq(%w[v1.0.0 v1.1.0 v2.0.0-beta])
       end
 
       it 'extracts oid correctly for annotated tags' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
+        allow_command('tag', '--list', format_arg, stdout: tag_output)
         result = command.call
         expect(result[0].oid).to eq('abc123def456')
         expect(result[2].oid).to eq('789abc456def')
       end
 
       it 'sets oid to nil for lightweight tags' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
+        allow_command('tag', '--list', format_arg, stdout: tag_output)
         result = command.call
         expect(result[1].oid).to be_nil
       end
 
       it 'extracts target_oid correctly for annotated tags (dereferenced commit)' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
+        allow_command('tag', '--list', format_arg, stdout: tag_output)
         result = command.call
         expect(result[0].target_oid).to eq('111111111111')
         expect(result[2].target_oid).to eq('222222222222')
       end
 
       it 'extracts target_oid correctly for lightweight tags (objectname)' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
+        allow_command('tag', '--list', format_arg, stdout: tag_output)
         result = command.call
         expect(result[1].target_oid).to eq('def456abc123')
       end
 
       it 'extracts object type correctly' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
+        allow_command('tag', '--list', format_arg, stdout: tag_output)
         result = command.call
         expect(result[0].objecttype).to eq('tag')
         expect(result[1].objecttype).to eq('commit')
@@ -173,7 +163,7 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'identifies annotated tags' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
+        allow_command('tag', '--list', format_arg, stdout: tag_output)
         result = command.call
         expect(result[0].annotated?).to be true
         expect(result[1].annotated?).to be false
@@ -181,7 +171,7 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'identifies lightweight tags' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(tag_output)
+        allow_command('tag', '--list', format_arg, stdout: tag_output)
         result = command.call
         expect(result[0].lightweight?).to be false
         expect(result[1].lightweight?).to be true
@@ -191,15 +181,12 @@ RSpec.describe Git::Commands::Tag::List do
 
     context 'with annotated tags' do
       let(:annotated_tag_output) do
-        [
-          "v1.0.0\x1fabc123def456\x1f111222333444\x1ftag\x1fJohn Doe\x1f<john@example.com>\x1f" \
+        "v1.0.0\x1fabc123def456\x1f111222333444\x1ftag\x1fJohn Doe\x1f<john@example.com>\x1f" \
           "2024-01-15T10:30:00-08:00\x1fRelease version 1.0.0"
-        ]
       end
 
       it 'returns TagInfo with all metadata fields populated' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list',
-                                                                  format_arg).and_return(annotated_tag_output)
+        allow_command('tag', '--list', format_arg, stdout: annotated_tag_output)
         result = command.call
         tag = result.first
         expect(tag.name).to eq('v1.0.0')
@@ -214,11 +201,10 @@ RSpec.describe Git::Commands::Tag::List do
     end
 
     context 'with lightweight tags' do
-      let(:lightweight_tag_output) { ["v2.0.0\x1fdef456abc123\x1f\x1fcommit\x1f\x1f\x1f\x1f\x1f"] }
+      let(:lightweight_tag_output) { "v2.0.0\x1fdef456abc123\x1f\x1fcommit\x1f\x1f\x1f\x1f\x1f" }
 
       it 'returns TagInfo with tagger fields as nil' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list',
-                                                                  format_arg).and_return(lightweight_tag_output)
+        allow_command('tag', '--list', format_arg, stdout: lightweight_tag_output)
         result = command.call
         tag = result.first
         expect(tag.name).to eq('v2.0.0')
@@ -234,7 +220,7 @@ RSpec.describe Git::Commands::Tag::List do
 
     context 'with empty result' do
       it 'returns an empty array' do
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return([])
+        allow_command('tag', '--list', format_arg)
         result = command.call
         expect(result).to eq([])
       end
@@ -242,38 +228,31 @@ RSpec.describe Git::Commands::Tag::List do
 
     context 'with special characters in tag names and messages' do
       it 'handles unicode in tag names' do
-        unicode_output = [
-          "tag-with-emoji-🚀\x1fabc123\x1f111222333\x1ftag\x1fDev\x1f<dev@example.com>\x1f" \
-          "2024-01-01T00:00:00Z\x1fTest"
-        ]
-        expect(execution_context).to receive(:command_lines).with('tag', '--list',
-                                                                  format_arg).and_return(unicode_output)
+        unicode_output = "tag-with-emoji-🚀\x1fabc123\x1f111222333\x1ftag\x1fDev\x1f<dev@example.com>\x1f" \
+                         "2024-01-01T00:00:00Z\x1fTest"
+        allow_command('tag', '--list', format_arg, stdout: unicode_output)
         result = command.call
         expect(result.first.name).to eq('tag-with-emoji-🚀')
       end
 
       it 'handles slashes in tag names' do
-        slash_output = ["release/v1.0\x1fabc123\x1f\x1fcommit\x1f\x1f\x1f\x1f\x1f"]
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(slash_output)
+        slash_output = "release/v1.0\x1fabc123\x1f\x1fcommit\x1f\x1f\x1f\x1f\x1f"
+        allow_command('tag', '--list', format_arg, stdout: slash_output)
         result = command.call
         expect(result.first.name).to eq('release/v1.0')
       end
 
       it 'handles unicode in messages' do
-        unicode_message_output = [
-          "v1.0\x1fabc123\x1f111222333\x1ftag\x1fDev\x1f<dev@example.com>\x1f" \
-          "2024-01-01T00:00:00Z\x1fRelease 🎉"
-        ]
-        expect(execution_context).to receive(:command_lines).with('tag', '--list',
-                                                                  format_arg).and_return(unicode_message_output)
+        unicode_message_output = "v1.0\x1fabc123\x1f111222333\x1ftag\x1fDev\x1f<dev@example.com>\x1f" \
+                                 "2024-01-01T00:00:00Z\x1fRelease 🎉"
+        allow_command('tag', '--list', format_arg, stdout: unicode_message_output)
         result = command.call
         expect(result.first.message).to eq('Release 🎉')
       end
 
       it 'handles empty message for annotated tags' do
-        no_message_output = ["v1.0\x1fabc123\x1f111222333\x1ftag\x1fDev\x1f<dev@example.com>\x1f2024-01-01T00:00:00Z\x1f"]
-        expect(execution_context).to receive(:command_lines).with('tag', '--list',
-                                                                  format_arg).and_return(no_message_output)
+        no_message_output = "v1.0\x1fabc123\x1f111222333\x1ftag\x1fDev\x1f<dev@example.com>\x1f2024-01-01T00:00:00Z\x1f"
+        allow_command('tag', '--list', format_arg, stdout: no_message_output)
         result = command.call
         expect(result.first.message).to be_nil
       end
@@ -281,8 +260,8 @@ RSpec.describe Git::Commands::Tag::List do
 
     context 'with malformed output' do
       it 'raises UnexpectedResultError with helpful message for wrong field count' do
-        bad_output = ["v1.0\x1fabc123\x1ftag"] # Only 3 fields instead of 8
-        expect(execution_context).to receive(:command_lines).with('tag', '--list', format_arg).and_return(bad_output)
+        bad_output = "v1.0\x1fabc123\x1ftag" # Only 3 fields instead of 8
+        allow_command('tag', '--list', format_arg, stdout: bad_output)
 
         expect { command.call }.to raise_error(Git::UnexpectedResultError) do |error|
           expect(error.message).to include('Unexpected line')

--- a/spec/unit/git/lib_command_spec.rb
+++ b/spec/unit/git/lib_command_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::Lib do
+  let(:base) { instance_double(Git::Base) }
+  let(:logger) { Logger.new(nil) }
+  let(:command_line) { instance_double(Git::CommandLine) }
+
+  subject(:lib) { described_class.new(base, logger) }
+
+  before do
+    allow(lib).to receive(:command_line).and_return(command_line)
+  end
+
+  describe '#command' do
+    let(:successful_result) do
+      instance_double(
+        Git::CommandLineResult,
+        stdout: 'git version 2.40.0',
+        stderr: '',
+        status: instance_double(Process::Status, success?: true)
+      )
+    end
+
+    let(:failed_result) do
+      instance_double(
+        Git::CommandLineResult,
+        git_cmd: %w[git rev-parse nonexistent],
+        stdout: '',
+        stderr: 'fatal: not a git repository',
+        status: instance_double(Process::Status, success?: false)
+      )
+    end
+
+    context 'when command succeeds' do
+      it 'returns a CommandLineResult' do
+        allow(command_line).to receive(:run).and_return(successful_result)
+
+        result = lib.command('version')
+
+        expect(result).to be(successful_result)
+      end
+    end
+
+    context 'when command fails with non-zero exit (default behavior)' do
+      it 'raises Git::FailedError' do
+        allow(command_line).to receive(:run).and_raise(Git::FailedError.new(failed_result))
+
+        expect do
+          lib.command('rev-parse', 'nonexistent')
+        end.to raise_error(Git::FailedError)
+      end
+    end
+
+    context 'when command fails with raise_on_failure: false' do
+      it 'returns CommandLineResult without raising' do
+        allow(command_line).to receive(:run).and_return(failed_result)
+
+        result = lib.command('rev-parse', 'nonexistent', raise_on_failure: false)
+
+        expect(result).to be(failed_result)
+        expect(result.status.success?).to be false
+      end
+    end
+
+    context 'with env: option' do
+      it 'merges env into the command_line call' do
+        allow(command_line).to receive(:run).and_return(successful_result)
+
+        lib.command('rev-parse', '--git-dir', env: { 'GIT_DIR' => '/custom/path' })
+
+        expect(command_line).to have_received(:run).with(
+          'rev-parse', '--git-dir',
+          hash_including(env: { 'GIT_DIR' => '/custom/path' })
+        )
+      end
+    end
+  end
+end

--- a/tests/units/test_command_line.rb
+++ b/tests/units/test_command_line.rb
@@ -86,7 +86,7 @@ class TestCommamndLine < Test::Unit::TestCase
         command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge,
                                 timeout: 0.01)
       rescue Git::Error => e
-        assert_equal(true, e.result.status.timeout?)
+        assert_equal(true, e.result.status.timed_out?)
       end
     end
   end

--- a/tests/units/test_command_line_env_overrides.rb
+++ b/tests/units/test_command_line_env_overrides.rb
@@ -92,24 +92,13 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
     end
   end
 
-  test 'worktree_command_line should exclude GIT_INDEX_FILE from environment' do
-    in_temp_dir do |_path|
-      git = Git.init('test_project')
+  test 'WORKTREE_ENV constant should exclude GIT_INDEX_FILE from environment' do
+    # WORKTREE_ENV is used by worktree commands to prevent index corruption
+    # by setting GIT_INDEX_FILE to nil (which unsets it per Process.spawn semantics)
+    worktree_env = Git::Lib::WORKTREE_ENV
 
-      # Get the worktree command line instance
-      worktree_cmd_line = git.lib.send(:worktree_command_line)
-
-      # Extract the env_overrides from the command line instance
-      env = worktree_cmd_line.instance_variable_get(:@env)
-
-      # GIT_INDEX_FILE should be set to nil (will be unset per Process.spawn semantics)
-      assert_nil env['GIT_INDEX_FILE']
-
-      # Other environment variables should still be present
-      assert_equal git.lib.git_dir, env['GIT_DIR']
-      assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
-      assert_equal 'en_US.UTF-8', env['LC_ALL']
-    end
+    assert_nil worktree_env['GIT_INDEX_FILE']
+    assert worktree_env.frozen?, 'WORKTREE_ENV should be frozen'
   end
 
   test 'env_overrides should allow both adding and excluding variables simultaneously' do

--- a/tests/units/test_command_raises_on_failure.rb
+++ b/tests/units/test_command_raises_on_failure.rb
@@ -1,0 +1,82 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Tests that Git::Lib#command raises Git::FailedError on non-zero exit status by default
+#
+# This behavior is critical for backward compatibility - the original command
+# method raised on failure, and raise_on_failure: true (the default) preserves this.
+#
+class TestCommandRaisesOnFailure < Test::Unit::TestCase
+  test 'command raises Git::FailedError on non-zero exit status by default' do
+    in_temp_dir do |_path|
+      git = Git.init('test_project')
+
+      Dir.chdir('test_project') do
+        # Try to show a non-existent ref - this should fail with exit code 128
+        assert_raise(Git::FailedError) do
+          git.lib.command('show', 'nonexistent-ref-that-does-not-exist')
+        end
+      end
+    end
+  end
+
+  test 'command includes exit status in the error' do
+    in_temp_dir do |_path|
+      git = Git.init('test_project')
+
+      Dir.chdir('test_project') do
+        git.lib.command('show', 'nonexistent-ref-that-does-not-exist')
+        flunk 'Expected Git::FailedError to be raised'
+      rescue Git::FailedError => e
+        assert_not_nil e.result
+        assert_not_nil e.result.status
+        assert_equal false, e.result.status.success?
+      end
+    end
+  end
+
+  test 'command with raise_on_failure: false does not raise on non-zero exit status' do
+    in_temp_dir do |_path|
+      git = Git.init('test_project')
+
+      Dir.chdir('test_project') do
+        # This should NOT raise - raise_on_failure: false suppresses the error
+        result = git.lib.command('show', 'nonexistent-ref-that-does-not-exist', raise_on_failure: false)
+
+        assert_instance_of Git::CommandLineResult, result
+        assert_equal false, result.status.success?
+      end
+    end
+  end
+
+  test 'config_get raises Git::FailedError for non-existent config key' do
+    in_temp_dir do |_path|
+      git = Git.init('test_project')
+
+      Dir.chdir('test_project') do
+        # git config --get returns exit code 1 when key doesn't exist
+        assert_raise(Git::FailedError) do
+          git.lib.config_get('nonexistent.config.key.that.does.not.exist')
+        end
+      end
+    end
+  end
+
+  test 'tag_sha returns empty string for non-existent tag' do
+    in_temp_dir do |_path|
+      git = Git.init('test_project')
+
+      Dir.chdir('test_project') do
+        # Create a commit so the repo isn't empty
+        File.write('test.txt', 'content')
+        git.add('test.txt')
+        git.commit('Initial commit')
+
+        # tag_sha for non-existent tag should return '' (special handling for exit code 1)
+        result = git.lib.tag_sha('nonexistent-tag')
+        assert_equal '', result
+      end
+    end
+  end
+end

--- a/tests/units/test_diff_path_status.rb
+++ b/tests/units/test_diff_path_status.rb
@@ -64,7 +64,9 @@ class TestDiffPathStatus < Test::Unit::TestCase
   end
 
   def test_path_status_with_empty_path_array
-    @git.lib.expects(:command_lines).with('diff', '--name-status', 'gitsearch1', 'v2.5').returns([])
+    status = Struct.new(:success?).new(true)
+    result = Git::CommandLineResult.new(%w[git diff], status, '', '')
+    @git.lib.expects(:command).with('diff', '--name-status', 'gitsearch1', 'v2.5').returns(result)
 
     status_hash = Git::DiffPathStatus.new(@git, 'gitsearch1', 'v2.5', []).to_h
     assert_equal({}, status_hash)

--- a/tests/units/test_diff_stats.rb
+++ b/tests/units/test_diff_stats.rb
@@ -44,7 +44,9 @@ class TestDiffStats < Test::Unit::TestCase
   end
 
   def test_diff_stats_with_empty_path_array
-    @git.lib.expects(:command_lines).with('diff', '--numstat', 'gitsearch1', 'v2.5').returns([])
+    status = Struct.new(:success?).new(true)
+    result = Git::CommandLineResult.new(%w[git diff], status, '', '')
+    @git.lib.expects(:command).with('diff', '--numstat', 'gitsearch1', 'v2.5').returns(result)
 
     stats = @git.diff_stats('gitsearch1', 'v2.5', path_limiter: [])
     assert_equal(0, stats.total[:files])

--- a/tests/units/test_git_clone.rb
+++ b/tests/units/test_git_clone.rb
@@ -18,7 +18,7 @@ class TestGitClone < Test::Unit::TestCase
           Git.clone('repository.git', 'temp2', timeout: nil)
         end
 
-        assert_equal(true, error.result.status.timeout?)
+        assert_equal(true, error.result.status.timed_out?)
       end
     ensure
       Git.config.timeout = saved_timeout
@@ -52,7 +52,7 @@ class TestGitClone < Test::Unit::TestCase
           Git.clone('repository.git', 'temp2', timeout: timeout_value)
         end
 
-        assert_equal(true, error.result.status.timeout?)
+        assert_equal(true, error.result.status.timed_out?)
       end
     end
   end
@@ -95,7 +95,7 @@ class TestGitClone < Test::Unit::TestCase
     in_temp_dir do |_path|
       git = Git.init('.')
 
-      # Mock the Git::Lib#command method to capture the actual command line args
+      # Mock the Git::Lib#command! method to capture the actual command line args
       git.lib.define_singleton_method(:command) do |cmd, *opts|
         actual_command_line = [cmd, *opts.flatten]
       end
@@ -118,7 +118,7 @@ class TestGitClone < Test::Unit::TestCase
     in_temp_dir do |_path|
       git = Git.init('.')
 
-      # Mock the Git::Lib#command method to capture the actual command line args
+      # Mock the Git::Lib#command! method to capture the actual command line args
       git.lib.define_singleton_method(:command) do |cmd, *opts|
         actual_command_line = [cmd, *opts.flatten]
       end
@@ -145,7 +145,7 @@ class TestGitClone < Test::Unit::TestCase
     in_temp_dir do |_path|
       git = Git.init('.')
 
-      # Mock the Git::Lib#command method to capture the actual command line args
+      # Mock the Git::Lib#command! method to capture the actual command line args
       git.lib.define_singleton_method(:command) do |cmd, *opts|
         actual_command_line = [cmd, *opts.flatten]
       end

--- a/tests/units/test_lib_meets_required_version.rb
+++ b/tests/units/test_lib_meets_required_version.rb
@@ -36,7 +36,10 @@ class TestLibMeetsRequiredVersion < Test::Unit::TestCase
     lib.define_singleton_method(:command) do |cmd, *_opts|
       raise ArgumentError unless cmd == 'version'
 
-      versions_to_test[@next_version_index][:version_string].tap { @next_version_index += 1 }
+      version_string = versions_to_test[@next_version_index][:version_string]
+      @next_version_index += 1
+      status = Struct.new(:success?).new(true)
+      Git::CommandLineResult.new(['git', cmd], status, version_string, '')
     end
 
     lib.define_singleton_method(:next_version_index) { @next_version_index }

--- a/tests/units/test_lib_repository_default_branch.rb
+++ b/tests/units/test_lib_repository_default_branch.rb
@@ -34,7 +34,8 @@ class TestLibRepositoryDefaultBranch < Test::Unit::TestCase
     lib.define_singleton_method(:command) do |cmd, *opts, &_block|
       test_case.assert_equal('ls-remote', cmd)
       test_case.assert_equal(['--symref', '--', repository, 'HEAD'], opts.flatten)
-      response
+      status = Struct.new(:success?).new(true)
+      Git::CommandLineResult.new(['git', cmd, *opts.flatten], status, response, '')
     end
   end
 

--- a/tests/units/test_log.rb
+++ b/tests/units/test_log.rb
@@ -151,7 +151,7 @@ class TestLog < Test::Unit::TestCase
   end
 
   def test_log_merges
-    expected_command_line = ['log', '--no-color', '--max-count=30', '--pretty=raw', '--merges', { chdir: nil }]
+    expected_command_line = ['log', '--no-color', '--max-count=30', '--pretty=raw', '--merges', {}]
     assert_command_line_eq(expected_command_line) do |git|
       git.log.merges.execute
     end

--- a/tests/units/test_log_execute.rb
+++ b/tests/units/test_log_execute.rb
@@ -132,7 +132,7 @@ class TestLogExecute < Test::Unit::TestCase
   end
 
   def test_log_merges
-    expected_command_line = ['log', '--no-color', '--max-count=30', '--pretty=raw', '--merges', { chdir: nil }]
+    expected_command_line = ['log', '--no-color', '--max-count=30', '--pretty=raw', '--merges', {}]
     assert_command_line_eq(expected_command_line) { |git| git.log.merges.execute }
   end
 

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -148,13 +148,13 @@ class TestRemotes < Test::Unit::TestCase
       local.remote_set_branches('origin', upstream.current_branch, add: true)
       local.remote_set_branches('origin', 'feature/*', add: true)
 
-      fetch_refspecs_before = local.lib.send(:command_lines, 'config', '--get-all', 'remote.origin.fetch')
+      fetch_refspecs_before = local.lib.command('config', '--get-all', 'remote.origin.fetch').stdout.split("\n")
       assert(fetch_refspecs_before.size > 1)
       assert_equal(1, fetch_refspecs_before.count('+refs/heads/feature/*:refs/remotes/origin/feature/*'))
 
       local.remote_set_branches('origin', 'feature/*')
 
-      fetch_refspecs_after = local.lib.send(:command_lines, 'config', '--get-all', 'remote.origin.fetch')
+      fetch_refspecs_after = local.lib.command('config', '--get-all', 'remote.origin.fetch').stdout.split("\n")
       assert_equal(['+refs/heads/feature/*:refs/remotes/origin/feature/*'], fetch_refspecs_after)
     end
   end

--- a/tests/units/test_set_index.rb
+++ b/tests/units/test_set_index.rb
@@ -123,9 +123,9 @@ class SetIndexTest < Test::Unit::TestCase
       file.write(new_content)
       file.rewind
       # Use `git hash-object -w` to write the blob to the object database and get its SHA
-      repo.lib.send(:command, 'hash-object', '-w', file.path)
+      repo.lib.command('hash-object', '-w', file.path).stdout
     end
-    repo.lib.send(:command, 'update-index', '--add', '--cacheinfo', "100644,#{blob_sha},new_file.txt")
+    repo.lib.command('update-index', '--add', '--cacheinfo', "100644,#{blob_sha},new_file.txt").stdout
 
     # 6. Write the state of the custom index to a new tree object in the Git database.
     new_tree_sha = repo.write_tree


### PR DESCRIPTION
## Summary

This PR consolidates the command execution interface in `Git::Lib` to provide a single, unified `command` method with explicit control over error handling and environment variables.

## Changes

### Removed Methods
- **`command_lines`**: Replaced by `command(...).stdout.split("\n")`
- **`worktree_command`** / **`worktree_command_line`**: Replaced by `command` with `env:` option

### New Options for `command` Method
- **`raise_on_failure:`** (default: `true`) - Controls whether `Git::FailedError` is raised on non-zero exit status
- **`env:`** - Per-command environment variable overrides (merged with base environment)

### Return Type Change
The `command` method now consistently returns `Git::CommandLineResult`. Callers access stdout via the `.stdout` accessor. This provides access to stderr and exit status when needed.

### Updated Components
- All `Git::Commands::*` classes updated to use unified interface
- List commands (`branch/list`, `tag/list`, `stash/list`) use `raise_on_failure: false` to gracefully handle empty results
- Worktree commands use `env: { 'GIT_INDEX_FILE' => nil }` instead of separate command method
- Documentation fix: `timeout?` → `timed_out?` in errors.rb

## Motivation

This aligns with the [v5/v6 architectural redesign](redesign/2_architecture_redesign.md) goal of having `ExecutionContext` provide a single, configurable `command` method as the execution layer foundation:

> **Responsibility**: Its purpose is to provide a configured `command` method for executing git commands. This method wraps `Git::CommandLine` with essential functionality including default options (normalize, chomp, timeout), option validation, and a simplified interface.

## Testing

- ✅ All 1062 RSpec examples pass
- ✅ All 534 Minitest tests pass  
- ✅ Rubocop clean

## Backward Compatibility

All public `Git::Lib` methods continue to return strings (via `.stdout`) to maintain backward compatibility. The internal API change only affects code that was accessing private methods directly.