### PR TITLE
refactor(skill): add execution_option pinning rule and operand repeatable guidance

### DIFF
--- a/.github/skills/review-command-implementation/SKILL.md
+++ b/.github/skills/review-command-implementation/SKILL.md
@@ -180,6 +180,11 @@ automatically during `args_definition.bind(...)` — do not set defaults manuall
 - [ ] `operand ... skip_cli: true` is used only for domain inputs that must bind/validate
   but must not emit to argv (for example, stdin-fed object lists)
 - [ ] `execution_option` is used for execution kwargs (`timeout:`, `chdir:`), not `skip_cli`
+- [ ] `execution_option` is **not** used for kwargs whose value must be unconditionally
+      fixed regardless of caller input. If a kwarg always has a specific required value
+      (e.g. `chomp: false` for commands returning raw content where trailing newlines are
+      data), hardcode it in a `def call` override instead — exposing it via
+      `execution_option` would allow callers to override a value that must never change.
 
 ### 5. Internal compatibility contract
 

--- a/.github/skills/scaffold-new-command/SKILL.md
+++ b/.github/skills/scaffold-new-command/SKILL.md
@@ -375,6 +375,11 @@ type, alias conventions, `as:` usage, modifier rules, constraint declarations
   (`value_option :pathspec, as_operand: true, separator: '--'`) for the post-`--`
   group
 - When the SYNOPSIS has pure nesting (`[<a> [<b>]]`), use plain `operand` entries
+- For each operand, derive `required:` and `repeatable:` directly from the SYNOPSIS
+  notation — `[<arg>]` → optional (default), `<arg>` → `required: true`,
+  `[<arg>…]` → `repeatable: true`, `<arg>…` → `required: true, repeatable: true`.
+  See [CHECKLIST.md section 4](../review-arguments-dsl/CHECKLIST.md#4-correct-modifiers)
+  for the complete table.
 - Avoid `as:` unless it's a Ruby keyword conflict, combined short flag, or
   multi-token flag
 


### PR DESCRIPTION
## Summary

Two targeted skill updates to prevent anomalies discovered during the `git show` command migration.

## Changes

### `scaffold-new-command/SKILL.md`

Added a bullet to the DSL ordering key principles explicitly mapping SYNOPSIS notation to `required:` / `repeatable:` modifiers, with a cross-reference to [CHECKLIST.md section 4](../.github/skills/review-arguments-dsl/CHECKLIST.md#4-correct-modifiers). This ensures modifiers are set correctly during initial scaffolding rather than being caught by a later review pass.

**Anomaly prevented:** `operand :objectish` was scaffolded without `repeatable: true` even though the git SYNOPSIS is `git show [<object>…]` (zero or more). The SYNOPSIS→modifier table existed in the review checklist but was not referenced from the scaffold skill.

### `review-command-implementation/SKILL.md`

Expanded the `execution_option` checklist item to explain *why* the DSL method must not be used for unconditionally-pinned kwargs. Because `execution_option` exposes the kwarg value to callers, using it for a value that must never change (e.g. `chomp: false` for commands returning raw file content) would allow callers to silently corrupt output.

**Anomaly prevented:** `execution_option :chomp` was initially added to `Git::Commands::Show`, allowing callers to pass `chomp: true` and silently strip trailing newlines from raw file blobs where those newlines are meaningful data. The correct pattern — hardcode the value in a `def call` override — was not clearly stated in the skill.