### PR TITLE
refactor(diff): wire Git::Lib diff methods to Diff command classes

### DIFF
--- a/tests/units/test_diff_path_status.rb
+++ b/tests/units/test_diff_path_status.rb
@@ -64,9 +64,11 @@ class TestDiffPathStatus < Test::Unit::TestCase
   end
 
   def test_path_status_with_empty_path_array
-    status = Struct.new(:success?).new(true)
+    status = Struct.new(:success?, :exitstatus) { def exitstatus = 0 }.new(true)
     result = Git::CommandLineResult.new(%w[git diff], status, '', '')
-    @git.lib.expects(:command).with('diff', '--name-status', 'gitsearch1', 'v2.5').returns(result)
+    raw_cmd = Git::Commands::Diff::Raw.new(@git.lib)
+    Git::Commands::Diff::Raw.expects(:new).with(@git.lib).returns(raw_cmd)
+    raw_cmd.expects(:call).with('gitsearch1', 'v2.5', pathspecs: nil).returns(result)
 
     status_hash = Git::DiffPathStatus.new(@git, 'gitsearch1', 'v2.5', []).to_h
     assert_equal({}, status_hash)

--- a/tests/units/test_diff_stats.rb
+++ b/tests/units/test_diff_stats.rb
@@ -44,9 +44,11 @@ class TestDiffStats < Test::Unit::TestCase
   end
 
   def test_diff_stats_with_empty_path_array
-    status = Struct.new(:success?).new(true)
+    status = Struct.new(:success?, :exitstatus) { def exitstatus = 0 }.new(true)
     result = Git::CommandLineResult.new(%w[git diff], status, '', '')
-    @git.lib.expects(:command).with('diff', '--numstat', 'gitsearch1', 'v2.5').returns(result)
+    numstat_cmd = Git::Commands::Diff::Numstat.new(@git.lib)
+    Git::Commands::Diff::Numstat.expects(:new).with(@git.lib).returns(numstat_cmd)
+    numstat_cmd.expects(:call).with('gitsearch1', 'v2.5', pathspecs: nil).returns(result)
 
     stats = @git.diff_stats('gitsearch1', 'v2.5', path_limiter: [])
     assert_equal(0, stats.total[:files])


### PR DESCRIPTION
## Description

Wire the three `Git::Lib` diff methods (`diff_full`, `diff_stats`, `diff_path_status`) to use the new `Git::Commands::Diff::*` command classes instead of calling `command('diff', ...)` directly.

This follows the same pattern established by the `fsck` wiring in PR #1020.

### Changes

- **`diff_full`** → delegates to `Git::Commands::Diff::Patch`, extracts patch text from combined output
- **`diff_stats`** → delegates to `Git::Commands::Diff::Numstat`, extracts numstat lines from combined output
- **`diff_path_status`** → delegates to `Git::Commands::Diff::Raw`, parses raw output lines to extract name-status data (status tokens + paths)
- Removed `DIFF_FULL_OPTION_MAP`, `DIFF_STATS_OPTION_MAP`, `DIFF_PATH_STATUS_OPTION_MAP` constants
- Added `DIFF_FULL_ALLOWED_OPTS`, `DIFF_STATS_ALLOWED_OPTS`, `DIFF_PATH_STATUS_ALLOWED_OPTS` constants for opts validation via `assert_valid_opts`
- Added `extract_patch_text`, `extract_numstat_lines`, and `extract_name_status_from_raw` private helpers
- Restored `handle_deprecated_path_option` for `:path` → `:path_limiter` migration in `diff_path_status`
- Added unit tests for all three methods in `lib_command_spec.rb`, including unknown-opts rejection tests
- Updated `test_diff_stats.rb` and `test_diff_path_status.rb` to stub the command classes instead of raw `command()`
- Added YARD docs with `@see`, `@return`, `@raise` tags on all changed methods

All existing callers (`Git::Diff`, `Git::DiffStats`, `Git::DiffPathStatus`) remain unchanged — the `Git::Lib` methods accept the same arguments and return the same types.

Closes #1021

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).