### PR TITLE
refactor(arguments): remove validator: param from flag_option public API

### DIFF
--- a/lib/git/commands/arguments.rb
+++ b/lib/git/commands/arguments.rb
@@ -412,13 +412,6 @@ module Git
     #   args_def.bind(timeout: "30")
     #   #=> raise ArgumentError, "The :timeout option must be a Integer or Float, but was a String"
     #
-    # The `type:` parameter cannot be combined with a custom `validator:` parameter.
-    # Attempting to use both will raise an ArgumentError during definition.
-    #
-    # Passing a non-`String` type (such as `Integer` or `Float`) is valid as long as
-    # its `#to_s` output is the intended CLI string. The `type:` check validates the
-    # Ruby class; `#to_s` handles the conversion (see the *String Conversion* section below).
-    #
     # ## String Conversion
     #
     # During the build phase, value-bearing option types (`value_option`,
@@ -575,8 +568,7 @@ module Git
     # raises ArgumentError with a descriptive message.
     #
     # This is typically used to model git options that accept only a fixed list of
-    # modes or strategies, and supersedes ad-hoc `validator:` lambdas for simple
-    # set-membership checks.
+    # modes or strategies.
     #
     # @example Restricting option values
     #   args_def = Arguments.define do
@@ -631,12 +623,6 @@ module Git
       # @param type [Class, Array<Class>, nil] expected type(s) for validation. Raises ArgumentError with
       #   descriptive message if value doesn't match.
       #
-      # @param validator [Proc, nil] optional validator proc; receives the bound value and
-      #   must return +true+ to indicate the value is valid, or return
-      #   a +String+ to raise ArgumentError using that string as the message, or return any
-      #   other non-true value to raise ArgumentError with a generic message. The proc may
-      #   also raise ArgumentError directly. Cannot be combined with type:.
-      #
       # @param negatable [Boolean] when true, outputs --no-flag when value is false (default: false)
       #
       # @param required [Boolean] whether the option must be provided (key must exist in opts)
@@ -675,9 +661,9 @@ module Git
       #   args_def.bind() #=> raise ArgumentError, "Required options not provided: :force"
       #   args_def.bind(force: nil) #=> raise ArgumentError, "Required options cannot be nil: :force"
       #
-      def flag_option(names, as: nil, type: nil, validator: nil, negatable: false, required: false, allow_nil: true)
+      def flag_option(names, as: nil, type: nil, negatable: false, required: false, allow_nil: true)
         option_type = negatable ? :negatable_flag : :flag
-        register_option(names, type: option_type, as: as, expected_type: type, validator: validator,
+        register_option(names, type: option_type, as: as, expected_type: type, validator: nil,
                                required: required, allow_nil: allow_nil)
       end
 

--- a/spec/unit/git/commands/arguments_spec.rb
+++ b/spec/unit/git/commands/arguments_spec.rb
@@ -1232,28 +1232,6 @@ RSpec.describe Git::Commands::Arguments do
       end
     end
 
-    context 'with validator on flag' do
-      let(:args) do
-        described_class.define do
-          flag_option :force, validator: ->(v) { [true, false].include?(v) }
-        end
-      end
-
-      it 'allows valid true value' do
-        expect(args.bind(force: true).to_ary).to eq(['--force'])
-      end
-
-      it 'allows valid false value' do
-        expect(args.bind(force: false).to_ary).to eq([])
-      end
-
-      it 'raises ArgumentError for invalid values' do
-        expect { args.bind(force: 'yes') }.to(
-          raise_error(ArgumentError, /Invalid value for option: force/)
-        )
-      end
-    end
-
     context 'with option aliases' do
       let(:args) do
         described_class.define do
@@ -1506,15 +1484,15 @@ RSpec.describe Git::Commands::Arguments do
           )
         end
       end
+    end
 
-      context 'when type: and validator: are both specified' do
-        it 'raises an error at definition time' do
-          expect do
-            described_class.define do
-              flag_option :single_branch, negatable: true, type: String, validator: ->(v) { [true, false].include?(v) }
-            end
-          end.to raise_error(ArgumentError, /cannot specify both type: and validator: for :single_branch/)
-        end
+    context 'when validator: is passed to flag_option' do
+      it 'raises ArgumentError at definition time' do
+        expect do
+          described_class.define do
+            flag_option :force, validator: ->(v) { [true, false].include?(v) }
+          end
+        end.to raise_error(ArgumentError, /unknown keyword: :validator/)
       end
     end
 


### PR DESCRIPTION
## Summary

Removes the `validator:` keyword parameter from `flag_option`'s public signature.

Fixes #1121

## Background

`flag_option` was the only DSL method that exposed a `validator:` parameter —
`value_option` and `operand` do not support it. A flag is essentially boolean
(`true`, `false`, or `nil`), so there is no realistic complex constraint that
requires a custom validator proc. The `type:` parameter already covers the only
useful type check (`TrueClass`/`FalseClass`).

Exposing `validator:` on `flag_option`:

1. **Contradicts the validation policy** — it invites custom constraint logic that
   should be delegated to git.
2. **Creates a false asymmetry** — it was present on the DSL method least likely to
   need it, and absent from `value_option`/`operand` where richer validation would
   at least make sense.
3. **Is dead code** — no command class used it.

## Changes

- **`lib/git/commands/arguments.rb`** — remove `validator:` from `flag_option`
  signature; it is now rejected by Ruby as an unknown keyword. Remove the
  `@param validator` YARD doc. Update class-level docs to remove references to
  `validator:` as a user-facing feature in the *Type Validation* and
  *Value Constraints* sections.
- **`spec/unit/git/commands/arguments_spec.rb`** — remove the `with validator on
  flag` context (3 examples) that tested now-removed behaviour. Replace the
  `type: and validator: both specified` context with a `when validator: is passed
  to flag_option` context that confirms `ArgumentError` is raised at definition
  time.

The internal validator mechanism (`run_validator!`, `apply_type_validator!`,
`create_type_validator`) is **unchanged** — it is still used by the `type:`
parameter path.
