### PR TITLE
refactor(arguments): add `allowed_values` DSL method for declarative value constraints

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2570,7 +2570,7 @@ When implementing a command using the `Git::Commands::Arguments` DSL, you **MUST
 - **Invalid Values**: Test that invalid values raise appropriate errors or are handled correctly.
 - **Argument Building**: Verify that the generated git command arguments match the expected CLI flags.
 - **Edge Cases**: Test nil values, empty strings/arrays, and special characters.
-- **Constraint Validation**: If the command uses `conflicts` or `requires_one_of` DSL declarations, include a `context 'input validation'` block that tests each constraint raises `ArgumentError` as expected (too many conflicting args present; none of the required group present).
+- **Constraint Validation**: If the command uses `conflicts`, `requires_one_of`, `requires`, or `allowed_values` DSL declarations, include a `context 'input validation'` block that tests each constraint raises `ArgumentError` as expected (too many conflicting args present; none of the required group present; value outside the allowed set).
 
 ### Coverage Target
 

--- a/lib/git/commands/add.rb
+++ b/lib/git/commands/add.rb
@@ -35,6 +35,7 @@ module Git
         flag_option :pathspec_file_nul
         operand :pathspec, repeatable: true, separator: '--'
 
+        allowed_values :chmod, in: ['+x', '-x']
         conflicts :all, :update
         requires :pathspec_from_file, when: :pathspec_file_nul
         requires :dry_run, when: :ignore_missing

--- a/lib/git/commands/arguments.rb
+++ b/lib/git/commands/arguments.rb
@@ -490,6 +490,27 @@ module Git
     #   #=> raise ArgumentError, ':annotate requires at least one of :message, :file'
     #   args_def.bind  # trigger absent — no error
     #
+    # ## Value Constraints
+    #
+    # In addition to presence-based validation ({#conflicts}, {#requires_one_of},
+    # and {#requires}), you can restrict the *set of acceptable values* for any
+    # value-type option using {#allowed_values}. If a bound value falls outside
+    # the configured set, {#bind} raises ArgumentError with a descriptive message.
+    #
+    # This is typically used to model git options that accept only a fixed list of
+    # modes or strategies, and supersedes ad-hoc `validator:` lambdas for simple
+    # set-membership checks.
+    #
+    # @example Restricting option values
+    #   args_def = Arguments.define do
+    #     value_option :strategy, inline: true
+    #     allowed_values :strategy, in: %w[ours theirs]
+    #   end
+    #   args_def.bind(strategy: 'ours').to_a      # => ['--strategy=ours']
+    #   args_def.bind(strategy: 'theirs').to_a # => ['--strategy=theirs']
+    #   args_def.bind(strategy: 'rebase')
+    #   # => raise ArgumentError, 'Invalid value for :strategy: expected one of ["ours", "theirs"], got "rebase"'
+    #
     # @api private
     #
     class Arguments
@@ -1161,6 +1182,68 @@ module Git
         @requires_one_of << { names: [@alias_map[sym] || sym], condition: canonical_trigger, single: true }
       end
 
