### PR TITLE
refactor(fsck): return CommandLineResult from Fsck#call

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -29,6 +29,7 @@ require_relative 'commands/stash/push'
 require 'git/command_line'
 require 'git/errors'
 require 'git/parsers/branch'
+require 'git/parsers/fsck'
 require 'git/parsers/stash'
 require 'git/parsers/tag'
 require 'git/url'
@@ -1695,7 +1696,8 @@ module Git
     #
     # rubocop:disable Style/ArgumentsForwarding
     def fsck(*objects, **opts)
-      Git::Commands::Fsck.new(self).call(*objects, **opts)
+      result = Git::Commands::Fsck.new(self).call(*objects, **opts)
+      Git::Parsers::Fsck.parse(result.stdout)
     end
     # rubocop:enable Style/ArgumentsForwarding
 

--- a/spec/integration/git/commands/fsck/fsck_spec.rb
+++ b/spec/integration/git/commands/fsck/fsck_spec.rb
@@ -21,17 +21,17 @@ RSpec.describe Git::Commands::Fsck, :integration do
     end
 
     describe 'when the command succeeds' do
-      it 'returns a FsckResult' do
+      it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::FsckResult)
+        expect(result).to be_a(Git::CommandLineResult)
       end
 
       context 'with options' do
         it 'accepts multiple options' do
           result = command.call(root: true, strict: true)
 
-          expect(result).to be_a(Git::FsckResult)
+          expect(result).to be_a(Git::CommandLineResult)
         end
       end
 
@@ -40,7 +40,7 @@ RSpec.describe Git::Commands::Fsck, :integration do
           head_sha = execution_context.command('rev-parse', 'HEAD').stdout.strip
           result = command.call(head_sha)
 
-          expect(result).to be_a(Git::FsckResult)
+          expect(result).to be_a(Git::CommandLineResult)
         end
       end
     end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Refactor `Git::Commands::Fsck#call` to return a `CommandLineResult` instead of a parsed `FsckResult`, aligning it with the command class contract that every `#call` method returns whatever `execution_context.command` returns.

**Changes:**

- **`lib/git/commands/fsck.rb`** — Remove `require 'git/parsers/fsck'` and the `Git::Parsers::Fsck.parse` call from `#call`; return the `CommandLineResult` directly. Update YARD docs: add `@see` link, `@raise` tag, `@example` blocks with git commands, `(nil)` defaults on all `@option` tags, and caller-focused descriptions.
- **`lib/git/lib.rb`** — Add `require 'git/parsers/fsck'` and move parsing into `Lib#fsck` so callers still receive a `FsckResult`.
- **`spec/unit/git/commands/fsck_spec.rb`** — Assert `CommandLineResult` return type in base invocation and exit code tests; remove output parsing tests (belong in parser specs); remove redundant `option: false` test for non-negatable flag.
- **`spec/integration/git/commands/fsck/fsck_spec.rb`** — Assert `CommandLineResult` instead of `FsckResult`.
- **`spec/unit/git/lib_command_spec.rb`** — Add `Lib#fsck` tests verifying parsing delegation and argument forwarding.

Closes #1017

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).