### PR TITLE
docs: document validation delegation policy

### DIFF
--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -94,6 +94,38 @@ Git::Base (facade)
 Command classes that need non-zero successful exits declare
 `allow_exit_status <Range>` with a rationale comment.
 
+### Validation Boundaries
+
+Command classes use per-argument validation parameters (`required:`, `type:`,
+`allow_nil:`, etc.) and operand format validation. They generally do **not** declare
+cross-argument constraint methods (`conflicts`, `requires`, `requires_one_of`,
+`requires_exactly_one_of`, `forbid_values`, `allowed_values`) — git is the single source of truth for its
+own option semantics. The narrow exception is **arguments git cannot observe in
+its argv**: if an argument is `skip_cli: true`, git never sees it and cannot detect
+incompatibilities — `conflicts` and/or `requires_one_of` are appropriate. Example:
+`cat-file --batch` uses both because `:objects` is `skip_cli: true`:
+
+| Validated by Commands | Mechanism |
+|---|---|
+| Unknown options | `validate_unsupported_options!` in Arguments DSL |
+| Required options | `required: true` in Arguments DSL |
+| Type checking | `type:` in Arguments DSL |
+| Option-like operand rejection | Automatic for operands before `--` |
+
+| Delegated to git (semantic) | Surfaced as |
+|---|---|
+| Option conflicts (`--soft` vs `--hard`) | `Git::FailedError` |
+| Option dependencies (`--all-match` requires `--grep`) | `Git::FailedError` |
+| At-least-one-of groups | `Git::FailedError` |
+| Value-set membership | `Git::FailedError` |
+| Forbidden value combinations | `Git::FailedError` |
+
+The constraint DSL infrastructure (`conflicts`, `requires`, `requires_one_of`,
+`requires_exactly_one_of`, `forbid_values`, `allowed_values`) remains available in `Git::Commands::Arguments`
+and is used only for `skip_cli: true` argument constraints, and in narrow documented cases for
+git-visible arguments whose combination causes silent data loss (no error, wrong result).
+See `redesign/3_architecture_implementation.md` Insight 6 for the full policy and exception criteria.
+
 ## Coding Standards
 
 ### Ruby Style

--- a/.github/skills/review-arguments-dsl/CHECKLIST.md
+++ b/.github/skills/review-arguments-dsl/CHECKLIST.md
@@ -149,14 +149,6 @@ short flags), prefer:
 4. value options
 5. operands (positional args / pathspecs after `--`)
 
-   Constraint declarations always come after all arguments they reference are defined:
-
-6. `conflicts` declarations
-7. `forbid_values` declarations (exact-value tuple constraints for negatable flags)
-8. `requires_exactly_one_of` declarations (when a group needs exactly-one semantics)
-9. `requires_one_of` declarations (unconditional and `when:` conditional forms)
-10. `requires` declarations (single-argument conditional form)
-
 ### 4. Correct modifiers
 
 Derive `required:` and `repeatable:` directly from the git-scm.com SYNOPSIS
@@ -241,234 +233,35 @@ Examples of options to **include** (do not affect stdout):
 **Default assumption for `--verbose` and `--quiet`:** their absence is intentional.
 Do **not** flag them as missing.
 
-#### Constraint identification from the man page
+#### Per-argument validation completeness
 
-After deciding which options to include, re-read the man page a second time
-specifically looking for constraint relationships. Do **not** skip this pass — the
-DSL machinery that enforces constraints exists to protect callers from invalid
-combinations that git itself will reject, and the review/scaffold phase is the only
-automated checkpoint where the man page is being read.
+For every `flag_option`, `value_option`, `flag_or_value_option`, and `operand`
+declaration, check whether per-argument validation parameters have been considered:
 
-Look for these specific language patterns and map them to DSL declarations:
-
-**Mutual exclusion → `conflicts`** (or `requires_exactly_one_of` if also required):
-
-| Man-page signal | Example |
+| Parameter | Flag it missing if… |
 |---|---|
