### PR TITLE
docs(prompts): add Extract Command from Lib prompt and usage instructions

### DIFF
--- a/prompts/Extract Command from Lib.md
+++ b/prompts/Extract Command from Lib.md
@@ -1,0 +1,276 @@
+## How to use this prompt
+
+Attach this file to your Copilot Chat context, then invoke it with a short message
+identifying the `Git::Lib` method or `#command` call to migrate. Examples:
+
+```text
+Using the Extract Command from Lib prompt, migrate Git::Lib#worktree_add —
+it calls command('worktree', 'add', ...).
+```
+
+```text
+Extract Command from Lib: command('ls-tree', ...)
+```
+
+The invocation needs either the `Git::Lib` method name or the git subcommand string
+from the `#command` call (or both).
+
+---
+
+## Extract Command from Lib
+
+Replace a direct `#command` call in `Git::Lib` with a call to a `Git::Commands::*`
+class. The git subcommand is determined by the first (or first few) arguments to the
+`#command` method call.
+
+### Related prompts
+
+Run or reference these prompts during the workflow:
+
+- **Scaffold New Command** — generates the `Git::Commands::*` class, unit tests,
+  integration tests, and YARD docs (used in Step 3 if the command class does not
+  exist yet)
+- **Review Command Implementation** — canonical class-shape checklist, phased
+  rollout gates, and internal compatibility contracts
+- **Review Arguments DSL** — verifying DSL entries match git CLI
+- **Review Command Tests** — unit/integration test expectations for command classes
+- **Review YARD Documentation** — documentation completeness for command classes
+- **Review Cross-Command Consistency** — sibling consistency within a command family
+- **Review Backward Compatibility** — preserving `Git::Lib` return-value contracts
+
+### Input
+
+You will be given:
+
+1. A `Git::Lib` method that contains one or more `command(...)` calls to replace
+2. The git subcommand name (derived from the first arguments to `#command`)
+
+### Workflow
+
+#### Step 1 — Identify the `#command` call
+
+1. Locate the `Git::Lib` method that calls `command(...)`.
+2. Note:
+   - the git subcommand (first argument(s) to `#command`)
+   - the options/arguments passed after the subcommand
+   - execution options (e.g., `timeout:`, `out:`, `err:`, `env:`)
+   - the return value and any post-processing (`.stdout`, parsing, regex matching)
+3. Document the method's current **public contract**: signature, return type, and
+   return-value format (String, Array, Hash, Boolean, etc.)
+4. Run linters and rubocop to confirm a clean baseline:
+   ```bash
+   bundle exec rubocop
+   ```
+   Fix any issues before continuing.
+
+#### Step 2 — Ensure adequate legacy tests
+
+Before making any changes, verify that `tests/units/` has adequate tests for the
+`Git::Lib` method being migrated.
+
+1. Search existing legacy tests for coverage of the method:
+   ```bash
+   grep -rn '<method_name>' tests/units/
+   ```
+2. If coverage is insufficient, add **minimal new tests** to the legacy test suite
+   that exercise the method's current behavior. These tests ensure the refactor does
+   not break backward compatibility.
+   - Do **not** change existing tests.
+   - Follow existing legacy test conventions (`Test::Unit::TestCase`,
+     `assert_command_line_eq`, `in_temp_dir`, etc.).
+   - Verify new tests pass:
+     ```bash
+     bundle exec bin/test <test-file-basename>
+     ```
+   - Run rubocop against the new test file:
+     ```bash
+     bundle exec rubocop tests/units/<test-file>
+     ```
+   - Fix any issues before continuing.
+3. Commit the new legacy tests:
+   ```bash
+   git add tests/units/<test-file>
+   git commit -m "refactor(test): add legacy tests for <method_name>"
+   ```
+
+#### Step 3 — Ensure the `Git::Commands::*` class exists
+
+1. Search `lib/git/commands/` for an existing command class that matches the git
+   subcommand:
+   ```bash
+   find lib/git/commands -name '*.rb' | sort
+   ```
+   Also check the class contents to confirm the existing class covers the same
+   subcommand variation (e.g., `branch --show-current` vs. `branch --list`).
+
+2. **If the command class already exists**, skip to Step 4.
+
+3. **If the command class does not exist**, scaffold it using the
+   **Scaffold New Command** prompt. This produces:
+   - `lib/git/commands/<command>.rb` (or `lib/git/commands/<family>/<action>.rb`)
+   - `spec/unit/git/commands/<command>_spec.rb`
+   - `spec/integration/git/commands/<command>_spec.rb`
+
+4. Verify the new command class:
+   ```bash
+   bundle exec rspec spec/unit/git/commands/<command>_spec.rb
+   bundle exec rspec spec/integration/git/commands/<command>_spec.rb
+   bundle exec rubocop lib/git/commands/<command>.rb
+   bundle exec yard
+   ```
+   Fix any issues before continuing.
+
+5. Commit the new command class and its tests:
+   ```bash
+   git add lib/git/commands/<command>*.rb spec/
+   git commit -m "refactor(command): add Git::Commands::<Command> class"
+   ```
+
+#### Step 4 — Update `Git::Lib` to delegate to the command class
+
+1. Replace the `command(...)` call with a call to the `Git::Commands::*` class:
+   ```ruby
+   # Before
+   def some_method(args)
+     command('some-command', '--flag', args).stdout
+   end
+
+   # After
+   def some_method(args)
+     Git::Commands::SomeCommand.new(self).call(args, flag: true).stdout
+   end
+   ```
+2. Preserve the method's **exact return value contract** — apply any parsing or
+   transformation after `.stdout` / `.stderr` / `.status` to match the original
+   return type.
+3. Add the appropriate `require_relative` at the top of `lib/git/lib.rb` if not
+   already present.
+4. Verify:
+   ```bash
+   bundle exec bin/test <legacy-test-file-basename>
+   bundle exec rspec
+   bundle exec rubocop
+   bundle exec yard
+   ```
+   Fix any issues before continuing.
+5. Commit the `Git::Lib` change:
+   ```bash
+   git add lib/git/lib.rb
+   git commit -m "refactor(lib): delegate <method_name> to Git::Commands::<Command>"
+   ```
+
+### Commit discipline
+
+Keep changes in **exactly three distinct commits** (each optional if no changes were
+needed for that step):
+
+1. `refactor(test): add legacy tests for <method_name>` — new tests in
+   `tests/units/`
+2. `refactor(command): add Git::Commands::<Command> class` — new command class,
+   unit specs, and integration specs
+3. `refactor(lib): delegate <method_name> to Git::Commands::<Command>` — `Git::Lib`
+   changes only
+
+If further changes are needed after these commits are created:
+
+- Amend the change to the **appropriate commit** (e.g., a command class fix goes
+  into the `refactor(command)` commit).
+- Rebase the later commits on top:
+  ```bash
+  git rebase -i <base-commit>
+  ```
+- After rebasing, verify all quality gates still pass:
+  ```bash
+  bundle exec rspec && bundle exec rake test && bundle exec rubocop && bundle exec yard
+  ```
+
+### Create a pull request
+
+Once all commits are clean and quality gates pass, create a PR for the branch.
+
+If changes are made after the PR is created:
+
+- Amend the change to the appropriate commit.
+- Rebase later commits on top.
+- Force-push the branch:
+  ```bash
+  git push --force-with-lease
+  ```
+
+### Quality gates (run at every step)
+
+```bash
+bundle exec rspec
+bundle exec rake test
+bundle exec rubocop
+bundle exec yard
+```
+
+All four must pass before committing at each step. If errors are found, fix them
+before continuing.
+
+### Common patterns
+
+#### Simple delegation (stdout passthrough)
+
+```ruby
+# Before
+def symbolic_ref(branch_name)
+  command('symbolic-ref', 'HEAD', "refs/heads/#{branch_name}")
+end
+
+# After
+def symbolic_ref(branch_name)
+  Git::Commands::SymbolicRef.new(self).call(branch_name).stdout
+end
+```
+
+#### Delegation with post-processing
+
+```ruby
+# Before
+def cat_file_type(object)
+  command('cat-file', '-t', object).stdout
+end
+
+# After
+def cat_file_type(object)
+  Git::Commands::CatFile::Type.new(self).call(object).stdout
+end
+```
+
+#### Delegation with parsed return value
+
+```ruby
+# Before
+def worktree_list
+  worktrees = {}
+  command('worktree', 'list', '--porcelain').stdout.split("\n").each do |w|
+    # ... parsing ...
+  end
+  worktrees
+end
+
+# After
+def worktree_list
+  result = Git::Commands::Worktree::List.new(self).call
+  worktrees = {}
+  result.stdout.split("\n").each do |w|
+    # ... parsing stays in Git::Lib ...
+  end
+  worktrees
+end
+```
+
+### What stays in `Git::Lib`
+
+- Output parsing and transformation (until a parser class is created)
+- Return-value adaptation to preserve backward compatibility
+- Deprecation shims (e.g., option renames)
+- Method signatures and public API surface
+
+### What moves to `Git::Commands::*`
+
+- Argument building and CLI flag generation
+- `#command` invocation
+- Exit-status handling via `allow_exit_status`

