### PR TITLE
docs(skills): enforce command test and YARD doc review in VERIFY and PR readiness

### DIFF
--- a/.github/skills/development-workflow/SKILL.md
+++ b/.github/skills/development-workflow/SKILL.md
@@ -258,6 +258,15 @@ moving to the next task.
 - **Run Linters:** Run `bundle exec rubocop` and `bundle exec rake yard` to verify
   code style and documentation standards.
 - **Check Code Quality:** Confirm the code is clean and well-factored.
+- **Audit Command Tests (command tasks only):** If this task added or modified tests
+  for any `Git::Commands::*` class, apply the
+  [Review Command Tests](../review-command-tests/SKILL.md) skill to every new or
+  changed spec file before committing. Fix any violations found before moving to the
+  COMMIT step.
+- **Audit Command YARD Docs (command tasks only):** If this task added or modified
+  any `Git::Commands::*` source file, apply the
+  [Review Command YARD Documentation](../review-command-yard-documentation/SKILL.md)
+  skill to each changed source file. Fix any documentation gaps before committing.
 - **STOP on Unexpected Failure:** If any test unexpectedly fails during VERIFY, STOP
   immediately and report the failure to the user. Do not attempt to fix the failure
   without first explaining what went wrong and getting confirmation to proceed.
@@ -336,6 +345,21 @@ commit and complete the feature or bug fix.
      `git commit` command needs to be re-run.
    - If the commit fails 3 times, STOP and report the issue to the user with the
      exact error message.
+9. **Create the Pull Request:** Push the branch and open the PR. **CRITICAL:** The
+   terminal tool mangles multi-line markdown (backticks, asterisks, newlines) in any
+   shell command — including heredocs and inline `--body "..."` arguments. Always
+   write the PR body using the **`create_file` tool** (not the terminal), then
+   reference that file:
+   - Use `create_file` to write the body to `./pr_body.md` (repo-relative path,
+     works on all platforms)
+   - Then run in the terminal: `git push origin <branch>`
+   - Then run in the terminal: `gh pr create --title "<title>" --base <target-branch> --body-file ./pr_body.md`
+     (choose `main` or `4.x` per the [branch strategy](/CONTRIBUTING.md))
+
+   After creating the PR, verify the stored body with
+   `gh pr view <number> --json body --jq '.body'`. If it is garbled, rewrite
+   `./pr_body.md` with `create_file` and fix with
+   `gh pr edit <number> --body-file ./pr_body.md`.
 
 
 ### Per-Task Commits

--- a/.github/skills/pr-readiness-review/SKILL.md
+++ b/.github/skills/pr-readiness-review/SKILL.md
@@ -59,11 +59,20 @@ Execute and report results for:
 - [ ] No redundancy - don't duplicate what unit tests already cover
 - [ ] Follow CONTRIBUTING.md guidelines: test gem's interaction with git, not git itself
 
+**Command Tests (if any `Git::Commands::*` specs are included):**
+- [ ] Apply the [Review Command Tests](../review-command-tests/SKILL.md) skill to
+  every new or modified unit and integration spec file for command classes. Resolve
+  all findings before proceeding.
+
 ## 3. Review Code Quality
 
 - [ ] YARD documentation complete for all public methods/classes
 - [ ] Include `@api public` or `@api private` tags appropriately
 - [ ] Usage examples in YARD docs show common patterns
+- [ ] **Command YARD Docs (if any `Git::Commands::*` source files are included):**
+  Apply the [Review Command YARD Documentation](../review-command-yard-documentation/SKILL.md)
+  skill to every new or modified command source file. Resolve all findings before
+  proceeding.
 - [ ] No breaking changes (or properly marked with `!` in commits)
 - [ ] Cross-platform compatible on all supported OSes; any platform-specific logic is properly guarded and tested
 - [ ] No security issues (command injection, path traversal, etc.)
@@ -142,12 +151,16 @@ Provide a comprehensive report with:
   - Checklist from .github/pull_request_template.md
 
 **PR Body Editing Safety:**
-- Prefer file-based updates for non-trivial markdown bodies:
+- The terminal tool mangles multi-line markdown (backticks, asterisks, newlines) in
+  any shell command, including heredocs. Always write the PR body using the
+  **`create_file` tool** (the VS Code Copilot agent tool that writes file content
+  directly, bypassing the terminal entirely), then reference the file:
   - `gh pr create --body-file <path>` when opening
   - `gh pr edit <number> --body-file <path>` when updating
-- Avoid long inline `--body "..."` strings for multiline markdown
+- **Never** use inline `--body "..."` or `cat > file << 'EOF'` heredocs for PR bodies
 - After any body update, verify the stored text with:
-  - `gh pr view <number> --json body`
+  - `gh pr view <number> --json body --jq '.body'`
+- If the body is garbled, rewrite the file with `create_file` and re-run `gh pr edit`
 
 **Next Steps:**
 - Any remaining items to address before PR submission


### PR DESCRIPTION
## Summary

Closes three gaps in the skills that allowed convention violations and PR body corruption to slip through undetected during autonomous coding sessions.

## Problem

1. The `development-workflow` VERIFY step had no explicit instruction to audit command tests or YARD docs against the `review-command-tests` and `review-command-yard-documentation` skills, so those reviews were skipped.

2. The `pr-readiness-review` checklist had no explicit prompts to run those command-specific review skills before opening a PR.

3. Both skills mentioned using `--body-file` for PR bodies but neither specified that the body file must be written with the **`create_file` tool**. Terminal heredocs (`cat > file << 'EOF'`) are mangled by the terminal tool just as much as inline `--body "..."` strings.

## Changes

### `.github/skills/development-workflow/SKILL.md`

- **VERIFY step** — added two new audit bullets after "Check Code Quality":
  - *Audit Command Tests* — load `review-command-tests` and run it against any `Git::Commands::*` specs touched in this task
  - *Audit Command YARD Docs* — load `review-command-yard-documentation` and run it against any `Git::Commands::*` source files touched in this task
- **FINALIZE step 9** — added explicit PR creation guidance: use the `create_file` tool (not a terminal heredoc) to write the body to `./pr_body.md` (cross-platform repo-relative path), use `--base <target-branch>` (not hardcoded `main`, to support both `main` and `4.x`), then use `gh pr create --body-file`; verify with `gh pr view <number> --json body --jq '.body'`

### `.github/skills/pr-readiness-review/SKILL.md`

- **Section 2 (Test Quality)** — added checklist item: run `review-command-tests` skill against every `Git::Commands::*` spec changed in this PR
- **Section 3 (Code Quality)** — added checklist item: run `review-command-yard-documentation` skill against every `Git::Commands::*` source file changed in this PR
- **Section 8 (PR Body Safety)** — strengthened to explicitly ban terminal heredocs and require `create_file` tool for writing PR body files

## Testing

These are documentation/skill changes only. No automated tests exist for skill content.
