### PR TITLE
Fix RSpec deprecation warning and suppress git command output

### DIFF
--- a/spec/integration/git/commands/fsck/fsck_spec.rb
+++ b/spec/integration/git/commands/fsck/fsck_spec.rb
@@ -77,7 +77,8 @@ RSpec.describe Git::Commands::Fsck, :integration do
         # Create another root commit by creating an orphan branch
         repo.branch('orphan-branch').checkout
         # Create the orphan via low-level git command
-        `cd #{repo_dir} && git checkout --orphan another-root && git commit --allow-empty -m "Another root"`
+        `cd #{repo_dir} && git checkout --orphan another-root >/dev/null 2>&1 && \
+git commit --allow-empty -m "Another root" >/dev/null 2>&1`
       end
 
       it 'reports root commits' do

--- a/spec/unit/git/stashes_spec.rb
+++ b/spec/unit/git/stashes_spec.rb
@@ -72,14 +72,11 @@ RSpec.describe Git::Stashes do
   describe '#all_legacy' do
     subject(:stashes) { described_class.new(base) }
 
-    it 'returns an array of [index, message] pairs' do
-      result = stashes.all_legacy
+    it 'returns an array of [index, message] pairs and emits a deprecation warning' do
+      result = nil
+      expect { result = stashes.all_legacy }.to output(/DEPRECATION/).to_stderr
       expect(result).to be_an(Array)
       expect(result).to eq(stash_legacy_data)
-    end
-
-    it 'emits a deprecation warning' do
-      expect { stashes.all_legacy }.to output(/DEPRECATION/).to_stderr
     end
   end
 


### PR DESCRIPTION
## Description

This PR fixes two issues that were causing unwanted output during RSpec test runs:

1. **Deprecation warning**: The test for `Git::Stashes#all_legacy` was emitting a deprecation warning that appeared in the test output
2. **Git command output**: The fsck integration test was showing "Switched to a new branch" messages

## Changes

- Capture stderr in `all_legacy` test to prevent deprecation warning from appearing in test output
- Combine duplicate deprecation tests into a single test that verifies both behavior and warning
- Suppress git checkout and commit output in fsck specs by redirecting to `/dev/null`

## Result

Tests now run cleanly without deprecation warnings or branch switching messages cluttering the output.