### PR TITLE
refactor(stash): migrate commands to Base pattern

### DIFF
--- a/lib/git/commands/stash/apply.rb
+++ b/lib/git/commands/stash/apply.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 
 module Git
   module Commands
@@ -25,21 +25,12 @@ module Git
       # @example Apply and restore index state
       #   Git::Commands::Stash::Apply.new(execution_context).call(index: true)
       #
-      class Apply
-        # Arguments DSL for building command-line arguments
-        ARGS = Arguments.define do
+      class Apply < Base
+        arguments do
           literal 'stash'
           literal 'apply'
           flag_option :index
           operand :stash
-        end.freeze
-
-        # Creates a new Apply command instance
-        #
-        # @param execution_context [Git::ExecutionContext] the execution context for running commands
-        #
-        def initialize(execution_context)
-          @execution_context = execution_context
         end
 
         # Apply stashed changes
@@ -66,9 +57,7 @@ module Git
         #
         # @raise [Git::FailedError] if the stash does not exist
         #
-        def call(*, **)
-          @execution_context.command(*ARGS.bind(*, **))
-        end
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/git/commands/stash/branch.rb
+++ b/lib/git/commands/stash/branch.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 
 module Git
   module Commands
@@ -28,21 +28,12 @@ module Git
       # @example Create branch from specific stash
       #   Git::Commands::Stash::Branch.new(execution_context).call('my-branch', 'stash@{2}')
       #
-      class Branch
-        # Arguments DSL for building command-line arguments
-        ARGS = Arguments.define do
+      class Branch < Base
+        arguments do
           literal 'stash'
           literal 'branch'
           operand :branchname, required: true
           operand :stash
-        end.freeze
-
-        # Creates a new Branch command instance
-        #
-        # @param execution_context [Git::ExecutionContext] the execution context for running commands
-        #
-        def initialize(execution_context)
-          @execution_context = execution_context
         end
 
         # Create a branch from a stash entry
@@ -65,9 +56,7 @@ module Git
         #
         # @raise [Git::FailedError] if the branch already exists or stash doesn't exist
         #
-        def call(*, **)
-          @execution_context.command(*ARGS.bind(*, **))
-        end
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/git/commands/stash/clear.rb
+++ b/lib/git/commands/stash/clear.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 
 module Git
   module Commands
@@ -18,28 +18,17 @@ module Git
       # @example Clear all stashes
       #   Git::Commands::Stash::Clear.new(execution_context).call
       #
-      class Clear
-        # Arguments DSL for building command-line arguments
-        ARGS = Arguments.define do
+      class Clear < Base
+        arguments do
           literal 'stash'
           literal 'clear'
-        end.freeze
-
-        # Creates a new Clear command instance
-        #
-        # @param execution_context [Git::ExecutionContext] the execution context for running commands
-        #
-        def initialize(execution_context)
-          @execution_context = execution_context
         end
 
         # Clear all stash entries
         #
         # @return [Git::CommandLineResult] the result of calling `git stash clear`
         #
-        def call
-          @execution_context.command(*ARGS.bind)
-        end
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/git/commands/stash/create.rb
+++ b/lib/git/commands/stash/create.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 
 module Git
   module Commands
@@ -26,20 +26,11 @@ module Git
       # @example Create a stash commit with a message
       #   Git::Commands::Stash::Create.new(execution_context).call('WIP: my changes')
       #
-      class Create
-        # Arguments DSL for building command-line arguments
-        ARGS = Arguments.define do
+      class Create < Base
+        arguments do
           literal 'stash'
           literal 'create'
           operand :message
-        end.freeze
-
-        # Creates a new Create command instance
-        #
-        # @param execution_context [Git::ExecutionContext] the execution context for running commands
-        #
-        def initialize(execution_context)
-          @execution_context = execution_context
         end
 
         # Create a stash commit
@@ -56,9 +47,7 @@ module Git
         #
         # @return [Git::CommandLineResult] the result of calling `git stash create`
         #
-        def call(*, **)
-          @execution_context.command(*ARGS.bind(*, **))
-        end
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/git/commands/stash/drop.rb
+++ b/lib/git/commands/stash/drop.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 
 module Git
   module Commands
@@ -22,20 +22,11 @@ module Git
       # @example Drop a specific stash
       #   Git::Commands::Stash::Drop.new(execution_context).call('stash@\\{2}')
       #
-      class Drop
-        # Arguments DSL for building command-line arguments
-        ARGS = Arguments.define do
+      class Drop < Base
+        arguments do
           literal 'stash'
           literal 'drop'
           operand :stash
-        end.freeze
-
-        # Creates a new Drop command instance
-        #
-        # @param execution_context [Git::ExecutionContext] the execution context for running commands
-        #
-        def initialize(execution_context)
-          @execution_context = execution_context
         end
 
         # Drop a stash entry
@@ -54,9 +45,7 @@ module Git
         #
         # @raise [Git::FailedError] if the stash does not exist
         #
-        def call(*, **)
-          @execution_context.command(*ARGS.bind(*, **))
-        end
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/git/commands/stash/list.rb
+++ b/lib/git/commands/stash/list.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 require 'git/parsers/stash'
 
 module Git
@@ -17,20 +17,11 @@ module Git
       # @example List all stashes
       #   Git::Commands::Stash::List.new(execution_context).call
       #
-      class List
-        # Arguments DSL for building command-line arguments
-        ARGS = Arguments.define do
+      class List < Base
+        arguments do
           literal 'stash'
           literal 'list'
           literal "--format=#{Git::Parsers::Stash::STASH_FORMAT}"
