### PR TITLE
refactor(skill): improve command extraction skills with DSL and scaffold guidance

### DIFF
--- a/.github/skills/review-arguments-dsl/CHECKLIST.md
+++ b/.github/skills/review-arguments-dsl/CHECKLIST.md
@@ -12,6 +12,24 @@
 | pathspec-style operands (keyword arg) | `value_option ... as_operand: true, separator: '--'` | `value_option :pathspec, as_operand: true, separator: '--', repeatable: true` — caller passes `pathspec: ['f1', 'f2']` |
 | pathspec-style operands (positional arg) | `operand ... separator: '--'` | `operand :pathspec, repeatable: true, separator: '--'` — caller passes positionals `cmd.call('f1', 'f2')` |
 
+#### Recognizing `flag_or_value_option` from the git man page
+
+The git-scm.com man page uses **`[=<value>]`** (square-bracketed `=<value>`)
+to mark an option's value as optional. That notation maps directly to
+`flag_or_value_option`:
+
+| Man-page signature | DSL method |
+|---|---|
+| `--foo` | `flag_option :foo` |
+| `--foo=<value>` | `value_option :foo, inline: true` |
+| `--foo[=<value>]` | `flag_or_value_option :foo, inline: true` |
+
+Common examples: `--branches[=<pattern>]`, `--tags[=<pattern>]`,
+`--remotes[=<pattern>]`, `--dirstat[=<param>...]`.
+
+**Do not** use `flag_option` for these — it silently drops the value when one
+is supplied.
+
 #### Choosing the correct pathspec form
 
 The two pathspec-style rows above look similar but represent meaningfully different
@@ -99,6 +117,23 @@ Flag any use of `as:` unless one of these three conditions applies:
 
 Outside these three cases, `as:` is a red flag. A DSL entry that uses `as:` where
 a plain symbol or alias would suffice should be corrected.
+
+#### Short-flag alias completeness
+
+Every option that the git man page documents with a short form must have an alias
+with the long name first:
+
+```ruby
+flag_option %i[regexp_ignore_case i]   # -i / --regexp-ignore-case
+flag_option %i[extended_regexp E]      # -E / --extended-regexp
+flag_option %i[fixed_strings F]        # -F / --fixed-strings
+```
+
+When reviewing, scan the man page's option headings for lines of the form
+`-X` / `--long-name` and verify each has a corresponding `%i[long_name X]`
+alias in the DSL. Missing short aliases are a completeness defect, not just
+a convenience omission — callers who pass the short key `:E` will get an
+`ArgumentError` rather than the expected flag.
 
 ### 3. Correct ordering
 
@@ -206,7 +241,56 @@ Examples of options to **include** (do not affect stdout):
 **Default assumption for `--verbose` and `--quiet`:** their absence is intentional.
 Do **not** flag them as missing.
 
