### PR TITLE
Add option-like operand validation to Arguments DSL

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -920,7 +920,6 @@ module Git
     #
     def diff_full(obj1 = 'HEAD', obj2 = nil, opts = {})
       assert_valid_opts(opts, DIFF_FULL_ALLOWED_OPTS)
-      assert_args_are_not_options('commit or commit range', obj1, obj2)
       pathspecs = normalize_pathspecs(opts[:path_limiter], 'path limiter')
       result = Git::Commands::Diff::Patch.new(self).call(*[obj1, obj2].compact, pathspecs: pathspecs)
       extract_patch_text(result.stdout)
@@ -948,7 +947,6 @@ module Git
     #
     def diff_stats(obj1 = 'HEAD', obj2 = nil, opts = {})
       assert_valid_opts(opts, DIFF_STATS_ALLOWED_OPTS)
-      assert_args_are_not_options('commit or commit range', obj1, obj2)
       pathspecs = normalize_pathspecs(opts[:path_limiter], 'path limiter')
       result = Git::Commands::Diff::Numstat.new(self).call(*[obj1, obj2].compact, pathspecs: pathspecs)
       output_lines = extract_numstat_lines(result.stdout)
@@ -981,7 +979,6 @@ module Git
     #
     def diff_path_status(reference1 = nil, reference2 = nil, opts = {})
       assert_valid_opts(opts, DIFF_PATH_STATUS_ALLOWED_OPTS)
-      assert_args_are_not_options('commit or commit range', reference1, reference2)
 
       path_limiter = handle_deprecated_path_option(opts)
       pathspecs = normalize_pathspecs(path_limiter, 'path limiter')

--- a/spec/integration/git/commands/tag/delete_spec.rb
+++ b/spec/integration/git/commands/tag/delete_spec.rb
@@ -41,10 +41,10 @@ RSpec.describe Git::Commands::Tag::Delete, :integration do
     end
 
     describe 'when the command fails' do
-      it 'raises FailedError for fatal errors' do
-        # Exit code > 1 should raise (tested via unit tests for specific threshold)
-        # Here we verify that completely invalid usage raises
-        expect { command.call('--invalid-flag-xyz') }.to raise_error(Git::FailedError)
+      it 'raises ArgumentError for option-like tag names' do
+        # Option-like operand validation rejects values starting with '-'
+        # before they reach git, preventing misinterpretation as flags
+        expect { command.call('--invalid-flag-xyz') }.to raise_error(ArgumentError, /option-like values/)
       end
     end
   end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Automatically reject positional operand values that look like command-line options (strings starting with `-`) when those operands appear **before** a `--` separator or `--` literal in the argument definition. This moves the safety guard currently implemented as manual `assert_args_are_not_options` calls in `Git::Lib` into the DSL itself, making it automatic for all command classes.

Additionally, prevent flag-producing options (`flag_option`, `value_option`, `key_value_option`, `flag_or_value_option`, `custom_option`) from being defined **after** a `--` separator boundary in the DSL. Git treats everything after `--` as operands, so flags emitted there would be misinterpreted. Only `value_option` with `as_operand: true` and `metadata` are allowed after the boundary.

Closes #1023

## What changed

### `lib/git/commands/arguments.rb`

#### Bind-time validation (option-like operand rejection)

- Added `validate_no_option_like_operands!` call in `bind` — runs after operand allocation and existing validations
- `operand_names_before_separator` — walks `@ordered_definitions` and collects operand names until hitting a `--` boundary (literal `'--'`, operand with `separator: '--'`, or value_option with `separator: '--'`)
- `separator_boundary_active?` / `operand_separator_active?` / `option_separator_active?` — extracted helpers that check bound values (not just definitions) to determine if a separator boundary is active
- `check_operand_not_option_like` — validates String values don't start with `-`, and for Arrays reports all offending elements
- YARD docs updated: "Option-like Operand Rejection" subsection in Operands section, `operand` method `@raise`, `bind` method `@raise`

#### Definition-time validation (options after separator)

- Added `@past_separator` flag to `initialize` — tracks whether a `--` boundary has been defined
- `literal`, `add_operand_definition`, `register_option` — set `@past_separator = true` when they define a `--` boundary
- `validate_option_after_separator!` — rejects flag-producing option types (anything except `:value_as_operand` and `:metadata`) when `@past_separator` is true
- `OPTION_TYPES_AFTER_SEPARATOR` — constant listing option types allowed after `--`
- YARD docs updated: "Options After Separator" subsection, `@raise` tags on `flag_option`, `value_option`, `flag_or_value_option`, `key_value_option`, `custom_option`

### `lib/git/lib.rb`

- Removed redundant `assert_args_are_not_options` calls from `diff_full`, `diff_stats`, and `diff_path_status` — these methods delegate to command classes (`Diff::Patch`, `Diff::Numstat`, `Diff::Raw`) whose Arguments DSL definitions already validate the commit operands before the `--` boundary

### `spec/unit/git/commands/arguments_spec.rb`

Added comprehensive test coverage for both validations:

**Option-like operand rejection (bind-time):**
- Operand before `separator: '--'` rejects `-` and `--` prefixed values
- Multiple operands validated independently
- Operand after separator is NOT validated
- Operand before `literal '--'` is validated
- Operand before `value_option ... separator: '--'` is validated
- All operands validated when no `--` boundary exists
- `nil` and non-String values are skipped
- Repeatable operands report all offending values
- Error messages include operand name and offending value
- Integration patterns: diff-style, no-index style, checkout-style
- Inactive separator boundaries (nil/empty values)

**Options after separator (definition-time):**
- `flag_option` after `literal '--'` raises
- `value_option` after `literal '--'` raises
- `flag_or_value_option` after `literal '--'` raises
- `key_value_option` after `literal '--'` raises
- `custom_option` after `literal '--'` raises
- Negatable and inline variants after `literal '--'` raise
- `value_option as_operand: true` after `literal '--'` is allowed
- `metadata` after `literal '--'` is allowed
- `operand` after `literal '--'` is allowed
- Options after `operand separator: '--'` raise
- Options after `value_option separator: '--'` raise
- Options before `--` boundary are allowed
- Non-separator literals don't trigger the restriction

### `spec/integration/git/commands/tag/delete_spec.rb`

Updated to expect `ArgumentError` (from the new DSL validation) instead of `FailedError` when passing an option-like value as a tag name.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).