--- a/prompts/Refactor Command to CommandLineResult.md
+++ b/prompts/Refactor Command to CommandLineResult.md
@@ -1,3 +1,22 @@
+## How to use this prompt
+
+Attach this file to your Copilot Chat context, then invoke it with the command
+class or source file to migrate. Examples:
+
+```text
+Using the Refactor Command to CommandLineResult prompt, migrate
+Git::Commands::Stash::Pop to the Base pattern.
+```
+
+```text
+Refactor Command to CommandLineResult: lib/git/commands/branch/delete.rb
+```
+
+The invocation needs the command class name or file path of the command to
+refactor.
+
+---
+
 ## Refactor Command to CommandLineResult
 
 Migrate a command that still performs parsing or custom execution logic to the

--- a/prompts/Review Arguments DSL.md
+++ b/prompts/Review Arguments DSL.md
@@ -1,3 +1,22 @@
+## How to use this prompt
+
+Attach this file to your Copilot Chat context, then invoke it with one or more
+command source files and the relevant git man page or documentation. Examples:
+
+```text
+Using the Review Arguments DSL prompt, review
+lib/git/commands/diff/numstat.rb against `git diff --numstat` docs.
+```
+
+```text
+Review Arguments DSL: lib/git/commands/stash/push.rb
+```
+
+The invocation needs the command file(s) to review. Providing the git man page
+or CLI documentation helps verify flag accuracy.
+
+---
+
 ## Review Arguments DSL
 
 Verify that a command class's `arguments do ... end` definition accurately maps Ruby