-### 6. Conflicts
+#### Constraint identification from the man page
+
+After deciding which options to include, re-read the man page a second time
+specifically looking for constraint relationships. Do **not** skip this pass — the
+DSL machinery that enforces constraints exists to protect callers from invalid
+combinations that git itself will reject, and the review/scaffold phase is the only
+automated checkpoint where the man page is being read.
+
+Look for these specific language patterns and map them to DSL declarations:
+
+**Mutual exclusion → `conflicts`** (or `requires_exactly_one_of` if also required):
+
+| Man-page signal | Example |
+|---|---|
+| "Cannot be combined with `--foo`" | `conflicts :this, :foo` |
+| "Synonym for `--a --b --no-c`" | `conflicts :this, :a`; `conflicts :this, :b`; `conflicts :this, :c` |
+| "Same as `--foo`" (exact synonym) | The synonym adds redundancy — either alias it or note the conflict with the long form |
+| Options in a "choose one" list | `conflicts :opt_a, :opt_b` for each pair; or `requires_exactly_one_of` if exactly one is also required |
+| Sorting/ordering modes (`--date-order`, `--topo-order`, `--author-date-order`) | One ordering mode at a time → `conflicts` each pair |
+| Regexp engine flags (`-E`, `-F`, `-P`) | Choose one engine → `conflicts` each pair |
+
+**Conditional requirement → `requires` or `requires_one_of ... when:`**:
+
+| Man-page signal | Example |
+|---|---|
+| "Works only for a single file" | `requires :option, :path` — and note in YARD that `:path` must have exactly one element |
+| "Only meaningful when `--foo` is in use" | `requires :this, when: :foo` |
+| "Only takes effect when" | `requires :this, when: :other` |
+| "It is an error to use this option unless `--foo`" | `requires :this, when: :foo` |
+| "Only when `<path>` is given" | `requires :option, :path` |
+
+**Implication → `literal` or `conflicts`**:
+
+When git says an option "implies" another (e.g. `--cherry` is "a synonym for
+`--right-only --cherry-mark --no-merges`"), the implied flags are not always
+safe to also accept as keyword arguments:
+- If the implied flag is already a keyword option in the DSL, add `conflicts`
+  between the implying option and any keyword option whose value would contradict
+  the implication.
+- If the implied flag has no keyword representation (output-affecting, excluded),
+  no action is needed.
+
+**"No effect without" / value-mode flags**: when a flag only changes its
+behavior depending on a value another option receives, use `requires` with a
+`when:` trigger rather than an unconditional `requires`.
+
+After this pass, any identified constraint should be added as DSL declarations
+placed in the correct order (§3: after all arguments they reference, positions 6–10).
+
+
 
 If arguments are mutually exclusive — whether option vs option, option vs operand,
 or operand vs operand — verify `conflicts ...` declarations exist. Names in a

--- a/.github/skills/review-backward-compatibility/SKILL.md
+++ b/.github/skills/review-backward-compatibility/SKILL.md
@@ -104,9 +104,9 @@ open a pull request — do not merge or push directly into `main`.
    - Return value type (String, Array, Hash, Boolean, etc.)
    - Exact return value format (e.g., `Array<[Integer, String]>`, `String` with specific content)
 
-4. Return to the main branch:
+4. Return to your feature branch:
    ```bash
-   git checkout main
+   git checkout -
    ```
 
 5. Search for the same command methods in the current version:

--- a/.github/skills/review-command-implementation/SKILL.md
+++ b/.github/skills/review-command-implementation/SKILL.md
@@ -81,7 +81,7 @@ end
 Shared behavior lives in `Base`:
 
 - binds arguments
-- calls `@execution_context.command(*args, **args.execution_options, raise_on_failure: false)`
+- calls `@execution_context.command_capturing(*args, **args.execution_options, raise_on_failure: false)`
 - raises `Git::FailedError` unless exit status is in allowed range (`0..0` default)
 
 ## What to Check
@@ -129,7 +129,7 @@ Most commands use `def call(...) = super`, which forwards all arguments to
 
 - Bind arguments via `args_definition.bind(...)` — do not reimplement binding
 - Delegate exit-status handling to `validate_exit_status!` — do not reimplement
-- Do not call `super` after manual binding; use `@execution_context.command` directly
+- Do not call `super` after manual binding; use `@execution_context.command_capturing` directly
 
 **`Base#with_stdin(content)` mechanics:**
 

--- a/.github/skills/review-cross-command-consistency/SKILL.md
+++ b/.github/skills/review-cross-command-consistency/SKILL.md
@@ -54,8 +54,8 @@ The invocation needs two or more sibling command files from the same family.
 - [ ] all classes use `class < Git::Commands::Base`
 - [ ] all require `git/commands/base`
 - [ ] all use `arguments do ... end` (no legacy `ARGS =` constants)
-- [ ] all use YARD directive `# @!method call(*, **)` with nested `@overload` blocks
-- [ ] all use YARD shim `def call(...) = super # rubocop:disable Lint/UselessMethodDefinition`, OR have a legitimate `call` override (stdin protocol, input validation, non-trivial option routing) — not both
+- [ ] simple commands carry YARD directive `# @!method call(*, **)` with nested `@overload` blocks and have no explicit `def call` definition
+- [ ] commands with legitimate `call` overrides (stdin protocol, input validation, non-trivial option routing) use explicit YARD docs instead and do **not** carry the `# @!method` directive
 - [ ] commands with `call` overrides use `Base#with_stdin` for stdin feeding and delegate exit-status validation to `validate_exit_status!`
 
 ### 2. Arguments DSL consistency

--- a/.github/skills/scaffold-new-command/SKILL.md
+++ b/.github/skills/scaffold-new-command/SKILL.md
@@ -15,8 +15,9 @@ docs using the `Git::Commands::Base` architecture.
 - [Files to generate](#files-to-generate)
 - [Single class vs. sub-command namespace](#single-class-vs-sub-command-namespace)
 - [Command template (Base pattern)](#command-template-base-pattern)
+- [Options completeness — consult the man page first](#options-completeness--consult-the-man-page-first)
 - [Output-format options are intentionally omitted](#output-format-options-are-intentionally-omitted)
-- [DSL ordering convention](#dsl-ordering-convention)
+- [DSL ordering and argument conventions](#dsl-ordering-and-argument-conventions)
 - [Exit status guidance](#exit-status-guidance)
 - [Unit tests](#unit-tests)
 - [Integration tests](#integration-tests)
@@ -205,7 +206,7 @@ in the Review Command Implementation skill.
 
 When `def call(...) = super` is not enough, override `call` explicitly. Call
 `args_definition.bind(...)` directly rather than `super`, and invoke
-`@execution_context.command` yourself:
+`@execution_context.command_capturing` yourself:
 
 ```ruby
 def call(*objects, **options)
@@ -218,7 +219,7 @@ end
 private
 
 def run_batch(bound, reader)
-  result = @execution_context.command(*bound, in: reader, **bound.execution_options, raise_on_failure: false)
+  result = @execution_context.command_capturing(*bound, in: reader, **bound.execution_options, raise_on_failure: false)
   validate_exit_status!(result)
   result
 end
@@ -269,6 +270,57 @@ Key points:
 - **Extract helpers** like `run_batch` to stay within Rubocop `Metrics/MethodLength`
   and `Metrics/AbcSize` thresholds. Aim to keep `call` under ~10 lines.
 
+## Options completeness — consult the man page first
+
+**Before writing any DSL entries**, fetch the git-scm.com man page for the
+subcommand and enumerate every option it documents:
+
+```text
+https://git-scm.com/docs/git-<subcommand>
+```
+
+For each option, make one of three decisions:
+
+| Decision | Reason | Action |
+|---|---|---|
+| **Include** | Behavioral — controls which objects are operated on or how the operation runs; does **not** affect stdout format | Add to `arguments do` |
+| **Exclude (format)** | Changes the structure or content of stdout (e.g. `--pretty=`, `--stat`, `--patch`, `--name-only`) | Omit — see "Output-format options are intentionally omitted" below |
+| **Exclude (inappropriate)** | Stdin/stdout redirection, scripting-only plumbing, or too niche to be useful via the Ruby API | Omit with a brief comment if the reasoning isn't obvious |
+
+Group related options with a comment in the DSL (e.g. `# Ref inclusion`, `# Date
+filtering`, `# Commit ordering`). Follow the section groupings from the man page —
+this makes it easy for a reviewer to cross-check against the docs.
+
+**Pairs and opposites:** when the man page documents `--foo` / `--no-foo` as
+explicit flags, model them as a single `flag_option :foo, negatable: true` rather
+than two separate entries. This prevents contradictory combinations and makes the
+three-state semantics (`true` / `false` / `nil`) explicit.
+
+**Second pass — constraint identification:** after the include/exclude decisions,
+re-read the man page looking specifically for constraint relationships between the
+options you chose to include. This pass is required — constraint declarations
+(`conflicts`, `requires`, `requires_one_of`) must be added during scaffolding,
+not discovered later during a review. Look for these signals:
+
+- **Mutual exclusion** — "cannot be combined with", "synonym for `--a --b`",
+  mutually exclusive mode flags (e.g. ordering modes, regexp-engine flags) →
+  `conflicts :a, :b` for each conflicting pair
+- **Conditional requirement** — "works only for a single file / path", "only
+  meaningful when `--foo` is in use", "it is an error to use this unless `--bar`"
+  → `requires :this, when: :trigger`
+- **Optional-value options** — option signature `--foo[=<value>]` in the man page
+  → use `flag_or_value_option`, not `flag_option`
+- **Short-flag aliases** — every `-X` / `--long-form` pair → alias with long name
+  first: `%i[long_name X]`
+
+For the full translation table mapping man-page language to DSL declarations,
+see the [Constraint identification section of the Arguments DSL Checklist](../review-arguments-dsl/CHECKLIST.md#constraint-identification-from-the-man-page).
+
+This step is required. A command class that only exposes the options that happen
+to be used today in `Git::Lib` is incomplete — callers of the future API should
+not need to re-open the man page just because the scaffold only covered current
+usage.
+
 ## Output-format options are intentionally omitted
 
 The library requires **deterministic, parseable output** from each command class.
@@ -297,6 +349,8 @@ type, alias conventions, `as:` usage, modifier rules, constraint declarations
 
 **Key principles (summary):**
 
+- Fetch the git-scm.com man page and enumerate all options before writing DSL entries
+  (see "Options completeness" above)
 - Define arguments in the order they appear in the git-scm.com SYNOPSIS
 - Within unordered groups: literals → flag options → flag-or-value options → value
   options → operands → pathspecs → constraint declarations
@@ -329,7 +383,7 @@ allow_exit_status 0..7
 
 Command unit tests should verify:
 
-- exact arguments passed to `execution_context.command`
+- exact arguments passed to `execution_context.command_capturing`
 - inclusion of `raise_on_failure: false` (from `Base` behavior)
 - execution-option forwarding where relevant (`timeout:`, etc.)
 - allow-exit-status behavior where declared


### PR DESCRIPTION
## Summary

Updates to skills used during the extract-command-from-lib migration workflow.

### Changes

- **review-arguments-dsl**: Added `flag_or_value_option` recognition guide with man-page notation table (`--foo[=<value>]` pattern); added `as:` alias guard rules
- **scaffold-new-command**: Added options completeness section (consult the man page first), fixed `command_capturing` references, expanded DSL ordering and argument conventions section
- **review-command-implementation**, **review-backward-compatibility**, **review-cross-command-consistency**: Minor clarifications

### Motivation

These updates were discovered while migrating the `log` command and address gaps in the skills that led to incorrect or incomplete implementations.