### PR TITLE
docs: clarify integration test guidance in implementation plan

### DIFF
--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -45,7 +45,9 @@ risk and allows for a gradual, controlled migration to the new architecture.
    - Verify argument building matches expected git CLI args
    - Unit tests go in `spec/unit/git/commands/`
    - Optionally add integration tests in `spec/integration/` to verify behavior
-     against real git (see CONTRIBUTING.md for integration test guidelines)
+     against real git (see CONTRIBUTING.md for integration test guidelines). Only
+     add essential integration tests for edge cases and testing that the assumptions
+     for git output used in unit tests are correct.
 
 4. **Implement**:
    - Use `Git::Commands::Arguments.define` DSL for argument handling


### PR DESCRIPTION
## Summary

Update the TDD workflow section in the implementation plan to clarify when integration tests should be added during command migrations.

## Changes

The guidance for step 3 (TDD) now explicitly states that integration tests should only be added for:
- Essential edge cases
- Verifying assumptions about git output used in unit tests

This helps contributors understand that comprehensive unit tests are the primary focus, while integration tests serve a more targeted purpose.

## Related

This is a documentation improvement to the v5.0.0 redesign implementation plan.