### PR TITLE
refactor(arguments): add forbid_values DSL for value-aware constraints

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2570,7 +2570,7 @@ When implementing a command using the `Git::Commands::Arguments` DSL, you **MUST
 - **Invalid Values**: Test that invalid values raise appropriate errors or are handled correctly.
 - **Argument Building**: Verify that the generated git command arguments match the expected CLI flags.
 - **Edge Cases**: Test nil values, empty strings/arrays, and special characters.
-- **Constraint Validation**: If the command uses `conflicts`, `requires_one_of`, `requires`, or `allowed_values` DSL declarations, include a `context 'input validation'` block that tests each constraint raises `ArgumentError` as expected (too many conflicting args present; none of the required group present; value outside the allowed set).
+- **Constraint Validation**: If the command uses `conflicts`, `forbid_values`, `requires_one_of`, `requires`, or `allowed_values` DSL declarations, include a `context 'input validation'` block that tests each constraint raises `ArgumentError` as expected (too many conflicting args present; forbidden exact-value tuple matched; none of the required group present; value outside the allowed set).
 
 ### Coverage Target
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -308,6 +308,23 @@ accept these via an options splat parameter (e.g., `def replace(object, replacem
   passing `false` (which emits `--no-flag`) also counts as using that option in the
   conflict check; non-negatable `false` is treated as absent.
 
+- **Forbidden value combinations (negatable flags)**: When two negatable flags may
+  both be present but only certain value pairings are contradictory, use
+  `forbid_values` declarations instead of (or in addition to) `conflicts`.
+  `conflicts` is presence-based and blocks all co-presence; `forbid_values` blocks
+  only the exact `name: value` tuples listed, leaving semantically equivalent pairs
+  valid. For example, `--all --no-ignore-removal` and `--no-all --ignore-removal`
+  are equivalent and should remain allowed, while `--all --ignore-removal` and
+  `--no-all --no-ignore-removal` are contradictory and should be rejected:
+
+  ```ruby
+  forbid_values all: true,  ignore_removal: true   # contradictory
+  forbid_values all: false, ignore_removal: false  # contradictory
+  ```
+
+  Unknown names raise `ArgumentError` at definition time. Alias names are
+  canonicalized automatically.
+
 - **Exactly-one required from a mutually exclusive group**: When exactly one of a
   group of arguments must be provided (e.g., a command that accepts exactly one of
   `--mode-a`, `--mode-b`, or `--mode-c`), omitting all of them or supplying more

--- a/lib/git/commands/add.rb
+++ b/lib/git/commands/add.rb
@@ -41,6 +41,11 @@ module Git
         conflicts :all, :update
         conflicts :ignore_removal, :update
         conflicts :pathspec, :pathspec_from_file
+        # --all=true  + --ignore-removal=true  : contradictory (stage all vs ignore removed files)
+        # --all=false + --ignore-removal=false : contradictory (--no-all vs --no-ignore-removal cancel out)
+        # Equivalent pairs (--no-all --ignore-removal or --all --no-ignore-removal) are allowed.
+        forbid_values all: true,  ignore_removal: true
+        forbid_values all: false, ignore_removal: false
         requires :pathspec_from_file, when: :pathspec_file_nul
         requires :dry_run, when: :ignore_missing
       end

--- a/prompts/Scaffold New Command.md
+++ b/prompts/Scaffold New Command.md
@@ -117,7 +117,9 @@ interchangeable flags), prefer:
    ```
 
 5. operands (positional args)
+
 6. separator-delimited pathspec entries — either form:
+
    - `operand :pathspec, repeatable: true, separator: '--'` (positional calling convention)
    - `value_option :pathspec, as_operand: true, separator: '--', repeatable: true` (keyword calling convention)
 
@@ -152,11 +154,21 @@ interchangeable flags), prefer:
      # cmd.call('HEAD~3', 'HEAD')  → git <sub> HEAD~3 HEAD
      ```
 
-Constraint declarations always come last, after all arguments they reference
-are defined:
+   Constraint declarations always come last, after all arguments they reference
+   are defined:
 
-7. `conflicts` declarations
-8. `requires_exactly_one_of` declarations — when a group must have exactly one
+7. `conflicts` declarations — presence-based mutual exclusion
+
+8. `forbid_values` declarations — exact-value tuple constraints for negatable
+   flags where some value-pairings are contradictory but others are equivalent:
+
+   ```ruby
+   forbid_values all: true,  ignore_removal: true   # contradictory
+   forbid_values all: false, ignore_removal: false  # contradictory
+   # allows: all: true + ignore_removal: false (equivalent pair)
+   ```
+
+9. `requires_exactly_one_of` declarations — when a group must have exactly one
    member present. Replaces the two-declaration pattern of `requires_one_of` +
    `conflicts` for the same names:
 
@@ -171,9 +183,10 @@ are defined:
    conflicts       :mode_a, :mode_b, :mode_c
    ```
 
