### PR TITLE
fix(checkout-index): add allowed_values for :stage and conflicts :all/:file

### DIFF
--- a/lib/git/commands/checkout_index.rb
+++ b/lib/git/commands/checkout_index.rb
@@ -43,6 +43,9 @@ module Git
         flag_option :temp
         flag_option :ignore_skip_worktree_bits
         operand :file, required: false, repeatable: true, separator: '--'
+
+        allowed_values :stage, in: %w[1 2 3 all]
+        conflicts :all, :file
       end
 
       # @!method call(*, **)

--- a/spec/integration/git/commands/checkout_index_spec.rb
+++ b/spec/integration/git/commands/checkout_index_spec.rb
@@ -40,5 +40,19 @@ RSpec.describe Git::Commands::CheckoutIndex, :integration do
         expect { command.call('nonexistent.txt') }.to raise_error(Git::FailedError)
       end
     end
+
+    describe 'input validation' do
+      it 'raises ArgumentError when :all and a file path are both given' do
+        expect { command.call('file.txt', all: true) }.to(
+          raise_error(ArgumentError, /cannot specify :all and :file/)
+        )
+      end
+
+      it 'raises ArgumentError for an invalid :stage value' do
+        expect { command.call(stage: 'invalid') }.to(
+          raise_error(ArgumentError, /Invalid value for :stage/)
+        )
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/checkout_index_spec.rb
+++ b/spec/unit/git/commands/checkout_index_spec.rb
@@ -96,10 +96,22 @@ RSpec.describe Git::Commands::CheckoutIndex do
     end
 
     context 'with the :stage option' do
-      it 'includes --stage=<value>' do
+      it 'includes --stage=1 for stage 1' do
+        expect_command('checkout-index', '--stage=1').and_return(command_result)
+
+        command.call(stage: '1')
+      end
+
+      it 'includes --stage=2 for stage 2' do
         expect_command('checkout-index', '--stage=2').and_return(command_result)
 
         command.call(stage: '2')
+      end
+
+      it 'includes --stage=3 for stage 3' do
+        expect_command('checkout-index', '--stage=3').and_return(command_result)
+
+        command.call(stage: '3')
       end
 
       it 'accepts "all" as the stage value' do
@@ -165,6 +177,24 @@ RSpec.describe Git::Commands::CheckoutIndex do
       it 'raises ArgumentError for unsupported options' do
         expect { command.call(invalid_option: true) }.to(
           raise_error(ArgumentError, /Unsupported options: :invalid_option/)
+        )
+      end
+
+      it 'raises ArgumentError when :all and :file are both given' do
+        expect { command.call('file.txt', all: true) }.to(
+          raise_error(ArgumentError, /cannot specify :all and :file/)
+        )
+      end
+
+      it 'raises ArgumentError for an invalid :stage value' do
+        expect { command.call(stage: '4') }.to(
+          raise_error(ArgumentError, /Invalid value for :stage/)
+        )
+      end
+
+      it 'raises ArgumentError for a non-numeric, non-"all" :stage value' do
+        expect { command.call(stage: 'other') }.to(
+          raise_error(ArgumentError, /Invalid value for :stage/)
         )
       end
     end


### PR DESCRIPTION
## Summary

Two DSL constraint anomalies were identified during an Arguments DSL review of `Git::Commands::CheckoutIndex` against the `git checkout-index` man page.

### Changes

**`lib/git/commands/checkout_index.rb`**

- Add `allowed_values :stage, in: %w[1 2 3 all]`  
  The man page documents `--stage=<number>|all` where `<number>` must be 1, 2, or 3. Without this constraint, any string was silently accepted and passed to git.

- Add `conflicts :all, :file`  
  The man page explicitly states that `-a`/`--all` "cannot be used together with explicit filenames." Without this constraint, callers could supply both without error.

**`spec/unit/git/commands/checkout_index_spec.rb`**

- Expand `:stage` context to cover all four valid values (`'1'`, `'2'`, `'3'`, `'all'`) individually (the previous test only covered `'2'` and `'all'`).
- Add `input validation` tests for both new constraints:
  - raises `ArgumentError` when `:all` and a file path are both given
  - raises `ArgumentError` for an out-of-range `:stage` value (`'4'`)
  - raises `ArgumentError` for a non-numeric, non-`'all'` `:stage` value (`'other'`)

**`spec/integration/git/commands/checkout_index_spec.rb`**

- Add `input validation` describe block with integration-level tests for both constraints (bind-time checks; git is never invoked).