-| "Cannot be combined with `--foo`" | `conflicts :this, :foo` |
-| "Synonym for `--a --b --no-c`" | `conflicts :this, :a`; `conflicts :this, :b`; `conflicts :this, :c` |
-| "Same as `--foo`" (exact synonym) | The synonym adds redundancy — either alias it or note the conflict with the long form |
-| Options in a "choose one" list | `conflicts :opt_a, :opt_b` for each pair; or `requires_exactly_one_of` if exactly one is also required |
-| Sorting/ordering modes (`--date-order`, `--topo-order`, `--author-date-order`) | One ordering mode at a time → `conflicts` each pair |
-| Regexp engine flags (`-E`, `-F`, `-P`) | Choose one engine → `conflicts` each pair |
+| `required: true` | The command always fails without this argument, making the Ruby caller's error clearer before spawning a process |
+| `allow_nil: false` | The argument is `required:` and a `nil` value is meaningless (not just absent) |
+| `type: <Class>` | A wrong Ruby type would produce a confusing git error or silent coercion |
+| `validator:` | A simple per-argument predicate exists that git expresses poorly in its error output |
 
-**Conditional requirement → `requires` or `requires_one_of ... when:`**:
+Do **not** flag the absence of these parameters as issues when no meaningful
+constraint exists for that argument — omitting them is correct in that case.
 
-| Man-page signal | Example |
-|---|---|
-| "Works only for a single file" | `requires :option, :path` — and note in YARD that `:path` must have exactly one element |
-| "Only meaningful when `--foo` is in use" | `requires :this, when: :foo` |
-| "Only takes effect when" | `requires :this, when: :other` |
-| "It is an error to use this option unless `--foo`" | `requires :this, when: :foo` |
-| "Only when `<path>` is given" | `requires :option, :path` |
+**Cross-argument constraint methods are generally not used in command classes.** Do not flag
+the absence of `conflicts`, `requires`, `requires_one_of`, `requires_exactly_one_of`,
+`forbid_values`, or `allowed_values` as a completeness issue. Command classes use
+per-argument validation parameters (`required:`, `type:`, `allow_nil:`, etc.) and
+operand format validation. Git validates its own option semantics. The narrow
+exception is **arguments git cannot observe in its argv** — the test is: does this
+argument appear in git's argv? If no (e.g., `skip_cli: true` operands routed via
+stdin), git cannot detect incompatibilities and constraint declarations are
+appropriate and should not be flagged as policy violations. Example: `cat-file
+--batch` declares `conflicts :objects, :batch_all_objects` and `requires_one_of
+:objects, :batch_all_objects` because `:objects` is `skip_cli: true`. See the
+validation delegation policy in `redesign/3_architecture_implementation.md` Insight 6.
 
