### PR TITLE
fix: address clone command test review issues

### DIFF
--- a/spec/integration/git/commands/clone_spec.rb
+++ b/spec/integration/git/commands/clone_spec.rb
@@ -51,7 +51,8 @@ RSpec.describe Git::Commands::Clone, :integration do
 
     describe 'when the command fails' do
       it 'raises FailedError with a nonexistent source' do
-        expect { command.call('/nonexistent/repo', File.join(clone_dir, 'cloned')) }.to raise_error(Git::FailedError)
+        nonexistent = File.join(clone_dir, 'nonexistent_source')
+        expect { command.call(nonexistent, File.join(clone_dir, 'cloned')) }.to raise_error(Git::FailedError)
       end
     end
   end


### PR DESCRIPTION
## Summary

Fixes issues found during a review of the `Git::Commands::Clone` unit and integration tests against the [Review Command Tests](prompts/Review%20Command%20Tests.md) prompt conventions.

## Unit test changes (`spec/unit/git/commands/clone_spec.rb`)

- **Merge validation contexts**: Combined the separate `context 'with constraint violations'` and `context 'input validation'` blocks into a single `context 'input validation'` at the end of `#call`, matching the prompt's three-section structure (argument building → exit code handling → input validation)
- **Relocate ref_format validation test**: Moved the `ref_format: 'invalid'` test from the argument building section into the input validation section where it belongs
- **Add unsupported options test**: Verifies `invalid_option: true` raises `ArgumentError` with `/Unsupported options/`
- **Add missing required operand test**: Verifies `command.call` with no arguments raises `ArgumentError` for the required `repository` operand
- **Add `:b` alias test**: Tests the `:b` alias for the `:branch` option (`:o` was already tested but `:b` was missing)
- **Add `:c` alias test**: Tests the `:c` alias for the `:config` option

## Integration test changes (`spec/integration/git/commands/clone_spec.rb`)

- **Fix non-portable path**: Replace hard-coded `/nonexistent/repo` with `File.join(clone_dir, 'nonexistent_source')` for cross-platform compatibility

## Test results

All 72 tests pass (4 new tests added, up from 68).