### PR TITLE
fix: overhaul Git::Commands::Clone DSL to match git-clone docs

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -37,12 +37,13 @@ Layout/LineLength:
     - "tests/units/**/*"
     - "*.gemspec"
 
-# Testing and gemspec DSL results in large blocks
+# Testing, gemspec, and command DSL blocks are intentionally long
 Metrics/BlockLength:
   Exclude:
     - "tests/test_helper.rb"
     - "tests/units/**/*"
     - "*.gemspec"
+    - "lib/git/commands/*.rb"
 
 # Don't force every test class to be described
 Style/Documentation:

--- a/lib/git/commands/clone.rb
+++ b/lib/git/commands/clone.rb
@@ -21,19 +21,51 @@ module Git
     class Clone < Git::Commands::Base
       arguments do
         literal 'clone'
+        value_option :template, inline: true
+        flag_option %i[local l], negatable: true
+        flag_option %i[shared s]
+        flag_option :no_hardlinks
+        flag_option %i[no_checkout n]
         flag_option :bare
         flag_option :mirror
         value_option %i[origin o]
         value_option %i[branch b]
+        value_option :revision, inline: true
+        value_option %i[upload_pack u]
+        value_option :reference, repeatable: true
+        value_option :reference_if_able, repeatable: true
+        flag_option :dissociate
+        value_option :separate_git_dir, inline: true
+        value_option :server_option, inline: true, repeatable: true
         value_option :depth
-        flag_option :single_branch, negatable: true, validator: ->(v) { [nil, true, false].include?(v) }
-        flag_or_value_option :recurse_submodules, inline: true
+        value_option :shallow_since, inline: true
+        value_option :shallow_exclude, inline: true, repeatable: true
+        flag_option :single_branch, negatable: true
+        flag_option :tags, negatable: true
+        flag_or_value_option :recurse_submodules, inline: true, repeatable: true
+        flag_option :shallow_submodules, negatable: true
+        flag_option :remote_submodules, negatable: true
+        value_option %i[jobs j]
+        flag_option :sparse
+        flag_option :reject_shallow, negatable: true
         value_option :filter, inline: true
+        flag_option :also_filter_submodules
         value_option %i[config c], repeatable: true
+        value_option :bundle_uri, inline: true
+        value_option :ref_format, inline: true
         operand :repository, required: true, separator: '--'
         operand :directory
         execution_option :timeout
         execution_option :chdir
+
+        conflicts :revision, :branch
+        conflicts :revision, :mirror
+        conflicts :bundle_uri, :depth
+        conflicts :bundle_uri, :shallow_since
+        conflicts :bundle_uri, :shallow_exclude
+        requires :filter,             when: :also_filter_submodules
+        requires :recurse_submodules, when: :also_filter_submodules
+        allowed_values :ref_format, in: %w[files reftable]
       end
 
       # @!method call(*, **)
@@ -49,6 +81,20 @@ module Git
       #
       #     @param options [Hash] command options
       #
+      #     @option options [String] :template (nil) Directory from which templates will be used.
+      #
+      #     @option options [Boolean, nil] :local (nil) Bypass the normal Git-aware transport for local
+      #       clones. Use false to emit --no-local. Alias: :l
+      #
+      #     @option options [Boolean] :shared (nil) Set up a shared clone using alternates instead
+      #       of hardlinks. Alias: :s
+      #
+      #     @option options [Boolean] :no_hardlinks (nil) Force file-copy instead of hardlinks when
+      #       cloning from a local filesystem.
+      #
+      #     @option options [Boolean] :no_checkout (nil) Skip checking out HEAD after the clone.
+      #       Alias: :n
+      #
       #     @option options [Boolean] :bare (nil) Clone as a bare repository
       #
       #     @option options [Boolean] :mirror (nil) Set up a mirror clone (implies --bare)
@@ -57,21 +103,78 @@ module Git
       #       Alias: :o
       #
       #     @option options [String] :branch (nil) The branch to checkout after cloning.