--- a/prompts/Review Backward Compatibility.md
+++ b/prompts/Review Backward Compatibility.md
@@ -1,3 +1,18 @@
+## How to use this prompt
+
+Attach this file to your Copilot Chat context, then invoke it with the git
+command name(s) to audit. Example:
+
+```text
+Remove methods added to Git::Lib since v4.3.0 for the `branch` git command
+and ensure the remaining methods are backward compatible.
+```
+
+Replace `branch` with the specific git command(s) you want to audit (e.g.,
+`worktree`, `tag`, `merge`, `reset`).
+
+---
+
 # Review Backward Compatibility
 
 Review `Git::Lib` methods for backward compatibility after commands are moved to

--- a/prompts/Review Command Implementation.md
+++ b/prompts/Review Command Implementation.md
@@ -1,3 +1,22 @@
+## How to use this prompt
+
+Attach this file to your Copilot Chat context, then invoke it with one or more
+command source files to review. Examples:
+
+```text
+Using the Review Command Implementation prompt, review
+lib/git/commands/branch/delete.rb.
+```
+
+```text
+Review Command Implementation: lib/git/commands/diff/patch.rb
+lib/git/commands/diff/numstat.rb
+```
+
+The invocation needs the command file(s) to review.
+
+---
+
 ## Review Command Implementation
 
 Verify a command class follows the current `Git::Commands::Base` architecture and