-        end.freeze
-
-        # Creates a new List command instance
-        #
-        # @param execution_context [Git::ExecutionContext] the execution context for running commands
-        #
-        def initialize(execution_context)
-          @execution_context = execution_context
         end
 
         # List all stash entries
@@ -39,9 +30,7 @@ module Git
         #
         # @return [Git::CommandLineResult] the result of calling `git stash list`
         #
-        def call
-          @execution_context.command(*ARGS.bind)
-        end
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/git/commands/stash/pop.rb
+++ b/lib/git/commands/stash/pop.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 
 module Git
   module Commands
@@ -25,21 +25,12 @@ module Git
       # @example Pop and restore index state
       #   Git::Commands::Stash::Pop.new(execution_context).call(index: true)
       #
-      class Pop
-        # Arguments DSL for building command-line arguments
-        ARGS = Arguments.define do
+      class Pop < Base
+        arguments do
           literal 'stash'
           literal 'pop'
           flag_option :index
           operand :stash
-        end.freeze
-
-        # Creates a new Pop command instance
-        #
-        # @param execution_context [Git::ExecutionContext] the execution context for running commands
-        #
-        def initialize(execution_context)
-          @execution_context = execution_context
         end
 
         # Pop stashed changes
@@ -66,9 +57,7 @@ module Git
         #
         # @raise [Git::FailedError] if the stash does not exist
         #
-        def call(*, **)
-          @execution_context.command(*ARGS.bind(*, **))
-        end
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/git/commands/stash/push.rb
+++ b/lib/git/commands/stash/push.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 
 module Git
   module Commands
@@ -29,9 +29,8 @@ module Git
       # @example Include untracked files
       #   Git::Commands::Stash::Push.new(execution_context).call(include_untracked: true)
       #
-      class Push
-        # Arguments DSL for building command-line arguments
-        ARGS = Arguments.define do
+      class Push < Base
+        arguments do
           literal 'stash'
           literal 'push'
           flag_option %i[patch p]
@@ -43,14 +42,6 @@ module Git
           value_option :pathspec_from_file, inline: true
           flag_option :pathspec_file_nul
           operand :pathspecs, repeatable: true, separator: '--'
-        end.freeze
-
-        # Creates a new Push command instance
-        #
-        # @param execution_context [Git::ExecutionContext] the execution context for running commands
-        #
-        def initialize(execution_context)
-          @execution_context = execution_context
         end
 
         # Stash changes in the working directory
@@ -91,9 +82,7 @@ module Git
         #
         # @return [Git::CommandLineResult] the result of calling `git stash push`
         #
-        def call(*, **)
-          @execution_context.command(*ARGS.bind(*, **))
-        end
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/git/commands/stash/show_numstat.rb
+++ b/lib/git/commands/stash/show_numstat.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 
 module Git
   module Commands
@@ -23,9 +23,8 @@ module Git
       #   Git::Commands::Stash::ShowNumstat.new(execution_context).call(dirstat: true)
       #   Git::Commands::Stash::ShowNumstat.new(execution_context).call(dirstat: 'lines,cumulative')
       #
-      class ShowNumstat
-        # Arguments DSL for building command-line arguments
-        ARGS = Arguments.define do
+      class ShowNumstat < Base
+        arguments do
           literal 'stash'
           literal 'show'
           literal '--numstat'
@@ -35,14 +34,6 @@ module Git
           flag_option :only_untracked
           flag_or_value_option :dirstat, inline: true
           operand :stash
-        end.freeze
-
-        # Creates a new ShowNumstat command instance
-        #
-        # @param execution_context [Git::ExecutionContext] the execution context for running commands
-        #
-        def initialize(execution_context)
-          @execution_context = execution_context
         end
 
         # Show stash numstat
@@ -81,9 +72,7 @@ module Git
         #
         # @return [Git::CommandLineResult] the result of calling `git stash show --numstat`
         #
-        def call(*, **)
-          @execution_context.command(*ARGS.bind(*, **))
-        end
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/git/commands/stash/show_patch.rb
+++ b/lib/git/commands/stash/show_patch.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 
 module Git
   module Commands
@@ -23,9 +23,8 @@ module Git
       #   Git::Commands::Stash::ShowPatch.new(execution_context).call(dirstat: true)
       #   Git::Commands::Stash::ShowPatch.new(execution_context).call(dirstat: 'lines,cumulative')
       #
-      class ShowPatch
-        # Arguments DSL for building command-line arguments
-        ARGS = Arguments.define do
+      class ShowPatch < Base
+        arguments do
           literal 'stash'
           literal 'show'
           literal '--patch'
@@ -35,14 +34,6 @@ module Git
           flag_option :only_untracked
           flag_or_value_option :dirstat, inline: true
           operand :stash
-        end.freeze
-
-        # Creates a new ShowPatch command instance
-        #
-        # @param execution_context [Git::ExecutionContext] the execution context for running commands
-        #
-        def initialize(execution_context)
-          @execution_context = execution_context
         end
 
         # Show stash patch
@@ -81,9 +72,7 @@ module Git
         #
         # @return [Git::CommandLineResult] the result of calling `git stash show --patch`
         #
-        def call(*, **)
-          @execution_context.command(*ARGS.bind(*, **))
-        end
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/git/commands/stash/show_raw.rb
+++ b/lib/git/commands/stash/show_raw.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 
 module Git
   module Commands
