### PR TITLE
refactor(arguments): consolidate DSL with orthogonal modifiers

### DIFF
--- a/lib/git/commands/branch/create.rb
+++ b/lib/git/commands/branch/create.rb
@@ -43,7 +43,7 @@ module Git
           flag :force
           flag :create_reflog
           flag :recurse_submodules
-          negatable_flag_or_inline_value :track
+          flag_or_value :track, negatable: true, inline: true
           positional :branch_name, required: true
           positional :start_point
         end.freeze

--- a/lib/git/commands/branch/list.rb
+++ b/lib/git/commands/branch/list.rb
@@ -56,10 +56,10 @@ module Git
         ARGS = Arguments.define do
           static 'branch'
           static '--list'
-          inline_value :format
+          value :format, inline: true
           flag :all, args: '-a'
           flag :remotes, args: '-r'
-          inline_value :sort, multi_valued: true
+          value :sort, inline: true, multi_valued: true
           value :contains
           value :no_contains
           value :merged

--- a/lib/git/commands/branch/set_upstream.rb
+++ b/lib/git/commands/branch/set_upstream.rb
@@ -31,7 +31,7 @@ module Git
         #
         ARGS = Arguments.define do
           static 'branch'
-          inline_value :set_upstream_to, required: true, allow_nil: false
+          value :set_upstream_to, inline: true, required: true, allow_nil: false
           positional :branch_name
         end.freeze
 

--- a/lib/git/commands/checkout/branch.rb
+++ b/lib/git/commands/checkout/branch.rb
@@ -44,18 +44,18 @@ module Git
           flag %i[detach d], args: '--detach'
 
           # Branch creation options (mutually exclusive)
-          # These use `value` (not `inline_value`) because git expects: -b <branch>, not -b=<branch>
+          # These use `value` (not `value :name, inline: true`) because git expects: -b <branch>, not -b=<branch>
           value %i[new_branch b], args: '-b'
           value %i[new_branch_force B], args: '-B'
           value :orphan, args: '--orphan'
 
           # Tracking options
-          negatable_flag_or_inline_value :track
+          flag_or_value :track, negatable: true, inline: true
 
           # Other options
-          negatable_flag :guess
+          flag :guess, negatable: true
           flag :ignore_other_worktrees, args: '--ignore-other-worktrees'
-          negatable_flag :recurse_submodules
+          flag :recurse_submodules, negatable: true
 
           # Positional arguments
           positional :branch

--- a/lib/git/commands/checkout/files.rb
+++ b/lib/git/commands/checkout/files.rb
@@ -46,9 +46,9 @@ module Git
           flag :ours, args: '--ours'
           flag :theirs, args: '--theirs'
           flag %i[merge m], args: '--merge'
-          inline_value :conflict, args: '--conflict'
-          negatable_flag :overlay
-          inline_value :pathspec_from_file, args: '--pathspec-from-file'
+          value :conflict, inline: true, args: '--conflict'
+          flag :overlay, negatable: true
+          value :pathspec_from_file, inline: true, args: '--pathspec-from-file'
           flag :pathspec_file_nul, args: '--pathspec-file-nul'
 
           positional :tree_ish, required: true, allow_nil: true

--- a/lib/git/commands/clone.rb
+++ b/lib/git/commands/clone.rb
@@ -30,7 +30,7 @@ module Git
         value :filter
         value %i[origin remote]
         value :config, multi_valued: true
-        negatable_flag :single_branch, validator: ->(v) { [nil, true, false].include?(v) }
+        flag :single_branch, negatable: true, validator: ->(v) { [nil, true, false].include?(v) }
         custom(:depth) { |v| ['--depth', v.to_i] }
         # Options handled by the command itself, not passed to git
         metadata :path

--- a/lib/git/commands/commit.rb
+++ b/lib/git/commands/commit.rb
@@ -38,11 +38,11 @@ module Git
         flag :allow_empty
         flag :no_verify
         flag :allow_empty_message
-        inline_value :author
-        inline_value :message, allow_empty: true
-        inline_value :date, type: String
+        value :author, inline: true
+        value :message, inline: true, allow_empty: true
+        value :date, inline: true, type: String
         flag :amend, args: ['--amend', '--no-edit']
-        negatable_flag_or_inline_value :gpg_sign
+        flag_or_value :gpg_sign, negatable: true, inline: true
       end.freeze
 
       # Initialize the Commit command

--- a/lib/git/commands/diff/numstat.rb
+++ b/lib/git/commands/diff/numstat.rb
@@ -26,10 +26,10 @@ module Git
           flag %i[cached staged]
           flag :merge_base
           flag :no_index
-          flag_or_inline_value :dirstat
+          flag_or_value :dirstat, inline: true
           positional :commit1
           positional :commit2