--- a/prompts/Review Command Tests.md
+++ b/prompts/Review Command Tests.md
@@ -1,3 +1,23 @@
+## How to use this prompt
+
+Attach this file to your Copilot Chat context, then invoke it with the unit
+and/or integration spec file(s) to review. Examples:
+
+```text
+Using the Review Command Tests prompt, review
+spec/unit/git/commands/branch/delete_spec.rb and
+spec/integration/git/commands/branch/delete_spec.rb.
+```
+
+```text
+Review Command Tests: spec/unit/git/commands/stash/push_spec.rb
+```
+
+The invocation needs the spec file(s) to review. Including the corresponding
+command source file provides useful context for verifying argument coverage.
+
+---
+
 ## Review Command Tests
 
 Verify unit and integration tests for `Git::Commands::*` classes follow project

--- a/prompts/Review Cross-Command Consistency.md
+++ b/prompts/Review Cross-Command Consistency.md
@@ -1,3 +1,22 @@
+## How to use this prompt
+
+Attach this file to your Copilot Chat context, then invoke it with the sibling
+command files (same module/family) to compare. Examples:
+
+```text
+Using the Review Cross-Command Consistency prompt, review the
+Git::Commands::Diff family: lib/git/commands/diff/patch.rb,
+lib/git/commands/diff/numstat.rb, lib/git/commands/diff/raw.rb.
+```
+
+```text
+Review Cross-Command Consistency: all files under lib/git/commands/stash/
+```
+
+The invocation needs two or more sibling command files from the same family.
+
+---
+
 ## Review Cross-Command Consistency
 
 Review sibling command classes (same module/family) for consistent structure,

--- a/prompts/Review YARD Documentation.md
+++ b/prompts/Review YARD Documentation.md
@@ -1,3 +1,22 @@
+## How to use this prompt
+
+Attach this file to your Copilot Chat context, then invoke it with one or more
+command source files whose YARD docs should be reviewed. Examples:
+
+```text
+Using the Review YARD Documentation prompt, review
+lib/git/commands/branch/delete.rb.
+```
+
+```text
+Review YARD Documentation: lib/git/commands/stash/push.rb
+lib/git/commands/stash/pop.rb
+```
+
+The invocation needs the command file(s) to review.
+
+---
+
 ## Review YARD Documentation
 
 Verify YARD documentation for command classes is complete, accurate, and aligned

--- a/prompts/Scaffold New Command.md
+++ b/prompts/Scaffold New Command.md
@@ -1,3 +1,22 @@
+## How to use this prompt
+
+Attach this file to your Copilot Chat context, then invoke it with the git
+subcommand name and the Ruby module path for the new class. Examples:
+
+```text
+Using the Scaffold New Command prompt, scaffold Git::Commands::Worktree::Add
+for `git worktree add`.
+```
+
+```text
+Scaffold New Command: Git::Commands::LsTree for `git ls-tree`.
+```
+
+The invocation needs the target `Git::Commands::*` class name and the git
+subcommand (or subcommand + sub-action) it wraps.
+
+---
+
 ## Scaffold New Command
 
 Generate a production-ready command class, unit tests, integration tests, and YARD


### PR DESCRIPTION
## Summary

This PR improves the `prompts/` directory in two ways:

### New prompt: Extract Command from Lib

Adds `prompts/Extract Command from Lib.md` — a workflow prompt for replacing a direct `#command(...)` call in `Git::Lib` with a call to a `Git::Commands::*` class.

The prompt covers:
- **Step 1** — Identify the `#command` call and document the method's public contract; confirm a clean rubocop baseline
- **Step 2** — Ensure adequate legacy tests in `tests/units/` exist (add minimal new ones without changing existing tests); commit as `refactor(test)`
- **Step 3** — Check if a `Git::Commands::*` class already exists; only scaffold one if needed (referencing the Scaffold New Command prompt); commit as `refactor(command)`
- **Step 4** — Update `Git::Lib` to delegate to the command class, preserving the exact return-value contract; commit as `refactor(lib)`
- Commit discipline: exactly 3 distinct conventional commits, with amend-and-rebase instructions for later fixes
- PR creation and `--force-with-lease` workflow for post-PR amendments
- Quality gates (`rspec`, `rake test`, `rubocop`, `yard`) required at every step

### How to use this prompt section (all files)

Adds a `## How to use this prompt` section to the top of every prompt file with tailored invocation examples, so the usage pattern is visible when opening the file directly.

### Code fence language tags

All bare ` ``` ` opening fences now have an explicit language tag (`text` for invocation examples; `ruby`/`bash` were already tagged elsewhere).