@@ -23,9 +23,8 @@ module Git
       #   Git::Commands::Stash::ShowRaw.new(execution_context).call(dirstat: true)
       #   Git::Commands::Stash::ShowRaw.new(execution_context).call(dirstat: 'lines,cumulative')
       #
-      class ShowRaw
-        # Arguments DSL for building command-line arguments
-        ARGS = Arguments.define do
+      class ShowRaw < Base
+        arguments do
           literal 'stash'
           literal 'show'
           literal '--raw'
@@ -37,14 +36,6 @@ module Git
           flag_option :find_copies, args: '-C'
           flag_or_value_option :dirstat, inline: true
           operand :stash
-        end.freeze
-
-        # Creates a new ShowRaw command instance
-        #
-        # @param execution_context [Git::ExecutionContext] the execution context for running commands
-        #
-        def initialize(execution_context)
-          @execution_context = execution_context
         end
 
         # Show stash raw diff
@@ -87,9 +78,7 @@ module Git
         #
         # @return [Git::CommandLineResult] the result of calling `git stash show --raw`
         #
-        def call(*, **)
-          @execution_context.command(*ARGS.bind(*, **))
-        end
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/git/commands/stash/store.rb
+++ b/lib/git/commands/stash/store.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/commands/arguments'
+require 'git/commands/base'
 
 module Git
   module Commands
@@ -25,21 +25,12 @@ module Git
       # @example Store with a custom message
       #   Git::Commands::Stash::Store.new(execution_context).call('abc123def456', message: 'WIP: feature')
       #
-      class Store
-        # Arguments DSL for building command-line arguments
-        ARGS = Arguments.define do
+      class Store < Base
+        arguments do
           literal 'stash'
           literal 'store'
           value_option %i[message m], inline: true
           operand :commit, required: true
-        end.freeze
-
-        # Creates a new Store command instance
-        #
-        # @param execution_context [Git::ExecutionContext] the execution context for running commands
-        #
-        def initialize(execution_context)
-          @execution_context = execution_context
         end
 
         # Store a commit in the stash reflog
@@ -58,9 +49,7 @@ module Git
         #
         # @raise [Git::FailedError] if the commit is not a valid stash commit
         #
-        def call(*, **)
-          @execution_context.command(*ARGS.bind(*, **))
-        end
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -78,3 +78,24 @@ def command_result(stdout = '', stderr: '', exitstatus: 0)
   status = double('status', success?: exitstatus.zero?, exitstatus: exitstatus, signaled?: false)
   Git::CommandLineResult.new(%w[git], status, stdout, stderr)
 end
+
+# Helper to expect a command call with raise_on_failure: false automatically included
+#
+# This helper simplifies testing commands that inherit from Commands::Base, which
+# always passes raise_on_failure: false to the execution context.
+#
+# @param args [Array] the command arguments to expect
+#
+# @param execution_options [Hash] additional execution options to expect
+#
+# @return [RSpec::Mocks::MessageExpectation] the expectation object for chaining
+#
+# @example
+#   expect_command('stash', 'apply').and_return(command_result(''))
+#   expect_command('stash', 'push', '--all').and_return(command_result(''))
+#   expect_command('fetch', 'origin', timeout: 30).and_return(command_result(''))
+#
+def expect_command(*, **execution_options)
+  expect(execution_context).to receive(:command)
+    .with(*, **execution_options, raise_on_failure: false)
+end

--- a/spec/unit/git/commands/stash/apply_spec.rb
+++ b/spec/unit/git/commands/stash/apply_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Apply do
   describe '#call' do
     context 'with no arguments (apply latest stash)' do
       it 'runs stash apply' do
-        expect(execution_context).to receive(:command).with('stash', 'apply').and_return(command_result(''))
+        expect_command('stash', 'apply').and_return(command_result(''))
 
         result = command.call
 
@@ -21,42 +21,36 @@ RSpec.describe Git::Commands::Stash::Apply do
 
     context 'with stash reference' do
       it 'applies specific stash by name' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'apply', 'stash@{0}').and_return(command_result(''))
+        expect_command('stash', 'apply', 'stash@{0}').and_return(command_result(''))
         command.call('stash@{0}')
       end
 
       it 'applies specific stash by index' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'apply', 'stash@{2}').and_return(command_result(''))
+        expect_command('stash', 'apply', 'stash@{2}').and_return(command_result(''))
         command.call('stash@{2}')
       end
 
       it 'applies stash using short form' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'apply', '1').and_return(command_result(''))
+        expect_command('stash', 'apply', '1').and_return(command_result(''))
         command.call('1')
       end
     end
 
     context 'with :index option' do
       it 'adds --index flag to restore index state' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'apply', '--index').and_return(command_result(''))
+        expect_command('stash', 'apply', '--index').and_return(command_result(''))
         command.call(index: true)
       end
 
       it 'does not add flag when false' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'apply').and_return(command_result(''))
+        expect_command('stash', 'apply').and_return(command_result(''))
         command.call(index: false)
       end
     end
 
     context 'with stash reference and options' do
       it 'combines stash reference with index option' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'apply', '--index', 'stash@{1}').and_return(command_result(''))
+        expect_command('stash', 'apply', '--index', 'stash@{1}').and_return(command_result(''))
         command.call('stash@{1}', index: true)
       end
     end

--- a/spec/unit/git/commands/stash/branch_spec.rb
+++ b/spec/unit/git/commands/stash/branch_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Git::Commands::Stash::Branch do
   describe '#call' do
     context 'with branch name only (latest stash)' do
       it 'runs stash branch with the given branch name' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'branch', 'my-feature')