-      #       Alias: :b
+      #       Mutually exclusive with :revision. Alias: :b
       #
-      #     @option options [Integer, String] :depth (nil) Create a shallow clone with the specified number of commits
+      #     @option options [String] :revision (nil) Detach HEAD at the given revision after cloning.
+      #       Incompatible with :branch and :mirror.
       #
-      #     @option options [Boolean, nil] :single_branch (nil) Clone only the history
-      #       leading to the tip of a single branch
+      #     @option options [String] :upload_pack (nil) Path to git-upload-pack on the remote (ssh only).
+      #       Alias: :u
       #
-      #     @option options [Boolean, String] :recurse_submodules (nil) Initialize all submodules
-      #       after cloning. When true, uses `--recurse-submodules`. When a string, passes the
-      #       pathspec to limit which submodules are initialized.
+      #     @option options [String, Array<String>] :reference (nil) Borrow objects from one or more
+      #       reference repositories.
       #
-      #     @option options [String] :filter (nil) Specify partial clone (e.g., 'tree:0', 'blob:none')
+      #     @option options [String, Array<String>] :reference_if_able (nil) Like :reference but skip
+      #       with a warning if the reference directory does not exist. Repeatable.
+      #
+      #     @option options [Boolean] :dissociate (nil) Stop borrowing from reference repositories after
+      #       the clone is complete.
+      #
+      #     @option options [String] :separate_git_dir (nil) Place the git directory at the given path
+      #       and create a gitfile symlink in the working tree.
+      #
+      #     @option options [String, Array<String>] :server_option (nil) Protocol-v2 server options.
+      #       Repeatable.
+      #
+      #     @option options [Integer, String] :depth (nil) Create a shallow clone with the specified
+      #       number of commits
+      #
+      #     @option options [String] :shallow_since (nil) Create a shallow clone with history after
+      #       the specified date.
+      #
+      #     @option options [String, Array<String>] :shallow_exclude (nil) Exclude commits reachable
+      #       from the specified remote branch or tag. Repeatable.
+      #
+      #     @option options [Boolean, nil] :single_branch (nil) Clone only the history leading to the
+      #       tip of a single branch. Use false to emit --no-single-branch.
+      #
+      #     @option options [Boolean, nil] :tags (nil) Control whether tags are cloned. Use false to
+      #       emit --no-tags.
+      #
+      #     @option options [Boolean, String, Array<String>] :recurse_submodules (nil) Initialize all
+      #       submodules after cloning. When true, uses `--recurse-submodules`. When a string, passes
+      #       one pathspec. When an array of strings, emits repeated
+      #       `--recurse-submodules=<pathspec>` options.
+      #
+      #     @option options [Boolean, nil] :shallow_submodules (nil) Clone submodules with depth 1.
+      #       Use false to emit --no-shallow-submodules.
+      #
+      #     @option options [Boolean, nil] :remote_submodules (nil) Use submodule remote-tracking
+      #       branch status. Use false to emit --no-remote-submodules.
+      #
+      #     @option options [Integer] :jobs (nil) Number of submodules fetched concurrently.
+      #       Alias: :j
+      #
+      #     @option options [Boolean] :sparse (nil) Enable sparse checkout with top-level files only.
+      #
+      #     @option options [Boolean, nil] :reject_shallow (nil) Fail if source is shallow.
+      #       Use false to emit --no-reject-shallow.
+      #
+      #     @option options [String] :filter (nil) Specify partial clone filter
+      #       (e.g., 'blob:none', 'tree:0'). Required when :also_filter_submodules is set.
+      #
+      #     @option options [Boolean] :also_filter_submodules (nil) Apply the partial clone filter
+      #       to submodules. Requires :filter and :recurse_submodules.
       #
       #     @option options [String, Array<String>] :config (nil) Configuration options to set.
       #       Alias: :c
