### PR TITLE
refactor(merge-base): return CommandLineResult instead of parsed Array

### DIFF
--- a/lib/git/commands/merge_base.rb
+++ b/lib/git/commands/merge_base.rb
@@ -16,18 +16,18 @@ module Git
     #
     # @example Find merge base of two branches
     #   merge_base = Git::Commands::MergeBase.new(execution_context)
-    #   shas = merge_base.call('main', 'feature')
-    #   # => ['abc123def456...']
+    #   result = merge_base.call('main', 'feature')
+    #   # => #<Git::CommandLineResult ...>
     #
     # @example Find all common ancestors
-    #   shas = merge_base.call('main', 'feature', all: true)
-    #   # => ['sha1', 'sha2']
+    #   result = merge_base.call('main', 'feature', all: true)
+    #   # => #<Git::CommandLineResult ...>
     #
     # @example Find merge base for octopus merge
-    #   shas = merge_base.call('main', 'branch1', 'branch2', octopus: true)
+    #   result = merge_base.call('main', 'branch1', 'branch2', octopus: true)
     #
     # @example Find fork point
-    #   shas = merge_base.call('main', 'feature', fork_point: true)
+    #   result = merge_base.call('main', 'feature', fork_point: true)
     #
     class MergeBase
       # Arguments DSL for building command-line arguments
@@ -75,25 +75,14 @@ module Git
       #   @option options [Boolean] :all (nil) Output all merge bases instead of
       #     just one (when multiple equally good bases exist)
       #
-      # @return [Array<String>] array of commit SHA strings (common ancestors)
+      # @return [Git::CommandLineResult] the result of calling `git merge-base`
       #
       # @raise [Git::FailedError] if the command fails
       #
       def call(*, **)
-        args = ARGS.bind(*, **)
-        output = @execution_context.command(*args).stdout
-        parse_output(output)
-      end
+        bound_args = ARGS.bind(*, **)
 
-      private
-
-      # Parse the command output into an array of SHAs
-      #
-      # @param output [String] the raw command output
-      # @return [Array<String>] array of commit SHAs
-      #
-      def parse_output(output)
-        output.lines.map(&:strip).reject(&:empty?)
+        @execution_context.command(*bound_args)
       end
     end
   end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1477,7 +1477,8 @@ module Git
     #
     def merge_base(*args)
       opts = args.last.is_a?(Hash) ? args.pop : {}
-      Git::Commands::MergeBase.new(self).call(*args, **opts)
+      result = Git::Commands::MergeBase.new(self).call(*args, **opts)
+      result.stdout.lines.map(&:strip).reject(&:empty?)
     end
 
     def unmerged

--- a/spec/integration/git/commands/merge_base_spec.rb
+++ b/spec/integration/git/commands/merge_base_spec.rb
@@ -24,16 +24,16 @@ RSpec.describe Git::Commands::MergeBase, :integration do
         repo.checkout('main')
       end
 
-      it 'returns an Array of commit SHAs' do
+      it 'returns a CommandLineResult with output' do
         result = command.call('main', 'feature')
 
-        expect(result).to be_an(Array)
-        expect(result).not_to be_empty
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.stdout).not_to be_empty
       end
     end
 
     describe 'when the command fails' do
-      it 'raises FailedError with a nonexistent ref' do
+      it 'raises FailedError for invalid revision' do
         expect { command.call('main', 'nonexistent') }.to raise_error(Git::FailedError)
       end
     end

--- a/spec/unit/git/commands/merge_base_spec.rb
+++ b/spec/unit/git/commands/merge_base_spec.rb
@@ -9,119 +9,81 @@ RSpec.describe Git::Commands::MergeBase do
 
   describe '#call' do
     context 'with two commits' do