+        expect_command('stash', 'branch', 'my-feature')
           .and_return(command_result("Switched to a new branch 'my-feature'\n"))
 
         result = command.call('my-feature')
@@ -23,16 +22,14 @@ RSpec.describe Git::Commands::Stash::Branch do
 
     context 'with branch name and stash reference' do
       it 'passes stash reference to command' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'branch', 'my-feature', 'stash@{2}')
+        expect_command('stash', 'branch', 'my-feature', 'stash@{2}')
           .and_return(command_result(''))
 
         command.call('my-feature', 'stash@{2}')
       end
 
       it 'accepts numeric stash reference' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'branch', 'bugfix', '1')
+        expect_command('stash', 'branch', 'bugfix', '1')
           .and_return(command_result(''))
 
         command.call('bugfix', '1')
@@ -41,16 +38,14 @@ RSpec.describe Git::Commands::Stash::Branch do
 
     context 'with special branch names' do
       it 'handles branch names with slashes' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'branch', 'feature/new-thing')
+        expect_command('stash', 'branch', 'feature/new-thing')
           .and_return(command_result(''))
 
         command.call('feature/new-thing')
       end
 
       it 'handles branch names with hyphens' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'branch', 'fix-bug-123')
+        expect_command('stash', 'branch', 'fix-bug-123')
           .and_return(command_result(''))
 
         command.call('fix-bug-123')
@@ -59,8 +54,7 @@ RSpec.describe Git::Commands::Stash::Branch do
 
     context 'with nil stash reference' do
       it 'omits nil stash from arguments' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'branch', 'my-branch')
+        expect_command('stash', 'branch', 'my-branch')
           .and_return(command_result(''))
 
         command.call('my-branch', nil)

--- a/spec/unit/git/commands/stash/clear_spec.rb
+++ b/spec/unit/git/commands/stash/clear_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Git::Commands::Stash::Clear do
   describe '#call' do
     it 'calls git stash clear' do
       expected_result = command_result
-      expect(execution_context).to receive(:command).with('stash', 'clear')
-                                                    .and_return(expected_result)
+      expect_command('stash', 'clear').and_return(expected_result)
 
       result = command.call
 

--- a/spec/unit/git/commands/stash/create_spec.rb
+++ b/spec/unit/git/commands/stash/create_spec.rb
@@ -10,8 +10,7 @@ RSpec.describe Git::Commands::Stash::Create do
   describe '#call' do
     context 'with no arguments' do
       it 'runs stash create' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'create')
+        expect_command('stash', 'create')
           .and_return(command_result("abc123def456789\n"))
 
         result = command.call
@@ -23,24 +22,21 @@ RSpec.describe Git::Commands::Stash::Create do
 
     context 'with message' do
       it 'passes message to command' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'create', 'WIP: my changes')
+        expect_command('stash', 'create', 'WIP: my changes')
           .and_return(command_result("abc123\n"))
 
         command.call('WIP: my changes')
       end
 
       it 'handles message with special characters' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'create', 'Fix "bug" in code')
+        expect_command('stash', 'create', 'Fix "bug" in code')
           .and_return(command_result("abc123\n"))
 
         command.call('Fix "bug" in code')
       end
 
       it 'handles empty string message' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'create', '')
+        expect_command('stash', 'create', '')
           .and_return(command_result("abc123\n"))
 
         command.call('')
@@ -49,8 +45,7 @@ RSpec.describe Git::Commands::Stash::Create do
 
     context 'with nil message' do
       it 'omits nil message from arguments' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'create')
+        expect_command('stash', 'create')
           .and_return(command_result("abc123\n"))
 
         command.call(nil)

--- a/spec/unit/git/commands/stash/drop_spec.rb
+++ b/spec/unit/git/commands/stash/drop_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Drop do
   describe '#call' do
     context 'with no arguments (drop latest stash)' do
       it 'runs stash drop' do
-        expect(execution_context).to receive(:command).with('stash', 'drop').and_return(command_result(''))
+        expect_command('stash', 'drop').and_return(command_result(''))
 
         result = command.call
 
@@ -21,20 +21,17 @@ RSpec.describe Git::Commands::Stash::Drop do
 
     context 'with stash reference' do
       it 'drops specific stash by name' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'drop', 'stash@{0}').and_return(command_result(''))
+        expect_command('stash', 'drop', 'stash@{0}').and_return(command_result(''))
         command.call('stash@{0}')
       end
 
       it 'drops specific stash by index' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'drop', 'stash@{2}').and_return(command_result(''))
+        expect_command('stash', 'drop', 'stash@{2}').and_return(command_result(''))
         command.call('stash@{2}')
       end
 
       it 'drops stash using short form' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'drop', '1').and_return(command_result(''))
+        expect_command('stash', 'drop', '1').and_return(command_result(''))
         command.call('1')
       end
     end

--- a/spec/unit/git/commands/stash/list_spec.rb
+++ b/spec/unit/git/commands/stash/list_spec.rb
@@ -18,8 +18,7 @@ RSpec.describe Git::Commands::Stash::List do
     it 'runs stash list with format' do
       format_arg = "--format=#{Git::Parsers::Stash::STASH_FORMAT}"
 
-      expect(execution_context).to receive(:command)
-        .with('stash', 'list', format_arg)
+      expect_command('stash', 'list', format_arg)
         .and_return(command_result(stash_output))
 
       result = command.call

