### PR TITLE
refactor(commands): fix YARD inheritance and replace call shim with @!method directive

### DIFF
--- a/lib/git/commands/add.rb
+++ b/lib/git/commands/add.rb
@@ -17,7 +17,7 @@ module Git
     #   add.call('file1.rb', 'file2.rb')
     #   add.call(all: true)
     #
-    class Add < Base
+    class Add < Git::Commands::Base
       arguments do
         literal 'add'
         flag_option %i[dry_run n]

--- a/lib/git/commands/base.rb
+++ b/lib/git/commands/base.rb
@@ -11,7 +11,7 @@ module Git
     # Provides default {#initialize} and {#call} methods so that simple commands
     # only need to declare their arguments:
     #
-    #   class Add < Base
+    #   class Add < Git::Commands::Base
     #     arguments do
     #       literal 'add'
     #       flag_option :all
@@ -27,7 +27,7 @@ module Git
     # Commands whose git process may exit with a non-zero status that is
     # *not* an error can declare the acceptable range of exit codes:
     #
-    #   class Delete < Base
+    #   class Delete < Git::Commands::Base
     #     arguments do
     #       literal 'branch'
     #       literal '--delete'

--- a/lib/git/commands/branch/copy.rb
+++ b/lib/git/commands/branch/copy.rb
@@ -26,7 +26,7 @@ module Git
       #   copy = Git::Commands::Branch::Copy.new(execution_context)
       #   copy.call('old-branch', 'existing-branch', force: true)
       #
-      class Copy < Base
+      class Copy < Git::Commands::Base
         # NOTE: The positional arguments follow Ruby semantics:
         # - When one positional is provided, it fills new_branch (required)
         # - When two positionals are provided, they fill old_branch and new_branch
@@ -40,41 +40,41 @@ module Git
           operand :new_branch, required: true
         end
 
-        # Execute the git branch --copy command to copy a branch
+        # @!method call(*, **)
         #
-        # @overload call(new_branch, **options)
+        #   Execute the git branch --copy command to copy a branch
         #
-        #   Copies the current branch to the new_branch
+        #   @overload call(new_branch, **options)
         #
-        #   @param new_branch [String] the new name for the copied branch
+        #     Copies the current branch to the new_branch
         #
-        #   @param options [Hash] command options
+        #     @param new_branch [String] the new name for the copied branch
         #
-        #   @option options [Boolean] :force (nil) Allow copying even if new_branch already exists.
+        #     @param options [Hash] command options
         #
-        #     Alias: :f
+        #     @option options [Boolean] :force (nil) Allow copying even if new_branch already exists.
         #
-        # @overload call(old_branch, new_branch, **options)
+        #       Alias: :f
         #
-        #   Copies old_branch to new_branch
+        #   @overload call(old_branch, new_branch, **options)
         #
-        #   @param old_branch [String] branch to copy from
+        #     Copies old_branch to new_branch
         #
-        #   @param new_branch [String] the new name for the copied branch
+        #     @param old_branch [String] branch to copy from
         #
-        #   @param options [Hash] command options
+        #     @param new_branch [String] the new name for the copied branch
         #
-        #   @option options [Boolean] :force (nil) Allow copying even if new_branch already exists.
+        #     @param options [Hash] command options
         #
-        #     Alias: :f
+        #     @option options [Boolean] :force (nil) Allow copying even if new_branch already exists.
         #
-        # @return [Git::CommandLineResult] the result of calling `git branch --copy`
+        #       Alias: :f
         #
-        # @raise [ArgumentError] if unsupported options are provided
+        #     @return [Git::CommandLineResult] the result of calling `git branch --copy`
         #
-        # @raise [Git::FailedError] if the branch doesn't exist or target exists (without force)
+        #     @raise [ArgumentError] if unsupported options are provided
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [Git::FailedError] if the branch doesn't exist or target exists (without force)
       end
     end
   end

--- a/lib/git/commands/branch/create.rb
+++ b/lib/git/commands/branch/create.rb
@@ -34,7 +34,7 @@ module Git
       #   create = Git::Commands::Branch::Create.new(execution_context)
       #   create.call('feature-branch', 'origin/main', track: 'inherit')
       #
-      class Create < Base
+      class Create < Git::Commands::Base
         arguments do
           literal 'branch'
           flag_or_value_option %i[track t], negatable: true, inline: true
@@ -45,80 +45,80 @@ module Git
           operand :start_point
         end
 
-        # Execute the git branch command to create a new branch
+        # @!method call(*, **)
         #
-        # @overload call(branch_name, **options)
+        #   Execute the git branch command to create a new branch
         #
-        #   Create a new branch from the current HEAD
+        #   @overload call(branch_name, **options)
         #
-        #   @param branch_name [String] The name of the branch to create
+        #     Create a new branch from the current HEAD
         #
-        #   @param options [Hash] command options
+        #     @param branch_name [String] The name of the branch to create
         #
-        #   @option options [Boolean, String, false] :track (nil) Configure upstream tracking for the new branch.
-        #     - `true`: Set up tracking using the start-point branch itself (`--track`)
-        #     - `false`: Do not set up tracking even if `branch.autoSetupMerge` is set (`--no-track`)
-        #     - `'direct'`: Same as `true`, explicitly use start-point as upstream (`--track=direct`)
-        #     - `'inherit'`: Copy upstream configuration from start-point branch (`--track=inherit`)
+        #     @param options [Hash] command options
         #
-        #     Alias: :t
+        #     @option options [Boolean, String, false] :track (nil) Configure upstream tracking for the new branch.
+        #       - `true`: Set up tracking using the start-point branch itself (`--track`)
+        #       - `false`: Do not set up tracking even if `branch.autoSetupMerge` is set (`--no-track`)
+        #       - `'direct'`: Same as `true`, explicitly use start-point as upstream (`--track=direct`)
+        #       - `'inherit'`: Copy upstream configuration from start-point branch (`--track=inherit`)
         #
-        #   @option options [Boolean] :force (nil) Reset the branch to `start_point` even if it already exists.
-        #     Without this, git branch refuses to change an existing branch.
-        #     Adds `--force` flag.
+        #       Alias: :t
         #
-        #     Alias: :f
+        #     @option options [Boolean] :force (nil) Reset the branch to `start_point` even if it already exists.
+        #       Without this, git branch refuses to change an existing branch.
+        #       Adds `--force` flag.
         #
-        #   @option options [Boolean] :recurse_submodules (nil) Create the branch in the superproject and all
-        #     submodules. This is an experimental feature.
-        #     Adds `--recurse-submodules` flag.
+        #       Alias: :f
         #
-        #   @option options [Boolean] :create_reflog (nil) Create the branch's reflog, enabling date-based sha1
-        #     expressions such as `branch@{yesterday}`. Note that in non-bare repositories,
-        #     reflogs are usually enabled by default via `core.logAllRefUpdates`.
-        #     Adds `--create-reflog` flag.
+        #     @option options [Boolean] :recurse_submodules (nil) Create the branch in the superproject and all
+        #       submodules. This is an experimental feature.
+        #       Adds `--recurse-submodules` flag.
         #
-        # @overload call(branch_name, start_point, **options)
+        #     @option options [Boolean] :create_reflog (nil) Create the branch's reflog, enabling date-based sha1
+        #       expressions such as `branch@{yesterday}`. Note that in non-bare repositories,
+        #       reflogs are usually enabled by default via `core.logAllRefUpdates`.
+        #       Adds `--create-reflog` flag.
         #
-        #   Create a new branch from the specified start point
+        #   @overload call(branch_name, start_point, **options)
         #
-        #   @param branch_name [String] The name of the branch to create
+        #     Create a new branch from the specified start point
         #
-        #   @param start_point [String, nil] The commit, branch, or tag to start the new branch from.
-        #     Can also use `<rev-A>...<rev-B>` syntax for merge base.
+        #     @param branch_name [String] The name of the branch to create
         #
-        #   @param options [Hash] command options
+        #     @param start_point [String, nil] The commit, branch, or tag to start the new branch from.
+        #       Can also use `<rev-A>...<rev-B>` syntax for merge base.
         #
-        #   @option options [Boolean, String, false] :track (nil) Configure upstream tracking for the new branch.
-        #     - `true`: Set up tracking using the start-point branch itself (`--track`)
-        #     - `false`: Do not set up tracking even if `branch.autoSetupMerge` is set (`--no-track`)
-        #     - `'direct'`: Same as `true`, explicitly use start-point as upstream (`--track=direct`)
-        #     - `'inherit'`: Copy upstream configuration from start-point branch (`--track=inherit`)
+        #     @param options [Hash] command options
         #
-        #     Alias: :t
+        #     @option options [Boolean, String, false] :track (nil) Configure upstream tracking for the new branch.
+        #       - `true`: Set up tracking using the start-point branch itself (`--track`)
+        #       - `false`: Do not set up tracking even if `branch.autoSetupMerge` is set (`--no-track`)
+        #       - `'direct'`: Same as `true`, explicitly use start-point as upstream (`--track=direct`)
+        #       - `'inherit'`: Copy upstream configuration from start-point branch (`--track=inherit`)
         #
-        #   @option options [Boolean] :force (nil) Reset the branch to `start_point` even if it already exists.
-        #     Without this, git branch refuses to change an existing branch.
-        #     Adds `--force` flag.
+        #       Alias: :t
         #
-        #     Alias: :f
+        #     @option options [Boolean] :force (nil) Reset the branch to `start_point` even if it already exists.
+        #       Without this, git branch refuses to change an existing branch.
+        #       Adds `--force` flag.
         #
-        #   @option options [Boolean] :recurse_submodules (nil) Create the branch in the superproject and all
-        #     submodules. This is an experimental feature.
-        #     Adds `--recurse-submodules` flag.
+        #       Alias: :f
         #
-        #   @option options [Boolean] :create_reflog (nil) Create the branch's reflog, enabling date-based sha1
-        #     expressions such as `branch@{yesterday}`. Note that in non-bare repositories,
-        #     reflogs are usually enabled by default via `core.logAllRefUpdates`.
-        #     Adds `--create-reflog` flag.
+        #     @option options [Boolean] :recurse_submodules (nil) Create the branch in the superproject and all
+        #       submodules. This is an experimental feature.
+        #       Adds `--recurse-submodules` flag.
         #
-        # @return [Git::CommandLineResult] the result of calling `git branch`
+        #     @option options [Boolean] :create_reflog (nil) Create the branch's reflog, enabling date-based sha1
+        #       expressions such as `branch@{yesterday}`. Note that in non-bare repositories,
+        #       reflogs are usually enabled by default via `core.logAllRefUpdates`.
+        #       Adds `--create-reflog` flag.
         #
-        # @raise [ArgumentError] if unsupported options are provided
+        #     @return [Git::CommandLineResult] the result of calling `git branch`
         #
-        # @raise [Git::FailedError] if git returns a non-zero exit code
+        #     @raise [ArgumentError] if unsupported options are provided
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [Git::FailedError] if git returns a non-zero exit code
       end
     end
   end

--- a/lib/git/commands/branch/delete.rb
+++ b/lib/git/commands/branch/delete.rb
@@ -27,7 +27,7 @@ module Git
       #   delete = Git::Commands::Branch::Delete.new(execution_context)
       #   result = delete.call('origin/feature', remotes: true)
       #
-      class Delete < Base
+      class Delete < Git::Commands::Base
         arguments do
           literal 'branch'
           literal '--delete'
@@ -39,34 +39,34 @@ module Git
         # git branch --delete exits 1 when one or more branches cannot be deleted
         allow_exit_status 0..1
 
-        # Execute the git branch --delete command to delete branches
+        # @!method call(*, **)
         #
-        # @overload call(*branch_name, **options)
+        #   Execute the git branch --delete command to delete branches
         #
-        #   @param branch_name [Array<String>] One or more branch names to delete.
+        #   @overload call(*branch_name, **options)
         #
-        #   @param options [Hash] command options
+        #     @param branch_name [Array<String>] One or more branch names to delete.
         #
-        #   @option options [Boolean] :force (nil) Allow deleting the branch irrespective of its merged
-        #     status, or whether it even points to a valid commit. This is equivalent
-        #     to the `-D` shortcut (`--delete --force`).
+        #     @param options [Hash] command options
         #
-        #     Alias: :f
+        #     @option options [Boolean] :force (nil) Allow deleting the branch irrespective of its merged
+        #       status, or whether it even points to a valid commit. This is equivalent
+        #       to the `-D` shortcut (`--delete --force`).
         #
-        #   @option options [Boolean] :remotes (nil) Delete remote-tracking branches. Use this together
-        #     with `--delete` to delete remote-tracking branches. Note that this only
-        #     makes sense if the remote-tracking branches no longer exist in the remote
-        #     repository or if `git fetch` was configured not to fetch them again.
+        #       Alias: :f
         #
-        #     Alias: :r
+        #     @option options [Boolean] :remotes (nil) Delete remote-tracking branches. Use this together
+        #       with `--delete` to delete remote-tracking branches. Note that this only
+        #       makes sense if the remote-tracking branches no longer exist in the remote
+        #       repository or if `git fetch` was configured not to fetch them again.
         #
-        # @return [Git::CommandLineResult] the result of calling `git branch --delete`
+        #       Alias: :r
         #
-        # @raise [ArgumentError] if no branch names are provided
+        #     @return [Git::CommandLineResult] the result of calling `git branch --delete`
         #
-        # @raise [Git::FailedError] for unexpected errors (exit code > 1)
+        #     @raise [ArgumentError] if no branch names are provided
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [Git::FailedError] for unexpected errors (exit code > 1)
       end
     end
   end

--- a/lib/git/commands/branch/list.rb
+++ b/lib/git/commands/branch/list.rb
@@ -28,7 +28,7 @@ module Git
       #   list = Git::Commands::Branch::List.new(execution_context)
       #   feature_branches = list.call(patterns: 'feature/*')
       #
-      class List < Base
+      class List < Git::Commands::Base
         arguments do
           literal 'branch'
           literal '--list'
@@ -45,63 +45,63 @@ module Git
           operand :pattern, repeatable: true
         end
 
-        # Execute the git branch --list command
+        # @!method call(*, **)
         #
-        # @overload call(*pattern, **options)
+        #   Execute the git branch --list command
         #
-        #   @param pattern [Array<String>] Shell wildcard patterns to filter
-        #   branches
+        #   @overload call(*pattern, **options)
         #
-        #     If multiple patterns are given, a branch is shown if it matches any of the patterns.
+        #     @param pattern [Array<String>] Shell wildcard patterns to filter
+        #     branches
         #
-        #   @param options [Hash] command options
+        #       If multiple patterns are given, a branch is shown if it matches any of the patterns.
         #
-        #   @option options [Boolean] :all (nil) List both local and remote branches.
+        #     @param options [Hash] command options
         #
-        #     Alias: :a
+        #     @option options [Boolean] :all (nil) List both local and remote branches.
         #
-        #   @option options [Boolean] :remotes (nil) List only remote-tracking
-        #     branches.
+        #       Alias: :a
         #
-        #     Alias: :r
+        #     @option options [Boolean] :remotes (nil) List only remote-tracking
+        #       branches.
         #
-        #   @option options [String, Array<String>] :sort (nil) Sort branches by the
-        #     specified key(s).
+        #       Alias: :r
         #
-        #     Give an array to add multiple --sort options. Prefix each key with '-' for
-        #     descending order. For example, sort: ['refname', '-committerdate'].
+        #     @option options [String, Array<String>] :sort (nil) Sort branches by the
+        #       specified key(s).
         #
-        #   @option options [Boolean, String] :merged (nil) List only branches merged
-        #     into the specified commit. Pass `true` to default to HEAD or a commit
-        #     ref string to filter by that commit.
+        #       Give an array to add multiple --sort options. Prefix each key with '-' for
+        #       descending order. For example, sort: ['refname', '-committerdate'].
         #
-        #   @option options [Boolean, String] :no_merged (nil) List only branches not
-        #     merged into the specified commit. Pass `true` to default to HEAD or a
-        #     commit ref string to filter by that commit.
+        #     @option options [Boolean, String] :merged (nil) List only branches merged
+        #       into the specified commit. Pass `true` to default to HEAD or a commit
+        #       ref string to filter by that commit.
         #
-        #   @option options [Boolean, String] :contains (nil) List only branches that
-        #     contain the specified commit. Pass `true` to default to HEAD or a commit
-        #     ref string to filter by that commit.
+        #     @option options [Boolean, String] :no_merged (nil) List only branches not
+        #       merged into the specified commit. Pass `true` to default to HEAD or a
+        #       commit ref string to filter by that commit.
         #
-        #   @option options [Boolean, String] :no_contains (nil) List only branches
-        #     that don't contain the specified commit. Pass `true` to default to HEAD
-        #     or a commit ref string to filter by that commit.
+        #     @option options [Boolean, String] :contains (nil) List only branches that
+        #       contain the specified commit. Pass `true` to default to HEAD or a commit
+        #       ref string to filter by that commit.
         #
-        #   @option options [String] :points_at (nil) List only branches that point
-        #     at the specified object
+        #     @option options [Boolean, String] :no_contains (nil) List only branches
+        #       that don't contain the specified commit. Pass `true` to default to HEAD
+        #       or a commit ref string to filter by that commit.
         #
-        #   @option options [Boolean] :ignore_case (nil) Sort and filter branches
-        #     case insensitively.
+        #     @option options [String] :points_at (nil) List only branches that point
+        #       at the specified object
         #
-        #     Alias: :i
+        #     @option options [Boolean] :ignore_case (nil) Sort and filter branches
+        #       case insensitively.
         #
-        # @return [Git::CommandLineResult] the result of calling `git branch --list`
+        #       Alias: :i
         #