+      #
+      #     @option options [String] :bundle_uri (nil) Fetch a bundle from the given URI before
+      #       fetching from the remote. Incompatible with :depth, :shallow_since, and
+      #       :shallow_exclude.
+      #
+      #     @option options [String] :ref_format (nil) Specify the ref storage format
+      #       (e.g., 'files', 'reftable').
       #
       #     @option options [Numeric, nil] :timeout (nil) the number of seconds to wait
       #       for the command to complete. If nil, uses the global timeout from
@@ -82,8 +185,11 @@ module Git
       #
       #     @return [Git::CommandLineResult] the result of the git clone command
       #
-      #     @raise [ArgumentError] if unsupported options are provided, if :single_branch is not true, false, or nil,
-      #       or if any option fails validation
+      #     @raise [ArgumentError] if unsupported options are provided, if :single_branch is not
+      #       true, false, or nil, if :also_filter_submodules is given without :filter or
+      #       :recurse_submodules, if :revision is combined with :branch or :mirror, if :bundle_uri
+      #       is combined with :depth, :shallow_since, or :shallow_exclude, or if any option fails
+      #       validation
       #
       #     @see Git::Lib#command for details on timeout behavior and other execution options
     end

--- a/spec/unit/git/commands/clone_spec.rb
+++ b/spec/unit/git/commands/clone_spec.rb
@@ -57,6 +57,13 @@ RSpec.describe Git::Commands::Clone do
 
         command.call(repository_url, directory, recurse_submodules: 'lib/')
       end
+
+      it 'includes multiple --recurse-submodules=<pathspec> options' do
+        expect_command('clone', '--recurse-submodules=lib/', '--recurse-submodules=ext/', '--',
+                       repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, recurse_submodules: %w[lib/ ext/])
+      end
     end
 
     context 'with :branch option' do
@@ -145,10 +152,348 @@ RSpec.describe Git::Commands::Clone do
       end
     end
 