-9. `requires_one_of` declarations (unconditional and `when:` conditional forms) —
-   use these when only an at-least-one constraint is needed (no at-most-one)
-10. `requires` declarations (single-argument conditional form)
+10.  `requires_one_of` declarations (unconditional and `when:` conditional forms) —
+    use these when only an at-least-one constraint is needed (no at-most-one)
+
+11.  `requires` declarations (single-argument conditional form)
 
 Use aliases for long/short forms (`%i[force f]`, `%i[all A]`, `%i[intent_to_add N]`),
 with long name first. The DSL preserves symbol case, so uppercase single-char aliases

--- a/spec/unit/git/commands/add_spec.rb
+++ b/spec/unit/git/commands/add_spec.rb
@@ -302,6 +302,20 @@ RSpec.describe Git::Commands::Add do
       end
     end
 
+    context 'with contradictory all/ignore_removal combinations' do
+      it 'raises ArgumentError for :all true with :ignore_removal true' do
+        expect { command.call('.', all: true, ignore_removal: true) }.to(
+          raise_error(ArgumentError, /cannot specify :all=true with :ignore_removal=true/)
+        )
+      end
+
+      it 'raises ArgumentError for :all false with :ignore_removal false' do
+        expect { command.call('.', all: false, ignore_removal: false) }.to(
+          raise_error(ArgumentError, /cannot specify :all=false with :ignore_removal=false/)
+        )
+      end
+    end
+
     context 'with requires constraint violations' do
       it 'raises ArgumentError when :pathspec_file_nul is given without :pathspec_from_file' do
         expect { command.call(pathspec_file_nul: true) }


### PR DESCRIPTION
## Summary

Adds a new `forbid_values` DSL method to `Git::Commands::Arguments` that raises `ArgumentError` when an exact tuple of name=value pairs is passed to `bind`.

This fills a gap identified in #1080: `conflicts` is presence-based — it fires whenever co-named arguments are both "present", regardless of their values. For **negatable flags**, this is too coarse. `--no-all --ignore-removal` and `--all --no-ignore-removal` are semantically *equivalent* (not contradictory), yet the old `conflicts :all, :ignore_removal` in `add.rb` was blocking them.

## Changes

### Core DSL (`lib/git/commands/arguments.rb`)
- Added `@forbidden_values = []` storage in `initialize`
- Added `forbid_values(**pairs)` public DSL method with full YARD docs
- Added private `validate_forbidden_values!` and `forbidden_tuple_matches?` helpers
- Extracted `validate_bind_inputs!` to group all cross-field validations; calls `validate_forbidden_values!` after `validate_conflicts!`
- Added `## Forbidden Value Combinations` section to class-level YARD docs

### Consumer (`lib/git/commands/add.rb`)
Replaced the over-broad `conflicts :all, :ignore_removal` with two targeted declarations:

```ruby
forbid_values all: true,  ignore_removal: true   # --all --ignore-removal (contradictory)
forbid_values all: false, ignore_removal: false  # --no-all --no-ignore-removal (contradictory)
```

This allows the semantically equivalent pairs (`--no-all --ignore-removal` and `--all --no-ignore-removal`) that the old `conflicts` incorrectly blocked.

### Tests
- `spec/unit/git/commands/arguments_spec.rb`: 183 lines of new tests covering exact tuple rejection, semantically equivalent pairs allowed, alias canonicalization, non-boolean value options, definition-time errors, and independence from `conflicts`
- `spec/unit/git/commands/add_spec.rb`: new `context 'with contradictory all/ignore_removal combinations'` asserting both forbidden tuples raise `ArgumentError` at the command level

### Developer docs
- `CONTRIBUTING.md`: new "Forbidden value combinations" bullet
- `.github/copilot-instructions.md`: constraint validation testing note updated
- `prompts/Review Arguments DSL.md`: §3 ordering, §6 conflicts guidance, new §7e
- `prompts/Scaffold New Command.md`: constraint ordering list updated

## Test Results

```
bundle exec rspec spec/unit/git/commands/arguments_spec.rb  # 639 examples, 0 failures
bundle exec rspec spec/unit/git/commands/add_spec.rb        #  50 examples, 0 failures
```

Closes #1080