### PR TITLE
Migrate remaining stash commands to Git::Commands

### DIFF
--- a/lib/git/commands/stash/apply.rb
+++ b/lib/git/commands/stash/apply.rb
@@ -18,7 +18,7 @@ module Git
       #   Git::Commands::Stash::Apply.new(execution_context).call
       #
       # @example Apply a specific stash
-      #   Git::Commands::Stash::Apply.new(execution_context).call('stash@{2}')
+      #   Git::Commands::Stash::Apply.new(execution_context).call('stash@\\{2}')
       #
       # @example Apply and restore index state
       #   Git::Commands::Stash::Apply.new(execution_context).call(index: true)
@@ -100,7 +100,7 @@ module Git
         # Normalize stash reference to canonical name format
         #
         # @param stash [String, Integer] stash reference
-        # @return [String] canonical name (e.g., 'stash@{0}')
+        # @return [String] canonical name (e.g., 'stash@\\{0}')
         #
         def normalize_stash_name(stash)
           name = stash.to_s

--- a/lib/git/commands/stash/branch.rb
+++ b/lib/git/commands/stash/branch.rb
@@ -1,0 +1,75 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+require 'git/commands/branch/list'
+
+module Git
+  module Commands
+    module Stash
+      # Create a branch from a stash entry
+      #
+      # Creates a new branch starting from the commit at which the stash was
+      # originally created, applies the stashed changes, and then drops the stash
+      # if the changes are applied successfully.
+      #
+      # This is useful if the branch on which you ran `git stash push` has changed
+      # enough that `git stash apply` fails due to conflicts. The new branch will
+      # be created at the commit that was HEAD when the stash was created, so
+      # applying the stash should succeed.
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      # @api private
+      #
+      # @example Create branch from latest stash
+      #   Git::Commands::Stash::Branch.new(execution_context).call('my-branch')
+      #
+      # @example Create branch from specific stash
+      #   Git::Commands::Stash::Branch.new(execution_context).call('my-branch', 'stash@{2}')
+      #
+      class Branch
+        # Arguments DSL for building command-line arguments
+        ARGS = Arguments.define do
+          static 'stash'
+          static 'branch'
+          positional :branchname, required: true
+          positional :stash
+        end.freeze
+
+        # Creates a new Branch command instance
+        #
+        # @param execution_context [Git::ExecutionContext] the execution context for running commands
+        #
+        def initialize(execution_context)
+          @execution_context = execution_context
+        end
+
+        # Create a branch from a stash entry
+        #
+        # @overload call(branchname)
+        #
+        #   Create a branch from the latest stash
+        #
+        #   @param branchname [String] the name of the branch to create (required)
+        #
+        # @overload call(branchname, stash)
+        #
+        #   Create a branch from a specific stash
+        #
+        #   @param branchname [String] the name of the branch to create (required)
+        #
+        #   @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
+        #
+        # @return [Git::BranchInfo] info for the newly created branch
+        #
+        # @raise [Git::FailedError] if the branch already exists or stash doesn't exist
+        #
+        def call(branchname, stash = nil)
+          @execution_context.command(*ARGS.build(branchname, stash))
+
+          # Return info for the newly created branch
+          Git::Commands::Branch::List.new(@execution_context).call(branchname).first
+        end
+      end
+    end
+  end
+end

--- a/lib/git/commands/stash/create.rb
+++ b/lib/git/commands/stash/create.rb
@@ -1,0 +1,68 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+
+module Git
+  module Commands
+    module Stash
+      # Create a stash commit without storing it in refs/stash
+      #
+      # This is a plumbing command used to create a stash commit object without
+      # actually storing it in the stash reflog. It's useful for scripts that
+      # need to create stash commits programmatically.
+      #
+      # The command creates a stash commit and outputs its SHA, but does not
+      # update refs/stash. Use {Store} to store the commit in the stash reflog.
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      # @api private
+      #
+      # @example Create a stash commit
+      #   sha = Git::Commands::Stash::Create.new(execution_context).call
+      #   # => "abc123def456..."
+      #
+      # @example Create a stash commit with a message
+      #   sha = Git::Commands::Stash::Create.new(execution_context).call('WIP: my changes')
+      #
+      class Create
+        # Arguments DSL for building command-line arguments
+        ARGS = Arguments.define do
+          static 'stash'
+          static 'create'
+          positional :message
+        end.freeze
+
+        # Creates a new Create command instance
+        #
+        # @param execution_context [Git::ExecutionContext] the execution context for running commands
+        #
+        def initialize(execution_context)
+          @execution_context = execution_context
+        end
+
+        # Create a stash commit
+        #
+        # @overload call()
+        #
+        #   Create a stash commit without a message
+        #
+        # @overload call(message)
+        #
+        #   Create a stash commit with a message
+        #
+        #   @param message [String] optional message for the stash commit
+        #
+        # @return [String, nil] the SHA of the created stash commit, or nil if
+        #   there were no local changes to stash
+        #
+        def call(message = nil)
+          result = @execution_context.command(*ARGS.build(message))
+
+          # Returns empty output if there were no local changes
+          sha = result.stdout.strip
+          sha.empty? ? nil : sha
+        end
+      end
+    end
+  end
+end

--- a/lib/git/commands/stash/drop.rb
+++ b/lib/git/commands/stash/drop.rb
@@ -18,7 +18,7 @@ module Git
       #   Git::Commands::Stash::Drop.new(execution_context).call
       #
       # @example Drop a specific stash
-      #   Git::Commands::Stash::Drop.new(execution_context).call('stash@{2}')
+      #   Git::Commands::Stash::Drop.new(execution_context).call('stash@\\{2}')
       #
       class Drop
         # Arguments DSL for building command-line arguments
@@ -38,11 +38,11 @@ module Git
 
         # Drop a stash entry
         #
-        # @overload call(**options)
+        # @overload call()
         #
         #   Drop the latest stash
         #
-        # @overload call(stash, **options)
+        # @overload call(stash)
         #
         #   Drop a specific stash
         #
@@ -88,7 +88,7 @@ module Git
         # Normalize stash reference to canonical name format
         #
         # @param stash [String, Integer] stash reference
-        # @return [String] canonical name (e.g., 'stash@{0}')
+        # @return [String] canonical name (e.g., 'stash@\\{0}')
         #
         def normalize_stash_name(stash)
           name = stash.to_s

--- a/lib/git/commands/stash/pop.rb
+++ b/lib/git/commands/stash/pop.rb
@@ -18,7 +18,7 @@ module Git
       #   Git::Commands::Stash::Pop.new(execution_context).call
       #
       # @example Pop a specific stash
-      #   Git::Commands::Stash::Pop.new(execution_context).call('stash@{2}')
+      #   Git::Commands::Stash::Pop.new(execution_context).call('stash@\\{2}')
       #
       # @example Pop and restore index state
       #   Git::Commands::Stash::Pop.new(execution_context).call(index: true)
@@ -54,7 +54,7 @@ module Git
         #
         #   Pop a specific stash
         #
-        #   @param stash [String, nil] stash reference (e.g., 'stash@\\{0}', '0');
+        #   @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
         #
         #   @param options [Hash] command options
         #
@@ -100,7 +100,7 @@ module Git
         # Normalize stash reference to canonical name format
         #
         # @param stash [String, Integer] stash reference
-        # @return [String] canonical name (e.g., 'stash@{0}')
+        # @return [String] canonical name (e.g., 'stash@\\{0}')
         #
         def normalize_stash_name(stash)
           name = stash.to_s

--- a/lib/git/commands/stash/push.rb
+++ b/lib/git/commands/stash/push.rb
@@ -32,14 +32,14 @@ module Git
         ARGS = Arguments.define do
           static 'stash'
           static 'push'
-          flag %i[patch p], args: '--patch'
-          flag %i[staged S], args: '--staged'
-          negatable_flag %i[keep_index k], args: '--keep-index'
-          flag %i[include_untracked u], args: '--include-untracked'
-          flag %i[all a], args: '--all'
-          inline_value %i[message m], args: '--message'
-          inline_value :pathspec_from_file, args: '--pathspec-from-file'
-          flag :pathspec_file_nul, args: '--pathspec-file-nul'
+          flag %i[patch p]
+          flag %i[staged S]
+          negatable_flag %i[keep_index k]
+          flag %i[include_untracked u]
+          flag %i[all a]
+          inline_value %i[message m]
+          inline_value :pathspec_from_file
+          flag :pathspec_file_nul
           positional :pathspecs, variadic: true, separator: '--'
         end.freeze
 

--- a/lib/git/commands/stash/show_numstat.rb
+++ b/lib/git/commands/stash/show_numstat.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+require 'git/diff_parser'
+
+module Git
+  module Commands
+    module Stash
+      # Show numstat (line counts) for changes recorded in a stash entry
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      # @api private
+      #
+      # @example Show stats for the latest stash
+      #   Git::Commands::Stash::ShowNumstat.new(execution_context).call
+      #   # => #<Git::DiffResult files_changed: 2, ...>
+      #
+      # @example Show stats for a specific stash
+      #   Git::Commands::Stash::ShowNumstat.new(execution_context).call('stash@\\{2}')
+      #
+      # @example Show with directory statistics
+      #   Git::Commands::Stash::ShowNumstat.new(execution_context).call(dirstat: true)
+      #   Git::Commands::Stash::ShowNumstat.new(execution_context).call(dirstat: 'lines,cumulative')
+      #
+      class ShowNumstat
+        # Arguments DSL for building command-line arguments
+        ARGS = Arguments.define do
+          static 'stash'
+          static 'show'
+          static '--numstat'
+          static '--shortstat'
+          static '-M'
+          negatable_flag %i[include_untracked u]
+          flag :only_untracked
+          flag_or_inline_value :dirstat
+          positional :stash
+        end.freeze
+
+        # Creates a new ShowNumstat command instance
+        #
+        # @param execution_context [Git::ExecutionContext] the execution context for running commands
+        #
+        def initialize(execution_context)
+          @execution_context = execution_context
+        end
+
+        # Show stash numstat
+        #
+        # @overload call(**options)
+        #
+        #   Show numstat for the latest stash
+        #
+        #   @param options [Hash] command options
+        #
+        #   @option options [Boolean] :include_untracked (nil) include untracked files in diff.
+        #     Alias: :u
+        #
+        #   @option options [Boolean] :only_untracked (nil) show only untracked files
+        #
+        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #
+        # @overload call(stash, **options)
+        #
+        #   Show numstat for a specific stash
+        #
+        #   @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
+        #
+        #   @param options [Hash] command options
+        #
+        #   @option options [Boolean] :include_untracked (nil) include untracked files in diff.
+        #     Alias: :u
+        #
+        #   @option options [Boolean] :only_untracked (nil) show only untracked files
+        #
+        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #
+        # @return [Git::DiffResult] diff result with per-file and total statistics
+        #
+        def call(stash = nil, dirstat: nil, **)
+          output = @execution_context.command(*ARGS.build(stash, dirstat: dirstat, **)).stdout
+          DiffParser::Numstat.parse(output, include_dirstat: !dirstat.nil?)
+        end
+      end
+    end
+  end
+end

