### PR TITLE
refactor(arguments): rename args: to as: in flag_option and value_option DSL methods

### DIFF
--- a/lib/git/commands/arguments.rb
+++ b/lib/git/commands/arguments.rb
@@ -171,7 +171,7 @@ module Git
     #
     # Negated flags always use double-dash format (e.g., `-f` → `--no-f` when false).
     #
-    # The `args:` parameter can override this automatic detection when needed.
+    # The `as:` parameter can override this automatic detection when needed.
     #
     # @example Short option detection
     #   args_def = Arguments.define do
@@ -184,9 +184,9 @@ module Git
     #   args_def.bind(f: true, force: true, n: 3, name: 'test').to_a
     #   # => ['-f', '--force', '-n3', '--name=test']
     #
-    # @example Explicit override with `args:`
+    # @example Explicit override with `as:`
     #   args_def = Arguments.define do
-    #     flag_option :f, args: '--force'
+    #     flag_option :f, as: '--force'
     #   end
     #   args_def.bind(f: true).to_a  # => ['--force']
     #
@@ -243,7 +243,7 @@ module Git
     # These parameters affect **output generation** (what CLI arguments are
     # produced):
     #
-    # - **args:** - Override the CLI argument(s) derived from the option name
+    # - **as:** - Override the CLI argument(s) derived from the option name
     #   Can be a String or an Array. Default is nil (derives from name).
     # - **allow_empty:** - ({#value_option} only) When true, output the option
     #   even if the value is an empty string. Default is false (empty strings skipped).
@@ -452,7 +452,7 @@ module Git
       #
       # @param names [Symbol, Array<Symbol>] the option name(s), first is primary
       #
-      # @param args [String, Array<String>, nil] custom argument(s) to output (e.g., '-r' or ['--amend', '--no-edit'])
+      # @param as [String, Array<String>, nil] custom argument(s) to output (e.g., '-r' or ['--amend', '--no-edit'])
       #
       # @param type [Class, Array<Class>, nil] expected type(s) for validation. Raises ArgumentError with
       #   descriptive message if value doesn't match. Cannot be combined with validator:.
@@ -501,9 +501,9 @@ module Git
       #   args_def.bind() #=> raise ArgumentError, "Required options not provided: :force"
       #   args_def.bind(force: nil) #=> raise ArgumentError, "Required options cannot be nil: :force"
       #
-      def flag_option(names, args: nil, type: nil, validator: nil, negatable: false, required: false, allow_nil: true)
+      def flag_option(names, as: nil, type: nil, validator: nil, negatable: false, required: false, allow_nil: true)
         option_type = negatable ? :negatable_flag : :flag
