### PR TITLE
docs: update implementation plan with actual progress

### DIFF
--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,7 +22,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (48/~50 commands migrated) |
+| Phase 2 | 🔄 In Progress | Migrating commands (29/54 checklist items done, 25 remaining) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 


### PR DESCRIPTION
## Summary

Reconcile the Phase 2 command migration checklist in
`redesign/3_architecture_implementation.md` with the current state tracked in
issue 1043.

## Changes

- **Add `ls_files` to the migrated commands summary table** — it was checked off
  in the To Migrate list but missing from the summary table above it.

- **Add two partially-migrated call sites** for commands where the
  `Git::Commands::*` class already exists but the `Git::Lib` delegation has not
  been updated yet:
  - `Git::Lib#unmerged` (`git diff`) — command classes already exist
  - `Git::Lib#diff_as_hash` (`git diff-files` / `git diff-index`) — command
    classes already exist

- **Annotate `commit_tree`** to note that `Git::Commands::CommitTree` already
  exists; only the `Git::Lib#commit_tree` delegation is missing.

- **Add 6 commands that were absent from the checklist entirely** (all
  documented in issue 1043 but not yet in the guide):
  - `status` → `Git::Commands::Status`
  - `show-ref` → `Git::Commands::ShowRef`
  - `write-tree` → `Git::Commands::WriteTree`
  - `gc` → `Git::Commands::Gc` (new **Administration** group)
  - `repack` → `Git::Commands::Repack`
  - `version` → `Git::Commands::Version`

Closes #1043 (tracking checklist gap — does not complete the migration work itself)