### PR TITLE
Achieve 100% unit test coverage for all commands

### DIFF
--- a/spec/unit/git/commands/stash/apply_spec.rb
+++ b/spec/unit/git/commands/stash/apply_spec.rb
@@ -110,5 +110,20 @@ RSpec.describe Git::Commands::Stash::Apply do
         )
       end
     end
+
+    context 'when no stashes exist' do
+      before do
+        allow(list_command).to receive(:call).and_return([])
+      end
+
+      it 'raises UnexpectedResultError with helpful message' do
+        expect do
+          command.call
+        end.to raise_error(
+          Git::UnexpectedResultError,
+          'No stash entries found. Run `git stash` to create one.'
+        )
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/stash/drop_spec.rb
+++ b/spec/unit/git/commands/stash/drop_spec.rb
@@ -90,5 +90,20 @@ RSpec.describe Git::Commands::Stash::Drop do
         )
       end
     end
+
+    context 'when no stashes exist' do
+      before do
+        allow(list_command).to receive(:call).and_return([])
+      end
+
+      it 'raises UnexpectedResultError with helpful message' do
+        expect do
+          command.call
+        end.to raise_error(
+          Git::UnexpectedResultError,
+          'No stash entries found. Run `git stash` to create one.'
+        )
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/stash/pop_spec.rb
+++ b/spec/unit/git/commands/stash/pop_spec.rb
@@ -110,5 +110,20 @@ RSpec.describe Git::Commands::Stash::Pop do
         )
       end
     end
+
+    context 'when no stashes exist' do
+      before do
+        allow(list_command).to receive(:call).and_return([])
+      end
+
+      it 'raises UnexpectedResultError with helpful message' do
+        expect do
+          command.call
+        end.to raise_error(
+          Git::UnexpectedResultError,
+          'No stash entries found. Run `git stash` to create one.'
+        )
+      end
+    end
   end
 end


### PR DESCRIPTION
## Description

This PR achieves 100% unit test coverage for all `lib/git/commands/**/*.rb` files by adding missing test cases for edge scenarios.

## Changes

Added test coverage for the empty stash list scenario in three stash command specs:
- `spec/unit/git/commands/stash/apply_spec.rb`
- `spec/unit/git/commands/stash/drop_spec.rb`
- `spec/unit/git/commands/stash/pop_spec.rb`

Each of these commands has a `stash_not_found_message` method with two branches:
1. When a specific stash is not found (already covered)
2. When no stashes exist at all (newly covered)

The new tests ensure that when calling these commands with an empty stash list, the appropriate error message is raised: "No stash entries found. Run `git stash` to create one."

## Coverage Results

All 36 command files in `lib/git/commands/` and subdirectories now have **100% unit test coverage**:

### Top-level commands (100%)
- add.rb, arguments.rb, clean.rb, clone.rb, commit.rb, diff.rb, fsck.rb, init.rb, merge_base.rb, mv.rb, reset.rb, rm.rb

### Subdirectory commands (100%)
- branch/: copy.rb, create.rb, delete.rb, list.rb, move.rb, set_upstream.rb, unset_upstream.rb
- checkout/: branch.rb, files.rb
- diff/: numstat.rb, patch.rb, raw.rb
- merge/: resolve.rb, start.rb
- stash/: apply.rb, clear.rb, drop.rb, list.rb, pop.rb, push.rb ✓
- tag/: create.rb, delete.rb, list.rb

## Testing

```
rake spec:unit
```

- 1199 examples, 0 failures
- Added 3 new test cases
- All commands files verified at 100% coverage