-      it 'calls git merge-base with both commits' do
-        expect(execution_context).to receive(:command).with('merge-base', 'main',
-                                                            'feature').and_return(command_result("abc123\n"))
+      it 'runs merge-base with both commits' do
+        expected_result = command_result("abc123\n")
+        expect(execution_context).to receive(:command)
+          .with('merge-base', 'main', 'feature')
+          .and_return(expected_result)
+
         result = command.call('main', 'feature')
-        expect(result).to eq(['abc123'])
+
+        expect(result).to eq(expected_result)
       end
     end
 
     context 'with multiple commits' do
-      it 'calls git merge-base with all commits' do
-        expect(execution_context).to receive(:command).with('merge-base', 'main', 'feature1',
-                                                            'feature2').and_return(command_result("abc123\n"))
-        result = command.call('main', 'feature1', 'feature2')
-        expect(result).to eq(['abc123'])
+      it 'passes all commits as operands' do
+        expect(execution_context).to receive(:command)
+          .with('merge-base', 'main', 'feature1', 'feature2')
+          .and_return(command_result("abc123\n"))
+
+        command.call('main', 'feature1', 'feature2')
       end
     end
 
     context 'with :octopus option' do
-      it 'adds --octopus flag' do
-        expect(execution_context).to receive(:command).with('merge-base', '--octopus', 'main', 'b1',
-                                                            'b2').and_return(command_result("abc123\n"))
-        result = command.call('main', 'b1', 'b2', octopus: true)
-        expect(result).to eq(['abc123'])
-      end
+      it 'includes the --octopus flag' do
+        expect(execution_context).to receive(:command)
+          .with('merge-base', '--octopus', 'main', 'b1', 'b2')
+          .and_return(command_result("abc123\n"))
 
-      it 'does not add flag when false' do
-        expect(execution_context).to receive(:command).with('merge-base', 'main',
-                                                            'feature').and_return(command_result("abc123\n"))
-        command.call('main', 'feature', octopus: false)
+        command.call('main', 'b1', 'b2', octopus: true)
       end
     end
 
     context 'with :independent option' do
-      it 'adds --independent flag' do
-        expect(execution_context).to receive(:command).with('merge-base', '--independent', 'a', 'b',
-                                                            'c').and_return(command_result("sha1\nsha2\n"))
-        result = command.call('a', 'b', 'c', independent: true)
-        expect(result).to eq(%w[sha1 sha2])
-      end
+      it 'includes the --independent flag' do
+        expect(execution_context).to receive(:command)
+          .with('merge-base', '--independent', 'a', 'b', 'c')
+          .and_return(command_result("sha1\nsha2\n"))
 
-      it 'does not add flag when false' do
-        expect(execution_context).to receive(:command).with('merge-base', 'main',
-                                                            'feature').and_return(command_result("abc123\n"))
-        command.call('main', 'feature', independent: false)
+        command.call('a', 'b', 'c', independent: true)
       end
     end
 
     context 'with :fork_point option' do
-      it 'adds --fork-point flag' do
-        expect(execution_context).to receive(:command).with('merge-base', '--fork-point', 'main',
-                                                            'feature').and_return(command_result("abc123\n"))
-        result = command.call('main', 'feature', fork_point: true)
-        expect(result).to eq(['abc123'])
-      end
+      it 'includes the --fork-point flag' do
+        expect(execution_context).to receive(:command)
+          .with('merge-base', '--fork-point', 'main', 'feature')
+          .and_return(command_result("abc123\n"))
 
-      it 'does not add flag when false' do
-        expect(execution_context).to receive(:command).with('merge-base', 'main',
-                                                            'feature').and_return(command_result("abc123\n"))
-        command.call('main', 'feature', fork_point: false)
+        command.call('main', 'feature', fork_point: true)
       end
     end
 
     context 'with :all option' do