--- a/lib/git/commands/stash/show_patch.rb
+++ b/lib/git/commands/stash/show_patch.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+require 'git/diff_parser'
+
+module Git
+  module Commands
+    module Stash
+      # Show full patch output for changes recorded in a stash entry
+      #
+      # Uses --patch combined with --numstat to include line change counts
+      # and --shortstat for totals.
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      # @api private
+      #
+      # @example Show patch for the latest stash
+      #   Git::Commands::Stash::ShowPatch.new(execution_context).call
+      #   # => #<Git::DiffResult files: [...]>
+      #
+      # @example Show patch for a specific stash
+      #   Git::Commands::Stash::ShowPatch.new(execution_context).call('stash@\\{2}')
+      #
+      # @example Show with directory statistics
+      #   Git::Commands::Stash::ShowPatch.new(execution_context).call(dirstat: true)
+      #   Git::Commands::Stash::ShowPatch.new(execution_context).call(dirstat: 'lines,cumulative')
+      #
+      class ShowPatch
+        # Arguments DSL for building command-line arguments
+        ARGS = Arguments.define do
+          static 'stash'
+          static 'show'
+          static '--patch'
+          static '--numstat'
+          static '--shortstat'
+          negatable_flag %i[include_untracked u]
+          flag :only_untracked
+          flag_or_inline_value :dirstat
+          positional :stash
+        end.freeze
+
+        # Creates a new ShowPatch command instance
+        #
+        # @param execution_context [Git::ExecutionContext] the execution context for running commands
+        #
+        def initialize(execution_context)
+          @execution_context = execution_context
+        end
+
+        # Show stash patch
+        #
+        # @overload call(**options)
+        #
+        #   Show patch for the latest stash
+        #
+        #   @param options [Hash] command options
+        #
+        #   @option options [Boolean] :include_untracked (nil) include untracked files.
+        #     Alias: :u
+        #
+        #   @option options [Boolean] :only_untracked (nil) show only untracked files
+        #
+        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #
+        # @overload call(stash, **options)
+        #
+        #   Show patch for a specific stash
+        #
+        #   @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
+        #
+        #   @param options [Hash] command options
+        #
+        #   @option options [Boolean] :include_untracked (nil) include untracked files.
+        #     Alias: :u
+        #
+        #   @option options [Boolean] :only_untracked (nil) show only untracked files
+        #
+        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #
+        # @return [Git::DiffResult] diff result with per-file patch information
+        #
+        def call(stash = nil, dirstat: nil, **)
+          output = @execution_context.command(*ARGS.build(stash, dirstat: dirstat, **)).stdout
+          DiffParser::Patch.parse(output, include_dirstat: !dirstat.nil?)
+        end
+      end
+    end
+  end
+end

--- a/lib/git/commands/stash/show_raw.rb
+++ b/lib/git/commands/stash/show_raw.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+require 'git/diff_parser'
+
+module Git
+  module Commands
+    module Stash
+      # Show raw diff output for a stash entry
+      #
+      # Uses --raw output format with rename detection (-M) enabled by default,
+      # combined with --numstat for line change counts and --shortstat for totals.
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      # @api private
+      #
+      # @example Show raw diff for the latest stash
+      #   Git::Commands::Stash::ShowRaw.new(execution_context).call
+      #   # => #<Git::DiffResult files: [...]>
+      #
+      # @example Show with copy detection
+      #   Git::Commands::Stash::ShowRaw.new(execution_context).call(find_copies: true)
+      #
+      # @example Show with directory statistics
+      #   Git::Commands::Stash::ShowRaw.new(execution_context).call(dirstat: true)
+      #   Git::Commands::Stash::ShowRaw.new(execution_context).call(dirstat: 'lines,cumulative')
+      #
+      class ShowRaw
+        # Arguments DSL for building command-line arguments
+        ARGS = Arguments.define do
+          static 'stash'
+          static 'show'
+          static '--raw'
+          static '--numstat'
+          static '--shortstat'
+          static '-M'
+          negatable_flag %i[include_untracked u]
+          flag :only_untracked
+          flag :find_copies, args: '-C'
+          flag_or_inline_value :dirstat
+          positional :stash
+        end.freeze
+
+        # Creates a new ShowRaw command instance
+        #
+        # @param execution_context [Git::ExecutionContext] the execution context for running commands
+        #
+        def initialize(execution_context)
+          @execution_context = execution_context
+        end
+
+        # Show stash raw diff
+        #
+        # @overload call(**options)
+        #
+        #   Show raw diff for the latest stash
+        #
+        #   @param options [Hash] command options
+        #
+        #   @option options [Boolean] :include_untracked (nil) include untracked files.
+        #     Alias: :u
+        #
+        #   @option options [Boolean] :only_untracked (nil) show only untracked files
+        #
+        #   @option options [Boolean] :find_copies (nil) detect copies as well as renames
+        #
+        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #
+        # @overload call(stash, **options)
+        #
+        #   Show raw diff for a specific stash
+        #
+        #   @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
+        #
+        #   @param options [Hash] command options
+        #
+        #   @option options [Boolean] :include_untracked (nil) include untracked files.
+        #     Alias: :u
+        #
+        #   @option options [Boolean] :only_untracked (nil) show only untracked files
+        #
+        #   @option options [Boolean] :find_copies (nil) detect copies as well as renames
+        #
+        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #
+        # @return [Git::DiffResult] diff result with per-file raw info
+        #
+        def call(stash = nil, dirstat: nil, **)
+          output = @execution_context.command(*ARGS.build(stash, dirstat: dirstat, **)).stdout
+          DiffParser::Raw.parse(output, include_dirstat: !dirstat.nil?)
+        end
+      end
+    end
+  end
+end

--- a/lib/git/commands/stash/store.rb
+++ b/lib/git/commands/stash/store.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'git/commands/arguments'
+
+module Git
+  module Commands
+    module Stash
+      # Store a commit in the stash reflog
+      #
+      # This is a plumbing command used to store a given stash commit (created
+      # by `git stash create`) in the stash reflog, updating refs/stash.
+      #
+      # This command is typically used after {Create} to actually record
+      # the stash in the reflog.
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      # @api private
+      #
+      # @example Store a stash commit
+      #   Git::Commands::Stash::Store.new(execution_context).call('abc123def456')
+      #
+      # @example Store with a custom message
+      #   Git::Commands::Stash::Store.new(execution_context).call('abc123def456', message: 'WIP: feature')
+      #
+      # @example Store quietly (suppress output)
+      #   Git::Commands::Stash::Store.new(execution_context).call('abc123def456', quiet: true)
+      #
+      class Store
+        # Arguments DSL for building command-line arguments
+        ARGS = Arguments.define do
+          static 'stash'
+          static 'store'
+          inline_value %i[message m]
+          flag %i[quiet q]
+          positional :commit, required: true
+        end.freeze
+
+        # Creates a new Store command instance
+        #
+        # @param execution_context [Git::ExecutionContext] the execution context for running commands
+        #
+        def initialize(execution_context)
+          @execution_context = execution_context
+        end
+
+        # Store a commit in the stash reflog
+        #
+        # @overload call(commit, **options)
+        #
+        #   @param commit [String] the commit SHA to store in the stash (required)
+        #
+        #   @param options [Hash] command options
+        #
+        #   @option options [String] :message (nil) description for the reflog entry.
+        #     Alias: :m
+        #
+        #   @option options [Boolean] :quiet (nil) suppress warning messages.
+        #     Alias: :q
+        #
+        # @return [Git::CommandLineResult] the command result
+        #
+        # @raise [Git::FailedError] if the commit is not a valid stash commit
+        #
+        def call(commit, **)
+          @execution_context.command(*ARGS.build(commit, **))
+        end
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -26,11 +26,17 @@ require_relative 'commands/tag/create'
 require_relative 'commands/tag/delete'
 require_relative 'commands/tag/list'
 require_relative 'commands/stash/apply'
+require_relative 'commands/stash/branch'
 require_relative 'commands/stash/clear'
+require_relative 'commands/stash/create'
 require_relative 'commands/stash/drop'
 require_relative 'commands/stash/list'
 require_relative 'commands/stash/pop'
 require_relative 'commands/stash/push'
+require_relative 'commands/stash/show_numstat'
+require_relative 'commands/stash/show_patch'
+require_relative 'commands/stash/show_raw'
+require_relative 'commands/stash/store'
 
 require 'git/command_line'
 require 'git/errors'
@@ -1220,9 +1226,7 @@ module Git
     #
     # @return [Boolean] true if stash was created, false otherwise
     #
-    # rubocop:disable Naming/PredicateMethod
-    def stash_save(message = nil, options = {})
-      # rubocop:enable Naming/PredicateMethod
+    def stash_save(message = nil, options = {}) # rubocop:disable Naming/PredicateMethod
       opts = message ? options.merge(message: message) : options
       stash_info = Git::Commands::Stash::Push.new(self).call(**opts)
 

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,13 +22,13 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (15/~50 commands migrated) |
+| Phase 2 | 🔄 In Progress | Migrating commands (17/~50 commands migrated) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate the `stash` commands** → `Git::Commands::Stash::Show`, `Git::Commands::Stash::Branch`, `Git::Commands::Stash::Create`, `Git::Commands::Stash::Store`
+**Migrate the `checkout` command** → `Git::Commands::Checkout::Branch`, `Git::Commands::Checkout::Files`
 
 #### Workflow
 
@@ -56,12 +56,10 @@ risk and allows for a gradual, controlled migration to the new architecture.
 
    **YARD Documentation Format for `#call` methods:**
 
-   Use `@overload` with `options = {}` to make `@option` tags render correctly:
-
    ```ruby
    # Execute the git example command
    #
-   # @overload call(positional_arg, *variadic_args, options = {})
+   # @overload call(positional_arg, *variadic_args, **options)
    #
    #   @param positional_arg [String] Description of the positional argument
    #
@@ -79,9 +77,6 @@ risk and allows for a gradual, controlled migration to the new architecture.
    #
    def call(*, **)
    ```
-
-   **Important**: The `@overload` signature must use `options = {}` (not keyword
-   arguments) for `@option` tags to render in generated documentation.
 
    **Important**: Keep empty comments between each yard tag
 
@@ -673,6 +668,18 @@ The following tracks the migration status of commands from `Git::Lib` to
 | `diff_full` | `Git::Commands::Diff::Patch` | `spec/git/commands/diff/patch_spec.rb` | `git diff` (patch format) |
 | `diff_stats` | `Git::Commands::Diff::Numstat` | `spec/git/commands/diff/numstat_spec.rb` | `git diff --numstat` |
 | `diff_path_status` / `diff_index` | `Git::Commands::Diff::Raw` | `spec/git/commands/diff/raw_spec.rb` | `git diff --raw` |
