### PR TITLE
fix: resolve NoMethodError for Git::Base#cat_file

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -812,8 +812,19 @@ module Git
       lib.ls_tree(objectish, opts)
     end
 
+    # Returns the contents of a git object
+    #
+    # Uses `git cat-file -p` to pretty-print the contents of the given object.
+    #
+    # @param objectish [String] a SHA, branch name, tag, or other revision reference
+    #   to the git object
+    #
+    # @return [String] the contents of the object
+    #
+    # @see https://git-scm.com/docs/git-cat-file git-cat-file
+    #
     def cat_file(objectish)
-      lib.cat_file(objectish)
+      lib.cat_file_contents(objectish)
     end
 
     # The name of the branch HEAD refers to or 'HEAD' if detached

--- a/tests/units/test_cat_file.rb
+++ b/tests/units/test_cat_file.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TestCatFile < Test::Unit::TestCase
+  def setup
+    clone_working_repo
+    @git = Git.open(@wdir)
+  end
+
+  def test_cat_file_commit
+    result = @git.cat_file('1cc8667014381')
+    assert_match(/^tree 94c827875e2cadb8bc8d4cdd900f19aa9e8634c7$/, result)
+    assert_match(/^author scott Chacon/, result)
+    assert_match(/test\z/, result)
+  end
+
+  def test_cat_file_tree
+    result = @git.cat_file('1cc8667014381^{tree}')
+    assert_match(/ex_dir/, result)
+    assert_match(/example\.txt/, result)
+  end
+
+  def test_cat_file_blob
+    result = @git.cat_file('v2.5:example.txt')
+    assert_equal("1\n1\n#{"1\n" * 61}2", result)
+  end
+
+  def test_cat_file_by_tag
+    result = @git.cat_file('v2.5')
+    assert_match(/^tree /, result)
+  end
+end


### PR DESCRIPTION
## Summary

Fixes #1058

`Git::Base#cat_file` raised `NoMethodError: undefined method 'cat_file'` because it called `lib.cat_file`, which does not exist on `Git::Lib`. The correct method is `lib.cat_file_contents`.

## Changes

- **Fix**: Changed `Git::Base#cat_file` to call `lib.cat_file_contents` instead of the nonexistent `lib.cat_file`
- **Docs**: Added YARD documentation for `Git::Base#cat_file`
- **Tests**: Added integration tests for `Git::Base#cat_file` covering commits, trees, blobs, and tags