-      it 'adds --all flag' do
-        expect(execution_context).to receive(:command).with('merge-base', '--all', 'main',
-                                                            'feature').and_return(command_result("sha1\nsha2\n"))
-        result = command.call('main', 'feature', all: true)
-        expect(result).to eq(%w[sha1 sha2])
-      end
+      it 'includes the --all flag' do
+        expect(execution_context).to receive(:command)
+          .with('merge-base', '--all', 'main', 'feature')
+          .and_return(command_result("sha1\nsha2\n"))
 
-      it 'does not add flag when false' do
-        expect(execution_context).to receive(:command).with('merge-base', 'main',
-                                                            'feature').and_return(command_result("abc123\n"))
-        command.call('main', 'feature', all: false)
+        command.call('main', 'feature', all: true)
       end
     end
 
     context 'with multiple options combined' do
       it 'includes all specified flags in correct order' do
-        expect(execution_context).to receive(:command).with(
-          'merge-base', '--octopus', '--all', 'main', 'b1', 'b2'
-        ).and_return(command_result("sha1\nsha2\n"))
-        result = command.call('main', 'b1', 'b2', octopus: true, all: true)
-        expect(result).to eq(%w[sha1 sha2])
+        expect(execution_context).to receive(:command)
+          .with('merge-base', '--octopus', '--all', 'main', 'b1', 'b2')
+          .and_return(command_result("sha1\nsha2\n"))
+
+        command.call('main', 'b1', 'b2', octopus: true, all: true)
       end
     end
 
     context 'input validation' do
-      it 'raises an error when no commits provided' do
+      it 'raises ArgumentError when no commits provided' do
         expect { command.call }.to raise_error(ArgumentError)
-      end
-    end
-
-    context 'return value parsing' do
-      it 'returns empty array when no output' do
-        expect(execution_context).to receive(:command).with('merge-base', 'main',
-                                                            'feature').and_return(command_result(''))
-        result = command.call('main', 'feature')
-        expect(result).to eq([])
-      end
-
-      it 'strips whitespace from each SHA' do
-        expect(execution_context).to receive(:command).with('merge-base', '--all', 'main', 'feature')
-                                                      .and_return(command_result("  sha1  \n  sha2  \n"))
-        result = command.call('main', 'feature', all: true)
-        expect(result).to eq(%w[sha1 sha2])
-      end
-
-      it 'filters out empty lines' do
-        expect(execution_context).to receive(:command).with('merge-base', 'main',
-                                                            'feature').and_return(command_result("sha1\n\nsha2\n\n"))
-        result = command.call('main', 'feature')
-        expect(result).to eq(%w[sha1 sha2])
       end
     end
   end


### PR DESCRIPTION
# Description

Move output parsing from `MergeBase#call` to the `Git::Lib#merge_base` facade method. `MergeBase` now returns a raw `CommandLineResult`, consistent with all other command classes. The facade layer handles splitting stdout into an array of SHAs.

This is prerequisite **0b** for #996 (introduce `Commands::Base` to reduce behavioral boilerplate).

## What changed

- **`lib/git/commands/merge_base.rb`** — Removed `parse_output` private method. `#call` now returns `CommandLineResult` directly using the standard two-liner pattern. Updated `@return` tag and `@example` annotations.
- **`lib/git/lib.rb`** — `Git::Lib#merge_base` now parses `result.stdout` into an array of SHAs (`lines.map(&:strip).reject(&:empty?)`), preserving the existing public API contract.
- **`spec/unit/git/commands/merge_base_spec.rb`** — Tests assert `CommandLineResult` return type and CLI args. Removed parsed-result assertions, `option: false` tests for non-negatable flags, and repeated return-type checks per testing guidelines.
- **`spec/integration/git/commands/merge_base_spec.rb`** — Reduced to smoke test + error handling with proper `describe 'when the command succeeds'` / `describe 'when the command fails'` grouping.

## No public API changes

`Git::Base#merge_base` and `Git::Lib#merge_base` continue to return the same types as before. This change only affects the internal contract of the `MergeBase` command class.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).