+| `stashes_list` | `Git::Commands::Stash::List` | `spec/unit/git/commands/stash/list_spec.rb` | `git stash list` |
+| `stash_save` | `Git::Commands::Stash::Push` | `spec/unit/git/commands/stash/push_spec.rb` | `git stash push` |
+| `stash_pop` | `Git::Commands::Stash::Pop` | `spec/unit/git/commands/stash/pop_spec.rb` | `git stash pop` |
+| `stash_apply` | `Git::Commands::Stash::Apply` | `spec/unit/git/commands/stash/apply_spec.rb` | `git stash apply` |
+| `stash_drop` | `Git::Commands::Stash::Drop` | `spec/unit/git/commands/stash/drop_spec.rb` | `git stash drop` |
+| `stash_clear` | `Git::Commands::Stash::Clear` | `spec/unit/git/commands/stash/clear_spec.rb` | `git stash clear` |
+| N/A (new) | `Git::Commands::Stash::Create` | `spec/unit/git/commands/stash/create_spec.rb` | `git stash create` |
+| N/A (new) | `Git::Commands::Stash::Store` | `spec/unit/git/commands/stash/store_spec.rb` | `git stash store` |
+| N/A (new) | `Git::Commands::Stash::Branch` | `spec/unit/git/commands/stash/branch_spec.rb` | `git stash branch` |
+| N/A (new) | `Git::Commands::Stash::ShowNumstat` | `spec/unit/git/commands/stash/show_numstat_spec.rb` | `git stash show --numstat` |
+| N/A (new) | `Git::Commands::Stash::ShowPatch` | `spec/unit/git/commands/stash/show_patch_spec.rb` | `git stash show --patch` |
+| N/A (new) | `Git::Commands::Stash::ShowRaw` | `spec/unit/git/commands/stash/show_raw_spec.rb` | `git stash show --raw` |
 
 #### ⏳ Commands To Migrate
 
@@ -692,10 +699,11 @@ order: Basic Snapshotting → Branching & Merging → etc.
 - [x] `branches_all` → `Git::Commands::Branch::List` — `git branch --list` (returns `BranchInfo` value objects)
 - [x] `branch_new` → `Git::Commands::Branch::Create` — `git branch <name> [start-point]`
 - [x] `branch_delete` → `Git::Commands::Branch::Delete` — `git branch --delete`
+- [x] `branch_move` → `Git::Commands::Branch::Move` — `git branch --move`
 - [ ] `checkout` / `checkout_file` → `Git::Commands::Checkout` — `git checkout`
 - [ ] `merge` / `merge_base` → `Git::Commands::Merge` — `git merge`
 - [ ] `tag` → `Git::Commands::Tag` — `git tag`
-- [ ] `stash_save` / `stash_apply` → `Git::Commands::Stash` — `git stash`
+- [x] `stash_*` → `Git::Commands::Stash::*` — `git stash` (List, Push, Pop, Apply, Drop, Clear, Create, Store, Branch, ShowNumstat, ShowPatch, ShowRaw)
 
 **Inspection & Comparison:**
 