-          value_to_positional :pathspecs, separator: '--', multi_valued: true
+          value :pathspecs, positional: true, separator: '--', multi_valued: true
         end.freeze
 
         # Creates a new Numstat command instance

--- a/lib/git/commands/diff/patch.rb
+++ b/lib/git/commands/diff/patch.rb
@@ -28,10 +28,10 @@ module Git
           flag :merge_base
           flag :no_index
           flag :find_copies, args: '-C'
-          flag_or_inline_value :dirstat
+          flag_or_value :dirstat, inline: true
           positional :commit1
           positional :commit2
-          value_to_positional :pathspecs, separator: '--', multi_valued: true
+          value :pathspecs, positional: true, separator: '--', multi_valued: true
         end.freeze
 
         # Creates a new Patch command instance

--- a/lib/git/commands/diff/raw.rb
+++ b/lib/git/commands/diff/raw.rb
@@ -27,10 +27,10 @@ module Git
           flag :merge_base
           flag :no_index
           flag :find_copies, args: '-C'
-          flag_or_inline_value :dirstat
+          flag_or_value :dirstat, inline: true
           positional :commit1
           positional :commit2
-          value_to_positional :pathspecs, separator: '--', multi_valued: true
+          value :pathspecs, positional: true, separator: '--', multi_valued: true
         end.freeze
 
         # Creates a new Raw command instance

--- a/lib/git/commands/fsck.rb
+++ b/lib/git/commands/fsck.rb
@@ -38,10 +38,10 @@ module Git
         flag :cache
         flag :no_reflogs
         flag :lost_found
-        negatable_flag :dangling
-        negatable_flag :full
-        negatable_flag :name_objects
-        negatable_flag :references
+        flag :dangling, negatable: true
+        flag :full, negatable: true
+        flag :name_objects, negatable: true
+        flag :references, negatable: true
         positional :objects, variadic: true
       end.freeze
 

--- a/lib/git/commands/init.rb
+++ b/lib/git/commands/init.rb
@@ -27,8 +27,8 @@ module Git
       ARGS = Arguments.define do
         static 'init'
         flag :bare
-        inline_value :initial_branch
-        inline_value :repository, args: '--separate-git-dir'
+        value :initial_branch, inline: true
+        value :repository, inline: true, args: '--separate-git-dir'
         positional :directory, default: '.'
       end.freeze
 

--- a/lib/git/commands/merge/start.rb
+++ b/lib/git/commands/merge/start.rb
@@ -42,35 +42,35 @@ module Git
           static '--no-edit'
 
           # Commit behavior
-          negatable_flag :commit
+          flag :commit, negatable: true
           flag :squash, args: '--squash'
 
           # Fast-forward behavior
-          negatable_flag :ff
+          flag :ff, negatable: true
           flag :ff_only, args: '--ff-only'
 
           # Message options
           value %i[message m], args: '-m'
           value %i[file F], args: '-F'
-          inline_value :into_name, args: '--into-name'
+          value :into_name, inline: true, args: '--into-name'
 
           # Strategy options
           value %i[strategy s], args: '-s'
           value %i[strategy_option X], args: '-X', multi_valued: true
 
           # Verification
-          negatable_flag :verify
-          negatable_flag :verify_signatures
-          negatable_flag :gpg_sign
+          flag :verify, negatable: true
+          flag :verify_signatures, negatable: true
+          flag :gpg_sign, negatable: true
 
           # History
-          negatable_flag :allow_unrelated_histories
-          negatable_flag :rerere_autoupdate
+          flag :allow_unrelated_histories, negatable: true
+          flag :rerere_autoupdate, negatable: true
 
           # Other
-          negatable_flag :autostash
-          negatable_flag :signoff
-          negatable_flag :log
+          flag :autostash, negatable: true
+          flag :signoff, negatable: true
+          flag :log, negatable: true
 
           # Positional: commits to merge (variadic, required)
           positional :commits, variadic: true, required: true

--- a/lib/git/commands/stash/push.rb
+++ b/lib/git/commands/stash/push.rb
@@ -34,11 +34,11 @@ module Git
           static 'push'
           flag %i[patch p]
           flag %i[staged S]
-          negatable_flag %i[keep_index k]
+          flag %i[keep_index k], negatable: true
           flag %i[include_untracked u]
           flag %i[all a]
-          inline_value %i[message m]
-          inline_value :pathspec_from_file
+          value %i[message m], inline: true
+          value :pathspec_from_file, inline: true
           flag :pathspec_file_nul
           positional :pathspecs, variadic: true, separator: '--'
         end.freeze

--- a/lib/git/commands/stash/show_numstat.rb
+++ b/lib/git/commands/stash/show_numstat.rb
@@ -30,9 +30,9 @@ module Git
           static '--numstat'
           static '--shortstat'
           static '-M'