-        # @raise [ArgumentError] if unsupported options are provided
+        #     @return [Git::CommandLineResult] the result of calling `git branch --list`
         #
-        # @raise [Git::FailedError] if git returns a non-zero exit code
+        #     @raise [ArgumentError] if unsupported options are provided
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [Git::FailedError] if git returns a non-zero exit code
       end
     end
   end

--- a/lib/git/commands/branch/move.rb
+++ b/lib/git/commands/branch/move.rb
@@ -26,7 +26,7 @@ module Git
       #   move = Git::Commands::Branch::Move.new(execution_context)
       #   move.call('old-branch', 'existing-branch', force: true)
       #
-      class Move < Base
+      class Move < Git::Commands::Base
         # NOTE: The positional arguments follow Ruby semantics:
         # - When one positional is provided, it fills new_branch (required)
         # - When two positionals are provided, they fill old_branch and new_branch
@@ -40,41 +40,41 @@ module Git
           operand :new_branch, required: true
         end
 
-        # Execute the git branch --move command to rename a branch
+        # @!method call(*, **)
         #
-        # @overload call(new_branch, **options)
+        #   Execute the git branch --move command to rename a branch
         #
-        #   Rename the current branch to new_branch
+        #   @overload call(new_branch, **options)
         #
-        #   @param new_branch [String] the new name for the branch
+        #     Rename the current branch to new_branch
         #
-        #   @param options [Hash] command options
+        #     @param new_branch [String] the new name for the branch
         #
-        #   @option options [Boolean] :force (nil) Allow renaming even if new_branch already exists.
+        #     @param options [Hash] command options
         #
-        #     Alias: :f
+        #     @option options [Boolean] :force (nil) Allow renaming even if new_branch already exists.
         #
-        # @overload call(old_branch, new_branch, **options)
+        #       Alias: :f
         #
-        #   Rename old_branch to new_branch
+        #   @overload call(old_branch, new_branch, **options)
         #
-        #   @param old_branch [String] the current name of the branch
+        #     Rename old_branch to new_branch
         #
-        #   @param new_branch [String] the new name for the branch
+        #     @param old_branch [String] the current name of the branch
         #
-        #   @param options [Hash] command options
+        #     @param new_branch [String] the new name for the branch
         #
-        #   @option options [Boolean] :force (nil) Allow renaming even if new_branch already exists.
+        #     @param options [Hash] command options
         #
-        #     Alias: :f
+        #     @option options [Boolean] :force (nil) Allow renaming even if new_branch already exists.
         #
-        # @return [Git::CommandLineResult] the result of calling `git branch --move`
+        #       Alias: :f
         #
-        # @raise [ArgumentError] if unsupported options are provided
+        #     @return [Git::CommandLineResult] the result of calling `git branch --move`
         #
-        # @raise [Git::FailedError] if the branch doesn't exist or target exists (without force)
+        #     @raise [ArgumentError] if unsupported options are provided
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [Git::FailedError] if the branch doesn't exist or target exists (without force)
       end
     end
   end

--- a/lib/git/commands/branch/set_upstream.rb
+++ b/lib/git/commands/branch/set_upstream.rb
@@ -22,7 +22,7 @@ module Git
       #   set_upstream = Git::Commands::Branch::SetUpstream.new(execution_context)
       #   set_upstream.call('feature', set_upstream_to: 'origin/main')
       #
-      class SetUpstream < Base
+      class SetUpstream < Git::Commands::Base
         # NOTE: The set_upstream_to option maps to git's --set-upstream-to=<upstream> syntax.
         # The branch_name positional is optional; if omitted, git uses the current branch.
         # The set_upstream_to keyword is required by the Ruby method signature, not the DSL.
@@ -32,39 +32,39 @@ module Git
           operand :branch_name
         end
 
-        # Execute the git branch --set-upstream-to command
+        # @!method call(*, **)
         #
-        # @overload call(**options)
+        #   Execute the git branch --set-upstream-to command
         #
-        #   Sets upstream for the current branch
+        #   @overload call(**options)
         #
-        #   @param options [Hash] command options
+        #     Sets upstream for the current branch
         #
-        #   @option options [String] :set_upstream_to (required) the upstream branch (e.g., 'origin/main').
+        #     @param options [Hash] command options
         #
-        #     Alias: :u
+        #     @option options [String] :set_upstream_to (required) the upstream branch (e.g., 'origin/main').
         #
-        # @overload call(branch_name, **options)
+        #       Alias: :u
         #
-        #    Set upstream for the specified branch
+        #   @overload call(branch_name, **options)
         #
-        #   @param branch_name [String] the branch to set upstream for
+        #      Set upstream for the specified branch
         #
-        #   @param options [Hash] command options
+        #     @param branch_name [String] the branch to set upstream for
         #
-        #   @option options [String] :set_upstream_to (required) the upstream branch (e.g., 'origin/main').
+        #     @param options [Hash] command options
         #
-        #     Alias: :u
+        #     @option options [String] :set_upstream_to (required) the upstream branch (e.g., 'origin/main').
         #
-        # @return [Git::CommandLineResult] the result of calling `git branch --set-upstream-to`
+        #       Alias: :u
         #
-        # @raise [ArgumentError] if set_upstream_to is not provided
+        #     @return [Git::CommandLineResult] the result of calling `git branch --set-upstream-to`
         #
-        # @raise [ArgumentError] if unsupported options are provided
+        #     @raise [ArgumentError] if set_upstream_to is not provided
         #
-        # @raise [Git::FailedError] if the branch or upstream doesn't exist
+        #     @raise [ArgumentError] if unsupported options are provided
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [Git::FailedError] if the branch or upstream doesn't exist
       end
     end
   end

--- a/lib/git/commands/branch/show_current.rb
+++ b/lib/git/commands/branch/show_current.rb
@@ -11,19 +11,21 @@ module Git
       #
       # @api private
       #
-      class ShowCurrent < Base
+      class ShowCurrent < Git::Commands::Base
         arguments do
           literal 'branch'
           literal '--show-current'
         end
 
-        # Execute the git branch --show-current command
+        # @!method call(*, **)
         #
-        # @return [Git::CommandLineResult] the result of calling `git branch --show-current`
+        #   Execute the git branch --show-current command
         #
-        # @raise [Git::FailedError] if git returns a non-zero exit code
+        #   @overload call()
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @return [Git::CommandLineResult] the result of calling `git branch --show-current`
+        #
+        #     @raise [Git::FailedError] if git returns a non-zero exit code
       end
     end
   end

--- a/lib/git/commands/branch/unset_upstream.rb
+++ b/lib/git/commands/branch/unset_upstream.rb
@@ -22,7 +22,7 @@ module Git
       #   unset_upstream = Git::Commands::Branch::UnsetUpstream.new(execution_context)
       #   unset_upstream.call('feature')
       #
-      class UnsetUpstream < Base
+      class UnsetUpstream < Git::Commands::Base
         # NOTE: The --unset-upstream flag is always present.
         # The branch_name positional is optional; if omitted, git uses the current branch.
         arguments do
@@ -31,21 +31,21 @@ module Git
           operand :branch_name
         end
 
-        # Execute the git branch --unset-upstream command
+        # @!method call(*, **)
         #
-        # @overload call(branch_name = nil, **options)
+        #   Execute the git branch --unset-upstream command
         #
-        #   @param branch_name [String, nil] The branch to configure (defaults to current branch if nil)
+        #   @overload call(branch_name = nil, **options)
         #
-        #   @param options [Hash] command options (none currently supported)
+        #     @param branch_name [String, nil] The branch to configure (defaults to current branch if nil)
         #
-        # @return [Git::CommandLineResult] the result of calling `git branch --unset-upstream`
+        #     @param options [Hash] command options (none currently supported)
         #
-        # @raise [ArgumentError] if unsupported options are provided
+        #     @return [Git::CommandLineResult] the result of calling `git branch --unset-upstream`
         #
-        # @raise [Git::FailedError] if the branch doesn't exist or has no upstream
+        #     @raise [ArgumentError] if unsupported options are provided
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [Git::FailedError] if the branch doesn't exist or has no upstream
       end
     end
   end

--- a/lib/git/commands/checkout/branch.rb
+++ b/lib/git/commands/checkout/branch.rb
@@ -31,7 +31,7 @@ module Git
       # @example Force checkout, discarding local changes
       #   checkout.call('main', force: true)
       #
-      class Branch < Base
+      class Branch < Git::Commands::Base
         arguments do
           literal 'checkout'
           flag_option %i[force f]
@@ -58,51 +58,51 @@ module Git
           operand :branch
         end
 
-        # Execute the git checkout command for branch switching
+        # @!method call(*, **)
         #
-        # @overload call(branch = nil, **options)
+        #   Execute the git checkout command for branch switching
         #
-        #   @param branch [String, nil] The branch name, commit SHA, or ref to
-        #     checkout. When used with branch creation options, this becomes the
-        #     start point.
+        #   @overload call(branch = nil, **options)
         #
-        #   @param options [Hash] command options
+        #     @param branch [String, nil] The branch name, commit SHA, or ref to
+        #       checkout. When used with branch creation options, this becomes the
+        #       start point.
         #
-        #   @option options [Boolean] :force (nil) Proceed even if the index or
-        #     working tree differs from HEAD. Local changes are discarded. Alias: :f
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean] :merge (nil) Perform a three-way merge.
-        #     Alias: :m
+        #     @option options [Boolean] :force (nil) Proceed even if the index or
+        #       working tree differs from HEAD. Local changes are discarded. Alias: :f
         #
-        #   @option options [String] :b (nil) Create a new branch with this name and switch to it
+        #     @option options [Boolean] :merge (nil) Perform a three-way merge.
+        #       Alias: :m
         #
-        #   @option options [String] :'B' (nil) Like :b, but reset if the branch already exists
+        #     @option options [String] :b (nil) Create a new branch with this name and switch to it
         #
-        #   @option options [Boolean, String] :track (nil) Set up upstream tracking.
-        #     true/false for --track/--no-track, or 'direct'/'inherit' for
-        #     --track=<value>.
-        #     Alias: :t
+        #     @option options [String] :'B' (nil) Like :b, but reset if the branch already exists
         #
-        #   @option options [Boolean] :guess (nil) Control automatic branch creation
-        #     from remotes. true for --guess, false for --no-guess
+        #     @option options [Boolean, String] :track (nil) Set up upstream tracking.
+        #       true/false for --track/--no-track, or 'direct'/'inherit' for
+        #       --track=<value>.
+        #       Alias: :t
         #
-        #   @option options [Boolean] :detach (nil) Detach HEAD at the specified
-        #     commit. Alias: :d
+        #     @option options [Boolean] :guess (nil) Control automatic branch creation
+        #       from remotes. true for --guess, false for --no-guess
         #
-        #   @option options [String] :orphan (nil) Create a new orphan branch with
-        #     no history
+        #     @option options [Boolean] :detach (nil) Detach HEAD at the specified
+        #       commit. Alias: :d
         #
-        #   @option options [Boolean] :ignore_other_worktrees (nil) Allow checking
-        #     out a branch checked out in another worktree
+        #     @option options [String] :orphan (nil) Create a new orphan branch with
+        #       no history
         #
-        #   @option options [Boolean] :recurse_submodules (nil) Update submodules.
-        #     true for --recurse-submodules, false for --no-recurse-submodules
+        #     @option options [Boolean] :ignore_other_worktrees (nil) Allow checking
+        #       out a branch checked out in another worktree
         #
-        # @return [Git::CommandLineResult] the result of the command
+        #     @option options [Boolean] :recurse_submodules (nil) Update submodules.
+        #       true for --recurse-submodules, false for --no-recurse-submodules
         #
-        # @raise [Git::FailedError] if the checkout fails
+        #     @return [Git::CommandLineResult] the result of the command
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [Git::FailedError] if the checkout fails
       end
     end
   end

--- a/lib/git/commands/checkout/files.rb
+++ b/lib/git/commands/checkout/files.rb
@@ -34,7 +34,7 @@ module Git
       # @example Read paths from a file
       #   files.call('main', pathspec_from_file: 'paths.txt')
       #
-      class Files < Base
+      class Files < Git::Commands::Base
         arguments do
           literal 'checkout'
           flag_option %i[force f]
@@ -50,49 +50,49 @@ module Git
           value_option :pathspec, as_operand: true, repeatable: true, separator: '--'
         end
 
-        # Execute the git checkout command for restoring files
+        # @!method call(*, **)
         #
-        # @overload call(tree_ish = nil, pathspec: nil, **options)
+        #   Execute the git checkout command for restoring files
         #
-        #   @param tree_ish [String, nil] The commit, branch, or tree to restore
-        #     files from. When nil, files are restored from the index.
+        #   @overload call(tree_ish = nil, pathspec: nil, **options)
         #
-        #   @param pathspec [String, Array<String>, nil] The files or directories
-        #     to restore. Required unless pathspec_from_file is provided.
+        #     @param tree_ish [String, nil] The commit, branch, or tree to restore
+        #       files from. When nil, files are restored from the index.
         #
-        #   @param options [Hash] command options
+        #     @param pathspec [String, Array<String>, nil] The files or directories
+        #       to restore. Required unless pathspec_from_file is provided.
         #
-        #   @option options [Array<String>, String] :pathspec The files or directories
-        #     to restore. Required unless :pathspec_from_file is provided.
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean] :force (nil) Ignore unmerged entries. Alias: :f
+        #     @option options [Array<String>, String] :pathspec The files or directories
+        #       to restore. Required unless :pathspec_from_file is provided.
         #
-        #   @option options [Boolean] :ours (nil) For unmerged paths, use stage #2
+        #     @option options [Boolean] :force (nil) Ignore unmerged entries. Alias: :f
         #
-        #   @option options [Boolean] :theirs (nil) For unmerged paths, use stage #3
+        #     @option options [Boolean] :ours (nil) For unmerged paths, use stage #2
         #
-        #   @option options [Boolean] :merge (nil) Recreate the conflicted merge.
-        #     Alias: :m
+        #     @option options [Boolean] :theirs (nil) For unmerged paths, use stage #3
         #
-        #   @option options [String] :conflict (nil) Conflict marker style: 'merge',
-        #     'diff3', 'zdiff3'
+        #     @option options [Boolean] :merge (nil) Recreate the conflicted merge.
+        #       Alias: :m
         #
-        #   @option options [Boolean] :overlay (nil) true for --overlay, false for
-        #     --no-overlay
+        #     @option options [String] :conflict (nil) Conflict marker style: 'merge',
+        #       'diff3', 'zdiff3'
         #
-        #   @option options [String] :pathspec_from_file (nil) Read paths from file
-        #     ('-' for stdin). Required unless :pathspec is provided.
+        #     @option options [Boolean] :overlay (nil) true for --overlay, false for
+        #       --no-overlay
         #
-        #   @option options [Boolean] :pathspec_file_nul (nil) NUL-separated paths in
-        #     pathspec file
+        #     @option options [String] :pathspec_from_file (nil) Read paths from file
+        #       ('-' for stdin). Required unless :pathspec is provided.
         #
-        # @return [Git::CommandLineResult] the result of the command
+        #     @option options [Boolean] :pathspec_file_nul (nil) NUL-separated paths in
+        #       pathspec file
         #
-        # @raise [ArgumentError] if neither :pathspec nor :pathspec_from_file is provided
+        #     @return [Git::CommandLineResult] the result of the command
         #
-        # @raise [Git::FailedError] if the checkout fails
+        #     @raise [ArgumentError] if neither :pathspec nor :pathspec_from_file is provided
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [Git::FailedError] if the checkout fails
       end
     end
   end

--- a/lib/git/commands/checkout_index.rb
+++ b/lib/git/commands/checkout_index.rb
@@ -31,7 +31,7 @@ module Git
     # @example Checkout a specific file with force
     #   checkout_index.call('path/to/file.txt', force: true)
     #
-    class CheckoutIndex < Base
+    class CheckoutIndex < Git::Commands::Base
       arguments do
         literal 'checkout-index'
         flag_option %i[index u]
@@ -45,45 +45,45 @@ module Git
         operand :file, required: false, repeatable: true, separator: '--'
       end
 
-      # Execute the git checkout-index command
+      # @!method call(*, **)
       #
-      # @overload call(*file, **options)
+      #   Execute the git checkout-index command
       #
-      #   @param file [Array<String>] Zero or more file paths to check out.
-      #     Appended after `--` to distinguish them from options. When empty, no
-      #     path separator is appended (use `:all` to check out everything).
+      #   @overload call(*file, **options)
       #
-      #   @param options [Hash] command options
+      #     @param file [Array<String>] Zero or more file paths to check out.
+      #       Appended after `--` to distinguish them from options. When empty, no
+      #       path separator is appended (use `:all` to check out everything).
       #
-      #   @option options [Boolean] :index (nil) Update the index rather than
-      #     checking out files to the working directory. Alias: :u
+      #     @param options [Hash] command options
       #
-      #   @option options [Boolean] :all (nil) Check out all files in the index.
-      #     Alias: :a
+      #     @option options [Boolean] :index (nil) Update the index rather than
+      #       checking out files to the working directory. Alias: :u
       #
-      #   @option options [Boolean] :force (nil) Force checkout even if
-      #     file already exists in the output location. Alias: :f
+      #     @option options [Boolean] :all (nil) Check out all files in the index.
+      #       Alias: :a
       #
-      #   @option options [Boolean] :no_create (nil) Don't checkout new files,
-      #     only refresh files already checked out. Alias: :n
+      #     @option options [Boolean] :force (nil) Force checkout even if
+      #       file already exists in the output location. Alias: :f
       #
