### PR TITLE
refactor(commands): migrate Add, Branch::Delete, Clone to Commands::Base

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -49,6 +49,10 @@ Style/Documentation:
   Exclude:
     - "tests/units/**/*"
 
+Lint/UselessMethodDefinition:
+  Exclude:
+    - "lib/git/commands/**/*"
+
 AllCops:
   # Pin this project to Ruby 3.1 in case the shared config above is upgraded to 3.2
   # or later.

--- a/lib/git/commands/add.rb
+++ b/lib/git/commands/add.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 
 module Git
   module Commands
@@ -17,21 +17,12 @@ module Git
     #   add.call('file1.rb', 'file2.rb')
     #   add.call(all: true)
     #
-    class Add
-      # Arguments DSL for building command-line arguments
-      ARGS = Arguments.define do
+    class Add < Base
+      arguments do
         literal 'add'
         flag_option :all
         flag_option :force
         operand :paths, repeatable: true, default: [], separator: '--'
-      end.freeze
-
-      # Initialize the Add command
-      #
-      # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
-      #
-      def initialize(execution_context)
-        @execution_context = execution_context
       end
 
       # Execute the git add command
@@ -49,10 +40,7 @@ module Git
       #
       # @return [Git::CommandLineResult] the result of the command
       #
-      def call(*, **)
-        args = ARGS.bind(*, **)
-        @execution_context.command(*args)
-      end
+      def call(...) = super
     end
   end
 end

--- a/lib/git/commands/branch/delete.rb
+++ b/lib/git/commands/branch/delete.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 
 module Git
   module Commands
@@ -27,24 +27,17 @@ module Git
       #   delete = Git::Commands::Branch::Delete.new(execution_context)
       #   result = delete.call('origin/feature', remotes: true)
       #
-      class Delete
-        # Arguments DSL for building command-line arguments
-        #
-        ARGS = Arguments.define do
+      class Delete < Base
+        arguments do
           literal 'branch'
           literal '--delete'
           flag_option %i[force f]
           flag_option %i[remotes r]
           operand :branch_names, repeatable: true, required: true
-        end.freeze
-
-        # Initialize the Delete command
-        #
-        # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
-        #
-        def initialize(execution_context)
-          @execution_context = execution_context
         end
+
+        # git branch --delete exits 1 when one or more branches cannot be deleted
+        allow_exit_status 0..1
 
         # Execute the git branch --delete command to delete branches
         #
@@ -73,14 +66,7 @@ module Git
         #
         # @raise [Git::FailedError] for unexpected errors (exit code > 1)
         #
-        def call(*, **)
-          bound_args = ARGS.bind(*, **)
-
-          # git branch --delete exit codes: 0 = all deleted, 1 = partial failure, 2+ = error
-          @execution_context.command(*bound_args, raise_on_failure: false).tap do |result|
-            raise Git::FailedError, result if result.status.exitstatus > 1
-          end
-        end
+        def call(...) = super
       end
     end
   end

--- a/lib/git/commands/clone.rb
+++ b/lib/git/commands/clone.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 
 module Git
   module Commands
@@ -18,9 +18,8 @@ module Git
     #   clone = Git::Commands::Clone.new(execution_context)
     #   result = clone.call('https://github.com/user/repo.git', 'local-dir', bare: true, depth: 1)
     #
-    class Clone
-      # Arguments DSL for building command-line arguments
-      ARGS = Arguments.define do
+    class Clone < Base
+      arguments do
         literal 'clone'
         flag_option :bare
         flag_option :recursive
@@ -34,14 +33,6 @@ module Git
         operand :repository_url, required: true, separator: '--'
         operand :directory
         execution_option :timeout
-      end.freeze
-
-      # Initialize the Clone command
-      #
-      # @param execution_context [Git::ExecutionContext, Git::Lib] the context for executing git commands
-      #
-      def initialize(execution_context)
-        @execution_context = execution_context
       end
 
       # Execute the git clone command
@@ -82,10 +73,7 @@ module Git
       # @raise [ArgumentError] if unsupported options are provided, if :single_branch is not true, false, or nil,
       #   or if any option fails validation
       #
-      def call(*, **)
-        args = ARGS.bind(*, **)
-        @execution_context.command(*args, timeout: args.timeout)
-      end
+      def call(...) = super
     end
   end
 end

--- a/spec/unit/git/commands/add_spec.rb
+++ b/spec/unit/git/commands/add_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Add do
     context 'with default arguments' do
       it 'adds nothing' do
         expected_result = command_result
