### PR TITLE
docs: update Phase 2 migration progress tracker to 41/~50 commands

### DIFF
--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,7 +22,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (36/~50 commands migrated) |
+| Phase 2 | 🔄 In Progress | Migrating commands (41/~50 commands migrated) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
@@ -707,6 +707,10 @@ The following tracks the migration status of commands from `Git::Lib` to
 | `branch_new` | `Git::Commands::Branch::Create` | `spec/unit/git/commands/branch/create_spec.rb` | `git branch <name>` |
 | `branch_delete` | `Git::Commands::Branch::Delete` | `spec/unit/git/commands/branch/delete_spec.rb` | `git branch --delete` |
 | N/A (new) | `Git::Commands::Branch::Move` | `spec/unit/git/commands/branch/move_spec.rb` | `git branch --move` |
+| `branch_current` | `Git::Commands::Branch::ShowCurrent` | `spec/unit/git/commands/branch/show_current_spec.rb` | `git branch --show-current` |
+| N/A (new) | `Git::Commands::Branch::Copy` | `spec/unit/git/commands/branch/copy_spec.rb` | `git branch --copy` |
+| N/A (new) | `Git::Commands::Branch::SetUpstream` | `spec/unit/git/commands/branch/set_upstream_spec.rb` | `git branch --set-upstream-to` |
+| N/A (new) | `Git::Commands::Branch::UnsetUpstream` | `spec/unit/git/commands/branch/unset_upstream_spec.rb` | `git branch --unset-upstream` |
 | `diff_full` | `Git::Commands::Diff::Patch` | `spec/unit/git/commands/diff/patch_spec.rb` | `git diff` (patch format) |
 | `diff_stats` | `Git::Commands::Diff::Numstat` | `spec/unit/git/commands/diff/numstat_spec.rb` | `git diff --numstat` |
 | `diff_path_status` / `diff_index` | `Git::Commands::Diff::Raw` | `spec/unit/git/commands/diff/raw_spec.rb` | `git diff --raw` |
@@ -722,6 +726,7 @@ The following tracks the migration status of commands from `Git::Lib` to
 | N/A (new) | `Git::Commands::Merge::Abort` | `spec/unit/git/commands/merge/abort_spec.rb` | `git merge --abort` |
 | N/A (new) | `Git::Commands::Merge::Continue` | `spec/unit/git/commands/merge/continue_spec.rb` | `git merge --continue` |
 | N/A (new) | `Git::Commands::Merge::Quit` | `spec/unit/git/commands/merge/quit_spec.rb` | `git merge --quit` |
+| `merge_base` | `Git::Commands::MergeBase` | `spec/unit/git/commands/merge_base_spec.rb` | `git merge-base` |
 | N/A (new) | `Git::Commands::Stash::Create` | `spec/unit/git/commands/stash/create_spec.rb` | `git stash create` |
 | N/A (new) | `Git::Commands::Stash::Store` | `spec/unit/git/commands/stash/store_spec.rb` | `git stash store` |
 | N/A (new) | `Git::Commands::Stash::Branch` | `spec/unit/git/commands/stash/branch_spec.rb` | `git stash branch` |
@@ -750,6 +755,11 @@ order: Basic Snapshotting → Branching & Merging → etc.
 - [x] `branch_new` → `Git::Commands::Branch::Create` — `git branch <name> [start-point]`
 - [x] `branch_delete` → `Git::Commands::Branch::Delete` — `git branch --delete`
 - [x] N/A (new) → `Git::Commands::Branch::Move` — `git branch --move`
+- [x] `branch_current` → `Git::Commands::Branch::ShowCurrent` — `git branch --show-current`
+- [x] N/A (new) → `Git::Commands::Branch::Copy` — `git branch --copy`
+- [x] N/A (new) → `Git::Commands::Branch::SetUpstream` — `git branch --set-upstream-to`
+- [x] N/A (new) → `Git::Commands::Branch::UnsetUpstream` — `git branch --unset-upstream`
+- [x] `merge_base` → `Git::Commands::MergeBase` — `git merge-base`
 - [x] `checkout` / `checkout_file` → `Git::Commands::Checkout::Branch` / `Git::Commands::Checkout::Files` — `git checkout`
 - [x] `merge` → `Git::Commands::Merge::Start` — `git merge`
 - [x] N/A (new) → `Git::Commands::Merge::Abort` / `Git::Commands::Merge::Continue` / `Git::Commands::Merge::Quit` — `git merge --abort/--continue/--quit`


### PR DESCRIPTION
## Summary

Updates the architecture redesign implementation tracker (`redesign/3_architecture_implementation.md`) to reflect the actual current migration state.

## Changes

Five previously-implemented command classes were missing from the migrated commands table and checklist:

| Command Class | Git Command | Git::Lib Method |
|---|---|---|
| `Git::Commands::Branch::ShowCurrent` | `git branch --show-current` | `branch_current` |
| `Git::Commands::Branch::Copy` | `git branch --copy` | N/A (new) |
| `Git::Commands::Branch::SetUpstream` | `git branch --set-upstream-to` | N/A (new) |
| `Git::Commands::Branch::UnsetUpstream` | `git branch --unset-upstream` | N/A (new) |
| `Git::Commands::MergeBase` | `git merge-base` | `merge_base` |

The Phase 2 progress count is updated from **36/~50** to **41/~50** to reflect these additions.

No code changes — documentation only.