### PR TITLE
refactor(arguments): extend conflicts to support operands

### DIFF
--- a/lib/git/commands/checkout/files.rb
+++ b/lib/git/commands/checkout/files.rb
@@ -48,6 +48,8 @@ module Git
 
           operand :tree_ish, required: true, allow_nil: true
           operand :paths, repeatable: true, separator: '--'
+
+          conflicts :merge, :tree_ish
         end
 
         # Execute the git checkout command for restoring files

--- a/prompts/Review Arguments DSL.md
+++ b/prompts/Review Arguments DSL.md
@@ -130,7 +130,10 @@ should be covered by tests.
 
 #### 6. Conflicts
 
-If options are mutually exclusive, verify `conflicts ...` declarations exist.
+If arguments are mutually exclusive — whether option vs option, option vs operand,
+or operand vs operand — verify `conflicts ...` declarations exist. Names in a
+`conflicts` group may be any mix of option names and operand names. Unknown names
+raise `ArgumentError` at definition time, so any typo is caught early.
 
 #### 7. Exit-status declaration consistency (class-level, outside the DSL)
 

--- a/prompts/Scaffold New Command.md
+++ b/prompts/Scaffold New Command.md
@@ -83,9 +83,19 @@ end
 3. flag-or-value options
 4. operands
 5. as-operand value options (e.g., pathspecs)
+6. `conflicts` declarations (after all arguments are defined)
 
 Use aliases for long/short forms (`%i[force f]`), with long name first.
 Use `as:` only when symbol mapping cannot produce the desired flag.
+
+When two or more arguments are mutually exclusive — options, operands, or a mix —
+declare them with `conflicts`. Names may be option names or operand names.
+Unknown names raise `ArgumentError` at load time. Examples:
+
+```ruby
+conflicts :gpg_sign, :no_gpg_sign        # option vs option
+conflicts :merge, :tree_ish              # option vs operand
+```
 
 ### Exit status guidance
 

--- a/spec/unit/git/commands/checkout/files_spec.rb
+++ b/spec/unit/git/commands/checkout/files_spec.rb
@@ -104,8 +104,8 @@ RSpec.describe Git::Commands::Checkout::Files do
 
     context 'with :merge option (recreate conflict markers)' do
       it 'adds --merge flag' do
-        expect_command('checkout', '--merge', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
-        command.call('HEAD', 'conflicted.txt', merge: true)
+        expect_command('checkout', '--merge', '--', 'conflicted.txt').and_return(command_result)
+        command.call(nil, 'conflicted.txt', merge: true)
       end
 
       it 'does not add flag when false' do
@@ -114,8 +114,13 @@ RSpec.describe Git::Commands::Checkout::Files do
       end
 
       it 'works with :m alias' do
-        expect_command('checkout', '--merge', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
-        command.call('HEAD', 'conflicted.txt', m: true)
+        expect_command('checkout', '--merge', '--', 'conflicted.txt').and_return(command_result)
+        command.call(nil, 'conflicted.txt', m: true)
+      end
+
+      it 'raises when :merge and tree_ish are both provided' do
+        expect { command.call('HEAD', 'conflicted.txt', merge: true) }
+          .to raise_error(ArgumentError, /cannot specify :merge and :tree_ish/)
       end
     end
 


### PR DESCRIPTION
## Summary

Extends the `conflicts` DSL in `Git::Commands::Arguments` to support **operand names** (positional arguments) in addition to keyword option names. Previously, `conflicts` silently ignored operand names because conflict detection ran before operands were allocated.

Closes #1062

## Changes

### Core implementation (`lib/git/commands/arguments.rb`)

- **`conflicts(*names)`** — validates each name against `known_argument?` at definition time; raises `ArgumentError` for unknown names (catches typos early)
- **`validate_conflicts!`** — extended signature to accept `allocated_positionals = {}`; looks up each name in opts first, then allocated_positionals
- **`bind`** — `validate_conflicts!` moved here (after `allocate_and_validate_positionals`) so both opts and allocated positionals are available
- **`validate_and_normalize_options!`** — `validate_conflicts!` call removed (was too early for operands)
- **`known_argument?(name)`** — new private helper; checks `@alias_map` (all options/aliases) and `@operand_definitions`
- **`argument_present?(value)`** — new private helper; `nil`, `false`, `[]`, `''` are absent; all other values are present

### Applied to `Checkout::Files` (`lib/git/commands/checkout/files.rb`)

```ruby
conflicts :merge, :tree_ish
```

`--merge` and a non-nil `<tree-ish>` are mutually exclusive per the git docs.

### Specs

- `spec/unit/git/commands/arguments_spec.rb` — new contexts: operand-vs-option, operand-vs-operand, `as_operand: true` in conflict group, unknown-name guard at definition time, multi-member mixed group, presence semantics edge cases
- `spec/unit/git/commands/checkout/files_spec.rb` — updated `:merge` tests to use `nil` as tree-ish; added test asserting the conflict error when both are provided

### Docs

- Class-level `## Conflict Detection` YARD section updated to cover options and operands, presence semantics, and a mixed example
- `prompts/Review Arguments DSL.md` section 6 — expanded from one line to cover option-vs-option, option-vs-operand, operand-vs-operand, and the typo guard
- `prompts/Scaffold New Command.md` — added `conflicts` as item 6 in the DSL ordering convention with prose and examples

## Presence semantics

An argument is **absent** when its value is `nil`, `false`, `[]`, or `''`. All other values are **present**. This matches the intuition that "not providing" a flag or operand means no conflict.

## Backward compatibility

All 1524 existing unit tests pass. The only behavioural change to existing specs was in `Checkout::Files` where `merge: true` with a non-nil tree-ish is now correctly rejected.