-      #   @option options [String] :prefix (nil) Write the content to files under
-      #     the given directory prefix instead of the working directory root
+      #     @option options [Boolean] :no_create (nil) Don't checkout new files,
+      #       only refresh files already checked out. Alias: :n
       #
-      #   @option options [String] :stage (nil) Check out from the named stage:
-      #     a number (1, 2, or 3) or the string 'all'
+      #     @option options [String] :prefix (nil) Write the content to files under
+      #       the given directory prefix instead of the working directory root
       #
-      #   @option options [Boolean] :temp (nil) Instead of checking the files out,
-      #     write the content to temporary files near the target location
+      #     @option options [String] :stage (nil) Check out from the named stage:
+      #       a number (1, 2, or 3) or the string 'all'
       #
-      #   @option options [Boolean] :ignore_skip_worktree_bits (nil) Ignore the
-      #     skip-worktree bits when checking out files
+      #     @option options [Boolean] :temp (nil) Instead of checking the files out,
+      #       write the content to temporary files near the target location
       #
-      # @return [Git::CommandLineResult] the result of the command
+      #     @option options [Boolean] :ignore_skip_worktree_bits (nil) Ignore the
+      #       skip-worktree bits when checking out files
       #
-      # @raise [Git::FailedError] if the git command fails
+      #     @return [Git::CommandLineResult] the result of the command
       #
-      def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+      #     @raise [Git::FailedError] if the git command fails
     end
   end
 end

--- a/lib/git/commands/clean.rb
+++ b/lib/git/commands/clean.rb
@@ -41,7 +41,7 @@ module Git
     # @example Clean specific paths only
     #   clean.call(force: true, pathspec: ['tmp/', 'build/'])
     #
-    class Clean < Base
+    class Clean < Git::Commands::Base
       arguments do
         literal 'clean'
         flag_option :d
@@ -55,42 +55,42 @@ module Git
         conflicts :x, :X
       end
 
-      # Execute the git clean command
+      # @!method call(*, **)
       #
-      # @overload call(**options)
+      #   Execute the git clean command
       #
-      #   @param options [Hash] command options
+      #   @overload call(**options)
       #
-      #   @option options [Boolean] :d (nil) Recurse into untracked directories
+      #     @param options [Hash] command options
       #
-      #   @option options [Boolean] :force (nil) Force the clean operation when clean.requireForce is
-      #     not set to false. If the Git configuration variable `clean.requireForce` is not set to `false`,
-      #     git clean will refuse to delete files or directories unless given `-f`.
-      #     Alias: :f
+      #     @option options [Boolean] :d (nil) Recurse into untracked directories
       #
-      #   @option options [Boolean] :force_force (nil) Remove untracked nested git repositories
-      #     (directories with a .git subdirectory). Alias: :ff
+      #     @option options [Boolean] :force (nil) Force the clean operation when clean.requireForce is
+      #       not set to false. If the Git configuration variable `clean.requireForce` is not set to `false`,
+      #       git clean will refuse to delete files or directories unless given `-f`.
+      #       Alias: :f
       #
-      #   @option options [Boolean] :dry_run (nil) Don't actually remove anything, just show what
-      #     would be done. Alias: :n
+      #     @option options [Boolean] :force_force (nil) Remove untracked nested git repositories
+      #       (directories with a .git subdirectory). Alias: :ff
       #
-      #   @option options [String, Array<String>] :exclude (nil) Use the given exclude pattern in
-      #     addition to the standard ignore rules. May be specified multiple times. Alias: :e
+      #     @option options [Boolean] :dry_run (nil) Don't actually remove anything, just show what
+      #       would be done. Alias: :n
       #
-      #   @option options [Boolean] :x (nil) Don't use the standard ignore rules (see gitignore).
-      #     Mutually exclusive with :X
+      #     @option options [String, Array<String>] :exclude (nil) Use the given exclude pattern in
+      #       addition to the standard ignore rules. May be specified multiple times. Alias: :e
       #
-      #   @option options [Boolean] :X (nil) Remove only files ignored by Git.
-      #     Mutually exclusive with :x
+      #     @option options [Boolean] :x (nil) Don't use the standard ignore rules (see gitignore).
+      #       Mutually exclusive with :X
       #
-      #   @option options [String, Array<String>] :pathspec (nil) Limit cleaning to files
-      #     matching the given pathspec(s)
+      #     @option options [Boolean] :X (nil) Remove only files ignored by Git.
+      #       Mutually exclusive with :x
       #
-      # @return [Git::CommandLineResult] the result of calling `git clean`
+      #     @option options [String, Array<String>] :pathspec (nil) Limit cleaning to files
+      #       matching the given pathspec(s)
       #
-      # @raise [Git::FailedError] if the command returns a non-zero exit status
+      #     @return [Git::CommandLineResult] the result of calling `git clean`
       #
-      def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+      #     @raise [Git::FailedError] if the command returns a non-zero exit status
     end
   end
 end

--- a/lib/git/commands/clone.rb
+++ b/lib/git/commands/clone.rb
@@ -18,7 +18,7 @@ module Git
     #   clone = Git::Commands::Clone.new(execution_context)
     #   result = clone.call('https://github.com/user/repo.git', 'local-dir', bare: true, depth: 1)
     #
-    class Clone < Base
+    class Clone < Git::Commands::Base
       arguments do
         literal 'clone'
         flag_option :bare
@@ -36,56 +36,56 @@ module Git
         execution_option :chdir
       end
 
-      # Execute the git clone command
+      # @!method call(*, **)
       #
-      # @overload call(repository, directory = nil, **options)
+      #   Execute the git clone command
       #
-      #   @param repository [String] the URL of the repository to clone
+      #   @overload call(repository, directory = nil, **options)
       #
-      #   @param directory [String, nil] the directory to clone into.
-      #     If nil, git derives the directory name from the repository URL.
+      #     @param repository [String] the URL of the repository to clone
       #
-      #   @param options [Hash] command options
+      #     @param directory [String, nil] the directory to clone into.
+      #       If nil, git derives the directory name from the repository URL.
       #
-      #   @option options [Boolean] :bare (nil) Clone as a bare repository
+      #     @param options [Hash] command options
       #
-      #   @option options [Boolean] :mirror (nil) Set up a mirror clone (implies --bare)
+      #     @option options [Boolean] :bare (nil) Clone as a bare repository
       #
-      #   @option options [String] :origin (nil) Name of the remote (defaults to 'origin').
-      #     Alias: :o
+      #     @option options [Boolean] :mirror (nil) Set up a mirror clone (implies --bare)
       #
-      #   @option options [String] :branch (nil) The branch to checkout after cloning.
-      #     Alias: :b
+      #     @option options [String] :origin (nil) Name of the remote (defaults to 'origin').
+      #       Alias: :o
       #
-      #   @option options [Integer, String] :depth (nil) Create a shallow clone with the specified number of commits
+      #     @option options [String] :branch (nil) The branch to checkout after cloning.
+      #       Alias: :b
       #
-      #   @option options [Boolean, nil] :single_branch (nil) Clone only the history
-      #     leading to the tip of a single branch
+      #     @option options [Integer, String] :depth (nil) Create a shallow clone with the specified number of commits
       #
-      #   @option options [Boolean, String] :recurse_submodules (nil) Initialize all submodules
-      #     after cloning. When true, uses `--recurse-submodules`. When a string, passes the
-      #     pathspec to limit which submodules are initialized.
+      #     @option options [Boolean, nil] :single_branch (nil) Clone only the history
+      #       leading to the tip of a single branch
       #
-      #   @option options [String] :filter (nil) Specify partial clone (e.g., 'tree:0', 'blob:none')
+      #     @option options [Boolean, String] :recurse_submodules (nil) Initialize all submodules
+      #       after cloning. When true, uses `--recurse-submodules`. When a string, passes the
+      #       pathspec to limit which submodules are initialized.
       #
-      #   @option options [String, Array<String>] :config (nil) Configuration options to set.
-      #     Alias: :c
+      #     @option options [String] :filter (nil) Specify partial clone (e.g., 'tree:0', 'blob:none')
       #
-      #   @option options [Numeric, nil] :timeout (nil) the number of seconds to wait
-      #     for the command to complete. If nil, uses the global timeout from
-      #     {Git::Config}. If 0, no timeout is enforced.
+      #     @option options [String, Array<String>] :config (nil) Configuration options to set.
+      #       Alias: :c
       #
-      #   @option options [String, nil] :chdir (nil) the directory to run the git clone
-      #     command in. When given, the clone is created relative to this directory.
+      #     @option options [Numeric, nil] :timeout (nil) the number of seconds to wait
+      #       for the command to complete. If nil, uses the global timeout from
+      #       {Git::Config}. If 0, no timeout is enforced.
       #
-      # @return [Git::CommandLineResult] the result of the git clone command
+      #     @option options [String, nil] :chdir (nil) the directory to run the git clone
+      #       command in. When given, the clone is created relative to this directory.
       #
-      # @raise [ArgumentError] if unsupported options are provided, if :single_branch is not true, false, or nil,
-      #   or if any option fails validation
+      #     @return [Git::CommandLineResult] the result of the git clone command
       #
-      # @see Git::Lib#command for details on timeout behavior and other execution options
+      #     @raise [ArgumentError] if unsupported options are provided, if :single_branch is not true, false, or nil,
+      #       or if any option fails validation
       #
-      def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+      #     @see Git::Lib#command for details on timeout behavior and other execution options
     end
   end
 end

--- a/lib/git/commands/commit.rb
+++ b/lib/git/commands/commit.rb
@@ -25,7 +25,7 @@ module Git
     #   commit = Git::Commands::Commit.new(execution_context)
     #   commit.call(amend: true)
     #
-    class Commit < Base
+    class Commit < Git::Commands::Base
       arguments do
         literal 'commit'
         # Always suppress editor (non-interactive use)
@@ -41,46 +41,46 @@ module Git
         flag_or_value_option %i[gpg_sign S], negatable: true, inline: true
       end
 
-      # Execute the git commit command
+      # @!method call(*, **)
       #
-      # @overload call(**options)
+      #   Execute the git commit command
       #
-      #   @param options [Hash] command options
+      #   @overload call(**options)
       #
-      #   @option options [Boolean] :all (nil) Automatically stage all modified and deleted files
-      #     before committing.
-      #     Alias: :a
+      #     @param options [Hash] command options
       #
-      #   @option options [Boolean] :amend (nil) Amend the previous commit instead of creating a new one
+      #     @option options [Boolean] :all (nil) Automatically stage all modified and deleted files
+      #       before committing.
+      #       Alias: :a
       #
-      #   @option options [String] :message (nil) The commit message.
-      #     Alias: :m
+      #     @option options [Boolean] :amend (nil) Amend the previous commit instead of creating a new one
       #
-      #   @option options [Boolean] :allow_empty (nil) Allow creating a commit with no changes
+      #     @option options [String] :message (nil) The commit message.
+      #       Alias: :m
       #
-      #   @option options [Boolean] :allow_empty_message (nil) Allow creating a commit with an empty message
+      #     @option options [Boolean] :allow_empty (nil) Allow creating a commit with no changes
       #
-      #   @option options [Boolean] :no_verify (nil) Bypass the pre-commit and commit-msg hooks
+      #     @option options [Boolean] :allow_empty_message (nil) Allow creating a commit with an empty message
       #
-      #   @option options [String] :author (nil) Override the commit author in the format 'Name <email>'
+      #     @option options [Boolean] :no_verify (nil) Bypass the pre-commit and commit-msg hooks
       #
-      #   @option options [String] :date (nil) Override the author date. Must be a string in a format
-      #     that git understands (e.g., '2023-01-15T10:30:00', 'now', 'yesterday')
+      #     @option options [String] :author (nil) Override the commit author in the format 'Name <email>'
       #
-      #   @option options [Boolean, String, false] :gpg_sign (nil) GPG-sign the commit. When true, uses the
-      #     default key. When a string, uses the specified key ID. When false, adds --no-gpg-sign
-      #     to override any commit.gpgsign configuration.
-      #     Alias: :S
+      #     @option options [String] :date (nil) Override the author date. Must be a string in a format
+      #       that git understands (e.g., '2023-01-15T10:30:00', 'now', 'yesterday')
       #
-      # @return [Git::CommandLineResult] the result of calling `git commit`
+      #     @option options [Boolean, String, false] :gpg_sign (nil) GPG-sign the commit. When true, uses the
+      #       default key. When a string, uses the specified key ID. When false, adds --no-gpg-sign
+      #       to override any commit.gpgsign configuration.
+      #       Alias: :S
       #
-      # @raise [ArgumentError] if unsupported options are provided
+      #     @return [Git::CommandLineResult] the result of calling `git commit`
       #
-      # @raise [ArgumentError] if :date is not a String
+      #     @raise [ArgumentError] if unsupported options are provided
       #
-      # @raise [Git::FailedError] if the command returns a non-zero exit status
+      #     @raise [ArgumentError] if :date is not a String
       #
-      def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+      #     @raise [Git::FailedError] if the command returns a non-zero exit status
     end
   end
 end

--- a/lib/git/commands/diff/numstat.rb
+++ b/lib/git/commands/diff/numstat.rb
@@ -16,7 +16,7 @@ module Git
       #
       # @api private
       #
-      class Numstat < Base
+      class Numstat < Git::Commands::Base
         arguments do
           literal 'diff'
           # These two format literals are always emitted together. Git::Parsers::Diff
@@ -45,129 +45,129 @@ module Git
         # git diff exit codes: 0 = no diff, 1 = diff found, 2+ = error
         allow_exit_status 0..1
 
-        # Show diff numstat
+        # @!method call(*, **)
         #
-        # @overload call(**options)
-        #   Compare the index to the working tree
+        #   Show diff numstat
         #
-        #   @example
-        #     # git diff [-- <pathspecs>...]
-        #     Numstat.new(ctx).call
-        #     Numstat.new(ctx).call(path: ['lib/', '*.rb'])
+        #   @overload call(**options)
+        #     Compare the index to the working tree
         #
-        #   @param options [Hash] command options
+        #     @example
+        #       # git diff [-- <pathspecs>...]
+        #       Numstat.new(ctx).call
+        #       Numstat.new(ctx).call(path: ['lib/', '*.rb'])
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
         #
-        # @overload call(path1, path2, no_index: true, **options)
-        #   Compare two paths on the filesystem (outside git)
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff --no-index <path> <path> [<pathspec>...]
-        #     Numstat.new(ctx).call('/path/a', '/path/b', no_index: true)
-        #     Numstat.new(ctx).call('/dir/a', '/dir/b', no_index: true, path: ['*.rb'])
+        #   @overload call(path1, path2, no_index: true, **options)
+        #     Compare two paths on the filesystem (outside git)
         #
-        #   @param path1 [String] first filesystem path
+        #     @example
+        #       # git diff --no-index <path> <path> [<pathspec>...]
+        #       Numstat.new(ctx).call('/path/a', '/path/b', no_index: true)
+        #       Numstat.new(ctx).call('/dir/a', '/dir/b', no_index: true, path: ['*.rb'])
         #
-        #   @param path2 [String] second filesystem path
+        #     @param path1 [String] first filesystem path
         #
-        #   @param no_index [Boolean] must be true
+        #     @param path2 [String] second filesystem path
         #
-        #   @param options [Hash] command options
+        #     @param no_index [Boolean] must be true
         #
-        #   @option options [Array<String>] :pathspecs (nil) when comparing directories, zero or more
-        #     relative pathspecs to limit diff to (applies to both sides)
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Array<String>] :pathspecs (nil) when comparing directories, zero or more
+        #       relative pathspecs to limit diff to (applies to both sides)
         #
-        # @overload call(commit = nil, cached:, **options)
-        #   Compare the index to HEAD or the named commit
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff --cached [<commit>] [-- <pathspecs>...]
-        #     Numstat.new(ctx).call(cached: true)
-        #     Numstat.new(ctx).call('HEAD~3', cached: true, path: ['lib/'])
+        #   @overload call(commit = nil, cached:, **options)
+        #     Compare the index to HEAD or the named commit
         #
-        #   @param commit [String] optional commit reference (defaults to HEAD)
+        #     @example
+        #       # git diff --cached [<commit>] [-- <pathspecs>...]
+        #       Numstat.new(ctx).call(cached: true)
+        #       Numstat.new(ctx).call('HEAD~3', cached: true, path: ['lib/'])
         #
-        #   @param cached [Boolean] must be true (alias: :staged)
+        #     @param commit [String] optional commit reference (defaults to HEAD)
         #
-        #   @param options [Hash] command options
+        #     @param cached [Boolean] must be true (alias: :staged)
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
         #
-        # @overload call(commit, **options)
-        #   Compare the working tree to the named commit
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff <commit> [-- <pathspecs>...]
-        #     Numstat.new(ctx).call('HEAD~3')
-        #     Numstat.new(ctx).call('abc123', path: ['lib/', '*.rb'])
+        #   @overload call(commit, **options)
+        #     Compare the working tree to the named commit
         #
-        #   @param commit [String] commit reference
+        #     @example
+        #       # git diff <commit> [-- <pathspecs>...]
+        #       Numstat.new(ctx).call('HEAD~3')
+        #       Numstat.new(ctx).call('abc123', path: ['lib/', '*.rb'])
         #
-        #   @param options [Hash] command options
+        #     @param commit [String] commit reference
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
         #
-        # @overload call(commit1, commit2, **options)
-        #   Compare two commits
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff <commit> <commit> [-- <pathspecs>...]
-        #     # git diff <commit>..<commit> [-- <pathspecs>...]
-        #     # git diff <commit>...<commit> [-- <pathspecs>...]
-        #     Numstat.new(ctx).call('abc123', 'def456')
-        #     Numstat.new(ctx).call('v1.0..v2.0')   # two-dot range syntax
-        #     Numstat.new(ctx).call('main...feature')  # three-dot (merge-base) syntax
+        #   @overload call(commit1, commit2, **options)
+        #     Compare two commits
         #
