### PR TITLE
refactor: migrate describe to Git::Commands::Describe

### DIFF
--- a/lib/git/commands/describe.rb
+++ b/lib/git/commands/describe.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    # Implements the `git describe` command
+    #
+    # Gives a human-readable name to a commit based on the most recent
+    # reachable tag. When the tag points directly at the commit, only the
+    # tag name is shown. Otherwise, the tag name is suffixed with the number
+    # of additional commits and the abbreviated commit SHA.
+    #
+    # @see https://git-scm.com/docs/git-describe git-describe
+    # @see Git::Commands
+    #
+    # @api private
+    #
+    # @example Describe the current HEAD
+    #   describe = Git::Commands::Describe.new(execution_context)
+    #   result = describe.call
+    #
+    # @example Describe a specific commit
+    #   describe = Git::Commands::Describe.new(execution_context)
+    #   result = describe.call('abc123')
+    #
+    # @example Describe using any tag (not just annotated)
+    #   describe = Git::Commands::Describe.new(execution_context)
+    #   result = describe.call(tags: true)
+    #
+    # @example Describe with dirty-tree marker
+    #   describe = Git::Commands::Describe.new(execution_context)
+    #   result = describe.call(dirty: true)
+    #   result = describe.call(dirty: '-dirty')
+    #
+    class Describe < Git::Commands::Base
+      arguments do
+        literal 'describe'
+        flag_option :all
+        flag_option :tags
+        flag_option :contains
+        flag_option :debug
+        flag_option :long
+        flag_option :always
+        flag_option :exact_match
+        flag_option :first_parent
+        flag_or_value_option :dirty, inline: true
+        flag_or_value_option :broken, inline: true
+        flag_or_value_option :abbrev, inline: true
+        value_option :candidates, inline: true
+        value_option :match, repeatable: true
+        value_option :exclude, repeatable: true
+        operand :commit_ish, repeatable: true
+        conflicts :exact_match, :candidates
+        conflicts :dirty, :commit_ish
+        conflicts :broken, :commit_ish
+      end
+
+      # @!method call(*, **)
+      #
+      #   Execute the git describe command
+      #
+      #   @overload call(*commit_ish, **options)
+      #
+      #     @param commit_ish [Array<String>] zero or more commit-ish objects to describe.
+      #       When none are given, describes HEAD.
+      #
+      #     @param options [Hash] command options
+      #
+      #     @option options [Boolean] :all (nil) Use any ref found in the `refs/`
+      #       namespace, not just tags.
+      #
+      #     @option options [Boolean] :tags (nil) Use any tag found in the `refs/tags`
+      #       namespace, instead of only annotated tags.
+      #
+      #     @option options [Boolean] :contains (nil) Find the tag that comes after
+      #       the commit and thus contains it, rather than the most recent tag
+      #       reachable from it.
+      #
+      #     @option options [Boolean] :debug (nil) Verbosely display information
+      #       about the searching strategy being employed.
+      #
+      #     @option options [Boolean] :long (nil) Always output the long format
+      #       (the tag, the number of commits, and the abbreviated object name)
+      #       even when it matches a tag exactly.
+      #
+      #     @option options [Boolean] :always (nil) Show uniquely abbreviated
+      #       commit object as fallback when the commit cannot be described.
+      #
+      #     @option options [Boolean] :exact_match (nil) Only output exact matches
+      #       (a tag directly references the supplied commit object). Maps to
+      #       `--exact-match`.
+      #
+      #     @option options [Boolean] :first_parent (nil) Follow only the first
+      #       parent of a merge commit. Maps to `--first-parent`.
+      #
+      #     @option options [Boolean, String] :abbrev (nil) Use this many digits (or
+      #       as many as needed to form a unique object name) for the abbreviated
+      #       commit object name. When `true`, emits bare `--abbrev` (which uses
+      #       git's default length). Maps to `--abbrev[=<n>]`.
+      #
+      #     @option options [String] :candidates (nil) Consider up to this many
+      #       candidates. Increasing above the default of 10 will take a slightly
+      #       longer time but may produce a more accurate result. Maps to
+      #       `--candidates=<n>`.
+      #
+      #     @option options [String, Array<String>] :match (nil) Only consider tags
+      #       matching the given `glob(7)` pattern. Pass an array to match against
+      #       multiple patterns. Maps to `--match <pattern>`.
+      #
+      #     @option options [String, Array<String>] :exclude (nil) Do not consider
+      #       tags matching the given `glob(7)` pattern. Pass an array to exclude
+      #       multiple patterns. Maps to `--exclude <pattern>`.
+      #
+      #     @option options [Boolean, String] :dirty (nil) Describe the working
+      #       tree. When `true`, appends `-dirty`; when a String, appends that
+      #       string as the dirty mark. Maps to `--dirty[=<mark>]`.
+      #
+      #     @option options [Boolean, String] :broken (nil) Describe the working
+      #       tree, treating broken links as dirty. When `true`, appends `-broken`;
+      #       when a String, appends that string as the broken mark. Maps to
+      #       `--broken[=<mark>]`.
+      #
+      #     @return [Git::CommandLineResult] the result of calling `git describe`
+      #
+      #     @raise [ArgumentError] if unsupported options are provided
+      #
+      #     @raise [Git::FailedError] if the command returns a non-zero exit status
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -16,6 +16,7 @@ require_relative 'commands/cat_file/typed'
 require_relative 'commands/clean'
 require_relative 'commands/clone'
 require_relative 'commands/commit'
