### PR TITLE
docs: add commitlint issue-reference rules and debugging guidance

### DIFF
--- a/.github/skills/dependency-management/SKILL.md
+++ b/.github/skills/dependency-management/SKILL.md
@@ -56,5 +56,17 @@ version constraints so updates remain consistent with gem project rules.
 ## Commit Guidelines
 
 This project uses [Conventional Commits](https://www.conventionalcommits.org/). A
-commit hook enforces the format. See the Git Commit Conventions section in
-`copilot-instructions.md` for the full format and allowed types.
+commit hook enforces the format. See the "Commit message guidelines" section in
+`CONTRIBUTING.md` for the full format and allowed types.
+
+**Issue and PR references in the body:** Do not use `#<number>` in the commit
+body — write `issue 1000` not `issue #1000`. A commitlint parser flaw treats any
+line containing `#<number>` as a footer token, breaking the body/footer split. To
+close an issue/PR, use `Closes`/`Fixes`/`Resolves #<number>` in the footer. To
+merely mention one for context, omit the `#` and no footer line is needed.
+
+To validate a commit message file before committing:
+
+```bash
+npx commitlint --format @commitlint/format < commit_msg.txt
+```

--- a/.github/skills/development-workflow/SKILL.md
+++ b/.github/skills/development-workflow/SKILL.md
@@ -340,6 +340,22 @@ commit and complete the feature or bug fix.
 8. **Handle Commit Hook Failure:** If the commit fails due to a `commit-msg` hook
    rejection (e.g., commitlint error):
    - Read the error message carefully to identify the formatting issue.
+   - To validate a message file before committing:
+     ```bash
+     npx commitlint --format @commitlint/format < commit_msg.txt
+     ```
+   - To diagnose *why* a message is rejected (e.g., unexpected body/footer split),
+     inspect how the parser tokenizes it:
+     ```bash
+     cat commit_msg.txt | node -e "
+     const parse = require('@commitlint/parse');
+     let msg = '';
+     process.stdin.on('data', d => msg += d);
+     process.stdin.on('end', () =>
+       parse.default(msg.trim()).then(r => console.log(JSON.stringify(r, null, 2)))
+     );
+     " | jq
+     ```
    - Fix the commit message to comply with the project's commit conventions.
    - Retry the commit. The changes remain staged after a hook failure, so only the
      `git commit` command needs to be re-run.
@@ -377,6 +393,14 @@ guidelines:
   (e.g., `feat(branch):`, `test(remote):`).
 - **Write Clear Subjects:** Use imperative mood, lowercase, no period (e.g.,
   `feat(branch): add create method`).
+- **Issue and PR References in the Body:** Do not use `#<number>` in the commit
+  body — write `issue 1000` not `issue #1000`. A commitlint parser flaw treats
+  any line containing `#<number>` as a footer token, permanently breaking the
+  body/footer split for all subsequent lines.
+  - To **close** an issue/PR, use `Closes`/`Fixes`/`Resolves` with `#` in the
+    footer — e.g. `Closes #1000`.
+  - To **mention** an issue for context only, omit the `#` in the body and no
+    footer line is needed.
 
 ## Additional Guidelines
 

--- a/.github/skills/extract-command-from-lib/SKILL.md
+++ b/.github/skills/extract-command-from-lib/SKILL.md
@@ -261,6 +261,13 @@ PR, follow the repository finalize workflow (see
 [Development Workflow](../development-workflow/SKILL.md)) and squash commits as
 required.
 
+**Issue and PR references in commit bodies:** Do not use `#<number>` in the
+commit body — write `issue 1000` not `issue #1000`. A commitlint parser flaw
+treats any line containing `#<number>` as a footer token, breaking the
+body/footer split. To close an issue/PR, use `Closes`/`Fixes`/`Resolves #<number>`
+in the footer. To merely mention one for context, omit the `#` and no footer line
+is needed.
+
 If further changes are needed after task commits are created:
 
 - Amend the change to the **appropriate commit** (e.g., a command class fix goes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@
   - [Commit message guidelines](#commit-message-guidelines)
     - [What does this mean for contributors?](#what-does-this-mean-for-contributors)
     - [What to know about Conventional Commits](#what-to-know-about-conventional-commits)
+    - [Issue and PR references](#issue-and-pr-references)
   - [Unit tests](#unit-tests)
     - [RSpec best practices](#rspec-best-practices)
     - [Unit tests vs Integration tests](#unit-tests-vs-integration-tests)
@@ -706,6 +707,40 @@ by not acted upon.
 
 See [the Conventional Commits
 specification](https://www.conventionalcommits.org/en/v1.0.0/) for more details.
+
+#### Issue and PR references
+
+Due to a parser limitation in commitlint, using `#<number>` anywhere in the commit
+**body** causes everything from that line onward to be treated as a footer, which
+triggers a `footer-leading-blank` error.
+
+To avoid this:
+
+- **In the body**, omit the `#` when mentioning an issue or PR — write `issue 1000`
+  not `issue #1000`.
+- **In the footer**, always include `#` for closing references:
+  `Closes #1000`, `Fixes #1000`, or `Resolves #1000`.
+- If you only want to mention an issue for context (not close it), omit the `#` in
+  the body — no footer line is needed.
+
+To validate a commit message before committing:
+
+```bash
+npx commitlint --format @commitlint/format < commit_msg.txt
+```
+
+To see how commitlint has parsed a commit message:
+
+```bash
+cat commit_msg.txt | node -e "
+const parse = require('@commitlint/parse');
+let msg = '';
+process.stdin.on('data', d => msg += d);
+process.stdin.on('end', () =>
+  parse.default(msg.trim()).then(r => console.log(JSON.stringify(r, null, 2)))
+);
+" | jq
+```
 
 ### Unit tests
 


### PR DESCRIPTION
## Summary

Documents a commitlint parser limitation and adds issue-reference rules to
contributor guidance and agent skills.

## Problem

Any line in the commit body containing `#NUMBER` permanently switches the
commitlint parser from body mode to footer mode. This causes everything from
that line onward to be treated as footer text, triggering a spurious
`footer-leading-blank` error. The parser behavior is hardcoded and cannot be
changed with configuration.

## Rules added

- In the commit **body**, omit the `#` when mentioning issues or PRs — write
  `issue 1000` not `issue #1000`.
- To close an issue/PR, use `Closes #1000` / `Fixes #1000` / `Resolves #1000`
  in the **footer**.
- To mention an issue for context only, omit the `#` in the body — no footer
  line is needed.

## Files changed

- **CONTRIBUTING.md** — new "Issue and PR references" subsection under "Commit
  message guidelines", including a `npx commitlint` validation command.
- **development-workflow skill** — rules added to "Per-Task Commits";
  `npx commitlint` validation command and `@commitlint/parse` diagnostic command
  added to the "Handle Commit Hook Failure" step.
- **extract-command-from-lib skill** — rules added to the "Commit discipline"
  section.
- **dependency-management skill** — rules and `npx commitlint` validation command
  added to "Commit Guidelines".