-        expect(execution_context).to receive(:command).with('add')
+        expect(execution_context).to receive(:command).with('add', raise_on_failure: false)
                                                       .and_return(expected_result)
 
         result = command.call
@@ -21,7 +21,9 @@ RSpec.describe Git::Commands::Add do
 
     context 'with a single file path' do
       it 'adds the specified file' do
-        expect(execution_context).to receive(:command).with('add', '--', 'path/to/file.rb')
+        expect(execution_context).to receive(:command)
+          .with('add', '--', 'path/to/file.rb', raise_on_failure: false)
+          .and_return(command_result)
 
         command.call('path/to/file.rb')
       end
@@ -29,7 +31,9 @@ RSpec.describe Git::Commands::Add do
 
     context 'with multiple file paths as an array' do
       it 'adds all specified files' do
-        expect(execution_context).to receive(:command).with('add', '--', 'file1.rb', 'file2.rb', 'file3.rb')
+        expect(execution_context).to receive(:command)
+          .with('add', '--', 'file1.rb', 'file2.rb', 'file3.rb', raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(%w[file1.rb file2.rb file3.rb])
       end
@@ -37,13 +41,17 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :all option' do
       it 'includes the --all flag' do
-        expect(execution_context).to receive(:command).with('add', '--all', '--', '.')
+        expect(execution_context).to receive(:command)
+          .with('add', '--all', '--', '.', raise_on_failure: false)
+          .and_return(command_result)
 
         command.call('.', all: true)
       end
 
       it 'does not include the flag when false' do
-        expect(execution_context).to receive(:command).with('add', '--', '.')
+        expect(execution_context).to receive(:command)
+          .with('add', '--', '.', raise_on_failure: false)
+          .and_return(command_result)
 
         command.call('.', all: false)
       end
@@ -51,13 +59,17 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :force option' do
       it 'includes the --force flag' do
-        expect(execution_context).to receive(:command).with('add', '--force', '--', 'ignored_file.txt')
+        expect(execution_context).to receive(:command)
+          .with('add', '--force', '--', 'ignored_file.txt', raise_on_failure: false)
+          .and_return(command_result)
 
         command.call('ignored_file.txt', force: true)
       end
 
       it 'does not include the flag when false' do
-        expect(execution_context).to receive(:command).with('add', '--', 'file.txt')
+        expect(execution_context).to receive(:command)
+          .with('add', '--', 'file.txt', raise_on_failure: false)
+          .and_return(command_result)
 
         command.call('file.txt', force: false)
       end
@@ -65,7 +77,9 @@ RSpec.describe Git::Commands::Add do
 
     context 'with multiple options combined' do
       it 'includes all specified flags' do
-        expect(execution_context).to receive(:command).with('add', '--all', '--force', '--', '.')
+        expect(execution_context).to receive(:command)
+          .with('add', '--all', '--force', '--', '.', raise_on_failure: false)
+          .and_return(command_result)
 
         command.call('.', all: true, force: true)
       end
@@ -73,13 +87,17 @@ RSpec.describe Git::Commands::Add do
 
     context 'with paths containing special characters' do
       it 'handles paths with spaces' do
-        expect(execution_context).to receive(:command).with('add', '--', 'path/to/my file.rb')
+        expect(execution_context).to receive(:command)
+          .with('add', '--', 'path/to/my file.rb', raise_on_failure: false)
+          .and_return(command_result)
 
         command.call('path/to/my file.rb')
       end
 
       it 'handles paths with unicode characters' do
-        expect(execution_context).to receive(:command).with('add', '--', 'path/to/файл.rb')
+        expect(execution_context).to receive(:command)
+          .with('add', '--', 'path/to/файл.rb', raise_on_failure: false)
+          .and_return(command_result)
 
         command.call('path/to/файл.rb')
       end

--- a/spec/unit/git/commands/clone_spec.rb
+++ b/spec/unit/git/commands/clone_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Commands::Clone do
       it 'clones into the specified directory' do
         expected_result = command_result
         expect(execution_context).to receive(:command)
-          .with('clone', '--', repository_url, directory, timeout: nil)
+          .with('clone', '--', repository_url, directory, raise_on_failure: false)
           .and_return(expected_result)
 
         result = command.call(repository_url, directory)
@@ -26,7 +26,8 @@ RSpec.describe Git::Commands::Clone do
     context 'with nil directory' do
       it 'omits the directory operand' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--', repository_url, timeout: nil)
+          .with('clone', '--', repository_url, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, nil)
       end
@@ -35,7 +36,8 @@ RSpec.describe Git::Commands::Clone do
     context 'with :bare option' do
       it 'includes the --bare flag' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--bare', '--', repository_url, directory, timeout: nil)
+          .with('clone', '--bare', '--', repository_url, directory, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, bare: true)
       end
@@ -44,7 +46,8 @@ RSpec.describe Git::Commands::Clone do
     context 'with :mirror option' do
       it 'includes the --mirror flag' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--mirror', '--', repository_url, directory, timeout: nil)
+          .with('clone', '--mirror', '--', repository_url, directory, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, mirror: true)
       end
@@ -53,7 +56,8 @@ RSpec.describe Git::Commands::Clone do
     context 'with :recursive option' do
       it 'includes the --recursive flag' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--recursive', '--', repository_url, directory, timeout: nil)
+          .with('clone', '--recursive', '--', repository_url, directory, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, recursive: true)
       end
@@ -62,7 +66,8 @@ RSpec.describe Git::Commands::Clone do
     context 'with :branch option' do
       it 'includes the --branch flag with value' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--branch', 'development', '--', repository_url, directory, timeout: nil)
+          .with('clone', '--branch', 'development', '--', repository_url, directory, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, branch: 'development')
       end
@@ -71,7 +76,8 @@ RSpec.describe Git::Commands::Clone do
     context 'with :filter option' do
       it 'includes the --filter flag with value' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--filter', 'tree:0', '--', repository_url, directory, timeout: nil)
+          .with('clone', '--filter', 'tree:0', '--', repository_url, directory, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, filter: 'tree:0')
       end
@@ -80,7 +86,8 @@ RSpec.describe Git::Commands::Clone do
     context 'with :origin option' do
       it 'includes the --origin flag with value' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--origin', 'upstream', '--', repository_url, directory, timeout: nil)
+          .with('clone', '--origin', 'upstream', '--', repository_url, directory, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, origin: 'upstream')
       end
@@ -89,7 +96,8 @@ RSpec.describe Git::Commands::Clone do
     context 'with :remote option (alias for origin)' do
       it 'includes the --origin flag with value' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--origin', 'upstream', '--', repository_url, directory, timeout: nil)
+          .with('clone', '--origin', 'upstream', '--', repository_url, directory, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, remote: 'upstream')
       end
@@ -98,7 +106,8 @@ RSpec.describe Git::Commands::Clone do
     context 'with :config option' do
       it 'includes a single config option' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--config', 'user.name=John Doe', '--', repository_url, directory, timeout: nil)
+          .with('clone', '--config', 'user.name=John Doe', '--', repository_url, directory, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, config: 'user.name=John Doe')
       end
@@ -106,7 +115,8 @@ RSpec.describe Git::Commands::Clone do
       it 'includes multiple config options' do
         expect(execution_context).to receive(:command)
           .with('clone', '--config', 'user.name=John Doe', '--config', 'user.email=john@doe.com',
-                '--', repository_url, directory, timeout: nil)
+                '--', repository_url, directory, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, config: ['user.name=John Doe', 'user.email=john@doe.com'])
       end
