### PR TITLE
refactor(arguments): rename metadata DSL method to execution_option

### DIFF
--- a/lib/git/commands/arguments.rb
+++ b/lib/git/commands/arguments.rb
@@ -203,7 +203,7 @@ module Git
     # - {#key_value_option} - Key-value option that can be repeated (--trailer key=value)
     # - {#literal} - Literal string always included in output
     # - {#custom_option} - Custom option with builder block
-    # - {#metadata} - Validation-only option (not included in command output)
+    # - {#execution_option} - Execution option (not included in CLI output, forwarded to command execution)
     #
     # {#value_option} supports a `repeatable: true` parameter that allows the option to accept
     # an array of values. This repeats the flag for each value (or outputs each as an
@@ -238,7 +238,7 @@ module Git
     #   phase (for example, via #to_s in {Bound#to_a}). Defaults to nil (no validation).
     #   Supported by: {#flag_option}, {#value_option}, {#flag_or_value_option}.
     #
-    # Note: {#literal} and {#metadata} do not support these validation parameters.
+    # Note: {#literal} and {#execution_option} do not support these validation parameters.
     #
     # These parameters affect **output generation** (what CLI arguments are
     # produced):
@@ -362,7 +362,7 @@ module Git
     # separator boundary. Git treats everything after `--` as operands, so
     # flags emitted there would be misinterpreted.
     #
-    # Only `value_option` with `as_operand: true` and `metadata` are allowed
+    # Only `value_option` with `as_operand: true` and `execution_option` are allowed
     # after the boundary because they do not produce flag-prefixed output.
     #
     # For example, this will raise +ArgumentError+ during definition:
@@ -855,14 +855,14 @@ module Git
         register_option(names, type: :custom, builder: block, required: required, allow_nil: allow_nil)
       end
 
-      # Define a metadata option (for validation only, not included in command)
+      # Define an execution option (not included in CLI output, forwarded to command execution)
       #
       # @param names [Symbol, Array<Symbol>] the option name(s), first is primary
       #
       # @return [void]
       #
-      def metadata(names)
-        register_option(names, type: :metadata)
+      def execution_option(names)
+        register_option(names, type: :execution_option)
       end
 
       # Declare that options conflict with each other (mutually exclusive)
@@ -1072,7 +1072,7 @@ module Git
       end
 
       # Option types allowed after a '--' separator boundary (they do not produce CLI flags)
-      OPTION_TYPES_AFTER_SEPARATOR = %i[value_as_operand metadata].freeze
+      OPTION_TYPES_AFTER_SEPARATOR = %i[value_as_operand execution_option].freeze
 
       private
 
@@ -1373,7 +1373,7 @@ module Git
           result = definition[:builder]&.call(value)
           result.is_a?(Array) ? args.concat(result) : (args << result if result)
         end,
-        metadata: ->(*) {}
+        execution_option: ->(*) {}
       }.freeze
       private_constant :BUILDERS
 

--- a/lib/git/commands/clone.rb
+++ b/lib/git/commands/clone.rb
@@ -33,7 +33,7 @@ module Git
         custom_option(:depth) { |v| ['--depth', v.to_i] }
         operand :repository_url, required: true, separator: '--'
         operand :directory
-        metadata :timeout
+        execution_option :timeout
       end.freeze
 
       # Initialize the Clone command

--- a/spec/unit/git/commands/arguments_spec.rb
+++ b/spec/unit/git/commands/arguments_spec.rb
@@ -149,20 +149,20 @@ RSpec.describe Git::Commands::Arguments do
       end
     end
 
-    context 'with metadata options' do
+    context 'with execution_option options' do
       let(:args) do
         described_class.define do
-          metadata :object
-          metadata :path_limiter
+          execution_option :object
+          execution_option :path_limiter
         end
       end
 
-      it 'does not output anything for metadata options' do
+      it 'does not output anything for execution_option options' do
         expect(args.bind(object: 'HEAD', path_limiter: 'src/').to_ary).to eq([])
       end
 
-      it 'allows validation of metadata presence' do
-        # metadata options are just for validation, not command building
+      it 'allows validation of execution_option presence' do
+        # execution_option options are just for validation, not command building
         expect(args.bind.to_ary).to eq([])
       end
     end
@@ -3605,11 +3605,11 @@ RSpec.describe Git::Commands::Arguments do
         end.not_to raise_error
       end
 
-      it 'allows metadata after literal \'--\'' do
+      it 'allows execution_option after literal \'--\'' do
         expect do
           described_class.define do
             literal '--'
-            metadata :internal
+            execution_option :internal
           end
         end.not_to raise_error
       end
@@ -3654,11 +3654,11 @@ RSpec.describe Git::Commands::Arguments do
         end.to raise_error(ArgumentError, /option :verbose cannot be defined after/)
       end
 
-      it 'allows metadata after value_option with as_operand separator \'--\'' do
+      it 'allows execution_option after value_option with as_operand separator \'--\'' do
         expect do
           described_class.define do
             value_option :pathspecs, as_operand: true, separator: '--', repeatable: true
-            metadata :internal
+            execution_option :internal
           end
         end.not_to raise_error
       end


### PR DESCRIPTION
## Summary

Rename the `metadata` DSL method in `Git::Commands::Arguments` to `execution_option`, and update the internal type symbol from `:metadata` to `:execution_option`. Update all references in code, specs, and documentation.

## Motivation

The name `metadata` is misleading for what this DSL method actually does. These options are not passive annotations — they are values forwarded to `Lib#command` as keyword arguments to control process execution (e.g., `timeout:`). The name `execution_option` communicates the actual role: an option that controls how the git process is executed rather than what CLI arguments are produced.

## Changes

- Renamed method `metadata` to `execution_option` in [arguments.rb](lib/git/commands/arguments.rb)
- Updated BUILDERS hash key from `:metadata` to `:execution_option`
- Updated OPTION_TYPES_AFTER_SEPARATOR constant
- Updated all documentation references (3 locations)
- Changed `metadata :timeout` to `execution_option :timeout` in [clone.rb](lib/git/commands/clone.rb)
- Updated all spec references and descriptions in [arguments_spec.rb](spec/unit/git/commands/arguments_spec.rb)

## Test Results

All tests pass successfully:
- ✅ 543 legacy tests, 0 failures
- ✅ 1457 unit tests, 0 failures
- ✅ 186 integration tests, 0 failures
- ✅ 306 files inspected by RuboCop, no offenses
- ✅ 60 YARD doctests, 0 failures

## Verification

This is a pure rename — no behavioral changes. All existing tests pass without modification (except for name updates in specs).

Fixes #1025