### PR TITLE
refactor: rename Arguments DSL methods to use CLI terminology

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2243,7 +2243,8 @@ classes using a "Strangler Fig" pattern.
        class <CommandName>
          ARGS = Arguments.define do
            # Define arguments using the DSL
-           # For variadic positional: positional :paths, variadic: true
+           # For repeatable operand:
+           operand :paths, repeatable: true
          end.freeze
 
          def initialize(execution_context)
@@ -2262,7 +2263,7 @@ classes using a "Strangler Fig" pattern.
    **Method Signature Convention:**
    - **SHOULD** use anonymous `def call(*, **)` and splat `ARGS.bind(*, **)` directly
    - **MAY** assign `bound_args = ARGS.bind(*, **)` when you need to access argument values (e.g., `bound_args.dirstat`)
-   - Note: defaults defined in the DSL (e.g., `positional :paths, default: ['.']`) are applied automatically by `ARGS.bind`
+   - Note: defaults defined in the DSL (e.g., `operand :paths, default: ['.']`) are applied automatically by `ARGS.bind`
 
    **Return Value Convention:**
    - `#call` **SHOULD** return `Git::CommandLineResult` by default

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -417,9 +417,9 @@ module Git
     class Add
       # Define arguments using the Arguments DSL
       ARGS = Arguments.define do
-        flag :all
-        flag :force
-        positional :paths, variadic: true, default: ['.'], separator: '--'
+        flag_option :all
+        flag_option :force
+        operand :paths, repeatable: true, default: ['.'], separator: '--'
       end
 
       def initialize(execution_context)
@@ -447,7 +447,7 @@ end
 ```
 
 **Method Signature Convention**: The `#call` signature SHOULD, if possible, use
-anonymous variadic arguments for both positional and keyword arguments:
+anonymous repeatable arguments for both positional and keyword arguments:
 
 ```ruby
 def call(*, **)
@@ -457,7 +457,7 @@ end
 
 The `#call` method MAY assign `bound_args = ARGS.bind(*, **)` when you need to
 access argument values (e.g., `bound_args.dirstat`). Note that default values
-defined in the DSL (e.g., `positional :paths, default: ['.']`) are applied
+defined in the DSL (e.g., `operand :paths, default: ['.']`) are applied
 automatically by `ARGS.bind`, so manual default checking is usually unnecessary.
 
 Specific arguments MAY be extracted when the command needs to inspect or manipulate

--- a/redesign/2_architecture_redesign.md
+++ b/redesign/2_architecture_redesign.md
@@ -263,10 +263,10 @@ into three distinct layers: a Facade, an Execution Context, and Command Objects.
       flag :force                    # --force when true
       flag :all                      # --all when true
       value :branch                  # --branch <value>
-      value :config, multi_valued: true  # --config <v1> --config <v2>
+      value :config, repeatable: true  # --config <v1> --config <v2>
       flag :single_branch, negatable: true  # --single-branch / --no-single-branch
       custom(:depth) { |v| ['--depth', v.to_i] }
-      positional :paths, variadic: true, separator: '--'
+      positional :paths, repeatable: true, separator: '--'
     end
     ```
 
@@ -274,7 +274,7 @@ into three distinct layers: a Facade, an Execution Context, and Command Objects.
     `custom`, `metadata`) and positional arguments, each with various modifiers. See
     [Git::Commands::Arguments](../lib/git/commands/arguments.rb) for full documentation.
 
-    **Interface Convention**: The `#call` signature SHOULD use anonymous variadic
+    **Interface Convention**: The `#call` signature SHOULD use anonymous repeatable
     arguments when possible. Arguments MAY be named when needed to inspect or manipulate
     them. Note that defaults defined in the DSL (e.g., `positional :paths, default: ['.']`)
     are applied automatically by `ARGS.bind`, so manual default checking is usually

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -59,11 +59,11 @@ risk and allows for a gradual, controlled migration to the new architecture.
    ```ruby
    # Execute the git example command
    #
-   # @overload call(positional_arg, *variadic_args, **options)
+   # @overload call(operand_arg, *repeatable_args, **options)
    #
-   #   @param positional_arg [String] Description of the positional argument
+   #   @param operand_arg [String] Description of the operand (positional argument)
    #
-   #   @param variadic_args [Array<String>] Description of variadic arguments
+   #   @param repeatable_args [Array<String>] Description of repeatable arguments
    #
    #   @param options [Hash] command options
    #
@@ -294,7 +294,7 @@ easier testing. Allow the public API to diverge when it adds real value, but wit
 obscuring what's actually happening underneath.
 
 **Method Signature Convention**: The `#call` signature SHOULD, if possible, use
-anonymous variadic arguments for both positional and keyword arguments:
+anonymous repeatable arguments for both positional and keyword arguments:
 
 ```ruby
 # ✅ Preferred: anonymous forwarding with ARGS.bind
@@ -446,7 +446,7 @@ future work:
      flag :force
      positional :tree_ish
      static '--'
-     positional :paths, variadic: true
+     positional :paths, repeatable: true
    end
    # build('HEAD', 'file.txt', force: true) => ['--force', 'HEAD', '--', 'file.txt']
 
@@ -454,7 +454,7 @@ future work:
    ARGS = Arguments.define do
      static '--delete'
      flag %i[force f], args: '--force'
-     positional :branch_names, variadic: true, required: true
+     positional :branch_names, repeatable: true, required: true
    end
    # build('feature', force: true) => ['--delete', '--force', 'feature']
    ```
@@ -473,15 +473,15 @@ future work:
    The first symbol becomes the primary name used in documentation and error
    messages; subsequent symbols are aliases.
 