--- a/spec/unit/git/commands/stash/pop_spec.rb
+++ b/spec/unit/git/commands/stash/pop_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Pop do
   describe '#call' do
     context 'with no arguments (pop latest stash)' do
       it 'runs stash pop' do
-        expect(execution_context).to receive(:command).with('stash', 'pop').and_return(command_result(''))
+        expect_command('stash', 'pop').and_return(command_result(''))
 
         result = command.call
 
@@ -21,37 +21,36 @@ RSpec.describe Git::Commands::Stash::Pop do
 
     context 'with stash reference' do
       it 'pops specific stash by name' do
-        expect(execution_context).to receive(:command).with('stash', 'pop', 'stash@{0}').and_return(command_result(''))
+        expect_command('stash', 'pop', 'stash@{0}').and_return(command_result(''))
         command.call('stash@{0}')
       end
 
       it 'pops specific stash by index' do
-        expect(execution_context).to receive(:command).with('stash', 'pop', 'stash@{2}').and_return(command_result(''))
+        expect_command('stash', 'pop', 'stash@{2}').and_return(command_result(''))
         command.call('stash@{2}')
       end
 
       it 'pops stash using short form' do
-        expect(execution_context).to receive(:command).with('stash', 'pop', '1').and_return(command_result(''))
+        expect_command('stash', 'pop', '1').and_return(command_result(''))
         command.call('1')
       end
     end
 
     context 'with :index option' do
       it 'adds --index flag to restore index state' do
-        expect(execution_context).to receive(:command).with('stash', 'pop', '--index').and_return(command_result(''))
+        expect_command('stash', 'pop', '--index').and_return(command_result(''))
         command.call(index: true)
       end
 
       it 'does not add flag when false' do
-        expect(execution_context).to receive(:command).with('stash', 'pop').and_return(command_result(''))
+        expect_command('stash', 'pop').and_return(command_result(''))
         command.call(index: false)
       end
     end
 
     context 'with stash reference and options' do
       it 'combines stash reference with index option' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'pop', '--index', 'stash@{1}').and_return(command_result(''))
+        expect_command('stash', 'pop', '--index', 'stash@{1}').and_return(command_result(''))
         command.call('stash@{1}', index: true)
       end
     end

--- a/spec/unit/git/commands/stash/push_spec.rb
+++ b/spec/unit/git/commands/stash/push_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Push do
   describe '#call' do
     context 'with no arguments' do
       it 'runs stash push' do
-        expect(execution_context).to receive(:command).with('stash', 'push').and_return(command_result(''))
+        expect_command('stash', 'push').and_return(command_result(''))
 
         result = command.call
 
@@ -21,155 +21,140 @@ RSpec.describe Git::Commands::Stash::Push do
 
     context 'with :message option' do
       it 'adds -m flag with message' do
-        expect(execution_context).to receive(:command).with('stash', 'push',
-                                                            '--message=WIP changes').and_return(command_result(''))
+        expect_command('stash', 'push', '--message=WIP changes').and_return(command_result(''))
         command.call(message: 'WIP changes')
       end
 
       it 'accepts :m alias' do
-        expect(execution_context).to receive(:command).with('stash', 'push',
-                                                            '--message=WIP').and_return(command_result(''))
+        expect_command('stash', 'push', '--message=WIP').and_return(command_result(''))
         command.call(m: 'WIP')
       end
 
       it 'handles message with special characters' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'push', '--message=Fix "bug" in code').and_return(command_result(''))
+        expect_command('stash', 'push', '--message=Fix "bug" in code').and_return(command_result(''))
         command.call(message: 'Fix "bug" in code')
       end
     end
 
     context 'with :patch option' do
       it 'adds -p flag for interactive selection' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--patch').and_return(command_result(''))
+        expect_command('stash', 'push', '--patch').and_return(command_result(''))
         command.call(patch: true)
       end
 
       it 'accepts :p alias' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--patch').and_return(command_result(''))
+        expect_command('stash', 'push', '--patch').and_return(command_result(''))
         command.call(p: true)
       end
 
       it 'does not add flag when false' do
-        expect(execution_context).to receive(:command).with('stash', 'push').and_return(command_result(''))
+        expect_command('stash', 'push').and_return(command_result(''))
         command.call(patch: false)
       end
     end
 
     context 'with :staged option' do
       it 'adds -S flag to stash only staged changes' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--staged').and_return(command_result(''))
+        expect_command('stash', 'push', '--staged').and_return(command_result(''))
         command.call(staged: true)
       end
 
       it 'accepts :S alias' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--staged').and_return(command_result(''))
+        expect_command('stash', 'push', '--staged').and_return(command_result(''))
         command.call(S: true)
       end
     end
 
     context 'with :keep_index option' do
       it 'adds --keep-index flag when true' do
-        expect(execution_context).to receive(:command).with('stash', 'push',
-                                                            '--keep-index').and_return(command_result(''))
+        expect_command('stash', 'push', '--keep-index').and_return(command_result(''))
         command.call(keep_index: true)
       end
 
       it 'adds --no-keep-index flag when false' do
-        expect(execution_context).to receive(:command).with('stash', 'push',
-                                                            '--no-keep-index').and_return(command_result(''))
+        expect_command('stash', 'push', '--no-keep-index').and_return(command_result(''))
         command.call(keep_index: false)
       end
 
       it 'accepts :k alias' do
