### PR TITLE
refactor: remove new methods from Git::Lib added after v4.3.0

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -2,14 +2,10 @@
 
 require_relative 'args_builder'
 require_relative 'commands/add'
-require_relative 'commands/branch/copy'
 require_relative 'commands/branch/create'
 require_relative 'commands/branch/delete'
 require_relative 'commands/branch/list'
-require_relative 'commands/branch/move'
-require_relative 'commands/branch/set_upstream'
 require_relative 'commands/branch/show_current'
-require_relative 'commands/branch/unset_upstream'
 require_relative 'commands/checkout/branch'
 require_relative 'commands/checkout/files'
 require_relative 'commands/clean'
@@ -18,9 +14,6 @@ require_relative 'commands/commit'
 require_relative 'commands/fsck'
 require_relative 'commands/init'
 require_relative 'commands/merge/start'
-require_relative 'commands/merge/abort'
-require_relative 'commands/merge/continue'
-require_relative 'commands/merge/quit'
 require_relative 'commands/merge_base'
 require_relative 'commands/mv'
 require_relative 'commands/reset'
@@ -1328,73 +1321,6 @@ module Git
       result.stdout.strip
     end
 
-    # Move/rename a branch
-    #
-    # @overload branch_move(new_branch, options = {})
-    #   Rename the current branch
-    #   @param new_branch [String] the new name for the current branch
-    #   @param options [Hash] command options
-    #
-    # @overload branch_move(old_branch, new_branch, options = {})
-    #   Rename a specific branch
-    #   @param old_branch [String] the branch to rename
-    #   @param new_branch [String] the new name for the branch
-    #   @param options [Hash] command options
-    #
-    # @option options [Boolean] :force allow renaming even if new_branch already exists
-    #
-    # @return [String] the name of the renamed branch
-    #
-    def branch_move(*args, **)
-      Git::Commands::Branch::Move.new(self).call(*args, **)
-      args.compact.last
-    end
-
-    # Copy a branch, along with its config and reflog
-    #
-    # @overload branch_copy(new_branch, options = {})
-    #   Copy the current branch
-    #   @param new_branch [String] the name for the new branch
-    #   @param options [Hash] command options
-    #
-    # @overload branch_copy(old_branch, new_branch, options = {})
-    #   Copy a specific branch
-    #   @param old_branch [String] the branch to copy
-    #   @param new_branch [String] the name for the new branch
-    #   @param options [Hash] command options
-    #
-    # @option options [Boolean] :force allow copying even if new_branch already exists
-    #
-    # @return [String] the name of the copied branch
-    #
-    def branch_copy(*args, **)
-      Git::Commands::Branch::Copy.new(self).call(*args, **)
-      args.compact.last
-    end
-
-    # Set upstream tracking information for a branch
-    #
-    # @param upstream [String] the upstream branch (e.g., 'origin/main')
-    # @param branch_name [String, nil] the branch to configure (defaults to current branch)
-    #
-    # @return [String] the name of the configured branch
-    #
-    def branch_set_upstream(upstream, branch_name = nil)
-      Git::Commands::Branch::SetUpstream.new(self).call(branch_name, set_upstream_to: upstream)
-      branch_name || branch_current
-    end
-
-    # Remove upstream tracking information for a branch
-    #
-    # @param branch_name [String, nil] the branch to configure (defaults to current branch)
-    #
-    # @return [String] the name of the configured branch
-    #
-    def branch_unset_upstream(branch_name = nil)
-      Git::Commands::Branch::UnsetUpstream.new(self).call(branch_name)
-      branch_name || branch_current
-    end
-
     # Runs checkout command to checkout or create branch
     #
     # accepts options:
@@ -1465,46 +1391,6 @@ module Git
       opts = translate_merge_options(opts)
 
       Git::Commands::Merge::Start.new(self).call(*Array(branch), **opts).stdout
-    end
-
-    # Abort the current merge in progress
-    #
-    # Reconstructs the pre-merge state. If an autostash entry is present,
-    # applies it to the worktree.
-    #
-    # @return [String] the command output
-    #
-    # @raise [Git::FailedError] if no merge is in progress
-    #
-    def merge_abort
-      Git::Commands::Merge::Abort.new(self).call.stdout
-    end
-
-    # Continue a merge after conflict resolution
-    #
-    # Completes the merge after conflicts have been resolved and staged.
-    #
-    # @return [String] the command output
-    #
-    # @raise [Git::FailedError] if conflicts remain unresolved
-    #
-    def merge_continue
-      Git::Commands::Merge::Continue.new(self).call.stdout
-    end
-
-    # Quit the current merge, leaving working tree as-is
-    #
-    # Forgets about the current merge in progress. Leaves the index and
-    # working tree as-is. If an autostash entry is present, saves it to
-    # the stash list.
-    #
-    # @return [String] the command output
-    #
-    # @raise [Git::FailedError] if the underlying git command exits non-zero
-    #   (for example, on Git versions before 2.35 when no merge is in progress)
-    #
-    def merge_quit
-      Git::Commands::Merge::Quit.new(self).call.stdout
     end
 
     # Find common ancestor commit(s) for merge

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -578,16 +578,19 @@ future work:
       end
     end
 