-        #   @param commit1 [String] first commit reference (or range string like 'main..feature')
+        #     @example
+        #       # git diff <commit> <commit> [-- <pathspecs>...]
+        #       # git diff <commit>..<commit> [-- <pathspecs>...]
+        #       # git diff <commit>...<commit> [-- <pathspecs>...]
+        #       Numstat.new(ctx).call('abc123', 'def456')
+        #       Numstat.new(ctx).call('v1.0..v2.0')   # two-dot range syntax
+        #       Numstat.new(ctx).call('main...feature')  # three-dot (merge-base) syntax
         #
-        #   @param commit2 [String] second commit reference (omit if commit1 is a range)
+        #     @param commit1 [String] first commit reference (or range string like 'main..feature')
         #
-        #   @param options [Hash] command options
+        #     @param commit2 [String] second commit reference (omit if commit1 is a range)
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean] :merge_base (false) use merge base of commits
-        #     (alternative to three-dot syntax)
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :merge_base (false) use merge base of commits
+        #       (alternative to three-dot syntax)
         #
-        # @overload call(merge_commit, range, **options)
-        #   Show changes introduced by a merge commit beyond the merged branches
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff <merge-commit> <commit>...<commit> [-- <pathspecs>...]
-        #     Numstat.new(ctx).call('merge_commit', 'main...feature')
+        #   @overload call(merge_commit, range, **options)
+        #     Show changes introduced by a merge commit beyond the merged branches
         #
-        #   @param merge_commit [String] merge commit reference
+        #     @example
+        #       # git diff <merge-commit> <commit>...<commit> [-- <pathspecs>...]
+        #       Numstat.new(ctx).call('merge_commit', 'main...feature')
         #
-        #   @param range [String] three-dot range of merged branches
+        #     @param merge_commit [String] merge commit reference
         #
-        #   @param options [Hash] command options
+        #     @param range [String] three-dot range of merged branches
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
         #
-        # @return [Git::CommandLineResult] the result of calling `git diff --numstat`
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        # @raise [Git::FailedError] if git returns exit code >= 2 (actual error)
+        #   @return [Git::CommandLineResult] the result of calling `git diff --numstat`
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #   @raise [Git::FailedError] if git returns exit code >= 2 (actual error)
       end
     end
   end

--- a/lib/git/commands/diff/patch.rb
+++ b/lib/git/commands/diff/patch.rb
@@ -16,7 +16,7 @@ module Git
       #
       # @api private
       #
-      class Patch < Base
+      class Patch < Git::Commands::Base
         arguments do
           literal 'diff'
           # These three format literals are always emitted together. Git::Parsers::Diff
@@ -47,124 +47,124 @@ module Git
         # git diff exit codes: 0 = no diff, 1 = diff found, 2+ = error
         allow_exit_status 0..1
 
-        # Show diff patch
+        # @!method call(*, **)
         #
-        # @overload call(**options)
-        #   Compare the index to the working tree
+        #   Show diff patch
         #
-        #   @example
-        #     # git diff --patch [--] [<path>...]
-        #     Patch.new(ctx).call
-        #     Patch.new(ctx).call(path: ['lib/', '*.rb'])
+        #   @overload call(**options)
+        #     Compare the index to the working tree
         #
-        #   @param options [Hash] command options
+        #     @example
+        #       # git diff --patch [--] [<path>...]
+        #       Patch.new(ctx).call
+        #       Patch.new(ctx).call(path: ['lib/', '*.rb'])
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
-        #   @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @param options [Hash] command options
         #
-        # @overload call(path1, path2, no_index:, **options)
-        #   Compare two paths on the filesystem (outside git)
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff --no-index [--] <path> <path>
-        #     Patch.new(ctx).call('/path/a', '/path/b', no_index: true)
+        #   @overload call(path1, path2, no_index:, **options)
+        #     Compare two paths on the filesystem (outside git)
         #
-        #   @param path1 [String] first filesystem path
-        #   @param path2 [String] second filesystem path
-        #   @param no_index [Boolean] must be true
-        #   @param options [Hash] command options
+        #     @example
+        #       # git diff --no-index [--] <path> <path>
+        #       Patch.new(ctx).call('/path/a', '/path/b', no_index: true)
         #
-        #   @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @param path1 [String] first filesystem path
+        #     @param path2 [String] second filesystem path
+        #     @param no_index [Boolean] must be true
+        #     @param options [Hash] command options
         #
-        # @overload call(commit = nil, cached:, **options)
-        #   Compare the index to HEAD or the named commit
+        #     @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff --patch --cached [<commit>] [--] [<path>...]
-        #     Patch.new(ctx).call(cached: true)
-        #     Patch.new(ctx).call('HEAD~3', cached: true, path: ['lib/'])
+        #   @overload call(commit = nil, cached:, **options)
+        #     Compare the index to HEAD or the named commit
         #
-        #   @param commit [String] optional commit reference (defaults to HEAD)
-        #   @param cached [Boolean] must be true (alias: :staged)
-        #   @param options [Hash] command options
+        #     @example
+        #       # git diff --patch --cached [<commit>] [--] [<path>...]
+        #       Patch.new(ctx).call(cached: true)
+        #       Patch.new(ctx).call('HEAD~3', cached: true, path: ['lib/'])
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @param commit [String] optional commit reference (defaults to HEAD)
+        #     @param cached [Boolean] must be true (alias: :staged)
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
         #
-        # @overload call(commit, **options)
-        #   Compare the working tree to the named commit
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff --patch <commit> [--] [<path>...]
-        #     Patch.new(ctx).call('HEAD~3')
-        #     Patch.new(ctx).call('abc123', path: ['lib/', '*.rb'])
+        #   @overload call(commit, **options)
+        #     Compare the working tree to the named commit
         #
-        #   @param commit [String] commit reference
-        #   @param options [Hash] command options
+        #     @example
+        #       # git diff --patch <commit> [--] [<path>...]
+        #       Patch.new(ctx).call('HEAD~3')
+        #       Patch.new(ctx).call('abc123', path: ['lib/', '*.rb'])
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @param commit [String] commit reference
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
         #
-        # @overload call(commit1, commit2, **options)
-        #   Compare two commits
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff --patch <commit> <commit> [--] [<path>...]
-        #     # git diff --patch <commit>..<commit> [--] [<path>...]
-        #     # git diff --patch <commit>...<commit> [--] [<path>...]
-        #     Patch.new(ctx).call('abc123', 'def456')
-        #     Patch.new(ctx).call('v1.0..v2.0')   # two-dot range syntax
-        #     Patch.new(ctx).call('main...feature')  # three-dot (merge-base) syntax
+        #   @overload call(commit1, commit2, **options)
+        #     Compare two commits
         #
-        #   @param commit1 [String] first commit reference (or range string like 'main..feature')
-        #   @param commit2 [String] second commit reference (omit if commit1 is a range)
-        #   @param options [Hash] command options
+        #     @example
+        #       # git diff --patch <commit> <commit> [--] [<path>...]
+        #       # git diff --patch <commit>..<commit> [--] [<path>...]
+        #       # git diff --patch <commit>...<commit> [--] [<path>...]
+        #       Patch.new(ctx).call('abc123', 'def456')
+        #       Patch.new(ctx).call('v1.0..v2.0')   # two-dot range syntax
+        #       Patch.new(ctx).call('main...feature')  # three-dot (merge-base) syntax
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @param commit1 [String] first commit reference (or range string like 'main..feature')
+        #     @param commit2 [String] second commit reference (omit if commit1 is a range)
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean] :merge_base (false) use merge base of commits
-        #     (alternative to three-dot syntax)
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
         #
-        #   @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
+        #     @option options [Boolean] :merge_base (false) use merge base of commits
+        #       (alternative to three-dot syntax)
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
         #
-        # @overload call(merge_commit, range, **options)
-        #   Show changes introduced by a merge commit beyond the merged branches
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff --patch <merge-commit> <commit>...<commit> [--] [<path>...]
-        #     Patch.new(ctx).call('merge_commit', 'main...feature')
+        #   @overload call(merge_commit, range, **options)
+        #     Show changes introduced by a merge commit beyond the merged branches
         #
-        #   @param merge_commit [String] merge commit reference
-        #   @param range [String] three-dot range of merged branches
-        #   @param options [Hash] command options
+        #     @example
+        #       # git diff --patch <merge-commit> <commit>...<commit> [--] [<path>...]
+        #       Patch.new(ctx).call('merge_commit', 'main...feature')
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @param merge_commit [String] merge commit reference
+        #     @param range [String] three-dot range of merged branches
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
         #
-        # @return [Git::CommandLineResult] the result of calling `git diff --patch`
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        # @raise [Git::FailedError] if git returns exit code >= 2 (actual error)
+        #   @return [Git::CommandLineResult] the result of calling `git diff --patch`
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #   @raise [Git::FailedError] if git returns exit code >= 2 (actual error)
       end
     end
   end

--- a/lib/git/commands/diff/raw.rb
+++ b/lib/git/commands/diff/raw.rb
@@ -16,7 +16,7 @@ module Git
       #
       # @api private
       #
-      class Raw < Base
+      class Raw < Git::Commands::Base
         arguments do
           literal 'diff'
           # These three format literals are always emitted together. Git::Parsers::Diff
@@ -47,124 +47,124 @@ module Git
         # git diff exit codes: 0 = no diff, 1 = diff found, 2+ = error
         allow_exit_status 0..1
 
-        # Show diff raw output
+        # @!method call(*, **)
         #
-        # @overload call(**options)
-        #   Compare the index to the working tree
+        #   Show diff raw output
         #
-        #   @example
-        #     # git diff --raw [--] [<path>...]
-        #     Raw.new(ctx).call
-        #     Raw.new(ctx).call(path: ['lib/', '*.rb'])
+        #   @overload call(**options)
+        #     Compare the index to the working tree
         #
-        #   @param options [Hash] command options
+        #     @example
+        #       # git diff --raw [--] [<path>...]
+        #       Raw.new(ctx).call
+        #       Raw.new(ctx).call(path: ['lib/', '*.rb'])
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
-        #   @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @param options [Hash] command options
         #
-        # @overload call(path1, path2, no_index:, **options)
-        #   Compare two paths on the filesystem (outside git)
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff --no-index [--] <path> <path>
-        #     Raw.new(ctx).call('/path/a', '/path/b', no_index: true)
+        #   @overload call(path1, path2, no_index:, **options)
+        #     Compare two paths on the filesystem (outside git)
         #
-        #   @param path1 [String] first filesystem path
-        #   @param path2 [String] second filesystem path
-        #   @param no_index [Boolean] must be true
-        #   @param options [Hash] command options
+        #     @example
+        #       # git diff --no-index [--] <path> <path>
+        #       Raw.new(ctx).call('/path/a', '/path/b', no_index: true)
         #
-        #   @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @param path1 [String] first filesystem path
+        #     @param path2 [String] second filesystem path
+        #     @param no_index [Boolean] must be true
+        #     @param options [Hash] command options
         #
-        # @overload call(commit = nil, cached:, **options)
-        #   Compare the index to HEAD or the named commit
+        #     @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff --raw --cached [<commit>] [--] [<path>...]
-        #     Raw.new(ctx).call(cached: true)
-        #     Raw.new(ctx).call('HEAD~3', cached: true, path: ['lib/'])
+        #   @overload call(commit = nil, cached:, **options)
+        #     Compare the index to HEAD or the named commit
         #
-        #   @param commit [String] optional commit reference (defaults to HEAD)
-        #   @param cached [Boolean] must be true (alias: :staged)
-        #   @param options [Hash] command options
+        #     @example
+        #       # git diff --raw --cached [<commit>] [--] [<path>...]
+        #       Raw.new(ctx).call(cached: true)
+        #       Raw.new(ctx).call('HEAD~3', cached: true, path: ['lib/'])
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @param commit [String] optional commit reference (defaults to HEAD)
+        #     @param cached [Boolean] must be true (alias: :staged)
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
         #
-        # @overload call(commit, **options)
-        #   Compare the working tree to the named commit
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff --raw <commit> [--] [<path>...]
-        #     Raw.new(ctx).call('HEAD~3')
-        #     Raw.new(ctx).call('abc123', path: ['lib/', '*.rb'])
+        #   @overload call(commit, **options)
+        #     Compare the working tree to the named commit
         #
-        #   @param commit [String] commit reference
-        #   @param options [Hash] command options
+        #     @example
+        #       # git diff --raw <commit> [--] [<path>...]
+        #       Raw.new(ctx).call('HEAD~3')
+        #       Raw.new(ctx).call('abc123', path: ['lib/', '*.rb'])
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @param commit [String] commit reference
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
         #
-        # @overload call(commit1, commit2, **options)
-        #   Compare two commits
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff --raw <commit> <commit> [--] [<path>...]
-        #     # git diff --raw <commit>..<commit> [--] [<path>...]
-        #     # git diff --raw <commit>...<commit> [--] [<path>...]
-        #     Raw.new(ctx).call('abc123', 'def456')
-        #     Raw.new(ctx).call('v1.0..v2.0')   # two-dot range syntax
-        #     Raw.new(ctx).call('main...feature')  # three-dot (merge-base) syntax
+        #   @overload call(commit1, commit2, **options)
+        #     Compare two commits
         #
-        #   @param commit1 [String] first commit reference (or range string like 'main..feature')
-        #   @param commit2 [String] second commit reference (omit if commit1 is a range)
-        #   @param options [Hash] command options
+        #     @example
+        #       # git diff --raw <commit> <commit> [--] [<path>...]
+        #       # git diff --raw <commit>..<commit> [--] [<path>...]
+        #       # git diff --raw <commit>...<commit> [--] [<path>...]
+        #       Raw.new(ctx).call('abc123', 'def456')
+        #       Raw.new(ctx).call('v1.0..v2.0')   # two-dot range syntax
+        #       Raw.new(ctx).call('main...feature')  # three-dot (merge-base) syntax
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @param commit1 [String] first commit reference (or range string like 'main..feature')
+        #     @param commit2 [String] second commit reference (omit if commit1 is a range)
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean] :merge_base (false) use merge base of commits
-        #     (alternative to three-dot syntax)
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
         #
-        #   @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
+        #     @option options [Boolean] :merge_base (false) use merge base of commits
+        #       (alternative to three-dot syntax)
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
         #
-        # @overload call(merge_commit, range, **options)
-        #   Show changes introduced by a merge commit beyond the merged branches
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   @example
-        #     # git diff --raw <merge-commit> <commit>...<commit> [--] [<path>...]
-        #     Raw.new(ctx).call('merge_commit', 'main...feature')
+        #   @overload call(merge_commit, range, **options)
+        #     Show changes introduced by a merge commit beyond the merged branches
         #
-        #   @param merge_commit [String] merge commit reference
-        #   @param range [String] three-dot range of merged branches
-        #   @param options [Hash] command options
+        #     @example
+        #       # git diff --raw <merge-commit> <commit>...<commit> [--] [<path>...]
+        #       Raw.new(ctx).call('merge_commit', 'main...feature')
         #
-        #   @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
+        #     @param merge_commit [String] merge commit reference
+        #     @param range [String] three-dot range of merged branches
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
+        #     @option options [Array<String>] :pathspecs (nil) zero or more pathspecs to limit diff to
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :find_copies (false) detect copies as well as renames (adds `-C`)
         #
-        # @return [Git::CommandLineResult] the result of calling `git diff --raw`
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        # @raise [Git::FailedError] if git returns exit code >= 2 (actual error)
+        #   @return [Git::CommandLineResult] the result of calling `git diff --raw`
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #   @raise [Git::FailedError] if git returns exit code >= 2 (actual error)
       end
     end
   end

--- a/lib/git/commands/fsck.rb
+++ b/lib/git/commands/fsck.rb
@@ -27,7 +27,7 @@ module Git
     #   fsck = Git::Commands::Fsck.new(execution_context)
     #   result = fsck.call(unreachable: true, strict: true)
     #
-    class Fsck < Base
+    class Fsck < Git::Commands::Base
       arguments do
         literal 'fsck'
         literal '--no-progress'
@@ -50,62 +50,62 @@ module Git
       # Exit code 0 = no issues, 1-7 = various issue types (still considered successful)
       allow_exit_status 0..7
 
-      # Execute the git fsck command
+      # @!method call(*, **)
       #
-      # @overload call(*object, **options)
+      #   Execute the git fsck command
       #
-      #   @example Check repository integrity
-      #     # git fsck --no-progress
-      #     result = fsck.call
+      #   @overload call(*object, **options)
       #
-      #   @example Check specific objects
-      #     # git fsck --no-progress abc1234 def5678
-      #     result = fsck.call('abc1234', 'def5678')
+      #     @example Check repository integrity
+      #       # git fsck --no-progress
+      #       result = fsck.call
       #
-      #   @example With options
-      #     # git fsck --no-progress --unreachable --strict
-      #     result = fsck.call(unreachable: true, strict: true)
+      #     @example Check specific objects
+      #       # git fsck --no-progress abc1234 def5678
+      #       result = fsck.call('abc1234', 'def5678')
       #
-      #   @param object [Array<String>] optional object identifiers to check
+      #     @example With options
+      #       # git fsck --no-progress --unreachable --strict
+      #       result = fsck.call(unreachable: true, strict: true)
       #
-      #   @param options [Hash] command options
+      #     @param object [Array<String>] optional object identifiers to check
       #
-      #   @option options [Boolean] :tags (nil) report tags
+      #     @param options [Hash] command options
       #