+require_relative 'commands/describe'
 require_relative 'commands/diff/numstat'
 require_relative 'commands/diff/patch'
 require_relative 'commands/diff/raw'
@@ -218,29 +219,6 @@ module Git
 
     ## READ COMMANDS ##
 
-    # The map defining how to translate user options to git command arguments.
-    DESCRIBE_OPTION_MAP = [
-      { keys: [:all], flag: '--all', type: :boolean },
-      { keys: [:tags], flag: '--tags', type: :boolean },
-      { keys: [:contains], flag: '--contains', type: :boolean },
-      { keys: [:debug], flag: '--debug', type: :boolean },
-      { keys: [:long], flag: '--long', type: :boolean },
-      { keys: [:always], flag: '--always', type: :boolean },
-      { keys: %i[exact_match exact-match], flag: '--exact-match', type: :boolean },
-      { keys: [:abbrev], flag: '--abbrev', type: :valued_equals },
-      { keys: [:candidates], flag: '--candidates', type: :valued_equals },
-      { keys: [:match], flag: '--match', type: :valued_equals },
-      {
-        keys: [:dirty],
-        type: :custom,
-        builder: lambda do |value|
-          return '--dirty' if value == true
-
-          "--dirty=#{value}" if value.is_a?(String)
-        end
-      }
-    ].freeze
-
     # Finds most recent tag that is reachable from a commit
     #
     # @see https://git-scm.com/docs/git-describe git-describe
@@ -268,10 +246,12 @@ module Git
     def describe(commit_ish = nil, opts = {})
       assert_args_are_not_options('commit-ish object', commit_ish)
 
-      args = build_args(opts, DESCRIBE_OPTION_MAP)
-      args << commit_ish if commit_ish
+      # Translate legacy :"exact-match" (hyphenated) key to :exact_match (underscored)
+      opts = opts.dup
+      opts[:exact_match] ||= opts.delete(:'exact-match') if opts.key?(:'exact-match')
 
-      command_capturing('describe', *args).stdout
+      commit_ishes = Array(commit_ish).compact
+      Git::Commands::Describe.new(self).call(*commit_ishes, **opts).stdout
     end
 
     # Return the commits that are within the given revision range

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,17 +22,17 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (43/~50 commands migrated) |
+| Phase 2 | 🔄 In Progress | Migrating commands (44/~50 commands migrated) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate `describe`** → `Git::Commands::Describe`
+**Migrate `grep`** → `Git::Commands::Grep`
 
 #### Workflow
 
-1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def describe`). Understand all options and edge cases.
+1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def grep`). Understand all options and edge cases.
 
 2. **Design**: Create command class following the pattern in
    `lib/git/commands/branch/delete.rb`. The interface for `#call` should only include
@@ -147,7 +147,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
    Parser classes and Result factories.
 
 6. **Verify**:
-  - `bundle exec rspec spec/unit/git/commands/describe_spec.rb` — new tests pass
+  - `bundle exec rspec spec/unit/git/commands/grep_spec.rb` — new tests pass
    - `bundle exec rspec` — all RSpec tests pass
    - `bundle exec rake test` — legacy TestUnit tests pass
    - `bundle exec rubocop` — no lint errors
