### PR TITLE
refactor(arguments): treat negatable false as present in conflict and satisfied-by checks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -302,9 +302,11 @@ accept these via an options splat parameter (e.g., `def replace(object, replacem
   - `git -c user.name=Scott` → `c: { 'user.name' => 'Scott' }`
 
 - **Mutually exclusive options**: If options are mutually exclusive (e.g.,
-  `--global`, `--local`, `--system`), only one may be set to `true`. Setting more
+  `--global`, `--local`, `--system`), only one may be used at a time. Setting more
   than one raises `ArgumentError`. The DSL enforces this via `conflicts`
-  declarations at bind time.
+  declarations at bind time. For **negatable flag options** (`negatable: true`),
+  passing `false` (which emits `--no-flag`) also counts as using that option in the
+  conflict check; non-negatable `false` is treated as absent.
 
 - **Exactly-one required from a mutually exclusive group**: When exactly one of a
   group of arguments must be provided (e.g., a command that accepts exactly one of

--- a/prompts/Review Arguments DSL.md
+++ b/prompts/Review Arguments DSL.md
@@ -278,6 +278,11 @@ or operand vs operand — verify `conflicts ...` declarations exist. Names in a
 `conflicts` group may be any mix of option names and operand names. Unknown names
 raise `ArgumentError` at definition time, so any typo is caught early.
 
+**Presence semantics for conflicts:** a value is considered present when it is not
+`nil`, `[]`, or `''`. For **negatable flag options** (`negatable: true`), an explicit
+`false` also counts as present because it emits `--no-flag` — a real CLI token that
+can conflict with other options. Non-negatable `false` is absent.
+
 **Preferred single declaration when a group is both required and mutually exclusive:**
 If a `conflicts` group also has a corresponding bare `requires_one_of` for the
 identical argument list, the two declarations should be collapsed into a single
@@ -294,6 +299,9 @@ operands, or a mix — verify `requires_one_of ...` declarations exist. As with
 `conflicts`, names may be any mix of option names and operand names. Alias
 resolution applies before the check, so supplying an alias counts as its canonical
 argument being present. Unknown names raise `ArgumentError` at definition time.
+
+**Presence semantics (satisfied-by):** same rule as `conflicts` — negatable `false`
+counts as present (the caller explicitly provided `--no-flag`).
 
 The error at bind time has the form:
 
@@ -324,6 +332,10 @@ If an argument is only required when another specific argument is present, verif
 when the trigger is absent. Unknown names (including the trigger) raise
 `ArgumentError` at definition time.
 
+**Presence semantics (trigger):** the trigger fires when its value is not `nil`,
+`false`, `[]`, or `''`. A negatable flag set to `false` means the feature is **off**,
+so the trigger does **not** fire and no dependency check is performed.
+
 The error at bind time has the form:
 
   ":trigger requires :name"
@@ -342,6 +354,9 @@ verify a `requires_one_of :a, :b, when: :trigger` declaration exists. Like the
 unconditional form, names may be any mix of option/operand names. The check is
 skipped when the trigger is absent. Unknown names (including the trigger) raise
 `ArgumentError` at definition time.
+
+**Presence semantics (trigger):** same rule as `requires` — a negatable trigger set
+to `false` means the feature is off; the group check is skipped.
 
 The error at bind time has the form:
 

--- a/prompts/Scaffold New Command.md
+++ b/prompts/Scaffold New Command.md
@@ -207,7 +207,13 @@ would work should be corrected.
 
 When two or more arguments are mutually exclusive — options, operands, or a mix —
 declare them with `conflicts`. Names may be option names or operand names.
-Unknown names raise `ArgumentError` at load time. Examples:
+Unknown names raise `ArgumentError` at load time.
+
+**Presence semantics:** a value is present when it is not `nil`, `[]`, or `''`. For
+**negatable flag options** (`negatable: true`), `false` also counts as present
+because it emits `--no-flag`. Non-negatable `false` is absent.
+
+Examples:
 
 ```ruby
 conflicts :gpg_sign, :no_gpg_sign        # option vs option
@@ -243,7 +249,14 @@ requires_one_of :all, :paths                     # option or operand required
 When an argument is only required if a *specific trigger* argument is present, use
 `requires` (single name) or `requires_one_of ... when:` (group). Both forms skip
 the check when the trigger is absent. Unknown names raise `ArgumentError` at load
-time. Examples:
+time.
+
+**Presence semantics (trigger):** the trigger fires when its value is not `nil`,
+`false`, `[]`, or `''`. A negatable flag set to `false` means the feature is **off**;
+the trigger does **not** fire. The satisfied-by check uses the same rule as
+`conflicts`: negatable `false` counts as present.
+
+Examples:
 
 ```ruby
 # Single: :pathspec_from_file must be present whenever :pathspec_file_nul is present

--- a/spec/unit/git/commands/add_spec.rb
+++ b/spec/unit/git/commands/add_spec.rb
@@ -240,6 +240,12 @@ RSpec.describe Git::Commands::Add do
           raise_error(ArgumentError, /:all.*:update|:update.*:all/)
         )
       end
+
+      it 'raises ArgumentError when :all is false (--no-all) and :update is given' do
+        expect { command.call('.', all: false, update: true) }.to(
+          raise_error(ArgumentError, /:all.*:update|:update.*:all/)
+        )
+      end
     end
 
     context 'with requires constraint violations' do


### PR DESCRIPTION
Closes #1078

## Summary

Introduce `argument_present_for_name?(name, value)` — a name-aware variant of `argument_present?` that returns `true` for `false` values when the named argument is a negatable flag type (`:negatable_flag`, `:negatable_flag_or_value`, `:negatable_flag_or_inline_value`).

## The problem

`argument_present?` returned `false` for any `false` value, making it impossible to distinguish "never supplied" (`nil`) from "explicitly set to the negative form" (`false` on a negatable flag). This caused silent misbehaviour in conflict and satisfied-by validation:

```ruby
# git add arguments do
flag_option %i[all A], negatable: true
flag_option :update
conflicts :all, :ignore_removal, :update

call('.', all: false, update: true)
# emits: --no-all --update  ← these conflict, but no error was raised
```

## The fix — three call-sites, two rules

| Call-site | Helper | Negatable `false` |
|---|---|---|
| `validate_conflicts!` | `argument_present_for_name?` | **Present** — `--no-all` is a real CLI token |
| `validate_requires_one_of_entry!` satisfied-by | `argument_present_for_name?` | **Present** — explicitly providing `--no-flag` satisfies a group |
| `validate_requires_one_of_entry!` `when:` trigger | `argument_present?` (unchanged) | **Absent** — feature is OFF; its requirements don't apply |

The trigger call-site intentionally diverges from the original proposal. `--no-sign` means GPG signing is disabled; firing `:sign requires at least one of :message, :file` would be incorrect. See the implementation note in #1078 for full rationale.

## Implementation details

- Negatable types are detected via `definition[:type]` (`:negatable_flag`, `:negatable_flag_or_value`, `:negatable_flag_or_inline_value`) — there is no separate `:negatable` key in `@option_definitions`
- `negatable_option?(name)` private helper extracted for the type lookup
- `Metrics/CyclomaticComplexity` kept clean by collapsing the absent-value guards and delegating to `negatable_option?`
- Full backward compatibility: non-negatable `false`, `nil`, `[]`, `''` remain absent in all three checks

## Changes

**`lib/git/commands/arguments.rb`**
- Add `argument_present_for_name?` and `negatable_option?` private helpers
- Update `validate_conflicts!` and the satisfied-by call-site in `validate_requires_one_of_entry!`
- Update YARD presence-semantics docs on all four public DSL methods (`conflicts`, `requires_one_of`, `requires_exactly_one_of`, `requires`)

**`spec/unit/git/commands/arguments_spec.rb`**
- New `context 'with negatable flag options in conflict groups'` — 4 tests + 3 for `flag_or_value_option negatable: true`
- New `context 'with negatable flag options in requires_one_of groups'` — satisfied-by (4 tests) and trigger (4 tests)

**`spec/unit/git/commands/add_spec.rb`**
- `all: false, update: true` conflict test (acceptance criterion from the issue)

**`CONTRIBUTING.md`, `prompts/Review Arguments DSL.md`, `prompts/Scaffold New Command.md`**
- Updated presence-semantics paragraphs to document the negatable-flag distinction and the trigger vs. satisfied-by split