@@ -115,21 +125,24 @@ RSpec.describe Git::Commands::Clone do
     context 'with :single_branch option' do
       it 'includes --single-branch when true' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--single-branch', '--', repository_url, directory, timeout: nil)
+          .with('clone', '--single-branch', '--', repository_url, directory, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, single_branch: true)
       end
 
       it 'includes --no-single-branch when false' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--no-single-branch', '--', repository_url, directory, timeout: nil)
+          .with('clone', '--no-single-branch', '--', repository_url, directory, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, single_branch: false)
       end
 
       it 'includes no flag when nil' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--', repository_url, directory, timeout: nil)
+          .with('clone', '--', repository_url, directory, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, single_branch: nil)
       end
@@ -138,14 +151,16 @@ RSpec.describe Git::Commands::Clone do
     context 'with :depth option' do
       it 'includes --depth with integer value' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--depth', 1, '--', repository_url, directory, timeout: nil)
+          .with('clone', '--depth', 1, '--', repository_url, directory, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, depth: 1)
       end
 
       it 'converts string depth to integer' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--depth', 5, '--', repository_url, directory, timeout: nil)
+          .with('clone', '--depth', 5, '--', repository_url, directory, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, depth: '5')
       end
@@ -154,7 +169,8 @@ RSpec.describe Git::Commands::Clone do
     context 'with :timeout option' do
       it 'passes timeout to the command' do
         expect(execution_context).to receive(:command)