+      # rubocop:disable Layout/LineLength
+
+      # Restrict a value option to a fixed set of accepted strings
+      #
+      # Declares that the named option must only receive values from the given list
+      # when a value is provided. Validation runs during {#bind}, after type checking.
+      # `nil` and absent values are always skipped. Empty strings are skipped when
+      # `allow_empty: true` is set on the option. For `repeatable: true` options
+      # each element of the array is validated individually.
+      #
+      # @param name [Symbol] the option name (primary or alias); must refer to a
+      #   previously defined {#value_option} or {#flag_or_value_option}
+      #
+      # @param in [Array<String>] the accepted string values
+      #
+      # @return [void]
+      #
+      # @raise [ArgumentError] if +name+ is not a known option at definition time
+      #
+      # @raise [ArgumentError] if +name+ refers to a non-value option (e.g., a flag)
+      #
+      # @raise [ArgumentError] during {#bind} if the bound value is not in the
+      #   accepted set, with a message of the form:
+      #   `"Invalid value for :name: expected one of [...], got \"actual\""`
+      #
+      # @example Constrain chmod to '+x' or '-x'
+      #   args_def = Arguments.define do
+      #     value_option :chmod, inline: true
+      #     allowed_values :chmod, in: ['+x', '-x']
+      #   end
+      #   args_def.bind(chmod: '+x').to_a   # => ['--chmod=+x']
+      #   args_def.bind(chmod: 'rx')
+      #     # => raise ArgumentError, 'Invalid value for :chmod: expected one of ["+x", "-x"], got "rx"'
+      #   args_def.bind.to_a              # => []  # (absent — no error)
+      #
+      # @example Constrain cleanup to an enumerated set
+      #   args_def = Arguments.define do
+      #     value_option :cleanup, inline: true
+      #     allowed_values :cleanup, in: %w[verbatim whitespace strip]
+      #   end
+      #   args_def.bind(cleanup: 'verbatim').to_a  # => ['--cleanup=verbatim']
+      #   args_def.bind(cleanup: 'compact')
+      #     # => raise ArgumentError, 'Invalid value for :cleanup: expected one of ["verbatim", "whitespace", "strip"], got "compact"'
+      #
+      # @example Repeatable option — each element is validated
+      #   args_def = Arguments.define do
+      #     value_option :strategy, inline: true, repeatable: true
+      #     allowed_values :strategy, in: %w[ours theirs]
+      #   end
+      #   args_def.bind(strategy: %w[ours theirs]).to_a
+      #     # => ['--strategy=ours', '--strategy=theirs']
+      #   args_def.bind(strategy: %w[ours other])
+      #     # => raise ArgumentError, 'Invalid value for :strategy: expected one of ["ours", "theirs"], got "other"'
+      #
+      def allowed_values(name, in:)
+        sym = name.to_sym
+        defn = validate_allowed_values_definition!(sym)
+        defn[:allowed_values] = coerce_allowed_values_set!(sym, binding.local_variable_get(:in))
+      end
+
+      # rubocop:enable Layout/LineLength
+
       # Define an operand (positional argument in Ruby terminology)
       #
       # Operands are mapped to values following Ruby method signature
@@ -1335,6 +1418,21 @@ module Git
 
       # Option types allowed after a '--' separator boundary (they do not produce CLI flags)
       OPTION_TYPES_AFTER_SEPARATOR = %i[value_as_operand execution_option].freeze
+
+      # Option types that accept a string value — eligible for `allowed_values` constraints
+      VALUE_OPTION_TYPES_FOR_ALLOWED_VALUES = %i[
+        value inline_value value_as_operand
+        flag_or_value flag_or_inline_value
+        negatable_flag_or_value negatable_flag_or_inline_value
+      ].freeze
+
+      # The subset of VALUE_OPTION_TYPES_FOR_ALLOWED_VALUES whose boolean values
+      # carry semantic meaning (true = emit flag, false = suppress flag) and must
+      # skip allowed_values validation rather than being compared against the set.
+      FLAG_OR_VALUE_OPTION_TYPES = %i[
+        flag_or_value flag_or_inline_value
+        negatable_flag_or_value negatable_flag_or_inline_value
+      ].freeze
 
       private
 
@@ -2159,19 +2257,90 @@ module Git
 
       def validate_option_values!(opts)
         @option_definitions.each do |name, definition|
-          validator = definition[:validator]
-          next unless validator
           next unless opts.key?(name)
 
-          value = opts[name]
-          result = validator.call(value)
-          next if result == true
-
-          # If validator returns a string, use it as the error message
-          # Otherwise, generate a generic error message
-          error_msg = result.is_a?(String) ? result : "Invalid value for option: #{name}"
-          raise ArgumentError, error_msg
+          validate_single_option!(name, opts[name], definition)
         end