--- a/spec/integration/git/commands/stash/apply_spec.rb
+++ b/spec/integration/git/commands/stash/apply_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/stash/apply'
+require 'git/commands/stash/list'
+
+RSpec.describe Git::Commands::Stash::Apply, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    # Create initial commit
+    write_file('file.txt', "initial content\n")
+    repo.add('file.txt')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    describe 'with :index option' do
+      context 'when stash was created with staged changes' do
+        before do
+          # Stage changes and create stash
+          write_file('file.txt', "staged changes\n")
+          repo.add('file.txt')
+          repo.lib.stash_save('WIP with staged')
+        end
+
+        it 'restores index state when index: true' do
+          command.call(index: true)
+
+          # Verify the changes are in the index (staged)
+          status = repo.status
+          expect(status['file.txt']).not_to be_nil
+          expect(status['file.txt'].type).to eq('M')
+        end
+
+        it 'does not restore index state by default' do
+          command.call
+
+          # Verify changes are in working directory but not staged
+          status = repo.status
+          expect(status['file.txt'].type).to eq('M')
+        end
+      end
+
+      context 'when stash was created with both staged and unstaged changes' do
+        before do
+          # Stage one change
+          write_file('file.txt', "staged change\n")
+          repo.add('file.txt')
+
+          # Add another change without staging
+          write_file('file.txt', "staged change\nunstaged change\n")
+
+          repo.lib.stash_save('WIP with mixed changes')
+        end
+
+        it 'restores both staged and unstaged states when index: true' do
+          command.call(index: true)
+
+          # Verify there are staged changes
+          status = repo.status
+          expect(status['file.txt']).not_to be_nil
+          expect(status['file.txt'].type).to eq('M')
+
+          # Verify the full content is restored
+          content = read_file('file.txt')
+          expect(content).to eq("staged change\nunstaged change\n")
+        end
+      end
+    end
+
+    describe 'basic apply behavior' do
+      before do
+        write_file('file.txt', "modified content\n")
+        repo.lib.stash_save('WIP')
+      end
+
+      it 'keeps the stash after apply (unlike pop)' do
+        stashes_before = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes_before.size).to eq(1)
+
+        command.call
+
+        stashes_after = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes_after.size).to eq(1)
+      end
+
+      it 'restores the working directory changes' do
+        command.call
+
+        content = read_file('file.txt')
+        expect(content).to eq("modified content\n")
+      end
+
+      it 'returns the StashInfo of the applied stash' do
+        result = command.call
+
+        expect(result).to be_a(Git::StashInfo)
+        expect(result.name).to eq('stash@{0}')
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/stash/branch_spec.rb
+++ b/spec/integration/git/commands/stash/branch_spec.rb
@@ -1,0 +1,162 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/stash/branch'
+
+RSpec.describe Git::Commands::Stash::Branch, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when creating a branch from a stash' do
+      before do
+        # Create initial commit
+        write_file('file.txt', 'initial content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+
+        # Create changes and stash them
+        write_file('file.txt', 'modified content')
+        repo.lib.stash_save('WIP changes')
+      end
+
+      it 'creates the branch and returns BranchInfo' do
+        result = command.call('stash-branch')
+
+        expect(result).to be_a(Git::BranchInfo)
+        expect(result.refname).to eq('stash-branch')
+      end
+
+      it 'creates a local branch' do
+        result = command.call('stash-branch')
+
+        expect(result.remote?).to be false
+      end
+
+      it 'switches to the new branch (makes it current)' do
+        result = command.call('stash-branch')
+
+        expect(result.current?).to be true
+      end
+
+      it 'applies the stashed changes to the working directory' do
+        command.call('stash-branch')
+
+        content = read_file('file.txt')
+        expect(content).to eq('modified content')
+      end
+
+      it 'drops the stash after successful application' do
+        command.call('stash-branch')
+
+        stashes = repo.lib.stashes_list
+        expect(stashes).to be_empty
+      end
+
+      it 'makes the branch visible in the repository' do
+        command.call('stash-branch')
+
+        branch_names = repo.branches.local.map(&:name)
+        expect(branch_names).to include('stash-branch')
+      end
+    end
+
+    context 'when creating a branch from a specific stash' do
+      before do
+        # Create initial commit
+        write_file('file.txt', 'initial content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+
+        # Create first stash
+        write_file('file.txt', 'first stash content')
+        repo.lib.stash_save('First stash')
+
+        # Create second stash
+        write_file('file.txt', 'second stash content')
+        repo.lib.stash_save('Second stash')
+      end
+
+      it 'creates branch from the specified stash' do
+        # stash@{1} is the first stash (older one)
+        result = command.call('from-first-stash', 'stash@{1}')
+
+        expect(result).to be_a(Git::BranchInfo)
+        expect(result.refname).to eq('from-first-stash')
+
+        content = read_file('file.txt')
+        expect(content).to eq('first stash content')
+      end
+
+      it 'accepts numeric stash index' do
+        result = command.call('from-second-stash', '0')
+
+        expect(result).to be_a(Git::BranchInfo)
+
+        content = read_file('file.txt')
+        expect(content).to eq('second stash content')
+      end
+    end
+
+    context 'when branch name already exists' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+
+        # Create the branch first
+        repo.branch('existing-branch').create
+
+        # Then create a stash
+        write_file('file.txt', 'stashed content')
+        repo.lib.stash_save('WIP')
+      end
+
+      it 'raises FailedError' do
+        expect { command.call('existing-branch') }.to raise_error(Git::FailedError) do |error|
+          expect(error.message).to include('existing-branch')
+          expect(error.message).to include('already exists')
+        end
+      end
+    end
+
+    context 'when stash does not exist' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+        # No stash created
+      end
+
+      it 'raises FailedError' do
+        expect { command.call('new-branch') }.to raise_error(Git::FailedError)
+      end
+    end
+
+    context 'with branch names containing special characters' do
+      before do
+        write_file('file.txt', 'content')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+
+        write_file('file.txt', 'stashed')
+        repo.lib.stash_save('WIP')
+      end
+
+      it 'handles branch names with slashes' do
+        result = command.call('feature/from-stash')
+
+        expect(result).to be_a(Git::BranchInfo)
+        expect(result.refname).to eq('feature/from-stash')
+      end
+
+      it 'handles branch names with hyphens' do
+        result = command.call('fix-from-stash-123')
+
+        expect(result).to be_a(Git::BranchInfo)
+        expect(result.refname).to eq('fix-from-stash-123')
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/stash/clear_spec.rb
+++ b/spec/integration/git/commands/stash/clear_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/stash/clear'
+require 'git/commands/stash/list'
+
+RSpec.describe Git::Commands::Stash::Clear, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    # Create initial commit
+    write_file('file.txt', "initial content\n")
+    repo.add('file.txt')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'with multiple stashes' do
+      before do
+        # Create three stashes
+        write_file('file.txt', "first change\n")
+        repo.lib.stash_save('First stash')
+
+        write_file('file.txt', "second change\n")
+        repo.lib.stash_save('Second stash')
+
+        write_file('file.txt', "third change\n")
+        repo.lib.stash_save('Third stash')
+      end
+
+      it 'removes all stash entries' do
+        stashes_before = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes_before.size).to eq(3)
+
+        command.call
+
+        stashes_after = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes_after).to be_empty
+      end
+    end
+
+    context 'with a single stash' do
+      before do
+        write_file('file.txt', "modified\n")
+        repo.lib.stash_save('WIP')
+      end
+
+      it 'removes the stash' do
+        stashes_before = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes_before.size).to eq(1)
+
+        command.call
+
+        stashes_after = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes_after).to be_empty
+      end
+    end
+
+    context 'with no stashes' do
+      it 'succeeds without error' do
+        stashes_before = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes_before).to be_empty
+
+        expect { command.call }.not_to raise_error
+
+        stashes_after = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes_after).to be_empty
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/stash/list_spec.rb
+++ b/spec/integration/git/commands/stash/list_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/stash/list'
+
+# Integration tests for Git::Commands::Stash::List
+#
+# These tests verify that the command's custom format string produces output
+# that matches our parsing expectations. This is essential since unit tests
+# mock this output.
+#
+RSpec.describe Git::Commands::Stash::List, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    # Create initial commit
+    write_file('file.txt', 'initial content')
+    repo.add('file.txt')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'with no stashes' do
+      it 'returns an empty array' do
+        result = command.call
+
+        expect(result).to eq([])
+      end
+    end
+
+    context 'with a single stash' do
+      before do
+        write_file('file.txt', 'modified content')
+        repo.lib.stash_save('WIP on feature')
+      end
+
+      it 'returns an array with one StashInfo' do
+        result = command.call
+
+        expect(result.size).to eq(1)
+        expect(result.first).to be_a(Git::StashInfo)
+      end
+
+      it 'parses the stash index correctly' do
+        result = command.call
+
+        expect(result.first.index).to eq(0)
+      end
+
+      it 'parses the stash name correctly' do
+        result = command.call
+
+        expect(result.first.name).to eq('stash@{0}')
+      end
+
+      it 'parses the OID fields (verifies format string produces valid SHA)' do
+        result = command.call
+
+        expect(result.first.oid).to match(/\A[0-9a-f]{40}\z/)
+        expect(result.first.short_oid).to match(/\A[0-9a-f]{7,}\z/)
+      end
+
+      it 'parses the message correctly' do
+        result = command.call
+
+        # Message includes the branch info from git
+        expect(result.first.message).to include('WIP on feature')
+      end
+
+      it 'parses author information (verifies format string includes author)' do
+        result = command.call
+
+        expect(result.first.author_name).to be_a(String)
+        expect(result.first.author_name).not_to be_empty
+        expect(result.first.author_email).to match(/@/)
+        expect(result.first.author_date).to be_a(String)
+      end
+
+      it 'parses committer information (verifies format string includes committer)' do
+        result = command.call
+
+        expect(result.first.committer_name).to be_a(String)
+        expect(result.first.committer_name).not_to be_empty
+        expect(result.first.committer_email).to match(/@/)
+        expect(result.first.committer_date).to be_a(String)
+      end
+    end
+
+    context 'with multiple stashes' do
+      before do
+        # Create first stash
+        write_file('file.txt', 'first change')
+        repo.lib.stash_save('First stash')
+
+        # Create second stash
+        write_file('file.txt', 'second change')
+        repo.lib.stash_save('Second stash')
+
+        # Create third stash
+        write_file('file.txt', 'third change')
+        repo.lib.stash_save('Third stash')
+      end
+
+      it 'returns stashes in order (newest first)' do
+        result = command.call
+
+        expect(result.size).to eq(3)
+        expect(result[0].index).to eq(0)
+        expect(result[1].index).to eq(1)
+        expect(result[2].index).to eq(2)
+      end
+
+      it 'assigns correct names to each stash' do
+        result = command.call
+
+        expect(result[0].name).to eq('stash@{0}')
+        expect(result[1].name).to eq('stash@{1}')
+        expect(result[2].name).to eq('stash@{2}')
+      end
+
+      it 'preserves distinct messages for each stash' do
+        result = command.call
+
+        messages = result.map(&:message)
+        expect(messages[0]).to include('Third stash')
+        expect(messages[1]).to include('Second stash')
+        expect(messages[2]).to include('First stash')
+      end
+
+      it 'assigns unique OIDs to each stash' do
+        result = command.call
+
+        oids = result.map(&:oid)
+        expect(oids.uniq.size).to eq(3)
+      end
+    end
+
+    context 'with custom message format (no branch prefix)' do
+      before do
+        # Create a stash using create + store to have a custom message
+        write_file('file.txt', 'modified')
+        result = repo.lib.command('stash', 'create', 'Custom message')
+        sha = result.is_a?(String) ? result.strip : result.stdout.strip
+        repo.lib.command('stash', 'store', '--message=custom: my message', sha)
+      end
+
+      it 'parses custom message correctly' do
+        result = command.call
+
+        # Custom messages don't have the "WIP on branch:" prefix
+        expect(result.first.message).to eq('custom: my message')
+        # Branch should be nil for custom messages without branch info
+        expect(result.first.branch).to be_nil
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/stash/pop_spec.rb
+++ b/spec/integration/git/commands/stash/pop_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/stash/pop'
+require 'git/commands/stash/list'
+
+RSpec.describe Git::Commands::Stash::Pop, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    # Create initial commit
+    write_file('file.txt', "initial content\n")
+    repo.add('file.txt')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    describe 'with :index option' do
+      context 'when stash was created with staged changes' do
+        before do
+          # Stage changes and create stash
+          write_file('file.txt', "staged changes\n")
+          repo.add('file.txt')
+          repo.lib.stash_save('WIP with staged')
+        end
+
+        it 'restores index state when index: true' do
+          command.call(index: true)
+
+          # Verify the changes are in the index (staged)
+          status = repo.status
+          expect(status['file.txt']).not_to be_nil
+          expect(status['file.txt'].type).to eq('M')
+        end
+
+        it 'does not restore index state by default' do
+          command.call
+
+          # Verify changes are in working directory but not staged
+          status = repo.status
+          # Changes appear as modified in worktree, not index
+          expect(status['file.txt'].type).to eq('M')
+        end
+      end
+
+      context 'when stash was created with both staged and unstaged changes' do
+        before do
+          # Stage one change
+          write_file('file.txt', "staged change\n")
+          repo.add('file.txt')
+
+          # Add another change without staging
+          write_file('file.txt', "staged change\nunstaged change\n")
+
+          repo.lib.stash_save('WIP with mixed changes')
+        end
+
+        it 'restores both staged and unstaged states when index: true' do
+          command.call(index: true)
+
+          # Verify there are staged changes
+          status = repo.status
+          expect(status['file.txt']).not_to be_nil
+          expect(status['file.txt'].type).to eq('M')
+
+          # Verify the full content is restored
+          content = read_file('file.txt')
+          expect(content).to eq("staged change\nunstaged change\n")
+        end
+      end
+    end
+
+    describe 'basic pop behavior' do
+      before do
+        write_file('file.txt', "modified content\n")
+        repo.lib.stash_save('WIP')
+      end
+
+      it 'removes the stash after successful pop' do
+        stashes_before = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes_before.size).to eq(1)
+
+        command.call
+
+        stashes_after = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes_after).to be_empty
+      end
+
+      it 'restores the working directory changes' do
+        command.call
+
+        content = read_file('file.txt')
+        expect(content).to eq("modified content\n")
+      end
+
+      it 'returns the StashInfo of the popped stash' do
+        result = command.call
+
+        expect(result).to be_a(Git::StashInfo)
+        expect(result.name).to eq('stash@{0}')
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/stash/push_spec.rb
+++ b/spec/integration/git/commands/stash/push_spec.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/stash/push'
+require 'git/commands/stash/list'
+
+RSpec.describe Git::Commands::Stash::Push, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    # Create initial commit
+    write_file('tracked.txt', "initial content\n")
+    repo.add('tracked.txt')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    describe 'with :keep_index option' do
+      before do
+        # Modify and stage a file
+        write_file('tracked.txt', "staged changes\n")
+        repo.add('tracked.txt')
+      end
+
+      it 'preserves staged changes in the index when keep_index: true' do
+        command.call(keep_index: true)
+
+        # Verify the stash was created
+        stashes = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes.size).to eq(1)
+
+        # Verify staged changes are still in the index
+        status = repo.status
+        expect(status['tracked.txt']).not_to be_nil
+        expect(status['tracked.txt'].type).to eq('M')
+      end
+
+      it 'removes staged changes from index when keep_index: false' do
+        command.call(keep_index: false)
+
+        # Verify the stash was created
+        stashes = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes.size).to eq(1)
+
+        # Verify staged changes were removed from the index (file is clean)
+        status = repo.status
+        expect(status.changed?('tracked.txt')).to be false
+      end
+
+      it 'removes staged changes from index by default (no keep_index option)' do
+        command.call
+
+        # Verify staged changes were removed from the index (file is clean)
+        status = repo.status
+        expect(status.changed?('tracked.txt')).to be false
+      end
+    end
+
+    describe 'with :staged option' do
+      before do
+        # Stage one file
+        write_file('staged.txt', "staged content\n")
+        repo.add('staged.txt')
+
+        # Modify another file without staging
+        write_file('tracked.txt', "unstaged changes\n")
+      end
+
+      it 'stashes only staged changes when staged: true' do
+        command.call(staged: true)
+
+        # Verify the stash was created
+        stashes = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes.size).to eq(1)
+
+        # Verify staged file is no longer staged (stashed away)
+        status = repo.status
+        expect(status['staged.txt']).to be_nil
+
+        # Verify unstaged changes remain in working directory
+        content = read_file('tracked.txt')
+        expect(content).to eq("unstaged changes\n")
+      end
+
+      it 'stashes all changes by default (without staged option)' do
+        command.call
+
+        # Verify both changes were stashed (files are clean)
+        status = repo.status
+        expect(status.changed?('staged.txt')).to be false
+        expect(status.changed?('tracked.txt')).to be false
+
+        # Working directory should be clean
+        content = read_file('tracked.txt')
+        expect(content).to eq("initial content\n")
+      end
+    end
+
+    describe 'with :include_untracked option' do
+      before do
+        # Create an untracked file
+        write_file('untracked.txt', "untracked content\n")
+        # Modify tracked file
+        write_file('tracked.txt', "modified\n")
+      end
+
+      it 'includes untracked files when include_untracked: true' do
+        command.call(include_untracked: true)
+
+        # Verify the stash was created
+        stashes = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes.size).to eq(1)
+
+        # Verify untracked file was removed (stashed)
+        expect(file_exist?('untracked.txt')).to be false
+      end
+
+      it 'leaves untracked files by default' do
+        command.call
+
+        # Verify the stash was created
+        stashes = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes.size).to eq(1)
+
+        # Verify untracked file still exists
+        expect(file_exist?('untracked.txt')).to be true
+        content = read_file('untracked.txt')
+        expect(content).to eq("untracked content\n")
+      end
+    end
+
+    describe 'with pathspecs' do
+      before do
+        # Modify multiple files
+        write_file('tracked.txt', "modified tracked\n")
+        write_file('other.txt', "other content\n")
+        repo.add('other.txt')
+        repo.commit('Add other.txt')
+        write_file('other.txt', "modified other\n")
+      end
+
+      it 'stashes only specified paths' do
+        command.call('tracked.txt')
+
+        # Verify the stash was created
+        stashes = Git::Commands::Stash::List.new(execution_context).call
+        expect(stashes.size).to eq(1)
+
+        # Verify tracked.txt was stashed (reverted)
+        content = read_file('tracked.txt')
+        expect(content).to eq("initial content\n")
+
+        # Verify other.txt was NOT stashed (still modified)
+        other_content = read_file('other.txt')
+        expect(other_content).to eq("modified other\n")
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/stash/show_spec.rb
+++ b/spec/integration/git/commands/stash/show_spec.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/stash/show_numstat'
+require 'git/commands/stash/show_patch'
+require 'git/commands/stash/show_raw'
+
+# Integration tests for git stash show commands.
+#
+# These tests verify that the commands work correctly with real git repositories.
+# Parsing edge cases (binary files, renames, special characters, etc.) are already
+# covered by Diff::* integration tests since both use DiffParser.
+#
+# Focus here is on stash-specific behavior:
+# - Basic stash show works
+# - Stash reference formats (stash@{0}, 0)
+# - --include-untracked option
+# - --only-untracked option
+#
+RSpec.describe 'Git::Commands::Stash::Show*', :integration do
+  include_context 'in an empty repository'
+
+  before do
+    # Create initial commit
+    write_file('tracked.txt', "initial content\n")
+    repo.add('tracked.txt')
+    repo.commit('Initial commit')
+  end
+
+  describe Git::Commands::Stash::ShowNumstat do
+    subject(:command) { described_class.new(execution_context) }
+
+    context 'with a basic stash' do
+      before do
+        write_file('tracked.txt', "modified content\nmore lines\n")
+        repo.lib.stash_save('WIP')
+      end
+
+      it 'returns DiffResult with file statistics' do
+        result = command.call
+
+        expect(result).to be_a(Git::DiffResult)
+        expect(result.files_changed).to eq(1)
+        expect(result.files.first.path).to eq('tracked.txt')
+        expect(result.files.first.insertions).to be > 0
+      end
+
+      it 'accepts stash reference as string' do
+        result = command.call('stash@{0}')
+
+        expect(result.files_changed).to eq(1)
+      end
+
+      it 'accepts stash index as string' do
+        result = command.call('0')
+
+        expect(result.files_changed).to eq(1)
+      end
+    end
+
+    context 'with untracked files' do
+      before do
+        # Modify tracked file
+        write_file('tracked.txt', "modified content\n")
+        # Create untracked file
+        write_file('untracked.txt', "new file content\n")
+        # Stash with --include-untracked
+        repo.lib.stash_save('WIP with untracked', include_untracked: true)
+      end
+
+      it 'shows only tracked files by default' do
+        result = command.call
+
+        paths = result.files.map(&:path)
+        expect(paths).to include('tracked.txt')
+        expect(paths).not_to include('untracked.txt')
+      end
+
+      it 'includes untracked files when include_untracked: true' do
+        result = command.call(include_untracked: true)
+
+        paths = result.files.map(&:path)
+        expect(paths).to include('tracked.txt')
+        expect(paths).to include('untracked.txt')
+      end
+
+      it 'shows only untracked files when only_untracked: true' do
+        result = command.call(only_untracked: true)
+
+        paths = result.files.map(&:path)
+        expect(paths).not_to include('tracked.txt')
+        expect(paths).to include('untracked.txt')
+      end
+    end
+
+    context 'with multiple stashes' do
+      before do
+        # First stash - modify tracked file
+        write_file('tracked.txt', "first modification\n")
+        repo.lib.stash_save('First stash')
+
+        # Second stash - add new tracked file
+        write_file('another.txt', "another file\n")
+        repo.add('another.txt')
+        repo.lib.stash_save('Second stash')
+      end
+
+      it 'shows the latest stash by default' do
+        result = command.call
+
+        # Second stash should have another.txt
+        paths = result.files.map(&:path)
+        expect(paths).to include('another.txt')
+      end
+
+      it 'can show an older stash by index' do
+        result = command.call('1')
+
+        # First stash should have tracked.txt
+        paths = result.files.map(&:path)
+        expect(paths).to include('tracked.txt')
+        expect(paths).not_to include('another.txt')
+      end
+    end
+  end
+
+  describe Git::Commands::Stash::ShowPatch do
+    subject(:command) { described_class.new(execution_context) }
+
+    context 'with a stash' do
+      before do
+        write_file('tracked.txt', "modified content\nmore lines\n")
+        repo.lib.stash_save('WIP')
+      end
+
+      it 'returns DiffResult with patch information' do
+        result = command.call
+
+        expect(result).to be_a(Git::DiffResult)
+        expect(result.files.first).to be_a(Git::DiffFilePatchInfo)
+        expect(result.files.first.patch).to include('diff --git')
+      end
+    end
+  end
+
+  describe Git::Commands::Stash::ShowRaw do
+    subject(:command) { described_class.new(execution_context) }
+
+    context 'with a stash' do
+      before do
+        write_file('tracked.txt', "modified content\nmore lines\n")
+        repo.lib.stash_save('WIP')
+      end
+
+      it 'returns DiffResult with raw file information' do
+        result = command.call
+
+        expect(result).to be_a(Git::DiffResult)
+        expect(result.files.first).to be_a(Git::DiffFileRawInfo)
+        expect(result.files.first.status).to eq(:modified)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/stash/workflow_spec.rb
+++ b/spec/integration/git/commands/stash/workflow_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/stash/create'
+require 'git/commands/stash/store'
+require 'git/commands/stash/list'
+require 'git/commands/stash/drop'
+
+# Integration tests for stash workflows that involve multiple commands working together.
+#
+RSpec.describe 'Stash workflows', :integration do
+  include_context 'in an empty repository'
+
+  before do
+    # Create initial commit
+    write_file('file.txt', "initial content\n")
+    repo.add('file.txt')
+    repo.commit('Initial commit')
+  end
+
+  describe 'Create + Store workflow' do
+    # git stash create + git stash store is the plumbing equivalent of git stash push
+    # This workflow is useful for scripting when you need more control over the stash
+
+    let(:create_command) { Git::Commands::Stash::Create.new(execution_context) }
+    let(:store_command) { Git::Commands::Stash::Store.new(execution_context) }
+    let(:list_command) { Git::Commands::Stash::List.new(execution_context) }
+
+    context 'with local changes' do
+      before do
+        write_file('file.txt', "modified content\n")
+      end
+
+      it 'creates a stash commit and stores it in the reflog' do
+        # Step 1: Create a stash commit (does not update refs/stash)
+        sha = create_command.call
+        expect(sha).to match(/\A[0-9a-f]{40}\z/)
+
+        # Verify stash list is still empty (create doesn't store)
+        stashes = list_command.call
+        expect(stashes).to be_empty
+
+        # Step 2: Store the commit in the stash reflog
+        store_command.call(sha, message: 'Manually stored stash')
+
+        # Verify stash now appears in list
+        stashes = list_command.call
+        expect(stashes.size).to eq(1)
+        expect(stashes.first.message).to eq('Manually stored stash')
+        expect(stashes.first.oid).to eq(sha)
+      end
+
+      it 'creates a stash commit with a message' do
+        sha = create_command.call('WIP: my changes')
+        expect(sha).to match(/\A[0-9a-f]{40}\z/)
+
+        # Store without custom message - git uses the create message
+        store_command.call(sha)
+
+        stashes = list_command.call
+        expect(stashes.size).to eq(1)
+      end
+
+      it 'does not modify the working directory' do
+        # Unlike stash push, create does not reset the working directory
+        create_command.call
+
+        content = read_file('file.txt')
+        expect(content).to eq("modified content\n")
+      end
+    end
+
+    context 'with no local changes' do
+      it 'returns nil when nothing to stash' do
+        sha = create_command.call
+        expect(sha).to be_nil
+      end
+    end
+
+    context 'storing multiple stashes' do
+      it 'maintains correct stash order (newest first)' do
+        # Create and store first stash
+        write_file('file.txt', "first change\n")
+        sha1 = create_command.call
+        store_command.call(sha1, message: 'First stash')
+
+        # Create and store second stash
+        write_file('file.txt', "second change\n")
+        sha2 = create_command.call
+        store_command.call(sha2, message: 'Second stash')
+
+        stashes = list_command.call
+        expect(stashes.size).to eq(2)
+        expect(stashes[0].message).to eq('Second stash')
+        expect(stashes[0].index).to eq(0)
+        expect(stashes[1].message).to eq('First stash')
+        expect(stashes[1].index).to eq(1)
+      end
+    end
+  end
+
+  describe 'Drop workflow' do
+    let(:drop_command) { Git::Commands::Stash::Drop.new(execution_context) }
+    let(:list_command) { Git::Commands::Stash::List.new(execution_context) }
+
+    context 'with multiple stashes' do
+      before do
+        write_file('file.txt', "first\n")
+        repo.lib.stash_save('First')
+
+        write_file('file.txt', "second\n")
+        repo.lib.stash_save('Second')
+
+        write_file('file.txt', "third\n")
+        repo.lib.stash_save('Third')
+      end
+
+      it 'drops the latest stash by default' do
+        stashes_before = list_command.call
+        expect(stashes_before.size).to eq(3)
+        expect(stashes_before[0].message).to include('Third')
+
+        drop_command.call
+
+        stashes_after = list_command.call
+        expect(stashes_after.size).to eq(2)
+        expect(stashes_after[0].message).to include('Second')
+      end
+
+      it 'drops a specific stash by index' do
+        # Drop the middle stash (index 1 = "Second")
+        drop_command.call('1')
+
+        stashes_after = list_command.call
+        expect(stashes_after.size).to eq(2)
+        messages = stashes_after.map(&:message)
+        expect(messages.any? { |m| m.include?('Third') }).to be true
+        expect(messages.any? { |m| m.include?('First') }).to be true
+        expect(messages.any? { |m| m.include?('Second') }).to be false
+      end
+
+      it 'returns the dropped stash info' do
+        result = drop_command.call
+
+        expect(result).to be_a(Git::StashInfo)
+        expect(result.message).to include('Third')
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/stash/branch_spec.rb
+++ b/spec/unit/git/commands/stash/branch_spec.rb
@@ -1,0 +1,115 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/stash/branch'
+require 'git/commands/branch/list'
+require 'git/branch_info'
+
+RSpec.describe Git::Commands::Stash::Branch do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+  let(:branch_info) do
+    Git::BranchInfo.new(
+      refname: 'my-feature',
+      target_oid: 'abc123def456789012345678901234567890abcd',
+      current: true,
+      worktree: false,
+      symref: nil,
+      upstream: nil
+    )
+  end
+  let(:list_command) { instance_double(Git::Commands::Branch::List) }
+
+  before do
+    allow(Git::Commands::Branch::List).to receive(:new).with(execution_context).and_return(list_command)
+    allow(list_command).to receive(:call).and_return([branch_info])
+  end
+
+  describe '#call' do
+    context 'with branch name only (latest stash)' do
+      it 'calls git stash branch with branch name' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'branch', 'my-feature')
+          .and_return(command_result(''))
+
+        command.call('my-feature')
+      end
+
+      it 'returns BranchInfo for the created branch' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'branch', 'my-feature')
+          .and_return(command_result("Switched to a new branch 'my-feature'\n"))
+
+        result = command.call('my-feature')
+
+        expect(result).to be_a(Git::BranchInfo)
+        expect(result.refname).to eq('my-feature')
+      end
+
+      it 'queries Branch::List for the new branch info' do
+        allow(execution_context).to receive(:command).and_return(command_result(''))
+
+        expect(list_command).to receive(:call).with('my-feature').and_return([branch_info])
+
+        command.call('my-feature')
+      end
+    end
+
+    context 'with branch name and stash reference' do
+      it 'passes stash reference to command' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'branch', 'my-feature', 'stash@{2}')
+          .and_return(command_result(''))
+
+        command.call('my-feature', 'stash@{2}')
+      end
+
+      it 'accepts numeric stash reference' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'branch', 'bugfix', '1')
+          .and_return(command_result(''))
+
+        command.call('bugfix', '1')
+      end
+    end
+
+    context 'with special branch names' do
+      it 'handles branch names with slashes' do
+        slashed_branch_info = Git::BranchInfo.new(
+          refname: 'feature/new-thing',
+          target_oid: 'abc123def456789012345678901234567890abcd',
+          current: true,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+        allow(list_command).to receive(:call).with('feature/new-thing').and_return([slashed_branch_info])
+
+        expect(execution_context).to receive(:command)
+          .with('stash', 'branch', 'feature/new-thing')
+          .and_return(command_result(''))
+
+        result = command.call('feature/new-thing')
+        expect(result.refname).to eq('feature/new-thing')
+      end
+
+      it 'handles branch names with hyphens' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'branch', 'fix-bug-123')
+          .and_return(command_result(''))
+
+        command.call('fix-bug-123')
+      end
+    end
+
+    context 'with nil stash reference' do
+      it 'omits nil stash from arguments' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'branch', 'my-branch')
+          .and_return(command_result(''))
+
+        command.call('my-branch', nil)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/stash/create_spec.rb
+++ b/spec/unit/git/commands/stash/create_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/stash/create'
+
+RSpec.describe Git::Commands::Stash::Create do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with no arguments' do
+      it 'calls git stash create' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'create')
+          .and_return(command_result("abc123def456789\n"))
+
+        command.call
+      end
+
+      it 'returns the commit SHA' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'create')
+          .and_return(command_result("abc123def456789\n"))
+
+        expect(command.call).to eq('abc123def456789')
+      end
+
+      it 'strips whitespace from SHA' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'create')
+          .and_return(command_result("  abc123def456789  \n"))
+
+        expect(command.call).to eq('abc123def456789')
+      end
+    end
+
+    context 'with message' do
+      it 'passes message to command' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'create', 'WIP: my changes')
+          .and_return(command_result("abc123\n"))
+
+        command.call('WIP: my changes')
+      end
+
+      it 'handles message with special characters' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'create', 'Fix "bug" in code')
+          .and_return(command_result("abc123\n"))
+
+        command.call('Fix "bug" in code')
+      end
+
+      it 'handles empty string message' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'create', '')
+          .and_return(command_result("abc123\n"))
+
+        command.call('')
+      end
+    end
+
+    context 'when nothing to stash' do
+      it 'returns nil for empty output' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'create')
+          .and_return(command_result(''))
+
+        expect(command.call).to be_nil
+      end
+
+      it 'returns nil for whitespace-only output' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'create')
+          .and_return(command_result("  \n"))
+
+        expect(command.call).to be_nil
+      end
+    end
+
+    context 'with nil message' do
+      it 'omits nil message from arguments' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'create')
+          .and_return(command_result("abc123\n"))
+
+        command.call(nil)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/stash/show_numstat_spec.rb
+++ b/spec/unit/git/commands/stash/show_numstat_spec.rb
@@ -1,0 +1,261 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/stash/show_numstat'
+
+RSpec.describe Git::Commands::Stash::ShowNumstat do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  let(:numstat_output) do
+    <<~OUTPUT
+      5\t2\tlib/foo.rb
+      3\t1\tlib/bar.rb
+       2 files changed, 8 insertions(+), 3 deletions(-)
+    OUTPUT
+  end
+
+  describe '#call' do
+    context 'with no arguments (latest stash)' do
+      it 'calls git stash show --numstat --shortstat -M' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(numstat_output))
+
+        command.call
+      end
+
+      it 'returns DiffResult with stats' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(numstat_output))
+
+        result = command.call
+
+        expect(result).to be_a(Git::DiffResult)
+        expect(result.files_changed).to eq(2)
+        expect(result.total_insertions).to eq(8)
+        expect(result.total_deletions).to eq(3)
+        expect(result.files.size).to eq(2)
+        expect(result.dirstat).to be_nil
+      end
+
+      it 'includes per-file stats as DiffFileNumstatInfo objects' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(numstat_output))
+
+        result = command.call
+
+        expect(result.files.size).to eq(2)
+        expect(result.files[0]).to be_a(Git::DiffFileNumstatInfo)
+        expect(result.files[0].path).to eq('lib/foo.rb')
+        expect(result.files[0].src_path).to be_nil
+        expect(result.files[0].renamed?).to be false
+        expect(result.files[0].insertions).to eq(5)
+        expect(result.files[0].deletions).to eq(2)
+      end
+    end
+
+    context 'with specific stash reference' do
+      it 'passes stash reference to command' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M', 'stash@{2}')
+          .and_return(command_result(numstat_output))
+
+        command.call('stash@{2}')
+      end
+    end
+
+    context 'with :include_untracked option' do
+      it 'adds --include-untracked flag when true' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M', '--include-untracked')
+          .and_return(command_result(numstat_output))
+
+        command.call(include_untracked: true)
+      end
+
+      it 'adds --no-include-untracked flag when false' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M', '--no-include-untracked')
+          .and_return(command_result(numstat_output))
+
+        command.call(include_untracked: false)
+      end
+
+      it 'accepts :u alias' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M', '--include-untracked')
+          .and_return(command_result(numstat_output))
+
+        command.call(u: true)
+      end
+    end
+
+    context 'with :only_untracked option' do
+      it 'adds --only-untracked flag' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M', '--only-untracked')
+          .and_return(command_result(numstat_output))
+
+        command.call(only_untracked: true)
+      end
+    end
+
+    context 'with empty stash diff' do
+      it 'returns DiffResult with zero stats' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(''))
+
+        result = command.call
+
+        expect(result.files_changed).to eq(0)
+        expect(result.total_insertions).to eq(0)
+        expect(result.total_deletions).to eq(0)
+        expect(result.files).to be_empty
+      end
+    end
+
+    context 'with binary files' do
+      let(:binary_numstat) do
+        <<~OUTPUT
+          -\t-\timage.png
+           1 file changed, 0 insertions(+), 0 deletions(-)
+        OUTPUT
+      end
+
+      it 'handles binary file stats (shown as -)' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(binary_numstat))
+
+        result = command.call
+
+        expect(result.files[0].path).to eq('image.png')
+        expect(result.files[0].insertions).to eq(0)
+        expect(result.files[0].deletions).to eq(0)
+      end
+    end
+
+    context 'with quoted paths containing special characters' do
+      let(:quoted_numstat) do
+        <<~OUTPUT
+          3\t1\t"lib/path with spaces.rb"
+           1 file changed, 3 insertions(+), 1 deletion(-)
+        OUTPUT
+      end
+
+      it 'unescapes quoted paths' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(quoted_numstat))
+
+        result = command.call
+
+        expect(result.files[0].path).to eq('lib/path with spaces.rb')
+      end
+    end
+
+    context 'with renamed files' do
+      let(:simple_rename) do
+        <<~OUTPUT
+          3\t1\told_name.rb => new_name.rb
+           1 file changed, 3 insertions(+), 1 deletion(-)
+        OUTPUT
+      end
+      let(:brace_rename_dir) do
+        <<~OUTPUT
+          2\t0\t{old_dir => new_dir}/file.rb
+           1 file changed, 2 insertions(+)
+        OUTPUT
+      end
+      let(:brace_rename_file) do
+        <<~OUTPUT
+          5\t2\tlib/{old.rb => new.rb}
+           1 file changed, 5 insertions(+), 2 deletions(-)
+        OUTPUT
+      end
+
+      it 'parses simple rename format' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(simple_rename))
+
+        result = command.call
+
+        expect(result.files[0].path).to eq('new_name.rb')
+        expect(result.files[0].src_path).to eq('old_name.rb')
+        expect(result.files[0].renamed?).to be true
+        expect(result.files[0].insertions).to eq(3)
+        expect(result.files[0].deletions).to eq(1)
+      end
+
+      it 'parses brace rename format for directories' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(brace_rename_dir))
+
+        result = command.call
+
+        expect(result.files[0].path).to eq('new_dir/file.rb')
+        expect(result.files[0].src_path).to eq('old_dir/file.rb')
+        expect(result.files[0].renamed?).to be true
+      end
+
+      it 'parses brace rename format for files' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(brace_rename_file))
+
+        result = command.call
+
+        expect(result.files[0].path).to eq('lib/new.rb')
+        expect(result.files[0].src_path).to eq('lib/old.rb')
+        expect(result.files[0].renamed?).to be true
+      end
+    end
+
+    context 'with :dirstat option' do
+      let(:dirstat_output) do
+        <<~OUTPUT
+          5\t2\tlib/foo.rb
+          3\t1\tlib/bar.rb
+           2 files changed, 8 insertions(+), 3 deletions(-)
+            62.5% lib/
+        OUTPUT
+      end
+
+      it 'adds --dirstat flag when true' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M', '--dirstat')
+          .and_return(command_result(dirstat_output))
+
+        command.call(dirstat: true)
+      end
+
+      it 'passes dirstat options when string' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M', '--dirstat=lines,cumulative')
+          .and_return(command_result(dirstat_output))
+
+        command.call(dirstat: 'lines,cumulative')
+      end
+
+      it 'parses dirstat output into DirstatInfo' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--numstat', '--shortstat', '-M', '--dirstat')
+          .and_return(command_result(dirstat_output))
+
+        result = command.call(dirstat: true)
+
+        expect(result.dirstat).to be_a(Git::DirstatInfo)
+        expect(result.dirstat.size).to eq(1)
+        expect(result.dirstat['lib/']).to eq(62.5)
+        expect(result.dirstat.entries.first.directory).to eq('lib/')
+        expect(result.dirstat.entries.first.percentage).to eq(62.5)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/stash/show_patch_spec.rb
+++ b/spec/unit/git/commands/stash/show_patch_spec.rb
@@ -1,0 +1,329 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/stash/show_patch'
+
+RSpec.describe Git::Commands::Stash::ShowPatch do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  # Combined --numstat, --shortstat, and --patch output (numstat first, then shortstat, then patches)
+  let(:patch_output) do
+    <<~PATCH
+      3\t1\tlib/foo.rb
+      1\t0\tlib/bar.rb
+       2 files changed, 4 insertions(+), 1 deletion(-)
+      diff --git a/lib/foo.rb b/lib/foo.rb
+      index abc1234..def5678 100644
+      --- a/lib/foo.rb
+      +++ b/lib/foo.rb
+      @@ -1,3 +1,5 @@
+      +# New comment
+       def foo
+      -  old_code
+      +  new_code
+      +  more_code
+       end
+      diff --git a/lib/bar.rb b/lib/bar.rb
+      index 1111111..2222222 100644
+      --- a/lib/bar.rb
+      +++ b/lib/bar.rb
+      @@ -1 +1,2 @@
+       def bar
+      +  code
+       end
+    PATCH
+  end
+
+  describe '#call' do
+    context 'with no arguments (latest stash)' do
+      it 'calls git stash show --patch --numstat --shortstat' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat')
+          .and_return(command_result(patch_output))
+
+        command.call
+      end
+
+      it 'returns DiffResult' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat')
+          .and_return(command_result(patch_output))
+
+        result = command.call
+
+        expect(result).to be_a(Git::DiffResult)
+        expect(result.files.size).to eq(2)
+        expect(result.files_changed).to eq(2)
+        expect(result.total_insertions).to eq(4)
+        expect(result.total_deletions).to eq(1)
+        expect(result.dirstat).to be_nil
+      end
+
+      it 'parses DiffFilePatchInfo correctly' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat')
+          .and_return(command_result(patch_output))
+
+        result = command.call
+
+        foo_patch = result.files.find { |f| f.path == 'lib/foo.rb' }
+        expect(foo_patch).to be_a(Git::DiffFilePatchInfo)
+        expect(foo_patch.path).to eq('lib/foo.rb')
+        expect(foo_patch.src).to be_a(Git::FileRef)
+        expect(foo_patch.src.sha).to eq('abc1234')
+        expect(foo_patch.src.mode).to eq('100644')
+        expect(foo_patch.src.path).to eq('lib/foo.rb')
+        expect(foo_patch.dst).to be_a(Git::FileRef)
+        expect(foo_patch.dst.sha).to eq('def5678')
+        expect(foo_patch.dst.mode).to eq('100644')
+        expect(foo_patch.dst.path).to eq('lib/foo.rb')
+        expect(foo_patch.status).to eq(:modified)
+        expect(foo_patch.binary?).to be false
+        expect(foo_patch.insertions).to eq(3)
+        expect(foo_patch.deletions).to eq(1)
+      end
+    end
+
+    context 'with specific stash reference' do
+      it 'passes stash reference to command' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat', 'stash@{2}')
+          .and_return(command_result(patch_output))
+
+        command.call('stash@{2}')
+      end
+    end
+
+    context 'with :include_untracked option' do
+      it 'adds --include-untracked flag when true' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat', '--include-untracked')
+          .and_return(command_result(patch_output))
+
+        command.call(include_untracked: true)
+      end
+
+      it 'adds --no-include-untracked flag when false' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat', '--no-include-untracked')
+          .and_return(command_result(patch_output))
+
+        command.call(include_untracked: false)
+      end
+
+      it 'accepts :u alias' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat', '--include-untracked')
+          .and_return(command_result(patch_output))
+
+        command.call(u: true)
+      end
+    end
+
+    context 'with :only_untracked option' do
+      it 'adds --only-untracked flag' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat', '--only-untracked')
+          .and_return(command_result(patch_output))
+
+        command.call(only_untracked: true)
+      end
+    end
+
+    context 'with empty stash diff' do
+      it 'returns DiffResult with no files' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat')
+          .and_return(command_result(''))
+
+        result = command.call
+
+        expect(result.files).to be_empty
+        expect(result.files_changed).to eq(0)
+      end
+    end
+
+    context 'patch parsing' do
+      let(:new_file_patch) do
+        <<~PATCH
+          1\t0\tnew_file.rb
+           1 file changed, 1 insertion(+)
+          diff --git a/new_file.rb b/new_file.rb
+          new file mode 100644
+          index 0000000..abc1234
+          --- /dev/null
+          +++ b/new_file.rb
+          @@ -0,0 +1 @@
+          +content
+        PATCH
+      end
+
+      let(:deleted_file_patch) do
+        <<~PATCH
+          0\t1\tdeleted.rb
+           1 file changed, 1 deletion(-)
+          diff --git a/deleted.rb b/deleted.rb
+          deleted file mode 100644
+          index abc1234..0000000
+          --- a/deleted.rb
+          +++ /dev/null
+          @@ -1 +0,0 @@
+          -content
+        PATCH
+      end
+
+      let(:binary_patch) do
+        <<~PATCH
+          -\t-\timage.png
+           1 file changed, 0 insertions(+), 0 deletions(-)
+          diff --git a/image.png b/image.png
+          index abc1234..def5678 100644
+          Binary files a/image.png and b/image.png differ
+        PATCH
+      end
+
+      let(:renamed_file_patch) do
+        <<~PATCH
+          0\t0\tnew_name.rb
+           1 file changed
+          diff --git a/old_name.rb b/new_name.rb
+          similarity index 95%
+          rename from old_name.rb
+          rename to new_name.rb
+          index abc1234..def5678 100644
+        PATCH
+      end
+
+      it 'parses new file as added status with dst only' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat')
+          .and_return(command_result(new_file_patch))
+
+        result = command.call
+        patch = result.files.find { |f| f.path == 'new_file.rb' }
+
+        expect(patch.status).to eq(:added)
+        expect(patch.added?).to be true
+        expect(patch.src).to be_nil
+        expect(patch.dst).to be_a(Git::FileRef)
+        expect(patch.dst.mode).to eq('100644')
+        expect(patch.insertions).to eq(1)
+        expect(patch.deletions).to eq(0)
+      end
+
+      it 'parses deleted file as deleted status with src only' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat')
+          .and_return(command_result(deleted_file_patch))
+
+        result = command.call
+        patch = result.files.find { |f| f.path == 'deleted.rb' }
+
+        expect(patch.status).to eq(:deleted)
+        expect(patch.deleted?).to be true
+        expect(patch.src).to be_a(Git::FileRef)
+        expect(patch.src.mode).to eq('100644')
+        expect(patch.dst).to be_nil
+        expect(patch.insertions).to eq(0)
+        expect(patch.deletions).to eq(1)
+      end
+
+      it 'parses binary file indicator' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat')
+          .and_return(command_result(binary_patch))
+
+        result = command.call
+        patch = result.files.find { |f| f.path == 'image.png' }
+
+        expect(patch.binary?).to be true
+        expect(patch.insertions).to eq(0)
+        expect(patch.deletions).to eq(0)
+      end
+
+      it 'parses renamed file with similarity index' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat')
+          .and_return(command_result(renamed_file_patch))
+
+        result = command.call
+        patch = result.files.find { |f| f.path == 'new_name.rb' }
+
+        expect(patch.status).to eq(:renamed)
+        expect(patch.renamed?).to be true
+        expect(patch.similarity).to eq(95)
+        expect(patch.src).to be_a(Git::FileRef)
+        expect(patch.src.path).to eq('old_name.rb')
+        expect(patch.dst).to be_a(Git::FileRef)
+        expect(patch.dst.path).to eq('new_name.rb')
+      end
+    end
+
+    context 'result totals from shortstat' do
+      it 'gets total_insertions from shortstat' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat')
+          .and_return(command_result(patch_output))
+
+        result = command.call
+
+        expect(result.total_insertions).to eq(4)
+      end
+
+      it 'gets total_deletions from shortstat' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat')
+          .and_return(command_result(patch_output))
+
+        result = command.call
+
+        expect(result.total_deletions).to eq(1)
+      end
+    end
+
+    context 'with :dirstat option' do
+      let(:dirstat_output) do
+        <<~PATCH
+          3\t1\tlib/foo.rb
+          1\t0\tlib/bar.rb
+           2 files changed, 4 insertions(+), 1 deletion(-)
+           100.0% lib/
+          diff --git a/lib/foo.rb b/lib/foo.rb
+          index abc1234..def5678 100644
+          --- a/lib/foo.rb
+          +++ b/lib/foo.rb
+          @@ -1 +1,2 @@
+          +code
+        PATCH
+      end
+
+      it 'adds --dirstat flag when true' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat', '--dirstat')
+          .and_return(command_result(dirstat_output))
+
+        command.call(dirstat: true)
+      end
+
+      it 'passes dirstat options when string' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat', '--dirstat=lines,cumulative')
+          .and_return(command_result(dirstat_output))
+
+        command.call(dirstat: 'lines,cumulative')
+      end
+
+      it 'parses dirstat output into DirstatInfo' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--patch', '--numstat', '--shortstat', '--dirstat')
+          .and_return(command_result(dirstat_output))
+
+        result = command.call(dirstat: true)
+
+        expect(result.dirstat).to be_a(Git::DirstatInfo)
+        expect(result.dirstat['lib/']).to eq(100.0)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/stash/show_raw_spec.rb
+++ b/spec/unit/git/commands/stash/show_raw_spec.rb
@@ -1,0 +1,323 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/stash/show_raw'
+
+RSpec.describe Git::Commands::Stash::ShowRaw do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  # Sample combined --raw, --numstat, and --shortstat output with rename detection
+  let(:raw_output) do
+    <<~OUTPUT
+      :100644 100644 abc1234 def5678 M\tlib/foo.rb
+      :000000 100644 0000000 1234567 A\tlib/bar.rb
+      5\t2\tlib/foo.rb
+      10\t0\tlib/bar.rb
+       2 files changed, 15 insertions(+), 2 deletions(-)
+    OUTPUT
+  end
+
+  let(:raw_output_with_rename) do
+    <<~OUTPUT
+      :100644 100644 abc1234 def5678 R075\told_name.rb\tnew_name.rb
+      :000000 100644 0000000 1234567 A\tlib/bar.rb
+      3\t1\tnew_name.rb
+      10\t0\tlib/bar.rb
+       2 files changed, 13 insertions(+), 1 deletion(-)
+    OUTPUT
+  end
+
+  describe '#call' do
+    context 'with no arguments (latest stash)' do
+      it 'calls git stash show --raw --numstat --shortstat -M' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(raw_output))
+
+        command.call
+      end
+
+      it 'returns DiffResult' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(raw_output))
+
+        result = command.call
+
+        expect(result).to be_a(Git::DiffResult)
+        expect(result.files.size).to eq(2)
+        expect(result.files_changed).to eq(2)
+        expect(result.total_insertions).to eq(15)
+        expect(result.total_deletions).to eq(2)
+        expect(result.dirstat).to be_nil
+      end
+
+      it 'parses file status correctly' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(raw_output))
+
+        result = command.call
+
+        expect(result.files[0]).to be_a(Git::DiffFileRawInfo)
+        expect(result.files[0].path).to eq('lib/foo.rb')
+        expect(result.files[0].status).to eq(:modified)
+        expect(result.files[0].insertions).to eq(5)
+        expect(result.files[0].deletions).to eq(2)
+        expect(result.files[0].src).to be_a(Git::FileRef)
+        expect(result.files[0].src.mode).to eq('100644')
+        expect(result.files[0].src.sha).to eq('abc1234')
+        expect(result.files[0].src.path).to eq('lib/foo.rb')
+        expect(result.files[0].dst).to be_a(Git::FileRef)
+        expect(result.files[0].dst.mode).to eq('100644')
+        expect(result.files[0].dst.sha).to eq('def5678')
+        expect(result.files[0].dst.path).to eq('lib/foo.rb')
+        expect(result.files[0].similarity).to be_nil
+      end
+
+      it 'parses added files correctly with nil src' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(raw_output))
+
+        result = command.call
+
+        added_file = result.files.find { |f| f.status == :added }
+        expect(added_file.path).to eq('lib/bar.rb')
+        expect(added_file.src).to be_nil
+        expect(added_file.dst).to be_a(Git::FileRef)
+        expect(added_file.dst.sha).to eq('1234567')
+        expect(added_file.insertions).to eq(10)
+        expect(added_file.deletions).to eq(0)
+      end
+    end
+
+    context 'with renamed files' do
+      it 'parses renames with similarity percentage' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(raw_output_with_rename))
+
+        result = command.call
+
+        renamed = result.files.find { |f| f.status == :renamed }
+        expect(renamed.path).to eq('new_name.rb')
+        expect(renamed.src_path).to eq('old_name.rb')
+        expect(renamed.similarity).to eq(75)
+        expect(renamed.insertions).to eq(3)
+        expect(renamed.deletions).to eq(1)
+      end
+    end
+
+    context 'with specific stash reference' do
+      it 'passes stash reference to command' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', 'stash@{2}')
+          .and_return(command_result(raw_output))
+
+        command.call('stash@{2}')
+      end
+    end
+
+    context 'with :include_untracked option' do
+      it 'adds --include-untracked flag when true' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '--include-untracked')
+          .and_return(command_result(raw_output))
+
+        command.call(include_untracked: true)
+      end
+
+      it 'adds --no-include-untracked flag when false' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '--no-include-untracked')
+          .and_return(command_result(raw_output))
+
+        command.call(include_untracked: false)
+      end
+    end
+
+    context 'with :only_untracked option' do
+      it 'adds --only-untracked flag' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '--only-untracked')
+          .and_return(command_result(raw_output))
+
+        command.call(only_untracked: true)
+      end
+    end
+
+    context 'with :find_copies option' do
+      it 'adds -C flag when true' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '-C')
+          .and_return(command_result(raw_output))
+
+        command.call(find_copies: true)
+      end
+    end
+
+    context 'with empty stash diff' do
+      it 'returns DiffResult with no files' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(''))
+
+        result = command.call
+
+        expect(result.files).to be_empty
+        expect(result.files_changed).to eq(0)
+      end
+    end
+
+    context 'with all status types' do
+      let(:all_statuses_output) do
+        <<~OUTPUT
+          :100644 100644 abc1234 def5678 M\tmodified.rb
+          :000000 100644 0000000 1234567 A\tadded.rb
+          :100644 000000 abc1234 0000000 D\tdeleted.rb
+          :100644 100644 abc1234 def5678 R090\told.rb\trenamed.rb
+          :100644 100644 abc1234 def5678 C080\tsource.rb\tcopied.rb
+          :100644 120000 abc1234 def5678 T\ttype_changed.rb
+          5\t2\tmodified.rb
+          10\t0\tadded.rb
+          0\t5\tdeleted.rb
+          2\t1\trenamed.rb
+          8\t0\tcopied.rb
+          0\t0\ttype_changed.rb
+           6 files changed, 25 insertions(+), 8 deletions(-)
+        OUTPUT
+      end
+
+      it 'parses all status types correctly' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(all_statuses_output))
+
+        result = command.call
+
+        statuses = result.files.map(&:status)
+        expect(statuses).to include(:modified, :added, :deleted, :renamed, :copied, :type_changed)
+      end
+
+      it 'parses deleted files with src only and nil dst' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(all_statuses_output))
+
+        result = command.call
+
+        deleted_file = result.files.find { |f| f.status == :deleted }
+        expect(deleted_file.path).to eq('deleted.rb')
+        expect(deleted_file.src).to be_a(Git::FileRef)
+        expect(deleted_file.src.mode).to eq('100644')
+        expect(deleted_file.src.sha).to eq('abc1234')
+        expect(deleted_file.dst).to be_nil
+        expect(deleted_file.deletions).to eq(5)
+      end
+
+      it 'parses renamed files with different src and dst paths' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(all_statuses_output))
+
+        result = command.call
+
+        renamed_file = result.files.find { |f| f.status == :renamed }
+        expect(renamed_file.path).to eq('renamed.rb')
+        expect(renamed_file.src).to be_a(Git::FileRef)
+        expect(renamed_file.src.path).to eq('old.rb')
+        expect(renamed_file.dst).to be_a(Git::FileRef)
+        expect(renamed_file.dst.path).to eq('renamed.rb')
+        expect(renamed_file.similarity).to eq(90)
+      end
+    end
+
+    context 'with binary files' do
+      let(:binary_output) do
+        <<~OUTPUT
+          :100644 100644 abc1234 def5678 M\timage.png
+          -\t-\timage.png
+           1 file changed, 0 insertions(+), 0 deletions(-)
+        OUTPUT
+      end
+
+      it 'detects binary files from numstat output' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(binary_output))
+
+        result = command.call
+
+        file = result.files.first
+        expect(file.path).to eq('image.png')
+        expect(file.binary?).to be true
+        expect(file.insertions).to eq(0)
+        expect(file.deletions).to eq(0)
+      end
+    end
+
+    context 'result totals from shortstat' do
+      it 'gets total_insertions from shortstat' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(raw_output))
+
+        result = command.call
+
+        expect(result.total_insertions).to eq(15)
+      end
+
+      it 'gets total_deletions from shortstat' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M')
+          .and_return(command_result(raw_output))
+
+        result = command.call
+
+        expect(result.total_deletions).to eq(2)
+      end
+    end
+
+    context 'with :dirstat option' do
+      let(:dirstat_output) do
+        <<~OUTPUT
+          :100644 100644 abc1234 def5678 M\tlib/foo.rb
+          :000000 100644 0000000 1234567 A\tlib/bar.rb
+          5\t2\tlib/foo.rb
+          10\t0\tlib/bar.rb
+           2 files changed, 15 insertions(+), 2 deletions(-)
+           100.0% lib/
+        OUTPUT
+      end
+
+      it 'adds --dirstat flag when true' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '--dirstat')
+          .and_return(command_result(dirstat_output))
+
+        command.call(dirstat: true)
+      end
+
+      it 'passes dirstat options when string' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '--dirstat=files')
+          .and_return(command_result(dirstat_output))
+
+        command.call(dirstat: 'files')
+      end
+
+      it 'parses dirstat output into DirstatInfo' do
+        allow(execution_context).to receive(:command)
+          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '--dirstat')
+          .and_return(command_result(dirstat_output))
+
+        result = command.call(dirstat: true)
+
+        expect(result.dirstat).to be_a(Git::DirstatInfo)
+        expect(result.dirstat['lib/']).to eq(100.0)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/stash/store_spec.rb
+++ b/spec/unit/git/commands/stash/store_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/stash/store'
+
+RSpec.describe Git::Commands::Stash::Store do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with commit SHA only' do
+      it 'calls git stash store with commit' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'store', 'abc123def456789')
+          .and_return(command_result(''))
+
+        command.call('abc123def456789')
+      end
+
+      it 'returns the command result' do
+        result = command_result('')
+        allow(execution_context).to receive(:command)
+          .with('stash', 'store', 'abc123def456789')
+          .and_return(result)
+
+        expect(command.call('abc123def456789')).to eq(result)
+      end
+    end
+
+    context 'with :message option' do
+      it 'adds --message flag with value' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'store', '--message=WIP: my changes', 'abc123')
+          .and_return(command_result(''))
+
+        command.call('abc123', message: 'WIP: my changes')
+      end
+
+      it 'accepts :m alias' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'store', '--message=WIP', 'abc123')
+          .and_return(command_result(''))
+
+        command.call('abc123', m: 'WIP')
+      end
+
+      it 'handles message with special characters' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'store', '--message=Fix "bug" in code', 'abc123')
+          .and_return(command_result(''))
+
+        command.call('abc123', message: 'Fix "bug" in code')
+      end
+
+      it 'handles message with spaces' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'store', '--message=work in progress', 'abc123')
+          .and_return(command_result(''))
+
+        command.call('abc123', message: 'work in progress')
+      end
+    end
+
+    context 'with :quiet option' do
+      it 'adds --quiet flag when true' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'store', '--quiet', 'abc123')
+          .and_return(command_result(''))
+
+        command.call('abc123', quiet: true)
+      end
+
+      it 'accepts :q alias' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'store', '--quiet', 'abc123')
+          .and_return(command_result(''))
+
+        command.call('abc123', q: true)
+      end
+
+      it 'does not add flag when false' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'store', 'abc123')
+          .and_return(command_result(''))
+
+        command.call('abc123', quiet: false)
+      end
+    end
+
+    context 'with combined options' do
+      it 'combines message and quiet flags' do
+        expect(execution_context).to receive(:command)
+          .with('stash', 'store', '--message=WIP', '--quiet', 'abc123')
+          .and_return(command_result(''))
+
+        command.call('abc123', message: 'WIP', quiet: true)
+      end
+    end
+
+    context 'with full SHA' do
+      it 'handles 40-character SHA' do
+        sha = 'a' * 40
+        expect(execution_context).to receive(:command)
+          .with('stash', 'store', sha)
+          .and_return(command_result(''))
+
+        command.call(sha)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Completes Phase 2 migration of stash commands to the new `Git::Commands` architecture by implementing the remaining 6 stash commands.