@@ -736,6 +736,8 @@ The following tracks the migration status of commands from `Git::Lib` to
 | `cat_file_*` | `Git::Commands::CatFile::*` | `spec/unit/git/commands/cat_file/*_spec.rb` | `git cat-file` |
 | `checkout_index` | `Git::Commands::CheckoutIndex` | `spec/unit/git/commands/checkout_index_spec.rb` | `git checkout-index` |
 | `log_commits` / `full_log_commits` | `Git::Commands::Log` | `spec/unit/git/commands/log_spec.rb` | `git log` |
+| `show` | `Git::Commands::Show` | `spec/unit/git/commands/show_spec.rb` | `git show` |
+| `describe` | `Git::Commands::Describe` | `spec/unit/git/commands/describe_spec.rb` | `git describe` |
 
 #### ⏳ Commands To Migrate
 
@@ -773,7 +775,7 @@ order: Basic Snapshotting → Branching & Merging → etc.
 - [x] `diff_full` / `diff_stats` / `diff_path_status` / `diff_index` →
   `Git::Commands::Diff::*` — `git diff` (implemented as `Patch`, `Numstat`, and `Raw`)
 - [x] `show` → `Git::Commands::Show` — `git show`
-- [ ] `describe` → `Git::Commands::Describe` — `git describe`
+- [x] `describe` → `Git::Commands::Describe` — `git describe`
 - [ ] `grep` → `Git::Commands::Grep` — `git grep`
 - [ ] `ls_files` → `Git::Commands::LsFiles` — `git ls-files`
 - [ ] `ls_tree` / `full_tree` / `tree_depth` → `Git::Commands::LsTree` — `git

--- a/spec/integration/git/commands/describe_spec.rb
+++ b/spec/integration/git/commands/describe_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/describe'
+
+RSpec.describe Git::Commands::Describe, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    write_file('file.txt', 'content')
+    repo.add('file.txt')
+    repo.commit('Initial commit')
+    repo.add_tag('v1.0.0')
+  end
+
+  describe '#call' do
+    describe 'when the command succeeds' do
+      it 'returns a CommandLineResult describing HEAD' do
+        result = command.call(tags: true)
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.stdout).not_to be_empty
+      end
+
+      it 'returns a CommandLineResult with :long option' do
+        result = command.call(tags: true, long: true)
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.stdout).not_to be_empty
+      end
+
+      it 'returns a CommandLineResult with :always option when no tag is reachable' do
+        write_file('file2.txt', 'more content')
+        repo.add('file2.txt')
+        repo.commit('Second commit')
+
+        result = command.call(always: true)
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.stdout).not_to be_empty
+      end
+    end
+
+    describe 'when the command fails' do
+      it 'raises FailedError for a nonexistent commit-ish' do
+        expect { command.call('nonexistent-sha') }.to raise_error(Git::FailedError)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/describe_spec.rb
+++ b/spec/unit/git/commands/describe_spec.rb
@@ -1,0 +1,257 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/describe'
+
+RSpec.describe Git::Commands::Describe do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with no arguments' do
+      it 'runs git describe with no extra arguments and returns the result' do
+        expected_result = command_result('v1.0')
+        expect_command_capturing('describe').and_return(expected_result)
+
+        result = command.call
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with a commit-ish' do
+      it 'passes a single commit-ish as a positional argument' do
+        expect_command_capturing('describe', 'abc123').and_return(command_result('v1.0-3-gabc123'))
+
+        command.call('abc123')
+      end
+
+      it 'passes multiple commit-ishes as positional arguments' do
+        expect_command_capturing('describe', 'abc123', 'def456').and_return(command_result("v1.0\nv1.1"))
+
+        command.call('abc123', 'def456')
+      end
+
+      it 'omits commit-ish when none are given' do
+        expect_command_capturing('describe').and_return(command_result('v1.0'))
+
+        command.call
+      end
+    end
+
+    context 'with :all option' do
+      it 'includes --all flag' do
+        expect_command_capturing('describe', '--all').and_return(command_result('heads/main'))
+
+        command.call(all: true)
+      end
+
+      it 'does not include --all when false' do
+        expect_command_capturing('describe').and_return(command_result('v1.0'))
+
+        command.call(all: false)
+      end
+    end
+
+    context 'with :tags option' do
+      it 'includes --tags flag' do
+        expect_command_capturing('describe', '--tags').and_return(command_result('v1.0'))
+
+        command.call(tags: true)
+      end
+    end
+
+    context 'with :contains option' do
+      it 'includes --contains flag' do
+        expect_command_capturing('describe', '--contains').and_return(command_result('v1.0^0'))
+
+        command.call(contains: true)
+      end
+    end
+
+    context 'with :debug option' do
+      it 'includes --debug flag' do
+        expect_command_capturing('describe', '--debug').and_return(command_result('v1.0'))
+
+        command.call(debug: true)
+      end
+    end
+
+    context 'with :long option' do
+      it 'includes --long flag' do
+        expect_command_capturing('describe', '--long').and_return(command_result('v1.0-0-g1234567'))
+
+        command.call(long: true)
+      end
+    end
+
+    context 'with :always option' do
+      it 'includes --always flag' do
+        expect_command_capturing('describe', '--always').and_return(command_result('1234567'))
+
+        command.call(always: true)
+      end
+    end
+
+    context 'with :exact_match option' do
+      it 'includes --exact-match flag' do
+        expect_command_capturing('describe', '--exact-match').and_return(command_result('v1.0'))
+
+        command.call(exact_match: true)
+      end
+    end
+
+    context 'with :first_parent option' do
+      it 'includes --first-parent flag' do
+        expect_command_capturing('describe', '--first-parent').and_return(command_result('v1.0'))
+
+        command.call(first_parent: true)
+      end
+    end
+
+    context 'with :abbrev option' do
+      it 'includes --abbrev=<n> as inline value' do
+        expect_command_capturing('describe', '--abbrev=10').and_return(command_result('v1.0-3-gabcdef0123'))
+
+        command.call(abbrev: '10')
+      end
+
+      it 'includes bare --abbrev when true' do
+        expect_command_capturing('describe', '--abbrev').and_return(command_result('v1.0-3-gabcdef'))
+
+        command.call(abbrev: true)
+      end
+    end
+
+    context 'with :candidates option' do
+      it 'includes --candidates=<n> as inline value' do
+        expect_command_capturing('describe', '--candidates=50').and_return(command_result('v1.0'))
+
+        command.call(candidates: '50')
+      end
+    end
+
+    context 'with :match option' do
+      it 'includes --match <pattern> as space-separated value' do
+        expect_command_capturing('describe', '--match', 'v[0-9]*').and_return(command_result('v1.0'))
+
+        command.call(match: 'v[0-9]*')
+      end
+
+      it 'accepts an array of patterns (repeatable)' do
+        expect_command_capturing('describe', '--match', 'v[0-9]*',
+                                 '--match', 'release-*').and_return(command_result('v1.0'))
+
+        command.call(match: ['v[0-9]*', 'release-*'])
+      end
+    end
+
+    context 'with :exclude option' do
+      it 'includes --exclude <pattern> as space-separated value' do
+        expect_command_capturing('describe', '--exclude', 'rc*').and_return(command_result('v1.0'))
+
+        command.call(exclude: 'rc*')
+      end
+
+      it 'accepts an array of patterns (repeatable)' do
+        expect_command_capturing('describe', '--exclude', 'rc*',
+                                 '--exclude', 'beta-*').and_return(command_result('v1.0'))
+
+        command.call(exclude: ['rc*', 'beta-*'])
+      end
+    end
+
+    context 'with :dirty option' do
+      it 'includes --dirty flag when true' do
+        expect_command_capturing('describe', '--dirty').and_return(command_result('v1.0-dirty'))
+
+        command.call(dirty: true)
+      end
+
+      it 'includes --dirty=<mark> when a string is given' do
+        expect_command_capturing('describe', '--dirty=-modified').and_return(command_result('v1.0-modified'))
+
+        command.call(dirty: '-modified')
+      end
+
+      it 'omits --dirty when false' do
+        expect_command_capturing('describe').and_return(command_result('v1.0'))
+
+        command.call(dirty: false)
+      end
+    end
+
+    context 'with :broken option' do
+      it 'includes --broken flag when true' do
+        expect_command_capturing('describe', '--broken').and_return(command_result('v1.0-broken'))
+
+        command.call(broken: true)
+      end
+
+      it 'includes --broken=<mark> when a string is given' do
+        expect_command_capturing('describe', '--broken=-invalid').and_return(command_result('v1.0-invalid'))
+
+        command.call(broken: '-invalid')
+      end
+    end
+
+    context 'with multiple options combined' do
+      it 'includes all specified flags in definition order' do
+        expect_command_capturing(
+          'describe',
+          '--tags',
+          '--long',
+          '--abbrev=7',
+          '--match', 'v[0-9]*',
+          'HEAD'
+        ).and_return(command_result('v1.0-0-g1234567'))
+
+        command.call('HEAD', tags: true, long: true, abbrev: '7', match: 'v[0-9]*')
+      end
+
+      it 'combines dirty with options (no commit-ish) in definition order' do
+        expect_command_capturing(
+          'describe',
+          '--tags',
+          '--long',
+          '--dirty',
+          '--abbrev=7'
+        ).and_return(command_result('v1.0-0-g1234567-dirty'))
+
+        command.call(tags: true, long: true, abbrev: '7', dirty: true)
+      end
+    end
+
+    context 'with conflicting :exact_match and :candidates' do
+      it 'raises ArgumentError because --exact-match is a synonym for --candidates=0' do
+        expect { command.call(exact_match: true, candidates: '5') }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with conflicting :dirty and commit_ish' do
+      it 'raises ArgumentError when dirty is true and a commit-ish is given' do
+        expect { command.call('abc123', dirty: true) }.to raise_error(ArgumentError)
+      end
+
+      it 'raises ArgumentError when dirty is a string and a commit-ish is given' do
+        expect { command.call('abc123', dirty: '-wip') }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with conflicting :broken and commit_ish' do
+      it 'raises ArgumentError when broken is true and a commit-ish is given' do
+        expect { command.call('abc123', broken: true) }.to raise_error(ArgumentError)
+      end
+
+      it 'raises ArgumentError when broken is a string and a commit-ish is given' do
+        expect { command.call('abc123', broken: '-invalid') }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'with an unrecognised keyword argument' do
+      it 'raises ArgumentError' do
+        expect { command.call(foo: true) }.to raise_error(ArgumentError)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Migrates `git describe` from the legacy `Git::Lib` option-map pattern to the
`Git::Commands::Base` architecture.

## Changes

### `lib/git/commands/describe.rb` (new command class)
- Implements `Git::Commands::Describe < Git::Commands::Base`
- Arguments DSL mirrors the `git describe` man page SYNOPSIS order:
  `all`, `tags`, `contains`, `abbrev`, `candidates`, `exact_match`, `debug`,
  `long`, `match`, `exclude`, `always`, `first_parent`, `dirty`, `broken`,
  `commit_ish`
- `abbrev` is correctly declared as `flag_or_value_option` — the man page shows
  `--abbrev[=<n>]` (value is optional), so `abbrev: true` emits `--abbrev` and
  `abbrev: '7'` emits `--abbrev=7`
- `conflicts :exact_match, :candidates` enforces the documented mutual exclusion
- Full `@!method call(*, **)` YARD documentation with `@overload`, `@param`,
  `@option`, `@return`, and `@raise` tags

### `lib/git/lib.rb`
- `Git::Lib#describe` now delegates to `Git::Commands::Describe`
- Removed dead `DESCRIBE_OPTION_MAP` constant (was never used after delegation)
- Preserved the legacy `:'exact-match'` → `:exact_match` key alias for
  backward compatibility

### `spec/unit/git/commands/describe_spec.rb` (new)
- Full unit test coverage: base invocation, every flag/value option, repeatable
  options, combined options in DSL order, conflict validation, unsupported-option
  validation

### `spec/integration/git/commands/describe_spec.rb` (new)
- Integration smoke tests against a real git repository

## Backward Compatibility

All changes are fully backward compatible:

- `Git::Lib#describe` public signature is unchanged (`describe(commit_ish = nil, opts = {})`)
- The `abbrev: '7'` string form continues to work as before
- `abbrev: true` previously produced invalid `--abbrev=true`; it now correctly produces `--abbrev` (a fix, not a break)
- `DESCRIBE_OPTION_MAP` was a private constant, not part of any public API