+      end
+
+      def validate_single_option!(name, value, definition)
+        run_validator!(name, value, definition[:validator]) if definition[:validator]
+        check_allowed_values!(name, value, definition) if definition[:allowed_values]
+      end
+
+      def run_validator!(name, value, validator)
+        result = validator.call(value)
+        return if result == true
+
+        error_msg = result.is_a?(String) ? result : "Invalid value for option: #{name}"
+        raise ArgumentError, error_msg
+      end
+
+      def check_allowed_values!(name, value, definition)
+        allowed = definition[:allowed_values]
+        type = definition[:type]
+        if definition[:repeatable]
+          check_repeatable_allowed_values!(name, value, allowed, definition[:allow_empty], type)
+        else
+          check_single_allowed_value!(name, value, allowed, definition[:allow_empty], type)
+        end
+      end
+
+      def coerce_allowed_values_set!(sym, values)
+        unless values.respond_to?(:map)
+          raise ArgumentError,
+                "allowed_values :#{sym} expects an Enumerable for `in:`, got #{values.class}"
+        end
+        arr = values.map(&:to_s)
+        raise ArgumentError, "allowed_values :#{sym} must specify at least one allowed value" if arr.empty?
+
+        arr.freeze
+      end
+
+      def validate_allowed_values_definition!(sym)
+        primary = @alias_map[sym]
+        defn = primary && @option_definitions[primary]
+        unless defn
+          raise ArgumentError, ":#{sym} is not a value option" if @operand_definitions.any? { |d| d[:name] == sym }
+
+          raise ArgumentError, "unknown argument :#{sym} in allowed_values declaration"
+        end
+        unless VALUE_OPTION_TYPES_FOR_ALLOWED_VALUES.include?(defn[:type])
+          raise ArgumentError, ":#{sym} is not a value option"
+        end
+
+        defn
+      end
+
+      def check_repeatable_allowed_values!(name, values, allowed, allow_empty, type)
+        Array(values).each do |v|
+          next if skip_allowed_values_check?(v, allow_empty, type)
+
+          unless allowed.include?(v.to_s)
+            raise ArgumentError,
+                  "Invalid value for :#{name}: expected one of #{allowed.inspect}, got #{v.inspect}"
+          end
+        end
+      end
+
+      def check_single_allowed_value!(name, value, allowed, allow_empty, type)
+        return if skip_allowed_values_check?(value, allow_empty, type)
+
+        return if allowed.include?(value.to_s)
+
+        raise ArgumentError,
+              "Invalid value for :#{name}: expected one of #{allowed.inspect}, got #{value.inspect}"
+      end
+
+      def skip_allowed_values_check?(value, allow_empty, type)
+        return true if value.nil?
+        # Only skip boolean values for flag_or_value option types where true/false carry
+        # semantic meaning (true = emit flag, false = suppress flag). For plain value
+        # options, a boolean is an invalid value and should fail the allowed_values check.
+        return true if [true, false].include?(value) && FLAG_OR_VALUE_OPTION_TYPES.include?(type)
+        return true if value.to_s.empty? && allow_empty
+
+        false
       end
 
       def create_type_validator(option_name, expected_type)

--- a/lib/git/commands/tag/create.rb
+++ b/lib/git/commands/tag/create.rb
@@ -43,6 +43,7 @@ module Git
           value_option %i[file F], inline: true
           key_value_option :trailer, key_separator: ': '
           value_option :cleanup, inline: true
+          allowed_values :cleanup, in: %w[verbatim whitespace strip]
           flag_option :create_reflog
           operand :tagname, required: true
           operand :commit