-10. **Consider variadic support in adapter methods when command supports it**
+10. **Consider repeatable support in adapter methods when command supports it**
 
-    When a command class supports variadic positional arguments (e.g., deleting
+    When a command class supports repeatable positional arguments (e.g., deleting
     multiple branches), consider whether the `Git::Lib` adapter should expose this
     capability:
 
     ```ruby
     # Command class supports multiple branches
-    def call(*, **)  # variadic positional
+    def call(*, **)  # repeatable positional
       @execution_context.command('branch', *ARGS.bind(*, **))
     end
 
@@ -490,7 +490,7 @@ future work:
       Git::Commands::Branch::Delete.new(self).call(branch, **options)
     end
 
-    # ✅ Adapter exposes variadic capability
+    # ✅ Adapter exposes repeatable capability
     def branch_delete(*branches, **options)
       options = { force: true }.merge(options)
       Git::Commands::Branch::Delete.new(self).call(*branches, **options)
@@ -600,7 +600,7 @@ future work:
     ```ruby
     ARGS = Arguments.define do
       positional :tree_ish, required: true, allow_nil: true
-      positional :paths, variadic: true, separator: '--'
+      positional :paths, repeatable: true, separator: '--'
     end
 
     # Restore from index (tree_ish intentionally nil)

--- a/spec/unit/git/commands/arguments_spec.rb
+++ b/spec/unit/git/commands/arguments_spec.rb
@@ -563,7 +563,7 @@ RSpec.describe Git::Commands::Arguments do
             end
           end.to raise_error(
             ArgumentError,
-            /only one variadic positional is allowed.*:sources is already variadic.*cannot add :paths/
+            /only one repeatable operand is allowed.*:sources is already repeatable.*cannot add :paths/
           )
         end
       end
@@ -1065,7 +1065,7 @@ RSpec.describe Git::Commands::Arguments do
           it 'rejects nil mixed within variadic values' do
             expect { args.bind('first', 'a', nil, 'b') }.to raise_error(
               ArgumentError,
-              /nil values are not allowed in variadic positional argument: rest/
+              /nil values are not allowed in repeatable positional argument: rest/
             )
           end
         end
@@ -1081,7 +1081,7 @@ RSpec.describe Git::Commands::Arguments do
           it 'rejects nil within variadic' do
             expect { args.bind('s1', nil, 's2', 'dest') }.to raise_error(
               ArgumentError,
-              /nil values are not allowed in variadic positional argument: sources/
+              /nil values are not allowed in repeatable positional argument: sources/
             )
           end
         end
@@ -1206,13 +1206,13 @@ RSpec.describe Git::Commands::Arguments do
 
       it 'rejects nil values with clear ArgumentError' do
         expect { args.bind('file1.rb', nil, 'file2.rb') }.to(
-          raise_error(ArgumentError, /nil values are not allowed in variadic positional argument: paths/)
+          raise_error(ArgumentError, /nil values are not allowed in repeatable positional argument: paths/)
         )
       end
 
       it 'rejects array containing nil values' do
         expect { args.bind(['file1.rb', nil, 'file2.rb']) }.to(
-          raise_error(ArgumentError, /nil values are not allowed in variadic positional argument: paths/)
+          raise_error(ArgumentError, /nil values are not allowed in repeatable positional argument: paths/)
         )
       end
 
@@ -2276,7 +2276,7 @@ RSpec.describe Git::Commands::Arguments do
         it 'raises an error when value is an array without multi_valued' do
           expect { args.bind(path: %w[file1.txt file2.txt]) }.to raise_error(
             ArgumentError,
-            /value_to_positional :path requires multi_valued: true to accept an array/
+            /value_to_positional :path requires repeatable: true to accept an array/
           )
         end
       end


### PR DESCRIPTION
## Summary

Rename the `Arguments` class DSL methods to use CLI/POSIX terminology for the output interface. Since `Arguments` is a CLI builder (Data→CLI), the DSL should describe what CLI constructs are being defined.

This is **PR 1** of the implementation plan from issue #994 - adding new names with aliases (no breaking changes).

## Changes

### DSL Method Renames (with backward-compatible aliases)

| Current | New | Alias |
|---------|-----|-------|
| `#flag` | `#flag_option` | `alias flag flag_option` |
| `#value` | `#value_option` | `alias value value_option` |
| `#flag_or_value` | `#flag_or_value_option` | `alias flag_or_value flag_or_value_option` |
| `#key_value` | `#key_value_option` | `alias key_value key_value_option` |
| `#positional` | `#operand` | `alias positional operand` |
| `#static` | `#literal` | `alias static literal` |
| `#custom` | `#custom_option` | `alias custom custom_option` |
| `#metadata` | *(unchanged)* | — |

### Parameter Renames (accept both old and new)

| Current | New |
|---------|-----|
| `positional:` (on `#value_option`) | `as_operand:` (accept both) |
| `variadic:` (on `#operand`) | `repeatable:` (accept both) |
| `multi_valued:` (on `#value_option`) | `repeatable:` (accept both) |

### Internal Renames

| Current | New |
|---------|-----|
| `@positional_definitions` | `@operand_definitions` |
| `PositionalAllocator` | `OperandAllocator` (with backward-compatible alias) |

### Documentation Updates

- All YARD docs in `arguments.rb` updated to use new names
- `redesign/*.md` files updated
- `.github/copilot-instructions.md` updated
- `CONTRIBUTING.md` updated

## Notes

- The `Arguments` class is marked `@api private`, so this is internal refactoring
- No deprecation warnings needed—just migrate in two steps (this PR adds aliases, PR 2 will update all Commands and remove aliases)
- All existing code continues to work unchanged

Closes #994