-        expect(execution_context).to receive(:command).with('stash', 'push',
-                                                            '--keep-index').and_return(command_result(''))
+        expect_command('stash', 'push', '--keep-index').and_return(command_result(''))
         command.call(k: true)
       end
     end
 
     context 'with :include_untracked option' do
       it 'adds -u flag to include untracked files' do
-        expect(execution_context).to receive(:command).with('stash', 'push',
-                                                            '--include-untracked').and_return(command_result(''))
+        expect_command('stash', 'push', '--include-untracked').and_return(command_result(''))
         command.call(include_untracked: true)
       end
 
       it 'accepts :u alias' do
-        expect(execution_context).to receive(:command).with('stash', 'push',
-                                                            '--include-untracked').and_return(command_result(''))
+        expect_command('stash', 'push', '--include-untracked').and_return(command_result(''))
         command.call(u: true)
       end
     end
 
     context 'with :all option' do
       it 'adds -a flag to include ignored and untracked files' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--all').and_return(command_result(''))
+        expect_command('stash', 'push', '--all').and_return(command_result(''))
         command.call(all: true)
       end
 
       it 'accepts :a alias' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--all').and_return(command_result(''))
+        expect_command('stash', 'push', '--all').and_return(command_result(''))
         command.call(a: true)
       end
     end
 
     context 'with :pathspec_from_file option' do
       it 'adds --pathspec-from-file flag' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'push', '--pathspec-from-file=paths.txt').and_return(command_result(''))
+        expect_command('stash', 'push', '--pathspec-from-file=paths.txt')
+          .and_return(command_result(''))
         command.call(pathspec_from_file: 'paths.txt')
       end
 
       it 'supports reading from stdin with -' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'push', '--pathspec-from-file=-').and_return(command_result(''))
+        expect_command('stash', 'push', '--pathspec-from-file=-').and_return(command_result(''))
         command.call(pathspec_from_file: '-')
       end
     end
 
     context 'with :pathspec_file_nul option' do
       it 'adds --pathspec-file-nul flag' do
-        expect(execution_context).to receive(:command).with(
-          'stash', 'push', '--pathspec-from-file=paths.txt', '--pathspec-file-nul'
-        ).and_return(command_result(''))
+        expect_command('stash', 'push', '--pathspec-from-file=paths.txt', '--pathspec-file-nul')
+          .and_return(command_result(''))
         command.call(pathspec_from_file: 'paths.txt', pathspec_file_nul: true)
       end
     end
 
     context 'with paths (pathspecs)' do
       it 'adds paths after -- separator' do
-        expect(execution_context).to receive(:command).with('stash', 'push', '--',
-                                                            'file.txt').and_return(command_result(''))
+        expect_command('stash', 'push', '--', 'file.txt').and_return(command_result(''))
         command.call('file.txt')
       end
 
       it 'accepts multiple paths' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'push', '--', 'file1.txt', 'file2.txt').and_return(command_result(''))
+        expect_command('stash', 'push', '--', 'file1.txt', 'file2.txt').and_return(command_result(''))
         command.call('file1.txt', 'file2.txt')
       end
 
       it 'combines paths with options' do
-        expect(execution_context).to receive(:command).with(
-          'stash', 'push', '--message=Partial stash', '--', 'src/'
-        ).and_return(command_result(''))
+        expect_command('stash', 'push', '--message=Partial stash', '--', 'src/')
+          .and_return(command_result(''))
         command.call('src/', message: 'Partial stash')
       end
     end
 
     context 'with multiple options combined' do
       it 'combines keep_index with message' do
-        expect(execution_context).to receive(:command).with(
-          'stash', 'push', '--keep-index', '--message=Testing'
-        ).and_return(command_result(''))
+        expect_command('stash', 'push', '--keep-index', '--message=Testing')
+          .and_return(command_result(''))
         command.call(keep_index: true, message: 'Testing')
       end
 
       it 'combines staged with paths' do
-        expect(execution_context).to receive(:command).with(
-          'stash', 'push', '--staged', '--', 'src/', 'lib/'
-        ).and_return(command_result(''))
+        expect_command('stash', 'push', '--staged', '--', 'src/', 'lib/')
+          .and_return(command_result(''))
         command.call('src/', 'lib/', staged: true)
       end
     end

--- a/spec/unit/git/commands/stash/show_numstat_spec.rb
+++ b/spec/unit/git/commands/stash/show_numstat_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe Git::Commands::Stash::ShowNumstat do
     context 'with no arguments (latest stash)' do
       it 'calls git stash show --numstat --shortstat -M' do
         expected_result = command_result(numstat_output)
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--numstat', '--shortstat', '-M')
+        expect_command('stash', 'show', '--numstat', '--shortstat', '-M')
           .and_return(expected_result)
 
         result = command.call
@@ -31,8 +30,7 @@ RSpec.describe Git::Commands::Stash::ShowNumstat do
 
     context 'with specific stash reference' do
       it 'passes stash reference to command' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--numstat', '--shortstat', '-M', 'stash@{2}')
+        expect_command('stash', 'show', '--numstat', '--shortstat', '-M', 'stash@{2}')
           .and_return(command_result(numstat_output))
 
         command.call('stash@{2}')
@@ -41,24 +39,21 @@ RSpec.describe Git::Commands::Stash::ShowNumstat do
 
     context 'with :include_untracked option' do
       it 'adds --include-untracked flag when true' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--numstat', '--shortstat', '-M', '--include-untracked')