--- a/prompts/Review Arguments DSL.md
+++ b/prompts/Review Arguments DSL.md
@@ -329,6 +329,39 @@ requires_one_of :message, :file, when: :sign
 requires_one_of :message, :file, when: :local_user
 ```
 
+### 7d. Allowed-values constraints
+
+If a `value_option`, `flag_or_value_option`, or `flag_or_inline_value_option`
+accepts a fixed, enumerated set of strings, verify an `allowed_values` declaration
+exists for that option:
+
+```ruby
+value_option :cleanup, inline: true
+allowed_values :cleanup, in: %w[verbatim whitespace strip]
+```
+
+Points to check:
+
+- `allowed_values` supersedes ad-hoc `validator:` lambdas for enumerated-string
+  cases — flag any `validator:` doing a simple set-membership test as a
+  candidate for replacement.
+- The declaration must reference a name already defined in `arguments do`; an
+  unknown name raises `ArgumentError` at load time.
+- Validation is **skipped** for `nil` / absent values; callers that want a
+  non-nil value must add a separate `required:` or `requires_one_of` check.
+- Validation is also skipped for empty strings when the option is declared with
+  `allow_empty: true`.
+- For `repeatable: true` options each element in the array is checked
+  individually.
+- Aliases are resolved before the check, so the declaration may use either the
+  primary name or any alias.
+
+Error form at bind time:
+
+```
+Invalid value for :name: expected one of ["a", "b"], got "actual"
+```
+
 ### 8. Exit-status declaration consistency (class-level, outside the DSL)
 
 `allow_exit_status` is a class-level declaration, not part of the `arguments do`

--- a/prompts/Review YARD Documentation.md
+++ b/prompts/Review YARD Documentation.md
@@ -87,6 +87,9 @@ subclass.
   | `operand` (single) | `[String]` |
 
 - [ ] option defaults/types are consistent with DSL definitions
+- [ ] `@option` descriptions for options that have an `allowed_values` declaration
+      enumerate the accepted values in the description text, e.g.:
+      `@option options [String] :cleanup (nil) Cleanup mode — one of `verbatim`, `whitespace`, `strip``
 
 ### 3. Return and raise tags
 

--- a/prompts/Scaffold New Command.md
+++ b/prompts/Scaffold New Command.md
@@ -107,7 +107,15 @@ interchangeable flags), prefer:
 1. literals
 2. flag options
 3. flag-or-value options
-4. value options
+4. value options, immediately followed by `allowed_values` for any option that
+   accepts only a fixed set of strings — `allowed_values` supersedes ad-hoc
+   `validator:` lambdas for enumerated cases:
+
+   ```ruby
+   value_option :cleanup, inline: true
+   allowed_values :cleanup, in: %w[verbatim whitespace strip]
+   ```
+
 5. operands (positional args)
 6. separator-delimited pathspec entries — either form:
    - `operand :pathspec, repeatable: true, separator: '--'` (positional calling convention)

--- a/spec/unit/git/commands/arguments_spec.rb
+++ b/spec/unit/git/commands/arguments_spec.rb
@@ -4498,6 +4498,313 @@ RSpec.describe Git::Commands::Arguments do
     end
   end
 
+  describe '#allowed_values' do
+    describe 'valid usage' do
+      let(:args_def) do
+        described_class.define do
+          value_option :chmod, inline: true
+          allowed_values :chmod, in: ['+x', '-x']
+        end
+      end
+
+      it 'passes when the value is in the allowed set' do
+        expect { args_def.bind(chmod: '+x') }.not_to raise_error
+      end
+
+      it 'produces correct CLI output for a valid value' do
+        expect(args_def.bind(chmod: '+x').to_a).to eq(['--chmod=+x'])
+      end
+
+      it 'raises when the value is not in the allowed set' do
+        expect { args_def.bind(chmod: 'rx') }
+          .to raise_error(ArgumentError, /expected one of \["\+x", "-x"\].*got "rx"/)
+      end
+
+      it 'skips validation when the option is absent' do
+        expect { args_def.bind }.not_to raise_error
+      end
+
+      it 'skips validation when the value is nil' do
+        expect { args_def.bind(chmod: nil) }.not_to raise_error
+      end
+
+      it 'raises when the value is boolean true (value_option, not flag_or_value)' do
+        # For plain value options, `true` is not a valid string value and must not
+        # bypass allowed_values — only flag_or_value* option types get the boolean skip.
+        expect { args_def.bind(chmod: true) }
+          .to raise_error(ArgumentError, /expected one of \["\+x", "-x"\]/)
+      end
+    end
+
+    describe 'with allow_empty: true' do
+      let(:args_def) do
+        described_class.define do
+          value_option :format, inline: true, allow_empty: true
+          allowed_values :format, in: %w[short medium]
+        end
+      end
+
+      it 'skips validation for an empty string when allow_empty: true' do
+        expect { args_def.bind(format: '') }.not_to raise_error
+      end
+
+      it 'still validates a non-empty string that is not in the allowed set' do
+        expect { args_def.bind(format: 'long') }
+          .to raise_error(ArgumentError, /expected one of/)
+      end
+    end
+
+    describe 'with repeatable: true' do
+      let(:args_def) do
+        described_class.define do
+          value_option :cleanup, inline: true, repeatable: true
+          allowed_values :cleanup, in: %w[verbatim whitespace strip]
+        end
+      end
+
+      it 'passes when all elements are in the allowed set' do
+        expect { args_def.bind(cleanup: %w[verbatim strip]) }.not_to raise_error
+      end
+
+      it 'validates each element individually and raises on first invalid' do
+        expect { args_def.bind(cleanup: %w[verbatim compact]) }
+          .to raise_error(ArgumentError, /got "compact"/)
+      end
+
+      it 'passes for a single valid scalar value' do
+        expect { args_def.bind(cleanup: 'verbatim') }.not_to raise_error
+      end
+
+      it 'skips validation when value is nil' do
+        expect { args_def.bind(cleanup: nil) }.not_to raise_error
+      end
+    end
+
+    describe 'with value_option inline: true' do
+      let(:args_def) do
+        described_class.define do
+          value_option :format, inline: true
+          allowed_values :format, in: %w[short medium]
+        end
+      end
+
+      it 'passes when the value is in the allowed set' do
+        expect { args_def.bind(format: 'short') }.not_to raise_error
+      end
+
+      it 'produces inline CLI output for a valid value' do
+        expect(args_def.bind(format: 'medium').to_a).to eq(['--format=medium'])
+      end
+
+      it 'raises when the value is not in the allowed set' do
+        expect { args_def.bind(format: 'long') }
+          .to raise_error(ArgumentError, /expected one of.*got "long"/)
+      end
+    end
+
+    describe 'with value_option as_operand: true' do
+      let(:args_def) do
+        described_class.define do
+          value_option :paths, as_operand: true, repeatable: true
+          allowed_values :paths, in: %w[README.md CHANGELOG.md]
+        end
+      end
+
+      it 'passes when all values are in the allowed set' do
+        expect { args_def.bind(paths: %w[README.md CHANGELOG.md]) }.not_to raise_error
+      end
+
+      it 'produces operand CLI output for valid values' do
+        expect(args_def.bind(paths: %w[README.md CHANGELOG.md]).to_a)
+          .to eq(%w[README.md CHANGELOG.md])
+      end
+
+      it 'raises when any operand value is not in the allowed set' do
+        expect { args_def.bind(paths: %w[README.md LICENSE]) }
+          .to raise_error(ArgumentError, /expected one of.*got "LICENSE"/)
+      end
+    end
+
+    describe 'with flag_or_value_option' do
+      let(:args_def) do
+        described_class.define do
+          flag_or_value_option :sign, inline: true
+          allowed_values :sign, in: %w[yes no]
+        end
+      end
+
+      it 'raises when the value is not in the allowed set' do
+        expect { args_def.bind(sign: 'maybe') }
+          .to raise_error(ArgumentError, /expected one of/)
+      end
+
+      it 'skips validation when the value is true (flag mode)' do
+        # true means emit the flag without a value (e.g. --sign)
+        # allowed_values should not validate flag-mode booleans
+        expect { args_def.bind(sign: true) }.not_to raise_error
+      end
+
+      it 'skips validation when the value is false (flag suppressed)' do
+        # false means suppress the flag entirely — not a value to validate
+        expect { args_def.bind(sign: false) }.not_to raise_error
+      end
+
+      it 'skips validation when the value is nil' do
+        expect { args_def.bind(sign: nil) }.not_to raise_error
+      end
+
+      it 'passes when the value is in the allowed set' do
+        expect { args_def.bind(sign: 'yes') }.not_to raise_error
+      end
+    end
+
+    describe 'with flag_or_value_option negatable: true and inline: true' do
+      let(:args_def) do
+        described_class.define do
+          flag_or_value_option :sign, negatable: true, inline: true
+          allowed_values :sign, in: %w[yes no]
+        end
+      end
+
+      it 'passes for an allowed string value and emits inline format' do
+        expect { args_def.bind(sign: 'yes') }.not_to raise_error
+        expect(args_def.bind(sign: 'yes').to_a).to eq(['--sign=yes'])
+      end
+
+      it 'raises when the string value is not in the allowed set' do
+        expect { args_def.bind(sign: 'maybe') }
+          .to raise_error(ArgumentError, /expected one of.*got "maybe"/)
+      end
+
+      it 'skips allowed_values validation in boolean modes' do
+        expect { args_def.bind(sign: true) }.not_to raise_error
+        expect { args_def.bind(sign: false) }.not_to raise_error
+        expect(args_def.bind(sign: false).to_a).to eq(['--no-sign'])
+      end
+    end
+
+    describe 'definition-time type guard' do
+      it 'raises for a flag_option (not a value option)' do
+        expect do
+          described_class.define do
+            flag_option :verbose
+            allowed_values :verbose, in: %w[yes no]
+          end
+        end.to raise_error(ArgumentError, /:verbose is not a value option/)
+      end
+
+      it 'raises for a key_value_option (not a value option)' do
+        expect do
+          described_class.define do
+            key_value_option :trailer
+            allowed_values :trailer, in: %w[a b]
+          end
+        end.to raise_error(ArgumentError, /:trailer is not a value option/)
+      end
+    end
+
+    describe 'definition-time typo guard' do
+      it 'raises for an unknown option name' do
+        expect do
+          described_class.define do
+            value_option :chmod, inline: true
+            allowed_values :typo, in: ['+x', '-x']
+          end
+        end.to raise_error(ArgumentError, /unknown argument :typo/)
+      end
+
+      it 'raises for an operand name (not an option)' do
+        expect do
+          described_class.define do
+            operand :paths, repeatable: true
+            allowed_values :paths, in: %w[a b]
+          end
+        end.to raise_error(ArgumentError, /:paths is not a value option/)
+      end
+    end
+
+    describe 'definition-time in: guard' do
+      it 'raises when in: is nil' do
+        expect do
+          described_class.define do
+            value_option :chmod, inline: true
+            allowed_values :chmod, in: nil
+          end
+        end.to raise_error(ArgumentError, /expects an Enumerable/)
+      end
+
+      it 'raises when in: is a non-enumerable' do
+        expect do
+          described_class.define do
+            value_option :chmod, inline: true
+            allowed_values :chmod, in: 42
+          end
+        end.to raise_error(ArgumentError, /expects an Enumerable/)
+      end
+
+      it 'raises when in: is empty' do
+        expect do
+          described_class.define do
+            value_option :chmod, inline: true
+            allowed_values :chmod, in: []
+          end
+        end.to raise_error(ArgumentError, /at least one allowed value/)
+      end
+    end
+
+    describe 'with alias' do
+      let(:args_def) do
+        described_class.define do
+          value_option %i[chmod c], inline: true
+          allowed_values :c, in: ['+x', '-x']
+        end
+      end
+
+      it 'resolves the alias to the primary name and applies the constraint' do
+        expect { args_def.bind(chmod: 'rx') }
+          .to raise_error(ArgumentError, /expected one of/)
+      end
+
+      it 'passes when the value is in the allowed set (supplied via alias)' do
+        expect { args_def.bind(c: '+x') }.not_to raise_error
+      end
+    end
+
+    describe 'applied to git add :chmod' do
+      let(:add_args) { Git::Commands::Add.args_definition }
+
+      it 'passes for +x' do
+        expect { add_args.bind(chmod: '+x') }.not_to raise_error
+      end
+
+      it 'passes for -x' do
+        expect { add_args.bind(chmod: '-x') }.not_to raise_error
+      end
+
+      it 'raises for an invalid value' do
+        expect { add_args.bind(chmod: 'rx') }
+          .to raise_error(ArgumentError, /expected one of.*got "rx"/)
+      end
+
+      it 'skips when chmod is absent' do
+        expect { add_args.bind }.not_to raise_error
+      end
+    end
+
+    describe 'applied to git tag create :cleanup' do
+      let(:create_args) { Git::Commands::Tag::Create.args_definition }
+
+      it 'passes for verbatim' do
+        expect { create_args.bind('v1.0', nil, cleanup: 'verbatim', message: 'msg') }.not_to raise_error
+      end
+
+      it 'raises for an invalid value' do
+        expect { create_args.bind('v1.0', nil, cleanup: 'compact', message: 'msg') }
+          .to raise_error(ArgumentError, /expected one of.*got "compact"/)
+      end
+    end
+  end
+
   describe Git::Commands::Arguments::Bound do
     describe 'RESERVED_NAMES' do
       it 'includes Object instance methods' do


### PR DESCRIPTION
## Summary

Implements #1069.

Adds an `allowed_values(name, in: [...])` DSL method to `Git::Commands::Arguments` that enforces an enumerated set of acceptable string values for any value-type option at bind time.

## Behaviour

```ruby
value_option :cleanup, inline: true
allowed_values :cleanup, in: %w[verbatim whitespace strip]
```

- Raises `ArgumentError` with `Invalid value for :cleanup: expected one of ["verbatim", "whitespace", "strip"], got "compact"` for out-of-range values
- Silently passes for `nil` / absent values (no separate `required:` implied)
- Skips empty strings when the option declares `allow_empty: true`
- Validates each element individually for `repeatable: true` options
- Resolves aliases before checking — either the primary name or any alias may be used in the declaration
- Supersedes ad-hoc `validator:` lambdas for simple set-membership checks

## Valid option types

`value_option`, `inline_value`, `value_as_operand`, `flag_or_value`, `flag_or_inline_value`, `negatable_flag_or_value`, `negatable_flag_or_inline_value`.

## Applied to consumers

| Command | Option | Allowed values |
|---|---|---|
| `git add` | `:chmod` | `['+x', '-x']` |
| `git tag create` | `:cleanup` | `%w[verbatim whitespace strip]` |

## Documentation

- **Review Arguments DSL** prompt: new section 7d
- **Scaffold New Command** prompt: `allowed_values` added to DSL ordering guide
- **Review YARD Documentation** prompt: check for enumerating accepted values in `@option` descriptions
- **copilot-instructions**: Constraint Validation testing guideline extended to cover `requires`, `allowed_values`, and out-of-range value tests