-          negatable_flag %i[include_untracked u]
+          flag %i[include_untracked u], negatable: true
           flag :only_untracked
-          flag_or_inline_value :dirstat
+          flag_or_value :dirstat, inline: true
           positional :stash
         end.freeze
 

--- a/lib/git/commands/stash/show_patch.rb
+++ b/lib/git/commands/stash/show_patch.rb
@@ -33,9 +33,9 @@ module Git
           static '--patch'
           static '--numstat'
           static '--shortstat'
-          negatable_flag %i[include_untracked u]
+          flag %i[include_untracked u], negatable: true
           flag :only_untracked
-          flag_or_inline_value :dirstat
+          flag_or_value :dirstat, inline: true
           positional :stash
         end.freeze
 

--- a/lib/git/commands/stash/show_raw.rb
+++ b/lib/git/commands/stash/show_raw.rb
@@ -34,10 +34,10 @@ module Git
           static '--numstat'
           static '--shortstat'
           static '-M'
-          negatable_flag %i[include_untracked u]
+          flag %i[include_untracked u], negatable: true
           flag :only_untracked
           flag :find_copies, args: '-C'
-          flag_or_inline_value :dirstat
+          flag_or_value :dirstat, inline: true
           positional :stash
         end.freeze
 

--- a/lib/git/commands/stash/store.rb
+++ b/lib/git/commands/stash/store.rb
@@ -30,7 +30,7 @@ module Git
         ARGS = Arguments.define do
           static 'stash'
           static 'store'
-          inline_value %i[message m]
+          value %i[message m], inline: true
           flag %i[quiet q]
           positional :commit, required: true
         end.freeze

--- a/lib/git/commands/tag/create.rb
+++ b/lib/git/commands/tag/create.rb
@@ -42,11 +42,11 @@ module Git
           flag %i[annotate a], args: '-a'
           flag %i[sign s], args: '-s'
           flag :no_sign
-          inline_value %i[local_user u]
+          value %i[local_user u], inline: true
           flag %i[force f], args: '-f'
           flag :create_reflog
-          inline_value %i[message m]
-          inline_value %i[file F]
+          value %i[message m], inline: true
+          value %i[file F], inline: true
           positional :tag_name, required: true
           positional :commit
         end.freeze

--- a/lib/git/commands/tag/list.rb
+++ b/lib/git/commands/tag/list.rb
@@ -72,7 +72,7 @@ module Git
           static 'tag'
           static '--list'
           static "--format=#{FORMAT_STRING}"
-          inline_value :sort, multi_valued: true
+          value :sort, inline: true, multi_valued: true
           value :contains
           value :no_contains
           value :merged


### PR DESCRIPTION
Closes #982

## Description

Consolidates the `Git::Commands::Arguments` DSL from 7 distinct option type methods into 3 base types with orthogonal modifier flags. This simplifies the API, reduces code duplication, and enables the new `flag_or_value` combination (without `inline: true`).

### API Changes

| Old Method | New Equivalent |
|------------|----------------|
| `flag :force` | `flag :force` (unchanged) |
| `negatable_flag :sign` | `flag :sign, negatable: true` |
| `value :branch` | `value :branch` (unchanged) |
| `inline_value :format` | `value :format, inline: true` |
| `value_to_positional :paths` | `value :paths, positional: true` |
| `flag_or_inline_value :gpg_sign` | `flag_or_value :gpg_sign, inline: true` |
| `negatable_flag_or_inline_value :sign` | `flag_or_value :sign, negatable: true, inline: true` |

### New Capability

The new `flag_or_value` base type enables combinations that were previously impossible:

```ruby
# New: flag_or_value without inline produces separate args
flag_or_value :contains  # --contains (flag) OR --contains abc123 (separate args)

# With inline: true (previous flag_or_inline_value behavior)  
flag_or_value :contains, inline: true  # --contains OR --contains=abc123
```

### Implementation Notes

- **Removed deprecated methods** instead of deprecating them, since the DSL is `@api private` and only used internally
- Added validation helpers (`validate_value_modifiers!`, `determine_value_option_type`, `determine_flag_or_value_option_type`)
- Added `flag_or_value` and `negatable_flag_or_value` builders to BUILDERS hash
- Internal option type names preserved (`:negatable_flag`, `:inline_value`, etc.) for backward compatibility in error messages and internal logic
- Migrated all command files to use the new API

### Files Changed

- `lib/git/commands/arguments.rb` - Consolidated DSL implementation
- `spec/unit/git/commands/arguments_spec.rb` - Updated tests (311 examples)
- All command files in `lib/git/commands/*/` - Migrated to new syntax

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).