+    context 'with :template option' do
+      it 'includes --template=<dir> with inline value' do
+        expect_command('clone', '--template=/usr/share/git-core/templates', '--', repository_url,
+                       directory).and_return(command_result)
+
+        command.call(repository_url, directory, template: '/usr/share/git-core/templates')
+      end
+    end
+
+    context 'with :local option' do
+      it 'includes --local flag' do
+        expect_command('clone', '--local', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, local: true)
+      end
+
+      it 'includes --no-local when false' do
+        expect_command('clone', '--no-local', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, local: false)
+      end
+
+      it 'accepts the :l alias' do
+        expect_command('clone', '--local', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, l: true)
+      end
+    end
+
+    context 'with :shared option' do
+      it 'includes --shared flag' do
+        expect_command('clone', '--shared', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, shared: true)
+      end
+
+      it 'accepts the :s alias' do
+        expect_command('clone', '--shared', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, s: true)
+      end
+    end
+
+    context 'with :no_hardlinks option' do
+      it 'includes --no-hardlinks flag' do
+        expect_command('clone', '--no-hardlinks', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, no_hardlinks: true)
+      end
+    end
+
+    context 'with :no_checkout option' do
+      it 'includes --no-checkout flag' do
+        expect_command('clone', '--no-checkout', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, no_checkout: true)
+      end
+
+      it 'accepts the :n alias' do
+        expect_command('clone', '--no-checkout', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, n: true)
+      end
+    end
+
+    context 'with :upload_pack option' do
+      it 'includes --upload-pack <path>' do
+        expect_command('clone', '--upload-pack', '/usr/bin/git-upload-pack', '--', repository_url,
+                       directory).and_return(command_result)
+
+        command.call(repository_url, directory, upload_pack: '/usr/bin/git-upload-pack')
+      end
+
+      it 'accepts the :u alias' do
+        expect_command('clone', '--upload-pack', '/usr/bin/git-upload-pack', '--', repository_url,
+                       directory).and_return(command_result)
+
+        command.call(repository_url, directory, u: '/usr/bin/git-upload-pack')
+      end
+    end
+
+    context 'with :reference option' do
+      it 'includes --reference <repository>' do
+        expect_command('clone', '--reference', '/path/to/local', '--', repository_url,
+                       directory).and_return(command_result)
+
+        command.call(repository_url, directory, reference: '/path/to/local')
+      end
+
+      it 'includes multiple --reference options' do
+        expect_command('clone', '--reference', '/path/one', '--reference', '/path/two', '--',
+                       repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, reference: ['/path/one', '/path/two'])
+      end
+    end
+
+    context 'with :reference_if_able option' do
+      it 'includes --reference-if-able <repository>' do
+        expect_command('clone', '--reference-if-able', '/path/to/local', '--', repository_url,
+                       directory).and_return(command_result)
+
+        command.call(repository_url, directory, reference_if_able: '/path/to/local')
+      end
+
+      it 'includes multiple --reference-if-able options' do
+        expect_command('clone', '--reference-if-able', '/path/one', '--reference-if-able', '/path/two',
+                       '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, reference_if_able: ['/path/one', '/path/two'])
+      end
+    end
+
+    context 'with :dissociate option' do
+      it 'includes --dissociate flag' do
+        expect_command('clone', '--dissociate', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, dissociate: true)
+      end
+    end
+
+    context 'with :separate_git_dir option' do
+      it 'includes --separate-git-dir=<dir>' do
+        expect_command('clone', '--separate-git-dir=/path/to/git-dir', '--', repository_url,
+                       directory).and_return(command_result)
+
+        command.call(repository_url, directory, separate_git_dir: '/path/to/git-dir')
+      end
+    end
+
+    context 'with :server_option option' do
+      it 'includes a single --server-option=<opt>' do
+        expect_command('clone', '--server-option=version=2', '--', repository_url,
+                       directory).and_return(command_result)
+
+        command.call(repository_url, directory, server_option: 'version=2')
+      end
+
+      it 'includes multiple --server-option flags' do
+        expect_command('clone', '--server-option=version=2', '--server-option=key=val',
+                       '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, server_option: %w[version=2 key=val])
+      end
+    end
+
+    context 'with :shallow_since option' do
+      it 'includes --shallow-since=<date>' do
+        expect_command('clone', '--shallow-since=2020-01-01', '--', repository_url,
+                       directory).and_return(command_result)
+
+        command.call(repository_url, directory, shallow_since: '2020-01-01')
+      end
+    end
+
+    context 'with :shallow_exclude option' do
+      it 'includes a single --shallow-exclude=<ref>' do
+        expect_command('clone', '--shallow-exclude=v1.0', '--', repository_url,
+                       directory).and_return(command_result)
+
+        command.call(repository_url, directory, shallow_exclude: 'v1.0')
+      end
+
+      it 'includes multiple --shallow-exclude flags' do
+        expect_command('clone', '--shallow-exclude=v1.0', '--shallow-exclude=v2.0',
+                       '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, shallow_exclude: %w[v1.0 v2.0])
+      end
+    end
+
+    context 'with :tags option' do
+      it 'includes --tags when true' do
+        expect_command('clone', '--tags', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, tags: true)
+      end
+
+      it 'includes --no-tags when false' do
+        expect_command('clone', '--no-tags', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, tags: false)
+      end
+    end
+
+    context 'with :shallow_submodules option' do
+      it 'includes --shallow-submodules when true' do
+        expect_command('clone', '--shallow-submodules', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, shallow_submodules: true)
+      end
+
+      it 'includes --no-shallow-submodules when false' do
+        expect_command('clone', '--no-shallow-submodules', '--', repository_url,
+                       directory).and_return(command_result)
+
+        command.call(repository_url, directory, shallow_submodules: false)
+      end
+    end
+
+    context 'with :remote_submodules option' do
+      it 'includes --remote-submodules when true' do
+        expect_command('clone', '--remote-submodules', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, remote_submodules: true)
+      end
+
+      it 'includes --no-remote-submodules when false' do
+        expect_command('clone', '--no-remote-submodules', '--', repository_url,
+                       directory).and_return(command_result)
+
+        command.call(repository_url, directory, remote_submodules: false)
+      end
+    end
+
+    context 'with :jobs option' do
+      it 'includes --jobs <n>' do
+        expect_command('clone', '--jobs', '4', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, jobs: 4)
+      end
+
+      it 'accepts the :j alias' do
+        expect_command('clone', '--jobs', '4', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, j: 4)
+      end
+    end
+
+    context 'with :sparse option' do
+      it 'includes --sparse flag' do
+        expect_command('clone', '--sparse', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, sparse: true)
+      end
+    end
+
+    context 'with :reject_shallow option' do
+      it 'includes --reject-shallow when true' do
+        expect_command('clone', '--reject-shallow', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, reject_shallow: true)
+      end
+
+      it 'includes --no-reject-shallow when false' do
+        expect_command('clone', '--no-reject-shallow', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, reject_shallow: false)
+      end
+    end
+
+    context 'with :also_filter_submodules option' do
+      it 'includes --also-filter-submodules alongside --filter and --recurse-submodules' do
+        expect_command('clone', '--recurse-submodules', '--filter=blob:none', '--also-filter-submodules',
+                       '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, filter: 'blob:none', recurse_submodules: true,
+                                                also_filter_submodules: true)
+      end
+    end
+
+    context 'with :bundle_uri option' do
+      it 'includes --bundle-uri=<uri>' do
+        expect_command('clone', '--bundle-uri=https://example.com/bundle', '--', repository_url,
+                       directory).and_return(command_result)
+
+        command.call(repository_url, directory, bundle_uri: 'https://example.com/bundle')
+      end
+    end
+
+    context 'with :ref_format option' do
+      it 'includes --ref-format=<fmt>' do
+        expect_command('clone', '--ref-format=reftable', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, ref_format: 'reftable')
+      end
+
+      it 'rejects invalid ref_format values' do
+        expect do
+          command.call(repository_url, directory, ref_format: 'invalid')
+        end.to raise_error(ArgumentError, /Invalid value for :ref_format/)
+      end
+    end
+
+    context 'with :revision option' do
+      it 'includes --revision=<rev>' do
+        expect_command('clone', '--revision=refs/heads/main', '--', repository_url,
+                       directory).and_return(command_result)
+
+        command.call(repository_url, directory, revision: 'refs/heads/main')
+      end
+    end
+
+    context 'with constraint violations' do
+      it 'raises ArgumentError when :also_filter_submodules is given without :filter' do
+        expect { command.call(repository_url, directory, recurse_submodules: true, also_filter_submodules: true) }
+          .to raise_error(ArgumentError, /:also_filter_submodules requires :filter/)
+      end
+
+      it 'raises ArgumentError when :also_filter_submodules is given without :recurse_submodules' do
+        expect do
+          command.call(repository_url, directory, filter: 'blob:none', also_filter_submodules: true)
+        end.to raise_error(ArgumentError, /:also_filter_submodules requires :recurse_submodules/)
+      end
+
+      it 'raises ArgumentError when :revision and :branch are both given' do
+        expect do
+          command.call(repository_url, directory, revision: 'refs/heads/main', branch: 'main')
+        end.to raise_error(ArgumentError, /:revision.*:branch|:branch.*:revision/)
+      end
+
+      it 'raises ArgumentError when :revision and :mirror are both given' do
+        expect do
+          command.call(repository_url, directory, revision: 'refs/heads/main', mirror: true)
+        end.to raise_error(ArgumentError, /:revision.*:mirror|:mirror.*:revision/)
+      end
+
+      it 'raises ArgumentError when :bundle_uri and :depth are both given' do
+        expect do
+          command.call(repository_url, directory, bundle_uri: 'https://example.com/bundle', depth: 1)
+        end.to raise_error(ArgumentError, /:bundle_uri.*:depth|:depth.*:bundle_uri/)
+      end
+
+      it 'raises ArgumentError when :bundle_uri and :shallow_since are both given' do
+        expect do
+          command.call(repository_url, directory, bundle_uri: 'https://example.com/bundle',
+                                                  shallow_since: '2020-01-01')
+        end.to raise_error(ArgumentError, /:bundle_uri.*:shallow_since|:shallow_since.*:bundle_uri/)
+      end
+
+      it 'raises ArgumentError when :bundle_uri and :shallow_exclude are both given' do
+        expect do
+          command.call(repository_url, directory, bundle_uri: 'https://example.com/bundle',
+                                                  shallow_exclude: 'v1.0')
+        end.to raise_error(ArgumentError, /:bundle_uri.*:shallow_exclude|:shallow_exclude.*:bundle_uri/)
+      end
+    end
+
     context 'input validation' do
-      it 'raises ArgumentError for invalid single_branch values' do
+      it 'raises ArgumentError for non-boolean single_branch values' do
         expect { command.call(repository_url, directory, single_branch: 'yes') }
-          .to raise_error(ArgumentError, /Invalid value for option/)
+          .to raise_error(ArgumentError, /negatable_flag expects a boolean value/)
       end
     end
   end


### PR DESCRIPTION
## Summary

Comprehensive audit and fix of the `git clone` arguments DSL against the
[git-scm.com documentation](https://git-scm.com/docs/git-clone).

### `lib/git/commands/clone.rb`

**Added missing options:**
- `:template` (`--template=<dir>`, inline)
- `:local` / `:l` — negatable (`--local` / `--no-local`)
- `:shared` / `:s`
- `:no_hardlinks`
- `:no_checkout` / `:n`
- `:revision` (`--revision=<rev>`, inline)
- `:upload_pack` / `:u`
- `:reference` — repeatable
- `:reference_if_able` — repeatable
- `:separate_git_dir` (`--separate-git-dir=<dir>`, inline)
- `:server_option` — inline, repeatable
- `:shallow_since` — inline
- `:shallow_exclude` — inline, repeatable
- `:tags` — negatable (`--tags` / `--no-tags`)
- `:shallow_submodules` — negatable
- `:remote_submodules` — negatable
- `:reject_shallow` — negatable
- `:config` / `:c` — repeatable
- `:bundle_uri` — inline
- `:ref_format` — inline

**Changed existing options:**
- `:single_branch` — added `negatable: true` (`--no-single-branch` was missing)
- `:recurse_submodules` — changed from `flag_option` to `flag_or_value_option` with `inline: true, repeatable: true` (supports `--recurse-submodules[=<pathspec>]`, repeatable)

**Added constraints:**
- `conflicts :revision, :branch`
- `conflicts :revision, :mirror`
- `conflicts :bundle_uri, :depth`
- `conflicts :bundle_uri, :shallow_since`
- `conflicts :bundle_uri, :shallow_exclude`
- `requires :filter, when: :also_filter_submodules`
- `requires :recurse_submodules, when: :also_filter_submodules`
- `allowed_values :ref_format, in: %w[files reftable]`

**Added full YARD `@option` documentation** for all 27 options.

### `lib/git/commands/arguments.rb`

- Extended `flag_or_value_option` to accept a `repeatable:` parameter, with
  array iteration support in all four flag-or-value builder variants
- Added `@param repeatable` and a `@example` showing repeatable inline usage to
  the `flag_or_value_option` YARD docs

### `spec/unit/git/commands/clone_spec.rb`

Added 64 examples covering:
- Every option and its CLI output
- Every alias (`:l`, `:s`, `:n`, `:o`, `:b`, `:u`, `:j`, `:c`)
- Repeatable options with single value, array value, and nil
- Negatable flags (`true` / `false` / `nil`)
- All constraint violations (conflicts + requires + allowed_values)
- Non-boolean input validation

### `.rubocop.yml`

Excluded `lib/git/commands/*.rb` from `Metrics/BlockLength` — the large `arguments do` blocks in command files legitimately exceed the default limit.