-      #   @option options [Boolean] :root (nil) report root nodes
+      #     @option options [Boolean] :tags (nil) report tags
       #
-      #   @option options [Boolean] :unreachable (nil) print out objects that exist but are not
-      #     reachable from any of the reference nodes
+      #     @option options [Boolean] :root (nil) report root nodes
       #
-      #   @option options [Boolean] :cache (nil) consider any object recorded in the index also
-      #     as a head node for reachability
+      #     @option options [Boolean] :unreachable (nil) print out objects that exist but are not
+      #       reachable from any of the reference nodes
       #
-      #   @option options [Boolean] :no_reflogs (nil) do not consider commits referenced only by
-      #     reflogs to be reachable
+      #     @option options [Boolean] :cache (nil) consider any object recorded in the index also
+      #       as a head node for reachability
       #
-      #   @option options [Boolean] :full (nil) check all objects, not just reachable ones. Pass
-      #     false to explicitly disable
+      #     @option options [Boolean] :no_reflogs (nil) do not consider commits referenced only by
+      #       reflogs to be reachable
       #
-      #   @option options [Boolean] :strict (nil) enable more strict checking
+      #     @option options [Boolean] :full (nil) check all objects, not just reachable ones. Pass
+      #       false to explicitly disable
       #
-      #   @option options [Boolean] :lost_found (nil) write dangling objects into .git/lost-found
+      #     @option options [Boolean] :strict (nil) enable more strict checking
       #
-      #   @option options [Boolean] :dangling (nil) report dangling objects. Pass false to suppress
-      #     dangling object reporting
+      #     @option options [Boolean] :lost_found (nil) write dangling objects into .git/lost-found
       #
-      #   @option options [Boolean] :connectivity_only (nil) check only the connectivity of objects
+      #     @option options [Boolean] :dangling (nil) report dangling objects. Pass false to suppress
+      #       dangling object reporting
       #
-      #   @option options [Boolean] :name_objects (nil) show the name of each reachable object
-      #     alongside its identifier. Pass false to explicitly disable
+      #     @option options [Boolean] :connectivity_only (nil) check only the connectivity of objects
       #
-      #   @option options [Boolean] :references (nil) check reference objects. Pass false to
-      #     explicitly disable reference checking
+      #     @option options [Boolean] :name_objects (nil) show the name of each reachable object
+      #       alongside its identifier. Pass false to explicitly disable
       #
-      # @return [Git::CommandLineResult] the result of calling `git fsck`
+      #     @option options [Boolean] :references (nil) check reference objects. Pass false to
+      #       explicitly disable reference checking
       #
-      # @raise [Git::FailedError] if git returns an exit code > 7
+      #     @return [Git::CommandLineResult] the result of calling `git fsck`
       #
-      def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+      #     @raise [Git::FailedError] if git returns an exit code > 7
     end
   end
 end

--- a/lib/git/commands/init.rb
+++ b/lib/git/commands/init.rb
@@ -24,7 +24,7 @@ module Git
     #   init = Git::Commands::Init.new(execution_context)
     #   init.call('my-repo', initial_branch: 'main')
     #
-    class Init < Base
+    class Init < Git::Commands::Base
       arguments do
         literal 'init'
         flag_option :bare
@@ -33,30 +33,30 @@ module Git
         operand :directory
       end
 
-      # Execute the git init command
+      # @!method call(*, **)
       #
-      # @overload call(directory = nil, **options)
+      #   Execute the git init command
       #
-      #   @param directory [String] the directory to initialize (default: '.')
-      #     If :bare is false, creates the repository in +<directory>/.git+.
-      #     If :bare is true, creates a bare repository in +<directory>+.
+      #   @overload call(directory = nil, **options)
       #
-      #   @param options [Hash] command options
+      #     @param directory [String] the directory to initialize (default: '.')
+      #       If :bare is false, creates the repository in +<directory>/.git+.
+      #       If :bare is true, creates a bare repository in +<directory>+.
       #
-      #   @option options [Boolean] :bare (nil) Create a bare repository
+      #     @param options [Hash] command options
       #
-      #   @option options [String] :initial_branch (nil) Use the specified name for the initial branch.
-      #     Alias: :b
+      #     @option options [Boolean] :bare (nil) Create a bare repository
       #
-      #   @option options [String] :separate_git_dir (nil) Path to put the .git directory (`--separate-git-dir`)
+      #     @option options [String] :initial_branch (nil) Use the specified name for the initial branch.
+      #       Alias: :b
       #
-      # @return [Git::CommandLineResult] the result of calling `git init`
+      #     @option options [String] :separate_git_dir (nil) Path to put the .git directory (`--separate-git-dir`)
       #
-      # @raise [ArgumentError] if unsupported options are provided
+      #     @return [Git::CommandLineResult] the result of calling `git init`
       #
-      # @raise [Git::FailedError] if the command returns a non-zero exit status
+      #     @raise [ArgumentError] if unsupported options are provided
       #
-      def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+      #     @raise [Git::FailedError] if the command returns a non-zero exit status
     end
   end
 end

--- a/lib/git/commands/merge/abort.rb
+++ b/lib/git/commands/merge/abort.rb
@@ -18,19 +18,21 @@ module Git
       #   abort_cmd = Git::Commands::Merge::Abort.new(execution_context)
       #   abort_cmd.call
       #
-      class Abort < Base
+      class Abort < Git::Commands::Base
         arguments do
           literal 'merge'
           literal '--abort'
         end
 
-        # Execute the git merge --abort command
+        # @!method call(*, **)
         #
-        # @return [Git::CommandLineResult] the result of the command
+        #   @overload call()
         #
-        # @raise [Git::FailedError] if no merge is in progress
+        #     Execute the git merge --abort command
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @return [Git::CommandLineResult] the result of the command
+        #
+        #     @raise [Git::FailedError] if no merge is in progress
       end
     end
   end

--- a/lib/git/commands/merge/continue.rb
+++ b/lib/git/commands/merge/continue.rb
@@ -18,19 +18,21 @@ module Git
       #   continue_cmd = Git::Commands::Merge::Continue.new(execution_context)
       #   continue_cmd.call
       #
-      class Continue < Base
+      class Continue < Git::Commands::Base
         arguments do
           literal 'merge'
           literal '--continue'
         end
 
-        # Execute the git merge --continue command
+        # @!method call(*, **)
         #
-        # @return [Git::CommandLineResult] the result of the command
+        #   @overload call()
         #
-        # @raise [Git::FailedError] if no merge is in progress or conflicts remain unresolved
+        #     Execute the git merge --continue command
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @return [Git::CommandLineResult] the result of the command
+        #
+        #     @raise [Git::FailedError] if no merge is in progress or conflicts remain unresolved
       end
     end
   end

--- a/lib/git/commands/merge/quit.rb
+++ b/lib/git/commands/merge/quit.rb
@@ -19,20 +19,22 @@ module Git
       #   quit_cmd = Git::Commands::Merge::Quit.new(execution_context)
       #   quit_cmd.call
       #
-      class Quit < Base
+      class Quit < Git::Commands::Base
         arguments do
           literal 'merge'
           literal '--quit'
         end
 
-        # Execute the git merge --quit command
+        # @!method call(*, **)
         #
-        # @return [Git::CommandLineResult] the result of the command
+        #   @overload call()
         #
-        # @raise [Git::FailedError] if the underlying git command exits non-zero
-        #   (for example, on Git versions before 2.35 when no merge is in progress)
+        #     Execute the git merge --quit command
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @return [Git::CommandLineResult] the result of the command
+        #
+        #     @raise [Git::FailedError] if the underlying git command exits non-zero
+        #       (for example, on Git versions before 2.35 when no merge is in progress)
       end
     end
   end

--- a/lib/git/commands/merge/start.rb
+++ b/lib/git/commands/merge/start.rb
@@ -30,7 +30,7 @@ module Git
       # @example Octopus merge (multiple branches)
       #   merge.call('branch1', 'branch2', 'branch3')
       #
-      class Start < Base
+      class Start < Git::Commands::Base
         arguments do
           literal 'merge'
           # Always suppress editor (non-interactive use)
@@ -75,78 +75,78 @@ module Git
           conflicts :m, :file
         end
 
-        # Execute the git merge command
+        # @!method call(*, **)
         #
-        # @overload call(*commit, **options)
+        #   Execute the git merge command
         #
-        #   @param commit [Array<String>] One or more branch names, commit SHAs,
-        #     or refs to merge into the current branch. Multiple commits create
-        #     an octopus merge.
+        #   @overload call(*commit, **options)
         #
-        #   @param options [Hash] command options
+        #     @param commit [Array<String>] One or more branch names, commit SHAs,
+        #       or refs to merge into the current branch. Multiple commits create
+        #       an octopus merge.
         #
-        #   @option options [Boolean] :commit (nil) Perform merge and commit.
-        #     true for --commit, false for --no-commit
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean] :squash (nil) Create a single commit on top
-        #     of current branch with the effect of merging another branch
+        #     @option options [Boolean] :commit (nil) Perform merge and commit.
+        #       true for --commit, false for --no-commit
         #
-        #   @option options [Boolean] :ff (nil) Fast-forward behavior.
-        #     true for --ff, false for --no-ff
+        #     @option options [Boolean] :squash (nil) Create a single commit on top
+        #       of current branch with the effect of merging another branch
         #
-        #   @option options [Boolean] :ff_only (nil) Refuse to merge unless
-        #     fast-forward is possible
+        #     @option options [Boolean] :ff (nil) Fast-forward behavior.
+        #       true for --ff, false for --no-ff
         #
-        #   @option options [String] :m (nil) Commit message for the merge commit.
+        #     @option options [Boolean] :ff_only (nil) Refuse to merge unless
+        #       fast-forward is possible
         #
-        #   @option options [String] :file (nil) Read commit message from file.
-        #     Alias: :F
+        #     @option options [String] :m (nil) Commit message for the merge commit.
         #
-        #   @option options [String] :into_name (nil) Prepare merge message as if
-        #     merging into this branch name
+        #     @option options [String] :file (nil) Read commit message from file.
+        #       Alias: :F
         #
-        #   @option options [String] :strategy (nil) Merge strategy to use
-        #     (e.g., 'ort', 'recursive', 'resolve', 'octopus', 'ours', 'subtree').
-        #     Alias: :s
+        #     @option options [String] :into_name (nil) Prepare merge message as if
+        #       merging into this branch name
         #
-        #   @option options [String, Array<String>] :strategy_option (nil) Pass
-        #     option(s) to the merge strategy (e.g., 'ours', 'theirs', 'patience').
-        #     Can be a single value or array for multiple -X flags. Alias: :X
+        #     @option options [String] :strategy (nil) Merge strategy to use
+        #       (e.g., 'ort', 'recursive', 'resolve', 'octopus', 'ours', 'subtree').
+        #       Alias: :s
         #
-        #   @option options [Boolean, String] :gpg_sign (nil) GPG-sign the merge commit.
-        #     true for --gpg-sign, a String key ID for --gpg-sign=<keyid>, false for --no-gpg-sign.
-        #     Alias: :S
+        #     @option options [String, Array<String>] :strategy_option (nil) Pass
+        #       option(s) to the merge strategy (e.g., 'ours', 'theirs', 'patience').
+        #       Can be a single value or array for multiple -X flags. Alias: :X
         #
-        #   @option options [Boolean] :verify (nil) Run pre-merge and commit-msg
-        #     hooks. true for --verify, false for --no-verify
+        #     @option options [Boolean, String] :gpg_sign (nil) GPG-sign the merge commit.
+        #       true for --gpg-sign, a String key ID for --gpg-sign=<keyid>, false for --no-gpg-sign.
+        #       Alias: :S
         #
-        #   @option options [Boolean] :verify_signatures (nil) Verify commit
-        #     signatures. true for --verify-signatures, false for
-        #     --no-verify-signatures
+        #     @option options [Boolean] :verify (nil) Run pre-merge and commit-msg
+        #       hooks. true for --verify, false for --no-verify
         #
-        #   @option options [Boolean] :allow_unrelated_histories (nil) Allow
-        #     merging histories without common ancestor. true for
-        #     --allow-unrelated-histories, false for --no-allow-unrelated-histories
+        #     @option options [Boolean] :verify_signatures (nil) Verify commit
+        #       signatures. true for --verify-signatures, false for
+        #       --no-verify-signatures
         #
-        #   @option options [Boolean] :rerere_autoupdate (nil) Allow rerere to
-        #     update index. true for --rerere-autoupdate, false for
-        #     --no-rerere-autoupdate
+        #     @option options [Boolean] :allow_unrelated_histories (nil) Allow
+        #       merging histories without common ancestor. true for
+        #       --allow-unrelated-histories, false for --no-allow-unrelated-histories
         #
-        #   @option options [Boolean] :autostash (nil) Automatically stash/unstash
-        #     before/after merge. true for --autostash, false for --no-autostash
+        #     @option options [Boolean] :rerere_autoupdate (nil) Allow rerere to
+        #       update index. true for --rerere-autoupdate, false for
+        #       --no-rerere-autoupdate
         #
-        #   @option options [Boolean] :signoff (nil) Add Signed-off-by trailer.
-        #     true for --signoff, false for --no-signoff
+        #     @option options [Boolean] :autostash (nil) Automatically stash/unstash
+        #       before/after merge. true for --autostash, false for --no-autostash
         #
-        #   @option options [Boolean, Integer] :log (nil) Include one-line descriptions
-        #     from commits in merge message. true for --log, false for --no-log,
-        #     or an integer for --log=<n> to limit the number of entries.
+        #     @option options [Boolean] :signoff (nil) Add Signed-off-by trailer.
+        #       true for --signoff, false for --no-signoff
         #
-        # @return [Git::CommandLineResult] the result of the command
+        #     @option options [Boolean, Integer] :log (nil) Include one-line descriptions
+        #       from commits in merge message. true for --log, false for --no-log,
+        #       or an integer for --log=<n> to limit the number of entries.
         #
-        # @raise [Git::FailedError] if the merge fails (e.g., conflicts)
+        #     @return [Git::CommandLineResult] the result of the command
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [Git::FailedError] if the merge fails (e.g., conflicts)
       end
     end
   end

--- a/lib/git/commands/merge_base.rb
+++ b/lib/git/commands/merge_base.rb
@@ -29,7 +29,7 @@ module Git
     # @example Find fork point
     #   result = merge_base.call('main', 'feature', fork_point: true)
     #
-    class MergeBase < Base
+    class MergeBase < Git::Commands::Base
       arguments do
         literal 'merge-base'
         flag_option %i[all a]
@@ -47,33 +47,33 @@ module Git
       # git merge-base --fork-point returns exit code 1 when no fork point is found (not an error)
       allow_exit_status 0..1
 
-      # Execute the git merge-base command
+      # @!method call(*, **)
       #
-      # @overload call(*commit, **options)
+      #   Execute the git merge-base command
       #
-      #   @param commit [Array<String>] Two or more commit SHAs, branch names,
-      #     or refs to find common ancestor(s) of
+      #   @overload call(*commit, **options)
       #
-      #   @param options [Hash] command options
+      #     @param commit [Array<String>] Two or more commit SHAs, branch names,
+      #       or refs to find common ancestor(s) of
       #
-      #   @option options [Boolean] :all (nil) Output all merge bases instead of
-      #     just one (when multiple equally good bases exist).
-      #     Alias: :a
+      #     @param options [Hash] command options
       #
-      #   @option options [Boolean] :octopus (nil) Compute best common ancestor
-      #     for an n-way merge (intersection of all merge bases)
+      #     @option options [Boolean] :all (nil) Output all merge bases instead of
+      #       just one (when multiple equally good bases exist).
+      #       Alias: :a
       #
-      #   @option options [Boolean] :independent (nil) List commits not reachable
-      #     from any other (useful for finding branch tips)
+      #     @option options [Boolean] :octopus (nil) Compute best common ancestor
+      #       for an n-way merge (intersection of all merge bases)
       #
-      #   @option options [Boolean] :fork_point (nil) Find the fork point where
-      #     a branch diverged from another
+      #     @option options [Boolean] :independent (nil) List commits not reachable
+      #       from any other (useful for finding branch tips)
       #
-      # @return [Git::CommandLineResult] the result of calling `git merge-base`
+      #     @option options [Boolean] :fork_point (nil) Find the fork point where
+      #       a branch diverged from another
       #
-      # @raise [Git::FailedError] if git returns an exit code > 1
+      #     @return [Git::CommandLineResult] the result of calling `git merge-base`
       #
-      def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+      #     @raise [Git::FailedError] if git returns an exit code > 1
     end
   end
 end

--- a/lib/git/commands/mv.rb
+++ b/lib/git/commands/mv.rb
@@ -23,7 +23,7 @@ module Git
     # @example Force overwrite if destination exists
     #   mv.call('source.rb', 'dest.rb', force: true)
     #
-    class Mv < Base
+    class Mv < Git::Commands::Base
       arguments do
         literal 'mv'
         literal '--verbose'
@@ -34,29 +34,29 @@ module Git
         operand :destination, required: true
       end
 
-      # Execute the git mv command
+      # @!method call(*, **)
       #
-      # @overload call(*source, destination, **options)
+      #   Execute the git mv command
       #
-      #   @param source [Array<String>] one or more source file(s) or directories to move
+      #   @overload call(*source, destination, **options)
       #
-      #   @param destination [String] the destination file or directory
+      #     @param source [Array<String>] one or more source file(s) or directories to move
       #
-      #   @param options [Hash] command options
+      #     @param destination [String] the destination file or directory
       #
-      #   @option options [Boolean] :force (nil) Force renaming or moving even if the destination exists.
-      #     Alias: :f
+      #     @param options [Hash] command options
       #
