### PR TITLE
docs(prompts): add branch workflow guidance to all prompts

### DIFF
--- a/prompts/Extract Command from Lib.md
+++ b/prompts/Extract Command from Lib.md
@@ -47,6 +47,20 @@ You will be given:
 
 ### Workflow
 
+#### Branch setup
+
+All work must be done on a feature branch. **Never commit or push directly to
+`main`.**
+
+Before starting, create a new branch:
+
+```bash
+git checkout -b <feature-branch-name>
+```
+
+All commits in this workflow go on the feature branch. When work is complete,
+open a pull request — do not merge or push directly into `main`.
+
 #### Step 1 — Identify the `#command` call
 
 1. Locate the `Git::Lib` method that calls `command(...)`.

--- a/prompts/Refactor Command to CommandLineResult.md
+++ b/prompts/Refactor Command to CommandLineResult.md
@@ -84,6 +84,9 @@ end
 See **Review Command Implementation** for the canonical phased rollout checklist
 and internal compatibility contract. In summary:
 
+- **always work on a feature branch** — never commit or push directly to `main`;
+  create a branch before starting (`git checkout -b <feature-branch-name>`) and
+  open a pull request when the slice is ready
 - perform refactor in phased slices (pilot/family)
 - keep each slice independently revertible
 - do not mix unrelated behavior changes with refactor-only changes

--- a/prompts/Review Arguments DSL.md
+++ b/prompts/Review Arguments DSL.md
@@ -169,3 +169,6 @@ Produce:
 
 2. A list of missing options/modifier/order/conflict issues
 3. Any `allow_exit_status` mismatches or missing rationale comments
+
+> **Branch workflow:** Implement any fixes on a feature branch. Never commit or
+> push directly to `main` — open a pull request when changes are ready to merge.

--- a/prompts/Review Backward Compatibility.md
+++ b/prompts/Review Backward Compatibility.md
@@ -45,6 +45,20 @@ command classes.
 
 ## Instructions
 
+### Branch setup
+
+All work must be done on a feature branch. **Never commit or push directly to
+`main`.**
+
+Before starting, create a new branch:
+
+```bash
+git checkout -b <feature-branch-name>
+```
+
+All commits in this workflow go on the feature branch. When work is complete,
+open a pull request — do not merge or push directly into `main`.
+
 ### Step 1: Identify Methods Added Since v4.3.0
 
 1. Check out the v4.3.0 tag to examine the historical state:
@@ -210,6 +224,7 @@ end
 
 ## Validation Checklist
 
+- [ ] Working on a feature branch (not `main`)
 - [ ] Identified all methods for the command in v4.3.0
 - [ ] Documented v4.3.0 return values exactly
 - [ ] Removed all methods not present in v4.3.0

--- a/prompts/Review Command Implementation.md
+++ b/prompts/Review Command Implementation.md
@@ -108,6 +108,7 @@ reference this section rather than duplicating the full checklist.
 
 For migration PRs, verify process constraints:
 
+- [ ] changes are on a feature branch — **never commit or push directly to `main`**
 - [ ] migration slice is scoped (pilot or one family), not all commands at once
 - [ ] each slice is independently revertible
 - [ ] refactor-only changes are not mixed with unrelated behavior changes

--- a/prompts/Review Command Tests.md
+++ b/prompts/Review Command Tests.md
@@ -233,6 +233,10 @@ behavior is testing git, not the command. If a particular flag needs to be teste
 (e.g., `-M` for rename detection), verify the flag appears in the arguments via a
 unit test.
 
+> **Branch workflow:** Implement any new or updated tests on a feature branch. Never
+> commit or push directly to `main` — open a pull request when changes are ready to
+> merge.
+
 #### Test grouping
 
 Integration tests must be organized into two `describe` blocks under `#call`:

--- a/prompts/Review Cross-Command Consistency.md
+++ b/prompts/Review Cross-Command Consistency.md
@@ -85,3 +85,6 @@ were migrated in the same slice and that the same quality gates were applied.
 
 | Issue | Files | Recommended canonical form |
 |---|---|---|
+
+> **Branch workflow:** Implement any fixes on a feature branch. Never commit or
+> push directly to `main` — open a pull request when changes are ready to merge.

--- a/prompts/Review YARD Documentation.md
+++ b/prompts/Review YARD Documentation.md
@@ -122,3 +122,6 @@ For each file, provide:
 |---|---|---|
 
 2. corrected doc block snippets (only where needed)
+
+> **Branch workflow:** Implement any fixes on a feature branch. Never commit or
+> push directly to `main` — open a pull request when changes are ready to merge.

--- a/prompts/Scaffold New Command.md
+++ b/prompts/Scaffold New Command.md
@@ -138,6 +138,9 @@ per-command documentation.
 See **Review Command Implementation** for the canonical phased rollout checklist,
 internal compatibility contract, and quality gate commands. In summary:
 
+- **always work on a feature branch** — never commit or push directly to `main`;
+  create a branch before starting (`git checkout -b <feature-branch-name>`) and
+  open a pull request when the slice is ready
 - migrate in small slices (pilot or family), not all commands at once
 - keep each slice independently revertible
 - pass per-slice gates: `bundle exec rspec`, `bundle exec rake test`,


### PR DESCRIPTION
## Summary

Add explicit guidance to all prompt files that work must be done on a feature branch — never committing or pushing directly to `main`.

## Changes

Each prompt received guidance appropriate to its role:

| Prompt | Change |
|---|---|
| **Extract Command from Lib** | New "Branch setup" section at the start of the Workflow, with `git checkout -b` instructions and prohibition on pushing to `main` |
| **Scaffold New Command** | Leading bullet added to phased rollout summary |
| **Refactor Command to CommandLineResult** | Leading bullet added to migration process summary |
| **Review Backward Compatibility** | New "Branch setup" section before Step 1; `- [ ] Working on a feature branch (not main)` added as first Validation Checklist item |
| **Review Command Implementation** | `- [ ] changes are on a feature branch — never commit or push directly to main` added as first item in the phased rollout checklist |
| **Review Arguments DSL** | Branch workflow callout added to Output section |
| **Review Command Tests** | Branch workflow callout added to end of integration tests section |
| **Review Cross-Command Consistency** | Branch workflow callout added to Output section |
| **Review YARD Documentation** | Branch workflow callout added to Output section |

## Motivation

The prompts guide AI agents through implementation tasks but previously contained no reminder about branch discipline. This adds the constraint at the natural decision points in each workflow so agents don't commit directly to `main`.