-          .with('clone', '--', repository_url, directory, timeout: 30)
+          .with('clone', '--', repository_url, directory, timeout: 30, raise_on_failure: false)
+          .and_return(command_result)
 
         command.call(repository_url, directory, timeout: 30)
       end

--- a/tests/units/test_git_clone.rb
+++ b/tests/units/test_git_clone.rb
@@ -105,8 +105,10 @@ class TestGitClone < Test::Unit::TestCase
       git.lib.clone(repository_url, destination, { config: 'user.name=John Doe' })
     end
 
-    expected_command_line = ['clone', '--config', 'user.name=John Doe', '--', repository_url, destination,
-                             { timeout: nil }]
+    expected_command_line = [
+      'clone', '--config', 'user.name=John Doe',
+      '--', repository_url, destination, { raise_on_failure: false }
+    ]
 
     assert_equal(expected_command_line, actual_command_line)
   end
@@ -134,7 +136,7 @@ class TestGitClone < Test::Unit::TestCase
       'clone',
       '--config', 'user.name=John Doe',
       '--config', 'user.email=john@doe.com',
-      '--', repository_url, destination, { timeout: nil }
+      '--', repository_url, destination, { raise_on_failure: false }
     ]
 
     assert_equal(expected_command_line, actual_command_line)
@@ -162,7 +164,7 @@ class TestGitClone < Test::Unit::TestCase
     expected_command_line = [
       'clone',
       '--filter', 'tree:0',
-      '--', repository_url, destination, { timeout: nil }
+      '--', repository_url, destination, { raise_on_failure: false }
     ]
 
     assert_equal(expected_command_line, actual_command_line)
@@ -188,7 +190,7 @@ class TestGitClone < Test::Unit::TestCase
 
     expected_command_line = [
       'clone',
-      '--', repository_url, destination, { timeout: nil }
+      '--', repository_url, destination, { raise_on_failure: false }
     ]
 
     assert_equal(expected_command_line, actual_command_line)
@@ -215,7 +217,7 @@ class TestGitClone < Test::Unit::TestCase
     expected_command_line = [
       'clone',
       '--single-branch',
-      '--', repository_url, destination, { timeout: nil }
+      '--', repository_url, destination, { raise_on_failure: false }
     ]
 
     assert_equal(expected_command_line, actual_command_line)
@@ -242,7 +244,7 @@ class TestGitClone < Test::Unit::TestCase
     expected_command_line = [
       'clone',
       '--no-single-branch',
-      '--', repository_url, destination, { timeout: nil }
+      '--', repository_url, destination, { raise_on_failure: false }
     ]
 
     assert_equal(expected_command_line, actual_command_line)
@@ -268,7 +270,7 @@ class TestGitClone < Test::Unit::TestCase
 
     expected_command_line = [
       'clone',
-      '--', repository_url, destination, { timeout: nil }
+      '--', repository_url, destination, { raise_on_failure: false }
     ]
 
     assert_equal(expected_command_line, actual_command_line)


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Migrate three pilot commands from standalone command classes to inherit from `Git::Commands::Base`, partially addressing #996 (task 2, Phase 1).

The three pilot commands cover each pattern variant described in the issue:

| Command | Pattern | Key Feature |
|---|---|---|
| `Add` | Simple command | `arguments do` + `def call(...) = super` |
| `Branch::Delete` | Exit-status command | `allow_exit_status 0..1` |
| `Clone` | Execution-option command | `timeout` auto-forwarded via `Base#call` |

### Changes in each command class

- Replace standalone `ARGS = Arguments.define do...end.freeze` with class-level `arguments do...end` DSL
- Remove custom `initialize` (inherited from `Base`)
- Replace custom `call` body with `def call(...) = super` (YARD documentation shim)
- `Base#call` always passes `raise_on_failure: false` and validates exit status against the declared `allow_exit_status` range

### Test updates

- All unit specs updated to expect `raise_on_failure: false` in command arguments (since `Base#call` always passes it)
- Clone specs no longer expect `timeout: nil` — execution options are only forwarded when non-nil
- TestUnit clone tests updated to match new command argument format

### Other

- Added `Lint/UselessMethodDefinition` exclusion for `lib/git/commands/**` in `.rubocop.yml` — `def call(...) = super` is intentional for YARD documentation anchoring

### Quality gates

All pass locally:
- `bundle exec rspec` ✓
- `bundle exec rake test` ✓
- `bundle exec rubocop` ✓
- `bundle exec yard` ✓ (79.2% coverage)

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).