-    # ✅ Git::Lib adapter: ergonomic Ruby API
+    # ✅ Higher-layer facade: ergonomic Ruby API (Phase 3)
+    # This wrapper belongs in Git::Repository or Git::Branch, NOT in Git::Lib.
+    # Git::Lib only adapts methods that existed in v4.3.0.
     def branch_set_upstream(upstream, branch_name = nil)
-      SetUpstream.new(self).call(branch_name, set_upstream_to: upstream)
+      SetUpstream.new(@execution_context).call(branch_name, set_upstream_to: upstream)
     end
     ```
 
     This separation keeps Commands classes predictable (they mirror git 1:1) while
-    allowing the adapter layer to provide intuitive Ruby interfaces. Ergonomic
+    allowing higher layers to provide intuitive Ruby interfaces. Ergonomic
     transformations—like reordering arguments or converting keywords to
-    positionals—belong in `Git::Lib` or higher layers (`Git::Base`, `Git::Branch`).
+    positionals—belong in higher layers (`Git::Repository`, `Git::Base`, `Git::Branch`),
+    not in `Git::Lib` (which only adapts pre-existing methods for backward compatibility).
 
 14. **Use `allow_nil: true` for positional arguments that can be intentionally omitted**
 
@@ -705,7 +708,7 @@ The following tracks the migration status of commands from `Git::Lib` to
 | `branches_all` | `Git::Commands::Branch::List` | `spec/git/commands/branch/list_spec.rb` | `git branch --list` |
 | `branch_new` | `Git::Commands::Branch::Create` | `spec/git/commands/branch/create_spec.rb` | `git branch <name>` |
 | `branch_delete` | `Git::Commands::Branch::Delete` | `spec/git/commands/branch/delete_spec.rb` | `git branch --delete` |
-| `branch_move` | `Git::Commands::Branch::Move` | `spec/git/commands/branch/move_spec.rb` | `git branch --move` |
+| N/A (new) | `Git::Commands::Branch::Move` | `spec/git/commands/branch/move_spec.rb` | `git branch --move` |
 | `diff_full` | `Git::Commands::Diff::Patch` | `spec/git/commands/diff/patch_spec.rb` | `git diff` (patch format) |
 | `diff_stats` | `Git::Commands::Diff::Numstat` | `spec/git/commands/diff/numstat_spec.rb` | `git diff --numstat` |
 | `diff_path_status` / `diff_index` | `Git::Commands::Diff::Raw` | `spec/git/commands/diff/raw_spec.rb` | `git diff --raw` |
@@ -717,9 +720,9 @@ The following tracks the migration status of commands from `Git::Lib` to
 | `stash_clear` | `Git::Commands::Stash::Clear` | `spec/unit/git/commands/stash/clear_spec.rb` | `git stash clear` |
 | `checkout` / `checkout_file` | `Git::Commands::Checkout::Branch` / `Git::Commands::Checkout::Files` | `spec/unit/git/commands/checkout/branch_spec.rb` / `spec/unit/git/commands/checkout/files_spec.rb` | `git checkout` (branch) / `git checkout` (files) |
 | `merge` | `Git::Commands::Merge::Start` | `spec/unit/git/commands/merge/start_spec.rb` | `git merge` |
-| `merge_abort` | `Git::Commands::Merge::Abort` | `spec/unit/git/commands/merge/abort_spec.rb` | `git merge --abort` |
-| `merge_continue` | `Git::Commands::Merge::Continue` | `spec/unit/git/commands/merge/continue_spec.rb` | `git merge --continue` |
-| `merge_quit` | `Git::Commands::Merge::Quit` | `spec/unit/git/commands/merge/quit_spec.rb` | `git merge --quit` |
+| N/A (new) | `Git::Commands::Merge::Abort` | `spec/unit/git/commands/merge/abort_spec.rb` | `git merge --abort` |
+| N/A (new) | `Git::Commands::Merge::Continue` | `spec/unit/git/commands/merge/continue_spec.rb` | `git merge --continue` |
+| N/A (new) | `Git::Commands::Merge::Quit` | `spec/unit/git/commands/merge/quit_spec.rb` | `git merge --quit` |
 | N/A (new) | `Git::Commands::Stash::Create` | `spec/unit/git/commands/stash/create_spec.rb` | `git stash create` |
 | N/A (new) | `Git::Commands::Stash::Store` | `spec/unit/git/commands/stash/store_spec.rb` | `git stash store` |
 | N/A (new) | `Git::Commands::Stash::Branch` | `spec/unit/git/commands/stash/branch_spec.rb` | `git stash branch` |
@@ -745,9 +748,10 @@ order: Basic Snapshotting → Branching & Merging → etc.
 - [x] `branches_all` → `Git::Commands::Branch::List` — `git branch --list` (returns `BranchInfo` value objects)
 - [x] `branch_new` → `Git::Commands::Branch::Create` — `git branch <name> [start-point]`
 - [x] `branch_delete` → `Git::Commands::Branch::Delete` — `git branch --delete`
-- [x] `branch_move` → `Git::Commands::Branch::Move` — `git branch --move`
+- [x] N/A (new) → `Git::Commands::Branch::Move` — `git branch --move`
 - [x] `checkout` / `checkout_file` → `Git::Commands::Checkout::Branch` / `Git::Commands::Checkout::Files` — `git checkout`
-- [x] `merge` / `merge_abort` / `merge_continue` / `merge_quit` → `Git::Commands::Merge::*` — `git merge` (Start, Abort, Continue, Quit)
+- [x] `merge` → `Git::Commands::Merge::Start` — `git merge`
+- [x] N/A (new) → `Git::Commands::Merge::Abort` / `Git::Commands::Merge::Continue` / `Git::Commands::Merge::Quit` — `git merge --abort/--continue/--quit`
 - [ ] `tag` → `Git::Commands::Tag` — `git tag`
 - [x] `stash_*` → `Git::Commands::Stash::*` — `git stash` (List, Push, Pop, Apply, Drop, Clear, Create, Store, Branch, ShowNumstat, ShowPatch, ShowRaw)
 


### PR DESCRIPTION
# Description

Remove 7 public methods and their corresponding `require` statements that were added to `Git::Lib` after v4.3.0, and update the redesign doc to correctly reflect which commands have pre-existing `Git::Lib` methods.

## Why

These commands (`merge_abort`, `merge_continue`, `merge_quit`, `branch_move`, `branch_copy`, `branch_set_upstream`, `branch_unset_upstream`) never had `Git::Lib` methods in v4.3.0. Per the redesign plan:

- **Phase 2** (current) only adapts *existing* `Git::Lib` methods to delegate to new `Git::Commands::*` classes. No new public methods are added to `Git::Lib`.
- **Phase 3** is where new public API surface (like `merge_abort`, `branch_move`, etc.) gets added — to `Git::Repository` facade modules, not `Git::Lib`.
- **Phase 4** deletes `Git::Lib` entirely.

Adding new public methods to `Git::Lib` during Phase 2 expands the API surface unnecessarily. The underlying `Git::Commands::*` classes remain available for direct use.

## Changes

### `lib/git/lib.rb`

Removed 7 public methods (all had zero callers anywhere in the codebase):

| Method | Purpose |
|---|---|
| `branch_move` | Wraps `Git::Commands::Branch::Move` |
| `branch_copy` | Wraps `Git::Commands::Branch::Copy` |
| `branch_set_upstream` | Wraps `Git::Commands::Branch::SetUpstream` |
| `branch_unset_upstream` | Wraps `Git::Commands::Branch::UnsetUpstream` |
| `merge_abort` | Wraps `Git::Commands::Merge::Abort` |
| `merge_continue` | Wraps `Git::Commands::Merge::Continue` |
| `merge_quit` | Wraps `Git::Commands::Merge::Quit` |

Removed 7 corresponding `require_relative` statements.

All legacy public methods that existed in v4.3.0 are preserved with their original signatures and return types.

### `redesign/3_architecture_implementation.md`

- Migration table: changed `branch_move`, `merge_abort`, `merge_continue`, `merge_quit` from listing `Git::Lib` method names to `N/A (new)` (same convention used for stash commands with no `Git::Lib` counterpart)
- `branch_set_upstream` example: clarified ergonomic wrapper belongs in higher layers (Phase 3), not `Git::Lib`
- Checklist: separated legacy adapter methods from new command classes

**Net change:** 124 deletions, 14 additions.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).