### PR TITLE
docs(prompts): add execution_option to DSL method table

### DIFF
--- a/prompts/Review Arguments DSL.md
+++ b/prompts/Review Arguments DSL.md
@@ -53,6 +53,7 @@ Key behaviors:
 | boolean flag | `flag_option` | `flag_option :cached` |
 | boolean-or-value | `flag_or_value_option` | `flag_or_value_option :dirstat, inline: true` |
 | value option | `value_option` | `value_option :message` |
+| execution kwarg (not a CLI arg) | `execution_option` | `execution_option :timeout` |
 | positional argument | `operand` | `operand :commit1` |
 | pathspec-style operands | `value_option ... as_operand: true, separator: '--'` | `value_option :pathspecs, as_operand: true, separator: '--', repeatable: true` |
 


### PR DESCRIPTION
## Summary

Add `execution_option` to the DSL method table in `prompts/Review Arguments DSL.md`. This was missed when `metadata` was renamed to `execution_option` in PRs #1027 and #1028.

## Changes

- Added `execution_option` row to the "Correct DSL method per option type" table

Closes #1019