-      #   @option options [Boolean] :dry_run (nil) Do nothing; only show what would happen.
-      #     Alias: :n
+      #     @option options [Boolean] :force (nil) Force renaming or moving even if the destination exists.
+      #       Alias: :f
       #
-      #   @option options [Boolean] :k (nil) Skip move or rename actions which would lead to an error
+      #     @option options [Boolean] :dry_run (nil) Do nothing; only show what would happen.
+      #       Alias: :n
       #
-      # @return [Git::CommandLineResult] the result of calling `git mv`
+      #     @option options [Boolean] :k (nil) Skip move or rename actions which would lead to an error
       #
-      # @raise [Git::FailedError] if the command returns a non-zero exit status
+      #     @return [Git::CommandLineResult] the result of calling `git mv`
       #
-      def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+      #     @raise [Git::FailedError] if the command returns a non-zero exit status
     end
   end
 end

--- a/lib/git/commands/reset.rb
+++ b/lib/git/commands/reset.rb
@@ -30,7 +30,7 @@ module Git
     # @example Mixed reset (keeps changes unstaged)
     #   reset.call('HEAD~1', mixed: true)
     #
-    class Reset < Base
+    class Reset < Git::Commands::Base
       arguments do
         literal 'reset'
         flag_option :soft
@@ -42,38 +42,38 @@ module Git
         operand :commit, required: false
       end
 
-      # Execute the git reset command
+      # @!method call(*, **)
       #
-      # @overload call(commit = nil, **options)
+      #   Execute the git reset command
       #
-      #   @param commit [String, nil] the commit to reset to (defaults to HEAD if not specified)
+      #   @overload call(commit = nil, **options)
       #
-      #   @param options [Hash] command options
+      #     @param commit [String, nil] the commit to reset to (defaults to HEAD if not specified)
       #
-      #   @option options [Boolean] :soft (nil) does not touch the index file or the working tree at all,
-      #     but resets the head to the commit
+      #     @param options [Hash] command options
       #
-      #   @option options [Boolean] :mixed (nil) resets the index but not the working tree (i.e., the
-      #     changed files are preserved but not marked for commit)
+      #     @option options [Boolean] :soft (nil) does not touch the index file or the working tree at all,
+      #       but resets the head to the commit
       #
-      #   @option options [Boolean] :hard (nil) reset the index and working tree. Any changes to tracked
-      #     files in the working tree since the commit are discarded
+      #     @option options [Boolean] :mixed (nil) resets the index but not the working tree (i.e., the
+      #       changed files are preserved but not marked for commit)
       #
-      #   @option options [Boolean] :merge (nil) reset the index and update the files in the working tree
-      #     that are different between the commit and HEAD, but keep those which are different between
-      #     the index and working tree
+      #     @option options [Boolean] :hard (nil) reset the index and working tree. Any changes to tracked
+      #       files in the working tree since the commit are discarded
       #
-      #   @option options [Boolean] :keep (nil) reset the index and update the files in the working tree
-      #     that are different between the commit and HEAD. If a file that is different between the
-      #     commit and HEAD has local changes, reset is aborted
+      #     @option options [Boolean] :merge (nil) reset the index and update the files in the working tree
+      #       that are different between the commit and HEAD, but keep those which are different between
+      #       the index and working tree
       #
-      # @return [Git::CommandLineResult] the result of calling `git reset`
+      #     @option options [Boolean] :keep (nil) reset the index and update the files in the working tree
+      #       that are different between the commit and HEAD. If a file that is different between the
+      #       commit and HEAD has local changes, reset is aborted
       #
-      # @raise [ArgumentError] if more than one of :soft, :mixed, :hard, :merge, or :keep is specified
+      #     @return [Git::CommandLineResult] the result of calling `git reset`
       #
-      # @raise [Git::FailedError] if the command returns a non-zero exit status
+      #     @raise [ArgumentError] if more than one of :soft, :mixed, :hard, :merge, or :keep is specified
       #
-      def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+      #     @raise [Git::FailedError] if the command returns a non-zero exit status
     end
   end
 end

--- a/lib/git/commands/rm.rb
+++ b/lib/git/commands/rm.rb
@@ -29,7 +29,7 @@ module Git
     #   rm = Git::Commands::Rm.new(execution_context)
     #   rm.call('modified_file.txt', force: true)
     #
-    class Rm < Base
+    class Rm < Git::Commands::Base
       arguments do
         literal 'rm'
         flag_option %i[force f]
@@ -38,28 +38,28 @@ module Git
         operand :pathspec, repeatable: true, required: true, separator: '--'
       end
 
-      # Execute the git rm command
+      # @!method call(*, **)
       #
-      # @overload call(*pathspec, **options)
+      #   Execute the git rm command
       #
-      #   @param pathspec [Array<String>] files or directories to be removed from the repository
-      #     (relative to the worktree root). At least one pathspec is required.
+      #   @overload call(*pathspec, **options)
       #
-      #   @param options [Hash] command options
+      #     @param pathspec [Array<String>] files or directories to be removed from the repository
+      #       (relative to the worktree root). At least one pathspec is required.
       #
-      #   @option options [Boolean] :force (nil) Override the up-to-date check and remove files with
-      #     local modifications. Without this, git rm will refuse to remove files that have
-      #     uncommitted changes. Alias: :f
+      #     @param options [Hash] command options
       #
-      #   @option options [Boolean] :r (nil) Remove directories and their contents recursively
+      #     @option options [Boolean] :force (nil) Override the up-to-date check and remove files with
+      #       local modifications. Without this, git rm will refuse to remove files that have
+      #       uncommitted changes. Alias: :f
       #
-      #   @option options [Boolean] :cached (nil) Only remove from the index, keeping the working tree files
+      #     @option options [Boolean] :r (nil) Remove directories and their contents recursively
       #
-      # @return [Git::CommandLineResult] the result of calling `git rm`
+      #     @option options [Boolean] :cached (nil) Only remove from the index, keeping the working tree files
       #
-      # @raise [Git::FailedError] if the git command fails (e.g., no paths provided)
+      #     @return [Git::CommandLineResult] the result of calling `git rm`
       #
-      def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+      #     @raise [Git::FailedError] if the git command fails (e.g., no paths provided)
     end
   end
 end

--- a/lib/git/commands/stash/apply.rb
+++ b/lib/git/commands/stash/apply.rb
@@ -25,7 +25,7 @@ module Git
       # @example Apply and restore index state
       #   Git::Commands::Stash::Apply.new(execution_context).call(index: true)
       #
-      class Apply < Base
+      class Apply < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'apply'
@@ -33,31 +33,31 @@ module Git
           operand :stash
         end
 
-        # Apply stashed changes
+        # @!method call(*, **)
         #
-        # @overload call(**options)
+        #   Apply stashed changes
         #
-        #   Apply the latest stash
+        #   @overload call(**options)
         #
-        #   @param options [Hash] command options
+        #     Apply the latest stash
         #
-        #   @option options [Boolean] :index (nil) restore the index state as well
+        #     @param options [Hash] command options
         #
-        # @overload call(stash, **options)
+        #     @option options [Boolean] :index (nil) restore the index state as well
         #
-        #   Apply a specific stash
+        #   @overload call(stash, **options)
         #
-        #   @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
+        #     Apply a specific stash
         #
-        #   @param options [Hash] command options
+        #     @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
         #
-        #   @option options [Boolean] :index (nil) restore the index state as well
+        #     @param options [Hash] command options
         #
-        # @return [Git::CommandLineResult] the result of calling `git stash apply`
+        #     @option options [Boolean] :index (nil) restore the index state as well
         #
-        # @raise [Git::FailedError] if the stash does not exist
+        #   @return [Git::CommandLineResult] the result of calling `git stash apply`
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #   @raise [Git::FailedError] if the stash does not exist
       end
     end
   end

--- a/lib/git/commands/stash/branch.rb
+++ b/lib/git/commands/stash/branch.rb
@@ -28,7 +28,7 @@ module Git
       # @example Create branch from specific stash
       #   Git::Commands::Stash::Branch.new(execution_context).call('my-branch', 'stash@{2}')
       #
-      class Branch < Base
+      class Branch < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'branch'
@@ -36,27 +36,27 @@ module Git
           operand :stash
         end
 
-        # Create a branch from a stash entry
+        # @!method call(*, **)
         #
-        # @overload call(branchname)
+        #   Create a branch from a stash entry
         #
-        #   Create a branch from the latest stash
+        #   @overload call(branchname)
         #
-        #   @param branchname [String] the name of the branch to create (required)
+        #     Create a branch from the latest stash
         #
-        # @overload call(branchname, stash)
+        #     @param branchname [String] the name of the branch to create (required)
         #
-        #   Create a branch from a specific stash
+        #   @overload call(branchname, stash)
         #
-        #   @param branchname [String] the name of the branch to create (required)
+        #     Create a branch from a specific stash
         #
-        #   @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
+        #     @param branchname [String] the name of the branch to create (required)
         #
-        # @return [Git::CommandLineResult] the result of calling `git stash branch`
+        #     @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
         #
-        # @raise [Git::FailedError] if the branch already exists or stash doesn't exist
+        #   @return [Git::CommandLineResult] the result of calling `git stash branch`
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #   @raise [Git::FailedError] if the branch already exists or stash doesn't exist
       end
     end
   end

--- a/lib/git/commands/stash/clear.rb
+++ b/lib/git/commands/stash/clear.rb
@@ -18,17 +18,19 @@ module Git
       # @example Clear all stashes
       #   Git::Commands::Stash::Clear.new(execution_context).call
       #
-      class Clear < Base
+      class Clear < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'clear'
         end
 
-        # Clear all stash entries
+        # @!method call(*, **)
         #
