### PR TITLE
fix(tests): use FileUtils.rm_rf in git_teardown to avoid ENOTEMPTY errors

### DIFF
--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -45,7 +45,11 @@ module Test
 
       teardown
       def git_teardown
-        FileUtils.rm_r(@tmp_path) if instance_variable_defined?(:@tmp_path)
+        # Use rm_rf (force) to silently ignore ENOTEMPTY errors that can occur on
+        # macOS/Windows when an OS daemon (e.g. Spotlight) has a brief lock on a file
+        # in the temp directory during cleanup. This mirrors the same defensive pattern
+        # used in in_temp_dir below.
+        FileUtils.rm_rf(@tmp_path) if instance_variable_defined?(:@tmp_path)
       end
 
       def in_bare_repo_clone


### PR DESCRIPTION
## Summary

Switches `FileUtils.rm_r` to `FileUtils.rm_rf` in the `git_teardown` helper in `tests/test_helper.rb`.

## Problem

On macOS and Windows, OS daemons such as Spotlight can briefly hold a lock on files inside temp directories created during tests. When teardown runs while such a lock is active, `rm_r` raises an `ENOTEMPTY` error, causing intermittent test failures that are unrelated to the code under test.

## Solution

Use `rm_rf` (force), which silently ignores such transient errors. This matches the defensive pattern already used in the `in_temp_dir` helper in the same file.

## Changes

- `tests/test_helper.rb` — replace `FileUtils.rm_r` with `FileUtils.rm_rf` in `git_teardown`, with an explanatory comment
