### PR TITLE
refactor: rename capturing entry points to prepare for streaming API

### DIFF
--- a/lib/git/command_line.rb
+++ b/lib/git/command_line.rb
@@ -19,7 +19,7 @@ module Git
     #   global_opts = %w[--git-dir /path/to/git/dir]
     #   logger = Logger.new(STDOUT)
     #   cli = CommandLine.new(env, binary_path, global_opts, logger)
-    #   cli.run('version') #=> #<Git::CommandLineResult:0x00007f9b0c0b0e00
+    #   cli.run_with_capture('version') #=> #<Git::CommandLineResult:0x00007f9b0c0b0e00
     #
     # @param env [Hash<String, String>] environment variables to set
     # @param global_opts [Array<String>] global options to pass to git
@@ -111,28 +111,31 @@ module Git
     # UTF-8 string. It uses the `rchardet` gem to detect the encoding of the binary
     # output and then converts it to UTF-8.
     #
-    # Normalization is not enabled by default. Pass `normalize: true` to Git::CommandLine#run
-    # to enable it. Normalization will only be performed on stdout and only if the `out:`` option
+    # Normalization is not enabled by default. Pass `normalize: true` to Git::CommandLine#run_with_capture
+    # to enable it. Normalization will only be performed on stdout and only if the `out:` option
     # is nil or is a StringIO object. If the out: option is set to a file or other IO object,
     # the normalize option will be ignored.
     #
     # @example Run a command and return the output
-    #   cli.run('version') #=> "git version 2.39.1\n"
+    #   result = cli.run_with_capture('version')
+    #   result.stdout #=> "git version 2.39.1\n"
     #
     # @example The args array should be splatted into the parameter list
     #   args = %w[log -n 1 --oneline]
-    #   cli.run(*args) #=> "f5baa11 beginning of Ruby/Git project\n"
+    #   result = cli.run_with_capture(*args)
+    #   result.stdout #=> "f5baa11 beginning of Ruby/Git project\n"
     #
     # @example Run a command and return the chomped output
-    #   cli.run('version', chomp: true) #=> "git version 2.39.1"
+    #   result = cli.run_with_capture('version', chomp: true)
+    #   result.stdout #=> "git version 2.39.1"
     #
     # @example Run a command and without normalizing the output
-    #   cli.run('version', normalize: false) #=> "git version 2.39.1\n"
+    #   cli.run_with_capture('version', normalize: false) #=> "git version 2.39.1\n"
     #
     # @example Capture stdout in a temporary file
     #   require 'tempfile'
     #   tempfile = Tempfile.create('git') do |file|
-    #     cli.run('version', out: file)
+    #     cli.run_with_capture('version', out: file)
     #     file.rewind
     #     file.read #=> "git version 2.39.1\n"
     #   end
@@ -141,7 +144,7 @@ module Git
     #   require 'stringio'
     #   stderr = StringIO.new
     #   begin
-    #     cli.run('log', 'nonexistent-branch', err: stderr)
+    #     cli.run_with_capture('log', 'nonexistent-branch', err: stderr)
     #   rescue Git::FailedError => e
     #     stderr.string #=> "unknown revision or path not in the working tree.\n"
     #   end
@@ -206,37 +209,14 @@ module Git
     #
     # @raise [Git::TimeoutError] if the command times out
     #
-    def run(*, **options_hash)
+    def run_with_capture(*, **options_hash)
       options_hash = RUN_ARGS.merge(options_hash)
       extra_options = options_hash.keys - RUN_ARGS.keys
       raise ArgumentError, "Unknown options: #{extra_options.join(', ')}" if extra_options.any?
 
-      result = run_with_capture(*, **options_hash)
+      result = execute_with_capture(*, **options_hash)
       process_result(result, options_hash[:normalize], options_hash[:chomp], options_hash[:timeout],
                      options_hash[:raise_on_failure])
-    end
-
-    # @return [Git::CommandLineResult] the result of running the command
-    #
-    # @api private
-    #
-    def run_with_capture(*args, **options_hash)
-      git_cmd = build_git_cmd(args)
-      options = run_with_capture_options(**options_hash)
-      merged_env = env.merge(options_hash[:env] || {})
-      ProcessExecuter.run_with_capture(merged_env, *git_cmd, **options)
-    rescue ProcessExecuter::ProcessIOError => e
-      raise Git::ProcessIOError.new(e.message), cause: e.exception.cause
-    end
-
-    def run_with_capture_options(**options_hash)
-      chdir = options_hash[:chdir] || :not_set
-      timeout_after = options_hash[:timeout]
-      merge_output = options_hash[:merge] || false
-
-      { chdir:, timeout_after:, merge_output:, raise_errors: false }.tap do |options|
-        redirect_options(options_hash).each { |k, v| options[k] = v }
-      end
     end
 
     RUN_ARGS = {
@@ -253,6 +233,26 @@ module Git
     }.freeze
 
     private
+
+    # @return [Git::CommandLineResult] the result of running the command
+    def execute_with_capture(*args, **options_hash)
+      git_cmd = build_git_cmd(args)
+      options = execute_with_capture_options(**options_hash)
+      merged_env = env.merge(options_hash[:env] || {})
+      ProcessExecuter.run_with_capture(merged_env, *git_cmd, **options)
+    rescue ProcessExecuter::ProcessIOError => e
+      raise Git::ProcessIOError.new(e.message), cause: e.exception.cause
+    end
+
+    def execute_with_capture_options(**options_hash)
+      chdir = options_hash[:chdir] || :not_set
+      timeout_after = options_hash[:timeout]
+      merge_output = options_hash[:merge] || false
+
+      { chdir:, timeout_after:, merge_output:, raise_errors: false }.tap do |options|
+        redirect_options(options_hash).each { |k, v| options[k] = v }
+      end
+    end
 
     def redirect_options(options_hash)
       %i[in out err].filter_map do |key|

--- a/lib/git/commands/arguments.rb
+++ b/lib/git/commands/arguments.rb
@@ -1620,7 +1620,7 @@ module Git
       #
       # @example Simple splatting (same behavior as build)
       #   def call(*, **)
-      #     @execution_context.command(*ARGS.bind(*, **))
+      #     @execution_context.command_with_capture(*ARGS.bind(*, **))
       #   end
       #
       # @example Inspecting options before command execution

--- a/lib/git/commands/base.rb
+++ b/lib/git/commands/base.rb
@@ -89,7 +89,7 @@ module Git
         end
       end
 
-      # @param execution_context [Git::ExecutionContext, Git::Lib] context that provides {Git::Lib#command}
+      # @param execution_context [Git::ExecutionContext, Git::Lib] context that provides {Git::Lib#command_with_capture}
       def initialize(execution_context)
         @execution_context = execution_context
       end
@@ -102,7 +102,7 @@ module Git
       #   Execution options (declared via `execution_option` in the Arguments
       #   DSL) are extracted from the bound arguments via
       #   {Git::Commands::Arguments::Bound#execution_options} and forwarded as
-      #   keyword arguments to `@execution_context.command`.
+      #   keyword arguments to `@execution_context.command_with_capture`.
       #
       #   @example
       #     # In a command subclass:
@@ -120,7 +120,7 @@ module Git
       def call(*, **)
         args = args_definition.bind(*, **)
 
-        result = @execution_context.command(*args, **args.execution_options, raise_on_failure: false)
+        result = @execution_context.command_with_capture(*args, **args.execution_options, raise_on_failure: false)
         validate_exit_status!(result)
         result
       end
@@ -144,7 +144,7 @@ module Git
       # the read end. The write and close happen concurrently with the block.
       #
       # The read end can be passed as the `in:` keyword to
-      # {Git::Lib#command} / {Git::CommandLine#run}, connecting it directly to
+      # {Git::Lib#command_with_capture} / {Git::CommandLine#run_with_capture}, connecting it directly to
       # the spawned git process's stdin without an intermediate file or shell
       # heredoc. This is required because `Process.spawn` only accepts real IO
       # objects with a file descriptor — `StringIO` does not work.
@@ -160,7 +160,7 @@ module Git
       #   bound = args_definition.bind(*, **)
       #   stdin_content = Array(bound.objects).map { |object| "#{object}\n" }.join
       #   with_stdin(stdin_content) do |reader|
-      #     @execution_context.command('cat-file', '--batch-check', in: reader, raise_on_failure: false)
+      #     @execution_context.command_with_capture('cat-file', '--batch-check', in: reader, raise_on_failure: false)
       #   end
       #
       # @param content [String] text to write to the process's stdin

--- a/lib/git/commands/cat_file/full.rb
+++ b/lib/git/commands/cat_file/full.rb
@@ -134,7 +134,7 @@ module Git
         # @return [Git::CommandLineResult]
         #
         def run_batch(bound, reader)
