### PR TITLE
refactor(command): migrate ls_tree/full_tree/tree_depth to Git::Commands::LsTree

### DIFF
--- a/.github/skills/review-command-implementation/SKILL.md
+++ b/.github/skills/review-command-implementation/SKILL.md
@@ -132,8 +132,11 @@ Shared behavior lives in `Base`:
 
 #### `#call` override guidance
 
-Most commands use `def call(...) = super`, which forwards all arguments to
-`Base#call` for binding, execution, and exit-status validation.
+Most commands use only a `# @!method call(*, **)` YARD directive with no
+explicit `def call` — the inherited `Base#call` handles binding, execution,
+and exit-status validation automatically. Do **not** add `def call(*, **) = super`
+or `def call(*, **) / super / end` for commands that need no custom logic; it
+adds no behavior and conflicts with the `@!method` directive.
 
 **Override `call` only when the command needs:**
 

--- a/.github/skills/scaffold-new-command/SKILL.md
+++ b/.github/skills/scaffold-new-command/SKILL.md
@@ -26,6 +26,9 @@ docs using the `Git::Commands::Base` architecture.
 - [Options completeness — consult the man page first](#options-completeness--consult-the-man-page-first)
 - [Execution-model conflicts are intentionally omitted](#execution-model-conflicts-are-intentionally-omitted)
 - [Exit status guidance](#exit-status-guidance)
+- [Common test generation mistakes](#common-test-generation-mistakes)
+  - [Unit tests](#unit-tests)
+  - [Integration tests](#integration-tests)
 - [Required review steps](#required-review-steps)
   - [Step 1 — Review Arguments DSL](#step-1--review-arguments-dsl)
   - [Step 2 — Review Command Tests](#step-2--review-command-tests)
@@ -420,6 +423,70 @@ allow_exit_status 0..1
 ```ruby
 # fsck uses exit codes 0-7 as bit flags for findings
 allow_exit_status 0..7
+```
+
+## Common test generation mistakes
+
+Apply these checks immediately after writing tests, before running the review skills.
+These are recurring mistakes that the review step should catch — but catching them at
+generation time avoids a rework loop.
+
+### Unit tests
+
+**Do not write string-variant pass-through tests for operands.** If the command
+accepts a positional operand (e.g. `tree_ish`, `stash_ref`, `commit`), write exactly
+one base-invocation test with a representative value (e.g. `'HEAD'`). Do not add a
+second test passing a different string (e.g. a SHA, a tag name, or a branch name) — it
+exercises the same code path as the base test. The DSL passes strings unchanged; there
+is nothing new to cover.
+
+**Put all validation cases in a single `context 'input validation'` block.** This
+means both required-argument violations and unsupported-option errors. Do **not** use
+a separate `context 'when X is missing'` block outside of `context 'input validation'`
+— it produces the same structure split across two places.
+
+```ruby
+# Correct — one 'input validation' block with all validation examples
+context 'input validation' do
+  it 'raises ArgumentError when tree_ish is missing' do
+    expect { command.call }.to raise_error(ArgumentError, /tree_ish/)
+  end
+
+  it 'raises ArgumentError for unsupported options' do
+    expect { command.call('HEAD', unknown: true) }
+      .to raise_error(ArgumentError, /Unsupported options/)
+  end
+end
+```
+
+### Integration tests
+
+**Do not assert on git's output content.** Integration tests confirm that the command
+executes against a real git repository — they are smoke tests, not output validators.
+Testing specific file names, SHA patterns, line counts, or any stdout content asserts
+git's formatting behavior, not the command's behavior. Every integration test in
+`context 'when the command succeeds'` should look like this:
+
+```ruby
+it 'returns a CommandLineResult' do
+  result = command.call('HEAD')
+  expect(result).to be_a(Git::CommandLineResult)
+end
+```
+
+When verifying that a command produces *some* output (e.g. for a listing command), it
+is acceptable to assert `expect(result.stdout).not_to be_empty` — but do not go
+further and assert what the content contains.
+
+**Add the Rule 22 version-variance comment on every bare `FailedError` assertion.**
+When a `raise_error(Git::FailedError)` assertion intentionally omits a message pattern
+(because the message varies by git version), add the required comment:
+
+```ruby
+it 'raises Git::FailedError for a nonexistent ref' do
+  # git's error message varies by version — Rule 22 version-variance exception applies
+  expect { command.call('nonexistent-ref') }.to raise_error(Git::FailedError)
+end
 ```
 
 ## Required review steps

--- a/lib/git/commands/ls_tree.rb
+++ b/lib/git/commands/ls_tree.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    # Implements the `git ls-tree` command
+    #
+    # Lists the contents of a tree object, showing the mode, type, object
+    # name, and file name of each item. Supports recursive listing, output
+    # format control, and path filtering.
+    #
+    # @see https://git-scm.com/docs/git-ls-tree git-ls-tree documentation
+    #
+    # @api private
+    #
+    # @example List the top-level tree of HEAD
+    #   ls_tree = Git::Commands::LsTree.new(execution_context)
+    #   ls_tree.call('HEAD')
+    #
+    # @example Recursively list all files under HEAD
+    #   ls_tree = Git::Commands::LsTree.new(execution_context)
+    #   ls_tree.call('HEAD', r: true)
+    #
+    # @example List only file names recursively
+    #   ls_tree = Git::Commands::LsTree.new(execution_context)
+    #   ls_tree.call('HEAD', r: true, name_only: true)
+    #
+    # @example List entries under a specific path
+    #   ls_tree = Git::Commands::LsTree.new(execution_context)
+    #   ls_tree.call('HEAD', 'lib/')
+    #
+    class LsTree < Git::Commands::Base
+      arguments do
+        literal 'ls-tree'
+
+        # Listing behavior
+        flag_option :d                                  # -d
+        flag_option :r                                  # -r
+        flag_option :t                                  # -t
+        flag_option %i[long l]                          # --long / -l (show object size)
+        flag_option :z                                  # -z (NUL termination)
+
+        # Output format
+        flag_option %i[name_only name_status]           # --name-only (alias: :name_status)
+        flag_option :object_only                        # --object-only
+        flag_option :full_name                          # --full-name
+        flag_option :full_tree                          # --full-tree
+        flag_or_value_option :abbrev, inline: true      # --abbrev[=<n>]
+        value_option :format, inline: true              # --format=<format>
+
+        operand :tree_ish, required: true               # <tree-ish>
+
+        end_of_options                                  # --
+
+        operand :path, repeatable: true                 # [<path>...]
+      end
+
+      # @!method call(*, **)
+      #
+      #   @overload call(tree_ish, *path, **options)
+      #
+      #     Execute the git ls-tree command
+      #
+      #     @param tree_ish [String] The tree object to list (SHA, branch name, tag, etc.)
+      #
+      #     @param path [Array<String>] Optional path(s) to restrict the listing. When given,
+      #       only entries matching these paths are shown.
+      #
+      #     @param options [Hash] command options
+      #
+      #     @option options [Boolean] :d (nil) Show only the named tree entry itself, not its
+      #       children. Only meaningful together with `:r`.
+      #
+      #     @option options [Boolean] :r (nil) Recurse into sub-trees.
+      #
+      #     @option options [Boolean] :t (nil) Show tree entries even when going to recurse
+      #       or truncate to a directory that would be shown in combination with `-r`.
+      #       Has no effect if `-r` was not passed. `-t` implies `-r`.
+      #
+      #     @option options [Boolean] :long (nil) Show object size of blob (file) objects.
+      #       Cannot be combined with `:name_only` or `:object_only`.
+      #
+      #       Alias: :l
+      #
+      #     @option options [Boolean] :z (nil) Use NUL (`\0`) as line terminator instead of
+      #       newline, and do not quote filenames.
+      #
+      #     @option options [Boolean] :name_only (nil) List only filenames, one per line.
+      #       Cannot be combined with `:long`.
+      #
+      #       Alias: :name_status
+      #
+      #     @option options [Boolean] :object_only (nil) List only the object names (SHAs),
+      #       one per line. Cannot be combined with `:long` or `:name_only`.
+      #
+      #     @option options [Boolean] :full_name (nil) Show full path names instead of paths
+      #       relative to the current working directory. Maps to `--full-name`.
+      #
+      #     @option options [Boolean] :full_tree (nil) Do not limit the listing to the current
+      #       working directory. Implies `:full_name`. Maps to `--full-tree`.
+      #
+      #     @option options [Boolean, String] :abbrev (nil) When `true`, use git's default
+      #       abbreviated object name length. When a string (e.g. `'8'`), use exactly that
+      #       many hex digits. Maps to `--abbrev[=<n>]`.
+      #
+      #     @option options [String] :format (nil) A format string that interpolates
+      #       `%(fieldname)` placeholders from tree entries. Maps to `--format=<format>`.
+      #
+      #     @return [Git::CommandLineResult] the result of calling `git ls-tree`
+      #
+      #     @raise [ArgumentError] if `:tree_ish` is not provided
+      #
+      #     @raise [ArgumentError] if unsupported options are provided
+      #
+      #     @raise [Git::FailedError] if the command returns a non-zero exit status
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -22,6 +22,7 @@ require_relative 'commands/grep'
 require_relative 'commands/init'
 require_relative 'commands/log'
 require_relative 'commands/ls_files'
+require_relative 'commands/ls_tree'
 require_relative 'commands/merge/start'
 require_relative 'commands/merge_base'
 require_relative 'commands/mv'
@@ -684,25 +685,29 @@ module Git
     end
     private_constant :RawLogParser
 
-    LS_TREE_OPTION_MAP = [
-      { keys: [:recursive], flag: '-r', type: :boolean }
-    ].freeze
+    # Allowed option keys for {#ls_tree}
+    LS_TREE_ALLOWED_OPTS = %i[recursive path].freeze
 
     def ls_tree(sha, opts = {})
+      assert_valid_opts(opts, LS_TREE_ALLOWED_OPTS)
+      r_value = opts[:recursive]
+      paths = Array(opts[:path]).compact
+      safe_options = {}
+      safe_options[:r] = r_value unless r_value.nil?
+      result = Git::Commands::LsTree.new(self).call(sha, *paths, **safe_options)
+      parse_ls_tree_output(result.stdout)
+    end
+
+    def parse_ls_tree_output(output)
       data = { 'blob' => {}, 'tree' => {}, 'commit' => {} }
-      args = build_args(opts, LS_TREE_OPTION_MAP)
-
-      args.unshift(sha)
-      args << opts[:path] if opts[:path]
-
-      command_capturing('ls-tree', *args).stdout.split("\n").each do |line|
+      output.split("\n").each do |line|
         (info, filenm) = split_status_line(line)
-        (mode, type, sha) = info.split
-        data[type][filenm] = { mode: mode, sha: sha }
+        (mode, type, entry_sha) = info.split
+        data[type][filenm] = { mode: mode, sha: entry_sha }
       end
-
       data
     end
+    private :parse_ls_tree_output
 
     # @return [String] the command output
     #
@@ -711,7 +716,7 @@ module Git
     end
 
     def full_tree(sha)
-      command_capturing('ls-tree', '-r', sha).stdout.split("\n")
+      Git::Commands::LsTree.new(self).call(sha, r: true).stdout.split("\n")
     end
 
     def tree_depth(sha)

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,17 +22,17 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (46/~50 commands migrated) |
+| Phase 2 | 🔄 In Progress | Migrating commands (47/~50 commands migrated) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate `ls_tree`** → `Git::Commands::LsTree`
+**Migrate `fetch`** → `Git::Commands::Fetch`
 
 #### Workflow
 
-1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def ls_files`). Understand all options and edge cases.
+1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def fetch`). Understand all options and edge cases.
 
 2. **Design**: Create command class following the pattern in
    `lib/git/commands/branch/delete.rb`. The interface for `#call` should only include
@@ -147,7 +147,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
    Parser classes and Result factories.
 
 6. **Verify**:
-   - `bundle exec rspec spec/unit/git/commands/ls_tree_spec.rb` — new tests pass
+   - `bundle exec rspec spec/unit/git/commands/fetch_spec.rb` — new tests pass
    - `bundle exec rspec` — all RSpec tests pass
    - `bundle exec rake test` — legacy TestUnit tests pass
    - `bundle exec rubocop` — no lint errors
@@ -891,6 +891,7 @@ The following tracks the migration status of commands from `Git::Lib` to
 | `log_commits` / `full_log_commits` | `Git::Commands::Log` | `spec/unit/git/commands/log_spec.rb` | `git log` |
 | `show` | `Git::Commands::Show` | `spec/unit/git/commands/show_spec.rb` | `git show` |
 | `describe` | `Git::Commands::Describe` | `spec/unit/git/commands/describe_spec.rb` | `git describe` |
+| `ls_tree` / `full_tree` / `tree_depth` | `Git::Commands::LsTree` | `spec/unit/git/commands/ls_tree_spec.rb` | `git ls-tree` |
 
 #### ⏳ Commands To Migrate
 
@@ -931,8 +932,7 @@ order: Basic Snapshotting → Branching & Merging → etc.
 - [x] `describe` → `Git::Commands::Describe` — `git describe`
 - [x] `grep` → `Git::Commands::Grep` — `git grep`
 - [x] `ls_files` → `Git::Commands::LsFiles` — `git ls-files`
-- [ ] `ls_tree` / `full_tree` / `tree_depth` → `Git::Commands::LsTree` — `git
-  ls-tree`
+- [x] `ls_tree` / `full_tree` / `tree_depth` → `Git::Commands::LsTree` — `git ls-tree`
 
 **Sharing & Updating:**
 

--- a/spec/integration/git/commands/ls_tree_spec.rb
+++ b/spec/integration/git/commands/ls_tree_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/ls_tree'
+
+RSpec.describe Git::Commands::LsTree, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    write_file('README.md', "# Hello\n")
+    write_file('lib/git.rb', "# git\n")
+    write_file('lib/git/base.rb', "# base\n")
+    repo.add('.')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult with output' do
+        result = command.call('HEAD')
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.stdout).not_to be_empty
+      end
+
+      context 'with the :r option (recursive)' do
+        it 'returns a CommandLineResult' do
+          result = command.call('HEAD', r: true)
+
+          expect(result).to be_a(Git::CommandLineResult)
+        end
+      end
+
+      context 'with the :name_only option' do
+        it 'returns a CommandLineResult' do
+          result = command.call('HEAD', r: true, name_only: true)
+
+          expect(result).to be_a(Git::CommandLineResult)
+        end
+      end
+
+      context 'with a path operand' do
+        it 'returns a CommandLineResult' do
+          result = command.call('HEAD', 'lib/')
+
+          expect(result).to be_a(Git::CommandLineResult)
+        end
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises Git::FailedError for a nonexistent tree-ish' do
+        # git's error message varies by version — Rule 22 version-variance exception applies
+        expect { command.call('nonexistent-sha-1234567') }.to raise_error(Git::FailedError)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/ls_tree_spec.rb
+++ b/spec/unit/git/commands/ls_tree_spec.rb
@@ -1,0 +1,176 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/ls_tree'
+
+RSpec.describe Git::Commands::LsTree do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with only the required tree_ish argument' do
+      it 'runs git ls-tree with only the tree-ish' do
+        expected_result = command_result
+        expect_command_capturing('ls-tree', 'HEAD').and_return(expected_result)
+
+        result = command.call('HEAD')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with the :d option' do
+      it 'adds -d to the command line' do
+        expect_command_capturing('ls-tree', '-d', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', d: true)
+      end
+    end
+
+    context 'with the :r option' do
+      it 'adds -r to the command line' do
+        expect_command_capturing('ls-tree', '-r', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', r: true)
+      end
+    end
+
+    context 'with the :t option' do
+      it 'adds -t to the command line' do
+        expect_command_capturing('ls-tree', '-t', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', t: true)
+      end
+    end
+
+    context 'with the :long option' do
+      it 'adds --long to the command line' do
+        expect_command_capturing('ls-tree', '--long', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', long: true)
+      end
+
+      it 'supports the :l alias' do
+        expect_command_capturing('ls-tree', '--long', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', l: true)
+      end
+    end
+
+    context 'with the :z option' do
+      it 'adds -z to the command line' do
+        expect_command_capturing('ls-tree', '-z', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', z: true)
+      end
+    end
+
+    context 'with the :name_only option' do
+      it 'adds --name-only to the command line' do
+        expect_command_capturing('ls-tree', '--name-only', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', name_only: true)
+      end
+    end
+
+    context 'with the :name_status option' do
+      it 'adds --name-only to the command line (name_status is an alias for name_only)' do
+        expect_command_capturing('ls-tree', '--name-only', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', name_status: true)
+      end
+    end
+
+    context 'with the :object_only option' do
+      it 'adds --object-only to the command line' do
+        expect_command_capturing('ls-tree', '--object-only', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', object_only: true)
+      end
+    end
+
+    context 'with the :full_name option' do
+      it 'adds --full-name to the command line' do
+        expect_command_capturing('ls-tree', '--full-name', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', full_name: true)
+      end
+    end
+
+    context 'with the :full_tree option' do
+      it 'adds --full-tree to the command line' do
+        expect_command_capturing('ls-tree', '--full-tree', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', full_tree: true)
+      end
+    end
+
+    context 'with the :abbrev option' do
+      it 'adds --abbrev when true' do
+        expect_command_capturing('ls-tree', '--abbrev', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', abbrev: true)
+      end
+
+      it 'adds --abbrev=<n> when a string is given' do
+        expect_command_capturing('ls-tree', '--abbrev=8', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', abbrev: '8')
+      end
+    end
+
+    context 'with the :format option' do
+      it 'adds --format=<format> to the command line' do
+        expect_command_capturing('ls-tree', '--format=%(objectname)', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', format: '%(objectname)')
+      end
+    end
+
+    context 'with a single path operand' do
+      it 'appends -- and the path after the tree-ish' do
+        expect_command_capturing('ls-tree', 'HEAD', '--', 'lib/').and_return(command_result)
+
+        command.call('HEAD', 'lib/')
+      end
+    end
+
+    context 'with multiple path operands' do
+      it 'appends -- and all paths after the tree-ish' do
+        expect_command_capturing('ls-tree', 'HEAD', '--', 'lib/', 'spec/').and_return(command_result)
+
+        command.call('HEAD', 'lib/', 'spec/')
+      end
+    end
+
+    context 'with options and path operands combined' do
+      it 'places flags before tree-ish, paths after --' do
+        expect_command_capturing('ls-tree', '-r', 'HEAD', '--', 'lib/').and_return(command_result)
+
+        command.call('HEAD', 'lib/', r: true)
+      end
+    end
+
+    context 'with :r and :t options combined' do
+      it 'adds both -r and -t to the command line' do
+        expect_command_capturing('ls-tree', '-r', '-t', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', r: true, t: true)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when tree_ish is missing' do
+        expect { command.call }.to raise_error(ArgumentError, /tree_ish/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('HEAD', unknown_flag: true) }.to(
+          raise_error(ArgumentError, /Unsupported options/)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Migrates `git ls-tree` from `Git::Lib` to a new `Git::Commands::LsTree` class as part of the Phase 2 Strangler Fig redesign (`redesign/3_architecture_implementation.md`).

## What changed

### `lib/git/commands/ls_tree.rb` (new)

New `Git::Commands::LsTree < Git::Commands::Base` class. The Arguments DSL maps the full `git ls-tree` option set from the man page:

- Listing behavior flags: `-d`, `-r`, `-t`, `--long`/`-l`, `-z`
- Output format flags: `--name-only` (alias `:name_status`), `--object-only`, `--full-name`, `--full-tree`, `--abbrev[=<n>]`, `--format=<format>`
- Positional operands: required `<tree-ish>`, optional repeatable `[<path>...]` (with `--` separator via `end_of_options`)

Note: `--name-only` and `--name-status` are documented git synonyms; modelled as `flag_option %i[name_only name_status]` so both Ruby keys emit `--name-only`.

### `lib/git/lib.rb` (modified)

- `#ls_tree`: delegates to `Git::Commands::LsTree`; translates legacy `:recursive` → `:r` and `:path` → positional splat; parsing extracted to `#parse_ls_tree_output` private helper
- `#full_tree`: delegates to `Git::Commands::LsTree` with `r: true`
- `#tree_depth`: unchanged (calls `full_tree(sha).size`)
- Removed `LS_TREE_OPTION_MAP` constant

### Skills updated

- `review-command-implementation/SKILL.md`: corrected guidance that incorrectly instructed adding `def call(*, **) = super` for simple commands (no override needed; `@!method` directive is sufficient)
- `scaffold-new-command/SKILL.md`: added "Common test generation mistakes" section covering string-variant operand tests, validation context grouping, integration test output assertions, and the Rule 22 version-variance comment pattern

## Tests

- **Unit** (`spec/unit/git/commands/ls_tree_spec.rb`): 21 examples covering all DSL options, aliases, operand combinations, and input validation
- **Integration** (`spec/integration/git/commands/ls_tree_spec.rb`): 5 smoke tests against a real repository plus one error-handling test

Full suite: 2300 examples, 0 failures, 2 pending (pre-existing skips unrelated to this change).

## Quality

- RuboCop: clean
- YARD: clean
- `bundle exec rake test`: 85 runs, 0 failures

## Checklist

- [x] All tests pass (`bundle exec rspec`, `bundle exec rake test`)
- [x] RuboCop clean (`bundle exec rubocop`)
- [x] YARD clean (`bundle exec rake yard`)
- [x] `redesign/3_architecture_implementation.md` updated (ls_tree marked ✅, progress 47/~50, next task → fetch)
- [x] Backward-compatible: `Git::Lib#ls_tree`, `#full_tree`, `#tree_depth` public API unchanged
- [x] Feature branch, not main
