### PR TITLE
refactor(arguments): add requires_exactly_one_of DSL convenience method

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,11 +303,20 @@ accept these via an options splat parameter (e.g., `def replace(object, replacem
 
 - **Mutually exclusive options**: If options are mutually exclusive (e.g.,
   `--global`, `--local`, `--system`), only one may be set to `true`. Setting more
-  than one raises `ArgumentError`.
+  than one raises `ArgumentError`. The DSL enforces this via `conflicts`
+  declarations at bind time.
+
+- **Exactly-one required from a mutually exclusive group**: When exactly one of a
+  group of arguments must be provided (e.g., a command that accepts exactly one of
+  `--mode-a`, `--mode-b`, or `--mode-c`), omitting all of them or supplying more
+  than one raises `ArgumentError`. The DSL enforces this via
+  `requires_exactly_one_of` declarations, which combine `requires_one_of`
+  (at-least-one) and `conflicts` (at-most-one) in a single declaration.
 
 - **At-least-one required**: When at least one of a group of arguments (options or
-  positional) must be provided, omitting all of them raises `ArgumentError`. The DSL
-  enforces this via `requires_one_of` declarations at bind time.
+  positional) must be provided, but the group is not mutually exclusive, omitting
+  all of them raises `ArgumentError`. The DSL enforces this via `requires_one_of`
+  declarations at bind time.
 
 #### Positional arguments
 

--- a/lib/git/commands/reset.rb
+++ b/lib/git/commands/reset.rb
@@ -38,8 +38,8 @@ module Git
         flag_option :hard
         flag_option :merge
         flag_option :keep
-        conflicts :soft, :mixed, :hard, :merge, :keep
         operand :commit, required: false
+        conflicts :soft, :mixed, :hard, :merge, :keep
       end
 
       # @!method call(*, **)

--- a/prompts/Scaffold New Command.md
+++ b/prompts/Scaffold New Command.md
@@ -156,8 +156,24 @@ Constraint declarations always come last, after all arguments they reference
 are defined:
 
 7. `conflicts` declarations
-8. `requires_one_of` declarations (unconditional and `when:` conditional forms)
-9. `requires` declarations (single-argument conditional form)
+8. `requires_exactly_one_of` declarations — when a group must have exactly one
+   member present. Replaces the two-declaration pattern of `requires_one_of` +
+   `conflicts` for the same names:
+
+   ```ruby
+   requires_exactly_one_of :mode_a, :mode_b, :mode_c
+   ```
+
+   This is equivalent to (but preferred over):
+
+   ```ruby
+   requires_one_of :mode_a, :mode_b, :mode_c
+   conflicts       :mode_a, :mode_b, :mode_c
+   ```
+
+9. `requires_one_of` declarations (unconditional and `when:` conditional forms) —
+   use these when only an at-least-one constraint is needed (no at-most-one)
+10. `requires` declarations (single-argument conditional form)
 
 Use aliases for long/short forms (`%i[force f]`, `%i[all A]`, `%i[intent_to_add N]`),
 with long name first. The DSL preserves symbol case, so uppercase single-char aliases
@@ -198,9 +214,26 @@ conflicts :gpg_sign, :no_gpg_sign        # option vs option
 conflicts :merge, :tree_ish              # option vs operand
 ```
 
+When a group of mutually exclusive arguments also requires **exactly one** member to
+be present, use `requires_exactly_one_of` instead of separate `requires_one_of` +
+`conflicts` declarations. It combines both constraints in a single declaration and
+eliminates the risk of the two lists diverging:
+
+```ruby
+requires_exactly_one_of :mode_a, :mode_b, :mode_c
+```
+
+This is equivalent to (but preferred over):
+
+```ruby
+requires_one_of :mode_a, :mode_b, :mode_c
+conflicts       :mode_a, :mode_b, :mode_c
+```
+
 When at least one of a group of arguments must be present — options, operands, or
-a mix — declare it with `requires_one_of`. Names may be option names or operand
-names. Unknown names raise `ArgumentError` at load time. Examples:
+a mix — but the group is **not** mutually exclusive, declare it with `requires_one_of`.
+Names may be option names or operand names. Unknown names raise `ArgumentError` at
+load time. Examples:
 
 ```ruby
 requires_one_of :pathspec, :pathspec_from_file   # at least one option required


### PR DESCRIPTION
Closes #1070

## Summary

Adds `requires_exactly_one_of` as a composite DSL convenience method that internally registers both a `requires_one_of` group and a `conflicts` group for the same names, enforcing exactly-one-present semantics at bind time.

```ruby
requires_exactly_one_of :soft, :mixed, :hard, :merge, :keep
```

is equivalent to (and preferred over):

```ruby
requires_one_of :soft, :mixed, :hard, :merge, :keep
conflicts       :soft, :mixed, :hard, :merge, :keep
```

## Changes

### Implementation

- **`lib/git/commands/arguments.rb`** — Added `requires_exactly_one_of(*names)` DSL method with full YARD documentation and examples. Implemented as a thin composite that delegates to `requires_one_of` + `conflicts`, inheriting both typo guards.

### Tests

- **`spec/unit/git/commands/arguments_spec.rb`** — New `context 'with requires_exactly_one_of method'` covering: zero-present (at-least-one error), one-present (passes), two-present (conflicts error), typo guard, and all-three-present.

### Documentation

- **`CONTRIBUTING.md`** — Added "Exactly-one required" bullet documenting `requires_exactly_one_of` alongside the existing mutually-exclusive and at-least-one bullets.
- **`prompts/Review Arguments DSL.md`** — Updated sections 6 and 7a; `requires_exactly_one_of` is the preferred single declaration when a group is both required and mutually exclusive; flags the two-declaration pattern as a consolidation candidate.
- **`prompts/Scaffold New Command.md`** — Added `requires_exactly_one_of` to the DSL ordering list (item 8) with example and equivalence note; prose block updated.

## Acceptance criteria

- [x] `requires_exactly_one_of(*names)` declared in `arguments do` block
- [x] Unknown names raise `ArgumentError` at definition time
- [x] Zero members present → `ArgumentError` (at-least-one violation)
- [x] Exactly one member present → no error
- [x] Two or more members present → `ArgumentError` (at-most-one violation)
- [x] YARD documentation with examples
- [x] Unit tests cover all three cases above
- [x] Updated `prompts/Review Arguments DSL.md`
- [x] Updated `prompts/Scaffold New Command.md`