-**Implication → `literal` or `conflicts`**:
-
-When git says an option "implies" another (e.g. `--cherry` is "a synonym for
-`--right-only --cherry-mark --no-merges`"), the implied flags are not always
-safe to also accept as keyword arguments:
-- If the implied flag is already a keyword option in the DSL, add `conflicts`
-  between the implying option and any keyword option whose value would contradict
-  the implication.
-- If the implied flag has no keyword representation (output-affecting, excluded),
-  no action is needed.
-
-**"No effect without" / value-mode flags**: when a flag only changes its
-behavior depending on a value another option receives, use `requires` with a
-`when:` trigger rather than an unconditional `requires`.
-
-After this pass, any identified constraint should be added as DSL declarations
-placed in the correct order (§3: after all arguments they reference, positions 6–10).
-
-
-
-If arguments are mutually exclusive — whether option vs option, option vs operand,
-or operand vs operand — verify `conflicts ...` declarations exist. Names in a
-`conflicts` group may be any mix of option names and operand names. Unknown names
-raise `ArgumentError` at definition time, so any typo is caught early.
-
-**Presence semantics for conflicts:** a value is considered present when it is not
-`nil`, `[]`, or `''`. For **negatable flag options** (`negatable: true`), an explicit
-`false` also counts as present because it emits `--no-flag` — a real CLI token that
-can conflict with other options. Non-negatable `false` is absent.
-
-**`conflicts` vs `forbid_values`:** `conflicts` is presence-based — it fires whenever
-more than one member of the group is "present", regardless of value. For **negatable
-flags** where some value-pairings are semantically equivalent rather than contradictory,
-`conflicts` is too coarse: it would block valid combinations like `--no-all
---ignore-removal`. In those cases use `forbid_values` (see §7e) instead of (or in
-place of) `conflicts`. Flag any `conflicts` declaration between two or more negatable
-flags as a candidate for replacement with targeted `forbid_values` declarations.
-
-**Preferred single declaration when a group is both required and mutually exclusive:**
-If a `conflicts` group also has a corresponding bare `requires_one_of` for the
-identical argument list, the two declarations should be collapsed into a single
-`requires_exactly_one_of` call (see §7a below). Flag any command where a bare
-`requires_one_of` and a `conflicts` share the same names as a candidate for this
-consolidation.
-
-### 7. Conditional and Unconditional Argument Requirements
-
-#### 7a. Unconditional at-least-one (`requires_one_of`) and exactly-one (`requires_exactly_one_of`)
-
-If a command requires at least one argument from a group to be present — options,
-operands, or a mix — verify `requires_one_of ...` declarations exist. As with
-`conflicts`, names may be any mix of option names and operand names. Alias
-resolution applies before the check, so supplying an alias counts as its canonical
-argument being present. Unknown names raise `ArgumentError` at definition time.
-
-**Presence semantics (satisfied-by):** same rule as `conflicts` — negatable `false`
-counts as present (the caller explicitly provided `--no-flag`).
-
-The error at bind time has the form:
-
-  "at least one of :name1, :name2 must be provided"
-
-When the group must have **exactly one** member present (both at-least-one and
-at-most-one), prefer `requires_exactly_one_of` over separate `requires_one_of` +
-`conflicts` declarations for the same names:
-
-```ruby
-# Preferred — single declaration for exactly-one semantics:
-requires_exactly_one_of :mode_a, :mode_b, :mode_c
-
-# Equivalent but verbose — two declarations that must stay in sync:
-requires_one_of :mode_a, :mode_b, :mode_c
-conflicts       :mode_a, :mode_b, :mode_c
-```
-
-`requires_exactly_one_of` raises at definition time for unknown names (typo guard),
-and at bind time:
-- zero members present → `"at least one of :a, :b, :c must be provided"`
-- two or more present → `"cannot specify :a and :b"`
-
-#### 7b. Conditional single requirement (`requires`)
-
-If an argument is only required when another specific argument is present, verify a
-`requires :name, when: :trigger` declaration exists. The check is skipped entirely
-when the trigger is absent. Unknown names (including the trigger) raise
-`ArgumentError` at definition time.
-
-**Presence semantics (trigger):** the trigger fires when its value is not `nil`,
-`false`, `[]`, or `''`. A negatable flag set to `false` means the feature is **off**,
-so the trigger does **not** fire and no dependency check is performed.
-
-The error at bind time has the form:
-
-  ":trigger requires :name"
-
-Example in `git add`:
-
-```ruby
-requires :pathspec_from_file, when: :pathspec_file_nul
-requires :dry_run,            when: :ignore_missing
-```
-
-#### 7c. Conditional at-least-one-of group (`requires_one_of ... when:`)
-
-If at least one of a group must be present only when another argument is present,
-verify a `requires_one_of :a, :b, when: :trigger` declaration exists. Like the
-unconditional form, names may be any mix of option/operand names. The check is
-skipped when the trigger is absent. Unknown names (including the trigger) raise
-`ArgumentError` at definition time.
-
-**Presence semantics (trigger):** same rule as `requires` — a negatable trigger set
-to `false` means the feature is off; the group check is skipped.
-
-The error at bind time has the form:
-
-  ":trigger requires at least one of :name1, :name2"
-
-Example in `git tag --create`:
-
-```ruby
-requires_one_of :message, :file, when: :annotate
-requires_one_of :message, :file, when: :sign
-requires_one_of :message, :file, when: :local_user
-```
-
-#### 7d. Forbidden value combinations
-
-`forbid_values` declares **exact-value tuples** that are invalid at bind time.
-Each call declares one forbidden tuple; a tuple matches only when every listed
-name is bound and each bound value equals the declared value (`==`). Non-matching
-tuples are allowed through without error.
-
-This fills the gap left by `conflicts` (which is presence-based and cannot
-distinguish equivalent from contradictory value-pairings of negatable flags):
-
-```ruby
-flag_option :all,            negatable: true
-flag_option :ignore_removal, negatable: true
-forbid_values all: true,  ignore_removal: true   # contradictory
-forbid_values all: false, ignore_removal: false  # contradictory
-# Equivalent pairs (all: true + ignore_removal: false, etc.) are allowed
-```
-
-Points to check:
-
-- Each `forbid_values` declaration uses keyword-pair syntax only (`name: value`).
-- All names must be known options or operands; an unknown name raises
-  `ArgumentError` at definition time.
-- Alias names are accepted and canonicalized to primary names.
-- `conflicts :a, :b` plus `forbid_values a: true, b: true` is **not** equivalent:
-  `conflicts` catches any presence combination; `forbid_values` catches only the
-  specific value tuple. When the intent is to block a specific value pairing (not
-  all co-presence), use `forbid_values` not `conflicts`.
-- For negatable flags that may share semantically equivalent combinations, prefer
-  `forbid_values` over `conflicts` so equivalent pairings (e.g. `--no-all
-  --ignore-removal`) remain valid.
-
-Error form at bind time:
-
-```
-cannot specify :name1=value1 with :name2=value2
-```
-
-#### 7e. Allowed-values constraints
-
-If a `value_option`, `flag_or_value_option`, or `flag_or_inline_value_option`
-accepts a fixed, enumerated set of strings, verify an `allowed_values` declaration
-exists for that option:
-
-```ruby
-value_option :cleanup, inline: true
-allowed_values :cleanup, in: %w[verbatim whitespace strip]
-```
-
-Points to check:
-
-- `allowed_values` supersedes ad-hoc `validator:` lambdas for enumerated-string
-  cases — flag any `validator:` doing a simple set-membership test as a
-  candidate for replacement.
-- The declaration must reference a name already defined in `arguments do`; an
-  unknown name raises `ArgumentError` at load time.
-- Validation is **skipped** for `nil` / absent values; callers that want a
-  non-nil value must add a separate `required:` or `requires_one_of` check.
-- Validation is also skipped for empty strings when the option is declared with
-  `allow_empty: true`.
-- For `repeatable: true` options each element in the array is checked
-  individually.
-- Aliases are resolved before the check, so the declaration may use either the
-  primary name or any alias.
-
-Error form at bind time:
-
-```
-Invalid value for :name: expected one of ["a", "b"], got "actual"
-```
-
-### 8. Exit-status declaration consistency (class-level, outside the DSL)
+### 6. Exit-status declaration consistency (class-level, outside the DSL)
 
 `allow_exit_status` is a class-level declaration, not part of the `arguments do`
 block. It is included here because it should be validated alongside DSL entries for

--- a/.github/skills/review-arguments-dsl/SKILL.md
+++ b/.github/skills/review-arguments-dsl/SKILL.md
@@ -91,16 +91,32 @@ Key behaviors:
 
 ## What to Check
 
-See [CHECKLIST.md](CHECKLIST.md) for the complete 8-point review checklist covering:
+See [CHECKLIST.md](CHECKLIST.md) for the complete review checklist covering:
 
 1. Correct DSL method per option type
 2. Correct alias and `as:` usage
 3. Correct ordering
 4. Correct modifiers
 5. Completeness
-6. Conflicts
-7. Conditional and unconditional argument requirements
-8. Exit-status declaration consistency
+6. Exit-status declaration consistency
+
+**Validation delegation policy:** Command classes generally do **not** declare
+cross-argument constraint methods (`conflicts`, `requires`, `requires_one_of`,
+`requires_exactly_one_of`, `forbid_values`, `allowed_values`). Git is the single
+source of truth for its own option semantics. There are two narrow exceptions:
+
+1. **`skip_cli: true` arguments** — the argument never appears in git's argv, so
+   git cannot detect incompatibilities and Ruby must enforce them. Example:
+   `cat-file --batch` declares `conflicts :objects, :batch_all_objects` and
+   `requires_one_of :objects, :batch_all_objects` because `:objects` is
+   `skip_cli: true` and never reaches git's argv.
+2. **Git-visible arguments that cause silent data loss** — if a combination of
+   git-visible arguments causes git to silently discard data (no error, wrong
+   result), a `conflicts` declaration MAY be added with: a code comment explaining
+   why, a reference to the git version(s) where the behavior was verified, and a
+   test. As of this writing, no such case has been identified.
+
+See `redesign/3_architecture_implementation.md` Insight 6 for the full policy.
 
 ## Verification Chain
 

--- a/.github/skills/review-command-implementation/SKILL.md
+++ b/.github/skills/review-command-implementation/SKILL.md
@@ -111,8 +111,14 @@ Shared behavior lives in `Base`:
 - [ ] Override calls `args_definition.bind(...)` directly — does *not* duplicate `Base#call` logic
 - [ ] Exit-status validation delegates to `validate_exit_status!` (not reimplemented inline)
 - [ ] Stdin-feeding commands use `Base#with_stdin` (not a manual `IO.pipe` inline)
-- [ ] Validation expressible in the DSL is declared in `arguments do` (`conflicts`,
-      `requires_one_of`, `forbid_values`, etc.) rather than manually raised in `call`
+- [ ] Any `ArgumentError` raised manually or via DSL constraint covers only what
+      git cannot validate: per-argument failures and constraints on `skip_cli: true`
+      arguments. Cross-argument constraint methods are **not** declared for
+      git-visible arguments — the narrow exception is arguments git cannot observe
+      in its argv (e.g., `skip_cli: true` operands: `conflicts :objects,
+      :batch_all_objects` and `requires_one_of :objects, :batch_all_objects`).
+      See the validation delegation policy in
+      `redesign/3_architecture_implementation.md` Insight 6.
 - [ ] Bulk of override is extracted into a private helper (`run_batch`, etc.) to satisfy Rubocop `Metrics` thresholds
 - [ ] Does not parse output in command class
 
@@ -123,9 +129,15 @@ Most commands use `def call(...) = super`, which forwards all arguments to
 
 **Override `call` only when the command needs:**
 
-1. **Input validation the DSL cannot express** — prefer declarative constraints in
-  `arguments do` (`conflicts`, `requires_one_of`, `forbid_values`, etc.) and only
-  raise `ArgumentError` manually when needed
+1. **Input validation the DSL cannot express** — per-argument validation parameters
+  (`required:`, `type:`, `allow_nil:`, etc.) and operand format validation belong
+  in `arguments do`. Cross-argument constraint methods are generally **not** declared;
+  git validates its own option semantics. The narrow exception is **arguments git
+  cannot observe in its argv**: if an argument is `skip_cli: true` and never
+  reaches git's argv, git cannot detect incompatibilities — use `conflicts` and/or
+  `requires_one_of` in the DSL (e.g., `cat-file --batch` uses both because
+  `:objects` is `skip_cli: true`). Do not raise `ArgumentError` manually for things
+  the DSL can express via a constraint declaration.
 2. **stdin feeding** — batch protocols (`--batch`, `--batch-check`) via
    `Base#with_stdin`
 3. **Non-trivial option routing** — build different argument sets based on

--- a/.github/skills/review-command-tests/SKILL.md
+++ b/.github/skills/review-command-tests/SKILL.md
@@ -79,10 +79,16 @@ Unit tests verify CLI argument building and command-layer behavior for each comm
   exit codes 2 and 128 raise `FailedError`. Commands that only succeed at exit code 0
   (the default) do not need a unit-level exit code test — the integration
   error-handling test covers that path.
-- Input validation (`ArgumentError`) for unsupported/conflicting/missing args
-- For validation declared in the Arguments DSL (`conflicts`, `requires_one_of`,
-  `forbid_values`), assert the DSL-generated behavior/message shape rather than
-  command-specific custom wording
+- Input validation (`ArgumentError`) for per-argument validation failures: unknown
+  options, `required:` violations, `type:` mismatches, etc. Command classes
+  generally do **not** declare cross-argument constraint methods (`conflicts`,
+  `requires`, `requires_one_of`, `requires_exactly_one_of`, `forbid_values`,
+  `allowed_values`, etc.) — git validates its
+  own option semantics. The narrow exception is **arguments git cannot observe in
+  its argv**: if an argument is `skip_cli: true`, it never reaches git's argv and
+  git cannot detect incompatibilities — constraint declarations are appropriate and
+  the resulting `ArgumentError` should be tested. See the validation delegation
+  policy in `redesign/3_architecture_implementation.md` Insight 6.
 
 ### Expectations for command invocation
 
@@ -135,6 +141,9 @@ it 'includes --batch-all-objects and writes nothing to stdin' do
   command.call(batch_all_objects: true)
 end
 
+# git-invisible argument exception: :objects is skip_cli: true, so git never sees
+# it in argv and cannot detect these incompatibilities. Ruby must enforce them.
+# conflicts: can't pass objects AND bypass stdin; requires_one_of: must choose one.
 it 'raises when mutually exclusive DSL inputs are combined' do
   expect { command.call('HEAD', batch_all_objects: true) }
     .to raise_error(ArgumentError, /cannot specify :objects and :batch_all_objects/)
@@ -190,8 +199,11 @@ Unit tests are organized under `describe '#call'` with three sections:
    that exit codes within the allowed range return a result and exit codes outside
    the range raise `FailedError`.
 3. **`context 'input validation'`** — only for commands with validation rules. Covers
-   unsupported options, conflicting options, at-least-one-required groups, and
-   required arguments that raise `ArgumentError`.
+   unsupported options and required arguments that raise `ArgumentError`. Cross-argument
+   constraints for git-visible arguments are not tested because command classes do not
+   declare them. The exception is constraints on `skip_cli: true` arguments (e.g.,
+   `conflicts :objects, :batch_all_objects` and `requires_one_of :objects,
+   :batch_all_objects`), which should be tested.
 
 The exit code and input validation blocks are optional — include them only when the
 command has those behaviors. They always appear at the end of `#call`, in that order.

--- a/.github/skills/scaffold-new-command/SKILL.md
+++ b/.github/skills/scaffold-new-command/SKILL.md
@@ -312,25 +312,22 @@ explicit flags, model them as a single `flag_option :foo, negatable: true` rathe
 than two separate entries. This prevents contradictory combinations and makes the
 three-state semantics (`true` / `false` / `nil`) explicit.
 
-**Second pass — constraint identification:** after the include/exclude decisions,
-re-read the man page looking specifically for constraint relationships between the
-options you chose to include. This pass is required — constraint declarations
-(`conflicts`, `requires`, `requires_one_of`) must be added during scaffolding,
-not discovered later during a review. Look for these signals:
+**Constraint declarations are generally not used in command classes.** Do not add
+`conflicts`, `requires`, `requires_one_of`, `requires_exactly_one_of`,
+`forbid_values`, or `allowed_values` declarations to command classes. Git is the
+single source of truth for its own option semantics. There are two narrow exceptions:
 
-- **Mutual exclusion** — "cannot be combined with", "synonym for `--a --b`",
-  mutually exclusive mode flags (e.g. ordering modes, regexp-engine flags) →
-  `conflicts :a, :b` for each conflicting pair
-- **Conditional requirement** — "works only for a single file / path", "only
-  meaningful when `--foo` is in use", "it is an error to use this unless `--bar`"
-  → `requires :this, when: :trigger`
-- **Optional-value options** — option signature `--foo[=<value>]` in the man page
-  → use `flag_or_value_option`, not `flag_option`
-- **Short-flag aliases** — every `-X` / `--long-form` pair → alias with long name
-  first: `%i[long_name X]`
+1. **`skip_cli: true` arguments** — the argument never reaches git's argv, so git
+   cannot detect incompatibilities and constraint declarations are appropriate (see
+   the `cat-file --batch` example above: `:objects` is `skip_cli: true`, so git
+   never sees it and cannot detect the conflict or the absent-both case).
+2. **Git-visible arguments that cause silent data loss** — if a combination of
+   git-visible arguments causes git to silently discard data (no error, wrong
+   result), a `conflicts` declaration MAY be added with: a code comment explaining
+   why, a reference to the git version(s) where the behavior was verified, and a
+   test. As of this writing, no such case has been identified.
 
-For the full translation table mapping man-page language to DSL declarations,
-see the [Constraint identification section of the Arguments DSL Checklist](../review-arguments-dsl/CHECKLIST.md#constraint-identification-from-the-man-page).
+See `redesign/3_architecture_implementation.md` Insight 6 for the full policy.
 
 This step is required. A command class that only exposes the options that happen
 to be used today in `Git::Lib` is incomplete — callers of the future API should
@@ -380,6 +377,16 @@ type, alias conventions, `as:` usage, modifier rules, constraint declarations
   `[<arg>…]` → `repeatable: true`, `<arg>…` → `required: true, repeatable: true`.
   See [CHECKLIST.md section 4](../review-arguments-dsl/CHECKLIST.md#4-correct-modifiers)
   for the complete table.
+- For each option and operand, actively evaluate whether per-argument validation
+  parameters apply:
+  - `required: true` — does the command fail outright if this argument is absent?
+  - `allow_nil: false` — when required, does passing `nil` make no sense?
+  - `type: <Class>` — is there a single expected Ruby type that catching early
+    would produce a clearer error than git's own output?
+  - `validator:` — is there a simple predicate (not a cross-argument rule) that
+    git cannot express clearly in its error output?
+  Omit these only if there is no meaningful per-argument constraint to express;
+  don't leave them out by default.
 - Avoid `as:` unless it's a Ruby keyword conflict, combined short flag, or
   multi-token flag
 

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -411,6 +411,84 @@ future work:
    conflicts :track, :no_track
    ```
 
+   **Validation delegation policy — constraint DSL declarations are not used in
+   command classes.** The Arguments DSL provides `conflicts`, `requires`,
+   `requires_one_of`, `requires_exactly_one_of`, `forbid_values`, and
+   `allowed_values` for declaring inter-option constraints. Command classes
+   generally do **not** use these declarations. Git is the single source of truth
+   for its own option semantics. Command classes use per-argument validation
+   parameters (`required:`, `type:`, `allow_nil:`, etc.) and operand format
+   validation (option-like operand rejection before `--`). The narrow exception is
+   arguments that git cannot observe — see the exception policy below.
+
+   **What command classes validate:**
+
+   | Validation | Mechanism | Rationale |
+   |---|---|---|
+   | Unknown options | `validate_unsupported_options!` in Arguments DSL | Catches typos/misspellings before spawning a process. Git would also reject these, but the error message would be less clear about the Ruby-side fix needed. |
+   | Required options | `required: true` in Arguments DSL | Enforces the minimum contract for a command to be meaningful. Avoids spawning a process that will certainly fail. |
+   | Type checking | `type:` in Arguments DSL | Catches programming errors (e.g., passing an Integer where a String is expected) that would produce confusing git errors or silent coercion. |
+   | Option-like operand rejection | Automatic for operands before `--` | Security concern: prevents user-supplied strings like `'-s'` from being misinterpreted as git flags. |
+
+   **What command classes do NOT validate (semantic concerns — delegated to git):**
+
+   | Validation | Delegated to | Rationale |
+   |---|---|---|
+   | Option conflicts (`--soft` vs `--hard`) | Git (stderr → `Git::FailedError`) | Git is the authority on which options conflict. Constraints drift as git evolves. |
+   | Option dependencies (`--all-match` requires `--grep`) | Git (stderr or silent behavior) | Same drift risk. Some dependencies are version-specific. |
+   | At-least-one-of groups | Git (stderr → `Git::FailedError`) | Git enforces its own required-argument semantics. |
+   | Value-set membership (`--chmod` only accepts `+x`/`-x`) | Git (stderr → `Git::FailedError`) | Git may expand accepted values in future versions. |
+   | Forbidden value combinations | Git (stderr → `Git::FailedError`) | Specific to git's internal semantics. |
+
+   **Design rationale:**
+
+   1. **Git is the single source of truth.** Git validates its own option
+      interactions and reports clear errors via stderr, surfaced as
+      `Git::FailedError`. Ruby-side constraints duplicate this validation and risk
+      becoming stale — potentially blocking valid usage when git relaxes a
+      restriction in a newer version.
+
+   2. **Partial coverage is worse than none.** Inconsistent constraint coverage
+      creates a false promise of safety: users can't know whether the absence of
+      an `ArgumentError` means "this combination is valid" or "this command
+      doesn't have constraints."
+
+   3. **Constraint violations are programming errors.** When a developer passes
+      conflicting options, they must stop and fix their code regardless of whether
+      the error is `ArgumentError` or `Git::FailedError`. The cost difference is
+      negligible.
+
+   4. **Uniform error semantics.** All invalid-option errors surface uniformly as
+      `Git::FailedError` with git's actual error message, rather than a mix of
+      `ArgumentError` (Ruby constraint) and `Git::FailedError` (git rejection).
+
+   5. **The DSL infrastructure remains available.** The constraint methods in
+      `Git::Commands::Arguments` are kept intact. If a compelling case arises for
+      a specific constraint (e.g., preventing data loss that git silently allows),
+      it can be added on a case-by-case basis with documented justification.
+
+   **Exception policy — declare constraints only for arguments git cannot observe:**
+
+   The test: *does this argument appear in git's argv?*
+   - **Yes** (normal `flag_option`, `value_option`, etc.) → git can observe it and
+     report the error → do not declare a constraint.
+   - **No** (`skip_cli: true` arguments, or arguments transformed before reaching
+     argv) → git has no mechanism to detect incompatibilities → Ruby must enforce
+     them with a constraint declaration.
+
+   The canonical case is `skip_cli: true` operands routed via stdin. `cat-file
+   --batch` commands declare both `conflicts :objects, :batch_all_objects` and
+   `requires_one_of :objects, :batch_all_objects`. `:objects` is `skip_cli: true`
+   — git never sees it, only `:batch_all_objects` reaches argv. Git cannot detect
+   that you passed both (silent wrong result: dumps entire object database) or
+   neither (empty output with exit 0), so Ruby must enforce those constraints.
+
+   A secondary exception: if a combination of **git-visible** arguments causes
+   git to **silently discard data** (no error, wrong result), a `conflicts`
+   declaration MAY be added with: a code comment explaining why, a reference to
+   the git version(s) where the behavior was verified, and a test. As of this
+   writing, no such case has been identified.
+
 7. **Adapter methods should forward all positional arguments, not just options**
 
    **BUT ONLY IF BACKWARD COMPATIBILITY IS MAINTAINED**
@@ -504,7 +582,14 @@ future work:
     When using the Arguments DSL with patterns where optional positionals precede
     required ones (matching Ruby's parameter binding semantics), prefer the
     catch-all signature `def call(*, **)` and let `ARGS.bind(*, **)` handle
-    all validation:
+    all validation.
+
+    Note: `ARGS.bind` validates per-argument parameters — unknown options,
+    `required:`, `type:`, `allow_nil:`, and operand format (option-like operand
+    rejection). Cross-argument constraint methods (`conflicts`, `requires`,
+    `requires_one_of`, `requires_exactly_one_of`, `forbid_values`, `allowed_values`)
+    are also evaluated by `bind` when declared, but command classes generally do not
+    declare them (see Insight 6 validation delegation policy).
 
     ```ruby
     # git branch -m [<old-branch>] <new-branch>


### PR DESCRIPTION
Establish and document the formal policy that `Git::Commands::*` classes do not validate inter-option constraints for git-visible arguments. Command classes use per-argument validation parameters (`required:`, `type:`, `allow_nil:`, etc.) and operand format validation (option-like operand rejection before `--`). Git is the single source of truth for its own option semantics. The narrow exception is arguments that git cannot observe in its argv: if an argument is `skip_cli: true`, it never reaches git's argument parser and Ruby must enforce incompatibilities via `conflicts` and/or `requires_one_of`.

## Architecture documentation

- Add validation delegation policy to Insight 6 with two tables (what Commands validates vs. what git validates), design rationale, and exception criteria
- Exception policy: declare constraints only for arguments git cannot observe in its argv (the `skip_cli: true` rule), with `cat-file --batch` as the concrete example
- Clarify Insight 11 that `ARGS.bind` validates per-argument parameters only — not cross-argument constraint methods

## Skills updated to reference the policy

- **scaffold-new-command**: remove constraint-identification instructions; add per-argument validation completeness prompt (actively evaluate `required:`, `allow_nil:`, `type:`, `validator:` for each argument)
- **review-command-implementation**: update `#call` checklist and override guidance
- **review-arguments-dsl**: remove constraint review sections from `SKILL.md`; update `CHECKLIST.md` to add per-argument validation completeness table and reframe constraint absence as correct, not a gap
- **review-command-tests**: update validation test guidance; annotate the `cat-file` example as an instance of the `skip_cli: true` exception
- **project-context**: add validation boundary tables

Closes #1119