+        expect_command('stash', 'show', '--numstat', '--shortstat', '-M', '--include-untracked')
           .and_return(command_result(numstat_output))
 
         command.call(include_untracked: true)
       end
 
       it 'adds --no-include-untracked flag when false' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--numstat', '--shortstat', '-M', '--no-include-untracked')
+        expect_command('stash', 'show', '--numstat', '--shortstat', '-M', '--no-include-untracked')
           .and_return(command_result(numstat_output))
 
         command.call(include_untracked: false)
       end
 
       it 'accepts :u alias' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--numstat', '--shortstat', '-M', '--include-untracked')
+        expect_command('stash', 'show', '--numstat', '--shortstat', '-M', '--include-untracked')
           .and_return(command_result(numstat_output))
 
         command.call(u: true)
@@ -67,8 +62,7 @@ RSpec.describe Git::Commands::Stash::ShowNumstat do
 
     context 'with :only_untracked option' do
       it 'adds --only-untracked flag' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--numstat', '--shortstat', '-M', '--only-untracked')
+        expect_command('stash', 'show', '--numstat', '--shortstat', '-M', '--only-untracked')
           .and_return(command_result(numstat_output))
 
         command.call(only_untracked: true)
@@ -77,16 +71,15 @@ RSpec.describe Git::Commands::Stash::ShowNumstat do
 
     context 'with :dirstat option' do
       it 'adds --dirstat flag when true' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--numstat', '--shortstat', '-M', '--dirstat')
+        expect_command('stash', 'show', '--numstat', '--shortstat', '-M', '--dirstat')
           .and_return(command_result(numstat_output))
 
         command.call(dirstat: true)
       end
 
       it 'passes dirstat options when string' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--numstat', '--shortstat', '-M', '--dirstat=lines,cumulative')
+        expect_command('stash', 'show', '--numstat', '--shortstat', '-M',
+                       '--dirstat=lines,cumulative')
           .and_return(command_result(numstat_output))
 
         command.call(dirstat: 'lines,cumulative')

--- a/spec/unit/git/commands/stash/show_patch_spec.rb
+++ b/spec/unit/git/commands/stash/show_patch_spec.rb
@@ -39,8 +39,7 @@ RSpec.describe Git::Commands::Stash::ShowPatch do
     context 'with no arguments (latest stash)' do
       it 'calls git stash show --patch --numstat --shortstat' do
         expected_result = command_result(patch_output)
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--patch', '--numstat', '--shortstat')
+        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat')
           .and_return(expected_result)
 
         result = command.call
@@ -51,8 +50,7 @@ RSpec.describe Git::Commands::Stash::ShowPatch do
 
     context 'with specific stash reference' do
       it 'passes stash reference to command' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--patch', '--numstat', '--shortstat', 'stash@{2}')
+        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat', 'stash@{2}')
           .and_return(command_result(patch_output))
 
         command.call('stash@{2}')
@@ -61,24 +59,22 @@ RSpec.describe Git::Commands::Stash::ShowPatch do
 
     context 'with :include_untracked option' do
       it 'adds --include-untracked flag when true' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--patch', '--numstat', '--shortstat', '--include-untracked')
+        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat', '--include-untracked')
           .and_return(command_result(patch_output))
 
         command.call(include_untracked: true)
       end
 
       it 'adds --no-include-untracked flag when false' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--patch', '--numstat', '--shortstat', '--no-include-untracked')
+        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat',
+                       '--no-include-untracked')
           .and_return(command_result(patch_output))
 
         command.call(include_untracked: false)
       end
 
       it 'accepts :u alias' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--patch', '--numstat', '--shortstat', '--include-untracked')
+        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat', '--include-untracked')
           .and_return(command_result(patch_output))
 
         command.call(u: true)
@@ -87,8 +83,7 @@ RSpec.describe Git::Commands::Stash::ShowPatch do
 
     context 'with :only_untracked option' do
       it 'adds --only-untracked flag' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--patch', '--numstat', '--shortstat', '--only-untracked')
+        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat', '--only-untracked')
           .and_return(command_result(patch_output))
 
         command.call(only_untracked: true)
@@ -97,16 +92,15 @@ RSpec.describe Git::Commands::Stash::ShowPatch do
 
     context 'with :dirstat option' do
       it 'adds --dirstat flag when true' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--patch', '--numstat', '--shortstat', '--dirstat')
+        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat', '--dirstat')
           .and_return(command_result(patch_output))
 
         command.call(dirstat: true)
       end
 
       it 'passes dirstat options when string' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--patch', '--numstat', '--shortstat', '--dirstat=lines,cumulative')
+        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat',
+                       '--dirstat=lines,cumulative')
           .and_return(command_result(patch_output))
 
         command.call(dirstat: 'lines,cumulative')

--- a/spec/unit/git/commands/stash/show_raw_spec.rb
+++ b/spec/unit/git/commands/stash/show_raw_spec.rb
@@ -32,8 +32,7 @@ RSpec.describe Git::Commands::Stash::ShowRaw do
     context 'with no arguments (latest stash)' do
       it 'calls git stash show --raw --numstat --shortstat -M' do
         expected_result = command_result(raw_output)
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M')
+        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat', '-M')
           .and_return(expected_result)
 
         result = command.call
@@ -44,8 +43,7 @@ RSpec.describe Git::Commands::Stash::ShowRaw do
 
     context 'with specific stash reference' do
       it 'passes stash reference to command' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', 'stash@{2}')
+        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', 'stash@{2}')
           .and_return(command_result(raw_output))
 
         command.call('stash@{2}')
