### PR TITLE
refactor(show_current): use Arguments DSL and align tests with guidelines

### DIFF
--- a/lib/git/commands/branch/show_current.rb
+++ b/lib/git/commands/branch/show_current.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'git/commands/arguments'
+
 module Git
   module Commands
     module Branch
@@ -10,6 +12,12 @@ module Git
       # @api private
       #
       class ShowCurrent
+        # Arguments DSL for building command-line arguments
+        ARGS = Arguments.define do
+          literal 'branch'
+          literal '--show-current'
+        end.freeze
+
         # Initialize the ShowCurrent command
         #
         # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
@@ -25,7 +33,9 @@ module Git
         # @raise [Git::FailedError] if git returns a non-zero exit code
         #
         def call
-          @execution_context.command('branch', '--show-current')
+          bound_args = ARGS.bind
+
+          @execution_context.command(*bound_args)
         end
       end
     end

--- a/spec/integration/git/commands/branch/show_current_spec.rb
+++ b/spec/integration/git/commands/branch/show_current_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Branch::ShowCurrent, :integration do
 
   describe '#call' do
     describe 'when the command succeeds' do
-      it 'returns a CommandLineResult with output' do
+      it 'returns a CommandLineResult' do
         write_file('README.md', 'Initial content')
         repo.add('README.md')
         repo.commit('Initial commit')
@@ -19,26 +19,6 @@ RSpec.describe Git::Commands::Branch::ShowCurrent, :integration do
 
         expect(result).to be_a(Git::CommandLineResult)
         expect(result.stdout).not_to be_empty
-      end
-
-      it 'returns empty stdout in detached HEAD state' do
-        write_file('README.md', 'Initial content')
-        repo.add('README.md')
-        repo.commit('Initial commit')
-        commit_sha = repo.log.execute.first.sha
-        repo.checkout(commit_sha)
-
-        result = command.call
-
-        expect(result).to be_a(Git::CommandLineResult)
-        expect(result.stdout.strip).to be_empty
-      end
-
-      it 'returns the branch name on an unborn branch' do
-        result = command.call
-
-        expect(result).to be_a(Git::CommandLineResult)
-        expect(result.stdout.strip).not_to be_empty
       end
     end
 

--- a/spec/unit/git/commands/branch/show_current_spec.rb
+++ b/spec/unit/git/commands/branch/show_current_spec.rb
@@ -9,42 +9,16 @@ RSpec.describe Git::Commands::Branch::ShowCurrent do
   let(:execution_context) { instance_double(Git::Lib) }
 
   describe '#call' do
-    context 'when on a branch' do
+    context 'with no arguments' do
       it 'runs branch --show-current' do
+        expected_result = command_result("main\n")
         expect(execution_context).to receive(:command)
           .with('branch', '--show-current')
-          .and_return(command_result("main\n"))
+          .and_return(expected_result)
 
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
-        expect(result.stdout).to eq("main\n")
-      end
-    end
-
-    context 'when in detached HEAD state' do
-      it 'returns empty stdout' do
-        expect(execution_context).to receive(:command)
-          .with('branch', '--show-current')
-          .and_return(command_result(''))
-
-        result = command.call
-
-        expect(result).to be_a(Git::CommandLineResult)
-        expect(result.stdout).to eq('')
-      end
-    end
-
-    context 'when on a feature branch with slashes' do
-      it 'returns the full branch name in stdout' do
-        expect(execution_context).to receive(:command)
-          .with('branch', '--show-current')
-          .and_return(command_result("feature/my-feature\n"))
-
-        result = command.call
-
-        expect(result).to be_a(Git::CommandLineResult)
-        expect(result.stdout).to eq("feature/my-feature\n")
+        expect(result).to eq(expected_result)
       end
     end
   end


### PR DESCRIPTION
# Description

Add the `Arguments` DSL to `Git::Commands::Branch::ShowCurrent` and align unit/integration tests with project testing guidelines.

## What changed

- **`lib/git/commands/branch/show_current.rb`** — Added `ARGS` definition with two `literal` entries (`'branch'`, `'--show-current'`). Updated `#call` to use the `ARGS.bind` pattern consistent with all other command classes. Added `require 'git/commands/arguments'`.
- **`spec/unit/git/commands/branch/show_current_spec.rb`** — Replaced three tests with a single base invocation test using the `expected_result` pattern. Removed redundant tests that varied mocked stdout for the same code path (detached HEAD, branch with slashes).
- **`spec/integration/git/commands/branch/show_current_spec.rb`** — Reduced to one smoke test and one error test. Removed output-variant tests (detached HEAD state, unborn branch) that tested git's behavior rather than the command's.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).