-          result = @execution_context.command(
+          result = @execution_context.command_with_capture(
             *bound,
             in: reader,
             **bound.execution_options,

--- a/lib/git/commands/cat_file/meta.rb
+++ b/lib/git/commands/cat_file/meta.rb
@@ -126,7 +126,7 @@ module Git
         # @return [Git::CommandLineResult]
         #
         def run_batch(bound, reader)
-          result = @execution_context.command(
+          result = @execution_context.command_with_capture(
             *bound, in: reader, **bound.execution_options, raise_on_failure: false
           )
           validate_exit_status!(result)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -203,7 +203,7 @@ module Git
     # @return [String] the name of the default branch
     #
     def repository_default_branch(repository)
-      output = command('ls-remote', '--symref', '--', repository, 'HEAD').stdout
+      output = command_with_capture('ls-remote', '--symref', '--', repository, 'HEAD').stdout
 
       match_data = output.match(%r{^ref: refs/remotes/origin/(?<default_branch>[^\t]+)\trefs/remotes/origin/HEAD$})
       return match_data[:default_branch] if match_data
@@ -269,7 +269,7 @@ module Git
       args = build_args(opts, DESCRIBE_OPTION_MAP)
       args << commit_ish if commit_ish
 
-      command('describe', *args).stdout
+      command_with_capture('describe', *args).stdout
     end
 
     # Return the commits that are within the given revision range
@@ -310,7 +310,7 @@ module Git
 
       arr_opts += log_path_options(opts)
 
-      command('log', *arr_opts).stdout.split("\n").map { |l| l.split.first }
+      command_with_capture('log', *arr_opts).stdout.split("\n").map { |l| l.split.first }
     end
 
     FULL_LOG_EXTRA_OPTIONS_MAP = [
@@ -381,7 +381,7 @@ module Git
       args += build_args(opts, FULL_LOG_EXTRA_OPTIONS_MAP)
       args += log_path_options(opts)
 
-      full_log = command('log', *args).stdout.split("\n")
+      full_log = command_with_capture('log', *args).stdout.split("\n")
       process_commit_log_data(full_log)
     end
 
@@ -406,7 +406,7 @@ module Git
     def rev_parse(revision)
       assert_args_are_not_options('rev', revision)
 
-      command('rev-parse', '--revs-only', '--end-of-options', revision, '--').stdout
+      command_with_capture('rev-parse', '--revs-only', '--end-of-options', revision, '--').stdout
     end
 
     # For backwards compatibility with the old method name
@@ -423,7 +423,7 @@ module Git
     def name_rev(commit_ish)
       assert_args_are_not_options('commit_ish', commit_ish)
 
-      command('name-rev', commit_ish).stdout.split[1]
+      command_with_capture('name-rev', commit_ish).stdout.split[1]
     end
 
     alias namerev name_rev
@@ -724,7 +724,7 @@ module Git
       args.unshift(sha)
       args << opts[:path] if opts[:path]
 
-      command('ls-tree', *args).stdout.split("\n").each do |line|
+      command_with_capture('ls-tree', *args).stdout.split("\n").each do |line|
         (info, filenm) = split_status_line(line)
         (mode, type, sha) = info.split
         data[type][filenm] = { mode: mode, sha: sha }
@@ -740,7 +740,7 @@ module Git
     end
 
     def full_tree(sha)
-      command('ls-tree', '-r', sha).stdout.split("\n")
+      command_with_capture('ls-tree', '-r', sha).stdout.split("\n")
     end
 
     def tree_depth(sha)
@@ -748,7 +748,7 @@ module Git
     end
 
     def change_head_branch(branch_name)
-      command('symbolic-ref', 'HEAD', "refs/heads/#{branch_name}")
+      command_with_capture('symbolic-ref', 'HEAD', "refs/heads/#{branch_name}")
     end
 
     def branches_all
@@ -768,7 +768,7 @@ module Git
       # HEAD b8c63206f8d10f57892060375a86ae911fad356e
       # detached
       #
-      command('worktree', 'list', '--porcelain').stdout.split("\n").each do |w|
+      command_with_capture('worktree', 'list', '--porcelain').stdout.split("\n").each do |w|
         s = w.split
         directory = s[1] if s[0] == 'worktree'
         arr << [directory, s[1]] if s[0] == 'HEAD'
@@ -782,17 +782,17 @@ module Git
     WORKTREE_ENV = { 'GIT_INDEX_FILE' => nil }.freeze
 
     def worktree_add(dir, commitish = nil)
-      return command('worktree', 'add', dir, commitish, env: WORKTREE_ENV).stdout unless commitish.nil?
+      return command_with_capture('worktree', 'add', dir, commitish, env: WORKTREE_ENV).stdout unless commitish.nil?
 
-      command('worktree', 'add', dir, env: WORKTREE_ENV).stdout
+      command_with_capture('worktree', 'add', dir, env: WORKTREE_ENV).stdout
     end
 
     def worktree_remove(dir)
-      command('worktree', 'remove', dir, env: WORKTREE_ENV).stdout
+      command_with_capture('worktree', 'remove', dir, env: WORKTREE_ENV).stdout
     end
 
     def worktree_prune
-      command('worktree', 'prune', env: WORKTREE_ENV).stdout
+      command_with_capture('worktree', 'prune', env: WORKTREE_ENV).stdout
     end
 
     def list_files(ref_dir)
@@ -1076,7 +1076,7 @@ module Git
     def ls_files(location = nil)
       location ||= '.'
       {}.tap do |files|
-        command('ls-files', '--stage', location).stdout.split("\n").each do |line|
+        command_with_capture('ls-files', '--stage', location).stdout.split("\n").each do |line|
           (info, file) = split_status_line(line)
           (mode, sha, stage) = info.split
           files[file] = {
@@ -1119,18 +1119,19 @@ module Git
       flags = build_args(opts, LS_REMOTE_OPTION_MAP)
       positional_arg = location || '.'
 
-      output_lines = command('ls-remote', *flags, positional_arg).stdout.split("\n")
+      output_lines = command_with_capture('ls-remote', *flags, positional_arg).stdout.split("\n")
       parse_ls_remote_output(output_lines)
     end
 
     def ignored_files
-      command('ls-files', '--others', '-i', '--exclude-standard').stdout.split("\n").map do |f|
+      command_with_capture('ls-files', '--others', '-i', '--exclude-standard').stdout.split("\n").map do |f|
         unescape_quoted_path(f)
       end
     end
 
     def untracked_files
-      command('ls-files', '--others', '--exclude-standard', chdir: @git_work_dir).stdout.split("\n").map do |f|
+      command_with_capture('ls-files', '--others', '--exclude-standard',
+                           chdir: @git_work_dir).stdout.split("\n").map do |f|
         unescape_quoted_path(f)
       end
     end
@@ -1144,19 +1145,19 @@ module Git
     end
 
     def config_get(name)
-      command('config', '--get', name, chdir: @git_dir).stdout
+      command_with_capture('config', '--get', name, chdir: @git_dir).stdout
     end
 
     def global_config_get(name)
-      command('config', '--global', '--get', name).stdout
+      command_with_capture('config', '--global', '--get', name).stdout
     end
 
     def config_list
-      parse_config_list command('config', '--list', chdir: @git_dir).stdout.split("\n")
+      parse_config_list command_with_capture('config', '--list', chdir: @git_dir).stdout.split("\n")
     end
 
     def global_config_list
-      parse_config_list command('config', '--global', '--list').stdout.split("\n")
+      parse_config_list command_with_capture('config', '--global', '--list').stdout.split("\n")
     end
 
     def parse_config_list(lines)
@@ -1169,7 +1170,7 @@ module Git
     end
 
     def parse_config(file)
-      parse_config_list command('config', '--list', '--file', file).stdout.split("\n")
+      parse_config_list command_with_capture('config', '--list', '--file', file).stdout.split("\n")
     end
 
     # Shows objects
@@ -1182,7 +1183,7 @@ module Git
 
       arr_opts << (path ? "#{objectish}:#{path}" : objectish)
 
-      command('show', *arr_opts.compact, chomp: false).stdout
+      command_with_capture('show', *arr_opts.compact, chomp: false).stdout
     end
 
     ## WRITE COMMANDS ##
@@ -1194,11 +1195,11 @@ module Git
     def config_set(name, value, options = {})
       ArgsBuilder.validate!(options, CONFIG_SET_OPTION_MAP)
       flags = build_args(options, CONFIG_SET_OPTION_MAP)
-      command('config', *flags, name, value)
+      command_with_capture('config', *flags, name, value)
     end
 
     def global_config_set(name, value)
-      command('config', '--global', name, value)
+      command_with_capture('config', '--global', name, value)
     end
 
     # Update the index from the current worktree to prepare the for the next commit
@@ -1240,7 +1241,7 @@ module Git
     # @return [Boolean]
     #
     def empty?
-      command('rev-parse', '--verify', 'HEAD')
+      command_with_capture('rev-parse', '--verify', 'HEAD')
       false
     rescue Git::FailedError => e
       raise unless e.result.status.exitstatus == 128 &&
@@ -1312,19 +1313,19 @@ module Git
       args = build_args(opts, REVERT_OPTION_MAP)
       args << commitish
 
-      command('revert', *args)
+      command_with_capture('revert', *args)
     end
 
     def apply(patch_file)
       arr_opts = []
       arr_opts << '--' << patch_file if patch_file
-      command('apply', *arr_opts)
+      command_with_capture('apply', *arr_opts)
     end
 
     def apply_mail(patch_file)
       arr_opts = []
       arr_opts << '--' << patch_file if patch_file
-      command('am', *arr_opts)
+      command_with_capture('am', *arr_opts)
     end
 
     # Returns all stash entries as an array of index and message pairs
@@ -1556,7 +1557,7 @@ module Git
 
     def unmerged
       unmerged = []
-      command('diff', '--cached').stdout.split("\n").each do |line|
+      command_with_capture('diff', '--cached').stdout.split("\n").each do |line|
         unmerged << ::Regexp.last_match(1) if line =~ /^\* Unmerged path (.*)/
       end
       unmerged
@@ -1587,7 +1588,7 @@ module Git
       positional_args = ['--', name, url]
       command_args = ['add'] + flags + positional_args
 
-      command('remote', *command_args)
+      command_with_capture('remote', *command_args)
     end
 
     REMOTE_SET_BRANCHES_OPTION_MAP = [
@@ -1601,7 +1602,7 @@ module Git
       branch_args = Array(branches).flatten
       command_args = ['set-branches'] + flags + [name] + branch_args
 
-      command('remote', *command_args)
+      command_with_capture('remote', *command_args)
     end
 
     def remote_set_url(name, url)
@@ -1609,15 +1610,15 @@ module Git
       arr_opts << name
       arr_opts << url
 
-      command('remote', *arr_opts)
+      command_with_capture('remote', *arr_opts)
     end
 
     def remote_remove(name)
-      command('remote', 'rm', name)
+      command_with_capture('remote', 'rm', name)
     end
 
     def remotes
-      command('remote').stdout.split("\n")
+      command_with_capture('remote').stdout.split("\n")
     end
 
     # List all tags in the repository
@@ -1745,7 +1746,7 @@ module Git
         args << opts[:ref] if opts[:ref]
       end
 
-      command('fetch', *args, merge: true).stdout
+      command_with_capture('fetch', *args, merge: true).stdout
     end
 
     PUSH_OPTION_MAP = [
@@ -1766,10 +1767,10 @@ module Git
       args = build_push_args(remote, branch, opts)
 
       if opts[:mirror]
-        command('push', *args)
+        command_with_capture('push', *args)
       else
-        command('push', *args)
-        command('push', '--tags', *(args - [branch].compact)) if opts[:tags]
+        command_with_capture('push', *args)
+        command_with_capture('push', '--tags', *(args - [branch].compact)) if opts[:tags]
       end
     end
 
@@ -1785,7 +1786,7 @@ module Git
       flags = build_args(opts, PULL_OPTION_MAP)
       positional_args = [remote, branch].compact
 
-      command('pull', *flags, *positional_args).stdout
+      command_with_capture('pull', *flags, *positional_args).stdout
     end
 
     # Return the SHA of a tag reference
@@ -1802,7 +1803,7 @@ module Git
       return File.read(head).chomp if File.exist?(head)
 
       begin
-        command('show-ref', '--tags', '-s', tag_name).stdout
+        command_with_capture('show-ref', '--tags', '-s', tag_name).stdout
       rescue Git::FailedError => e
         raise unless e.result.status.exitstatus == 1 && e.result.stderr == ''
 
@@ -1811,11 +1812,11 @@ module Git
     end
 
     def repack
-      command('repack', '-a', '-d')
+      command_with_capture('repack', '-a', '-d')
     end
 
     def gc
-      command('gc', '--prune', '--aggressive', '--auto')
+      command_with_capture('gc', '--prune', '--aggressive', '--auto')
     end
 
     # Execute git fsck to verify repository integrity
@@ -1839,11 +1840,11 @@ module Git
     def read_tree(treeish, opts = {})
       ArgsBuilder.validate!(opts, READ_TREE_OPTION_MAP)
       flags = build_args(opts, READ_TREE_OPTION_MAP)
-      command('read-tree', *flags, treeish)
+      command_with_capture('read-tree', *flags, treeish)
     end
 
     def write_tree
-      command('write-tree').stdout
+      command_with_capture('write-tree').stdout
     end
 
     COMMIT_TREE_OPTION_MAP = [
@@ -1856,11 +1857,11 @@ module Git
       ArgsBuilder.validate!(opts, COMMIT_TREE_OPTION_MAP)
 
       flags = build_args(opts, COMMIT_TREE_OPTION_MAP)
-      command('commit-tree', tree, *flags).stdout
+      command_with_capture('commit-tree', tree, *flags).stdout
     end
 
     def update_ref(ref, commit)
-      command('update-ref', ref, commit)
+      command_with_capture('update-ref', ref, commit)
     end
 
     def checkout_index(opts = {})
@@ -1888,7 +1889,7 @@ module Git
       args << sha
       args.push('--', opts[:path]) if opts[:path]
 
-      File.open(file, 'wb') { |f| command('archive', *args, out: f) }
+      File.open(file, 'wb') { |f| command_with_capture('archive', *args, out: f) }
       apply_gzip(file) if gzip
 
       file
@@ -1896,7 +1897,7 @@ module Git
 
     # returns the current version of git, as an Array of Fixnums.
     def current_command_version
-      output = command('version').stdout
+      output = command_with_capture('version').stdout
       version = output[/\d+(\.\d+)+/]
       version_parts = version.split('.').collect(&:to_i)
       version_parts.fill(0, version_parts.length...3)
@@ -1983,22 +1984,22 @@ module Git
     # By default, raises {Git::FailedError} if the command exits with a non-zero
     # status. Pass `raise_on_failure: false` to suppress this behavior.
     #
-    # @overload command(*args, **options_hash)
+    # @overload command_with_capture(*args, **options_hash)
     #   Runs a git command and returns the result
     #
     #   Args should exclude the 'git' command itself and global options.
     #   Remember to splat the arguments if given as an array.
     #
     #   @example Run git log
-    #     result = command('log', '--pretty=oneline')
+    #     result = command_with_capture('log', '--pretty=oneline')
     #     result.stdout #=> "abc123 First commit\ndef456 Second commit\n"
     #
     #   @example Using an array of arguments
     #     args = ['log', '--pretty=oneline']
-    #     result = command(*args)
+    #     result = command_with_capture(*args)
     #
     #   @example Suppress raising on failure
-    #     result = command('show', 'nonexistent', raise_on_failure: false)
+    #     result = command_with_capture('show', 'nonexistent', raise_on_failure: false)
     #     result.status.success? #=> false
     #
     #   @param args [Array<String>] the command and its arguments
@@ -2040,7 +2041,7 @@ module Git
     #   them to this method. See {Git::Commands::Clone#call} for an example
     #   of a command that exposes `:timeout`.
     #
-    # @see Git::CommandLine#run
+    # @see Git::CommandLine#run_with_capture
     #
     # @return [Git::CommandLineResult] the result of the command
     #
@@ -2058,9 +2059,7 @@ module Git
     #   contain the result of the command including the exit status, stdout, and
     #   stderr.
     #
-    # @api private
-    #
-    def command(*, **options_hash)
+    def command_with_capture(*, **options_hash)
       options_hash = COMMAND_ARG_DEFAULTS.merge(options_hash)
       options_hash[:timeout] ||= Git.config.timeout
 
@@ -2069,7 +2068,7 @@ module Git
 
       env_overrides = options_hash.delete(:env)
       raise_on_failure = options_hash.delete(:raise_on_failure)
-      command_line.run(*, raise_on_failure: raise_on_failure, env: env_overrides, **options_hash)
+      command_line.run_with_capture(*, raise_on_failure: raise_on_failure, env: env_overrides, **options_hash)
     end
 
     private
@@ -2316,7 +2315,7 @@ module Git
     end
 
     def get_branch_state(branch_name)
-      command('rev-parse', '--verify', '--quiet', branch_name)
+      command_with_capture('rev-parse', '--verify', '--quiet', branch_name)
       :active
     rescue Git::FailedError => e
       # An exit status of 1 with empty stderr from `rev-parse --verify`
@@ -2327,7 +2326,7 @@ module Git
     end
 
     def execute_grep_command(args)
-      command('grep', *args).stdout.split("\n")
+      command_with_capture('grep', *args).stdout.split("\n")
     rescue Git::FailedError => e
       # `git grep` returns 1 when no lines are selected.
       raise unless e.result.status.exitstatus == 1 && e.result.stderr.empty?
@@ -2441,7 +2440,7 @@ module Git
     # @return [IO] the IO object that was written to
     #
     def write_staged_content(path, stage, out_io)
-      command('show', ":#{stage}:#{path}", out: out_io)
+      command_with_capture('show', ":#{stage}:#{path}", out: out_io)
       out_io
     end
 
@@ -2570,8 +2569,8 @@ module Git
     # @return [Hash] the diff as Hash
     def diff_as_hash(diff_command, opts = [])
       # update index before diffing to avoid spurious diffs
-      command('status')
-      command(diff_command, *opts).stdout.split("\n").each_with_object({}) do |line, memo|
+      command_with_capture('status')
+      command_with_capture(diff_command, *opts).stdout.split("\n").each_with_object({}) do |line, memo|
         info, file = split_status_line(line)
         mode_src, mode_dest, sha_src, sha_dest, type = info.split
 

--- a/spec/integration/git/command_line_spec.rb
+++ b/spec/integration/git/command_line_spec.rb
@@ -2,7 +2,7 @@
 
 require 'spec_helper'
 
-RSpec.describe 'CommandLine#run raise_on_failure integration' do
+RSpec.describe 'CommandLine#run_with_capture raise_on_failure integration' do
   include_context 'in an empty repository'
 
   let(:command_line) do
@@ -11,7 +11,7 @@ RSpec.describe 'CommandLine#run raise_on_failure integration' do
 
   describe 'raise_on_failure: false' do
     it 'returns CommandLineResult without raising on non-zero exit' do
-      result = command_line.run('rev-parse', 'nonexistent-ref', chdir: repo_dir, raise_on_failure: false)
+      result = command_line.run_with_capture('rev-parse', 'nonexistent-ref', chdir: repo_dir, raise_on_failure: false)
 
       expect(result).to be_a(Git::CommandLineResult)
       expect(result.status.success?).to be false
@@ -22,7 +22,7 @@ RSpec.describe 'CommandLine#run raise_on_failure integration' do
   describe 'raise_on_failure: true (default)' do
     it 'raises FailedError on non-zero exit' do
       expect do
-        command_line.run('rev-parse', 'nonexistent-ref', chdir: repo_dir)
+        command_line.run_with_capture('rev-parse', 'nonexistent-ref', chdir: repo_dir)
       end.to raise_error(Git::FailedError)
     end
   end

--- a/spec/integration/git/commands/branch/unset_upstream_spec.rb
+++ b/spec/integration/git/commands/branch/unset_upstream_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Git::Commands::Branch::UnsetUpstream, :integration do
       Git.init(bare_dir, bare: true)
       repo.add_remote('origin', bare_dir)
       repo.push('origin', 'main')
-      execution_context.command('branch', '--set-upstream-to=origin/main', 'main')
+      execution_context.command_with_capture('branch', '--set-upstream-to=origin/main', 'main')
     end
 
     describe 'when the command succeeds' do

--- a/spec/integration/git/commands/fsck/fsck_spec.rb
+++ b/spec/integration/git/commands/fsck/fsck_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Git::Commands::Fsck, :integration do
 
       context 'with specific objects' do
         it 'checks specific objects by oid' do
-          head_sha = execution_context.command('rev-parse', 'HEAD').stdout.strip
+          head_sha = execution_context.command_with_capture('rev-parse', 'HEAD').stdout.strip
           result = command.call(head_sha)
 
           expect(result).to be_a(Git::CommandLineResult)

--- a/spec/integration/git/commands/stash/store_spec.rb
+++ b/spec/integration/git/commands/stash/store_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::Stash::Store, :integration do
       before { write_file('file.txt', "modified\n") }
 
       it 'returns a CommandLineResult' do
-        sha = execution_context.command('stash', 'create').stdout.strip
+        sha = execution_context.command_with_capture('stash', 'create').stdout.strip
 
         result = command.call(sha)
 

--- a/spec/integration/git/parsers/branch_spec.rb
+++ b/spec/integration/git/parsers/branch_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Git::Parsers::Branch, :integration do
   # Helper to run git branch --list with the parser's format and return raw output
   def git_branch_output(*args)
     format_arg = "--format=#{described_class::FORMAT_STRING}"
-    repo.lib.command('branch', '--list', format_arg, *args).stdout
+    repo.lib.command_with_capture('branch', '--list', format_arg, *args).stdout
   end
 
   describe 'FORMAT_STRING validation' do
@@ -154,7 +154,7 @@ RSpec.describe Git::Parsers::Branch, :integration do
         Git.init(bare_dir, bare: true)
         repo.add_remote('origin', bare_dir)
         repo.push('origin', 'main')
-        repo.lib.command('branch', '-u', 'origin/main', 'main')
+        repo.lib.command_with_capture('branch', '-u', 'origin/main', 'main')
       end
 
       it 'populates upstream as BranchInfo with refname' do

--- a/spec/integration/git/parsers/fsck_spec.rb
+++ b/spec/integration/git/parsers/fsck_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Git::Parsers::Fsck, :integration do
 
   # Helper to run git fsck and return raw output
   def git_fsck_output(*args)
-    result = repo.lib.command('fsck', '--no-progress', *args, raise_on_failure: false)
+    result = repo.lib.command_with_capture('fsck', '--no-progress', *args, raise_on_failure: false)
     result.stdout
   end
 

--- a/spec/integration/git/parsers/stash_spec.rb
+++ b/spec/integration/git/parsers/stash_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Parsers::Stash, :integration do
   # Helper to run git stash list with the parser's format and return raw output
   def git_stash_output
     format_arg = "--format=#{described_class::STASH_FORMAT}"
-    repo.lib.command('stash', 'list', format_arg).stdout
+    repo.lib.command_with_capture('stash', 'list', format_arg).stdout
   end
 
   before do
@@ -148,9 +148,9 @@ RSpec.describe Git::Parsers::Stash, :integration do
     context 'with custom message format (no branch prefix)' do
       before do
         write_file('file.txt', 'modified')
-        result = repo.lib.command('stash', 'create', 'Custom message')
+        result = repo.lib.command_with_capture('stash', 'create', 'Custom message')
         sha = result.is_a?(String) ? result.strip : result.stdout.strip
-        repo.lib.command('stash', 'store', '--message=custom: my message', sha)
+        repo.lib.command_with_capture('stash', 'store', '--message=custom: my message', sha)
       end
 
       it 'parses custom message correctly' do

--- a/spec/integration/git/parsers/tag_spec.rb
+++ b/spec/integration/git/parsers/tag_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Parsers::Tag, :integration do
   # Helper to run git tag --list with the parser's format and return raw output
   def git_tag_output(*args)
     format_arg = "--format=#{described_class::FORMAT_STRING}"
-    repo.lib.command('tag', '--list', format_arg, *args).stdout
+    repo.lib.command_with_capture('tag', '--list', format_arg, *args).stdout
   end
 
   describe '.parse_list' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -91,13 +91,13 @@ end
 # @return [RSpec::Mocks::MessageExpectation] the expectation object for chaining
 #
 # @example
-#   expect_command('stash', 'apply').and_return(command_result(''))
-#   expect_command('stash', 'push', '--all').and_return(command_result(''))
-#   expect_command('fetch', 'origin', timeout: 30).and_return(command_result(''))
-#   expect_command('fetch', 'origin', timeout: -1).and_raise(ArgumentError, 'Invalid timeout value')
+#   expect_command_with_capture('stash', 'apply').and_return(command_result(''))
+#   expect_command_with_capture('stash', 'push', '--all').and_return(command_result(''))
+#   expect_command_with_capture('fetch', 'origin', timeout: 30).and_return(command_result(''))
+#   expect_command_with_capture('fetch', 'origin', timeout: -1).and_raise(ArgumentError, 'Invalid timeout value')
 #
-def expect_command(*, **execution_options)
+def expect_command_with_capture(*, **execution_options)
   expect(execution_context).to(
-    receive(:command).with(*, **execution_options, raise_on_failure: false)
+    receive(:command_with_capture).with(*, **execution_options, raise_on_failure: false)
   )
 end

--- a/spec/unit/git/command_line_spec.rb
+++ b/spec/unit/git/command_line_spec.rb
@@ -34,14 +34,14 @@ RSpec.describe Git::CommandLine do
     context 'when raise_on_failure is true (default)' do
       it 'raises FailedError on non-zero exit status' do
         expect do
-          command_line.run('status')
+          command_line.run_with_capture('status')
         end.to raise_error(Git::FailedError)
       end
     end
 
     context 'when raise_on_failure is false' do
       it 'returns CommandLineResult on non-zero exit status without raising' do
-        result = command_line.run('status', raise_on_failure: false)
+        result = command_line.run_with_capture('status', raise_on_failure: false)
 
         expect(result).to be_a(Git::CommandLineResult)
         expect(result.status.success?).to be false
@@ -54,7 +54,7 @@ RSpec.describe Git::CommandLine do
         end
 
         it 'returns CommandLineResult on success' do
-          result = command_line.run('--version', raise_on_failure: false)
+          result = command_line.run_with_capture('--version', raise_on_failure: false)
 
           expect(result).to be_a(Git::CommandLineResult)
           expect(result.status.success?).to be true
@@ -71,7 +71,7 @@ RSpec.describe Git::CommandLine do
 
         it 'raises TimeoutError even with raise_on_failure: false' do
           expect do
-            command_line.run('status', raise_on_failure: false, timeout: 1)
+            command_line.run_with_capture('status', raise_on_failure: false, timeout: 1)
           end.to raise_error(Git::TimeoutError)
         end
       end
@@ -84,7 +84,7 @@ RSpec.describe Git::CommandLine do
 
         it 'raises SignaledError even with raise_on_failure: false' do
           expect do
-            command_line.run('status', raise_on_failure: false)
+            command_line.run_with_capture('status', raise_on_failure: false)
           end.to raise_error(Git::SignaledError)
         end
       end

--- a/spec/unit/git/commands/add_spec.rb
+++ b/spec/unit/git/commands/add_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Add do
     context 'with default arguments' do
       it 'adds nothing' do
         expected_result = command_result
-        expect_command('add').and_return(expected_result)
+        expect_command_with_capture('add').and_return(expected_result)
 
         result = command.call
 
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::Add do
 
     context 'with a single file path' do
       it 'adds the specified file' do
-        expect_command('add', '--', 'path/to/file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--', 'path/to/file.rb').and_return(command_result)
 
         command.call('path/to/file.rb')
       end
@@ -28,7 +28,7 @@ RSpec.describe Git::Commands::Add do
 
     context 'with multiple file paths as an array' do
       it 'adds all specified files' do
-        expect_command('add', '--', 'file1.rb', 'file2.rb', 'file3.rb').and_return(command_result)
+        expect_command_with_capture('add', '--', 'file1.rb', 'file2.rb', 'file3.rb').and_return(command_result)
 
         command.call(%w[file1.rb file2.rb file3.rb])
       end
@@ -36,19 +36,19 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :dry_run option' do
       it 'includes the --dry-run flag' do
-        expect_command('add', '--dry-run', '--', 'file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--dry-run', '--', 'file.rb').and_return(command_result)
 
         command.call('file.rb', dry_run: true)
       end
 
       it 'accepts the :n alias' do
-        expect_command('add', '--dry-run', '--', 'file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--dry-run', '--', 'file.rb').and_return(command_result)
 
         command.call('file.rb', n: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('add', '--', 'file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--', 'file.rb').and_return(command_result)
 
         command.call('file.rb', dry_run: false)
       end
@@ -56,13 +56,13 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :force option' do
       it 'includes the --force flag' do
-        expect_command('add', '--force', '--', 'ignored_file.txt').and_return(command_result)
+        expect_command_with_capture('add', '--force', '--', 'ignored_file.txt').and_return(command_result)
 
         command.call('ignored_file.txt', force: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('add', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('add', '--', 'file.txt').and_return(command_result)
 
         command.call('file.txt', force: false)
       end
@@ -70,19 +70,19 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :update option' do
       it 'includes the --update flag' do
-        expect_command('add', '--update', '--', 'file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--update', '--', 'file.rb').and_return(command_result)
 
         command.call('file.rb', update: true)
       end
 
       it 'accepts the :u alias' do
-        expect_command('add', '--update', '--', 'file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--update', '--', 'file.rb').and_return(command_result)
 
         command.call('file.rb', u: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('add', '--', 'file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--', 'file.rb').and_return(command_result)
 
         command.call('file.rb', update: false)
       end
@@ -90,19 +90,19 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :all option' do
       it 'includes the --all flag when true' do
-        expect_command('add', '--all', '--', '.').and_return(command_result)
+        expect_command_with_capture('add', '--all', '--', '.').and_return(command_result)
 
         command.call('.', all: true)
       end
 
       it 'includes --no-all when false (negatable flag)' do
-        expect_command('add', '--no-all', '--', '.').and_return(command_result)
+        expect_command_with_capture('add', '--no-all', '--', '.').and_return(command_result)
 
         command.call('.', all: false)
       end
 
       it 'omits the flag when not provided' do
-        expect_command('add', '--', '.').and_return(command_result)
+        expect_command_with_capture('add', '--', '.').and_return(command_result)
 
         command.call('.')
       end
@@ -110,19 +110,19 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :ignore_removal option' do
       it 'includes the --ignore-removal flag when true' do
-        expect_command('add', '--ignore-removal', '--', '.').and_return(command_result)
+        expect_command_with_capture('add', '--ignore-removal', '--', '.').and_return(command_result)
 
         command.call('.', ignore_removal: true)
       end
 
       it 'includes --no-ignore-removal when false (negatable flag)' do
-        expect_command('add', '--no-ignore-removal', '--', '.').and_return(command_result)
+        expect_command_with_capture('add', '--no-ignore-removal', '--', '.').and_return(command_result)
 
         command.call('.', ignore_removal: false)
       end
 
       it 'omits the flag when not provided' do
-        expect_command('add', '--', '.').and_return(command_result)
+        expect_command_with_capture('add', '--', '.').and_return(command_result)
 
         command.call('.')
       end
@@ -130,19 +130,19 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :intent_to_add option' do
       it 'includes the --intent-to-add flag' do
-        expect_command('add', '--intent-to-add', '--', 'new_file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--intent-to-add', '--', 'new_file.rb').and_return(command_result)
 
         command.call('new_file.rb', intent_to_add: true)
       end
 
       it 'accepts the :N alias' do
-        expect_command('add', '--intent-to-add', '--', 'new_file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--intent-to-add', '--', 'new_file.rb').and_return(command_result)
 
         command.call('new_file.rb', N: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('add', '--', 'new_file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--', 'new_file.rb').and_return(command_result)
 
         command.call('new_file.rb', intent_to_add: false)
       end
@@ -150,13 +150,13 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :ignore_errors option' do
       it 'includes the --ignore-errors flag' do
-        expect_command('add', '--ignore-errors', '--', 'file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--ignore-errors', '--', 'file.rb').and_return(command_result)
 
         command.call('file.rb', ignore_errors: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('add', '--', 'file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--', 'file.rb').and_return(command_result)
 
         command.call('file.rb', ignore_errors: false)
       end
@@ -164,13 +164,13 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :sparse option' do
       it 'includes the --sparse flag' do
-        expect_command('add', '--sparse', '--', 'file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--sparse', '--', 'file.rb').and_return(command_result)
 
         command.call('file.rb', sparse: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('add', '--', 'file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--', 'file.rb').and_return(command_result)
 
         command.call('file.rb', sparse: false)
       end
@@ -178,13 +178,13 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :refresh option' do
       it 'includes the --refresh flag' do
-        expect_command('add', '--refresh').and_return(command_result)
+        expect_command_with_capture('add', '--refresh').and_return(command_result)
 
         command.call(refresh: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('add').and_return(command_result)
+        expect_command_with_capture('add').and_return(command_result)
 
         command.call(refresh: false)
       end
@@ -192,13 +192,13 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :ignore_missing option' do
       it 'includes the --ignore-missing flag' do
-        expect_command('add', '--dry-run', '--ignore-missing', '--', 'file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--dry-run', '--ignore-missing', '--', 'file.rb').and_return(command_result)
 
         command.call('file.rb', dry_run: true, ignore_missing: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('add', '--', 'file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--', 'file.rb').and_return(command_result)
 
         command.call('file.rb', ignore_missing: false)
       end
@@ -206,13 +206,13 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :no_warn_embedded_repo option' do
       it 'includes the --no-warn-embedded-repo flag' do
-        expect_command('add', '--no-warn-embedded-repo', '--', 'repo-dir').and_return(command_result)
+        expect_command_with_capture('add', '--no-warn-embedded-repo', '--', 'repo-dir').and_return(command_result)
 
         command.call('repo-dir', no_warn_embedded_repo: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('add', '--', 'repo-dir').and_return(command_result)
+        expect_command_with_capture('add', '--', 'repo-dir').and_return(command_result)
 
         command.call('repo-dir', no_warn_embedded_repo: false)
       end
@@ -220,13 +220,13 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :renormalize option' do
       it 'includes the --renormalize flag' do
-        expect_command('add', '--renormalize').and_return(command_result)
+        expect_command_with_capture('add', '--renormalize').and_return(command_result)
 
         command.call(renormalize: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('add').and_return(command_result)
+        expect_command_with_capture('add').and_return(command_result)
 
         command.call(renormalize: false)
       end
@@ -234,13 +234,13 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :chmod option' do
       it 'includes --chmod=+x' do
-        expect_command('add', '--chmod=+x', '--', 'file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--chmod=+x', '--', 'file.rb').and_return(command_result)
 
         command.call('file.rb', chmod: '+x')
       end
 
       it 'includes --chmod=-x' do
-        expect_command('add', '--chmod=-x', '--', 'file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--chmod=-x', '--', 'file.rb').and_return(command_result)
 
         command.call('file.rb', chmod: '-x')
       end
@@ -248,13 +248,13 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :pathspec_from_file option' do
       it 'includes --pathspec-from-file with the given path' do
-        expect_command('add', '--pathspec-from-file=paths.txt').and_return(command_result)
+        expect_command_with_capture('add', '--pathspec-from-file=paths.txt').and_return(command_result)
 
         command.call(pathspec_from_file: 'paths.txt')
       end
 
       it 'accepts stdin via -' do
-        expect_command('add', '--pathspec-from-file=-').and_return(command_result)
+        expect_command_with_capture('add', '--pathspec-from-file=-').and_return(command_result)
 
         command.call(pathspec_from_file: '-')
       end
@@ -262,7 +262,8 @@ RSpec.describe Git::Commands::Add do
 
     context 'with the :pathspec_file_nul option' do
       it 'includes --pathspec-file-nul alongside --pathspec-from-file' do
-        expect_command('add', '--pathspec-from-file=paths.txt', '--pathspec-file-nul').and_return(command_result)
+        expect_command_with_capture('add', '--pathspec-from-file=paths.txt',
+                                    '--pathspec-file-nul').and_return(command_result)
 
         command.call(pathspec_from_file: 'paths.txt', pathspec_file_nul: true)
       end
@@ -290,13 +291,13 @@ RSpec.describe Git::Commands::Add do
 
     context 'with equivalent all/ignore_removal combinations' do
       it 'allows :all false with :ignore_removal true' do
-        expect_command('add', '--no-all', '--ignore-removal', '--', '.').and_return(command_result)
+        expect_command_with_capture('add', '--no-all', '--ignore-removal', '--', '.').and_return(command_result)
 
         command.call('.', all: false, ignore_removal: true)
       end
 
       it 'allows :all true with :ignore_removal false' do
-        expect_command('add', '--all', '--no-ignore-removal', '--', '.').and_return(command_result)
+        expect_command_with_capture('add', '--all', '--no-ignore-removal', '--', '.').and_return(command_result)
 
         command.call('.', all: true, ignore_removal: false)
       end
@@ -330,7 +331,7 @@ RSpec.describe Git::Commands::Add do
 
     context 'with multiple options combined' do
       it 'includes all specified flags' do
-        expect_command('add', '--force', '--all', '--', '.').and_return(command_result)
+        expect_command_with_capture('add', '--force', '--all', '--', '.').and_return(command_result)
 
         command.call('.', all: true, force: true)
       end
@@ -338,13 +339,13 @@ RSpec.describe Git::Commands::Add do
 
     context 'with paths containing special characters' do
       it 'handles paths with spaces' do
-        expect_command('add', '--', 'path/to/my file.rb').and_return(command_result)
+        expect_command_with_capture('add', '--', 'path/to/my file.rb').and_return(command_result)
 
         command.call('path/to/my file.rb')
       end
 
       it 'handles paths with unicode characters' do
-        expect_command('add', '--', 'path/to/файл.rb').and_return(command_result)
+        expect_command_with_capture('add', '--', 'path/to/файл.rb').and_return(command_result)
 
         command.call('path/to/файл.rb')
       end

--- a/spec/unit/git/commands/base_spec.rb
+++ b/spec/unit/git/commands/base_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Git::Commands::Base do
     let(:command) { command_class.new(execution_context) }
 
     it 'raises on non-zero exit status by default' do
-      allow(execution_context).to receive(:command)
+      allow(execution_context).to receive(:command_with_capture)
         .with('status', raise_on_failure: false)
         .and_return(command_result('', exitstatus: 1))
 
@@ -79,7 +79,7 @@ RSpec.describe Git::Commands::Base do
 
     it 'accepts status 1 when allow_exit_status 0..1 is configured' do
       command_class.allow_exit_status(0..1)
-      allow(execution_context).to receive(:command)
+      allow(execution_context).to receive(:command_with_capture)
         .with('status', raise_on_failure: false)
         .and_return(command_result('', exitstatus: 1))
 
@@ -92,7 +92,7 @@ RSpec.describe Git::Commands::Base do
       command_class.allow_exit_status(0..7)
 
       (1..7).each do |exitstatus|
-        allow(execution_context).to receive(:command)
+        allow(execution_context).to receive(:command_with_capture)
           .with('status', raise_on_failure: false)
           .and_return(command_result('', exitstatus: exitstatus))
 
@@ -103,7 +103,7 @@ RSpec.describe Git::Commands::Base do
 
     it 'accepts exit status only when included in declared range' do
       command_class.allow_exit_status(0..1)
-      allow(execution_context).to receive(:command)
+      allow(execution_context).to receive(:command_with_capture)
         .with('status', raise_on_failure: false)
         .and_return(command_result('', exitstatus: 2))
 
@@ -121,7 +121,7 @@ RSpec.describe Git::Commands::Base do
 
     it 'propagates timeout errors from execution context' do
       timeout_error = Git::TimeoutError.new(command_result('', stderr: 'timed out'), 1)
-      allow(execution_context).to receive(:command)
+      allow(execution_context).to receive(:command_with_capture)
         .with('status', raise_on_failure: false)
         .and_raise(timeout_error)
 
@@ -131,7 +131,7 @@ RSpec.describe Git::Commands::Base do
 
     it 'propagates signal errors from execution context' do
       signaled_error = Git::SignaledError.new(command_result('', stderr: 'killed'))
-      allow(execution_context).to receive(:command)
+      allow(execution_context).to receive(:command_with_capture)
         .with('status', raise_on_failure: false)
         .and_raise(signaled_error)
 
@@ -140,7 +140,7 @@ RSpec.describe Git::Commands::Base do
     end
 
     it 'forwards execution options extracted from bound arguments' do
-      allow(execution_context).to receive(:command)
+      allow(execution_context).to receive(:command_with_capture)
         .with('status', timeout: 30, raise_on_failure: false)
         .and_return(command_result)
 
@@ -148,7 +148,7 @@ RSpec.describe Git::Commands::Base do
     end
 
     it 'does not forward execution option keywords when none are provided' do
-      allow(execution_context).to receive(:command)
+      allow(execution_context).to receive(:command_with_capture)
         .with('status', raise_on_failure: false)
         .and_return(command_result)
 
@@ -163,7 +163,7 @@ RSpec.describe Git::Commands::Base do
       end
       no_exec_opts_command = no_exec_opts_class.new(execution_context)
 
-      allow(execution_context).to receive(:command)
+      allow(execution_context).to receive(:command_with_capture)
         .with('status', raise_on_failure: false)
         .and_return(command_result)
 

--- a/spec/unit/git/commands/branch/copy_spec.rb
+++ b/spec/unit/git/commands/branch/copy_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Branch::Copy do
   describe '#call' do
     context 'with only new_branch (copy current branch)' do
       it 'runs branch --copy with only the new branch name' do
-        expect_command('branch', '--copy', 'new-name')
+        expect_command_with_capture('branch', '--copy', 'new-name')
           .and_return(command_result(''))
 
         result = command.call('new-name')
@@ -22,7 +22,7 @@ RSpec.describe Git::Commands::Branch::Copy do
 
     context 'with old_branch and new_branch' do
       it 'runs branch --copy with both branch names' do
-        expect_command('branch', '--copy', 'old-name', 'new-name')
+        expect_command_with_capture('branch', '--copy', 'old-name', 'new-name')
           .and_return(command_result(''))
 
         result = command.call('old-name', 'new-name')
@@ -33,7 +33,7 @@ RSpec.describe Git::Commands::Branch::Copy do
 
     context 'with :force option' do
       it 'adds --force flag when copying current branch' do
-        expect_command('branch', '--copy', '--force', 'new-name')
+        expect_command_with_capture('branch', '--copy', '--force', 'new-name')
           .and_return(command_result(''))
 
         result = command.call('new-name', force: true)
@@ -42,7 +42,7 @@ RSpec.describe Git::Commands::Branch::Copy do
       end
 
       it 'adds --force flag when copying specific branch' do
-        expect_command('branch', '--copy', '--force', 'old-name', 'new-name')
+        expect_command_with_capture('branch', '--copy', '--force', 'old-name', 'new-name')
           .and_return(command_result(''))
 
         result = command.call('old-name', 'new-name', force: true)
@@ -51,7 +51,7 @@ RSpec.describe Git::Commands::Branch::Copy do
       end
 
       it 'does not add flag when false' do
-        expect_command('branch', '--copy', 'new-name')
+        expect_command_with_capture('branch', '--copy', 'new-name')
           .and_return(command_result(''))
 
         result = command.call('new-name', force: false)
@@ -62,7 +62,7 @@ RSpec.describe Git::Commands::Branch::Copy do
 
     context 'with :f short option alias' do
       it 'adds --force flag when copying current branch' do
-        expect_command('branch', '--copy', '--force', 'new-name')
+        expect_command_with_capture('branch', '--copy', '--force', 'new-name')
           .and_return(command_result(''))
 
         result = command.call('new-name', f: true)
@@ -71,7 +71,7 @@ RSpec.describe Git::Commands::Branch::Copy do
       end
 
       it 'adds --force flag when copying specific branch' do
-        expect_command('branch', '--copy', '--force', 'old-name', 'new-name')
+        expect_command_with_capture('branch', '--copy', '--force', 'old-name', 'new-name')
           .and_return(command_result(''))
 
         result = command.call('old-name', 'new-name', f: true)

--- a/spec/unit/git/commands/branch/create_spec.rb
+++ b/spec/unit/git/commands/branch/create_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Branch::Create do
   describe '#call' do
     context 'with branch name only (basic creation)' do
       it 'runs branch with the branch name' do
-        expect_command('branch', 'feature-branch')
+        expect_command_with_capture('branch', 'feature-branch')
           .and_return(command_result(''))
 
         result = command.call('feature-branch')
@@ -22,7 +22,7 @@ RSpec.describe Git::Commands::Branch::Create do
 
     context 'with start_point' do
       it 'adds the start point after the branch name' do
-        expect_command('branch', 'feature-branch', 'main')
+        expect_command_with_capture('branch', 'feature-branch', 'main')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', 'main')
@@ -31,7 +31,7 @@ RSpec.describe Git::Commands::Branch::Create do
       end
 
       it 'accepts a commit SHA as start point' do
-        expect_command('branch', 'feature-branch', 'abc123')
+        expect_command_with_capture('branch', 'feature-branch', 'abc123')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', 'abc123')
@@ -40,7 +40,7 @@ RSpec.describe Git::Commands::Branch::Create do
       end
 
       it 'accepts a tag as start point' do
-        expect_command('branch', 'feature-branch', 'v1.0.0')
+        expect_command_with_capture('branch', 'feature-branch', 'v1.0.0')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', 'v1.0.0')
@@ -49,7 +49,7 @@ RSpec.describe Git::Commands::Branch::Create do
       end
 
       it 'accepts a remote branch as start point' do
-        expect_command('branch', 'feature-branch', 'origin/main')
+        expect_command_with_capture('branch', 'feature-branch', 'origin/main')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', 'origin/main')
@@ -60,7 +60,7 @@ RSpec.describe Git::Commands::Branch::Create do
 
     context 'with :force option' do
       it 'adds --force flag' do
-        expect_command('branch', '--force', 'feature-branch')
+        expect_command_with_capture('branch', '--force', 'feature-branch')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', force: true)
@@ -69,7 +69,7 @@ RSpec.describe Git::Commands::Branch::Create do
       end
 
       it 'allows resetting an existing branch to a new start point' do
-        expect_command('branch', '--force', 'feature-branch', 'main')
+        expect_command_with_capture('branch', '--force', 'feature-branch', 'main')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', 'main', force: true)
@@ -78,7 +78,7 @@ RSpec.describe Git::Commands::Branch::Create do
       end
 
       it 'does not add flag when false' do
-        expect_command('branch', 'feature-branch')
+        expect_command_with_capture('branch', 'feature-branch')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', force: false)
@@ -89,7 +89,7 @@ RSpec.describe Git::Commands::Branch::Create do
 
     context 'with :f short option alias' do
       it 'adds --force flag' do
-        expect_command('branch', '--force', 'feature-branch')
+        expect_command_with_capture('branch', '--force', 'feature-branch')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', f: true)
@@ -100,7 +100,7 @@ RSpec.describe Git::Commands::Branch::Create do
 
     context 'with :create_reflog option' do
       it 'adds --create-reflog flag' do
-        expect_command('branch', '--create-reflog', 'feature-branch')
+        expect_command_with_capture('branch', '--create-reflog', 'feature-branch')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', create_reflog: true)
@@ -109,7 +109,7 @@ RSpec.describe Git::Commands::Branch::Create do
       end
 
       it 'adds --no-create-reflog flag when false' do
-        expect_command('branch', '--no-create-reflog', 'feature-branch')
+        expect_command_with_capture('branch', '--no-create-reflog', 'feature-branch')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', create_reflog: false)
@@ -120,7 +120,7 @@ RSpec.describe Git::Commands::Branch::Create do
 
     context 'with :recurse_submodules option' do
       it 'adds --recurse-submodules flag' do
-        expect_command('branch', '--recurse-submodules', 'feature-branch')
+        expect_command_with_capture('branch', '--recurse-submodules', 'feature-branch')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', recurse_submodules: true)
@@ -129,7 +129,7 @@ RSpec.describe Git::Commands::Branch::Create do
       end
 
       it 'does not add flag when false' do
-        expect_command('branch', 'feature-branch')
+        expect_command_with_capture('branch', 'feature-branch')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', recurse_submodules: false)
@@ -141,7 +141,7 @@ RSpec.describe Git::Commands::Branch::Create do
     context 'with :track option' do
       context 'when true' do
         it 'adds --track flag' do
-          expect_command('branch', '--track', 'feature-branch', 'origin/main')
+          expect_command_with_capture('branch', '--track', 'feature-branch', 'origin/main')
             .and_return(command_result(''))
 
           result = command.call('feature-branch', 'origin/main', track: true)
@@ -152,7 +152,7 @@ RSpec.describe Git::Commands::Branch::Create do
 
       context 'when false' do
         it 'adds --no-track flag' do
-          expect_command('branch', '--no-track', 'feature-branch', 'origin/main')
+          expect_command_with_capture('branch', '--no-track', 'feature-branch', 'origin/main')
             .and_return(command_result(''))
 
           result = command.call('feature-branch', 'origin/main', track: false)
@@ -163,7 +163,7 @@ RSpec.describe Git::Commands::Branch::Create do
 
       context 'when "direct"' do
         it 'adds --track=direct flag' do
-          expect_command('branch', '--track=direct', 'feature-branch', 'origin/main')
+          expect_command_with_capture('branch', '--track=direct', 'feature-branch', 'origin/main')
             .and_return(command_result(''))
 
           result = command.call('feature-branch', 'origin/main', track: 'direct')
@@ -174,7 +174,7 @@ RSpec.describe Git::Commands::Branch::Create do
 
       context 'when "inherit"' do
         it 'adds --track=inherit flag' do
-          expect_command('branch', '--track=inherit', 'feature-branch', 'origin/main')
+          expect_command_with_capture('branch', '--track=inherit', 'feature-branch', 'origin/main')
             .and_return(command_result(''))
 
           result = command.call('feature-branch', 'origin/main', track: 'inherit')
@@ -186,7 +186,7 @@ RSpec.describe Git::Commands::Branch::Create do
 
     context 'with :t short option alias' do
       it 'adds --track flag when true' do
-        expect_command('branch', '--track', 'feature-branch', 'origin/main')
+        expect_command_with_capture('branch', '--track', 'feature-branch', 'origin/main')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', 'origin/main', t: true)
@@ -195,7 +195,7 @@ RSpec.describe Git::Commands::Branch::Create do
       end
 
       it 'adds --track=inherit when string value' do
-        expect_command('branch', '--track=inherit', 'feature-branch', 'origin/main')
+        expect_command_with_capture('branch', '--track=inherit', 'feature-branch', 'origin/main')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', 'origin/main', t: 'inherit')
@@ -206,7 +206,7 @@ RSpec.describe Git::Commands::Branch::Create do
 
     context 'with multiple options combined' do
       it 'includes all specified flags in correct order' do
-        expect_command('branch', '--track', '--force', '--create-reflog', 'feature-branch', 'origin/main')
+        expect_command_with_capture('branch', '--track', '--force', '--create-reflog', 'feature-branch', 'origin/main')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', 'origin/main', force: true, create_reflog: true, track: true)
@@ -215,7 +215,7 @@ RSpec.describe Git::Commands::Branch::Create do
       end
 
       it 'combines force with no-track' do
-        expect_command('branch', '--no-track', '--force', 'feature-branch', 'main')
+        expect_command_with_capture('branch', '--no-track', '--force', 'feature-branch', 'main')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', 'main', force: true, track: false)
@@ -226,7 +226,7 @@ RSpec.describe Git::Commands::Branch::Create do
 
     context 'with nil start_point' do
       it 'omits the start point from the command' do
-        expect_command('branch', 'feature-branch')
+        expect_command_with_capture('branch', 'feature-branch')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', nil)
@@ -235,7 +235,7 @@ RSpec.describe Git::Commands::Branch::Create do
       end
 
       it 'omits the start point when options are provided' do
-        expect_command('branch', '--force', 'feature-branch')
+        expect_command_with_capture('branch', '--force', 'feature-branch')
           .and_return(command_result(''))
 
         result = command.call('feature-branch', nil, force: true)

--- a/spec/unit/git/commands/branch/delete_spec.rb
+++ b/spec/unit/git/commands/branch/delete_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Branch::Delete do
   describe '#call' do
     context 'with single branch name' do
       it 'runs branch --delete with the branch name' do
-        expect_command('branch', '--delete', 'feature-branch')
+        expect_command_with_capture('branch', '--delete', 'feature-branch')
           .and_return(command_result("Deleted branch feature-branch (was abc1234).\n"))
 
         result = command.call('feature-branch')
@@ -25,7 +25,7 @@ RSpec.describe Git::Commands::Branch::Delete do
         stdout = "Deleted branch branch1 (was abc1234).\n" \
                  "Deleted branch branch2 (was abc1234).\n" \
                  "Deleted branch branch3 (was abc1234).\n"
-        expect_command('branch', '--delete', 'branch1', 'branch2', 'branch3')
+        expect_command_with_capture('branch', '--delete', 'branch1', 'branch2', 'branch3')
           .and_return(command_result(stdout))
 
         result = command.call('branch1', 'branch2', 'branch3')
@@ -36,7 +36,7 @@ RSpec.describe Git::Commands::Branch::Delete do
 
     context 'with :force option' do
       it 'adds --force flag' do
-        expect_command('branch', '--delete', '--force', 'feature-branch')
+        expect_command_with_capture('branch', '--delete', '--force', 'feature-branch')
           .and_return(command_result("Deleted branch feature-branch (was abc1234).\n"))
 
         result = command.call('feature-branch', force: true)
@@ -45,7 +45,7 @@ RSpec.describe Git::Commands::Branch::Delete do
       end
 
       it 'accepts :f alias' do
-        expect_command('branch', '--delete', '--force', 'feature-branch')
+        expect_command_with_capture('branch', '--delete', '--force', 'feature-branch')
           .and_return(command_result("Deleted branch feature-branch (was abc1234).\n"))
 
         result = command.call('feature-branch', f: true)
@@ -56,7 +56,7 @@ RSpec.describe Git::Commands::Branch::Delete do
 
     context 'with :remotes option' do
       it 'adds --remotes flag' do
-        expect_command('branch', '--delete', '--remotes', 'origin/feature')
+        expect_command_with_capture('branch', '--delete', '--remotes', 'origin/feature')
           .and_return(command_result("Deleted remote-tracking branch origin/feature (was abc1234).\n"))
 
         result = command.call('origin/feature', remotes: true)
@@ -65,7 +65,7 @@ RSpec.describe Git::Commands::Branch::Delete do
       end
 
       it 'accepts :r alias' do
-        expect_command('branch', '--delete', '--remotes', 'origin/feature')
+        expect_command_with_capture('branch', '--delete', '--remotes', 'origin/feature')
           .and_return(command_result("Deleted remote-tracking branch origin/feature (was abc1234).\n"))
 
         result = command.call('origin/feature', r: true)
@@ -76,7 +76,7 @@ RSpec.describe Git::Commands::Branch::Delete do
 
     context 'with multiple options combined' do
       it 'includes all specified flags in correct order' do
-        expect_command('branch', '--delete', '--force', '--remotes', 'origin/feature')
+        expect_command_with_capture('branch', '--delete', '--force', '--remotes', 'origin/feature')
           .and_return(command_result("Deleted remote-tracking branch origin/feature (was abc1234).\n"))
 
         result = command.call('origin/feature', force: true, remotes: true)
@@ -87,7 +87,7 @@ RSpec.describe Git::Commands::Branch::Delete do
 
     context 'exit code handling' do
       it 'returns result for exit code 0 (all deleted)' do
-        expect_command('branch', '--delete', 'feature')
+        expect_command_with_capture('branch', '--delete', 'feature')
           .and_return(command_result("Deleted branch feature (was abc1234).\n", exitstatus: 0))
 
         result = command.call('feature')
@@ -97,7 +97,7 @@ RSpec.describe Git::Commands::Branch::Delete do
       end
 
       it 'returns result for exit code 1 (partial failure)' do
-        expect_command('branch', '--delete', 'feature', 'nonexistent')
+        expect_command_with_capture('branch', '--delete', 'feature', 'nonexistent')
           .and_return(
             command_result(
               "Deleted branch feature (was abc1234).\n",
@@ -113,7 +113,7 @@ RSpec.describe Git::Commands::Branch::Delete do
       end
 
       it 'raises FailedError for exit code > 1' do
-        expect_command('branch', '--delete', 'feature')
+        expect_command_with_capture('branch', '--delete', 'feature')
           .and_return(command_result('', stderr: 'fatal: error', exitstatus: 128))
 
         expect { command.call('feature') }.to raise_error(Git::FailedError)

--- a/spec/unit/git/commands/branch/list_spec.rb
+++ b/spec/unit/git/commands/branch/list_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Git::Commands::Branch::List do
   describe '#call' do
     context 'with no options (basic list)' do
       it 'runs branch with --list and format flags' do
-        expect_command(*expected_args)
+        expect_command_with_capture(*expected_args)
           .and_return(command_result(sample_output))
 
         result = command.call
@@ -33,7 +33,7 @@ RSpec.describe Git::Commands::Branch::List do
 
     context 'with :all option' do
       it 'adds --all flag' do
-        expect_command(*expected_args('--all'))
+        expect_command_with_capture(*expected_args('--all'))
           .and_return(command_result(''))
 
         result = command.call(all: true)
@@ -42,7 +42,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'accepts :a alias' do
-        expect_command(*expected_args('--all'))
+        expect_command_with_capture(*expected_args('--all'))
           .and_return(command_result(''))
 
         result = command.call(a: true)
@@ -53,7 +53,7 @@ RSpec.describe Git::Commands::Branch::List do
 
     context 'with :remotes option' do
       it 'adds --remotes flag' do
-        expect_command(*expected_args('--remotes'))
+        expect_command_with_capture(*expected_args('--remotes'))
           .and_return(command_result(''))
 
         result = command.call(remotes: true)
@@ -62,7 +62,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'accepts :r alias' do
-        expect_command(*expected_args('--remotes'))
+        expect_command_with_capture(*expected_args('--remotes'))
           .and_return(command_result(''))
 
         result = command.call(r: true)
@@ -73,7 +73,7 @@ RSpec.describe Git::Commands::Branch::List do
 
     context 'with :sort option' do
       it 'adds --sort=<key> with single value' do
-        expect_command(*expected_args('--sort=refname'))
+        expect_command_with_capture(*expected_args('--sort=refname'))
           .and_return(command_result(''))
 
         result = command.call(sort: 'refname')
@@ -82,7 +82,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'adds multiple --sort=<key> with array of values' do
-        expect_command(*expected_args('--sort=refname', '--sort=-committerdate'))
+        expect_command_with_capture(*expected_args('--sort=refname', '--sort=-committerdate'))
           .and_return(command_result(''))
 
         result = command.call(sort: ['refname', '-committerdate'])
@@ -93,7 +93,7 @@ RSpec.describe Git::Commands::Branch::List do
 
     context 'with :ignore_case option' do
       it 'adds --ignore-case flag' do
-        expect_command(*expected_args('--ignore-case'))
+        expect_command_with_capture(*expected_args('--ignore-case'))
           .and_return(command_result(''))
 
         result = command.call(ignore_case: true)
@@ -102,7 +102,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'accepts :i alias' do
-        expect_command(*expected_args('--ignore-case'))
+        expect_command_with_capture(*expected_args('--ignore-case'))
           .and_return(command_result(''))
 
         result = command.call(i: true)
@@ -113,7 +113,7 @@ RSpec.describe Git::Commands::Branch::List do
 
     context 'with :contains option' do
       it 'adds --contains <commit> with string value' do
-        expect_command(*expected_args('--contains', 'abc123'))
+        expect_command_with_capture(*expected_args('--contains', 'abc123'))
           .and_return(command_result(''))
 
         result = command.call(contains: 'abc123')
@@ -122,7 +122,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'adds --contains flag with true (defaults to HEAD)' do
-        expect_command(*expected_args('--contains'))
+        expect_command_with_capture(*expected_args('--contains'))
           .and_return(command_result(''))
 
         result = command.call(contains: true)
@@ -133,7 +133,7 @@ RSpec.describe Git::Commands::Branch::List do
 
     context 'with :no_contains option' do
       it 'adds --no-contains <commit> with string value' do
-        expect_command(*expected_args('--no-contains', 'abc123'))
+        expect_command_with_capture(*expected_args('--no-contains', 'abc123'))
           .and_return(command_result(''))
 
         result = command.call(no_contains: 'abc123')
@@ -142,7 +142,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'adds --no-contains flag with true (defaults to HEAD)' do
-        expect_command(*expected_args('--no-contains'))
+        expect_command_with_capture(*expected_args('--no-contains'))
           .and_return(command_result(''))
 
         result = command.call(no_contains: true)
@@ -153,7 +153,7 @@ RSpec.describe Git::Commands::Branch::List do
 
     context 'with :merged option' do
       it 'adds --merged <commit> with string value' do
-        expect_command(*expected_args('--merged', 'main'))
+        expect_command_with_capture(*expected_args('--merged', 'main'))
           .and_return(command_result(''))
 
         result = command.call(merged: 'main')
@@ -162,7 +162,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'adds --merged flag with true (defaults to HEAD)' do
-        expect_command(*expected_args('--merged'))
+        expect_command_with_capture(*expected_args('--merged'))
           .and_return(command_result(''))
 
         result = command.call(merged: true)
@@ -173,7 +173,7 @@ RSpec.describe Git::Commands::Branch::List do
 
     context 'with :no_merged option' do
       it 'adds --no-merged <commit> with string value' do
-        expect_command(*expected_args('--no-merged', 'main'))
+        expect_command_with_capture(*expected_args('--no-merged', 'main'))
           .and_return(command_result(''))
 
         result = command.call(no_merged: 'main')
@@ -182,7 +182,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'adds --no-merged flag with true (defaults to HEAD)' do
-        expect_command(*expected_args('--no-merged'))
+        expect_command_with_capture(*expected_args('--no-merged'))
           .and_return(command_result(''))
 
         result = command.call(no_merged: true)
@@ -193,7 +193,7 @@ RSpec.describe Git::Commands::Branch::List do
 
     context 'with :points_at option' do
       it 'adds --points-at <object>' do
-        expect_command(*expected_args('--points-at', 'v1.0'))
+        expect_command_with_capture(*expected_args('--points-at', 'v1.0'))
           .and_return(command_result(''))
 
         result = command.call(points_at: 'v1.0')
@@ -204,7 +204,7 @@ RSpec.describe Git::Commands::Branch::List do
 
     context 'with patterns' do
       it 'adds pattern arguments' do
-        expect_command(*expected_args('feature/*'))
+        expect_command_with_capture(*expected_args('feature/*'))
           .and_return(command_result(''))
 
         result = command.call('feature/*')
@@ -213,7 +213,7 @@ RSpec.describe Git::Commands::Branch::List do
       end
 
       it 'adds multiple pattern arguments' do
-        expect_command(*expected_args('feature/*', 'bugfix/*'))
+        expect_command_with_capture(*expected_args('feature/*', 'bugfix/*'))
           .and_return(command_result(''))
 
         result = command.call('feature/*', 'bugfix/*')
@@ -224,7 +224,7 @@ RSpec.describe Git::Commands::Branch::List do
 
     context 'with multiple options' do
       it 'combines flags correctly' do
-        expect_command(*expected_args('--all', '--sort=refname', '--contains', 'abc123'))
+        expect_command_with_capture(*expected_args('--all', '--sort=refname', '--contains', 'abc123'))
           .and_return(command_result(''))
 
         result = command.call(all: true, sort: 'refname', contains: 'abc123')

--- a/spec/unit/git/commands/branch/move_spec.rb
+++ b/spec/unit/git/commands/branch/move_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Branch::Move do
   describe '#call' do
     context 'with only new_branch (rename current branch)' do
       it 'runs branch --move with only the new branch name' do
-        expect_command('branch', '--move', 'new-name')
+        expect_command_with_capture('branch', '--move', 'new-name')
           .and_return(command_result(''))
 
         result = command.call('new-name')
@@ -22,7 +22,7 @@ RSpec.describe Git::Commands::Branch::Move do
 
     context 'with old_branch and new_branch' do
       it 'runs branch --move with both branch names' do
-        expect_command('branch', '--move', 'old-name', 'new-name')
+        expect_command_with_capture('branch', '--move', 'old-name', 'new-name')
           .and_return(command_result(''))
 
         result = command.call('old-name', 'new-name')
@@ -33,7 +33,7 @@ RSpec.describe Git::Commands::Branch::Move do
 
     context 'with :force option' do
       it 'adds --force flag when renaming current branch' do
-        expect_command('branch', '--move', '--force', 'new-name')
+        expect_command_with_capture('branch', '--move', '--force', 'new-name')
           .and_return(command_result(''))
 
         result = command.call('new-name', force: true)
@@ -42,7 +42,7 @@ RSpec.describe Git::Commands::Branch::Move do
       end
 
       it 'adds --force flag when renaming specific branch' do
-        expect_command('branch', '--move', '--force', 'old-name', 'new-name')
+        expect_command_with_capture('branch', '--move', '--force', 'old-name', 'new-name')
           .and_return(command_result(''))
 
         result = command.call('old-name', 'new-name', force: true)
@@ -51,7 +51,7 @@ RSpec.describe Git::Commands::Branch::Move do
       end
 
       it 'does not add flag when false' do
-        expect_command('branch', '--move', 'new-name')
+        expect_command_with_capture('branch', '--move', 'new-name')
           .and_return(command_result(''))
 
         result = command.call('new-name', force: false)
@@ -62,7 +62,7 @@ RSpec.describe Git::Commands::Branch::Move do
 
     context 'with :f short option alias' do
       it 'adds --force flag when renaming current branch' do
-        expect_command('branch', '--move', '--force', 'new-name')
+        expect_command_with_capture('branch', '--move', '--force', 'new-name')
           .and_return(command_result(''))
 
         result = command.call('new-name', f: true)
@@ -71,7 +71,7 @@ RSpec.describe Git::Commands::Branch::Move do
       end
 
       it 'adds --force flag when renaming specific branch' do
-        expect_command('branch', '--move', '--force', 'old-name', 'new-name')
+        expect_command_with_capture('branch', '--move', '--force', 'old-name', 'new-name')
           .and_return(command_result(''))
 
         result = command.call('old-name', 'new-name', f: true)

--- a/spec/unit/git/commands/branch/set_upstream_spec.rb
+++ b/spec/unit/git/commands/branch/set_upstream_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Branch::SetUpstream do
   describe '#call' do
     context 'with only set_upstream_to (set upstream for current branch)' do
       it 'runs branch --set-upstream-to=<upstream>' do
-        expect_command('branch', '--set-upstream-to=origin/main')
+        expect_command_with_capture('branch', '--set-upstream-to=origin/main')
           .and_return(command_result("branch 'main' set up to track 'origin/main'.\n"))
 
         result = command.call(set_upstream_to: 'origin/main')
@@ -22,7 +22,7 @@ RSpec.describe Git::Commands::Branch::SetUpstream do
 
     context 'with -u short alias' do
       it 'runs branch --set-upstream-to=<upstream>' do
-        expect_command('branch', '--set-upstream-to=origin/main')
+        expect_command_with_capture('branch', '--set-upstream-to=origin/main')
           .and_return(command_result(''))
 
         result = command.call(u: 'origin/main')
@@ -33,7 +33,7 @@ RSpec.describe Git::Commands::Branch::SetUpstream do
 
     context 'with set_upstream_to and branch_name' do
       it 'runs branch --set-upstream-to=<upstream> <branch>' do
-        expect_command('branch', '--set-upstream-to=origin/main', 'feature')
+        expect_command_with_capture('branch', '--set-upstream-to=origin/main', 'feature')
           .and_return(command_result(''))
 
         result = command.call('feature', set_upstream_to: 'origin/main')
@@ -44,7 +44,7 @@ RSpec.describe Git::Commands::Branch::SetUpstream do
 
     context 'with remote-tracking branch as upstream' do
       it 'accepts various remote-tracking branch formats' do
-        expect_command('branch', '--set-upstream-to=upstream/develop')
+        expect_command_with_capture('branch', '--set-upstream-to=upstream/develop')
           .and_return(command_result(''))
 
         result = command.call(set_upstream_to: 'upstream/develop')

--- a/spec/unit/git/commands/branch/show_current_spec.rb
+++ b/spec/unit/git/commands/branch/show_current_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Git::Commands::Branch::ShowCurrent do
     context 'with no arguments' do
       it 'runs branch --show-current' do
         expected_result = command_result("main\n")
-        expect_command('branch', '--show-current')
+        expect_command_with_capture('branch', '--show-current')
           .and_return(expected_result)
 
         result = command.call

--- a/spec/unit/git/commands/branch/unset_upstream_spec.rb
+++ b/spec/unit/git/commands/branch/unset_upstream_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Branch::UnsetUpstream do
   describe '#call' do
     context 'with no arguments (unset upstream for current branch)' do
       it 'runs branch --unset-upstream' do
-        expect_command('branch', '--unset-upstream')
+        expect_command_with_capture('branch', '--unset-upstream')
           .and_return(command_result(''))
 
         result = command.call
@@ -22,7 +22,7 @@ RSpec.describe Git::Commands::Branch::UnsetUpstream do
 
     context 'with branch_name' do
       it 'runs branch --unset-upstream <branch>' do
-        expect_command('branch', '--unset-upstream', 'feature')
+        expect_command_with_capture('branch', '--unset-upstream', 'feature')
           .and_return(command_result(''))
 
         result = command.call('feature')
@@ -33,7 +33,7 @@ RSpec.describe Git::Commands::Branch::UnsetUpstream do
 
     context 'with nil branch_name' do
       it 'runs branch --unset-upstream (nil is treated as not provided)' do
-        expect_command('branch', '--unset-upstream')
+        expect_command_with_capture('branch', '--unset-upstream')
           .and_return(command_result(''))
 
         result = command.call(nil)

--- a/spec/unit/git/commands/cat_file/full_spec.rb
+++ b/spec/unit/git/commands/cat_file/full_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::CatFile::Full do
   # Helper that stubs execution_context.command, captures the :in IO, and verifies
   # the stdin content matches expected_stdin. Returns the given result.
   def expect_batch_command(*extra_args, stdin_content: nil, **extra_opts) # rubocop:disable Metrics/AbcSize
-    expect(execution_context).to receive(:command) do |*args, **kwargs|
+    expect(execution_context).to receive(:command_with_capture) do |*args, **kwargs|
       expect(args).to eq([*static_args, *extra_args])
       expect(kwargs).to include(raise_on_failure: false)
       if stdin_content

--- a/spec/unit/git/commands/cat_file/meta_spec.rb
+++ b/spec/unit/git/commands/cat_file/meta_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::CatFile::Meta do
   # Helper that stubs execution_context.command, captures the :in IO, and verifies
   # the stdin content matches expected_stdin. Returns the given result.
   def expect_batch_command(*extra_args, stdin_content: nil, **extra_opts) # rubocop:disable Metrics/AbcSize
-    expect(execution_context).to receive(:command) do |*args, **kwargs|
+    expect(execution_context).to receive(:command_with_capture) do |*args, **kwargs|
       expect(args).to eq([*static_args, *extra_args])
       expect(kwargs).to include(raise_on_failure: false)
       if stdin_content

--- a/spec/unit/git/commands/cat_file/pretty_spec.rb
+++ b/spec/unit/git/commands/cat_file/pretty_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Git::Commands::CatFile::Pretty do
     context 'with an object argument' do
       it 'runs git cat-file -p with the object' do
         expected_result = command_result('')
-        expect_command('cat-file', '-p', 'HEAD').and_return(expected_result)
+        expect_command_with_capture('cat-file', '-p', 'HEAD').and_return(expected_result)
         result = command.call('HEAD')
         expect(result).to eq(expected_result)
       end

--- a/spec/unit/git/commands/cat_file/typed_spec.rb
+++ b/spec/unit/git/commands/cat_file/typed_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Git::Commands::CatFile::Typed do
     context 'with type and object arguments' do
       it 'runs git cat-file with type then object' do
         expected_result = command_result('')
-        expect_command('cat-file', 'commit', 'HEAD').and_return(expected_result)
+        expect_command_with_capture('cat-file', 'commit', 'HEAD').and_return(expected_result)
         result = command.call('commit', 'HEAD')
         expect(result).to eq(expected_result)
       end

--- a/spec/unit/git/commands/checkout/branch_spec.rb
+++ b/spec/unit/git/commands/checkout/branch_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Git::Commands::Checkout::Branch do
     context 'with no arguments' do
       it 'calls git checkout with no arguments' do
         expected_result = command_result
-        expect_command('checkout').and_return(expected_result)
+        expect_command_with_capture('checkout').and_return(expected_result)
 
         result = command.call
 
@@ -21,104 +21,104 @@ RSpec.describe Git::Commands::Checkout::Branch do
 
     context 'with branch name only' do
       it 'calls git checkout with the branch name' do
-        expect_command('checkout', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', 'main').and_return(command_result)
         command.call('main')
       end
 
       it 'accepts a commit SHA' do
-        expect_command('checkout', 'abc123').and_return(command_result)
+        expect_command_with_capture('checkout', 'abc123').and_return(command_result)
         command.call('abc123')
       end
 
       it 'accepts a remote branch' do
-        expect_command('checkout', 'origin/main').and_return(command_result)
+        expect_command_with_capture('checkout', 'origin/main').and_return(command_result)
         command.call('origin/main')
       end
     end
 
     context 'with :force option' do
       it 'adds --force flag' do
-        expect_command('checkout', '--force', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', '--force', 'main').and_return(command_result)
         command.call('main', force: true)
       end
 
       it 'does not add flag when false' do
-        expect_command('checkout', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', 'main').and_return(command_result)
         command.call('main', force: false)
       end
 
       it 'works with :f alias' do
-        expect_command('checkout', '--force', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', '--force', 'main').and_return(command_result)
         command.call('main', f: true)
       end
     end
 
     context 'with :merge option' do
       it 'adds --merge flag' do
-        expect_command('checkout', '--merge', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', '--merge', 'main').and_return(command_result)
         command.call('main', merge: true)
       end
 
       it 'does not add flag when false' do
-        expect_command('checkout', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', 'main').and_return(command_result)
         command.call('main', merge: false)
       end
 
       it 'works with :m alias' do
-        expect_command('checkout', '--merge', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', '--merge', 'main').and_return(command_result)
         command.call('main', m: true)
       end
     end
 
     context 'with :detach option' do
       it 'adds --detach flag' do
-        expect_command('checkout', '--detach', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', '--detach', 'main').and_return(command_result)
         command.call('main', detach: true)
       end
 
       it 'does not add flag when false' do
-        expect_command('checkout', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', 'main').and_return(command_result)
         command.call('main', detach: false)
       end
 
       it 'works with :d alias' do
-        expect_command('checkout', '--detach', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', '--detach', 'main').and_return(command_result)
         command.call('main', d: true)
       end
     end
 
     context 'with :b option (creates and switches to new branch)' do
       it 'adds -b flag with branch name' do
-        expect_command('checkout', '-b', 'feature-branch').and_return(command_result)
+        expect_command_with_capture('checkout', '-b', 'feature-branch').and_return(command_result)
         command.call(b: 'feature-branch')
       end
 
       it 'adds start_point after -b branch' do
-        expect_command('checkout', '-b', 'feature-branch', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', '-b', 'feature-branch', 'main').and_return(command_result)
         command.call('main', b: 'feature-branch')
       end
     end
 
     context "with :'B' option (creates/resets and switches)" do
       it 'adds -B flag with branch name' do
-        expect_command('checkout', '-B', 'feature-branch').and_return(command_result)
+        expect_command_with_capture('checkout', '-B', 'feature-branch').and_return(command_result)
         command.call(B: 'feature-branch')
       end
 
       it 'adds start_point after -B branch' do
-        expect_command('checkout', '-B', 'feature-branch', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', '-B', 'feature-branch', 'main').and_return(command_result)
         command.call('main', B: 'feature-branch')
       end
     end
 
     context 'with :orphan option' do
       it 'adds --orphan flag with branch name' do
-        expect_command('checkout', '--orphan', 'gh-pages').and_return(command_result)
+        expect_command_with_capture('checkout', '--orphan', 'gh-pages').and_return(command_result)
         command.call(orphan: 'gh-pages')
       end
 
       it 'adds start_point after --orphan branch' do
-        expect_command('checkout', '--orphan', 'gh-pages', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', '--orphan', 'gh-pages', 'main').and_return(command_result)
         command.call('main', orphan: 'gh-pages')
       end
     end
@@ -126,34 +126,34 @@ RSpec.describe Git::Commands::Checkout::Branch do
     context 'with :track option' do
       context 'when true' do
         it 'adds --track flag' do
-          expect_command('checkout', '--track', 'origin/feature').and_return(command_result)
+          expect_command_with_capture('checkout', '--track', 'origin/feature').and_return(command_result)
           command.call('origin/feature', track: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-track flag' do
-          expect_command('checkout', '--no-track', 'origin/feature').and_return(command_result)
+          expect_command_with_capture('checkout', '--no-track', 'origin/feature').and_return(command_result)
           command.call('origin/feature', track: false)
         end
       end
 
       context 'when "direct"' do
         it 'adds --track=direct flag' do
-          expect_command('checkout', '--track=direct', 'origin/feature').and_return(command_result)
+          expect_command_with_capture('checkout', '--track=direct', 'origin/feature').and_return(command_result)
           command.call('origin/feature', track: 'direct')
         end
       end
 
       context 'when "inherit"' do
         it 'adds --track=inherit flag' do
-          expect_command('checkout', '--track=inherit', 'origin/feature').and_return(command_result)
+          expect_command_with_capture('checkout', '--track=inherit', 'origin/feature').and_return(command_result)
           command.call('origin/feature', track: 'inherit')
         end
       end
 
       it 'works with -b to set upstream' do
-        expect_command('checkout', '-b', 'feature', '--track', 'origin/feature').and_return(command_result)
+        expect_command_with_capture('checkout', '-b', 'feature', '--track', 'origin/feature').and_return(command_result)
         command.call('origin/feature', b: 'feature', track: true)
       end
     end
@@ -161,14 +161,14 @@ RSpec.describe Git::Commands::Checkout::Branch do
     context 'with :guess option' do
       context 'when true' do
         it 'adds --guess flag' do
-          expect_command('checkout', '--guess', 'feature').and_return(command_result)
+          expect_command_with_capture('checkout', '--guess', 'feature').and_return(command_result)
           command.call('feature', guess: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-guess flag' do
-          expect_command('checkout', '--no-guess', 'feature').and_return(command_result)
+          expect_command_with_capture('checkout', '--no-guess', 'feature').and_return(command_result)
           command.call('feature', guess: false)
         end
       end
@@ -176,12 +176,12 @@ RSpec.describe Git::Commands::Checkout::Branch do
 
     context 'with :ignore_other_worktrees option' do
       it 'adds --ignore-other-worktrees flag' do
-        expect_command('checkout', '--ignore-other-worktrees', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', '--ignore-other-worktrees', 'main').and_return(command_result)
         command.call('main', ignore_other_worktrees: true)
       end
 
       it 'does not add flag when false' do
-        expect_command('checkout', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', 'main').and_return(command_result)
         command.call('main', ignore_other_worktrees: false)
       end
     end
@@ -189,14 +189,14 @@ RSpec.describe Git::Commands::Checkout::Branch do
     context 'with :recurse_submodules option' do
       context 'when true' do
         it 'adds --recurse-submodules flag' do
-          expect_command('checkout', '--recurse-submodules', 'main').and_return(command_result)
+          expect_command_with_capture('checkout', '--recurse-submodules', 'main').and_return(command_result)
           command.call('main', recurse_submodules: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-recurse-submodules flag' do
-          expect_command('checkout', '--no-recurse-submodules', 'main').and_return(command_result)
+          expect_command_with_capture('checkout', '--no-recurse-submodules', 'main').and_return(command_result)
           command.call('main', recurse_submodules: false)
         end
       end
@@ -204,31 +204,31 @@ RSpec.describe Git::Commands::Checkout::Branch do
 
     context 'with multiple options combined' do
       it 'includes all specified flags in correct order' do
-        expect_command('checkout',
-                       '--force',
-                       '-b', 'feature',
-                       '--track',
-                       'origin/main').and_return(command_result)
+        expect_command_with_capture('checkout',
+                                    '--force',
+                                    '-b', 'feature',
+                                    '--track',
+                                    'origin/main').and_return(command_result)
         command.call('origin/main', force: true, b: 'feature', track: true)
       end
 
       it 'combines detach with force' do
-        expect_command('checkout',
-                       '--force',
-                       '--detach',
-                       'abc123').and_return(command_result)
+        expect_command_with_capture('checkout',
+                                    '--force',
+                                    '--detach',
+                                    'abc123').and_return(command_result)
         command.call('abc123', force: true, detach: true)
       end
     end
 
     context 'with nil branch' do
       it 'omits the branch from the command' do
-        expect_command('checkout').and_return(command_result)
+        expect_command_with_capture('checkout').and_return(command_result)
         command.call(nil)
       end
 
       it 'allows creating a branch with -b and no start point' do
-        expect_command('checkout', '-b', 'new-feature').and_return(command_result)
+        expect_command_with_capture('checkout', '-b', 'new-feature').and_return(command_result)
         command.call(nil, b: 'new-feature')
       end
     end

--- a/spec/unit/git/commands/checkout/files_spec.rb
+++ b/spec/unit/git/commands/checkout/files_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Git::Commands::Checkout::Files do
     context 'with nil tree_ish (restore from index)' do
       it 'omits tree_ish from command when nil' do
         expected_result = command_result
-        expect_command('checkout', '--', 'file.txt').and_return(expected_result)
+        expect_command_with_capture('checkout', '--', 'file.txt').and_return(expected_result)
 
         result = command.call(pathspec: ['file.txt'])
 
@@ -19,173 +19,174 @@ RSpec.describe Git::Commands::Checkout::Files do
       end
 
       it 'restores multiple files from index' do
-        expect_command('checkout', '--', 'file1.txt', 'file2.txt').and_return(command_result)
+        expect_command_with_capture('checkout', '--', 'file1.txt', 'file2.txt').and_return(command_result)
         command.call(pathspec: ['file1.txt', 'file2.txt'])
       end
 
       it 'works with options' do
-        expect_command('checkout', '--force', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('checkout', '--force', '--', 'file.txt').and_return(command_result)
         command.call(pathspec: ['file.txt'], force: true)
       end
     end
 
     context 'with tree_ish and pathspec' do
       it 'places tree_ish before -- separator' do
-        expect_command('checkout', 'HEAD~1', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('checkout', 'HEAD~1', '--', 'file.txt').and_return(command_result)
         command.call('HEAD~1', pathspec: ['file.txt'])
       end
 
       it 'accepts branch name as tree_ish' do
-        expect_command('checkout', 'main', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('checkout', 'main', '--', 'file.txt').and_return(command_result)
         command.call('main', pathspec: ['file.txt'])
       end
 
       it 'accepts commit SHA as tree_ish' do
-        expect_command('checkout', 'abc123', '--', 'file.txt', 'other.txt').and_return(command_result)
+        expect_command_with_capture('checkout', 'abc123', '--', 'file.txt', 'other.txt').and_return(command_result)
         command.call('abc123', pathspec: %w[file.txt other.txt])
       end
 
       it 'accepts tag as tree_ish' do
-        expect_command('checkout', 'v1.0.0', '--', 'config.yml').and_return(command_result)
+        expect_command_with_capture('checkout', 'v1.0.0', '--', 'config.yml').and_return(command_result)
         command.call('v1.0.0', pathspec: ['config.yml'])
       end
 
       it 'accepts glob patterns' do
-        expect_command('checkout', 'HEAD', '--', '*.rb').and_return(command_result)
+        expect_command_with_capture('checkout', 'HEAD', '--', '*.rb').and_return(command_result)
         command.call('HEAD', pathspec: ['*.rb'])
       end
 
       it 'accepts directory paths' do
-        expect_command('checkout', 'HEAD', '--', 'src/').and_return(command_result)
+        expect_command_with_capture('checkout', 'HEAD', '--', 'src/').and_return(command_result)
         command.call('HEAD', pathspec: ['src/'])
       end
     end
 
     context 'with :force option' do
       it 'adds --force flag' do
-        expect_command('checkout', '--force', 'HEAD', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('checkout', '--force', 'HEAD', '--', 'file.txt').and_return(command_result)
         command.call('HEAD', pathspec: ['file.txt'], force: true)
       end
 
       it 'does not add flag when false' do
-        expect_command('checkout', 'HEAD', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('checkout', 'HEAD', '--', 'file.txt').and_return(command_result)
         command.call('HEAD', pathspec: ['file.txt'], force: false)
       end
 
       it 'works with :f alias' do
-        expect_command('checkout', '--force', 'HEAD', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('checkout', '--force', 'HEAD', '--', 'file.txt').and_return(command_result)
         command.call('HEAD', pathspec: ['file.txt'], f: true)
       end
     end
 
     context 'with :ours option (for merge conflicts)' do
       it 'adds --ours flag' do
-        expect_command('checkout', '--ours', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
+        expect_command_with_capture('checkout', '--ours', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
         command.call('HEAD', pathspec: ['conflicted.txt'], ours: true)
       end
 
       it 'does not add flag when false' do
-        expect_command('checkout', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
+        expect_command_with_capture('checkout', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
         command.call('HEAD', pathspec: ['conflicted.txt'], ours: false)
       end
     end
 
     context 'with :theirs option (for merge conflicts)' do
       it 'adds --theirs flag' do
-        expect_command('checkout', '--theirs', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
+        expect_command_with_capture('checkout', '--theirs', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
         command.call('HEAD', pathspec: ['conflicted.txt'], theirs: true)
       end
 
       it 'does not add flag when false' do
-        expect_command('checkout', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
+        expect_command_with_capture('checkout', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
         command.call('HEAD', pathspec: ['conflicted.txt'], theirs: false)
       end
     end
 
     context 'with :merge option (recreate conflict markers)' do
       it 'adds --merge flag' do
-        expect_command('checkout', '--merge', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
+        expect_command_with_capture('checkout', '--merge', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
         command.call('HEAD', pathspec: ['conflicted.txt'], merge: true)
       end
 
       it 'does not add flag when false' do
-        expect_command('checkout', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
+        expect_command_with_capture('checkout', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
         command.call('HEAD', pathspec: ['conflicted.txt'], merge: false)
       end
 
       it 'works with :m alias' do
-        expect_command('checkout', '--merge', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
+        expect_command_with_capture('checkout', '--merge', 'HEAD', '--', 'conflicted.txt').and_return(command_result)
         command.call('HEAD', pathspec: ['conflicted.txt'], m: true)
       end
     end
 
     context 'with :conflict option' do
       it 'adds --conflict=merge flag' do
-        expect_command('checkout', '--conflict=merge', 'HEAD', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('checkout', '--conflict=merge', 'HEAD', '--', 'file.txt').and_return(command_result)
         command.call('HEAD', pathspec: ['file.txt'], conflict: 'merge')
       end
 
       it 'adds --conflict=diff3 flag' do
-        expect_command('checkout', '--conflict=diff3', 'HEAD', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('checkout', '--conflict=diff3', 'HEAD', '--', 'file.txt').and_return(command_result)
         command.call('HEAD', pathspec: ['file.txt'], conflict: 'diff3')
       end
 
       it 'adds --conflict=zdiff3 flag' do
-        expect_command('checkout', '--conflict=zdiff3', 'HEAD', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('checkout', '--conflict=zdiff3', 'HEAD', '--',
+                                    'file.txt').and_return(command_result)
         command.call('HEAD', pathspec: ['file.txt'], conflict: 'zdiff3')
       end
     end
 
     context 'with :overlay option' do
       it 'adds --overlay flag when true' do
-        expect_command('checkout', '--overlay', 'main', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('checkout', '--overlay', 'main', '--', 'file.txt').and_return(command_result)
         command.call('main', pathspec: ['file.txt'], overlay: true)
       end
 
       it 'adds --no-overlay flag when false' do
-        expect_command('checkout', '--no-overlay', 'main', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('checkout', '--no-overlay', 'main', '--', 'file.txt').and_return(command_result)
         command.call('main', pathspec: ['file.txt'], overlay: false)
       end
     end
 
     context 'with :pathspec_from_file option' do
       it 'adds --pathspec-from-file flag' do
-        expect_command('checkout', '--pathspec-from-file=paths.txt', 'main').and_return(command_result)
+        expect_command_with_capture('checkout', '--pathspec-from-file=paths.txt', 'main').and_return(command_result)
         command.call('main', pathspec_from_file: 'paths.txt')
       end
 
       it 'accepts stdin with -' do
-        expect_command('checkout', '--pathspec-from-file=-', 'HEAD').and_return(command_result)
+        expect_command_with_capture('checkout', '--pathspec-from-file=-', 'HEAD').and_return(command_result)
         command.call('HEAD', pathspec_from_file: '-')
       end
     end
 
     context 'with :pathspec_file_nul option' do
       it 'adds --pathspec-file-nul flag with pathspec_from_file' do
-        expect_command('checkout', '--pathspec-from-file=paths.txt', '--pathspec-file-nul',
-                       'main').and_return(command_result)
+        expect_command_with_capture('checkout', '--pathspec-from-file=paths.txt', '--pathspec-file-nul',
+                                    'main').and_return(command_result)
         command.call('main', pathspec_from_file: 'paths.txt', pathspec_file_nul: true)
       end
     end
 
     context 'with multiple options combined' do
       it 'includes all specified flags in correct order' do
-        expect_command('checkout',
-                       '--force',
-                       '--ours',
-                       'HEAD',
-                       '--',
-                       'file1.txt',
-                       'file2.txt').and_return(command_result)
+        expect_command_with_capture('checkout',
+                                    '--force',
+                                    '--ours',
+                                    'HEAD',
+                                    '--',
+                                    'file1.txt',
+                                    'file2.txt').and_return(command_result)
         command.call('HEAD', pathspec: %w[file1.txt file2.txt], force: true, ours: true)
       end
 
       it 'combines tree_ish with conflict resolution' do
-        expect_command('checkout',
-                       '--conflict=diff3',
-                       'main',
-                       '--',
-                       'conflicted.txt').and_return(command_result)
+        expect_command_with_capture('checkout',
+                                    '--conflict=diff3',
+                                    'main',
+                                    '--',
+                                    'conflicted.txt').and_return(command_result)
         command.call('main', pathspec: ['conflicted.txt'], conflict: 'diff3')
       end
     end

--- a/spec/unit/git/commands/checkout_index_spec.rb
+++ b/spec/unit/git/commands/checkout_index_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Git::Commands::CheckoutIndex do
     context 'with no arguments' do
       it 'runs git checkout-index without any flags' do
         expected_result = command_result
-        expect_command('checkout-index').and_return(expected_result)
+        expect_command_with_capture('checkout-index').and_return(expected_result)
 
         result = command.call
 
@@ -21,19 +21,19 @@ RSpec.describe Git::Commands::CheckoutIndex do
 
     context 'with the :all option' do
       it 'includes --all when true' do
-        expect_command('checkout-index', '--all').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--all').and_return(command_result)
 
         command.call(all: true)
       end
 
       it 'accepts :a as an alias' do
-        expect_command('checkout-index', '--all').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--all').and_return(command_result)
 
         command.call(a: true)
       end
 
       it 'does not include --all when false' do
-        expect_command('checkout-index').and_return(command_result)
+        expect_command_with_capture('checkout-index').and_return(command_result)
 
         command.call(all: false)
       end
@@ -41,19 +41,19 @@ RSpec.describe Git::Commands::CheckoutIndex do
 
     context 'with the :force option' do
       it 'includes --force when true' do
-        expect_command('checkout-index', '--force').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--force').and_return(command_result)
 
         command.call(force: true)
       end
 
       it 'accepts :f as an alias' do
-        expect_command('checkout-index', '--force').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--force').and_return(command_result)
 
         command.call(f: true)
       end
 
       it 'does not include --force when false' do
-        expect_command('checkout-index').and_return(command_result)
+        expect_command_with_capture('checkout-index').and_return(command_result)
 
         command.call(force: false)
       end
@@ -61,13 +61,13 @@ RSpec.describe Git::Commands::CheckoutIndex do
 
     context 'with the :index option' do
       it 'includes --index when true' do
-        expect_command('checkout-index', '--index').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--index').and_return(command_result)
 
         command.call(index: true)
       end
 
       it 'accepts :u as an alias' do
-        expect_command('checkout-index', '--index').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--index').and_return(command_result)
 
         command.call(u: true)
       end
@@ -75,13 +75,13 @@ RSpec.describe Git::Commands::CheckoutIndex do
 
     context 'with the :no_create option' do
       it 'includes --no-create when true' do
-        expect_command('checkout-index', '--no-create').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--no-create').and_return(command_result)
 
         command.call(no_create: true)
       end
 
       it 'accepts :n as an alias' do
-        expect_command('checkout-index', '--no-create').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--no-create').and_return(command_result)
 
         command.call(n: true)
       end
@@ -89,7 +89,7 @@ RSpec.describe Git::Commands::CheckoutIndex do
 
     context 'with the :prefix option' do
       it 'includes --prefix=<value>' do
-        expect_command('checkout-index', '--prefix=output/').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--prefix=output/').and_return(command_result)
 
         command.call(prefix: 'output/')
       end
@@ -97,25 +97,25 @@ RSpec.describe Git::Commands::CheckoutIndex do
 
     context 'with the :stage option' do
       it 'includes --stage=1 for stage 1' do
-        expect_command('checkout-index', '--stage=1').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--stage=1').and_return(command_result)
 
         command.call(stage: '1')
       end
 
       it 'includes --stage=2 for stage 2' do
-        expect_command('checkout-index', '--stage=2').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--stage=2').and_return(command_result)
 
         command.call(stage: '2')
       end
 
       it 'includes --stage=3 for stage 3' do
-        expect_command('checkout-index', '--stage=3').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--stage=3').and_return(command_result)
 
         command.call(stage: '3')
       end
 
       it 'accepts "all" as the stage value' do
-        expect_command('checkout-index', '--stage=all').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--stage=all').and_return(command_result)
 
         command.call(stage: 'all')
       end
@@ -123,7 +123,7 @@ RSpec.describe Git::Commands::CheckoutIndex do
 
     context 'with the :temp option' do
       it 'includes --temp when true' do
-        expect_command('checkout-index', '--temp').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--temp').and_return(command_result)
 
         command.call(temp: true)
       end
@@ -131,7 +131,7 @@ RSpec.describe Git::Commands::CheckoutIndex do
 
     context 'with the :ignore_skip_worktree_bits option' do
       it 'includes --ignore-skip-worktree-bits when true' do
-        expect_command('checkout-index', '--ignore-skip-worktree-bits').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--ignore-skip-worktree-bits').and_return(command_result)
 
         command.call(ignore_skip_worktree_bits: true)
       end
@@ -139,19 +139,19 @@ RSpec.describe Git::Commands::CheckoutIndex do
 
     context 'with path_limiter positional arguments' do
       it 'appends -- and a single path' do
-        expect_command('checkout-index', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--', 'file.txt').and_return(command_result)
 
         command.call('file.txt')
       end
 
       it 'appends -- and multiple paths when given as separate arguments' do
-        expect_command('checkout-index', '--', 'file1.txt', 'file2.txt').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--', 'file1.txt', 'file2.txt').and_return(command_result)
 
         command.call('file1.txt', 'file2.txt')
       end
 
       it 'omits -- when no paths are given' do
-        expect_command('checkout-index').and_return(command_result)
+        expect_command_with_capture('checkout-index').and_return(command_result)
 
         command.call
       end
@@ -159,7 +159,7 @@ RSpec.describe Git::Commands::CheckoutIndex do
 
     context 'with multiple options combined' do
       it 'includes all specified flags' do
-        expect_command('checkout-index', '--all', '--force', '--prefix=output/').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--all', '--force', '--prefix=output/').and_return(command_result)
 
         command.call(prefix: 'output/', force: true, all: true)
       end
@@ -167,7 +167,7 @@ RSpec.describe Git::Commands::CheckoutIndex do
 
     context 'with :force and file operand combined' do
       it 'includes --force and appends -- path' do
-        expect_command('checkout-index', '--force', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('checkout-index', '--force', '--', 'file.txt').and_return(command_result)
 
         command.call('file.txt', force: true)
       end

--- a/spec/unit/git/commands/clean_spec.rb
+++ b/spec/unit/git/commands/clean_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Clean do
     context 'with no arguments' do
       it 'runs git clean without any flags' do
         expected_result = command_result
-        expect_command('clean').and_return(expected_result)
+        expect_command_with_capture('clean').and_return(expected_result)
 
         result = command.call
 
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::Clean do
 
     context 'with the :force argument' do
       it 'adds --force to the command line' do
-        expect_command('clean', '--force').and_return(command_result)
+        expect_command_with_capture('clean', '--force').and_return(command_result)
 
         command.call(force: true)
       end
@@ -28,26 +28,26 @@ RSpec.describe Git::Commands::Clean do
 
     context 'with the :force_force argument' do
       it 'adds -ff to the command line' do
-        expect_command('clean', '-ff').and_return(command_result)
+        expect_command_with_capture('clean', '-ff').and_return(command_result)
         command.call(force_force: true)
       end
     end
 
     context 'with both :force and :force_force arguments' do
       it 'allows force: true with force_force: false' do
-        expect_command('clean', '--force').and_return(command_result)
+        expect_command_with_capture('clean', '--force').and_return(command_result)
         command.call(force: true, force_force: false)
       end
 
       it 'allows force_force: true with force: false' do
-        expect_command('clean', '-ff').and_return(command_result)
+        expect_command_with_capture('clean', '-ff').and_return(command_result)
         command.call(force_force: true, force: false)
       end
     end
 
     context 'with the :d argument' do
       it 'adds -d to the command line' do
-        expect_command('clean', '-d').and_return(command_result)
+        expect_command_with_capture('clean', '-d').and_return(command_result)
 
         command.call(d: true)
       end
@@ -55,7 +55,7 @@ RSpec.describe Git::Commands::Clean do
 
     context 'with the :x argument' do
       it 'adds -x to the command line' do
-        expect_command('clean', '-x').and_return(command_result)
+        expect_command_with_capture('clean', '-x').and_return(command_result)
 
         command.call(x: true)
       end
@@ -63,7 +63,7 @@ RSpec.describe Git::Commands::Clean do
 
     context 'with multiple options combined' do
       it 'includes all specified flags' do
-        expect_command('clean', '-d', '--force', '-x').and_return(command_result)
+        expect_command_with_capture('clean', '-d', '--force', '-x').and_return(command_result)
         command.call(force: true, d: true, x: true)
       end
     end

--- a/spec/unit/git/commands/clone_spec.rb
+++ b/spec/unit/git/commands/clone_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::Clone do
     context 'with minimal arguments' do
       it 'clones into the specified directory' do
         expected_result = command_result
-        expect_command('clone', '--', repository_url, directory).and_return(expected_result)
+        expect_command_with_capture('clone', '--', repository_url, directory).and_return(expected_result)
 
         result = command.call(repository_url, directory)
 
@@ -23,7 +23,7 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with nil directory' do
       it 'omits the directory operand' do
-        expect_command('clone', '--', repository_url).and_return(command_result)
+        expect_command_with_capture('clone', '--', repository_url).and_return(command_result)
 
         command.call(repository_url, nil)
       end
@@ -31,7 +31,7 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :bare option' do
       it 'includes the --bare flag' do
-        expect_command('clone', '--bare', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--bare', '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, bare: true)
       end
@@ -39,7 +39,7 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :mirror option' do
       it 'includes the --mirror flag' do
-        expect_command('clone', '--mirror', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--mirror', '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, mirror: true)
       end
@@ -47,20 +47,22 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :recurse_submodules option' do
       it 'includes the --recurse-submodules flag' do
-        expect_command('clone', '--recurse-submodules', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--recurse-submodules', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, recurse_submodules: true)
       end
 
       it 'includes --recurse-submodules=<pathspec> with inline value' do
-        expect_command('clone', '--recurse-submodules=lib/', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--recurse-submodules=lib/', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, recurse_submodules: 'lib/')
       end
 
       it 'includes multiple --recurse-submodules=<pathspec> options' do
-        expect_command('clone', '--recurse-submodules=lib/', '--recurse-submodules=ext/', '--',
-                       repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--recurse-submodules=lib/', '--recurse-submodules=ext/', '--',
+                                    repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, recurse_submodules: %w[lib/ ext/])
       end
@@ -68,13 +70,15 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :branch option' do
       it 'includes the --branch flag with value' do
-        expect_command('clone', '--branch', 'development', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--branch', 'development', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, branch: 'development')
       end
 
       it 'accepts the :b alias' do
-        expect_command('clone', '--branch', 'development', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--branch', 'development', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, b: 'development')
       end
@@ -82,7 +86,8 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :filter option' do
       it 'includes the --filter flag with value' do
-        expect_command('clone', '--filter=tree:0', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--filter=tree:0', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, filter: 'tree:0')
       end
@@ -90,7 +95,8 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :origin option' do
       it 'includes the --origin flag with value' do
-        expect_command('clone', '--origin', 'upstream', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--origin', 'upstream', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, origin: 'upstream')
       end
@@ -98,7 +104,8 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :o option (alias for origin)' do
       it 'includes the --origin flag with value' do
-        expect_command('clone', '--origin', 'upstream', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--origin', 'upstream', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, o: 'upstream')
       end
@@ -106,22 +113,22 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :config option' do
       it 'includes a single config option' do
-        expect_command('clone', '--config', 'user.name=John Doe', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--config', 'user.name=John Doe', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, config: 'user.name=John Doe')
       end
 
       it 'includes multiple config options' do
-        expect_command('clone', '--config', 'user.name=John Doe', '--config', 'user.email=john@doe.com',
-                       '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--config', 'user.name=John Doe', '--config', 'user.email=john@doe.com',
+                                    '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, config: ['user.name=John Doe', 'user.email=john@doe.com'])
       end
 
       it 'accepts the :c alias' do
-        expect_command('clone', '--config', 'user.name=John Doe', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--config', 'user.name=John Doe', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, c: 'user.name=John Doe')
       end
@@ -129,13 +136,15 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :single_branch option' do
       it 'includes --single-branch when true' do
-        expect_command('clone', '--single-branch', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--single-branch', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, single_branch: true)
       end
 
       it 'includes --no-single-branch when false' do
-        expect_command('clone', '--no-single-branch', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--no-single-branch', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, single_branch: false)
       end
@@ -143,7 +152,7 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :depth option' do
       it 'includes --depth with integer value' do
-        expect_command('clone', '--depth', '1', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--depth', '1', '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, depth: 1)
       end
@@ -151,7 +160,7 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :timeout option' do
       it 'passes timeout to the command' do
-        expect_command('clone', '--', repository_url, directory, timeout: 30).and_return(command_result)
+        expect_command_with_capture('clone', '--', repository_url, directory, timeout: 30).and_return(command_result)
 
         command.call(repository_url, directory, timeout: 30)
       end
@@ -159,7 +168,8 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :chdir option' do
       it 'passes chdir to the command' do
-        expect_command('clone', '--', repository_url, directory, chdir: '/parent/dir').and_return(command_result)
+        expect_command_with_capture('clone', '--', repository_url, directory,
+                                    chdir: '/parent/dir').and_return(command_result)
 
         command.call(repository_url, directory, chdir: '/parent/dir')
       end
@@ -167,8 +177,8 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :template option' do
       it 'includes --template=<dir> with inline value' do
-        expect_command('clone', '--template=/usr/share/git-core/templates', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--template=/usr/share/git-core/templates', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, template: '/usr/share/git-core/templates')
       end
@@ -176,19 +186,19 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :local option' do
       it 'includes --local flag' do
-        expect_command('clone', '--local', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--local', '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, local: true)
       end
 
       it 'includes --no-local when false' do
-        expect_command('clone', '--no-local', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--no-local', '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, local: false)
       end
 
       it 'accepts the :l alias' do
-        expect_command('clone', '--local', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--local', '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, l: true)
       end
@@ -196,13 +206,13 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :shared option' do
       it 'includes --shared flag' do
-        expect_command('clone', '--shared', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--shared', '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, shared: true)
       end
 
       it 'accepts the :s alias' do
-        expect_command('clone', '--shared', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--shared', '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, s: true)
       end
@@ -210,7 +220,8 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :no_hardlinks option' do
       it 'includes --no-hardlinks flag' do
-        expect_command('clone', '--no-hardlinks', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--no-hardlinks', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, no_hardlinks: true)
       end
@@ -218,13 +229,15 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :no_checkout option' do
       it 'includes --no-checkout flag' do
-        expect_command('clone', '--no-checkout', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--no-checkout', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, no_checkout: true)
       end
 
       it 'accepts the :n alias' do
-        expect_command('clone', '--no-checkout', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--no-checkout', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, n: true)
       end
@@ -232,15 +245,15 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :upload_pack option' do
       it 'includes --upload-pack <path>' do
-        expect_command('clone', '--upload-pack', '/usr/bin/git-upload-pack', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--upload-pack', '/usr/bin/git-upload-pack', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, upload_pack: '/usr/bin/git-upload-pack')
       end
 
       it 'accepts the :u alias' do
-        expect_command('clone', '--upload-pack', '/usr/bin/git-upload-pack', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--upload-pack', '/usr/bin/git-upload-pack', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, u: '/usr/bin/git-upload-pack')
       end
@@ -248,15 +261,15 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :reference option' do
       it 'includes --reference <repository>' do
-        expect_command('clone', '--reference', '/path/to/local', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--reference', '/path/to/local', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, reference: '/path/to/local')
       end
 
       it 'includes multiple --reference options' do
-        expect_command('clone', '--reference', '/path/one', '--reference', '/path/two', '--',
-                       repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--reference', '/path/one', '--reference', '/path/two', '--',
+                                    repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, reference: ['/path/one', '/path/two'])
       end
@@ -264,15 +277,15 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :reference_if_able option' do
       it 'includes --reference-if-able <repository>' do
-        expect_command('clone', '--reference-if-able', '/path/to/local', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--reference-if-able', '/path/to/local', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, reference_if_able: '/path/to/local')
       end
 
       it 'includes multiple --reference-if-able options' do
-        expect_command('clone', '--reference-if-able', '/path/one', '--reference-if-able', '/path/two',
-                       '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--reference-if-able', '/path/one', '--reference-if-able', '/path/two',
+                                    '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, reference_if_able: ['/path/one', '/path/two'])
       end
@@ -280,7 +293,7 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :dissociate option' do
       it 'includes --dissociate flag' do
-        expect_command('clone', '--dissociate', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--dissociate', '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, dissociate: true)
       end
@@ -288,8 +301,8 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :separate_git_dir option' do
       it 'includes --separate-git-dir=<dir>' do
-        expect_command('clone', '--separate-git-dir=/path/to/git-dir', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--separate-git-dir=/path/to/git-dir', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, separate_git_dir: '/path/to/git-dir')
       end
@@ -297,15 +310,15 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :server_option option' do
       it 'includes a single --server-option=<opt>' do
-        expect_command('clone', '--server-option=version=2', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--server-option=version=2', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, server_option: 'version=2')
       end
 
       it 'includes multiple --server-option flags' do
-        expect_command('clone', '--server-option=version=2', '--server-option=key=val',
-                       '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--server-option=version=2', '--server-option=key=val',
+                                    '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, server_option: %w[version=2 key=val])
       end
@@ -313,8 +326,8 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :shallow_since option' do
       it 'includes --shallow-since=<date>' do
-        expect_command('clone', '--shallow-since=2020-01-01', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--shallow-since=2020-01-01', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, shallow_since: '2020-01-01')
       end
@@ -322,15 +335,15 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :shallow_exclude option' do
       it 'includes a single --shallow-exclude=<ref>' do
-        expect_command('clone', '--shallow-exclude=v1.0', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--shallow-exclude=v1.0', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, shallow_exclude: 'v1.0')
       end
 
       it 'includes multiple --shallow-exclude flags' do
-        expect_command('clone', '--shallow-exclude=v1.0', '--shallow-exclude=v2.0',
-                       '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--shallow-exclude=v1.0', '--shallow-exclude=v2.0',
+                                    '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, shallow_exclude: %w[v1.0 v2.0])
       end
@@ -338,13 +351,13 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :tags option' do
       it 'includes --tags when true' do
-        expect_command('clone', '--tags', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--tags', '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, tags: true)
       end
 
       it 'includes --no-tags when false' do
-        expect_command('clone', '--no-tags', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--no-tags', '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, tags: false)
       end
@@ -352,14 +365,15 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :shallow_submodules option' do
       it 'includes --shallow-submodules when true' do
-        expect_command('clone', '--shallow-submodules', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--shallow-submodules', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, shallow_submodules: true)
       end
 
       it 'includes --no-shallow-submodules when false' do
-        expect_command('clone', '--no-shallow-submodules', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--no-shallow-submodules', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, shallow_submodules: false)
       end
@@ -367,14 +381,15 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :remote_submodules option' do
       it 'includes --remote-submodules when true' do
-        expect_command('clone', '--remote-submodules', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--remote-submodules', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, remote_submodules: true)
       end
 
       it 'includes --no-remote-submodules when false' do
-        expect_command('clone', '--no-remote-submodules', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--no-remote-submodules', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, remote_submodules: false)
       end
@@ -382,13 +397,13 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :jobs option' do
       it 'includes --jobs <n>' do
-        expect_command('clone', '--jobs', '4', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--jobs', '4', '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, jobs: 4)
       end
 
       it 'accepts the :j alias' do
-        expect_command('clone', '--jobs', '4', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--jobs', '4', '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, j: 4)
       end
@@ -396,7 +411,7 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :sparse option' do
       it 'includes --sparse flag' do
-        expect_command('clone', '--sparse', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--sparse', '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, sparse: true)
       end
@@ -404,13 +419,15 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :reject_shallow option' do
       it 'includes --reject-shallow when true' do
-        expect_command('clone', '--reject-shallow', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--reject-shallow', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, reject_shallow: true)
       end
 
       it 'includes --no-reject-shallow when false' do
-        expect_command('clone', '--no-reject-shallow', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--no-reject-shallow', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, reject_shallow: false)
       end
@@ -418,8 +435,8 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :also_filter_submodules option' do
       it 'includes --also-filter-submodules alongside --filter and --recurse-submodules' do
-        expect_command('clone', '--recurse-submodules', '--filter=blob:none', '--also-filter-submodules',
-                       '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--recurse-submodules', '--filter=blob:none', '--also-filter-submodules',
+                                    '--', repository_url, directory).and_return(command_result)
 
         command.call(repository_url, directory, filter: 'blob:none', recurse_submodules: true,
                                                 also_filter_submodules: true)
@@ -428,8 +445,8 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :bundle_uri option' do
       it 'includes --bundle-uri=<uri>' do
-        expect_command('clone', '--bundle-uri=https://example.com/bundle', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--bundle-uri=https://example.com/bundle', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, bundle_uri: 'https://example.com/bundle')
       end
@@ -437,7 +454,8 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :ref_format option' do
       it 'includes --ref-format=<fmt>' do
-        expect_command('clone', '--ref-format=reftable', '--', repository_url, directory).and_return(command_result)
+        expect_command_with_capture('clone', '--ref-format=reftable', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, ref_format: 'reftable')
       end
@@ -445,8 +463,8 @@ RSpec.describe Git::Commands::Clone do
 
     context 'with :revision option' do
       it 'includes --revision=<rev>' do
-        expect_command('clone', '--revision=refs/heads/main', '--', repository_url,
-                       directory).and_return(command_result)
+        expect_command_with_capture('clone', '--revision=refs/heads/main', '--', repository_url,
+                                    directory).and_return(command_result)
 
         command.call(repository_url, directory, revision: 'refs/heads/main')
       end

--- a/spec/unit/git/commands/commit_spec.rb
+++ b/spec/unit/git/commands/commit_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Commit do
     context 'with a simple message' do
       it 'commits with the given message' do
         expected_result = command_result
-        expect_command('commit', '--no-edit', '--message=Initial commit').and_return(expected_result)
+        expect_command_with_capture('commit', '--no-edit', '--message=Initial commit').and_return(expected_result)
 
         result = command.call(message: 'Initial commit')
 
@@ -20,19 +20,21 @@ RSpec.describe Git::Commands::Commit do
 
     context 'with the :all option' do
       it 'includes the --all flag' do
-        expect_command('commit', '--no-edit', '--all', '--message=Add all changes').and_return(command_result)
+        expect_command_with_capture('commit', '--no-edit', '--all',
+                                    '--message=Add all changes').and_return(command_result)
 
         command.call(message: 'Add all changes', all: true)
       end
 
       it 'also accepts :a as an alias' do
-        expect_command('commit', '--no-edit', '--all', '--message=Add all changes').and_return(command_result)
+        expect_command_with_capture('commit', '--no-edit', '--all',
+                                    '--message=Add all changes').and_return(command_result)
 
         command.call(message: 'Add all changes', a: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('commit', '--no-edit', '--message=Message').and_return(command_result)
+        expect_command_with_capture('commit', '--no-edit', '--message=Message').and_return(command_result)
 
         command.call(message: 'Message', all: false)
       end
@@ -40,7 +42,8 @@ RSpec.describe Git::Commands::Commit do
 
     context 'with the :allow_empty option' do
       it 'includes the --allow-empty flag' do
-        expect_command('commit', '--no-edit', '--message=Empty commit', '--allow-empty').and_return(command_result)
+        expect_command_with_capture('commit', '--no-edit', '--message=Empty commit',
+                                    '--allow-empty').and_return(command_result)
 
         command.call(message: 'Empty commit', allow_empty: true)
       end
@@ -48,7 +51,7 @@ RSpec.describe Git::Commands::Commit do
 
     context 'with the :allow_empty_message option' do
       it 'includes the --allow-empty-message flag without a message' do
-        expect_command('commit', '--no-edit', '--allow-empty-message').and_return(command_result)
+        expect_command_with_capture('commit', '--no-edit', '--allow-empty-message').and_return(command_result)
 
         command.call(allow_empty_message: true)
       end
@@ -56,7 +59,8 @@ RSpec.describe Git::Commands::Commit do
 
     context 'with the :no_verify option' do
       it 'includes the --no-verify flag' do
-        expect_command('commit', '--no-edit', '--message=Skip hooks', '--no-verify').and_return(command_result)
+        expect_command_with_capture('commit', '--no-edit', '--message=Skip hooks',
+                                    '--no-verify').and_return(command_result)
 
         command.call(message: 'Skip hooks', no_verify: true)
       end
@@ -64,7 +68,7 @@ RSpec.describe Git::Commands::Commit do
 
     context 'with the :author option' do
       it 'includes the --author flag with the specified value' do
-        expect_command(
+        expect_command_with_capture(
           'commit',
           '--no-edit',
           '--message=Authored commit',
@@ -77,7 +81,7 @@ RSpec.describe Git::Commands::Commit do
 
     context 'with the :date option' do
       it 'includes the --date flag with the specified value' do
-        expect_command(
+        expect_command_with_capture(
           'commit',
           '--no-edit',
           '--message=Dated commit',
@@ -90,13 +94,13 @@ RSpec.describe Git::Commands::Commit do
 
     context 'with the :amend option' do
       it 'includes --no-edit always; also includes --amend when true' do
-        expect_command('commit', '--no-edit', '--amend').and_return(command_result)
+        expect_command_with_capture('commit', '--no-edit', '--amend').and_return(command_result)
 
         command.call(amend: true)
       end
 
       it 'does not include --amend when false; --no-edit still present' do
-        expect_command('commit', '--no-edit', '--message=Normal commit').and_return(command_result)
+        expect_command_with_capture('commit', '--no-edit', '--message=Normal commit').and_return(command_result)
 
         command.call(message: 'Normal commit', amend: false)
       end
@@ -105,7 +109,8 @@ RSpec.describe Git::Commands::Commit do
     context 'with GPG signing options' do
       context 'when :gpg_sign is true' do
         it 'includes --gpg-sign flag' do
-          expect_command('commit', '--no-edit', '--message=Signed commit', '--gpg-sign').and_return(command_result)
+          expect_command_with_capture('commit', '--no-edit', '--message=Signed commit',
+                                      '--gpg-sign').and_return(command_result)
 
           command.call(message: 'Signed commit', gpg_sign: true)
         end
@@ -113,7 +118,7 @@ RSpec.describe Git::Commands::Commit do
 
       context 'when :gpg_sign is a key ID' do
         it 'includes --gpg-sign with the key ID' do
-          expect_command(
+          expect_command_with_capture(
             'commit',
             '--no-edit',
             '--message=Signed commit',
@@ -126,7 +131,8 @@ RSpec.describe Git::Commands::Commit do
 
       context 'when :gpg_sign is false' do
         it 'includes --no-gpg-sign flag' do
-          expect_command('commit', '--no-edit', '--message=Unsigned commit', '--no-gpg-sign').and_return(command_result)
+          expect_command_with_capture('commit', '--no-edit', '--message=Unsigned commit',
+                                      '--no-gpg-sign').and_return(command_result)
 
           command.call(message: 'Unsigned commit', gpg_sign: false)
         end
@@ -135,7 +141,7 @@ RSpec.describe Git::Commands::Commit do
 
     context 'with multiple options combined' do
       it 'includes all specified flags' do
-        expect_command(
+        expect_command_with_capture(
           'commit',
           '--no-edit',
           '--all',

--- a/spec/unit/git/commands/diff/numstat_spec.rb
+++ b/spec/unit/git/commands/diff/numstat_spec.rb
@@ -19,8 +19,8 @@ RSpec.describe Git::Commands::Diff::Numstat do
     context 'with no arguments (working tree vs index)' do
       it 'runs diff with --numstat, --shortstat, and -M flags' do
         expected_result = command_result(numstat_output)
-        expect_command('diff', '--numstat', '--shortstat', '--src-prefix=a/',
-                       '--dst-prefix=b/').and_return(expected_result)
+        expect_command_with_capture('diff', '--numstat', '--shortstat', '--src-prefix=a/',
+                                    '--dst-prefix=b/').and_return(expected_result)
 
         result = command.call
 
@@ -30,8 +30,8 @@ RSpec.describe Git::Commands::Diff::Numstat do
 
     context 'with single commit (compare to HEAD)' do
       it 'passes the commit as an operand' do
-        expect_command('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
-                       'abc123').and_return(command_result(numstat_output))
+        expect_command_with_capture('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
+                                    'abc123').and_return(command_result(numstat_output))
 
         command.call('abc123')
       end
@@ -39,8 +39,8 @@ RSpec.describe Git::Commands::Diff::Numstat do
 
     context 'with two commits (compare between commits)' do
       it 'passes both commits as operands' do
-        expect_command('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/', 'abc123',
-                       'def456').and_return(command_result(numstat_output))
+        expect_command_with_capture('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/', 'abc123',
+                                    'def456').and_return(command_result(numstat_output))
 
         command.call('abc123', 'def456')
       end
@@ -48,8 +48,8 @@ RSpec.describe Git::Commands::Diff::Numstat do
 
     context 'with merge-base syntax' do
       it 'passes the triple-dot syntax directly' do
-        expect_command('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
-                       'main...feature').and_return(command_result(numstat_output))
+        expect_command_with_capture('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
+                                    'main...feature').and_return(command_result(numstat_output))
 
         command.call('main...feature')
       end
@@ -57,15 +57,15 @@ RSpec.describe Git::Commands::Diff::Numstat do
 
     context 'with :cached option (staged changes)' do
       it 'includes the --cached flag' do
-        expect_command('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
-                       '--cached').and_return(command_result(numstat_output))
+        expect_command_with_capture('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
+                                    '--cached').and_return(command_result(numstat_output))
 
         command.call(cached: true)
       end
 
       it 'accepts :staged alias' do
-        expect_command('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
-                       '--cached').and_return(command_result(numstat_output))
+        expect_command_with_capture('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
+                                    '--cached').and_return(command_result(numstat_output))
 
         command.call(staged: true)
       end
@@ -73,15 +73,17 @@ RSpec.describe Git::Commands::Diff::Numstat do
 
     context 'with :merge_base option' do
       it 'includes the --merge-base flag' do
-        expect_command('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/', '--merge-base',
-                       'feature').and_return(command_result(numstat_output))
+        expect_command_with_capture('diff', '--numstat', '--shortstat',
+                                    '--src-prefix=a/', '--dst-prefix=b/', '--merge-base',
+                                    'feature').and_return(command_result(numstat_output))
 
         command.call('feature', merge_base: true)
       end
 
       it 'includes --merge-base with two commits' do
-        expect_command('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/', '--merge-base', 'main',
-                       'feature').and_return(command_result(numstat_output))
+        expect_command_with_capture('diff', '--numstat', '--shortstat',
+                                    '--src-prefix=a/', '--dst-prefix=b/', '--merge-base', 'main',
+                                    'feature').and_return(command_result(numstat_output))
 
         command.call('main', 'feature', merge_base: true)
       end
@@ -89,9 +91,9 @@ RSpec.describe Git::Commands::Diff::Numstat do
 
     context 'with :no_index option' do
       it 'includes the --no-index flag' do
-        expect_command('diff', '--numstat', '--shortstat',
-                       '--src-prefix=a/', '--dst-prefix=b/', '--no-index',
-                       '/path/a', '/path/b').and_return(command_result(numstat_output))
+        expect_command_with_capture('diff', '--numstat', '--shortstat',
+                                    '--src-prefix=a/', '--dst-prefix=b/', '--no-index',
+                                    '/path/a', '/path/b').and_return(command_result(numstat_output))
 
         command.call('/path/a', '/path/b', no_index: true)
       end
@@ -99,15 +101,17 @@ RSpec.describe Git::Commands::Diff::Numstat do
 
     context 'with pathspec limiting' do
       it 'adds pathspecs after the -- separator' do
-        expect_command('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/', '--', 'lib/',
-                       'spec/').and_return(command_result(numstat_output))
+        expect_command_with_capture('diff', '--numstat', '--shortstat',
+                                    '--src-prefix=a/', '--dst-prefix=b/', '--', 'lib/',
+                                    'spec/').and_return(command_result(numstat_output))
 
         command.call(pathspecs: ['lib/', 'spec/'])
       end
 
       it 'combines commit with pathspecs' do
-        expect_command('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/', 'HEAD~3', '--',
-                       'lib/').and_return(command_result(numstat_output))
+        expect_command_with_capture('diff', '--numstat', '--shortstat',
+                                    '--src-prefix=a/', '--dst-prefix=b/', 'HEAD~3', '--',
+                                    'lib/').and_return(command_result(numstat_output))
 
         command.call('HEAD~3', pathspecs: ['lib/'])
       end
@@ -124,8 +128,8 @@ RSpec.describe Git::Commands::Diff::Numstat do
       end
 
       it 'includes the --dirstat flag when true' do
-        expect_command('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
-                       '--dirstat').and_return(command_result(dirstat_output))
+        expect_command_with_capture('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
+                                    '--dirstat').and_return(command_result(dirstat_output))
 
         result = command.call(dirstat: true)
 
@@ -133,8 +137,8 @@ RSpec.describe Git::Commands::Diff::Numstat do
       end
 
       it 'passes dirstat options as an inline value' do
-        expect_command('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
-                       '--dirstat=lines,cumulative').and_return(command_result(dirstat_output))
+        expect_command_with_capture('diff', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
+                                    '--dirstat=lines,cumulative').and_return(command_result(dirstat_output))
 
         command.call(dirstat: 'lines,cumulative')
       end
@@ -142,8 +146,8 @@ RSpec.describe Git::Commands::Diff::Numstat do
 
     context 'exit code handling' do
       it 'returns successfully with exit code 0 when no differences' do
-        expect_command('diff', '--numstat', '--shortstat', '--src-prefix=a/',
-                       '--dst-prefix=b/').and_return(command_result('', exitstatus: 0))
+        expect_command_with_capture('diff', '--numstat', '--shortstat', '--src-prefix=a/',
+                                    '--dst-prefix=b/').and_return(command_result('', exitstatus: 0))
 
         result = command.call
 
@@ -152,8 +156,8 @@ RSpec.describe Git::Commands::Diff::Numstat do
       end
 
       it 'returns successfully with exit code 1 when differences found' do
-        expect_command('diff', '--numstat', '--shortstat', '--src-prefix=a/',
-                       '--dst-prefix=b/').and_return(command_result(numstat_output, exitstatus: 1))
+        expect_command_with_capture('diff', '--numstat', '--shortstat', '--src-prefix=a/',
+                                    '--dst-prefix=b/').and_return(command_result(numstat_output, exitstatus: 1))
 
         result = command.call
 
@@ -163,16 +167,16 @@ RSpec.describe Git::Commands::Diff::Numstat do
       end
 
       it 'raises FailedError with exit code 2 (error)' do
-        expect_command('diff', '--numstat', '--shortstat',
-                       '--src-prefix=a/', '--dst-prefix=b/')
+        expect_command_with_capture('diff', '--numstat', '--shortstat',
+                                    '--src-prefix=a/', '--dst-prefix=b/')
           .and_return(command_result('', stderr: 'fatal: bad revision', exitstatus: 2))
 
         expect { command.call }.to raise_error(Git::FailedError)
       end
 
       it 'raises FailedError with exit code 128 (git error)' do
-        expect_command('diff', '--numstat', '--shortstat',
-                       '--src-prefix=a/', '--dst-prefix=b/')
+        expect_command_with_capture('diff', '--numstat', '--shortstat',
+                                    '--src-prefix=a/', '--dst-prefix=b/')
           .and_return(command_result('', stderr: 'fatal: not a git repository', exitstatus: 128))
 
         expect { command.call }.to raise_error(Git::FailedError)

--- a/spec/unit/git/commands/diff/patch_spec.rb
+++ b/spec/unit/git/commands/diff/patch_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Git::Commands::Diff::Patch do
     context 'with no arguments (working tree vs index)' do
       it 'runs diff with --patch, --numstat, --shortstat, prefix options, and -M flag' do
         expected_result = command_result(patch_output)
-        expect_command(*static_args)
+        expect_command_with_capture(*static_args)
           .and_return(expected_result)
 
         result = command.call
@@ -41,7 +41,7 @@ RSpec.describe Git::Commands::Diff::Patch do
 
     context 'with single commit' do
       it 'passes the commit as an operand' do
-        expect_command(*static_args, 'abc123')
+        expect_command_with_capture(*static_args, 'abc123')
           .and_return(command_result(patch_output))
 
         command.call('abc123')
@@ -50,7 +50,7 @@ RSpec.describe Git::Commands::Diff::Patch do
 
     context 'with two commits' do
       it 'passes both commits as operands' do
-        expect_command(*static_args, 'abc123', 'def456')
+        expect_command_with_capture(*static_args, 'abc123', 'def456')
           .and_return(command_result(patch_output))
 
         command.call('abc123', 'def456')
@@ -59,14 +59,14 @@ RSpec.describe Git::Commands::Diff::Patch do
 
     context 'with :cached option' do
       it 'includes the --cached flag' do
-        expect_command(*static_args, '--cached')
+        expect_command_with_capture(*static_args, '--cached')
           .and_return(command_result(patch_output))
 
         command.call(cached: true)
       end
 
       it 'accepts :staged alias' do
-        expect_command(*static_args, '--cached')
+        expect_command_with_capture(*static_args, '--cached')
           .and_return(command_result(patch_output))
 
         command.call(staged: true)
@@ -75,7 +75,7 @@ RSpec.describe Git::Commands::Diff::Patch do
 
     context 'with :find_copies option' do
       it 'includes the -C flag' do
-        expect_command(*static_args, '--find-copies')
+        expect_command_with_capture(*static_args, '--find-copies')
           .and_return(command_result(patch_output))
 
         command.call(find_copies: true)
@@ -84,14 +84,14 @@ RSpec.describe Git::Commands::Diff::Patch do
 
     context 'with :merge_base option' do
       it 'includes the --merge-base flag' do
-        expect_command(*static_args, '--merge-base', 'feature')
+        expect_command_with_capture(*static_args, '--merge-base', 'feature')
           .and_return(command_result(patch_output))
 
         command.call('feature', merge_base: true)
       end
 
       it 'includes --merge-base with two commits' do
-        expect_command(*static_args, '--merge-base', 'main', 'feature')
+        expect_command_with_capture(*static_args, '--merge-base', 'main', 'feature')
           .and_return(command_result(patch_output))
 
         command.call('main', 'feature', merge_base: true)
@@ -100,7 +100,7 @@ RSpec.describe Git::Commands::Diff::Patch do
 
     context 'with :no_index option' do
       it 'includes the --no-index flag' do
-        expect_command(*static_args, '--no-index', '/path/a', '/path/b')
+        expect_command_with_capture(*static_args, '--no-index', '/path/a', '/path/b')
           .and_return(command_result(patch_output))
 
         command.call('/path/a', '/path/b', no_index: true)
@@ -109,14 +109,14 @@ RSpec.describe Git::Commands::Diff::Patch do
 
     context 'with pathspec limiting' do
       it 'adds pathspecs after the -- separator' do
-        expect_command(*static_args, '--', 'lib/', 'spec/')
+        expect_command_with_capture(*static_args, '--', 'lib/', 'spec/')
           .and_return(command_result(patch_output))
 
         command.call(pathspecs: ['lib/', 'spec/'])
       end
 
       it 'combines commit with pathspecs' do
-        expect_command(*static_args, 'HEAD~3', '--', 'lib/')
+        expect_command_with_capture(*static_args, 'HEAD~3', '--', 'lib/')
           .and_return(command_result(patch_output))
 
         command.call('HEAD~3', pathspecs: ['lib/'])
@@ -140,7 +140,7 @@ RSpec.describe Git::Commands::Diff::Patch do
       end
 
       it 'includes the --dirstat flag when true' do
-        expect_command(*static_args, '--dirstat')
+        expect_command_with_capture(*static_args, '--dirstat')
           .and_return(command_result(dirstat_output))
 
         result = command.call(dirstat: true)
@@ -149,7 +149,7 @@ RSpec.describe Git::Commands::Diff::Patch do
       end
 
       it 'passes dirstat options when string' do
-        expect_command(*static_args, '--dirstat=lines,cumulative')
+        expect_command_with_capture(*static_args, '--dirstat=lines,cumulative')
           .and_return(command_result(dirstat_output))
 
         command.call(dirstat: 'lines,cumulative')
@@ -158,7 +158,7 @@ RSpec.describe Git::Commands::Diff::Patch do
 
     context 'exit code handling' do
       it 'returns successfully with exit code 0 when no differences' do
-        expect_command(*static_args)
+        expect_command_with_capture(*static_args)
           .and_return(command_result('', exitstatus: 0))
 
         result = command.call
@@ -169,7 +169,7 @@ RSpec.describe Git::Commands::Diff::Patch do
       end
 
       it 'returns successfully with exit code 1 when differences found' do
-        expect_command(*static_args)
+        expect_command_with_capture(*static_args)
           .and_return(command_result(patch_output, exitstatus: 1))
 
         result = command.call
@@ -180,14 +180,14 @@ RSpec.describe Git::Commands::Diff::Patch do
       end
 
       it 'raises FailedError with exit code 2 (error)' do
-        expect_command(*static_args)
+        expect_command_with_capture(*static_args)
           .and_return(command_result('', stderr: 'fatal: bad revision', exitstatus: 2))
 
         expect { command.call }.to raise_error(Git::FailedError)
       end
 
       it 'raises FailedError with exit code 128 (git error)' do
-        expect_command(*static_args)
+        expect_command_with_capture(*static_args)
           .and_return(command_result('', stderr: 'fatal: not a git repository', exitstatus: 128))
 
         expect { command.call }.to raise_error(Git::FailedError)

--- a/spec/unit/git/commands/diff/raw_spec.rb
+++ b/spec/unit/git/commands/diff/raw_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Git::Commands::Diff::Raw do
     context 'with no arguments (working tree vs index)' do
       it 'runs diff with --raw, --numstat, --shortstat, and -M flags' do
         expected_result = command_result(raw_output)
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/')
           .and_return(expected_result)
 
         result = command.call
@@ -32,7 +32,8 @@ RSpec.describe Git::Commands::Diff::Raw do
 
     context 'with single commit' do
       it 'passes the commit as an operand' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/', 'abc123')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
+                                    'abc123')
           .and_return(command_result(raw_output))
 
         command.call('abc123')
@@ -41,8 +42,8 @@ RSpec.describe Git::Commands::Diff::Raw do
 
     context 'with two commits' do
       it 'passes both commits as operands' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/', 'abc123',
-                       'def456')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat',
+                                    '--src-prefix=a/', '--dst-prefix=b/', 'abc123', 'def456')
           .and_return(command_result(raw_output))
 
         command.call('abc123', 'def456')
@@ -51,14 +52,16 @@ RSpec.describe Git::Commands::Diff::Raw do
 
     context 'with :cached option' do
       it 'includes the --cached flag' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/', '--cached')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
+                                    '--cached')
           .and_return(command_result(raw_output))
 
         command.call(cached: true)
       end
 
       it 'accepts :staged alias' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/', '--cached')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
+                                    '--cached')
           .and_return(command_result(raw_output))
 
         command.call(staged: true)
@@ -67,8 +70,8 @@ RSpec.describe Git::Commands::Diff::Raw do
 
     context 'with :find_copies option' do
       it 'includes the -C flag' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
-                       '--find-copies')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
+                                    '--find-copies')
           .and_return(command_result(raw_output))
 
         command.call(find_copies: true)
@@ -77,16 +80,16 @@ RSpec.describe Git::Commands::Diff::Raw do
 
     context 'with :merge_base option' do
       it 'includes the --merge-base flag' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
-                       '--merge-base', 'feature')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
+                                    '--merge-base', 'feature')
           .and_return(command_result(raw_output))
 
         command.call('feature', merge_base: true)
       end
 
       it 'includes --merge-base with two commits' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
-                       '--merge-base', 'main', 'feature')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
+                                    '--merge-base', 'main', 'feature')
           .and_return(command_result(raw_output))
 
         command.call('main', 'feature', merge_base: true)
@@ -95,8 +98,9 @@ RSpec.describe Git::Commands::Diff::Raw do
 
     context 'with :no_index option' do
       it 'includes the --no-index flag' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/', '--no-index',
-                       '/path/a', '/path/b')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat',
+                                    '--src-prefix=a/', '--dst-prefix=b/', '--no-index',
+                                    '/path/a', '/path/b')
           .and_return(command_result(raw_output))
 
         command.call('/path/a', '/path/b', no_index: true)
@@ -105,16 +109,17 @@ RSpec.describe Git::Commands::Diff::Raw do
 
     context 'with pathspec limiting' do
       it 'adds pathspecs after the -- separator' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/', '--', 'lib/',
-                       'spec/')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat',
+                                    '--src-prefix=a/', '--dst-prefix=b/', '--', 'lib/', 'spec/')
           .and_return(command_result(raw_output))
 
         command.call(pathspecs: ['lib/', 'spec/'])
       end
 
       it 'combines commit with pathspecs' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/', 'HEAD~3',
-                       '--', 'lib/')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat',
+                                    '--src-prefix=a/', '--dst-prefix=b/', 'HEAD~3',
+                                    '--', 'lib/')
           .and_return(command_result(raw_output))
 
         command.call('HEAD~3', pathspecs: ['lib/'])
@@ -132,7 +137,8 @@ RSpec.describe Git::Commands::Diff::Raw do
       end
 
       it 'includes the --dirstat flag when true' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/', '--dirstat')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
+                                    '--dirstat')
           .and_return(command_result(dirstat_output))
 
         result = command.call(dirstat: true)
@@ -141,8 +147,8 @@ RSpec.describe Git::Commands::Diff::Raw do
       end
 
       it 'passes dirstat options when string' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
-                       '--dirstat=lines,cumulative')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/',
+                                    '--dirstat=lines,cumulative')
           .and_return(command_result(dirstat_output))
 
         command.call(dirstat: 'lines,cumulative')
@@ -151,7 +157,7 @@ RSpec.describe Git::Commands::Diff::Raw do
 
     context 'exit code handling' do
       it 'returns successfully with exit code 0 when no differences' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/')
           .and_return(command_result('', exitstatus: 0))
 
         result = command.call
@@ -162,7 +168,7 @@ RSpec.describe Git::Commands::Diff::Raw do
       end
 
       it 'returns successfully with exit code 1 when differences found' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/')
           .and_return(command_result(raw_output, exitstatus: 1))
 
         result = command.call
@@ -173,14 +179,14 @@ RSpec.describe Git::Commands::Diff::Raw do
       end
 
       it 'raises FailedError with exit code 2 (error)' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/')
           .and_return(command_result('', stderr: 'fatal: bad revision', exitstatus: 2))
 
         expect { command.call }.to raise_error(Git::FailedError)
       end
 
       it 'raises FailedError with exit code 128 (git error)' do
-        expect_command('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/')
+        expect_command_with_capture('diff', '--raw', '--numstat', '--shortstat', '--src-prefix=a/', '--dst-prefix=b/')
           .and_return(command_result('', stderr: 'fatal: not a git repository', exitstatus: 128))
 
         expect { command.call }.to raise_error(Git::FailedError)

--- a/spec/unit/git/commands/fsck_spec.rb
+++ b/spec/unit/git/commands/fsck_spec.rb
@@ -8,16 +8,16 @@ RSpec.describe Git::Commands::Fsck do
 
   # Helper to mock command call - accepts any keyword arguments
   def mock_command(*args, stdout: '', stderr: '', exitstatus: 0)
-    allow(execution_context).to receive(:command).with(*args, raise_on_failure: false)
-                                                 .and_return(command_result(stdout, stderr: stderr,
-                                                                                    exitstatus: exitstatus))
+    allow(execution_context).to receive(:command_with_capture)
+      .with(*args, raise_on_failure: false)
+      .and_return(command_result(stdout, stderr: stderr, exitstatus: exitstatus))
   end
 
   describe '#call' do
     context 'with default arguments' do
       it 'runs fsck with --no-progress' do
         expected_result = command_result('')
-        expect_command('fsck', '--no-progress').and_return(expected_result)
+        expect_command_with_capture('fsck', '--no-progress').and_return(expected_result)
 
         result = command.call
 
@@ -27,7 +27,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with specific objects' do
       it 'includes the object identifiers' do
-        expect_command('fsck', '--no-progress', 'abc1234', 'def5678').and_return(command_result(''))
+        expect_command_with_capture('fsck', '--no-progress', 'abc1234', 'def5678').and_return(command_result(''))
 
         command.call('abc1234', 'def5678')
       end
@@ -35,7 +35,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :unreachable option' do
       it 'includes the --unreachable flag' do
-        expect_command('fsck', '--no-progress', '--unreachable').and_return(command_result(''))
+        expect_command_with_capture('fsck', '--no-progress', '--unreachable').and_return(command_result(''))
 
         command.call(unreachable: true)
       end
@@ -43,7 +43,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :strict option' do
       it 'includes the --strict flag' do
-        expect_command('fsck', '--no-progress', '--strict').and_return(command_result(''))
+        expect_command_with_capture('fsck', '--no-progress', '--strict').and_return(command_result(''))
 
         command.call(strict: true)
       end
@@ -51,7 +51,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :connectivity_only option' do
       it 'includes the --connectivity-only flag' do
-        expect_command('fsck', '--no-progress', '--connectivity-only').and_return(command_result(''))
+        expect_command_with_capture('fsck', '--no-progress', '--connectivity-only').and_return(command_result(''))
 
         command.call(connectivity_only: true)
       end
@@ -59,7 +59,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :root option' do
       it 'includes the --root flag' do
-        expect_command('fsck', '--no-progress', '--root').and_return(command_result(''))
+        expect_command_with_capture('fsck', '--no-progress', '--root').and_return(command_result(''))
 
         command.call(root: true)
       end
@@ -67,7 +67,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :tags option' do
       it 'includes the --tags flag' do
-        expect_command('fsck', '--no-progress', '--tags').and_return(command_result(''))
+        expect_command_with_capture('fsck', '--no-progress', '--tags').and_return(command_result(''))
 
         command.call(tags: true)
       end
@@ -75,7 +75,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :cache option' do
       it 'includes the --cache flag' do
-        expect_command('fsck', '--no-progress', '--cache').and_return(command_result(''))
+        expect_command_with_capture('fsck', '--no-progress', '--cache').and_return(command_result(''))
 
         command.call(cache: true)
       end
@@ -83,7 +83,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :no_reflogs option' do
       it 'includes the --no-reflogs flag' do
-        expect_command('fsck', '--no-progress', '--no-reflogs').and_return(command_result(''))
+        expect_command_with_capture('fsck', '--no-progress', '--no-reflogs').and_return(command_result(''))
 
         command.call(no_reflogs: true)
       end
@@ -91,7 +91,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :lost_found option' do
       it 'includes the --lost-found flag' do
-        expect_command('fsck', '--no-progress', '--lost-found').and_return(command_result(''))
+        expect_command_with_capture('fsck', '--no-progress', '--lost-found').and_return(command_result(''))
 
         command.call(lost_found: true)
       end
@@ -100,13 +100,13 @@ RSpec.describe Git::Commands::Fsck do
     context 'with boolean_negatable options' do
       context ':dangling' do
         it 'includes --dangling when true' do
-          expect_command('fsck', '--no-progress', '--dangling').and_return(command_result(''))
+          expect_command_with_capture('fsck', '--no-progress', '--dangling').and_return(command_result(''))
 
           command.call(dangling: true)
         end
 
         it 'includes --no-dangling when false' do
-          expect_command('fsck', '--no-progress', '--no-dangling').and_return(command_result(''))
+          expect_command_with_capture('fsck', '--no-progress', '--no-dangling').and_return(command_result(''))
 
           command.call(dangling: false)
         end
@@ -114,13 +114,13 @@ RSpec.describe Git::Commands::Fsck do
 
       context ':full' do
         it 'includes --full when true' do
-          expect_command('fsck', '--no-progress', '--full').and_return(command_result(''))
+          expect_command_with_capture('fsck', '--no-progress', '--full').and_return(command_result(''))
 
           command.call(full: true)
         end
 
         it 'includes --no-full when false' do
-          expect_command('fsck', '--no-progress', '--no-full').and_return(command_result(''))
+          expect_command_with_capture('fsck', '--no-progress', '--no-full').and_return(command_result(''))
 
           command.call(full: false)
         end
@@ -128,13 +128,13 @@ RSpec.describe Git::Commands::Fsck do
 
       context ':name_objects' do
         it 'includes --name-objects when true' do
-          expect_command('fsck', '--no-progress', '--name-objects').and_return(command_result(''))
+          expect_command_with_capture('fsck', '--no-progress', '--name-objects').and_return(command_result(''))
 
           command.call(name_objects: true)
         end
 
         it 'includes --no-name-objects when false' do
-          expect_command('fsck', '--no-progress', '--no-name-objects').and_return(command_result(''))
+          expect_command_with_capture('fsck', '--no-progress', '--no-name-objects').and_return(command_result(''))
 
           command.call(name_objects: false)
         end
@@ -142,13 +142,13 @@ RSpec.describe Git::Commands::Fsck do
 
       context ':references' do
         it 'includes --references when true' do
-          expect_command('fsck', '--no-progress', '--references').and_return(command_result(''))
+          expect_command_with_capture('fsck', '--no-progress', '--references').and_return(command_result(''))
 
           command.call(references: true)
         end
 
         it 'includes --no-references when false' do
-          expect_command('fsck', '--no-progress', '--no-references').and_return(command_result(''))
+          expect_command_with_capture('fsck', '--no-progress', '--no-references').and_return(command_result(''))
 
           command.call(references: false)
         end
@@ -157,7 +157,8 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with multiple options combined' do
       it 'includes all specified flags' do
-        expect_command('fsck', '--no-progress', '--unreachable', '--full', '--strict').and_return(command_result(''))
+        expect_command_with_capture('fsck', '--no-progress', '--unreachable', '--full',
+                                    '--strict').and_return(command_result(''))
 
         command.call(unreachable: true, strict: true, full: true)
       end
@@ -165,7 +166,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with objects and options combined' do
       it 'includes both objects and flags' do
-        expect_command('fsck', '--no-progress', '--strict', 'abc1234').and_return(command_result(''))
+        expect_command_with_capture('fsck', '--no-progress', '--strict', 'abc1234').and_return(command_result(''))
 
         command.call('abc1234', strict: true)
       end

--- a/spec/unit/git/commands/init_spec.rb
+++ b/spec/unit/git/commands/init_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Init do
     context 'with default arguments' do
       it 'runs git init in the current directory' do
         expected_result = command_result
-        expect_command('init').and_return(expected_result)
+        expect_command_with_capture('init').and_return(expected_result)
 
         result = command.call
 
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::Init do
 
     context 'with a directory argument' do
       it 'initializes in the specified directory' do
-        expect_command('init', 'my-repo').and_return(command_result)
+        expect_command_with_capture('init', 'my-repo').and_return(command_result)
 
         command.call('my-repo')
       end
@@ -28,13 +28,13 @@ RSpec.describe Git::Commands::Init do
 
     context 'with the :bare option' do
       it 'includes the --bare flag when true' do
-        expect_command('init', '--bare', 'my-repo.git').and_return(command_result)
+        expect_command_with_capture('init', '--bare', 'my-repo.git').and_return(command_result)
 
         command.call('my-repo.git', bare: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('init', 'my-repo').and_return(command_result)
+        expect_command_with_capture('init', 'my-repo').and_return(command_result)
 
         command.call('my-repo', bare: false)
       end
@@ -42,13 +42,13 @@ RSpec.describe Git::Commands::Init do
 
     context 'with the :initial_branch option' do
       it 'includes the --initial-branch flag with the specified value' do
-        expect_command('init', '--initial-branch=main', 'my-repo').and_return(command_result)
+        expect_command_with_capture('init', '--initial-branch=main', 'my-repo').and_return(command_result)
 
         command.call('my-repo', initial_branch: 'main')
       end
 
       it 'handles branch names with special characters' do
-        expect_command('init', '--initial-branch=feature/my-branch', 'my-repo').and_return(command_result)
+        expect_command_with_capture('init', '--initial-branch=feature/my-branch', 'my-repo').and_return(command_result)
 
         command.call('my-repo', initial_branch: 'feature/my-branch')
       end
@@ -57,7 +57,7 @@ RSpec.describe Git::Commands::Init do
     context 'with the :separate_git_dir option' do
       it 'uses --separate-git-dir for the repository path' do
         # The repository path is passed through as-is (not expanded by the command)
-        expect_command('init', '--separate-git-dir=repo.git', 'work').and_return(command_result)
+        expect_command_with_capture('init', '--separate-git-dir=repo.git', 'work').and_return(command_result)
 
         command.call('work', separate_git_dir: 'repo.git')
       end
@@ -71,7 +71,7 @@ RSpec.describe Git::Commands::Init do
 
     context 'with multiple options combined' do
       it 'includes all specified flags' do
-        expect_command('init', '--bare', '--initial-branch=develop', 'bare.git').and_return(command_result)
+        expect_command_with_capture('init', '--bare', '--initial-branch=develop', 'bare.git').and_return(command_result)
 
         command.call('bare.git', bare: true, initial_branch: 'develop')
       end

--- a/spec/unit/git/commands/merge/abort_spec.rb
+++ b/spec/unit/git/commands/merge/abort_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Merge::Abort do
   describe '#call' do
     it 'calls git merge --abort' do
       expected_result = command_result('')
-      expect_command('merge', '--abort').and_return(expected_result)
+      expect_command_with_capture('merge', '--abort').and_return(expected_result)
 
       result = command.call
 

--- a/spec/unit/git/commands/merge/continue_spec.rb
+++ b/spec/unit/git/commands/merge/continue_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Merge::Continue do
   describe '#call' do
     it 'calls git merge --continue' do
       expected_result = command_result('')
-      expect_command('merge', '--continue').and_return(expected_result)
+      expect_command_with_capture('merge', '--continue').and_return(expected_result)
 
       result = command.call
 

--- a/spec/unit/git/commands/merge/quit_spec.rb
+++ b/spec/unit/git/commands/merge/quit_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Merge::Quit do
   describe '#call' do
     it 'calls git merge --quit' do
       expected_result = command_result('')
-      expect_command('merge', '--quit').and_return(expected_result)
+      expect_command_with_capture('merge', '--quit').and_return(expected_result)
 
       result = command.call
 

--- a/spec/unit/git/commands/merge/start_spec.rb
+++ b/spec/unit/git/commands/merge/start_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe Git::Commands::Merge::Start do
 
   describe '#call' do
     before do
-      allow(execution_context).to receive(:command).and_return(command_result)
+      allow(execution_context).to receive(:command_with_capture).and_return(command_result)
     end
 
     context 'with single branch to merge' do
       it 'calls git merge with --no-edit and the branch name' do
         expected_result = command_result
-        expect_command('merge', '--no-edit', 'feature').and_return(expected_result)
+        expect_command_with_capture('merge', '--no-edit', 'feature').and_return(expected_result)
 
         result = command.call('feature')
 
@@ -25,12 +25,12 @@ RSpec.describe Git::Commands::Merge::Start do
 
     context 'with multiple branches (octopus merge)' do
       it 'merges multiple branches' do
-        expect_command('merge', '--no-edit', 'branch1', 'branch2')
+        expect_command_with_capture('merge', '--no-edit', 'branch1', 'branch2')
         command.call('branch1', 'branch2')
       end
 
       it 'merges three branches' do
-        expect_command('merge', '--no-edit', 'a', 'b', 'c')
+        expect_command_with_capture('merge', '--no-edit', 'a', 'b', 'c')
         command.call('a', 'b', 'c')
       end
     end
@@ -38,14 +38,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :commit option' do
       context 'when true' do
         it 'adds --commit flag' do
-          expect_command('merge', '--no-edit', '--commit', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--commit', 'feature')
           command.call('feature', commit: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-commit flag' do
-          expect_command('merge', '--no-edit', '--no-commit', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--no-commit', 'feature')
           command.call('feature', commit: false)
         end
       end
@@ -53,12 +53,12 @@ RSpec.describe Git::Commands::Merge::Start do
 
     context 'with :squash option' do
       it 'adds --squash flag' do
-        expect_command('merge', '--no-edit', '--squash', 'feature')
+        expect_command_with_capture('merge', '--no-edit', '--squash', 'feature')
         command.call('feature', squash: true)
       end
 
       it 'does not add flag when false' do
-        expect_command('merge', '--no-edit', 'feature')
+        expect_command_with_capture('merge', '--no-edit', 'feature')
         command.call('feature', squash: false)
       end
     end
@@ -66,14 +66,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :ff option (fast-forward)' do
       context 'when true' do
         it 'adds --ff flag' do
-          expect_command('merge', '--no-edit', '--ff', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--ff', 'feature')
           command.call('feature', ff: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-ff flag' do
-          expect_command('merge', '--no-edit', '--no-ff', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--no-ff', 'feature')
           command.call('feature', ff: false)
         end
       end
@@ -81,19 +81,19 @@ RSpec.describe Git::Commands::Merge::Start do
 
     context 'with :ff_only option' do
       it 'adds --ff-only flag' do
-        expect_command('merge', '--no-edit', '--ff-only', 'feature')
+        expect_command_with_capture('merge', '--no-edit', '--ff-only', 'feature')
         command.call('feature', ff_only: true)
       end
 
       it 'does not add flag when false' do
-        expect_command('merge', '--no-edit', 'feature')
+        expect_command_with_capture('merge', '--no-edit', 'feature')
         command.call('feature', ff_only: false)
       end
     end
 
     context 'with :m option' do
       it 'adds -m flag with message' do
-        expect_command('merge', '--no-edit', '-m', 'Merge feature', 'feature')
+        expect_command_with_capture('merge', '--no-edit', '-m', 'Merge feature', 'feature')
         command.call('feature', m: 'Merge feature')
       end
 
@@ -105,48 +105,48 @@ RSpec.describe Git::Commands::Merge::Start do
 
     context 'with :file option' do
       it 'adds --file flag with file path' do
-        expect_command('merge', '--no-edit', '--file', '/path/to/msg.txt', 'feature')
+        expect_command_with_capture('merge', '--no-edit', '--file', '/path/to/msg.txt', 'feature')
         command.call('feature', file: '/path/to/msg.txt')
       end
 
       it 'works with :F alias' do
-        expect_command('merge', '--no-edit', '--file', 'msg.txt', 'feature')
+        expect_command_with_capture('merge', '--no-edit', '--file', 'msg.txt', 'feature')
         command.call('feature', F: 'msg.txt')
       end
     end
 
     context 'with :into_name option' do
       it 'adds --into-name flag with value' do
-        expect_command('merge', '--no-edit', '--into-name=main', 'feature')
+        expect_command_with_capture('merge', '--no-edit', '--into-name=main', 'feature')
         command.call('feature', into_name: 'main')
       end
     end
 
     context 'with :strategy option' do
       it 'adds --strategy flag with strategy name' do
-        expect_command('merge', '--no-edit', '--strategy', 'ours', 'feature')
+        expect_command_with_capture('merge', '--no-edit', '--strategy', 'ours', 'feature')
         command.call('feature', strategy: 'ours')
       end
 
       it 'works with :s alias' do
-        expect_command('merge', '--no-edit', '--strategy', 'recursive', 'feature')
+        expect_command_with_capture('merge', '--no-edit', '--strategy', 'recursive', 'feature')
         command.call('feature', s: 'recursive')
       end
     end
 
     context 'with :strategy_option option' do
       it 'adds --strategy-option flag with strategy option' do
-        expect_command('merge', '--no-edit', '--strategy-option', 'ours', 'feature')
+        expect_command_with_capture('merge', '--no-edit', '--strategy-option', 'ours', 'feature')
         command.call('feature', strategy_option: 'ours')
       end
 
       it 'works with :X alias' do
-        expect_command('merge', '--no-edit', '--strategy-option', 'theirs', 'feature')
+        expect_command_with_capture('merge', '--no-edit', '--strategy-option', 'theirs', 'feature')
         command.call('feature', X: 'theirs')
       end
 
       it 'supports multiple strategy options' do
-        expect_command(
+        expect_command_with_capture(
           'merge', '--no-edit', '--strategy-option', 'ours', '--strategy-option', 'patience', 'feature'
         )
         command.call('feature', strategy_option: %w[ours patience])
@@ -156,14 +156,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :verify option' do
       context 'when true' do
         it 'adds --verify flag' do
-          expect_command('merge', '--no-edit', '--verify', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--verify', 'feature')
           command.call('feature', verify: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-verify flag' do
-          expect_command('merge', '--no-edit', '--no-verify', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--no-verify', 'feature')
           command.call('feature', verify: false)
         end
       end
@@ -172,14 +172,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :verify_signatures option' do
       context 'when true' do
         it 'adds --verify-signatures flag' do
-          expect_command('merge', '--no-edit', '--verify-signatures', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--verify-signatures', 'feature')
           command.call('feature', verify_signatures: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-verify-signatures flag' do
-          expect_command(
+          expect_command_with_capture(
             'merge', '--no-edit', '--no-verify-signatures', 'feature'
           )
           command.call('feature', verify_signatures: false)
@@ -190,14 +190,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :gpg_sign option' do
       context 'when true' do
         it 'adds --gpg-sign flag' do
-          expect_command('merge', '--no-edit', '--gpg-sign', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--gpg-sign', 'feature')
           command.call('feature', gpg_sign: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-gpg-sign flag' do
-          expect_command('merge', '--no-edit', '--no-gpg-sign', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--no-gpg-sign', 'feature')
           command.call('feature', gpg_sign: false)
         end
       end
@@ -206,7 +206,7 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :allow_unrelated_histories option' do
       context 'when true' do
         it 'adds --allow-unrelated-histories flag' do
-          expect_command(
+          expect_command_with_capture(
             'merge', '--no-edit', '--allow-unrelated-histories', 'feature'
           )
           command.call('feature', allow_unrelated_histories: true)
@@ -215,7 +215,7 @@ RSpec.describe Git::Commands::Merge::Start do
 
       context 'when false' do
         it 'adds --no-allow-unrelated-histories flag' do
-          expect_command(
+          expect_command_with_capture(
             'merge', '--no-edit', '--no-allow-unrelated-histories', 'feature'
           )
           command.call('feature', allow_unrelated_histories: false)
@@ -226,14 +226,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :rerere_autoupdate option' do
       context 'when true' do
         it 'adds --rerere-autoupdate flag' do
-          expect_command('merge', '--no-edit', '--rerere-autoupdate', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--rerere-autoupdate', 'feature')
           command.call('feature', rerere_autoupdate: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-rerere-autoupdate flag' do
-          expect_command(
+          expect_command_with_capture(
             'merge', '--no-edit', '--no-rerere-autoupdate', 'feature'
           )
           command.call('feature', rerere_autoupdate: false)
@@ -244,14 +244,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :autostash option' do
       context 'when true' do
         it 'adds --autostash flag' do
-          expect_command('merge', '--no-edit', '--autostash', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--autostash', 'feature')
           command.call('feature', autostash: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-autostash flag' do
-          expect_command('merge', '--no-edit', '--no-autostash', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--no-autostash', 'feature')
           command.call('feature', autostash: false)
         end
       end
@@ -260,14 +260,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :signoff option' do
       context 'when true' do
         it 'adds --signoff flag' do
-          expect_command('merge', '--no-edit', '--signoff', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--signoff', 'feature')
           command.call('feature', signoff: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-signoff flag' do
-          expect_command('merge', '--no-edit', '--no-signoff', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--no-signoff', 'feature')
           command.call('feature', signoff: false)
         end
       end
@@ -276,14 +276,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :log option' do
       context 'when true' do
         it 'adds --log flag' do
-          expect_command('merge', '--no-edit', '--log', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--log', 'feature')
           command.call('feature', log: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-log flag' do
-          expect_command('merge', '--no-edit', '--no-log', 'feature')
+          expect_command_with_capture('merge', '--no-edit', '--no-log', 'feature')
           command.call('feature', log: false)
         end
       end
@@ -291,7 +291,7 @@ RSpec.describe Git::Commands::Merge::Start do
 
     context 'with multiple options combined' do
       it 'includes all specified flags in correct order' do
-        expect_command(
+        expect_command_with_capture(
           'merge', '--no-edit', '--no-commit', '--no-ff',
           '-m', 'Merge feature branch',
           '--strategy', 'ort',
@@ -309,12 +309,12 @@ RSpec.describe Git::Commands::Merge::Start do
       end
 
       it 'combines squash with no-commit behavior' do
-        expect_command('merge', '--no-edit', '--squash', 'feature')
+        expect_command_with_capture('merge', '--no-edit', '--squash', 'feature')
         command.call('feature', squash: true)
       end
 
       it 'combines ff_only with allow_unrelated_histories' do
-        expect_command(
+        expect_command_with_capture(
           'merge', '--no-edit', '--ff-only', '--allow-unrelated-histories', 'feature'
         )
         command.call('feature', ff_only: true, allow_unrelated_histories: true)

--- a/spec/unit/git/commands/merge_base_spec.rb
+++ b/spec/unit/git/commands/merge_base_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Git::Commands::MergeBase do
     context 'with two commits' do
       it 'runs merge-base with both commits' do
         expected_result = command_result("abc123\n")
-        expect_command('merge-base', 'main', 'feature').and_return(expected_result)
+        expect_command_with_capture('merge-base', 'main', 'feature').and_return(expected_result)
 
         result = command.call('main', 'feature')
 
@@ -21,7 +21,7 @@ RSpec.describe Git::Commands::MergeBase do
 
     context 'with multiple commits' do
       it 'passes all commits as operands' do
-        expect_command('merge-base', 'main', 'feature1', 'feature2').and_return(command_result("abc123\n"))
+        expect_command_with_capture('merge-base', 'main', 'feature1', 'feature2').and_return(command_result("abc123\n"))
 
         command.call('main', 'feature1', 'feature2')
       end
@@ -29,7 +29,8 @@ RSpec.describe Git::Commands::MergeBase do
 
     context 'with :octopus option' do
       it 'includes the --octopus flag' do
-        expect_command('merge-base', '--octopus', 'main', 'b1', 'b2').and_return(command_result("abc123\n"))
+        expect_command_with_capture('merge-base', '--octopus', 'main', 'b1',
+                                    'b2').and_return(command_result("abc123\n"))
 
         command.call('main', 'b1', 'b2', octopus: true)
       end
@@ -37,7 +38,8 @@ RSpec.describe Git::Commands::MergeBase do
 
     context 'with :independent option' do
       it 'includes the --independent flag' do
-        expect_command('merge-base', '--independent', 'a', 'b', 'c').and_return(command_result("sha1\nsha2\n"))
+        expect_command_with_capture('merge-base', '--independent', 'a', 'b',
+                                    'c').and_return(command_result("sha1\nsha2\n"))
 
         command.call('a', 'b', 'c', independent: true)
       end
@@ -45,7 +47,8 @@ RSpec.describe Git::Commands::MergeBase do
 
     context 'with :fork_point option' do
       it 'includes the --fork-point flag' do
-        expect_command('merge-base', '--fork-point', 'main', 'feature').and_return(command_result("abc123\n"))
+        expect_command_with_capture('merge-base', '--fork-point', 'main',
+                                    'feature').and_return(command_result("abc123\n"))
 
         command.call('main', 'feature', fork_point: true)
       end
@@ -53,7 +56,7 @@ RSpec.describe Git::Commands::MergeBase do
 
     context 'with :all option' do
       it 'includes the --all flag' do
-        expect_command('merge-base', '--all', 'main', 'feature').and_return(command_result("sha1\nsha2\n"))
+        expect_command_with_capture('merge-base', '--all', 'main', 'feature').and_return(command_result("sha1\nsha2\n"))
 
         command.call('main', 'feature', all: true)
       end
@@ -61,8 +64,8 @@ RSpec.describe Git::Commands::MergeBase do
 
     context 'with multiple options combined' do
       it 'includes all specified flags in correct order' do
-        expect_command('merge-base', '--all', '--octopus', 'main', 'b1',
-                       'b2').and_return(command_result("sha1\nsha2\n"))
+        expect_command_with_capture('merge-base', '--all', '--octopus', 'main', 'b1',
+                                    'b2').and_return(command_result("sha1\nsha2\n"))
 
         command.call('main', 'b1', 'b2', octopus: true, all: true)
       end

--- a/spec/unit/git/commands/mv_spec.rb
+++ b/spec/unit/git/commands/mv_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Mv do
     context 'with a single file to move' do
       it 'moves the file to the destination' do
         expected_result = command_result
-        expect_command('mv', '--verbose', '--', 'old_name.rb', 'new_name.rb').and_return(expected_result)
+        expect_command_with_capture('mv', '--verbose', '--', 'old_name.rb', 'new_name.rb').and_return(expected_result)
 
         result = command.call('old_name.rb', 'new_name.rb')
 
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::Mv do
 
     context 'with multiple source files' do
       it 'moves all files to the destination directory' do
-        expect_command(
+        expect_command_with_capture(
           'mv', '--verbose', '--', 'file1.rb', 'file2.rb', 'file3.rb', 'destination_dir/'
         ).and_return(command_result)
 
@@ -30,13 +30,14 @@ RSpec.describe Git::Commands::Mv do
 
     context 'with the :force option' do
       it 'includes the --force flag' do
-        expect_command('mv', '--verbose', '--force', '--', 'source.rb', 'dest.rb').and_return(command_result)
+        expect_command_with_capture('mv', '--verbose', '--force', '--', 'source.rb',
+                                    'dest.rb').and_return(command_result)
 
         command.call('source.rb', 'dest.rb', force: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('mv', '--verbose', '--', 'source.rb', 'dest.rb').and_return(command_result)
+        expect_command_with_capture('mv', '--verbose', '--', 'source.rb', 'dest.rb').and_return(command_result)
 
         command.call('source.rb', 'dest.rb', force: false)
       end
@@ -44,13 +45,14 @@ RSpec.describe Git::Commands::Mv do
 
     context 'with the :dry_run option' do
       it 'includes the --dry-run flag' do
-        expect_command('mv', '--verbose', '--dry-run', '--', 'source.rb', 'dest.rb').and_return(command_result)
+        expect_command_with_capture('mv', '--verbose', '--dry-run', '--', 'source.rb',
+                                    'dest.rb').and_return(command_result)
 
         command.call('source.rb', 'dest.rb', dry_run: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('mv', '--verbose', '--', 'source.rb', 'dest.rb').and_return(command_result)
+        expect_command_with_capture('mv', '--verbose', '--', 'source.rb', 'dest.rb').and_return(command_result)
 
         command.call('source.rb', 'dest.rb', dry_run: false)
       end
@@ -58,13 +60,13 @@ RSpec.describe Git::Commands::Mv do
 
     context 'with the :k option' do
       it 'includes the -k flag' do
-        expect_command('mv', '--verbose', '-k', '--', 'source.rb', 'dest.rb').and_return(command_result)
+        expect_command_with_capture('mv', '--verbose', '-k', '--', 'source.rb', 'dest.rb').and_return(command_result)
 
         command.call('source.rb', 'dest.rb', k: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('mv', '--verbose', '--', 'source.rb', 'dest.rb').and_return(command_result)
+        expect_command_with_capture('mv', '--verbose', '--', 'source.rb', 'dest.rb').and_return(command_result)
 
         command.call('source.rb', 'dest.rb', k: false)
       end
@@ -72,7 +74,7 @@ RSpec.describe Git::Commands::Mv do
 
     context 'with multiple options combined' do
       it 'includes all specified flags' do
-        expect_command(
+        expect_command_with_capture(
           'mv', '--verbose', '--force', '--dry-run', '--', 'source.rb', 'dest.rb'
         ).and_return(command_result)
 
@@ -80,7 +82,7 @@ RSpec.describe Git::Commands::Mv do
       end
 
       it 'handles force and k together' do
-        expect_command(
+        expect_command_with_capture(
           'mv', '--verbose', '--force', '-k', '--', 'file1.rb', 'file2.rb', 'dest_dir/'
         ).and_return(command_result)
 
@@ -90,19 +92,19 @@ RSpec.describe Git::Commands::Mv do
 
     context 'with paths containing special characters' do
       it 'handles paths with spaces' do
-        expect_command('mv', '--verbose', '--', 'old file.rb', 'new file.rb').and_return(command_result)
+        expect_command_with_capture('mv', '--verbose', '--', 'old file.rb', 'new file.rb').and_return(command_result)
 
         command.call('old file.rb', 'new file.rb')
       end
 
       it 'handles paths with unicode characters' do
-        expect_command('mv', '--verbose', '--', 'старый.rb', 'новый.rb').and_return(command_result)
+        expect_command_with_capture('mv', '--verbose', '--', 'старый.rb', 'новый.rb').and_return(command_result)
 
         command.call('старый.rb', 'новый.rb')
       end
 
       it 'handles paths with special characters' do
-        expect_command('mv', '--verbose', '--', 'file[1].rb', 'file(2).rb').and_return(command_result)
+        expect_command_with_capture('mv', '--verbose', '--', 'file[1].rb', 'file(2).rb').and_return(command_result)
 
         command.call('file[1].rb', 'file(2).rb')
       end
@@ -110,13 +112,13 @@ RSpec.describe Git::Commands::Mv do
 
     context 'with directory paths' do
       it 'moves a directory to a new location' do
-        expect_command('mv', '--verbose', '--', 'old_dir/', 'new_dir/').and_return(command_result)
+        expect_command_with_capture('mv', '--verbose', '--', 'old_dir/', 'new_dir/').and_return(command_result)
 
         command.call('old_dir/', 'new_dir/')
       end
 
       it 'moves files into an existing directory' do
-        expect_command(
+        expect_command_with_capture(
           'mv', '--verbose', '--', 'file1.rb', 'file2.rb', 'existing_dir/'
         ).and_return(command_result)
 

--- a/spec/unit/git/commands/reset_spec.rb
+++ b/spec/unit/git/commands/reset_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Reset do
     context 'with no arguments' do
       it 'runs git reset without a commit' do
         expected_result = command_result
-        expect_command('reset').and_return(expected_result)
+        expect_command_with_capture('reset').and_return(expected_result)
 
         result = command.call
 
@@ -20,19 +20,19 @@ RSpec.describe Git::Commands::Reset do
 
     context 'with a commit argument' do
       it 'resets to the specified commit' do
-        expect_command('reset', 'HEAD~1').and_return(command_result)
+        expect_command_with_capture('reset', 'HEAD~1').and_return(command_result)
 
         command.call('HEAD~1')
       end
 
       it 'resets to a SHA' do
-        expect_command('reset', 'abc123').and_return(command_result)
+        expect_command_with_capture('reset', 'abc123').and_return(command_result)
 
         command.call('abc123')
       end
 
       it 'accepts nil as the commit' do
-        expect_command('reset').and_return(command_result)
+        expect_command_with_capture('reset').and_return(command_result)
 
         command.call(nil)
       end
@@ -40,19 +40,19 @@ RSpec.describe Git::Commands::Reset do
 
     context 'with the :hard option' do
       it 'includes the --hard flag when true' do
-        expect_command('reset', '--hard').and_return(command_result)
+        expect_command_with_capture('reset', '--hard').and_return(command_result)
 
         command.call(hard: true)
       end
 
       it 'includes --hard with a commit' do
-        expect_command('reset', '--hard', 'HEAD~1').and_return(command_result)
+        expect_command_with_capture('reset', '--hard', 'HEAD~1').and_return(command_result)
 
         command.call('HEAD~1', hard: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('reset').and_return(command_result)
+        expect_command_with_capture('reset').and_return(command_result)
 
         command.call(hard: false)
       end
@@ -60,19 +60,19 @@ RSpec.describe Git::Commands::Reset do
 
     context 'with the :soft option' do
       it 'includes the --soft flag when true' do
-        expect_command('reset', '--soft').and_return(command_result)
+        expect_command_with_capture('reset', '--soft').and_return(command_result)
 
         command.call(soft: true)
       end
 
       it 'includes --soft with a commit' do
-        expect_command('reset', '--soft', 'HEAD~1').and_return(command_result)
+        expect_command_with_capture('reset', '--soft', 'HEAD~1').and_return(command_result)
 
         command.call('HEAD~1', soft: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('reset').and_return(command_result)
+        expect_command_with_capture('reset').and_return(command_result)
 
         command.call(soft: false)
       end
@@ -80,19 +80,19 @@ RSpec.describe Git::Commands::Reset do
 
     context 'with the :mixed option' do
       it 'includes the --mixed flag when true' do
-        expect_command('reset', '--mixed').and_return(command_result)
+        expect_command_with_capture('reset', '--mixed').and_return(command_result)
 
         command.call(mixed: true)
       end
 
       it 'includes --mixed with a commit' do
-        expect_command('reset', '--mixed', 'HEAD~1').and_return(command_result)
+        expect_command_with_capture('reset', '--mixed', 'HEAD~1').and_return(command_result)
 
         command.call('HEAD~1', mixed: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('reset').and_return(command_result)
+        expect_command_with_capture('reset').and_return(command_result)
 
         command.call(mixed: false)
       end

--- a/spec/unit/git/commands/rm_spec.rb
+++ b/spec/unit/git/commands/rm_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Rm do
     context 'with a single file path' do
       it 'removes the specified file' do
         expected_result = command_result
-        expect_command('rm', '--', 'file.txt').and_return(expected_result)
+        expect_command_with_capture('rm', '--', 'file.txt').and_return(expected_result)
 
         result = command.call('file.txt')
 
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::Rm do
 
     context 'with multiple file paths as an array' do
       it 'removes all specified files' do
-        expect_command('rm', '--', 'file1.txt', 'file2.txt').and_return(command_result)
+        expect_command_with_capture('rm', '--', 'file1.txt', 'file2.txt').and_return(command_result)
 
         command.call(%w[file1.txt file2.txt])
       end
@@ -28,19 +28,19 @@ RSpec.describe Git::Commands::Rm do
 
     context 'with the :force option' do
       it 'includes the --force flag when true' do
-        expect_command('rm', '--force', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('rm', '--force', '--', 'file.txt').and_return(command_result)
 
         command.call('file.txt', force: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('rm', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('rm', '--', 'file.txt').and_return(command_result)
 
         command.call('file.txt', force: false)
       end
 
       it 'accepts :f as an alias for :force' do
-        expect_command('rm', '--force', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('rm', '--force', '--', 'file.txt').and_return(command_result)
 
         command.call('file.txt', f: true)
       end
@@ -48,13 +48,13 @@ RSpec.describe Git::Commands::Rm do
 
     context 'with the :r option' do
       it 'includes the -r flag when true' do
-        expect_command('rm', '-r', '--', 'directory').and_return(command_result)
+        expect_command_with_capture('rm', '-r', '--', 'directory').and_return(command_result)
 
         command.call('directory', r: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('rm', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('rm', '--', 'file.txt').and_return(command_result)
 
         command.call('file.txt', r: false)
       end
@@ -62,13 +62,13 @@ RSpec.describe Git::Commands::Rm do
 
     context 'with the :cached option' do
       it 'includes the --cached flag when true' do
-        expect_command('rm', '--cached', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('rm', '--cached', '--', 'file.txt').and_return(command_result)
 
         command.call('file.txt', cached: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command('rm', '--', 'file.txt').and_return(command_result)
+        expect_command_with_capture('rm', '--', 'file.txt').and_return(command_result)
 
         command.call('file.txt', cached: false)
       end
@@ -76,7 +76,7 @@ RSpec.describe Git::Commands::Rm do
 
     context 'with multiple options combined' do
       it 'includes all specified flags' do
-        expect_command('rm', '--force', '-r', '--cached', '--', 'directory').and_return(command_result)
+        expect_command_with_capture('rm', '--force', '-r', '--cached', '--', 'directory').and_return(command_result)
 
         command.call('directory', force: true, r: true, cached: true)
       end
@@ -84,13 +84,13 @@ RSpec.describe Git::Commands::Rm do
 
     context 'with paths containing special characters' do
       it 'handles paths with spaces' do
-        expect_command('rm', '--', 'path/to/my file.txt').and_return(command_result)
+        expect_command_with_capture('rm', '--', 'path/to/my file.txt').and_return(command_result)
 
         command.call('path/to/my file.txt')
       end
 
       it 'handles paths with unicode characters' do
-        expect_command('rm', '--', 'path/to/файл.txt').and_return(command_result)
+        expect_command_with_capture('rm', '--', 'path/to/файл.txt').and_return(command_result)
 
         command.call('path/to/файл.txt')
       end

--- a/spec/unit/git/commands/stash/apply_spec.rb
+++ b/spec/unit/git/commands/stash/apply_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Apply do
   describe '#call' do
     context 'with no arguments (apply latest stash)' do
       it 'runs stash apply' do
-        expect_command('stash', 'apply').and_return(command_result(''))
+        expect_command_with_capture('stash', 'apply').and_return(command_result(''))
 
         result = command.call
 
@@ -21,36 +21,36 @@ RSpec.describe Git::Commands::Stash::Apply do
 
     context 'with stash reference' do
       it 'applies specific stash by name' do
-        expect_command('stash', 'apply', 'stash@{0}').and_return(command_result(''))
+        expect_command_with_capture('stash', 'apply', 'stash@{0}').and_return(command_result(''))
         command.call('stash@{0}')
       end
 
       it 'applies specific stash by index' do
-        expect_command('stash', 'apply', 'stash@{2}').and_return(command_result(''))
+        expect_command_with_capture('stash', 'apply', 'stash@{2}').and_return(command_result(''))
         command.call('stash@{2}')
       end
 
       it 'applies stash using short form' do
-        expect_command('stash', 'apply', '1').and_return(command_result(''))
+        expect_command_with_capture('stash', 'apply', '1').and_return(command_result(''))
         command.call('1')
       end
     end
 
     context 'with :index option' do
       it 'adds --index flag to restore index state' do
-        expect_command('stash', 'apply', '--index').and_return(command_result(''))
+        expect_command_with_capture('stash', 'apply', '--index').and_return(command_result(''))
         command.call(index: true)
       end
 
       it 'does not add flag when false' do
-        expect_command('stash', 'apply').and_return(command_result(''))
+        expect_command_with_capture('stash', 'apply').and_return(command_result(''))
         command.call(index: false)
       end
     end
 
     context 'with stash reference and options' do
       it 'combines stash reference with index option' do
-        expect_command('stash', 'apply', '--index', 'stash@{1}').and_return(command_result(''))
+        expect_command_with_capture('stash', 'apply', '--index', 'stash@{1}').and_return(command_result(''))
         command.call('stash@{1}', index: true)
       end
     end

--- a/spec/unit/git/commands/stash/branch_spec.rb
+++ b/spec/unit/git/commands/stash/branch_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Branch do
   describe '#call' do
     context 'with branch name only (latest stash)' do
       it 'runs stash branch with the given branch name' do
-        expect_command('stash', 'branch', 'my-feature')
+        expect_command_with_capture('stash', 'branch', 'my-feature')
           .and_return(command_result("Switched to a new branch 'my-feature'\n"))
 
         result = command.call('my-feature')
@@ -22,14 +22,14 @@ RSpec.describe Git::Commands::Stash::Branch do
 
     context 'with branch name and stash reference' do
       it 'passes stash reference to command' do
-        expect_command('stash', 'branch', 'my-feature', 'stash@{2}')
+        expect_command_with_capture('stash', 'branch', 'my-feature', 'stash@{2}')
           .and_return(command_result(''))
 
         command.call('my-feature', 'stash@{2}')
       end
 
       it 'accepts numeric stash reference' do
-        expect_command('stash', 'branch', 'bugfix', '1')
+        expect_command_with_capture('stash', 'branch', 'bugfix', '1')
           .and_return(command_result(''))
 
         command.call('bugfix', '1')
@@ -38,14 +38,14 @@ RSpec.describe Git::Commands::Stash::Branch do
 
     context 'with special branch names' do
       it 'handles branch names with slashes' do
-        expect_command('stash', 'branch', 'feature/new-thing')
+        expect_command_with_capture('stash', 'branch', 'feature/new-thing')
           .and_return(command_result(''))
 
         command.call('feature/new-thing')
       end
 
       it 'handles branch names with hyphens' do
-        expect_command('stash', 'branch', 'fix-bug-123')
+        expect_command_with_capture('stash', 'branch', 'fix-bug-123')
           .and_return(command_result(''))
 
         command.call('fix-bug-123')
@@ -54,7 +54,7 @@ RSpec.describe Git::Commands::Stash::Branch do
 
     context 'with nil stash reference' do
       it 'omits nil stash from arguments' do
-        expect_command('stash', 'branch', 'my-branch')
+        expect_command_with_capture('stash', 'branch', 'my-branch')
           .and_return(command_result(''))
 
         command.call('my-branch', nil)

--- a/spec/unit/git/commands/stash/clear_spec.rb
+++ b/spec/unit/git/commands/stash/clear_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Clear do
   describe '#call' do
     it 'calls git stash clear' do
       expected_result = command_result
-      expect_command('stash', 'clear').and_return(expected_result)
+      expect_command_with_capture('stash', 'clear').and_return(expected_result)
 
       result = command.call
 

--- a/spec/unit/git/commands/stash/create_spec.rb
+++ b/spec/unit/git/commands/stash/create_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Create do
   describe '#call' do
     context 'with no arguments' do
       it 'runs stash create' do
-        expect_command('stash', 'create')
+        expect_command_with_capture('stash', 'create')
           .and_return(command_result("abc123def456789\n"))
 
         result = command.call
@@ -22,21 +22,21 @@ RSpec.describe Git::Commands::Stash::Create do
 
     context 'with message' do
       it 'passes message to command' do
-        expect_command('stash', 'create', 'WIP: my changes')
+        expect_command_with_capture('stash', 'create', 'WIP: my changes')
           .and_return(command_result("abc123\n"))
 
         command.call('WIP: my changes')
       end
 
       it 'handles message with special characters' do
-        expect_command('stash', 'create', 'Fix "bug" in code')
+        expect_command_with_capture('stash', 'create', 'Fix "bug" in code')
           .and_return(command_result("abc123\n"))
 
         command.call('Fix "bug" in code')
       end
 
       it 'handles empty string message' do
-        expect_command('stash', 'create', '')
+        expect_command_with_capture('stash', 'create', '')
           .and_return(command_result("abc123\n"))
 
         command.call('')
@@ -45,7 +45,7 @@ RSpec.describe Git::Commands::Stash::Create do
 
     context 'with nil message' do
       it 'omits nil message from arguments' do
-        expect_command('stash', 'create')
+        expect_command_with_capture('stash', 'create')
           .and_return(command_result("abc123\n"))
 
         command.call(nil)

--- a/spec/unit/git/commands/stash/drop_spec.rb
+++ b/spec/unit/git/commands/stash/drop_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Drop do
   describe '#call' do
     context 'with no arguments (drop latest stash)' do
       it 'runs stash drop' do
-        expect_command('stash', 'drop').and_return(command_result(''))
+        expect_command_with_capture('stash', 'drop').and_return(command_result(''))
 
         result = command.call
 
@@ -21,17 +21,17 @@ RSpec.describe Git::Commands::Stash::Drop do
 
     context 'with stash reference' do
       it 'drops specific stash by name' do
-        expect_command('stash', 'drop', 'stash@{0}').and_return(command_result(''))
+        expect_command_with_capture('stash', 'drop', 'stash@{0}').and_return(command_result(''))
         command.call('stash@{0}')
       end
 
       it 'drops specific stash by index' do
-        expect_command('stash', 'drop', 'stash@{2}').and_return(command_result(''))
+        expect_command_with_capture('stash', 'drop', 'stash@{2}').and_return(command_result(''))
         command.call('stash@{2}')
       end
 
       it 'drops stash using short form' do
-        expect_command('stash', 'drop', '1').and_return(command_result(''))
+        expect_command_with_capture('stash', 'drop', '1').and_return(command_result(''))
         command.call('1')
       end
     end

--- a/spec/unit/git/commands/stash/list_spec.rb
+++ b/spec/unit/git/commands/stash/list_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Git::Commands::Stash::List do
     it 'runs stash list with format' do
       format_arg = "--format=#{Git::Parsers::Stash::STASH_FORMAT}"
 
-      expect_command('stash', 'list', format_arg)
+      expect_command_with_capture('stash', 'list', format_arg)
         .and_return(command_result(stash_output))
 
       result = command.call

--- a/spec/unit/git/commands/stash/pop_spec.rb
+++ b/spec/unit/git/commands/stash/pop_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Pop do
   describe '#call' do
     context 'with no arguments (pop latest stash)' do
       it 'runs stash pop' do
-        expect_command('stash', 'pop').and_return(command_result(''))
+        expect_command_with_capture('stash', 'pop').and_return(command_result(''))
 
         result = command.call
 
@@ -21,36 +21,36 @@ RSpec.describe Git::Commands::Stash::Pop do
 
     context 'with stash reference' do
       it 'pops specific stash by name' do
-        expect_command('stash', 'pop', 'stash@{0}').and_return(command_result(''))
+        expect_command_with_capture('stash', 'pop', 'stash@{0}').and_return(command_result(''))
         command.call('stash@{0}')
       end
 
       it 'pops specific stash by index' do
-        expect_command('stash', 'pop', 'stash@{2}').and_return(command_result(''))
+        expect_command_with_capture('stash', 'pop', 'stash@{2}').and_return(command_result(''))
         command.call('stash@{2}')
       end
 
       it 'pops stash using short form' do
-        expect_command('stash', 'pop', '1').and_return(command_result(''))
+        expect_command_with_capture('stash', 'pop', '1').and_return(command_result(''))
         command.call('1')
       end
     end
 
     context 'with :index option' do
       it 'adds --index flag to restore index state' do
-        expect_command('stash', 'pop', '--index').and_return(command_result(''))
+        expect_command_with_capture('stash', 'pop', '--index').and_return(command_result(''))
         command.call(index: true)
       end
 
       it 'does not add flag when false' do
-        expect_command('stash', 'pop').and_return(command_result(''))
+        expect_command_with_capture('stash', 'pop').and_return(command_result(''))
         command.call(index: false)
       end
     end
 
     context 'with stash reference and options' do
       it 'combines stash reference with index option' do
-        expect_command('stash', 'pop', '--index', 'stash@{1}').and_return(command_result(''))
+        expect_command_with_capture('stash', 'pop', '--index', 'stash@{1}').and_return(command_result(''))
         command.call('stash@{1}', index: true)
       end
     end

--- a/spec/unit/git/commands/stash/push_spec.rb
+++ b/spec/unit/git/commands/stash/push_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Stash::Push do
   describe '#call' do
     context 'with no arguments' do
       it 'runs stash push' do
-        expect_command('stash', 'push').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push').and_return(command_result(''))
 
         result = command.call
 
@@ -21,107 +21,107 @@ RSpec.describe Git::Commands::Stash::Push do
 
     context 'with :message option' do
       it 'adds -m flag with message' do
-        expect_command('stash', 'push', '--message', 'WIP changes').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--message', 'WIP changes').and_return(command_result(''))
         command.call(message: 'WIP changes')
       end
 
       it 'accepts :m alias' do
-        expect_command('stash', 'push', '--message', 'WIP').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--message', 'WIP').and_return(command_result(''))
         command.call(m: 'WIP')
       end
 
       it 'handles message with special characters' do
-        expect_command('stash', 'push', '--message', 'Fix "bug" in code').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--message', 'Fix "bug" in code').and_return(command_result(''))
         command.call(message: 'Fix "bug" in code')
       end
     end
 
     context 'with :patch option' do
       it 'adds -p flag for interactive selection' do
-        expect_command('stash', 'push', '--patch').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--patch').and_return(command_result(''))
         command.call(patch: true)
       end
 
       it 'accepts :p alias' do
-        expect_command('stash', 'push', '--patch').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--patch').and_return(command_result(''))
         command.call(p: true)
       end
 
       it 'does not add flag when false' do
-        expect_command('stash', 'push').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push').and_return(command_result(''))
         command.call(patch: false)
       end
     end
 
     context 'with :staged option' do
       it 'adds -S flag to stash only staged changes' do
-        expect_command('stash', 'push', '--staged').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--staged').and_return(command_result(''))
         command.call(staged: true)
       end
 
       it 'accepts :S alias' do
-        expect_command('stash', 'push', '--staged').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--staged').and_return(command_result(''))
         command.call(S: true)
       end
     end
 
     context 'with :keep_index option' do
       it 'adds --keep-index flag when true' do
-        expect_command('stash', 'push', '--keep-index').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--keep-index').and_return(command_result(''))
         command.call(keep_index: true)
       end
 
       it 'adds --no-keep-index flag when false' do
-        expect_command('stash', 'push', '--no-keep-index').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--no-keep-index').and_return(command_result(''))
         command.call(keep_index: false)
       end
 
       it 'accepts :k alias' do
-        expect_command('stash', 'push', '--keep-index').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--keep-index').and_return(command_result(''))
         command.call(k: true)
       end
     end
 
     context 'with :include_untracked option' do
       it 'adds -u flag to include untracked files' do
-        expect_command('stash', 'push', '--include-untracked').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--include-untracked').and_return(command_result(''))
         command.call(include_untracked: true)
       end
 
       it 'accepts :u alias' do
-        expect_command('stash', 'push', '--include-untracked').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--include-untracked').and_return(command_result(''))
         command.call(u: true)
       end
     end
 
     context 'with :all option' do
       it 'adds -a flag to include ignored and untracked files' do
-        expect_command('stash', 'push', '--all').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--all').and_return(command_result(''))
         command.call(all: true)
       end
 
       it 'accepts :a alias' do
-        expect_command('stash', 'push', '--all').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--all').and_return(command_result(''))
         command.call(a: true)
       end
     end
 
     context 'with :pathspec_from_file option' do
       it 'adds --pathspec-from-file flag' do
-        expect_command('stash', 'push', '--pathspec-from-file=paths.txt')
+        expect_command_with_capture('stash', 'push', '--pathspec-from-file=paths.txt')
           .and_return(command_result(''))
         command.call(pathspec_from_file: 'paths.txt')
       end
 
       it 'supports reading from stdin with -' do
-        expect_command('stash', 'push', '--pathspec-from-file=-').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--pathspec-from-file=-').and_return(command_result(''))
         command.call(pathspec_from_file: '-')
       end
     end
 
     context 'with :pathspec_file_nul option' do
       it 'adds --pathspec-file-nul flag' do
-        expect_command('stash', 'push', '--pathspec-from-file=paths.txt', '--pathspec-file-nul')
+        expect_command_with_capture('stash', 'push', '--pathspec-from-file=paths.txt', '--pathspec-file-nul')
           .and_return(command_result(''))
         command.call(pathspec_from_file: 'paths.txt', pathspec_file_nul: true)
       end
@@ -129,17 +129,17 @@ RSpec.describe Git::Commands::Stash::Push do
 
     context 'with paths (pathspecs)' do
       it 'adds paths after -- separator' do
-        expect_command('stash', 'push', '--', 'file.txt').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--', 'file.txt').and_return(command_result(''))
         command.call('file.txt')
       end
 
       it 'accepts multiple paths' do
-        expect_command('stash', 'push', '--', 'file1.txt', 'file2.txt').and_return(command_result(''))
+        expect_command_with_capture('stash', 'push', '--', 'file1.txt', 'file2.txt').and_return(command_result(''))
         command.call('file1.txt', 'file2.txt')
       end
 
       it 'combines paths with options' do
-        expect_command('stash', 'push', '--message', 'Partial stash', '--', 'src/')
+        expect_command_with_capture('stash', 'push', '--message', 'Partial stash', '--', 'src/')
           .and_return(command_result(''))
         command.call('src/', message: 'Partial stash')
       end
@@ -147,13 +147,13 @@ RSpec.describe Git::Commands::Stash::Push do
 
     context 'with multiple options combined' do
       it 'combines keep_index with message' do
-        expect_command('stash', 'push', '--keep-index', '--message', 'Testing')
+        expect_command_with_capture('stash', 'push', '--keep-index', '--message', 'Testing')
           .and_return(command_result(''))
         command.call(keep_index: true, message: 'Testing')
       end
 
       it 'combines staged with paths' do
-        expect_command('stash', 'push', '--staged', '--', 'src/', 'lib/')
+        expect_command_with_capture('stash', 'push', '--staged', '--', 'src/', 'lib/')
           .and_return(command_result(''))
         command.call('src/', 'lib/', staged: true)
       end

--- a/spec/unit/git/commands/stash/show_numstat_spec.rb
+++ b/spec/unit/git/commands/stash/show_numstat_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::Stash::ShowNumstat do
     context 'with no arguments (latest stash)' do
       it 'calls git stash show --numstat --shortstat -M' do
         expected_result = command_result(numstat_output)
-        expect_command('stash', 'show', '--numstat', '--shortstat')
+        expect_command_with_capture('stash', 'show', '--numstat', '--shortstat')
           .and_return(expected_result)
 
         result = command.call
@@ -30,7 +30,7 @@ RSpec.describe Git::Commands::Stash::ShowNumstat do
 
     context 'with specific stash reference' do
       it 'passes stash reference to command' do
-        expect_command('stash', 'show', '--numstat', '--shortstat', 'stash@{2}')
+        expect_command_with_capture('stash', 'show', '--numstat', '--shortstat', 'stash@{2}')
           .and_return(command_result(numstat_output))
 
         command.call('stash@{2}')
@@ -39,21 +39,21 @@ RSpec.describe Git::Commands::Stash::ShowNumstat do
 
     context 'with :include_untracked option' do
       it 'adds --include-untracked flag when true' do
-        expect_command('stash', 'show', '--numstat', '--shortstat', '--include-untracked')
+        expect_command_with_capture('stash', 'show', '--numstat', '--shortstat', '--include-untracked')
           .and_return(command_result(numstat_output))
 
         command.call(include_untracked: true)
       end
 
       it 'adds --no-include-untracked flag when false' do
-        expect_command('stash', 'show', '--numstat', '--shortstat', '--no-include-untracked')
+        expect_command_with_capture('stash', 'show', '--numstat', '--shortstat', '--no-include-untracked')
           .and_return(command_result(numstat_output))
 
         command.call(include_untracked: false)
       end
 
       it 'accepts :u alias' do
-        expect_command('stash', 'show', '--numstat', '--shortstat', '--include-untracked')
+        expect_command_with_capture('stash', 'show', '--numstat', '--shortstat', '--include-untracked')
           .and_return(command_result(numstat_output))
 
         command.call(u: true)
@@ -62,7 +62,7 @@ RSpec.describe Git::Commands::Stash::ShowNumstat do
 
     context 'with :only_untracked option' do
       it 'adds --only-untracked flag' do
-        expect_command('stash', 'show', '--numstat', '--shortstat', '--only-untracked')
+        expect_command_with_capture('stash', 'show', '--numstat', '--shortstat', '--only-untracked')
           .and_return(command_result(numstat_output))
 
         command.call(only_untracked: true)
@@ -71,15 +71,15 @@ RSpec.describe Git::Commands::Stash::ShowNumstat do
 
     context 'with :dirstat option' do
       it 'adds --dirstat flag when true' do
-        expect_command('stash', 'show', '--numstat', '--shortstat', '--dirstat')
+        expect_command_with_capture('stash', 'show', '--numstat', '--shortstat', '--dirstat')
           .and_return(command_result(numstat_output))
 
         command.call(dirstat: true)
       end
 
       it 'passes dirstat options when string' do
-        expect_command('stash', 'show', '--numstat', '--shortstat',
-                       '--dirstat=lines,cumulative')
+        expect_command_with_capture('stash', 'show', '--numstat', '--shortstat',
+                                    '--dirstat=lines,cumulative')
           .and_return(command_result(numstat_output))
 
         command.call(dirstat: 'lines,cumulative')

--- a/spec/unit/git/commands/stash/show_patch_spec.rb
+++ b/spec/unit/git/commands/stash/show_patch_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Git::Commands::Stash::ShowPatch do
     context 'with no arguments (latest stash)' do
       it 'calls git stash show --patch --numstat --shortstat' do
         expected_result = command_result(patch_output)
-        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat')
+        expect_command_with_capture('stash', 'show', '--patch', '--numstat', '--shortstat')
           .and_return(expected_result)
 
         result = command.call
@@ -50,7 +50,7 @@ RSpec.describe Git::Commands::Stash::ShowPatch do
 
     context 'with specific stash reference' do
       it 'passes stash reference to command' do
-        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat', 'stash@{2}')
+        expect_command_with_capture('stash', 'show', '--patch', '--numstat', '--shortstat', 'stash@{2}')
           .and_return(command_result(patch_output))
 
         command.call('stash@{2}')
@@ -59,22 +59,22 @@ RSpec.describe Git::Commands::Stash::ShowPatch do
 
     context 'with :include_untracked option' do
       it 'adds --include-untracked flag when true' do
-        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat', '--include-untracked')
+        expect_command_with_capture('stash', 'show', '--patch', '--numstat', '--shortstat', '--include-untracked')
           .and_return(command_result(patch_output))
 
         command.call(include_untracked: true)
       end
 
       it 'adds --no-include-untracked flag when false' do
-        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat',
-                       '--no-include-untracked')
+        expect_command_with_capture('stash', 'show', '--patch', '--numstat', '--shortstat',
+                                    '--no-include-untracked')
           .and_return(command_result(patch_output))
 
         command.call(include_untracked: false)
       end
 
       it 'accepts :u alias' do
-        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat', '--include-untracked')
+        expect_command_with_capture('stash', 'show', '--patch', '--numstat', '--shortstat', '--include-untracked')
           .and_return(command_result(patch_output))
 
         command.call(u: true)
@@ -83,7 +83,7 @@ RSpec.describe Git::Commands::Stash::ShowPatch do
 
     context 'with :only_untracked option' do
       it 'adds --only-untracked flag' do
-        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat', '--only-untracked')
+        expect_command_with_capture('stash', 'show', '--patch', '--numstat', '--shortstat', '--only-untracked')
           .and_return(command_result(patch_output))
 
         command.call(only_untracked: true)
@@ -92,15 +92,15 @@ RSpec.describe Git::Commands::Stash::ShowPatch do
 
     context 'with :dirstat option' do
       it 'adds --dirstat flag when true' do
-        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat', '--dirstat')
+        expect_command_with_capture('stash', 'show', '--patch', '--numstat', '--shortstat', '--dirstat')
           .and_return(command_result(patch_output))
 
         command.call(dirstat: true)
       end
 
       it 'passes dirstat options when string' do
-        expect_command('stash', 'show', '--patch', '--numstat', '--shortstat',
-                       '--dirstat=lines,cumulative')
+        expect_command_with_capture('stash', 'show', '--patch', '--numstat', '--shortstat',
+                                    '--dirstat=lines,cumulative')
           .and_return(command_result(patch_output))
 
         command.call(dirstat: 'lines,cumulative')

--- a/spec/unit/git/commands/stash/show_raw_spec.rb
+++ b/spec/unit/git/commands/stash/show_raw_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Git::Commands::Stash::ShowRaw do
     context 'with no arguments (latest stash)' do
       it 'calls git stash show --raw --numstat --shortstat -M' do
         expected_result = command_result(raw_output)
-        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat')
+        expect_command_with_capture('stash', 'show', '--raw', '--numstat', '--shortstat')
           .and_return(expected_result)
 
         result = command.call
@@ -43,7 +43,7 @@ RSpec.describe Git::Commands::Stash::ShowRaw do
 
     context 'with specific stash reference' do
       it 'passes stash reference to command' do
-        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat', 'stash@{2}')
+        expect_command_with_capture('stash', 'show', '--raw', '--numstat', '--shortstat', 'stash@{2}')
           .and_return(command_result(raw_output))
 
         command.call('stash@{2}')
@@ -52,16 +52,16 @@ RSpec.describe Git::Commands::Stash::ShowRaw do
 
     context 'with :include_untracked option' do
       it 'adds --include-untracked flag when true' do
-        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat',
-                       '--include-untracked')
+        expect_command_with_capture('stash', 'show', '--raw', '--numstat', '--shortstat',
+                                    '--include-untracked')
           .and_return(command_result(raw_output))
 
         command.call(include_untracked: true)
       end
 
       it 'adds --no-include-untracked flag when false' do
-        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat',
-                       '--no-include-untracked')
+        expect_command_with_capture('stash', 'show', '--raw', '--numstat', '--shortstat',
+                                    '--no-include-untracked')
           .and_return(command_result(raw_output))
 
         command.call(include_untracked: false)
@@ -70,7 +70,7 @@ RSpec.describe Git::Commands::Stash::ShowRaw do
 
     context 'with :only_untracked option' do
       it 'adds --only-untracked flag' do
-        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat', '--only-untracked')
+        expect_command_with_capture('stash', 'show', '--raw', '--numstat', '--shortstat', '--only-untracked')
           .and_return(command_result(raw_output))
 
         command.call(only_untracked: true)
@@ -79,7 +79,7 @@ RSpec.describe Git::Commands::Stash::ShowRaw do
 
     context 'with :find_copies option' do
       it 'adds -C flag when true' do
-        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat', '--find-copies')
+        expect_command_with_capture('stash', 'show', '--raw', '--numstat', '--shortstat', '--find-copies')
           .and_return(command_result(raw_output))
 
         command.call(find_copies: true)
@@ -88,14 +88,14 @@ RSpec.describe Git::Commands::Stash::ShowRaw do
 
     context 'with :dirstat option' do
       it 'adds --dirstat flag when true' do
-        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat', '--dirstat')
+        expect_command_with_capture('stash', 'show', '--raw', '--numstat', '--shortstat', '--dirstat')
           .and_return(command_result(raw_output))
 
         command.call(dirstat: true)
       end
 
       it 'passes dirstat options when string' do
-        expect_command('stash', 'show', '--raw', '--numstat', '--shortstat', '--dirstat=files')
+        expect_command_with_capture('stash', 'show', '--raw', '--numstat', '--shortstat', '--dirstat=files')
           .and_return(command_result(raw_output))
 
         command.call(dirstat: 'files')

--- a/spec/unit/git/commands/stash/store_spec.rb
+++ b/spec/unit/git/commands/stash/store_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Git::Commands::Stash::Store do
     context 'with commit SHA only' do
       it 'calls git stash store with commit' do
         expected_result = command_result('')
-        expect_command('stash', 'store', 'abc123def456789')
+        expect_command_with_capture('stash', 'store', 'abc123def456789')
           .and_return(expected_result)
 
         result = command.call('abc123def456789')
@@ -22,28 +22,28 @@ RSpec.describe Git::Commands::Stash::Store do
 
     context 'with :message option' do
       it 'adds --message flag with value' do
-        expect_command('stash', 'store', '--message', 'WIP: my changes', 'abc123')
+        expect_command_with_capture('stash', 'store', '--message', 'WIP: my changes', 'abc123')
           .and_return(command_result(''))
 
         command.call('abc123', message: 'WIP: my changes')
       end
 
       it 'accepts :m alias' do
-        expect_command('stash', 'store', '--message', 'WIP', 'abc123')
+        expect_command_with_capture('stash', 'store', '--message', 'WIP', 'abc123')
           .and_return(command_result(''))
 
         command.call('abc123', m: 'WIP')
       end
 
       it 'handles message with special characters' do
-        expect_command('stash', 'store', '--message', 'Fix "bug" in code', 'abc123')
+        expect_command_with_capture('stash', 'store', '--message', 'Fix "bug" in code', 'abc123')
           .and_return(command_result(''))
 
         command.call('abc123', message: 'Fix "bug" in code')
       end
 
       it 'handles message with spaces' do
-        expect_command('stash', 'store', '--message', 'work in progress', 'abc123')
+        expect_command_with_capture('stash', 'store', '--message', 'work in progress', 'abc123')
           .and_return(command_result(''))
 
         command.call('abc123', message: 'work in progress')
@@ -53,7 +53,7 @@ RSpec.describe Git::Commands::Stash::Store do
     context 'with full SHA' do
       it 'handles 40-character SHA' do
         sha = 'a' * 40
-        expect_command('stash', 'store', sha)
+        expect_command_with_capture('stash', 'store', sha)
           .and_return(command_result(''))
 
         command.call(sha)

--- a/spec/unit/git/commands/tag/create_spec.rb
+++ b/spec/unit/git/commands/tag/create_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Tag::Create do
   describe '#call' do
     context 'with tag name only (lightweight tag)' do
       it 'creates a lightweight tag' do
-        expect_command('tag', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0')
 
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
     context 'with commit target' do
       it 'adds the commit after the tag name' do
-        expect_command('tag', 'v1.0.0', 'abc123').and_return(command_result)
+        expect_command_with_capture('tag', 'v1.0.0', 'abc123').and_return(command_result)
 
         result = command.call('v1.0.0', 'abc123')
 
@@ -28,7 +28,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'accepts a branch as target' do
-        expect_command('tag', 'v1.0.0', 'main').and_return(command_result)
+        expect_command_with_capture('tag', 'v1.0.0', 'main').and_return(command_result)
 
         result = command.call('v1.0.0', 'main')
 
@@ -36,7 +36,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'accepts HEAD as target' do
-        expect_command('tag', 'v1.0.0', 'HEAD').and_return(command_result)
+        expect_command_with_capture('tag', 'v1.0.0', 'HEAD').and_return(command_result)
 
         result = command.call('v1.0.0', 'HEAD')
 
@@ -46,7 +46,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
     context 'with :annotate option' do
       it 'includes --annotate flag' do
-        expect_command('tag', '--annotate', '--message=Release', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--annotate', '--message=Release', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', annotate: true, message: 'Release')
 
@@ -54,7 +54,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'accepts :a alias' do
-        expect_command('tag', '--annotate', '--message=Release', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--annotate', '--message=Release', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', a: true, message: 'Release')
 
@@ -62,7 +62,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'does not add flag when false' do
-        expect_command('tag', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', annotate: false)
 
@@ -72,7 +72,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
     context 'with :sign option' do
       it 'includes --sign flag' do
-        expect_command('tag', '--sign', '--message=Release', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--sign', '--message=Release', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', sign: true, message: 'Release')
 
@@ -80,7 +80,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'accepts :s alias' do
-        expect_command('tag', '--sign', '--message=Release', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--sign', '--message=Release', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', s: true, message: 'Release')
 
@@ -88,7 +88,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'includes --no-sign flag when false' do
-        expect_command('tag', '--no-sign', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--no-sign', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', sign: false)
 
@@ -98,7 +98,8 @@ RSpec.describe Git::Commands::Tag::Create do
 
     context 'with :local_user option' do
       it 'includes --local-user flag with key' do
-        expect_command('tag', '--local-user=ABCD1234', '--message=Release', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--local-user=ABCD1234', '--message=Release',
+                                    'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', local_user: 'ABCD1234', message: 'Release')
 
@@ -106,7 +107,8 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'accepts :u alias' do
-        expect_command('tag', '--local-user=ABCD1234', '--message=Release', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--local-user=ABCD1234', '--message=Release',
+                                    'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', u: 'ABCD1234', message: 'Release')
 
@@ -116,7 +118,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
     context 'with :force option' do
       it 'includes --force flag' do
-        expect_command('tag', '--force', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--force', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', force: true)
 
@@ -124,7 +126,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'accepts :f alias' do
-        expect_command('tag', '--force', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--force', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', f: true)
 
@@ -132,7 +134,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'does not add flag when false' do
-        expect_command('tag', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', force: false)
 
@@ -142,7 +144,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
     context 'with :message option' do
       it 'includes --message flag with value' do
-        expect_command('tag', '--message=Release version 1.0.0', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--message=Release version 1.0.0', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', message: 'Release version 1.0.0')
 
@@ -150,7 +152,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'accepts :m alias' do
-        expect_command('tag', '--message=Release', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--message=Release', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', m: 'Release')
 
@@ -158,7 +160,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'handles message with special characters' do
-        expect_command('tag', '--message=Release "quoted"', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--message=Release "quoted"', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', message: 'Release "quoted"')
 
@@ -168,7 +170,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
     context 'with :file option' do
       it 'includes --file flag with path' do
-        expect_command('tag', '--file=/path/to/message.txt', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--file=/path/to/message.txt', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', file: '/path/to/message.txt')
 
@@ -176,7 +178,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'accepts :F alias' do
-        expect_command('tag', '--file=/path/to/message.txt', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--file=/path/to/message.txt', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', F: '/path/to/message.txt')
 
@@ -184,7 +186,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'supports reading from stdin with -' do
-        expect_command('tag', '--file=-', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--file=-', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', file: '-')
 
@@ -194,7 +196,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
     context 'with :create_reflog option' do
       it 'includes --create-reflog flag' do
-        expect_command('tag', '--create-reflog', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--create-reflog', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', create_reflog: true)
 
@@ -202,7 +204,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'does not add flag when false' do
-        expect_command('tag', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', create_reflog: false)
 
@@ -212,7 +214,8 @@ RSpec.describe Git::Commands::Tag::Create do
 
     context 'with multiple options combined' do
       it 'creates an annotated tag with message and force' do
-        expect_command('tag', '--annotate', '--force', '--message=Release', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--annotate', '--force', '--message=Release',
+                                    'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', annotate: true, force: true, message: 'Release')
 
@@ -220,7 +223,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'creates a signed tag at specific commit' do
-        expect_command('tag', '--sign', '--message=Signed release', 'v1.0.0', 'abc123')
+        expect_command_with_capture('tag', '--sign', '--message=Signed release', 'v1.0.0', 'abc123')
           .and_return(command_result)
 
         result = command.call('v1.0.0', 'abc123', sign: true, message: 'Signed release')
@@ -229,7 +232,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'creates tag with custom signing key at specific commit' do
-        expect_command('tag', '--local-user=KEY123', '--message=Release', 'v1.0.0', 'main')
+        expect_command_with_capture('tag', '--local-user=KEY123', '--message=Release', 'v1.0.0', 'main')
           .and_return(command_result)
 
         result = command.call('v1.0.0', 'main', local_user: 'KEY123', message: 'Release')
@@ -238,7 +241,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'combines create_reflog with annotated tag' do
-        expect_command('tag', '--annotate', '--message=Release', '--create-reflog', 'v1.0.0')
+        expect_command_with_capture('tag', '--annotate', '--message=Release', '--create-reflog', 'v1.0.0')
           .and_return(command_result)
 
         result = command.call('v1.0.0', annotate: true, create_reflog: true, message: 'Release')
@@ -247,7 +250,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'allows annotate with file instead of message' do
-        expect_command('tag', '--annotate', '--file=/path/to/msg.txt', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--annotate', '--file=/path/to/msg.txt', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', annotate: true, file: '/path/to/msg.txt')
 
@@ -257,7 +260,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
     context 'with :trailer option' do
       it 'includes trailers with key-value pairs' do
-        expect_command('tag', '--message=Release', '--trailer', 'Signed-off-by: John Doe', 'v1.0.0')
+        expect_command_with_capture('tag', '--message=Release', '--trailer', 'Signed-off-by: John Doe', 'v1.0.0')
           .and_return(command_result)
 
         result = command.call('v1.0.0', message: 'Release', trailer: { 'Signed-off-by' => 'John Doe' })
@@ -266,7 +269,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'includes multiple trailers' do
-        expect_command(
+        expect_command_with_capture(
           'tag', '--message=Release',
           '--trailer', 'Signed-off-by: John Doe',
           '--trailer', 'Reviewed-by: Jane Smith',
@@ -282,7 +285,7 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'includes trailers with array of pairs' do
-        expect_command(
+        expect_command_with_capture(
           'tag', '--message=Release',
           '--trailer', 'Co-authored-by: Alice',
           '--trailer', 'Co-authored-by: Bob',
@@ -300,7 +303,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
     context 'with :cleanup option' do
       it 'includes --cleanup=strip' do
-        expect_command('tag', '--message=Release', '--cleanup=strip', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--message=Release', '--cleanup=strip', 'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', message: 'Release', cleanup: 'strip')
 
@@ -308,7 +311,8 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'includes --cleanup=verbatim' do
-        expect_command('tag', '--message=Release', '--cleanup=verbatim', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--message=Release', '--cleanup=verbatim',
+                                    'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', message: 'Release', cleanup: 'verbatim')
 
@@ -316,7 +320,8 @@ RSpec.describe Git::Commands::Tag::Create do
       end
 
       it 'includes --cleanup=whitespace' do
-        expect_command('tag', '--message=Release', '--cleanup=whitespace', 'v1.0.0').and_return(command_result)
+        expect_command_with_capture('tag', '--message=Release', '--cleanup=whitespace',
+                                    'v1.0.0').and_return(command_result)
 
         result = command.call('v1.0.0', message: 'Release', cleanup: 'whitespace')
 

--- a/spec/unit/git/commands/tag/delete_spec.rb
+++ b/spec/unit/git/commands/tag/delete_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Git::Commands::Tag::Delete do
 
     context 'with single tag name' do
       it 'deletes the tag' do
-        expect_command('tag', '--delete', 'v1.0.0').and_return(command_result(delete_output))
+        expect_command_with_capture('tag', '--delete', 'v1.0.0').and_return(command_result(delete_output))
 
         result = command.call('v1.0.0')
 
@@ -29,7 +29,7 @@ RSpec.describe Git::Commands::Tag::Delete do
       end
 
       it 'deletes all specified tags in one command' do
-        expect_command('tag', '--delete', 'v1.0.0', 'v2.0.0', 'v3.0.0')
+        expect_command_with_capture('tag', '--delete', 'v1.0.0', 'v2.0.0', 'v3.0.0')
           .and_return(command_result(multi_delete_output))
 
         result = command.call('v1.0.0', 'v2.0.0', 'v3.0.0')
@@ -41,7 +41,7 @@ RSpec.describe Git::Commands::Tag::Delete do
 
     context 'with various tag name formats' do
       it 'handles semver tags' do
-        expect_command('tag', '--delete', 'v1.2.3')
+        expect_command_with_capture('tag', '--delete', 'v1.2.3')
           .and_return(command_result("Deleted tag 'v1.2.3' (was abc)\n"))
 
         result = command.call('v1.2.3')
@@ -50,7 +50,7 @@ RSpec.describe Git::Commands::Tag::Delete do
       end
 
       it 'handles tags with slashes' do
-        expect_command('tag', '--delete', 'release/v1.0')
+        expect_command_with_capture('tag', '--delete', 'release/v1.0')
           .and_return(command_result("Deleted tag 'release/v1.0' (was abc)\n"))
 
         result = command.call('release/v1.0')
@@ -59,7 +59,7 @@ RSpec.describe Git::Commands::Tag::Delete do
       end
 
       it 'handles tags with hyphens and underscores' do
-        expect_command('tag', '--delete', 'my-tag_name')
+        expect_command_with_capture('tag', '--delete', 'my-tag_name')
           .and_return(command_result("Deleted tag 'my-tag_name' (was abc)\n"))
 
         result = command.call('my-tag_name')
@@ -70,7 +70,7 @@ RSpec.describe Git::Commands::Tag::Delete do
 
     context 'exit code handling' do
       it 'returns result for exit code 0 (all deleted)' do
-        allow(execution_context).to receive(:command)
+        allow(execution_context).to receive(:command_with_capture)
           .with('tag', '--delete', 'v1.0.0', raise_on_failure: false)
           .and_return(command_result(delete_output))
 
@@ -86,7 +86,7 @@ RSpec.describe Git::Commands::Tag::Delete do
           stderr: "error: tag 'nonexistent' not found.",
           exitstatus: 1
         )
-        allow(execution_context).to receive(:command)
+        allow(execution_context).to receive(:command_with_capture)
           .with('tag', '--delete', 'v1.0.0', 'nonexistent', raise_on_failure: false)
           .and_return(partial_result)
 
@@ -102,7 +102,7 @@ RSpec.describe Git::Commands::Tag::Delete do
           stderr: 'fatal: some unexpected error',
           exitstatus: 128
         )
-        allow(execution_context).to receive(:command)
+        allow(execution_context).to receive(:command_with_capture)
           .with('tag', '--delete', 'v1.0.0', raise_on_failure: false)
           .and_return(fatal_result)
 

--- a/spec/unit/git/commands/tag/list_spec.rb
+++ b/spec/unit/git/commands/tag/list_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Commands::Tag::List do
 
     context 'with no options (basic list)' do
       it 'includes tag and --list literals with format' do
-        expect_command('tag', '--list', format_arg)
+        expect_command_with_capture('tag', '--list', format_arg)
           .and_return(command_result(sample_output))
 
         result = command.call
@@ -26,7 +26,7 @@ RSpec.describe Git::Commands::Tag::List do
 
     context 'with patterns' do
       it 'adds a single pattern argument' do
-        expect_command('tag', '--list', format_arg, 'v1.*').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, 'v1.*').and_return(command_result)
 
         result = command.call('v1.*')
 
@@ -34,7 +34,7 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'adds multiple pattern arguments' do
-        expect_command('tag', '--list', format_arg, 'v1.*', 'v2.*').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, 'v1.*', 'v2.*').and_return(command_result)
 
         result = command.call('v1.*', 'v2.*')
 
@@ -44,7 +44,7 @@ RSpec.describe Git::Commands::Tag::List do
 
     context 'with :sort option' do
       it 'includes --sort with single key' do
-        expect_command('tag', '--list', format_arg, '--sort=refname').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, '--sort=refname').and_return(command_result)
 
         result = command.call(sort: 'refname')
 
@@ -52,7 +52,7 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'includes multiple --sort flags for array' do
-        expect_command('tag', '--list', format_arg, '--sort=refname', '--sort=-creatordate')
+        expect_command_with_capture('tag', '--list', format_arg, '--sort=refname', '--sort=-creatordate')
           .and_return(command_result)
 
         result = command.call(sort: ['refname', '-creatordate'])
@@ -61,7 +61,7 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'supports version:refname sort key' do
-        expect_command('tag', '--list', format_arg, '--sort=version:refname').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, '--sort=version:refname').and_return(command_result)
 
         result = command.call(sort: 'version:refname')
 
@@ -71,7 +71,7 @@ RSpec.describe Git::Commands::Tag::List do
 
     context 'with :contains option' do
       it 'includes --contains with commit value' do
-        expect_command('tag', '--list', format_arg, '--contains', 'abc123').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, '--contains', 'abc123').and_return(command_result)
 
         result = command.call(contains: 'abc123')
 
@@ -79,7 +79,7 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'includes --contains flag when true' do
-        expect_command('tag', '--list', format_arg, '--contains').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, '--contains').and_return(command_result)
 
         result = command.call(contains: true)
 
@@ -89,7 +89,7 @@ RSpec.describe Git::Commands::Tag::List do
 
     context 'with :no_contains option' do
       it 'includes --no-contains with commit value' do
-        expect_command('tag', '--list', format_arg, '--no-contains', 'abc123').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, '--no-contains', 'abc123').and_return(command_result)
 
         result = command.call(no_contains: 'abc123')
 
@@ -97,7 +97,7 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'includes --no-contains flag when true' do
-        expect_command('tag', '--list', format_arg, '--no-contains').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, '--no-contains').and_return(command_result)
 
         result = command.call(no_contains: true)
 
@@ -107,7 +107,7 @@ RSpec.describe Git::Commands::Tag::List do
 
     context 'with :merged option' do
       it 'includes --merged with commit value' do
-        expect_command('tag', '--list', format_arg, '--merged', 'main').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, '--merged', 'main').and_return(command_result)
 
         result = command.call(merged: 'main')
 
@@ -115,7 +115,7 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'includes --merged flag when true' do
-        expect_command('tag', '--list', format_arg, '--merged').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, '--merged').and_return(command_result)
 
         result = command.call(merged: true)
 
@@ -125,7 +125,7 @@ RSpec.describe Git::Commands::Tag::List do
 
     context 'with :no_merged option' do
       it 'includes --no-merged with commit value' do
-        expect_command('tag', '--list', format_arg, '--no-merged', 'main').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, '--no-merged', 'main').and_return(command_result)
 
         result = command.call(no_merged: 'main')
 
@@ -133,7 +133,7 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'includes --no-merged flag when true' do
-        expect_command('tag', '--list', format_arg, '--no-merged').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, '--no-merged').and_return(command_result)
 
         result = command.call(no_merged: true)
 
@@ -143,7 +143,7 @@ RSpec.describe Git::Commands::Tag::List do
 
     context 'with :points_at option' do
       it 'includes --points-at with object value' do
-        expect_command('tag', '--list', format_arg, '--points-at', 'HEAD').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, '--points-at', 'HEAD').and_return(command_result)
 
         result = command.call(points_at: 'HEAD')
 
@@ -151,7 +151,7 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'includes --points-at flag when true' do
-        expect_command('tag', '--list', format_arg, '--points-at').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, '--points-at').and_return(command_result)
 
         result = command.call(points_at: true)
 
@@ -161,7 +161,7 @@ RSpec.describe Git::Commands::Tag::List do
 
     context 'with :ignore_case option' do
       it 'includes --ignore-case flag' do
-        expect_command('tag', '--list', format_arg, '--ignore-case').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, '--ignore-case').and_return(command_result)
 
         result = command.call(ignore_case: true)
 
@@ -169,7 +169,7 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'accepts :i alias' do
-        expect_command('tag', '--list', format_arg, '--ignore-case').and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg, '--ignore-case').and_return(command_result)
 
         result = command.call(i: true)
 
@@ -177,7 +177,7 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'does not add flag when false' do
-        expect_command('tag', '--list', format_arg).and_return(command_result)
+        expect_command_with_capture('tag', '--list', format_arg).and_return(command_result)
 
         result = command.call(ignore_case: false)
 
@@ -187,7 +187,7 @@ RSpec.describe Git::Commands::Tag::List do
 
     context 'with multiple options combined' do
       it 'combines flags correctly' do
-        expect_command('tag', '--list', format_arg, '--contains', 'abc123', '--sort=refname', 'v1.*')
+        expect_command_with_capture('tag', '--list', format_arg, '--contains', 'abc123', '--sort=refname', 'v1.*')
           .and_return(command_result)
 
         result = command.call('v1.*', sort: 'refname', contains: 'abc123')
@@ -196,7 +196,7 @@ RSpec.describe Git::Commands::Tag::List do
       end
 
       it 'combines multiple patterns with options' do
-        expect_command('tag', '--list', format_arg, '--merged', 'main', 'release-*', 'v*')
+        expect_command_with_capture('tag', '--list', format_arg, '--merged', 'main', 'release-*', 'v*')
           .and_return(command_result)
 
         result = command.call('release-*', 'v*', merged: 'main')

--- a/spec/unit/git/commands/tag/verify_spec.rb
+++ b/spec/unit/git/commands/tag/verify_spec.rb
@@ -9,13 +9,13 @@ RSpec.describe Git::Commands::Tag::Verify do
 
   describe '#call' do
     before do
-      allow(execution_context).to receive(:command).and_return(command_result)
+      allow(execution_context).to receive(:command_with_capture).and_return(command_result)
     end
 
     context 'with a single tag name' do
       it 'calls git tag --verify with the tag name' do
         expected_result = command_result
-        expect_command('tag', '--verify', 'v1.0.0').and_return(expected_result)
+        expect_command_with_capture('tag', '--verify', 'v1.0.0').and_return(expected_result)
 
         result = command.call('v1.0.0')
 
@@ -25,19 +25,19 @@ RSpec.describe Git::Commands::Tag::Verify do
 
     context 'with multiple tag names' do
       it 'passes all tag names to the command' do
-        expect_command('tag', '--verify', 'v1.0.0', 'v2.0.0', 'v3.0.0')
+        expect_command_with_capture('tag', '--verify', 'v1.0.0', 'v2.0.0', 'v3.0.0')
         command.call('v1.0.0', 'v2.0.0', 'v3.0.0')
       end
     end
 
     context 'with :format option' do
       it 'adds --format flag with the specified format string' do
-        expect_command('tag', '--verify', '--format=%(refname:short)', 'v1.0.0')
+        expect_command_with_capture('tag', '--verify', '--format=%(refname:short)', 'v1.0.0')
         command.call('v1.0.0', format: '%(refname:short)')
       end
 
       it 'works with multiple tags and format' do
-        expect_command('tag', '--verify', '--format=%(objectname)', 'v1.0.0', 'v2.0.0')
+        expect_command_with_capture('tag', '--verify', '--format=%(objectname)', 'v1.0.0', 'v2.0.0')
         command.call('v1.0.0', 'v2.0.0', format: '%(objectname)')
       end
     end

--- a/spec/unit/git/lib_command_spec.rb
+++ b/spec/unit/git/lib_command_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Lib do
     allow(lib).to receive(:command_line).and_return(command_line)
   end
 
-  describe '#command' do
+  describe '#command_with_capture' do
     let(:successful_result) do
       instance_double(
         Git::CommandLineResult,
@@ -35,9 +35,9 @@ RSpec.describe Git::Lib do
 
     context 'when command succeeds' do
       it 'returns a CommandLineResult' do
-        allow(command_line).to receive(:run).and_return(successful_result)
+        allow(command_line).to receive(:run_with_capture).and_return(successful_result)
 
-        result = lib.command('version')
+        result = lib.command_with_capture('version')
 
         expect(result).to be(successful_result)
       end
@@ -45,19 +45,19 @@ RSpec.describe Git::Lib do
 
     context 'when command fails with non-zero exit (default behavior)' do
       it 'raises Git::FailedError' do
-        allow(command_line).to receive(:run).and_raise(Git::FailedError.new(failed_result))
+        allow(command_line).to receive(:run_with_capture).and_raise(Git::FailedError.new(failed_result))
 
         expect do
-          lib.command('rev-parse', 'nonexistent')
+          lib.command_with_capture('rev-parse', 'nonexistent')
         end.to raise_error(Git::FailedError)
       end
     end
 
     context 'when command fails with raise_on_failure: false' do
       it 'returns CommandLineResult without raising' do
-        allow(command_line).to receive(:run).and_return(failed_result)
+        allow(command_line).to receive(:run_with_capture).and_return(failed_result)
 
-        result = lib.command('rev-parse', 'nonexistent', raise_on_failure: false)
+        result = lib.command_with_capture('rev-parse', 'nonexistent', raise_on_failure: false)
 
         expect(result).to be(failed_result)
         expect(result.status.success?).to be false
@@ -66,11 +66,11 @@ RSpec.describe Git::Lib do
 
     context 'with env: option' do
       it 'merges env into the command_line call' do
-        allow(command_line).to receive(:run).and_return(successful_result)
+        allow(command_line).to receive(:run_with_capture).and_return(successful_result)
 
-        lib.command('rev-parse', '--git-dir', env: { 'GIT_DIR' => '/custom/path' })
+        lib.command_with_capture('rev-parse', '--git-dir', env: { 'GIT_DIR' => '/custom/path' })
 
-        expect(command_line).to have_received(:run).with(
+        expect(command_line).to have_received(:run_with_capture).with(
           'rev-parse', '--git-dir',
           hash_including(env: { 'GIT_DIR' => '/custom/path' })
         )

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -140,8 +140,8 @@ module Test
       #   expected_command_line = ['fetch', '--depth', '2', '--', 'origin', 'master']
       #   assert_command_line_eq(expected_command_line) { |git| git.fetch('origin', { ref: 'master', depth: '2' }) }
       #
-      # @param expected_command_line [Array<String>] The expected arguments to be sent to Git::Lib#command
-      # @param git_output [String] The mocked output to be returned by the Git::Lib#command method
+      # @param expected_command_line [Array<String>] The expected arguments to be sent to Git::Lib#command_with_capture
+      # @param mocked_output [String] The mocked output to be returned by the Git::Lib#command_with_capture method
       #
       # @yield [git] a block to call the method to be tested
       # @yieldparam git [Git::Base] The Git::Base object resulting from initializing the test project
@@ -149,7 +149,7 @@ module Test
       #
       # @return [void]
       #
-      def assert_command_line_eq(expected_command_line, _method: :command, mocked_output: '', include_env: false)
+      def assert_command_line_eq(expected_command_line, method: :command_with_capture, mocked_output: '', include_env: false)
         actual_command_line = nil
 
         # Internal options that should not be included in command line comparisons
@@ -174,7 +174,7 @@ module Test
             Git::CommandLineResult.new(['git', *cmd], status, mocked_output, '')
           end
 
-          git.lib.define_singleton_method(:command, &mock_command)
+          git.lib.define_singleton_method(method, &mock_command)
 
           Dir.chdir 'test_project' do
             yield(git) if block_given?
@@ -205,7 +205,7 @@ module Test
 
       # Build a mock CommandLineResult for clone commands
       #
-      # Used in tests that mock Git::Lib#command to capture command line args.
+      # Used in tests that mock Git::Lib#command_with_capture to capture command line args.
       # Returns a CommandLineResult with realistic stderr so that
       # Lib#build_clone_result can parse the clone directory.
       #

--- a/tests/units/test_command_line.rb
+++ b/tests/units/test_command_line.rb
@@ -61,7 +61,7 @@ class TestCommamndLine < Test::Unit::TestCase
       command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
       args = []
       assert_raise ArgumentError do
-        command_line.run(*args, normalize: normalize, chomp: chomp, timeout_after: 'not a number')
+        command_line.run_with_capture(*args, normalize: normalize, chomp: chomp, timeout_after: 'not a number')
       end
     end
 
@@ -70,8 +70,8 @@ class TestCommamndLine < Test::Unit::TestCase
       args = ['--duration=5']
 
       assert_raise Git::TimeoutError do
-        command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge,
-                                timeout: 0.01)
+        command_line.run_with_capture(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge,
+                                             timeout: 0.01)
       end
     end
 
@@ -83,18 +83,18 @@ class TestCommamndLine < Test::Unit::TestCase
       # subclass of Git::Error
 
       begin
-        command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge,
-                                timeout: 0.01)
+        command_line.run_with_capture(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge,
+                                             timeout: 0.01)
       rescue Git::Error => e
         assert_equal(true, e.result.status.timed_out?)
       end
     end
   end
 
-  test 'run should return a result that includes the command ran, its output, and resulting status' do
+  test 'run_with_capture should return a result that includes the command ran, its output, and resulting status' do
     command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
     args = ['--stdout=stdout output', '--stderr=stderr output']
-    result = command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
+    result = command_line.run_with_capture(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
 
     assert_equal([{}, 'ruby', 'bin/command_line_test', '--stdout=stdout output', '--stderr=stderr output'],
                  result.git_cmd)
@@ -103,11 +103,11 @@ class TestCommamndLine < Test::Unit::TestCase
     assert_equal(0, result.status.exitstatus)
   end
 
-  test 'run should raise FailedError if command fails' do
+  test 'run_with_capture should raise FailedError if command fails' do
     command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
     args = ['--exitstatus=1', '--stdout=O1', '--stderr=O2']
     error = assert_raise Git::FailedError do
-      command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
+      command_line.run_with_capture(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
     end
 
     # The error raised should include the result of the command
@@ -122,11 +122,11 @@ class TestCommamndLine < Test::Unit::TestCase
   unless Gem.win_platform?
     # Ruby on Windows doesn't support signals fully (at all?)
     # See https://blog.simplificator.com/2016/01/18/how-to-kill-processes-on-windows-using-ruby/
-    test 'run should raise SignaledError if command exits because of an uncaught signal' do
+    test 'run_with_capture should raise SignaledError if command exits because of an uncaught signal' do
       command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
       args = ['--signal=9', '--stdout=O1', '--stderr=O2']
       error = assert_raise Git::SignaledError do
-        command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
+        command_line.run_with_capture(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
       end
 
       # The error raised should include the result of the command
@@ -140,20 +140,20 @@ class TestCommamndLine < Test::Unit::TestCase
     end
   end
 
-  test 'run should chomp output if chomp is true' do
+  test 'run_with_capture should chomp output if chomp is true' do
     command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
     args = ['--stdout=stdout output']
     chomp = true
-    result = command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
+    result = command_line.run_with_capture(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
 
     assert_equal('stdout output', result.stdout)
   end
 
-  test 'run should normalize output if normalize is true' do
+  test 'run_with_capture should normalize output if normalize is true' do
     command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
     args = ['--stdout-file=tests/files/encoding/test1.txt']
     normalize = true
-    result = command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
+    result = command_line.run_with_capture(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
 
     expected_output = <<~OUTPUT
       Λορεμ ιπσθμ δολορ σιτ
@@ -165,11 +165,11 @@ class TestCommamndLine < Test::Unit::TestCase
     assert_equal(expected_output, result.stdout.delete("\r"))
   end
 
-  test 'run should NOT normalize output if normalize is false' do
+  test 'run_with_capture should NOT normalize output if normalize is false' do
     command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
     args = ['--stdout-file=tests/files/encoding/test1.txt']
     normalize = false
-    result = command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
+    result = command_line.run_with_capture(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
 
     eol = RUBY_PLATFORM =~ /mswin|mingw/ ? "\r\n" : "\n"
 
@@ -182,11 +182,11 @@ class TestCommamndLine < Test::Unit::TestCase
     assert_equal(expected_output, result.stdout)
   end
 
-  test 'run should redirect stderr to stdout if merge is true' do
+  test 'run_with_capture should redirect stderr to stdout if merge is true' do
     command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
     args = ['--stdout=stdout output', '--stderr=stderr output']
     merge = true
-    result = command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
+    result = command_line.run_with_capture(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
 
     # The output should be merged, but the order depends on a number of
     # external factors
@@ -194,12 +194,12 @@ class TestCommamndLine < Test::Unit::TestCase
     assert_include(result.stdout, 'stderr output')
   end
 
-  test 'run should log command and output if logger is given' do
+  test 'run_with_capture should log command and output if logger is given' do
     log_output = StringIO.new
     logger = Logger.new(log_output, level: Logger::DEBUG)
     command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
     args = ['--stdout=stdout output']
-    command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
+    command_line.run_with_capture(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
 
     # The command and its exitstatus should be logged on INFO level
     assert_match(/^I, .*exited with status pid \d+ exit \d+$/, log_output.string)
@@ -208,19 +208,19 @@ class TestCommamndLine < Test::Unit::TestCase
     assert_match(/^D, .*stdout:\n.*\nstderr:\n.*$/, log_output.string)
   end
 
-  test 'run should be able to redirect stdout to a file' do
+  test 'run_with_capture should be able to redirect stdout to a file' do
     command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
     args = ['--stdout=stdout output']
     Tempfile.create do |f|
       out_writer = f
-      command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp,
-                              merge: merge)
+      command_line.run_with_capture(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp,
+                                           merge: merge)
       f.rewind
       assert_equal('stdout output', f.read.chomp)
     end
   end
 
-  test 'run should raise a Git::ProcessIOError if there was an error raised writing stdout' do
+  test 'run_with_capture should raise a Git::ProcessIOError if there was an error raised writing stdout' do
     command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
     args = ['--stdout=stdout output']
     out_writer = Class.new do
@@ -230,7 +230,7 @@ class TestCommamndLine < Test::Unit::TestCase
     end.new
 
     error = assert_raise Git::ProcessIOError do
-      command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
+      command_line.run_with_capture(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
     end
 
     assert_kind_of(Git::ProcessIOError, error)
@@ -238,16 +238,16 @@ class TestCommamndLine < Test::Unit::TestCase
     assert_equal('error writing to file', error.cause.message)
   end
 
-  test 'run should be able to redirect stderr to a file' do
+  test 'run_with_capture should be able to redirect stderr to a file' do
     command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
     args = ['--stderr=ERROR: fatal error', '--stdout=STARTING PROCESS']
     Tempfile.create do |_f|
-      result = command_line.run(*args, normalize: normalize, chomp: chomp, merge: merge)
+      result = command_line.run_with_capture(*args, normalize: normalize, chomp: chomp, merge: merge)
       assert_equal('ERROR: fatal error', result.stderr.chomp)
     end
   end
 
-  test 'run should raise a Git::ProcessIOError if there was an error raised writing stderr' do
+  test 'run_with_capture should raise a Git::ProcessIOError if there was an error raised writing stderr' do
     command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
     args = ['--stderr=ERROR: fatal error']
     err_writer = Class.new do
@@ -257,7 +257,7 @@ class TestCommamndLine < Test::Unit::TestCase
     end.new
 
     error = assert_raise Git::ProcessIOError do
-      command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
+      command_line.run_with_capture(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp, merge: merge)
     end
 
     assert_kind_of(Git::ProcessIOError, error)
@@ -265,14 +265,14 @@ class TestCommamndLine < Test::Unit::TestCase
     assert_equal('error writing to stderr file', error.cause.message)
   end
 
-  test 'run should be able to redirect stdout and stderr to the same file' do
+  test 'run_with_capture should be able to redirect stdout and stderr to the same file' do
     command_line = Git::CommandLine.new(env, binary_path, global_opts, logger)
     args = ['--stderr=ERROR: fatal error', '--stdout=STARTING PROCESS']
     Tempfile.create do |f|
       out_writer = f
       merge = true
-      command_line.run(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp,
-                              merge: merge)
+      command_line.run_with_capture(*args, out: out_writer, err: err_writer, normalize: normalize, chomp: chomp,
+                                           merge: merge)
       f.rewind
       output = f.read
 

--- a/tests/units/test_command_raises_on_failure.rb
+++ b/tests/units/test_command_raises_on_failure.rb
@@ -15,7 +15,7 @@ class TestCommandRaisesOnFailure < Test::Unit::TestCase
       Dir.chdir('test_project') do
         # Try to show a non-existent ref - this should fail with exit code 128
         assert_raise(Git::FailedError) do
-          git.lib.command('show', 'nonexistent-ref-that-does-not-exist')
+          git.lib.command_with_capture('show', 'nonexistent-ref-that-does-not-exist')
         end
       end
     end
@@ -26,7 +26,7 @@ class TestCommandRaisesOnFailure < Test::Unit::TestCase
       git = Git.init('test_project')
 
       Dir.chdir('test_project') do
-        git.lib.command('show', 'nonexistent-ref-that-does-not-exist')
+        git.lib.command_with_capture('show', 'nonexistent-ref-that-does-not-exist')
         flunk 'Expected Git::FailedError to be raised'
       rescue Git::FailedError => e
         assert_not_nil e.result
@@ -42,7 +42,7 @@ class TestCommandRaisesOnFailure < Test::Unit::TestCase
 
       Dir.chdir('test_project') do
         # This should NOT raise - raise_on_failure: false suppresses the error
-        result = git.lib.command('show', 'nonexistent-ref-that-does-not-exist', raise_on_failure: false)
+        result = git.lib.command_with_capture('show', 'nonexistent-ref-that-does-not-exist', raise_on_failure: false)
 
         assert_instance_of Git::CommandLineResult, result
         assert_equal false, result.status.success?

--- a/tests/units/test_git_clone.rb
+++ b/tests/units/test_git_clone.rb
@@ -97,7 +97,7 @@ class TestGitClone < Test::Unit::TestCase
 
       # Mock the Git::Lib#command! method to capture the actual command line args
       clone_result = mock_clone_result(destination)
-      git.lib.define_singleton_method(:command) do |cmd, *opts|
+      git.lib.define_singleton_method(:command_with_capture) do |cmd, *opts|
         actual_command_line = [cmd, *opts.flatten]
         clone_result
       end
@@ -124,7 +124,7 @@ class TestGitClone < Test::Unit::TestCase
 
       # Mock the Git::Lib#command! method to capture the actual command line args
       clone_result = mock_clone_result(destination)
-      git.lib.define_singleton_method(:command) do |cmd, *opts|
+      git.lib.define_singleton_method(:command_with_capture) do |cmd, *opts|
         actual_command_line = [cmd, *opts.flatten]
         clone_result
       end
@@ -153,7 +153,7 @@ class TestGitClone < Test::Unit::TestCase
 
       # Mock the Git::Lib#command! method to capture the actual command line args
       clone_result = mock_clone_result(destination)
-      git.lib.define_singleton_method(:command) do |cmd, *opts|
+      git.lib.define_singleton_method(:command_with_capture) do |cmd, *opts|
         actual_command_line = [cmd, *opts.flatten]
         clone_result
       end
@@ -180,7 +180,7 @@ class TestGitClone < Test::Unit::TestCase
       git = Git.init('.')
 
       clone_result = mock_clone_result(destination)
-      git.lib.define_singleton_method(:command) do |cmd, *opts|
+      git.lib.define_singleton_method(:command_with_capture) do |cmd, *opts|
         actual_command_line = [cmd, *opts.flatten]
         clone_result
       end
@@ -206,7 +206,7 @@ class TestGitClone < Test::Unit::TestCase
       git = Git.init('.')
 
       clone_result = mock_clone_result(destination)
-      git.lib.define_singleton_method(:command) do |cmd, *opts|
+      git.lib.define_singleton_method(:command_with_capture) do |cmd, *opts|
         actual_command_line = [cmd, *opts.flatten]
         clone_result
       end
@@ -233,7 +233,7 @@ class TestGitClone < Test::Unit::TestCase
       git = Git.init('.')
 
       clone_result = mock_clone_result(destination)
-      git.lib.define_singleton_method(:command) do |cmd, *opts|
+      git.lib.define_singleton_method(:command_with_capture) do |cmd, *opts|
         actual_command_line = [cmd, *opts.flatten]
         clone_result
       end
@@ -260,7 +260,7 @@ class TestGitClone < Test::Unit::TestCase
       git = Git.init('.')
 
       clone_result = mock_clone_result(destination)
-      git.lib.define_singleton_method(:command) do |cmd, *opts|
+      git.lib.define_singleton_method(:command_with_capture) do |cmd, *opts|
         actual_command_line = [cmd, *opts.flatten]
         clone_result
       end
@@ -327,7 +327,7 @@ class TestGitClone < Test::Unit::TestCase
     #   git = Git.init('.')
 
     #   # Mock the Git::Lib#command method to capture the actual command line args
-    #   git.lib.define_singleton_method(:command) do |cmd, *opts, &block|
+    #   git.lib.define_singleton_method(:command_with_capture) do |cmd, *opts, &block|
     #     actual_command_line = [cmd, *opts.flatten]
     #   end
 

--- a/tests/units/test_lib_meets_required_version.rb
+++ b/tests/units/test_lib_meets_required_version.rb
@@ -33,7 +33,7 @@ class TestLibMeetsRequiredVersion < Test::Unit::TestCase
 
     lib.instance_variable_set(:@next_version_index, 0)
 
-    lib.define_singleton_method(:command) do |cmd, *_opts|
+    lib.define_singleton_method(:command_with_capture) do |cmd, *_opts|
       raise ArgumentError unless cmd == 'version'
 
       version_string = versions_to_test[@next_version_index][:version_string]

--- a/tests/units/test_lib_repository_default_branch.rb
+++ b/tests/units/test_lib_repository_default_branch.rb
@@ -31,7 +31,7 @@ class TestLibRepositoryDefaultBranch < Test::Unit::TestCase
 
   def mock_command(lib, repository, response)
     test_case = self
-    lib.define_singleton_method(:command) do |cmd, *opts, &_block|
+    lib.define_singleton_method(:command_with_capture) do |cmd, *opts, &_block|
       test_case.assert_equal('ls-remote', cmd)
       test_case.assert_equal(['--symref', '--', repository, 'HEAD'], opts.flatten)
       status = Struct.new(:success?).new(true)

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -148,13 +148,13 @@ class TestRemotes < Test::Unit::TestCase
       local.remote_set_branches('origin', upstream.current_branch, add: true)
       local.remote_set_branches('origin', 'feature/*', add: true)
 
-      fetch_refspecs_before = local.lib.command('config', '--get-all', 'remote.origin.fetch').stdout.split("\n")
+      fetch_refspecs_before = local.lib.command_with_capture('config', '--get-all', 'remote.origin.fetch').stdout.split("\n")
       assert(fetch_refspecs_before.size > 1)
       assert_equal(1, fetch_refspecs_before.count('+refs/heads/feature/*:refs/remotes/origin/feature/*'))
 
       local.remote_set_branches('origin', 'feature/*')
 
-      fetch_refspecs_after = local.lib.command('config', '--get-all', 'remote.origin.fetch').stdout.split("\n")
+      fetch_refspecs_after = local.lib.command_with_capture('config', '--get-all', 'remote.origin.fetch').stdout.split("\n")
       assert_equal(['+refs/heads/feature/*:refs/remotes/origin/feature/*'], fetch_refspecs_after)
     end
   end

--- a/tests/units/test_set_index.rb
+++ b/tests/units/test_set_index.rb
@@ -123,9 +123,9 @@ class SetIndexTest < Test::Unit::TestCase
       file.write(new_content)
       file.rewind
       # Use `git hash-object -w` to write the blob to the object database and get its SHA
-      repo.lib.command('hash-object', '-w', file.path).stdout
+      repo.lib.command_with_capture('hash-object', '-w', file.path).stdout
     end
-    repo.lib.command('update-index', '--add', '--cacheinfo', "100644,#{blob_sha},new_file.txt").stdout
+    repo.lib.command_with_capture('update-index', '--add', '--cacheinfo', "100644,#{blob_sha},new_file.txt").stdout
 
     # 6. Write the state of the custom index to a new tree object in the Git database.
     new_tree_sha = repo.write_tree


### PR DESCRIPTION
## Summary

Implements **PR 1** from issue #1097: mechanical rename of capture-oriented entry points with no behavior change.

This frees up the short names (`run`, `command`) for the new streaming entry points to be added in PR 2.

## Changes

### `Git::CommandLine`

| Before | After | Visibility |
|---|---|---|
| `run` | `run_with_capture` | public |
| `run_with_capture` | `execute_with_capture` | private |
| `run_with_capture_options` | `execute_with_capture_options` | private |

### `Git::Lib`

| Before | After | Visibility |
|---|---|---|
| `command` | `command_with_capture` | public |

## Call Sites Updated

- ~64 `command(...)` calls in `Git::Lib` internals
- `Git::Commands::Base#call` (`@execution_context.command(...)`)
- `Git::Commands::CatFile::Meta` and `::Full` direct command calls
- All unit/integration specs updated (RSpec stubs, minitest mocks)
- `tests/test_helper.rb` `assert_command_line_eq` helper mock
- All integration parser and command specs

## Behavior

**No behavior change.** This is a pure rename. All tests pass identically.

## Testing

- 551 minitest tests: 0 failures, 0 errors
- 2020 RSpec examples: 0 failures
- `bundle exec rubocop`: no offenses
- `bundle exec rake yard`: all passes

Closes #1097 (partially — PR 1 of 2)
