### PR TITLE
test: add parallel test execution support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -5,11 +5,36 @@ require 'rake/clean'
 # Load all .rake files from tasks and its subdirectories.
 Dir.glob('tasks/**/*.rake').each { |r| load r }
 
+desc 'Run all tests (TestUnit and RSpec)'
+task 'test-all': %i[test spec]
+
+desc 'Run all tests in parallel (TestUnit and RSpec run concurrently)'
+task 'test-all:parallel' do
+  errors = []
+  mutex = Mutex.new
+  threads = %w[test:parallel spec:parallel].map do |t|
+    Thread.new do
+      Rake::Task[t].invoke
+    rescue Exception => e # rubocop:disable Lint/RescueException
+      mutex.synchronize { errors << e }
+    end
+  end
+  threads.each(&:join)
+  raise errors.first if errors.any?
+end
+
 default_tasks = %i[test spec:unit spec:integration rubocop]
 default_tasks << :yard if Rake::Task.task_defined?(:yard)
 default_tasks << :build
 
 task default: default_tasks
+
+default_parallel = %w[test:parallel spec:unit:parallel spec:integration:parallel rubocop]
+default_parallel << :yard if Rake::Task.task_defined?(:yard)
+default_parallel << :build
+
+desc 'Same as default but runs tests in parallel'
+task 'default:parallel': default_parallel
 
 module Rake
   # Overload Rake::Task to add logging

--- a/git.gemspec
+++ b/git.gemspec
@@ -39,6 +39,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'main_branch_shared_rubocop_config', '~> 0.1'
   spec.add_development_dependency 'minitar', '~> 1.1'
   spec.add_development_dependency 'mocha', '~> 2.8'
+  spec.add_development_dependency 'parallel_tests', '~> 5.6'
   spec.add_development_dependency 'rake', '~> 13.3'
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'rubocop', '~> 1.82'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -66,7 +66,9 @@ SimpleCov::RSpec.start(
   coverage_threshold: 100,
   fail_on_low_coverage: false,
   list_uncovered_lines: false
-)
+) do
+  command_name "RSpec-#{ENV['TEST_ENV_NUMBER']}" if ENV['TEST_ENV_NUMBER']
+end
 
 require 'git'
 

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -17,6 +17,24 @@ RSpec::Core::RakeTask.new('spec:integration') do |t|
   t.pattern = 'spec/integration/**/*_spec.rb'
 end
 
+# Run all specs in parallel
+desc 'Run all specs in parallel'
+task 'spec:parallel' do
+  sh 'bundle exec parallel_rspec spec/'
+end
+
+# Run only unit specs in parallel
+desc 'Run unit specs in parallel'
+task 'spec:unit:parallel' do
+  sh 'bundle exec parallel_rspec spec/unit/'
+end
+
+# Run only integration specs in parallel
+desc 'Run integration specs in parallel'
+task 'spec:integration:parallel' do
+  sh 'bundle exec parallel_rspec spec/integration/'
+end
+
 CLEAN << 'coverage'
 CLEAN << '.rspec_status'
 CLEAN << 'rspec-report.xml'

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -12,5 +12,8 @@ task :test do
   # $ bin/test test_archive.rb test_object.rb
 end
 
-desc 'Run all tests (TestUnit and RSpec)'
-task test_all: %i[test spec]
+desc 'Run Test::Unit tests in parallel'
+task 'test:parallel' do
+  sh({ 'PARALLEL_TESTS_EXECUTABLE' => 'ruby -Itests' },
+     "bundle exec parallel_test tests/units/ --suffix 'test_.+\\.rb$'")
+end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -45,7 +45,7 @@ module Test
 
       teardown
       def git_teardown
-        FileUtils.rm_r(@tmp_path) if instance_variable_defined?(:@tmp_path)
+        FileUtils.rm_rf(@tmp_path) if instance_variable_defined?(:@tmp_path)
       end
 
       def in_bare_repo_clone
@@ -64,10 +64,7 @@ module Test
 
       def create_temp_repo(clone_name)
         clone_path = File.join(TEST_FIXTURES, clone_name)
-        filename = "git_test#{Time.now.to_i}#{rand(300).to_s.rjust(3, '0')}"
-        path = File.expand_path(File.join(Dir.tmpdir, filename))
-        FileUtils.mkdir_p(path)
-        @tmp_path = File.realpath(path)
+        @tmp_path = File.realpath(Dir.mktmpdir('git_test'))
         FileUtils.cp_r(clone_path, @tmp_path)
         tmp_path = File.join(@tmp_path, File.basename(clone_path))
         FileUtils.cd tmp_path do


### PR DESCRIPTION
## Summary

Adds parallel test execution using the [`parallel_tests`](https://github.com/grosser/parallel_tests) gem, providing significant speedups for local development workflows.

## Changes

### New rake tasks
| Task | Description |
|---|---|
| `rake test:parallel` | Run Test::Unit tests in parallel |
| `rake spec:parallel` | Run RSpec tests in parallel |
| `rake test-all` | Run all tests sequentially (replaces old `test_all`) |
| `rake test-all:parallel` | Run all tests in parallel |
| `rake default:parallel` | Parallel equivalent of `rake default` |

### Parallel safety fixes (`tests/test_helper.rb`)
- **`FileUtils.rm_rf` in teardown** — replaces `rm_r` to gracefully handle temp directories still held by git subprocesses when multiple workers are tearing down concurrently
- **`Dir.mktmpdir` for temp directories** — replaces manual `"git_test#{Time.now.to_i}#{rand(300)}"` path generation, which caused `ENOENT` collisions with ≥12 parallel workers (second-precision timestamps + rand(300) are not unique enough)

### SimpleCov parallel support (`spec/spec_helper.rb`)
- Sets `command_name` per worker using `TEST_ENV_NUMBER` so coverage results are correctly merged across parallel RSpec workers

### Dependency (`git.gemspec`)
- Adds `parallel_tests ~> 5.6` as a development dependency

## Benchmark Results

Measured on a MacBook Pro M2 Max:

| Task (sequential) | Time | Task (parallel) | Time | Speedup |
|---|---|---|---|---|
| `rake test` | 1m 22s | `rake test:parallel` | 30s | **2.7x** |
| `rake spec` | 34s | `rake spec:parallel` | 9s | **3.8x** |
| `rake test-all` | 1m 54s | `rake test-all:parallel` | 39s | **2.9x** |
| `rake default` | 2m 4s | `rake default:parallel` | 47s | **2.6x** |

## Usage

```bash
# Run just Test::Unit in parallel
rake test:parallel

# Run just RSpec in parallel
rake spec:parallel

# Run everything (tests + rubocop + yard + build) in parallel
rake default:parallel
```

> **Note:** Parallel tasks are intended for local development. CI continues to use `rake default` (sequential) for reliability and easier failure diagnosis.