-        # @return [Git::CommandLineResult] the result of calling `git stash clear`
+        #   @overload call()
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     Clear all stash entries
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git stash clear`
       end
     end
   end

--- a/lib/git/commands/stash/create.rb
+++ b/lib/git/commands/stash/create.rb
@@ -26,28 +26,28 @@ module Git
       # @example Create a stash commit with a message
       #   Git::Commands::Stash::Create.new(execution_context).call('WIP: my changes')
       #
-      class Create < Base
+      class Create < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'create'
           operand :message
         end
 
-        # Create a stash commit
+        # @!method call(*, **)
         #
-        # @overload call()
+        #   Create a stash commit
         #
-        #   Create a stash commit without a message
+        #   @overload call()
         #
-        # @overload call(message)
+        #     Create a stash commit without a message
         #
-        #   Create a stash commit with a message
+        #   @overload call(message)
         #
-        #   @param message [String] optional message for the stash commit
+        #     Create a stash commit with a message
         #
-        # @return [Git::CommandLineResult] the result of calling `git stash create`
+        #     @param message [String] optional message for the stash commit
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #   @return [Git::CommandLineResult] the result of calling `git stash create`
       end
     end
   end

--- a/lib/git/commands/stash/drop.rb
+++ b/lib/git/commands/stash/drop.rb
@@ -22,30 +22,30 @@ module Git
       # @example Drop a specific stash
       #   Git::Commands::Stash::Drop.new(execution_context).call('stash@\\{2}')
       #
-      class Drop < Base
+      class Drop < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'drop'
           operand :stash
         end
 
-        # Drop a stash entry
+        # @!method call(*, **)
         #
-        # @overload call()
+        #   Drop a stash entry
         #
-        #   Drop the latest stash
+        #   @overload call()
         #
-        # @overload call(stash)
+        #     Drop the latest stash
         #
-        #   Drop a specific stash
+        #   @overload call(stash)
         #
-        #   @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
+        #     Drop a specific stash
         #
-        # @return [Git::CommandLineResult] the result of calling `git stash drop`
+        #     @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
         #
-        # @raise [Git::FailedError] if the stash does not exist
+        #   @return [Git::CommandLineResult] the result of calling `git stash drop`
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #   @raise [Git::FailedError] if the stash does not exist
       end
     end
   end

--- a/lib/git/commands/stash/list.rb
+++ b/lib/git/commands/stash/list.rb
@@ -17,20 +17,20 @@ module Git
       # @example List all stashes
       #   Git::Commands::Stash::List.new(execution_context).call
       #
-      class List < Base
+      class List < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'list'
           literal "--format=#{Git::Parsers::Stash::STASH_FORMAT}"
         end
 
-        # List all stash entries
+        # @!method call(*, **)
         #
-        # @overload call()
+        #   List all stash entries
         #
-        # @return [Git::CommandLineResult] the result of calling `git stash list`
+        #   @overload call()
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @return [Git::CommandLineResult] the result of calling `git stash list`
       end
     end
   end

--- a/lib/git/commands/stash/pop.rb
+++ b/lib/git/commands/stash/pop.rb
@@ -25,7 +25,7 @@ module Git
       # @example Pop and restore index state
       #   Git::Commands::Stash::Pop.new(execution_context).call(index: true)
       #
-      class Pop < Base
+      class Pop < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'pop'
@@ -33,31 +33,31 @@ module Git
           operand :stash
         end
 
-        # Pop stashed changes
+        # @!method call(*, **)
         #
-        # @overload call(**options)
+        #   Pop stashed changes
         #
-        #   Pop the latest stash
+        #   @overload call(**options)
         #
-        #   @param options [Hash] command options
+        #     Pop the latest stash
         #
-        #   @option options [Boolean] :index (nil) restore the index state as well
+        #     @param options [Hash] command options
         #
-        # @overload call(stash, **options)
+        #     @option options [Boolean] :index (nil) restore the index state as well
         #
-        #   Pop a specific stash
+        #   @overload call(stash, **options)
         #
-        #   @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
+        #     Pop a specific stash
         #
-        #   @param options [Hash] command options
+        #     @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
         #
-        #   @option options [Boolean] :index (nil) restore the index state as well
+        #     @param options [Hash] command options
         #
-        # @return [Git::CommandLineResult] the result of calling `git stash pop`
+        #     @option options [Boolean] :index (nil) restore the index state as well
         #
-        # @raise [Git::FailedError] if the stash does not exist
+        #   @return [Git::CommandLineResult] the result of calling `git stash pop`
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #   @raise [Git::FailedError] if the stash does not exist
       end
     end
   end

--- a/lib/git/commands/stash/push.rb
+++ b/lib/git/commands/stash/push.rb
@@ -29,7 +29,7 @@ module Git
       # @example Include untracked files
       #   Git::Commands::Stash::Push.new(execution_context).call(include_untracked: true)
       #
-      class Push < Base
+      class Push < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'push'
@@ -44,45 +44,45 @@ module Git
           operand :pathspec, repeatable: true, separator: '--'
         end
 
-        # Stash changes in the working directory
+        # @!method call(*, **)
         #
-        # @overload call(*pathspec, **options)
+        #   Stash changes in the working directory
         #
-        #   @param pathspec [Array<String>] optional paths to limit what gets stashed
+        #   @overload call(*pathspec, **options)
         #
-        #   @param options [Hash] command options
+        #     @param pathspec [Array<String>] optional paths to limit what gets stashed
         #
-        #   @option options [String] :message (nil) descriptive message for the stash.
+        #     @param options [Hash] command options
         #
-        #     Alias: :m
+        #     @option options [String] :message (nil) descriptive message for the stash.
         #
-        #   @option options [Boolean] :patch (nil) interactively select hunks to stash.
+        #       Alias: :m
         #
-        #     Alias: :p
+        #     @option options [Boolean] :patch (nil) interactively select hunks to stash.
         #
-        #   @option options [Boolean] :staged (nil) stash only staged changes.
+        #       Alias: :p
         #
-        #     Alias: :S
+        #     @option options [Boolean] :staged (nil) stash only staged changes.
         #
-        #   @option options [Boolean, nil] :keep_index (nil) keep staged changes in index.
+        #       Alias: :S
         #
-        #     Alias: :k
+        #     @option options [Boolean, nil] :keep_index (nil) keep staged changes in index.
         #
-        #   @option options [Boolean] :include_untracked (nil) include untracked files.
+        #       Alias: :k
         #
-        #     Alias: :u
+        #     @option options [Boolean] :include_untracked (nil) include untracked files.
         #
-        #   @option options [Boolean] :all (nil) include untracked and ignored files.
+        #       Alias: :u
         #
-        #     Alias: :a
+        #     @option options [Boolean] :all (nil) include untracked and ignored files.
         #
-        #   @option options [String] :pathspec_from_file (nil) read pathspecs from file
+        #       Alias: :a
         #
-        #   @option options [Boolean] :pathspec_file_nul (nil) pathspecs are NUL separated
+        #     @option options [String] :pathspec_from_file (nil) read pathspecs from file
         #
-        # @return [Git::CommandLineResult] the result of calling `git stash push`
+        #     @option options [Boolean] :pathspec_file_nul (nil) pathspecs are NUL separated
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @return [Git::CommandLineResult] the result of calling `git stash push`
       end
     end
   end

--- a/lib/git/commands/stash/show_numstat.rb
+++ b/lib/git/commands/stash/show_numstat.rb
@@ -23,7 +23,7 @@ module Git
       #   Git::Commands::Stash::ShowNumstat.new(execution_context).call(dirstat: true)
       #   Git::Commands::Stash::ShowNumstat.new(execution_context).call(dirstat: 'lines,cumulative')
       #
-      class ShowNumstat < Base
+      class ShowNumstat < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'show'
@@ -43,59 +43,59 @@ module Git
           conflicts :include_untracked, :only_untracked
         end
 
-        # Show stash numstat
+        # @!method call(*, **)
         #
-        # @overload call(**options)
+        #   Show stash numstat
         #
-        #   Show numstat for the latest stash
+        #   @overload call(**options)
         #
-        #   @param options [Hash] command options
+        #     Show numstat for the latest stash
         #
-        #   @option options [Boolean] :include_untracked (nil) include untracked files.
+        #     @param options [Hash] command options
         #
-        #     Alias: :u
+        #     @option options [Boolean] :include_untracked (nil) include untracked files.
         #
-        #   @option options [Boolean] :only_untracked (nil) show only untracked files
+        #       Alias: :u
         #
-        #   @option options [Boolean, Integer] :find_renames (nil) detect renames; optionally pass a
-        #     similarity threshold (e.g., 50 for 50%). Alias: :M
+        #     @option options [Boolean] :only_untracked (nil) show only untracked files
         #
-        #   @option options [Boolean, Integer] :find_copies (nil) detect copies as well as renames;
-        #     optionally pass a threshold. Alias: :C
+        #     @option options [Boolean, Integer] :find_renames (nil) detect renames; optionally pass a
+        #       similarity threshold (e.g., 50 for 50%). Alias: :M
         #
-        #   @option options [Boolean] :find_copies_harder (nil) inspect all files as copy sources; expensive
+        #     @option options [Boolean, Integer] :find_copies (nil) detect copies as well as renames;
+        #       optionally pass a threshold. Alias: :C
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :find_copies_harder (nil) inspect all files as copy sources; expensive
         #
-        # @overload call(stash, **options)
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   Show numstat for a specific stash
+        #   @overload call(stash, **options)
         #
-        #   @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
+        #     Show numstat for a specific stash
         #
-        #   @param options [Hash] command options
+        #     @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
         #
-        #   @option options [Boolean] :include_untracked (nil) include untracked files.
+        #     @param options [Hash] command options
         #
-        #     Alias: :u
+        #     @option options [Boolean] :include_untracked (nil) include untracked files.
         #
-        #   @option options [Boolean] :only_untracked (nil) show only untracked files
+        #       Alias: :u
         #
-        #   @option options [Boolean, Integer] :find_renames (nil) detect renames; optionally pass a
-        #     similarity threshold (e.g., 50 for 50%). Alias: :M
+        #     @option options [Boolean] :only_untracked (nil) show only untracked files
         #
-        #   @option options [Boolean, Integer] :find_copies (nil) detect copies as well as renames;
-        #     optionally pass a threshold. Alias: :C
+        #     @option options [Boolean, Integer] :find_renames (nil) detect renames; optionally pass a
+        #       similarity threshold (e.g., 50 for 50%). Alias: :M
         #
-        #   @option options [Boolean] :find_copies_harder (nil) inspect all files as copy sources; expensive
+        #     @option options [Boolean, Integer] :find_copies (nil) detect copies as well as renames;
+        #       optionally pass a threshold. Alias: :C
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :find_copies_harder (nil) inspect all files as copy sources; expensive
         #
-        # @return [Git::CommandLineResult] the result of calling `git stash show --numstat`
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #   @return [Git::CommandLineResult] the result of calling `git stash show --numstat`
       end
     end
   end

--- a/lib/git/commands/stash/show_patch.rb
+++ b/lib/git/commands/stash/show_patch.rb
@@ -23,7 +23,7 @@ module Git
       #   Git::Commands::Stash::ShowPatch.new(execution_context).call(dirstat: true)
       #   Git::Commands::Stash::ShowPatch.new(execution_context).call(dirstat: 'lines,cumulative')
       #
-      class ShowPatch < Base
+      class ShowPatch < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'show'
@@ -45,59 +45,59 @@ module Git
           conflicts :include_untracked, :only_untracked
         end
 
-        # Show stash patch
+        # @!method call(*, **)
         #
-        # @overload call(**options)
+        #   Show stash patch
         #
-        #   Show patch for the latest stash
+        #   @overload call(**options)
         #
-        #   @param options [Hash] command options
+        #     Show patch for the latest stash
         #
-        #   @option options [Boolean] :include_untracked (nil) include untracked files.
+        #     @param options [Hash] command options
         #
-        #     Alias: :u
+        #     @option options [Boolean] :include_untracked (nil) include untracked files.
         #
-        #   @option options [Boolean] :only_untracked (nil) show only untracked files
+        #       Alias: :u
         #
-        #   @option options [Boolean, Integer] :find_renames (nil) detect renames; optionally pass a
-        #     similarity threshold (e.g., 50 for 50%). Alias: :M
+        #     @option options [Boolean] :only_untracked (nil) show only untracked files
         #
-        #   @option options [Boolean, Integer] :find_copies (nil) detect copies as well as renames;
-        #     optionally pass a threshold. Alias: :C
+        #     @option options [Boolean, Integer] :find_renames (nil) detect renames; optionally pass a
+        #       similarity threshold (e.g., 50 for 50%). Alias: :M
         #
-        #   @option options [Boolean] :find_copies_harder (nil) inspect all files as copy sources; expensive
+        #     @option options [Boolean, Integer] :find_copies (nil) detect copies as well as renames;
+        #       optionally pass a threshold. Alias: :C
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :find_copies_harder (nil) inspect all files as copy sources; expensive
         #
-        # @overload call(stash, **options)
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   Show patch for a specific stash
+        #   @overload call(stash, **options)
         #
-        #   @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
+        #     Show patch for a specific stash
         #
-        #   @param options [Hash] command options
+        #     @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
         #
-        #   @option options [Boolean] :include_untracked (nil) include untracked files.
+        #     @param options [Hash] command options
         #
-        #     Alias: :u
+        #     @option options [Boolean] :include_untracked (nil) include untracked files.
         #
-        #   @option options [Boolean] :only_untracked (nil) show only untracked files
+        #       Alias: :u
         #
-        #   @option options [Boolean, Integer] :find_renames (nil) detect renames; optionally pass a
-        #     similarity threshold (e.g., 50 for 50%). Alias: :M
+        #     @option options [Boolean] :only_untracked (nil) show only untracked files
         #
-        #   @option options [Boolean, Integer] :find_copies (nil) detect copies as well as renames;
-        #     optionally pass a threshold. Alias: :C
+        #     @option options [Boolean, Integer] :find_renames (nil) detect renames; optionally pass a
+        #       similarity threshold (e.g., 50 for 50%). Alias: :M
         #
-        #   @option options [Boolean] :find_copies_harder (nil) inspect all files as copy sources; expensive
+        #     @option options [Boolean, Integer] :find_copies (nil) detect copies as well as renames;
+        #       optionally pass a threshold. Alias: :C
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :find_copies_harder (nil) inspect all files as copy sources; expensive
         #
-        # @return [Git::CommandLineResult] the result of calling `git stash show --patch`
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #   @return [Git::CommandLineResult] the result of calling `git stash show --patch`
       end
     end
   end

--- a/lib/git/commands/stash/show_raw.rb
+++ b/lib/git/commands/stash/show_raw.rb
@@ -23,7 +23,7 @@ module Git
       #   Git::Commands::Stash::ShowRaw.new(execution_context).call(dirstat: true)
       #   Git::Commands::Stash::ShowRaw.new(execution_context).call(dirstat: 'lines,cumulative')
       #
-      class ShowRaw < Base
+      class ShowRaw < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'show'
@@ -45,59 +45,59 @@ module Git
           conflicts :include_untracked, :only_untracked
         end
 
-        # Show stash raw diff
+        # @!method call(*, **)
         #
-        # @overload call(**options)
+        #   Show stash raw diff
         #
-        #   Show raw diff for the latest stash
+        #   @overload call(**options)
         #
-        #   @param options [Hash] command options
+        #     Show raw diff for the latest stash
         #
-        #   @option options [Boolean] :include_untracked (nil) include untracked files.
+        #     @param options [Hash] command options
         #
-        #     Alias: :u
+        #     @option options [Boolean] :include_untracked (nil) include untracked files.
         #
-        #   @option options [Boolean] :only_untracked (nil) show only untracked files
+        #       Alias: :u
         #
-        #   @option options [Boolean, Integer] :find_renames (nil) detect renames; optionally pass a
-        #     similarity threshold (e.g., 50 for 50%). Alias: :M
+        #     @option options [Boolean] :only_untracked (nil) show only untracked files
         #
-        #   @option options [Boolean, Integer] :find_copies (nil) detect copies as well as renames;
-        #     optionally pass a threshold. Alias: :C
+        #     @option options [Boolean, Integer] :find_renames (nil) detect renames; optionally pass a
+        #       similarity threshold (e.g., 50 for 50%). Alias: :M
         #
-        #   @option options [Boolean] :find_copies_harder (nil) inspect all files as copy sources; expensive
+        #     @option options [Boolean, Integer] :find_copies (nil) detect copies as well as renames;
+        #       optionally pass a threshold. Alias: :C
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :find_copies_harder (nil) inspect all files as copy sources; expensive
         #
-        # @overload call(stash, **options)
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        #   Show raw diff for a specific stash
+        #   @overload call(stash, **options)
         #
-        #   @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
+        #     Show raw diff for a specific stash
         #
-        #   @param options [Hash] command options
+        #     @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
         #
-        #   @option options [Boolean] :include_untracked (nil) include untracked files.
+        #     @param options [Hash] command options
         #
-        #     Alias: :u
+        #     @option options [Boolean] :include_untracked (nil) include untracked files.
         #
-        #   @option options [Boolean] :only_untracked (nil) show only untracked files
+        #       Alias: :u
         #
-        #   @option options [Boolean, Integer] :find_renames (nil) detect renames; optionally pass a
-        #     similarity threshold (e.g., 50 for 50%). Alias: :M
+        #     @option options [Boolean] :only_untracked (nil) show only untracked files
         #
-        #   @option options [Boolean, Integer] :find_copies (nil) detect copies as well as renames;
-        #     optionally pass a threshold. Alias: :C
+        #     @option options [Boolean, Integer] :find_renames (nil) detect renames; optionally pass a
+        #       similarity threshold (e.g., 50 for 50%). Alias: :M
         #
-        #   @option options [Boolean] :find_copies_harder (nil) inspect all files as copy sources; expensive
+        #     @option options [Boolean, Integer] :find_copies (nil) detect copies as well as renames;
+        #       optionally pass a threshold. Alias: :C
         #
-        #   @option options [Boolean, String] :dirstat (nil) include directory statistics.
-        #     Pass true for default, or a string like 'lines,cumulative' for options.
+        #     @option options [Boolean] :find_copies_harder (nil) inspect all files as copy sources; expensive
         #
-        # @return [Git::CommandLineResult] the result of calling `git stash show --raw`
+        #     @option options [Boolean, String] :dirstat (nil) include directory statistics.
+        #       Pass true for default, or a string like 'lines,cumulative' for options.
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #   @return [Git::CommandLineResult] the result of calling `git stash show --raw`
       end
     end
   end

--- a/lib/git/commands/stash/store.rb
+++ b/lib/git/commands/stash/store.rb
@@ -25,7 +25,7 @@ module Git
       # @example Store with a custom message
       #   Git::Commands::Stash::Store.new(execution_context).call('abc123def456', message: 'WIP: feature')
       #
-      class Store < Base
+      class Store < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'store'
@@ -33,23 +33,23 @@ module Git
           operand :commit, required: true
         end
 
-        # Store a commit in the stash reflog
+        # @!method call(*, **)
         #
-        # @overload call(commit, **options)
+        #   Store a commit in the stash reflog
         #
-        #   @param commit [String] the commit SHA to store in the stash (required)
+        #   @overload call(commit, **options)
         #
-        #   @param options [Hash] command options
+        #     @param commit [String] the commit SHA to store in the stash (required)
         #
-        #   @option options [String] :message (nil) description for the reflog entry.
+        #     @param options [Hash] command options
         #
-        #     Alias: :m
+        #     @option options [String] :message (nil) description for the reflog entry.
         #
-        # @return [Git::CommandLineResult] the result of calling `git stash store`
+        #       Alias: :m
         #
-        # @raise [Git::FailedError] if the commit is not a valid stash commit
+        #     @return [Git::CommandLineResult] the result of calling `git stash store`
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [Git::FailedError] if the commit is not a valid stash commit
       end
     end
   end

--- a/lib/git/commands/tag/create.rb
+++ b/lib/git/commands/tag/create.rb
@@ -32,7 +32,7 @@ module Git
       #   create = Git::Commands::Tag::Create.new(execution_context)
       #   create.call('v1.0.0', force: true)
       #
-      class Create < Base
+      class Create < Git::Commands::Base
         arguments do
           literal 'tag'
           flag_option %i[annotate a]
@@ -51,55 +51,56 @@ module Git
           conflicts :message, :file
         end
 
-        # Execute the git tag command to create a new tag
+        # @!method call(*, **)
         #
-        # @overload call(tagname, commit = nil, **options)
+        #   Execute the git tag command to create a new tag
         #
-        #   @param tagname [String] The name of the tag to create. Must pass all checks
-        #     defined by git-check-ref-format.
+        #   @overload call(tagname, commit = nil, **options)
         #
-        #   @param commit [String, nil] The commit, branch, or object to tag.
-        #     If omitted, defaults to HEAD.
+        #     @param tagname [String] The name of the tag to create. Must pass all checks
+        #       defined by git-check-ref-format.
         #
-        #   @param options [Hash] command options
+        #     @param commit [String, nil] The commit, branch, or object to tag.
+        #       If omitted, defaults to HEAD.
         #
-        #   @option options [Boolean] :annotate (nil) Create an unsigned, annotated tag object.
-        #     Requires a message via `:message` or `:file`. Also available as `:a`.
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean] :sign (nil) Create a GPG-signed tag using the default
-        #     signing key. Requires a message via `:message` or `:file`. Set to `false` to
-        #     override `tag.gpgSign` config. Also available as `:s`.
+        #     @option options [Boolean] :annotate (nil) Create an unsigned, annotated tag object.
+        #       Requires a message via `:message` or `:file`. Also available as `:a`.
         #
-        #   @option options [String] :local_user (nil) Create a GPG-signed tag using the
-        #     specified key. Requires a message via `:message` or `:file`. Also available as `:u`.
+        #     @option options [Boolean] :sign (nil) Create a GPG-signed tag using the default
+        #       signing key. Requires a message via `:message` or `:file`. Set to `false` to
+        #       override `tag.gpgSign` config. Also available as `:s`.
         #
-        #   @option options [Boolean] :force (nil) Replace an existing tag with the given
-        #     name (instead of failing). Also available as `:f`.
+        #     @option options [String] :local_user (nil) Create a GPG-signed tag using the
+        #       specified key. Requires a message via `:message` or `:file`. Also available as `:u`.
         #
-        #   @option options [String] :message (nil) Use the given message as the tag message.
-        #     Implies `-a` if none of `-a`, `-s`, or `-u` is given. Also available as `:m`.
+        #     @option options [Boolean] :force (nil) Replace an existing tag with the given
+        #       name (instead of failing). Also available as `:f`.
         #
-        #   @option options [String] :file (nil) Take the tag message from the given file.
-        #     Use `-` to read from standard input. Implies `-a` if none of `-a`, `-s`, or `-u`
-        #     is given. Also available as `:F`.
+        #     @option options [String] :message (nil) Use the given message as the tag message.
+        #       Implies `-a` if none of `-a`, `-s`, or `-u` is given. Also available as `:m`.
         #
-        #   @option options [Hash, Array<Array>] :trailer (nil) Add trailers to the tag message.
-        #     Can be a Hash `{ 'Key' => 'value' }` or Array of pairs `[['Key', 'value']]`.
-        #     Multiple trailers can be specified.
+        #     @option options [String] :file (nil) Take the tag message from the given file.
+        #       Use `-` to read from standard input. Implies `-a` if none of `-a`, `-s`, or `-u`
+        #       is given. Also available as `:F`.
         #
-        #   @option options [String] :cleanup (nil) Set how the tag message is cleaned up.
-        #     Must be one of: `verbatim` (no changes), `whitespace` (remove leading/trailing
-        #     whitespace lines), or `strip` (remove whitespace and commentary). Default is `strip`.
+        #     @option options [Hash, Array<Array>] :trailer (nil) Add trailers to the tag message.
+        #       Can be a Hash `{ 'Key' => 'value' }` or Array of pairs `[['Key', 'value']]`.
+        #       Multiple trailers can be specified.
         #
-        #   @option options [Boolean] :create_reflog (nil) Create a reflog for the tag,
-        #     enabling date-based sha1 expressions such as `tag@{yesterday}`.
+        #     @option options [String] :cleanup (nil) Set how the tag message is cleaned up.
+        #       Must be one of: `verbatim` (no changes), `whitespace` (remove leading/trailing
+        #       whitespace lines), or `strip` (remove whitespace and commentary). Default is `strip`.
         #
-        # @return [Git::CommandLineResult] the result of calling `git tag`
+        #     @option options [Boolean] :create_reflog (nil) Create a reflog for the tag,
+        #       enabling date-based sha1 expressions such as `tag@{yesterday}`.
         #
-        # @raise [Git::FailedError] if the tag already exists (without force) or if
-        #   an annotated tag is requested without a message
+        #     @return [Git::CommandLineResult] the result of calling `git tag`
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [Git::FailedError] if the tag already exists (without force) or if
+        #       an annotated tag is requested without a message
+        #
       end
     end
   end

--- a/lib/git/commands/tag/delete.rb
+++ b/lib/git/commands/tag/delete.rb
@@ -24,7 +24,7 @@ module Git
       #   delete = Git::Commands::Tag::Delete.new(execution_context)
       #   result = delete.call('v1.0.0', 'v2.0.0')
       #
-      class Delete < Base
+      class Delete < Git::Commands::Base
         arguments do
           literal 'tag'
           literal '--delete'
@@ -34,19 +34,20 @@ module Git
         # git tag --delete exits with status 1 when a tag does not exist, which is acceptable
         allow_exit_status 0..1
 
-        # Execute the git tag -d command to delete tags
+        # @!method call(*, **)
         #
-        # @overload call(*tagname)
+        #   Execute the git tag -d command to delete tags
         #
-        #   @param tagname [Array<String>] One or more tag names to delete.
+        #   @overload call(*tagname)
         #
-        # @return [Git::CommandLineResult] the result of calling `git tag --delete`
+        #     @param tagname [Array<String>] One or more tag names to delete.
         #
-        # @raise [ArgumentError] if no tag names are provided
+        #     @return [Git::CommandLineResult] the result of calling `git tag --delete`
         #
-        # @raise [Git::FailedError] for fatal errors (exit code > 1)
+        #     @raise [ArgumentError] if no tag names are provided
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [Git::FailedError] for fatal errors (exit code > 1)
+        #
       end
     end
   end

--- a/lib/git/commands/tag/list.rb
+++ b/lib/git/commands/tag/list.rb
@@ -32,7 +32,7 @@ module Git
       #   list = Git::Commands::Tag::List.new(execution_context)
       #   tags = list.call('v1.*', 'v2.*', sort: 'version:refname')
       #
-      class List < Base
+      class List < Git::Commands::Base
         arguments do
           literal 'tag'
           literal '--list'
@@ -47,43 +47,44 @@ module Git
           operand :pattern, repeatable: true
         end
 
-        # Execute the git tag --list command
+        # @!method call(*, **)
         #
-        # @overload call(*pattern, **options)
+        #   Execute the git tag --list command
         #
-        #   @param pattern [Array<String>] Shell wildcard patterns to filter tags.
-        #     Multiple patterns can be provided; a tag is shown if it matches any pattern.
+        #   @overload call(*pattern, **options)
         #
-        #   @param options [Hash] command options
+        #     @param pattern [Array<String>] Shell wildcard patterns to filter tags.
+        #       Multiple patterns can be provided; a tag is shown if it matches any pattern.
         #
-        #   @option options [Boolean, String] :contains (nil) List only tags that contain the
-        #     specified commit. Pass `true` to use HEAD, or a commit reference string.
+        #     @param options [Hash] command options
         #
-        #   @option options [Boolean, String] :no_contains (nil) List only tags that don't contain
-        #     the specified commit. Pass `true` to use HEAD, or a commit reference string.
+        #     @option options [Boolean, String] :contains (nil) List only tags that contain the
+        #       specified commit. Pass `true` to use HEAD, or a commit reference string.
         #
-        #   @option options [Boolean, String] :points_at (nil) List only tags that point at the
-        #     specified object. Pass `true` to use HEAD, or an object reference string.
+        #     @option options [Boolean, String] :no_contains (nil) List only tags that don't contain
+        #       the specified commit. Pass `true` to use HEAD, or a commit reference string.
         #
-        #   @option options [String, Array<String>] :sort (nil) Sort tags by the specified
-        #     key(s). Prefix `-` to sort in descending order. Common keys: 'refname',
-        #     '-refname', 'creatordate', '-creatordate', 'version:refname' (for semantic
-        #     version sorting).
+        #     @option options [Boolean, String] :points_at (nil) List only tags that point at the
+        #       specified object. Pass `true` to use HEAD, or an object reference string.
         #
-        #   @option options [Boolean, String] :merged (nil) List only tags whose commits are
-        #     reachable from the specified commit. Pass `true` to use HEAD, or a commit reference string.
+        #     @option options [String, Array<String>] :sort (nil) Sort tags by the specified
+        #       key(s). Prefix `-` to sort in descending order. Common keys: 'refname',
+        #       '-refname', 'creatordate', '-creatordate', 'version:refname' (for semantic
+        #       version sorting).
         #
-        #   @option options [Boolean, String] :no_merged (nil) List only tags whose commits are
-        #     not reachable from the specified commit. Pass `true` to use HEAD, or a commit reference string.
+        #     @option options [Boolean, String] :merged (nil) List only tags whose commits are
+        #       reachable from the specified commit. Pass `true` to use HEAD, or a commit reference string.
         #
-        #   @option options [Boolean] :ignore_case (nil) Sorting and filtering tags are
-        #     case insensitive. Also available as `:i`.
+        #     @option options [Boolean, String] :no_merged (nil) List only tags whose commits are
+        #       not reachable from the specified commit. Pass `true` to use HEAD, or a commit reference string.
         #
-        # @return [Git::CommandLineResult] the result of calling `git tag --list`
+        #     @option options [Boolean] :ignore_case (nil) Sorting and filtering tags are
+        #       case insensitive. Also available as `:i`.
         #
-        # @raise [Git::FailedError] if git returns a non-zero exit code
+        #     @return [Git::CommandLineResult] the result of calling `git tag --list`
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [Git::FailedError] if git returns a non-zero exit code
+        #
       end
     end
   end

--- a/lib/git/commands/tag/verify.rb
+++ b/lib/git/commands/tag/verify.rb
@@ -29,7 +29,7 @@ module Git
       #   verify = Git::Commands::Tag::Verify.new(execution_context)
       #   verify.call('v1.0.0', format: '%(refname:short) %(contents:subject)')
       #
-      class Verify < Base
+      class Verify < Git::Commands::Base
         arguments do
           literal 'tag'
           literal '--verify'
@@ -37,26 +37,27 @@ module Git
           operand :tagname, repeatable: true, required: true
         end
 
-        # Execute the git tag --verify command to verify tag signatures
+        # @!method call(*, **)
         #
-        # @overload call(*tagname, **options)
+        #   Execute the git tag --verify command to verify tag signatures
         #
-        #   @param tagname [Array<String>] One or more tag names to verify.
-        #     At least one tag name is required.
+        #   @overload call(*tagname, **options)
         #
-        #   @param options [Hash] command options
+        #     @param tagname [Array<String>] One or more tag names to verify.
+        #       At least one tag name is required.
         #
-        #   @option options [String] :format (nil) A format string that interpolates
-        #     `%(fieldname)` from the tag ref being shown and the object it points at.
-        #     The format is the same as that of git-for-each-ref.
+        #     @param options [Hash] command options
         #
-        # @return [Git::CommandLineResult] the result of calling `git tag --verify`
+        #     @option options [String] :format (nil) A format string that interpolates
+        #       `%(fieldname)` from the tag ref being shown and the object it points at.
+        #       The format is the same as that of git-for-each-ref.
         #
-        # @raise [Git::FailedError] if the tag does not exist or signature verification fails
+        #     @return [Git::CommandLineResult] the result of calling `git tag --verify`
         #
-        # @raise [ArgumentError] if no tag names are provided
+        #     @raise [Git::FailedError] if the tag does not exist or signature verification fails
         #
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #     @raise [ArgumentError] if no tag names are provided
+        #
       end
     end
   end

--- a/prompts/Refactor Command to CommandLineResult.md
+++ b/prompts/Refactor Command to CommandLineResult.md
@@ -32,7 +32,7 @@ refactor.
 ## Target end state
 
 ```ruby
