### PR TITLE
refactor(arguments): add Bound#execution_options method

### DIFF
--- a/spec/unit/git/commands/arguments_spec.rb
+++ b/spec/unit/git/commands/arguments_spec.rb
@@ -3202,6 +3202,62 @@ RSpec.describe Git::Commands::Arguments do
       end
     end
 
+    context 'with execution options' do
+      context 'when execution option is bound' do
+        let(:args) do
+          described_class.define do
+            execution_option :timeout
+          end
+        end
+
+        it 'returns execution option values' do
+          bound = args.bind(timeout: 30)
+          expect(bound.execution_options).to eq({ timeout: 30 })
+        end
+      end
+
+      context 'when no execution options are defined' do
+        let(:args) do
+          described_class.define do
+            flag_option :force
+          end
+        end
+
+        it 'returns an empty hash' do
+          bound = args.bind(force: true)
+          expect(bound.execution_options).to eq({})
+        end
+      end
+
+      context 'when execution options are defined but nil' do
+        let(:args) do
+          described_class.define do
+            execution_option :timeout
+            execution_option :retries
+          end
+        end
+
+        it 'returns an empty hash when all values are nil' do
+          bound = args.bind
+          expect(bound.execution_options).to eq({})
+        end
+
+        it 'excludes nil-valued execution options' do
+          bound = args.bind(timeout: 15, retries: nil)
+          expect(bound.execution_options).to eq({ timeout: 15 })
+        end
+      end
+
+      it 'returns a frozen hash' do
+        args = described_class.define do
+          execution_option :timeout
+        end
+
+        bound = args.bind(timeout: 30)
+        expect(bound.execution_options).to be_frozen
+      end
+    end
+
     context 'with default values for positionals' do
       let(:args) do
         described_class.define do


### PR DESCRIPTION
# Description

Implement `Arguments::Bound#execution_options` which returns a frozen hash of execution option names and their bound values, excluding nil values. This is **task 0a** from #996.

Execution options (declared via the `execution_option` DSL method) are forwarded to command execution rather than included in the CLI argument array. The new method provides access to these options from a `Bound` instance.

### Changes

- Add `Bound#execution_options` attr_reader
- Add `EMPTY_EXECUTION_OPTIONS` constant for the no-options case
- Add `build_execution_options` private helper
- Pass `execution_option_names` from `bind` to `Bound.new`
- Add 5 RSpec examples covering the new method
- Add YARD documentation for the new API

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).