## Changes

### New Command Classes

- **Git::Commands::Stash::Branch** - Create branch from stash entry
- **Git::Commands::Stash::Create** - Plumbing command to create stash commit without storing
- **Git::Commands::Stash::Store** - Plumbing command to store stash commit in reflog
- **Git::Commands::Stash::ShowNumstat** - Show stash with numstat format
- **Git::Commands::Stash::ShowPatch** - Show stash with full patch output
- **Git::Commands::Stash::ShowRaw** - Show stash with raw diff format

### Test Coverage

**Unit Tests (158+ examples)**
- Comprehensive coverage for all commands
- Edge cases: nil parameters, empty output, special characters
- Parsing validation: renames, binary files, dirstat, quoted paths

**Integration Tests (66+ examples)**
- End-to-end validation with real git repositories
- Push options: `keep_index`, `staged`, `include_untracked`, pathspecs
- Pop/Apply `--index` option for restoring staged state
- Clear, Drop, and Create+Store workflows
- Show commands with untracked files
- Branch creation with error scenarios

### Backward Compatibility

Changes maintain backward compatibility with existing `Git::Lib` methods:
- `stash_save` - continues to return boolean
- `stash_apply` - returns stash name string
- `stash_pop`, `stash_drop` - now return `Git::StashInfo` objects (previously returned raw strings)

Error handling improved:
- Pre-validates stash existence before operations
- Raises clear `Git::UnexpectedResultError` when stash not found

## Testing

All tests pass:
```bash
bundle exec rake spec:unit    # 158+ examples, 0 failures
bundle exec rake spec:integration  # 66+ examples, 0 failures
bundle exec rubocop           # No offenses
```

## Documentation

- Full YARD documentation for all commands with examples
- Consistent `@overload` signatures using `**options`
- Properly escaped stash references in examples (`stash@\\{0}`)

## Related

Part of the v5.0.0 redesign (Phase 2). Updates [redesign/3_architecture_implementation.md](https://github.com/ruby-git/ruby-git/blob/main/redesign/3_architecture_implementation.md) checklist.