### PR TITLE
refactor(commands): migrate Git::Lib#show to Git::Commands::Show

### DIFF
--- a/lib/git/commands/show.rb
+++ b/lib/git/commands/show.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    # Implements the `git show` command
+    #
+    # Displays information about git objects (commits, annotated tags, trees,
+    # or blobs). Output format varies by object type and is intended for human
+    # consumption rather than machine parsing.
+    #
+    # @see https://git-scm.com/docs/git-show git-show documentation
+    # @see Git::Commands
+    #
+    # @api private
+    #
+    # @example Show the HEAD commit
+    #   show = Git::Commands::Show.new(execution_context)
+    #   result = show.call
+    #
+    # @example Show a specific commit
+    #   show = Git::Commands::Show.new(execution_context)
+    #   result = show.call('HEAD')
+    #
+    # @example Show the contents of a file at a given revision
+    #   show = Git::Commands::Show.new(execution_context)
+    #   result = show.call('abc123:README.md')
+    #
+    # @example Show multiple objects
+    #   show = Git::Commands::Show.new(execution_context)
+    #   result = show.call('v1.0', 'v2.0')
+    #
+    class Show < Git::Commands::Base
+      arguments do
+        literal 'show'
+        operand :objects, repeatable: true
+      end
+
+      # Execute the `git show` command.
+      #
+      # @overload call(*objects)
+      #
+      #   Trailing newlines are preserved in the result stdout. Pass the result's
+      #   `.stdout` to callers that need the raw object content unchanged.
+      #
+      #   @param objects [Array<String>] zero or more object specifiers (refs, SHAs,
+      #     `objectish:path` expressions, etc.). When empty, defaults to `HEAD`.
+      #
+      #   @return [Git::CommandLineResult] the result of calling `git show`
+      #
+      #   @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def call(*, **)
+        bound = args_definition.bind(*, **)
+        result = @execution_context.command_capturing(
+          *bound,
+          **bound.execution_options,
+          chomp: false,
+          raise_on_failure: false
+        )
+        validate_exit_status!(result)
+        result
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -27,6 +27,7 @@ require_relative 'commands/merge_base'
 require_relative 'commands/mv'
 require_relative 'commands/reset'
 require_relative 'commands/rm'
+require_relative 'commands/show'
 require_relative 'commands/tag/create'
 require_relative 'commands/tag/delete'
 require_relative 'commands/tag/list'
@@ -1162,11 +1163,8 @@ module Git
     # @param [String|NilClass] path the path of the file to be shown
     # @return [String] the object information
     def show(objectish = nil, path = nil)
-      arr_opts = []
-
-      arr_opts << (path ? "#{objectish}:#{path}" : objectish)
-
-      command_capturing('show', *arr_opts.compact, chomp: false).stdout
+      object = path ? "#{objectish}:#{path}" : objectish
+      Git::Commands::Show.new(self).call(*[object].compact).stdout
     end
 
     ## WRITE COMMANDS ##

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,17 +22,17 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (42/~50 commands migrated) |
+| Phase 2 | 🔄 In Progress | Migrating commands (43/~50 commands migrated) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate `show`** → `Git::Commands::Show`
+**Migrate `describe`** → `Git::Commands::Describe`
 
 #### Workflow
 
-1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def show`). Understand all options and edge cases.
+1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def describe`). Understand all options and edge cases.
 
 2. **Design**: Create command class following the pattern in
    `lib/git/commands/branch/delete.rb`. The interface for `#call` should only include
@@ -147,7 +147,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
    Parser classes and Result factories.
 
 6. **Verify**:
-  - `bundle exec rspec spec/unit/git/commands/show_spec.rb` — new tests pass
+  - `bundle exec rspec spec/unit/git/commands/describe_spec.rb` — new tests pass
    - `bundle exec rspec` — all RSpec tests pass
    - `bundle exec rake test` — legacy TestUnit tests pass
    - `bundle exec rubocop` — no lint errors
@@ -772,7 +772,7 @@ order: Basic Snapshotting → Branching & Merging → etc.
 - [x] `log_commits` / `full_log_commits` → `Git::Commands::Log` — `git log`
 - [x] `diff_full` / `diff_stats` / `diff_path_status` / `diff_index` →
   `Git::Commands::Diff::*` — `git diff` (implemented as `Patch`, `Numstat`, and `Raw`)
-- [ ] `show` → `Git::Commands::Show` — `git show`
+- [x] `show` → `Git::Commands::Show` — `git show`
 - [ ] `describe` → `Git::Commands::Describe` — `git describe`
 - [ ] `grep` → `Git::Commands::Grep` — `git grep`
 - [ ] `ls_files` → `Git::Commands::LsFiles` — `git ls-files`

--- a/spec/unit/git/commands/show_spec.rb
+++ b/spec/unit/git/commands/show_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/show'
+
+RSpec.describe Git::Commands::Show do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with no arguments' do
+      it 'runs git show with no extra arguments and returns the result' do
+        expected_result = command_result
+        expect_command_capturing('show', chomp: false).and_return(expected_result)
+
+        result = command.call
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with a single object' do
+      it 'passes the object specifier to git show' do
+        expect_command_capturing('show', 'HEAD', chomp: false).and_return(command_result)
+
+        command.call('HEAD')
+      end
+    end
+
+    context 'with an objectish:path expression' do
+      it 'passes the combined expression as a single argument' do
+        expect_command_capturing('show', 'abc123:README.md', chomp: false).and_return(command_result)
+
+        command.call('abc123:README.md')
+      end
+    end
+
+    context 'with multiple objects' do
+      it 'passes each object specifier as a separate argument' do
+        expect_command_capturing('show', 'v1.0', 'v2.0', chomp: false).and_return(command_result)
+
+        command.call('v1.0', 'v2.0')
+      end
+    end
+
+    context 'with an unrecognised keyword argument' do
+      it 'raises ArgumentError' do
+        expect { command.call(foo: true) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Migrates `Git::Lib#show` to a dedicated `Git::Commands::Show` class, continuing the Strangler Fig architectural redesign.

## Changes

### `lib/git/commands/show.rb` (new)

New `Git::Commands::Show` class wrapping `git show`:

- `arguments do` DSL with `literal 'show'` and `operand :objects, repeatable: true`, correctly reflecting the git SYNOPSIS `git show [<object>…]` (zero or more objects)
- Explicit `def call` override to unconditionally pin `chomp: false` — `git show` can return raw file blob content where trailing newlines are meaningful data, not formatting noise
- Full YARD docs with `@overload`, `@param`, `@return`, and `@raise` tags

### `lib/git/lib.rb`

`Git::Lib#show` updated to delegate to `Git::Commands::Show`. The adapter combines `objectish` + `path` into a single `objectish:path` operand before delegating, then extracts `.stdout` for backward compatibility — the public return type is unchanged.

### `spec/unit/git/commands/show_spec.rb` (new)

Unit tests covering:
- Base invocation (no arguments) with return value pass-through assertion
- Single objectish argument
- Multiple objectish arguments
- Input validation (`ArgumentError` for unsupported options)

### `redesign/3_architecture_implementation.md`

Checklist updated to mark `show` as migrated and identify `describe` as the next command to migrate.

## Backward Compatibility

`Git::Lib#show` public contract is preserved:
- Same signature: `show(objectish = nil, path = nil)`
- Same return type: `String` (the git output with trailing newlines preserved)
- Same error behavior: raises `Git::FailedError` on non-zero exit

## Testing

All existing tests continue to pass. The unit tests for `Git::Commands::Show` cover all argument paths.