-        register_option(names, type: option_type, args: args, expected_type: type, validator: validator,
+        register_option(names, type: option_type, as: as, expected_type: type, validator: validator,
                                required: required, allow_nil: allow_nil)
       end
 
@@ -517,7 +517,7 @@ module Git
       #
       # @param names [Symbol, Array<Symbol>] the option name(s), first is primary
       #
-      # @param args [String, nil] custom option string (arrays not supported for value types)
+      # @param as [String, nil] custom option string (arrays not supported for value types)
       #
       # @param type [Class, Array<Class>, nil] expected type(s) for validation. Raises ArgumentError with
       #   descriptive message if value doesn't match. Cannot be combined with validator:.
@@ -635,12 +635,12 @@ module Git
       #   args_def.bind(message: nil) #=> raise ArgumentError, "Required options cannot be nil: :message"
       #   args_def.bind() #=> raise ArgumentError, "Required options not provided: :message"
       #
-      def value_option(names, args: nil, type: nil, inline: false, as_operand: false, separator: nil,
+      def value_option(names, as: nil, type: nil, inline: false, as_operand: false, separator: nil,
                        allow_empty: false, repeatable: false, required: false, allow_nil: true)
         validate_value_modifiers!(names, inline, as_operand, separator)
 
         option_type = determine_value_option_type(inline, as_operand)
-        register_option(names, type: option_type, args: args, expected_type: type, separator: separator,
+        register_option(names, type: option_type, as: as, expected_type: type, separator: separator,
                                allow_empty: allow_empty, repeatable: repeatable, required: required,
                                allow_nil: allow_nil)
       end
@@ -655,7 +655,7 @@ module Git
       #
       # @param names [Symbol, Array<Symbol>] the option name(s), first is primary
       #
-      # @param args [String, nil] custom option string
+      # @param as [String, nil] custom option string
       #
       # @param type [Class, Array<Class>, nil] expected type(s) for validation
       #
@@ -709,10 +709,10 @@ module Git
       #   args_def.bind(sign: "KEY").to_a   # => ['--sign=KEY']
       #   args_def.bind(sign: nil).to_a     # => []
       #
-      def flag_or_value_option(names, args: nil, type: nil, negatable: false, inline: false,
+      def flag_or_value_option(names, as: nil, type: nil, negatable: false, inline: false,
                                required: false, allow_nil: true)
         option_type = determine_flag_or_value_option_type(negatable, inline)
-        register_option(names, type: option_type, args: args, expected_type: type,
+        register_option(names, type: option_type, as: as, expected_type: type,
                                required: required, allow_nil: allow_nil)
       end
 
@@ -723,7 +723,7 @@ module Git
       #
       # @param names [Symbol, Array<Symbol>] the option name(s), first is primary
       #
-      # @param args [String, nil] custom option string (e.g., '--trailer')
+      # @param as [String, nil] custom option string (e.g., '--trailer')
       #
       # @param key_separator [String] separator between key and value (default: '=')
       #
@@ -748,57 +748,57 @@ module Git
       #
       # @example Basic key-value (like --trailer)
       #   args_def = Arguments.define do
-      #     key_value_option :trailers, args: '--trailer'
+      #     key_value_option :trailers, as: '--trailer'
       #   end
       #   args_def.bind(trailers: { 'Signed-off-by' => 'John' }).to_a
       #   # => ['--trailer', 'Signed-off-by=John']
       #
       # @example Hash with array values (multiple values for same key)
       #   args_def = Arguments.define do
-      #     key_value_option :trailers, args: '--trailer'
+      #     key_value_option :trailers, as: '--trailer'
       #   end
       #   args_def.bind(trailers: { 'Signed-off-by' => ['John', 'Jane'] }).to_a
       #   # => ['--trailer', 'Signed-off-by=John', '--trailer', 'Signed-off-by=Jane']
       #
       # @example Array of arrays (full ordering control)
       #   args_def = Arguments.define do
-      #     key_value_option :trailers, args: '--trailer'
+      #     key_value_option :trailers, as: '--trailer'
       #   end
       #   args_def.bind(trailers: [['Signed-off-by', 'John'], ['Acked-by', 'Bob']]).to_a
       #   # => ['--trailer', 'Signed-off-by=John', '--trailer', 'Acked-by=Bob']
       #
       # @example Key without value (nil value omits separator)
       #   args_def = Arguments.define do
-      #     key_value_option :trailers, args: '--trailer'
+      #     key_value_option :trailers, as: '--trailer'
       #   end
       #   args_def.bind(trailers: [['Acked-by', nil]]).to_a
       #   # => ['--trailer', 'Acked-by']
       #
       # @example Nil in array values produces key-only entries
       #   args_def = Arguments.define do
-      #     key_value_option :trailers, args: '--trailer'
+      #     key_value_option :trailers, as: '--trailer'
       #   end
       #   args_def.bind(trailers: { 'Key' => ['Value1', nil, 'Value2'] }).to_a
       #   # => ['--trailer', 'Key=Value1', '--trailer', 'Key', '--trailer', 'Key=Value2']
       #
       # @example With custom separator
       #   args_def = Arguments.define do
-      #     key_value_option :trailers, args: '--trailer', key_separator: ': '
+      #     key_value_option :trailers, as: '--trailer', key_separator: ': '
       #   end
       #   args_def.bind(trailers: { 'Signed-off-by' => 'John' }).to_a
       #   # => ['--trailer', 'Signed-off-by: John']
       #
       # @example Empty values produce no output
       #   args_def = Arguments.define do
-      #     key_value_option :trailers, args: '--trailer', required: true
+      #     key_value_option :trailers, as: '--trailer', required: true
       #   end
       #   args_def.bind(trailers: {}).to_a   # => []
       #   args_def.bind(trailers: []).to_a   # => []
       #   args_def.bind(trailers: nil).to_a  # => []
       #
-      def key_value_option(names, args: nil, key_separator: '=', inline: false, required: false, allow_nil: true)
+      def key_value_option(names, as: nil, key_separator: '=', inline: false, required: false, allow_nil: true)
         option_type = inline ? :inline_key_value : :key_value
-        register_option(names, type: option_type, args: args, key_separator: key_separator,
+        register_option(names, type: option_type, as: as, key_separator: key_separator,
                                required: required, allow_nil: allow_nil)
       end
 
@@ -1045,7 +1045,7 @@ module Git
       # @example Inspecting options before command execution
       #   args_def = Arguments.define do
       #     flag_option :force
-      #     flag_option :remotes, args: ['-r', '--remotes']
+      #     flag_option :remotes, as: ['-r', '--remotes']
       #     operand :branch_names, repeatable: true
       #   end
       #   bound_args = args_def.bind('branch1', 'branch2', force: true, remotes: true)
@@ -1192,7 +1192,7 @@ module Git
         primary = keys.first
         definition[:aliases] = keys
         validate_option_after_separator!(definition[:type], primary)
-        validate_args_parameter!(definition, primary)
+        validate_as_parameter!(definition, primary)
         apply_type_validator!(definition, primary)
         @option_definitions[primary] = definition
         keys.each { |key| @alias_map[key] = primary }
@@ -1226,19 +1226,19 @@ module Git
         definition[:validator] = create_type_validator(option_name, definition[:expected_type])
       end
 
-      def validate_args_parameter!(definition, option_name)
-        return unless definition[:args].is_a?(Array)
+      def validate_as_parameter!(definition, option_name)
+        return unless definition[:as].is_a?(Array)
 
         if definition[:type] == :negatable_flag
           raise ArgumentError,
-                "arrays for args: parameter cannot be combined with negatable: true (option :#{option_name})"
+                "arrays for as: parameter cannot be combined with negatable: true (option :#{option_name})"
         end
 
         return if definition[:type] == :flag
 
         type = definition[:type]
         raise ArgumentError,
-              "arrays for args: parameter are only supported for flag types, not :#{type} (option :#{option_name})"
+              "arrays for as: parameter are only supported for flag types, not :#{type} (option :#{option_name})"
       end
 
       # Build arguments by iterating over definitions in their defined order
@@ -1394,7 +1394,7 @@ module Git
       def build_option(args, name, definition, value)
         return if should_skip_option?(value, definition)
 
-        arg_spec = definition[:args] || default_arg_spec(name)
+        arg_spec = definition[:as] || default_arg_spec(name)
         builder = BUILDERS[definition[:type]]
         if builder.is_a?(Symbol)
           send(builder, args, arg_spec, value, definition)
@@ -1959,7 +1959,7 @@ module Git
       # @example Accessing bound arguments
       #   args_def = Arguments.define do
       #     flag_option :force
-      #     flag_option :remotes, args: ['-r', '--remotes']
+      #     flag_option :remotes, as: ['-r', '--remotes']
       #     operand :branch_names, repeatable: true
       #   end
       #   bound = args_def.bind('branch1', 'branch2', force: true, remotes: true)

--- a/lib/git/commands/checkout/branch.rb
+++ b/lib/git/commands/checkout/branch.rb
@@ -34,22 +34,22 @@ module Git
       class Branch < Base
         arguments do
           literal 'checkout'
-          flag_option %i[force f], args: '--force'
-          flag_option %i[merge m], args: '--merge'
-          flag_option %i[detach d], args: '--detach'
+          flag_option %i[force f], as: '--force'
+          flag_option %i[merge m], as: '--merge'
+          flag_option %i[detach d], as: '--detach'
 
           # Branch creation options (mutually exclusive)
           # These use `value` (not `value :name, inline: true`) because git expects: -b <branch>, not -b=<branch>
-          value_option %i[new_branch b], args: '-b'
-          value_option %i[new_branch_force B], args: '-B'
-          value_option :orphan, args: '--orphan'
+          value_option %i[new_branch b], as: '-b'
+          value_option %i[new_branch_force B], as: '-B'
+          value_option :orphan, as: '--orphan'
 
           # Tracking options
           flag_or_value_option :track, negatable: true, inline: true
 
           # Other options
           flag_option :guess, negatable: true
-          flag_option :ignore_other_worktrees, args: '--ignore-other-worktrees'
+          flag_option :ignore_other_worktrees, as: '--ignore-other-worktrees'
           flag_option :recurse_submodules, negatable: true
 
           # Positional arguments

--- a/lib/git/commands/checkout/files.rb
+++ b/lib/git/commands/checkout/files.rb
@@ -37,14 +37,14 @@ module Git
       class Files < Base
         arguments do
           literal 'checkout'
-          flag_option %i[force f], args: '--force'
-          flag_option :ours, args: '--ours'
-          flag_option :theirs, args: '--theirs'
-          flag_option %i[merge m], args: '--merge'
-          value_option :conflict, inline: true, args: '--conflict'
+          flag_option %i[force f], as: '--force'
+          flag_option :ours, as: '--ours'
+          flag_option :theirs, as: '--theirs'
+          flag_option %i[merge m], as: '--merge'
+          value_option :conflict, inline: true, as: '--conflict'
           flag_option :overlay, negatable: true
-          value_option :pathspec_from_file, inline: true, args: '--pathspec-from-file'
-          flag_option :pathspec_file_nul, args: '--pathspec-file-nul'
+          value_option :pathspec_from_file, inline: true, as: '--pathspec-from-file'
+          flag_option :pathspec_file_nul, as: '--pathspec-file-nul'
 
           operand :tree_ish, required: true, allow_nil: true
           operand :paths, repeatable: true, separator: '--'

--- a/lib/git/commands/clean.rb
+++ b/lib/git/commands/clean.rb
@@ -33,9 +33,9 @@ module Git
       arguments do
         literal 'clean'
         flag_option :force
-        flag_option :force_force, args: '-ff'
-        flag_option :d, args: '-d'
-        flag_option :x, args: '-x'
+        flag_option :force_force, as: '-ff'
+        flag_option :d, as: '-d'
+        flag_option :x, as: '-x'
         conflicts :force, :force_force
       end
 

--- a/lib/git/commands/commit.rb
+++ b/lib/git/commands/commit.rb
@@ -35,7 +35,7 @@ module Git
         value_option :author, inline: true
         value_option :message, inline: true, allow_empty: true
         value_option :date, inline: true, type: String
-        flag_option :amend, args: ['--amend', '--no-edit']
+        flag_option :amend, as: ['--amend', '--no-edit']
         flag_or_value_option :gpg_sign, negatable: true, inline: true
       end
 

--- a/lib/git/commands/diff/patch.rb
+++ b/lib/git/commands/diff/patch.rb
@@ -28,7 +28,7 @@ module Git
           flag_option %i[cached staged]
           flag_option :merge_base
           flag_option :no_index
-          flag_option :find_copies, args: '-C'
+          flag_option :find_copies, as: '-C'
           flag_or_value_option :dirstat, inline: true
           operand :commit1
           operand :commit2

--- a/lib/git/commands/diff/raw.rb
+++ b/lib/git/commands/diff/raw.rb
@@ -26,7 +26,7 @@ module Git
           flag_option %i[cached staged]
           flag_option :merge_base
           flag_option :no_index
-          flag_option :find_copies, args: '-C'
+          flag_option :find_copies, as: '-C'
           flag_or_value_option :dirstat, inline: true
           operand :commit1
           operand :commit2

--- a/lib/git/commands/init.rb
+++ b/lib/git/commands/init.rb
@@ -29,7 +29,7 @@ module Git
         literal 'init'
         flag_option :bare
         value_option :initial_branch, inline: true
-        value_option :repository, inline: true, args: '--separate-git-dir'
+        value_option :repository, inline: true, as: '--separate-git-dir'
         operand :directory
       end
 

--- a/lib/git/commands/merge/start.rb
+++ b/lib/git/commands/merge/start.rb
@@ -38,20 +38,20 @@ module Git
 
           # Commit behavior
           flag_option :commit, negatable: true
-          flag_option :squash, args: '--squash'
+          flag_option :squash, as: '--squash'
 
           # Fast-forward behavior
           flag_option :ff, negatable: true
-          flag_option :ff_only, args: '--ff-only'
+          flag_option :ff_only, as: '--ff-only'
 
           # Message options
-          value_option %i[message m], args: '-m'
-          value_option %i[file F], args: '-F'
-          value_option :into_name, inline: true, args: '--into-name'
+          value_option %i[message m], as: '-m'
+          value_option %i[file F], as: '-F'
+          value_option :into_name, inline: true, as: '--into-name'
 
           # Strategy options
-          value_option %i[strategy s], args: '-s'
-          value_option %i[strategy_option X], args: '-X', repeatable: true
+          value_option %i[strategy s], as: '-s'
+          value_option %i[strategy_option X], as: '-X', repeatable: true
 
           # Verification
           flag_option :verify, negatable: true

--- a/lib/git/commands/merge_base.rb
+++ b/lib/git/commands/merge_base.rb
@@ -32,10 +32,10 @@ module Git
     class MergeBase < Base
       arguments do
         literal 'merge-base'
-        flag_option :octopus, args: '--octopus'
-        flag_option :independent, args: '--independent'
-        flag_option :fork_point, args: '--fork-point'
-        flag_option :all, args: '--all'
+        flag_option :octopus, as: '--octopus'
+        flag_option :independent, as: '--independent'
+        flag_option :fork_point, as: '--fork-point'
+        flag_option :all, as: '--all'
 
         # Positional: commits to find common ancestor(s) of
         operand :commits, repeatable: true, required: true

--- a/lib/git/commands/mv.rb
+++ b/lib/git/commands/mv.rb
@@ -26,10 +26,10 @@ module Git
     class Mv < Base
       arguments do
         literal 'mv'
-        flag_option :force, args: '--force'
-        flag_option :dry_run, args: '--dry-run'
-        flag_option :verbose, args: '--verbose'
-        flag_option :skip_errors, args: '-k'
+        flag_option :force, as: '--force'
+        flag_option :dry_run, as: '--dry-run'
+        flag_option :verbose, as: '--verbose'
+        flag_option :skip_errors, as: '-k'
         operand :source, repeatable: true, required: true, separator: '--'
         operand :destination, required: true
       end

--- a/lib/git/commands/rm.rb
+++ b/lib/git/commands/rm.rb
@@ -32,8 +32,8 @@ module Git
     class Rm < Base
       arguments do
         literal 'rm'
-        flag_option :force, args: '-f'
-        flag_option :recursive, args: '-r'
+        flag_option :force, as: '-f'
+        flag_option :recursive, as: '-r'
         flag_option :cached
         operand :paths, repeatable: true, required: true, separator: '--'
       end

--- a/lib/git/commands/stash/show_raw.rb
+++ b/lib/git/commands/stash/show_raw.rb
@@ -33,7 +33,7 @@ module Git
           literal '-M'
           flag_option %i[include_untracked u], negatable: true
           flag_option :only_untracked
-          flag_option :find_copies, args: '-C'
+          flag_option :find_copies, as: '-C'
           flag_or_value_option :dirstat, inline: true
           operand :stash
         end

--- a/prompts/Review Arguments DSL.md
+++ b/prompts/Review Arguments DSL.md
@@ -57,7 +57,7 @@ Key behaviors:
   order entries appear in `arguments do`
 - **Name-to-flag mapping** — underscores become hyphens, single-char names map to
   `-x`, multi-char names map to `--name`
-- **`args:` override** — only for flags that cannot be expressed by symbol naming
+- **`as:` override** — only for flags that cannot be expressed by symbol naming
   (e.g., `-C`)
 - **Aliases** — first alias is canonical and determines generated flag (long name
   first: `%i[force f]`, not `%i[f force]`)
@@ -80,10 +80,10 @@ Key behaviors:
 | positional argument | `operand` | `operand :commit1` |
 | pathspec-style operands | `value_option ... as_operand: true, separator: '--'` | `value_option :pathspecs, as_operand: true, separator: '--', repeatable: true` |
 
-#### 2. Correct alias and `args:` usage
+#### 2. Correct alias and `as:` usage
 
 - Prefer aliases for long/short pairs (`%i[force f]`, `%i[all a]`)
-- Use `args:` only when automatic mapping cannot generate the git flag
+- Use `as:` only when automatic mapping cannot generate the git flag
 - Ensure long name is first in alias arrays
 
 #### 3. Correct ordering

--- a/prompts/Scaffold New Command.md
+++ b/prompts/Scaffold New Command.md
@@ -85,7 +85,7 @@ end
 5. as-operand value options (e.g., pathspecs)
 
 Use aliases for long/short forms (`%i[force f]`), with long name first.
-Use `args:` only when symbol mapping cannot produce the desired flag.
+Use `as:` only when symbol mapping cannot produce the desired flag.
 
 ### Exit status guidance
 

--- a/spec/unit/git/commands/arguments_spec.rb
+++ b/spec/unit/git/commands/arguments_spec.rb
@@ -1091,8 +1091,8 @@ RSpec.describe Git::Commands::Arguments do
     context 'with custom flag names' do
       let(:args) do
         described_class.define do
-          flag_option :recursive, args: '-r'
-          value_option :skip, args: '--skip-worktree'
+          flag_option :recursive, as: '-r'
+          value_option :skip, as: '--skip-worktree'
         end
       end
 
@@ -1185,7 +1185,7 @@ RSpec.describe Git::Commands::Arguments do
       end
 
       it 'allows custom flag with aliases' do
-        args = described_class.define { flag_option %i[recursive r], args: '-R' }
+        args = described_class.define { flag_option %i[recursive r], as: '-R' }
         expect(args.bind(recursive: true).to_ary).to eq(['-R'])
         expect(args.bind(r: true).to_ary).to eq(['-R'])
       end
@@ -1221,10 +1221,10 @@ RSpec.describe Git::Commands::Arguments do
       end
     end
 
-    context 'with args: parameter arrays' do
+    context 'with as: parameter arrays' do
       it 'supports arrays for flag type' do
         args = described_class.define do
-          flag_option :amend, args: ['--amend', '--no-edit']
+          flag_option :amend, as: ['--amend', '--no-edit']
         end
         expect(args.bind(amend: true).to_ary).to eq(['--amend', '--no-edit'])
       end
@@ -1232,41 +1232,41 @@ RSpec.describe Git::Commands::Arguments do
       it 'rejects arrays for flag negatable: true type' do
         expect do
           described_class.define do
-            flag_option :verbose, negatable: true, args: ['--verbose', '--all']
+            flag_option :verbose, negatable: true, as: ['--verbose', '--all']
           end
-        end.to raise_error(ArgumentError, /arrays for args: parameter cannot be combined with negatable: true/)
+        end.to raise_error(ArgumentError, /arrays for as: parameter cannot be combined with negatable: true/)
       end
 
       it 'rejects arrays for value type' do
         expect do
           described_class.define do
-            value_option :branch, args: ['--branch', '--set-upstream']
+            value_option :branch, as: ['--branch', '--set-upstream']
           end
-        end.to raise_error(ArgumentError, /arrays for args: parameter are only supported for flag types/)
+        end.to raise_error(ArgumentError, /arrays for as: parameter are only supported for flag types/)
       end
 
       it 'rejects arrays for value inline: true type' do
         expect do
           described_class.define do
-            value_option :message, inline: true, args: ['--message', '--edit']
+            value_option :message, inline: true, as: ['--message', '--edit']
           end
-        end.to raise_error(ArgumentError, /arrays for args: parameter are only supported for flag types/)
+        end.to raise_error(ArgumentError, /arrays for as: parameter are only supported for flag types/)
       end
 
       it 'rejects arrays for flag_or_value inline: true type' do
         expect do
           described_class.define do
-            flag_or_value_option :gpg_sign, inline: true, args: ['--gpg-sign', '--verify']
+            flag_or_value_option :gpg_sign, inline: true, as: ['--gpg-sign', '--verify']
           end
-        end.to raise_error(ArgumentError, /arrays for args: parameter are only supported for flag types/)
+        end.to raise_error(ArgumentError, /arrays for as: parameter are only supported for flag types/)
       end
 
       it 'rejects arrays for flag_or_value negatable: true, inline: true type' do
         expect do
           described_class.define do
-            flag_or_value_option :sign, negatable: true, inline: true, args: ['--sign', '--verify']
+            flag_or_value_option :sign, negatable: true, inline: true, as: ['--sign', '--verify']
           end
-        end.to raise_error(ArgumentError, /arrays for args: parameter are only supported for flag types/)
+        end.to raise_error(ArgumentError, /arrays for as: parameter are only supported for flag types/)
       end
     end
 
@@ -2475,7 +2475,7 @@ RSpec.describe Git::Commands::Arguments do
       context 'basic Hash input' do
         let(:args) do
           described_class.define do
-            key_value_option :trailers, args: '--trailer'
+            key_value_option :trailers, as: '--trailer'
           end
         end
 
@@ -2495,7 +2495,7 @@ RSpec.describe Git::Commands::Arguments do
       context 'Hash with array values' do
         let(:args) do
           described_class.define do
-            key_value_option :trailers, args: '--trailer'
+            key_value_option :trailers, as: '--trailer'
           end
         end
 
@@ -2515,7 +2515,7 @@ RSpec.describe Git::Commands::Arguments do
       context 'Array of arrays input' do
         let(:args) do
           described_class.define do
-            key_value_option :trailers, args: '--trailer'
+            key_value_option :trailers, as: '--trailer'
           end
         end
 
@@ -2541,7 +2541,7 @@ RSpec.describe Git::Commands::Arguments do
       context 'nil and empty value handling' do
         let(:args) do
           described_class.define do
-            key_value_option :trailers, args: '--trailer'
+            key_value_option :trailers, as: '--trailer'
           end
         end
 
@@ -2589,7 +2589,7 @@ RSpec.describe Git::Commands::Arguments do
       context 'with inline: true' do
         let(:args) do
           described_class.define do
-            key_value_option :trailers, args: '--trailer', inline: true
+            key_value_option :trailers, as: '--trailer', inline: true
           end
         end
 
@@ -2615,7 +2615,7 @@ RSpec.describe Git::Commands::Arguments do
       context 'key validation' do
         let(:args) do
           described_class.define do
-            key_value_option :trailers, args: '--trailer'
+            key_value_option :trailers, as: '--trailer'
           end
         end
 
@@ -2640,7 +2640,7 @@ RSpec.describe Git::Commands::Arguments do
         context 'with custom separator' do
           let(:args) do
             described_class.define do
-              key_value_option :trailers, args: '--trailer', key_separator: ': '
+              key_value_option :trailers, as: '--trailer', key_separator: ': '
             end
           end
 
@@ -2721,7 +2721,7 @@ RSpec.describe Git::Commands::Arguments do
       context 'with custom key_separator' do
         let(:args) do
           described_class.define do
-            key_value_option :trailers, args: '--trailer', key_separator: ': '
+            key_value_option :trailers, as: '--trailer', key_separator: ': '
           end
         end
 
@@ -2735,7 +2735,7 @@ RSpec.describe Git::Commands::Arguments do
       context 'with required: true' do
         let(:args) do
           described_class.define do
-            key_value_option :trailers, args: '--trailer', required: true
+            key_value_option :trailers, as: '--trailer', required: true
           end
         end
 
@@ -2765,7 +2765,7 @@ RSpec.describe Git::Commands::Arguments do
       context 'with required: true and allow_nil: false' do
         let(:args) do
           described_class.define do
-            key_value_option :trailers, args: '--trailer', required: true, allow_nil: false
+            key_value_option :trailers, as: '--trailer', required: true, allow_nil: false
           end
         end
 
@@ -2783,7 +2783,7 @@ RSpec.describe Git::Commands::Arguments do
       context 'with symbol keys and values' do
         let(:args) do
           described_class.define do
-            key_value_option :trailers, args: '--trailer'
+            key_value_option :trailers, as: '--trailer'
           end
         end
 
@@ -2974,24 +2974,24 @@ RSpec.describe Git::Commands::Arguments do
         end
       end
 
-      context 'with explicit args: override' do
-        subject(:args) { described_class.define { flag_option :f, args: '--force' } }
+      context 'with explicit as: override' do
+        subject(:args) { described_class.define { flag_option :f, as: '--force' } }
 
         it 'uses the explicit args even for single-character name' do
           expect(args.bind(f: true).to_ary).to eq(['--force'])
         end
       end
 
-      context 'with multi-character name and explicit short args: override' do
-        subject(:args) { described_class.define { flag_option :all, args: '-a' } }
+      context 'with multi-character name and explicit short as: override' do
+        subject(:args) { described_class.define { flag_option :all, as: '-a' } }
 
         it 'uses the explicit short args instead of deriving from name' do
           expect(args.bind(all: true).to_ary).to eq(['-a'])
         end
       end
 
-      context 'with multi-character name and explicit short args: for inline value' do
-        subject(:args) { described_class.define { value_option :number, inline: true, args: '-n' } }
+      context 'with multi-character name and explicit short as: for inline value' do
+        subject(:args) { described_class.define { value_option :number, inline: true, as: '-n' } }
 
         it 'uses no separator for explicitly short args' do
           expect(args.bind(number: 5).to_ary).to eq(['-n5'])


### PR DESCRIPTION
## Summary

Renames the `args:` keyword parameter to `as:` in all four DSL methods to improve readability.

## Motivation

`args:` is ambiguous — it could mean "the full argument list," "positional arguments," or many other things. `as:` reads like plain English:

```ruby
flag_option :force, as: '--force'
# "use this option as '--force'"
```

## Changes

- Rename `args:` keyword to `as:` in `flag_option`, `value_option`, `flag_or_value_option`, and `key_value_option` signatures
- Update `register_option` to store the value under `:as` instead of `:args`
- Rename `validate_args_parameter!` to `validate_as_parameter!`
- Update error messages to reference `as:` instead of `args:`
- Update `build_option` to read `definition[:as]`
- Update all YARD `@param` tags and inline examples
- Update all command files under `lib/git/commands/` to use `as:`
- Update `spec/unit/git/commands/arguments_spec.rb` (context labels, error message matchers, and all DSL call sites)
- Update `prompts/Review Arguments DSL.md` and `prompts/Scaffold New Command.md`

## Before / After

```ruby
# Before
flag_option :amend_no_edit, args: ['--amend', '--no-edit']
value_option :trailer, args: '--trailer'

# After
flag_option :amend_no_edit, as: ['--amend', '--no-edit']
value_option :trailer, as: '--trailer'
```

## Tests

All 1505 unit tests pass (`bundle exec rspec spec/unit/`).

Closes #1051