@@ -54,16 +52,16 @@ RSpec.describe Git::Commands::Stash::ShowRaw do
 
     context 'with :include_untracked option' do
       it 'adds --include-untracked flag when true' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '--include-untracked')
+        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat', '-M',
+                       '--include-untracked')
           .and_return(command_result(raw_output))
 
         command.call(include_untracked: true)
       end
 
       it 'adds --no-include-untracked flag when false' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '--no-include-untracked')
+        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat', '-M',
+                       '--no-include-untracked')
           .and_return(command_result(raw_output))
 
         command.call(include_untracked: false)
@@ -72,8 +70,7 @@ RSpec.describe Git::Commands::Stash::ShowRaw do
 
     context 'with :only_untracked option' do
       it 'adds --only-untracked flag' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '--only-untracked')
+        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '--only-untracked')
           .and_return(command_result(raw_output))
 
         command.call(only_untracked: true)
@@ -82,8 +79,7 @@ RSpec.describe Git::Commands::Stash::ShowRaw do
 
     context 'with :find_copies option' do
       it 'adds -C flag when true' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '-C')
+        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '-C')
           .and_return(command_result(raw_output))
 
         command.call(find_copies: true)
@@ -92,16 +88,14 @@ RSpec.describe Git::Commands::Stash::ShowRaw do
 
     context 'with :dirstat option' do
       it 'adds --dirstat flag when true' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '--dirstat')
+        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '--dirstat')
           .and_return(command_result(raw_output))
 
         command.call(dirstat: true)
       end
 
       it 'passes dirstat options when string' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '--dirstat=files')
+        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat', '-M', '--dirstat=files')
           .and_return(command_result(raw_output))
 
         command.call(dirstat: 'files')

--- a/spec/unit/git/commands/stash/store_spec.rb
+++ b/spec/unit/git/commands/stash/store_spec.rb
@@ -11,8 +11,7 @@ RSpec.describe Git::Commands::Stash::Store do
     context 'with commit SHA only' do
       it 'calls git stash store with commit' do
         expected_result = command_result('')
-        expect(execution_context).to receive(:command)
-          .with('stash', 'store', 'abc123def456789')
+        expect_command('stash', 'store', 'abc123def456789')
           .and_return(expected_result)
 
         result = command.call('abc123def456789')
@@ -23,32 +22,28 @@ RSpec.describe Git::Commands::Stash::Store do
 
     context 'with :message option' do
       it 'adds --message flag with value' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'store', '--message=WIP: my changes', 'abc123')
+        expect_command('stash', 'store', '--message=WIP: my changes', 'abc123')
           .and_return(command_result(''))
 
         command.call('abc123', message: 'WIP: my changes')
       end
 
       it 'accepts :m alias' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'store', '--message=WIP', 'abc123')
+        expect_command('stash', 'store', '--message=WIP', 'abc123')
           .and_return(command_result(''))
 
         command.call('abc123', m: 'WIP')
       end
 
       it 'handles message with special characters' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'store', '--message=Fix "bug" in code', 'abc123')
+        expect_command('stash', 'store', '--message=Fix "bug" in code', 'abc123')
           .and_return(command_result(''))
 
         command.call('abc123', message: 'Fix "bug" in code')
       end
 
       it 'handles message with spaces' do
-        expect(execution_context).to receive(:command)
-          .with('stash', 'store', '--message=work in progress', 'abc123')
+        expect_command('stash', 'store', '--message=work in progress', 'abc123')
           .and_return(command_result(''))
 
         command.call('abc123', message: 'work in progress')
@@ -58,8 +53,7 @@ RSpec.describe Git::Commands::Stash::Store do
     context 'with full SHA' do
       it 'handles 40-character SHA' do
         sha = 'a' * 40
-        expect(execution_context).to receive(:command)
-          .with('stash', 'store', sha)
+        expect_command('stash', 'store', sha)
           .and_return(command_result(''))
 
         command.call(sha)


### PR DESCRIPTION
## Summary

This PR migrates all 12 `Git::Commands::Stash::*` commands to inherit from `Commands::Base`, implementing tasks 2 and 4 of issue #996.

## Changes

### Command Migration
- Migrated all 12 stash commands from the ARGS constant pattern to `Commands::Base` inheritance
- Commands migrated: apply, branch, clear, create, drop, list, pop, push, show_numstat, show_patch, show_raw, store
- Replaced `ARGS = Arguments.define` with `arguments do...end` blocks
- Removed custom `initialize` and `call` methods (now inherited from Base)
- Added YARD shim: `def call(...) = super`

### Test Infrastructure
- Created `expect_command` helper in `spec/spec_helper.rb` to reduce test repetition
- The helper automatically includes `raise_on_failure: false` in command expectations
- Updated all 12 stash spec files to use the new helper (85 total expectations simplified)

### Impact
- **Net reduction**: 174 lines of code removed (338 deletions - 164 insertions)
- **Internal compatibility**: Preserved constructor, call signature, and args_definition
- **Quality gates**: All tests passing (85 stash examples), no rubocop offenses

## Validation

```bash
# RSpec tests
bundle exec rspec spec/unit/git/commands/stash/
# 85 examples, 0 failures

# Full test suite
rake test
# All passing

# Code quality
rubocop lib/git/commands/stash/ spec/unit/git/commands/stash/
# 24 files inspected, no offenses
```

## Related Issues

Implements #996 (tasks 2 and 4)

## Future Work

Created issue #1035 to apply the `expect_command` helper to all remaining command specs.