-class SomeCommand < Base
+class SomeCommand < Git::Commands::Base
   arguments do
     ...
   end
@@ -41,7 +41,13 @@ class SomeCommand < Base
   # rationale comment
   # allow_exit_status 0..1
 
-  def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+  # @!method call(*, **)
+  #
+  #   @overload call(**options)
+  #
+  #     Execute the git ... command.
+  #
+  #     @return [Git::CommandLineResult]
 end
 ```
 
@@ -50,7 +56,7 @@ end
 1. Move parsing/transforming logic out of command class into caller/facade/parser.
 2. Replace legacy `ARGS` constant + custom `initialize` with `arguments do` +
    inheritance from `Base`.
-3. Replace custom `#call` body with `def call(...) = super`.
+3. Remove custom `#call` body and add `# @!method call(*, **)` YARD directive.
 4. If command requires non-default success exits, add `allow_exit_status` with
    rationale comment.
 5. Update callers to consume `CommandLineResult` and parse `result.stdout` where
@@ -74,7 +80,7 @@ end
 ## YARD updates
 
 - update `@return` to `Git::CommandLineResult`
-- keep command-specific `@overload` docs on `def call(...) = super`
+- keep command-specific `@overload` docs nested under `# @!method call(*, **)` directive
 - ensure `@raise` wording reflects allowed range behavior
 
 ## Migration process and internal compatibility

--- a/prompts/Review Arguments DSL.md
+++ b/prompts/Review Arguments DSL.md
@@ -31,7 +31,7 @@ or CLI documentation helps verify flag accuracy.
 ## Input
 
 You will be given:
-1. One or more command source files containing a `class < Base` and an
+1. One or more command source files containing a `class < Git::Commands::Base` and an
    `arguments do` block
 2. The git man page or documentation for the subcommand
 
@@ -42,7 +42,7 @@ Command classes now follow this structure:
 - `class < Git::Commands::Base`
 - class-level `arguments do ... end`
 - optional `allow_exit_status <range>` for commands where non-zero exits are valid
-- one-line YARD shim: `def call(...) = super # rubocop:disable Lint/UselessMethodDefinition`
+- YARD directive: `# @!method call(*, **)` with nested `@overload` blocks
 
 The CLI argument mapping is still defined exclusively by the Arguments DSL. The
 `Base` class handles binding and execution.

--- a/prompts/Review Backward Compatibility.md
+++ b/prompts/Review Backward Compatibility.md
@@ -33,8 +33,8 @@ For the specified git command(s), remove methods added to `Git::Lib` since v4.3.
 
 When auditing modern implementations, assume command classes follow `Git::Commands::Base`:
 
-- classes use `class < Base` with `arguments do ... end`
-- command entrypoint is typically `def call(...) = super`
+- classes use `class < Git::Commands::Base` with `arguments do ... end`
+- command entrypoint is `call(*, **)` (inherited from `Base`)
 - exit-status behavior is centralized via `allow_exit_status` declarations on the class
 
 Because of this, backward-compatibility adaptation should happen in `Git::Lib`

--- a/prompts/Review Command Implementation.md
+++ b/prompts/Review Command Implementation.md
@@ -38,7 +38,7 @@ For migrated commands, the expected structure is:
 ```ruby
 require 'git/commands/base'
 
-class SomeCommand < Base
+class SomeCommand < Git::Commands::Base
   arguments do
     ...
   end
@@ -47,8 +47,13 @@ class SomeCommand < Base
   # reason comment
   allow_exit_status 0..1
 
-  # YARD docs for this command's call signature
-  def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+  # @!method call(*, **)
+  #
+  #   @overload call(**options)
+  #
+  #     YARD docs for this command's call signature.
+  #
+  #     @return [Git::CommandLineResult]
 end
 ```
 
@@ -62,7 +67,7 @@ Shared behavior lives in `Base`:
 
 ### 1. Class shape
 
-- [ ] Class inherits from `Base`
+- [ ] Class inherits from `Git::Commands::Base`
 - [ ] Requires `git/commands/base` (not `git/commands/arguments`)
 - [ ] Has exactly one `arguments do` declaration
 - [ ] Does not define command-specific `initialize` that only assigns
@@ -70,7 +75,7 @@ Shared behavior lives in `Base`:
 
 ### 2. `#call` implementation
 
-- [ ] Uses `def call(...) = super # rubocop:disable Lint/UselessMethodDefinition` as YARD documentation shim
+- [ ] Uses `# @!method call(*, **)` YARD directive with nested `@overload` blocks as documentation shim
 - [ ] Contains no custom bind/execute/exit-status logic in migrated commands
 - [ ] Does not parse output in command class
 
@@ -118,7 +123,7 @@ For migration PRs, verify process constraints:
 - lingering `ARGS = Arguments.define` constant and custom `#call`
 - command-specific duplicated exit-status checks instead of `allow_exit_status`
 - missing rationale comment for `allow_exit_status`
-- missing YARD shim method (`def call(...) = super`)
+- missing YARD directive (`# @!method call(*, **)`)
 - migration PR scope too broad (not phased)
 
 ## Output

--- a/prompts/Review Command Tests.md
+++ b/prompts/Review Command Tests.md
@@ -4,8 +4,8 @@ Verify unit and integration tests for `Git::Commands::*` classes follow project
 conventions.
 
 Command classes follow `Git::Commands::Base`: they declare `arguments do`, may
-declare `allow_exit_status`, and provide a YARD shim `def call(...) = super`.
-`Base#call` performs binding and execution and always passes
+declare `allow_exit_status`, and use a `# @!method call(*, **)` YARD directive to
+document overloads. `Base#call` performs binding and execution and always passes
 `raise_on_failure: false`, then validates exit status membership against the
 allowed range (`0..0` by default).
 

--- a/prompts/Review Cross-Command Consistency.md
+++ b/prompts/Review Cross-Command Consistency.md
@@ -32,10 +32,10 @@ The invocation needs two or more sibling command files from the same family.
 
 ### 1. Class structure consistency
 
-- [ ] all classes use `class < Base`
+- [ ] all classes use `class < Git::Commands::Base`
 - [ ] all require `git/commands/base`
 - [ ] all use `arguments do ... end` (no legacy `ARGS =` constants)
-- [ ] all use YARD shim `def call(...) = super # rubocop:disable Lint/UselessMethodDefinition`
+- [ ] all use YARD directive `# @!method call(*, **)` with nested `@overload` blocks
 
 ### 2. Arguments DSL consistency
 

--- a/prompts/Review YARD Documentation.md
+++ b/prompts/Review YARD Documentation.md
@@ -31,23 +31,33 @@ The invocation needs the command file(s) to review.
 
 One or more command files from `lib/git/commands/` containing:
 
-- `class < Base`
+- `class < Git::Commands::Base`
 - `arguments do ... end`
 - optional `allow_exit_status`
-- one-line method shim `def call(...) = super`
+- `# @!method call(*, **)` YARD directive with nested `@overload` blocks
 
 ## Required documentation model
 
-Because YARD does not attach command-specific `@overload` docs to purely inherited
-methods, each command must keep:
+Each command must use the `@!method` YARD directive to attach per-command
+documentation to the inherited `call` method:
 
 ```ruby
-def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+# @!method call(*, **)
+#
+#   @overload call(**options)
+#
+#     Execute the git ... command.
+#
+#     @param options [Hash] command options
+#
+#     @option options [Boolean] :force (nil) ...
+#
+#     @return [Git::CommandLineResult]
 ```
 
-This method is documentation scaffolding and should have full per-command YARD tags.
-The rubocop disable comment suppresses the Lint/UselessMethodDefinition warning that
-occurs because the method appears "useless" to the linter (it is required for YARD).
+This directive is documentation scaffolding — YARD uses it to render per-command
+docs on the inherited `call` method without requiring a method definition in the
+subclass.
 
 ## What to Check
 
@@ -105,7 +115,7 @@ Prefer interface-level wording (what callers can pass/expect), not internals.
 
 ## Common issues
 
-- Missing `def call(...) = super` (loses child-specific docs in generated YARD)
+- Missing `# @!method call(*, **)` directive (loses child-specific docs in generated YARD)
 - `@option` docs out of sync with `arguments do`
 - Missing/incorrect `@raise` guidance for `allow_exit_status`
 - Legacy references to `ARGS` constant or command-specific `initialize`

--- a/prompts/Scaffold New Command.md
+++ b/prompts/Scaffold New Command.md
@@ -53,7 +53,7 @@ module Git
       # Summary...
       #
       # @api private
-      class Bar < Base
+      class Bar < Git::Commands::Base
         arguments do
           # literals/options/operands
         end
@@ -62,12 +62,15 @@ module Git
         # rationale comment
         # allow_exit_status 0..1
 
-        # Execute the git ... command
+        # @!method call(*, **)
         #
-        # @overload ...
-        # @return [Git::CommandLineResult] the result of calling `git ...`
-        # @raise [Git::FailedError] if git exits outside allowed status range
-        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
+        #   @overload ...
+        #
+        #     Execute the git ... command.
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git ...`
+        #
+        #     @raise [Git::FailedError] if git exits outside allowed status range
       end
     end
   end
@@ -233,13 +236,9 @@ Include at least one failure case per command.
 
 ## YARD requirements
 
-- keep `def call(...) = super # rubocop:disable Lint/UselessMethodDefinition` for per-command docs
-- add `@overload` blocks for valid call shapes
+- use `# @!method call(*, **)` YARD directive with nested `@overload` blocks for per-command docs
+- add `@overload` blocks for valid call shapes, indented under `@!method`
 - keep tags aligned with `arguments do` and `allow_exit_status` behavior
-
-Note: The rubocop disable comment suppresses the Lint/UselessMethodDefinition warning.
-The method appears "useless" to the linter but is required for YARD to render
-per-command documentation.
 
 ## Phased rollout, compatibility, and quality gates
 


### PR DESCRIPTION
## Summary

Two mechanical fixes across all command class files, plus updating AI prompt files:

1. **Qualify superclass** — `class Foo < Base` → `class Foo < Git::Commands::Base` so YARD resolves the inheritance link to the correct class instead of `Git::Base`
2. **Replace call shim with `@!method` directive** — remove `def call(...) = super # rubocop:disable Lint/UselessMethodDefinition` and replace with `# @!method call(*, **)` YARD virtual method directive
3. **Update prompt files** — all 8 AI prompt files updated to reference the new patterns

## Changes

- 44 command files: superclass qualified + call shim replaced with `@!method` directive
- 8 prompt files: old patterns replaced with new conventions
- 53 files changed total

## Verification

- `bundle exec rubocop lib/git/commands/` — 47 files, 0 offenses
- `bundle exec rspec spec/unit/` — 1572 examples, 0 failures
- `bundle exec yard doc lib/git/commands/ --no-cache` — 0 undocumented command methods
- YARD inheritance links resolve to `Git::Commands::Base` (not `Git::Base`)
- No `def call(...) = super` shims remain
- No `rubocop:disable Lint/UselessMethodDefinition` comments remain

Closes #1071