### PR TITLE
refactor(command): migrate Git::Lib#push to Git::Commands::Push

### DIFF
--- a/.github/skills/review-arguments-dsl/CHECKLIST.md
+++ b/.github/skills/review-arguments-dsl/CHECKLIST.md
@@ -157,6 +157,27 @@ Missing short aliases are a completeness defect, not just a convenience omission
 callers who pass the short key `:E` will get an `ArgumentError` rather than the
 expected flag.
 
+### Spurious short-flag aliases
+
+**Never invent a short-flag alias that the man page does not document.** Check the
+actual man page (or `man git-<subcommand>`) before adding any alias entry. The
+canonical audit is: does the git man page show `-X, --long-name` on the same option
+heading? If not, do not add `:X` to the alias list.
+
+A spurious alias looks correct to a reader but generates an unknown flag when git
+rejects it:
+
+```ruby
+# ❌ Wrong — git push has no -t flag; man page shows --tags only
+flag_option %i[tags t]   # emits -t → git: error: unknown switch 't'
+
+# ✅ Correct
+flag_option :tags        # emits --tags only
+```
+
+Flag any alias whose short character cannot be found in the man page's option
+headings as an error (not just a style issue).
+
 ## 3. Correct ordering
 
 Mirror the order options appear in the git-scm.com SYNOPSIS for the command. This

--- a/.github/skills/review-command-yard-documentation/SKILL.md
+++ b/.github/skills/review-command-yard-documentation/SKILL.md
@@ -229,6 +229,18 @@ Prefer interface-level wording (what callers can pass/expect), not internals.
   type and option key must not end with a period. This is easy to miss when
   transcribing from the git man page, which ends flag descriptions with periods.
   Run `bundle exec rake yard` to catch this — YARD treats any failure as fatal.
+- **Raw blank line inside a doc comment block** — a raw blank line (an empty line
+  with no leading `#`) silently terminates the YARD block. Any comment lines after
+  the raw blank line are dropped from generated docs. Replace every raw blank line
+  inside a block with a blank comment line (`#`). This is easy to miss in
+  continuation paragraphs and alias notes. Correct form:
+
+  ```ruby
+  # @option options [Boolean] :ipv4 (nil) Use IPv4 addresses only
+  #
+  #   Alias: :"4"
+  ```
+
 - **Multi-sentence short description without a blank comment line** — when an
   `@option` needs more than one sentence, the first sentence is the short description
   and all additional detail must go in a continuation paragraph separated by a blank

--- a/.github/skills/scaffold-new-command/SKILL.md
+++ b/.github/skills/scaffold-new-command/SKILL.md
@@ -397,6 +397,20 @@ explicit flags, model them as a single `flag_option :foo, negatable: true` rathe
 than two separate entries. This prevents contradictory combinations and makes the
 three-state semantics (`true` / `false` / `nil`) explicit.
 
+**Short-flag aliases — cross-check the man page:** before adding any short-flag
+alias (e.g. `%i[dry_run n]`), verify the alias character appears on the same option
+heading in the man page (`-n, --dry-run`). Do **not** invent an alias that the man
+page does not document — it will generate an unknown flag that git rejects.
+Symmetrically, every option the man page documents with a short form **must** have an
+alias in the DSL (long name first: `%i[dry_run n]`).
+
+**`inline: true` for `=<value>` options:** when the man page shows `--option=<value>`
+(with an `=`), the DSL entry must include `inline: true` regardless of whether the
+DSL method is `value_option` or `flag_or_value_option`. Without it, the value is
+emitted as a separate token (`--option value`) instead of the expected inline form
+(`--option=value`). Check every `value_option` and `flag_or_value_option` entry
+against the man page signature.
+
 **Constraint declarations are generally not used in command classes.** Do not add
 `conflicts`, `requires`, `requires_one_of`, `requires_exactly_one_of`,
 `forbid_values`, or `allowed_values` declarations to command classes. Git is the
@@ -498,6 +512,53 @@ context 'input validation' do
 end
 ```
 
+**Test both `true` and `false` for every negatable option.** A `flag_option :foo,
+negatable: true` or `flag_or_value_option :foo, negatable: true` has two distinct
+code paths: `true` emits `--foo` and `false` emits `--no-foo`. Both must be tested —
+omitting the `false` case is a Rule 21 branch coverage failure. When the option also
+accepts a String, test that form too (see `force_with_lease`, `signed`,
+`recurse_submodules` for examples).
+
+```ruby
+context 'with the :verify option' do
+  it 'adds --verify when true' do
+    expect_command_capturing('push', '--verify').and_return(command_result)
+    command.call(verify: true)
+  end
+
+  it 'adds --no-verify when false' do
+    expect_command_capturing('push', '--no-verify').and_return(command_result)
+    command.call(verify: false)
+  end
+end
+```
+
+**Test every DSL alias.** When a DSL entry groups keys in an array
+(`flag_option %i[dry_run n]`, `value_option %i[receive_pack exec]`), every alias
+beyond the primary key must have its own `it` block verifying the canonical flag is
+emitted. Do not assume the primary-key test covers the alias — the DSL wires them
+independently and an alias misconfiguration would go undetected.
+
+```ruby
+# DSL: flag_option %i[dry_run n]
+# ✅ Both tested:
+it 'adds --dry-run to the command line' do
+  expect_command_capturing('push', '--dry-run').and_return(command_result)
+  command.call(dry_run: true)
+end
+
+it 'supports the :n alias' do
+  expect_command_capturing('push', '--dry-run').and_return(command_result)
+  command.call(n: true)
+end
+```
+
+**Do not test `option: false` for non-negatable flags.** Passing `false` to a
+`flag_option` declared without `negatable: true` produces no CLI output — the same
+code path as the base invocation with no options. The "no arguments" test already
+covers this path. Do not write `command.call(prune: false)` or similar for flags
+that have no `--no-<flag>` form.
+
 ### Integration tests
 
 **Creating the integration test file is mandatory.** Every new command MUST have a
@@ -536,8 +597,9 @@ RSpec.describe Git::Commands::Foo, :integration do
 
     context 'when the command fails' do
       it 'raises FailedError for an invalid argument' do
-        # git's error message varies by version — Rule 22 version-variance exception applies
-        expect { command.call('nonexistent-ref') }.to raise_error(Git::FailedError)
+        # git's error message phrasing varies by version — anchor on the stable input value
+        expect { command.call('nonexistent-ref') }
+          .to raise_error(Git::FailedError, /nonexistent-ref/)
       end
     end
   end
@@ -580,13 +642,21 @@ When verifying that a command produces *some* output (e.g. for a listing command
 is acceptable to assert `expect(result.stdout).not_to be_empty` — but do not go
 further and assert what the content contains.
 
-**Add the Rule 22 version-variance comment on every bare `FailedError` assertion.**
-When a `raise_error(Git::FailedError)` assertion intentionally omits a message pattern
-(because the message varies by git version), add the required comment:
+**Always include a message pattern on `FailedError` assertions.** Rule 22 requires
+both an error class and a message pattern — the version-variance exception never
+permits omitting the pattern entirely; it only permits using a loose regexp. Use the
+stable input value you passed (e.g., `'nonexistent-ref'`) as the anchor:
 
 ```ruby
-it 'raises Git::FailedError for a nonexistent ref' do
-  # git's error message varies by version — Rule 22 version-variance exception applies
+# ✅ Correct — anchors on the stable input value, tolerates phrasing differences
+it 'raises FailedError for a nonexistent ref' do
+  # git's error message phrasing varies by version — anchor on the stable input value
+  expect { command.call('nonexistent-ref') }
+    .to raise_error(Git::FailedError, /nonexistent-ref/)
+end
+
+# ❌ Wrong — omits the message pattern; passes for any FailedError regardless of cause
+it 'raises FailedError for a nonexistent ref' do
   expect { command.call('nonexistent-ref') }.to raise_error(Git::FailedError)
 end
 ```

--- a/.github/skills/write-yard-documentation/SKILL.md
+++ b/.github/skills/write-yard-documentation/SKILL.md
@@ -55,6 +55,34 @@ etc.) or `@!word` (directives such as `@!attribute`, `@!method`, `@!scope`, etc.
 Within the tag block there are no other exceptions: consecutive same-kind tags (e.g.
 multiple `@param` lines) each require their own preceding blank line.
 
+**Never use raw blank lines inside a doc comment block**
+
+A raw blank line — an empty line with no leading `#` — terminates the YARD doc
+comment block at that point. Any comment lines that follow the raw blank line are
+treated as separate, unattached comments and will not appear in the generated
+documentation. Always use a blank comment line (`#`) to separate paragraphs or
+continuation text within a YARD block:
+
+Correct — blank comment line keeps the block intact:
+
+```ruby
+# @option options [Boolean] :ipv4 (nil) Use IPv4 addresses only
+#
+#   Alias: :"4"
+```
+
+Incorrect — raw blank line silently drops the alias note:
+
+```ruby
+# @option options [Boolean] :ipv4 (nil) Use IPv4 addresses only
+
+#   Alias: :"4"
+```
+
+This is especially easy to miss in multi-paragraph `@option` or `@param`
+descriptions where an editor's auto-formatter strips trailing spaces and removes
+the `#` from what appeared to be a blank comment line.
+
 Correct:
 
 ```ruby

--- a/lib/git/commands/push.rb
+++ b/lib/git/commands/push.rb
@@ -1,0 +1,232 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    # Encapsulates the `git push` command
+    #
+    # Updates remote refs using local refs, while sending objects necessary to
+    # complete the given refs.
+    #
+    # @see https://git-scm.com/docs/git-push git-push documentation
+    #
+    # @api private
+    #
+    # @example Push to the default remote
+    #   push = Git::Commands::Push.new(execution_context)
+    #   push.call
+    #
+    # @example Push to a named remote
+    #   push = Git::Commands::Push.new(execution_context)
+    #   push.call('origin')
+    #
+    # @example Push a specific branch to a remote
+    #   push = Git::Commands::Push.new(execution_context)
+    #   push.call('origin', 'main')
+    #
+    # @example Force push to a remote branch
+    #   push = Git::Commands::Push.new(execution_context)
+    #   push.call('origin', 'main', force: true)
+    #
+    # @example Push with a server-side option
+    #   push = Git::Commands::Push.new(execution_context)
+    #   push.call('origin', push_option: 'ci.skip')
+    #
+    # @example Push all tags to a remote
+    #   push = Git::Commands::Push.new(execution_context)
+    #   push.call('origin', tags: true)
+    #
+    class Push < Git::Commands::Base
+      arguments do
+        literal 'push'
+
+        # Push scope (SYNOPSIS order: [--all | --branches | --mirror | --tags])
+        flag_option %i[all branches]                               # --all
+        flag_option :mirror                                        # --mirror
+        flag_option :tags                                          # --tags
+        flag_option :follow_tags, negatable: true                  # --follow-tags / --no-follow-tags
+        flag_option :atomic, negatable: true                       # --atomic / --no-atomic
+
+        # Transfer options
+        flag_option %i[dry_run n]                                  # --dry-run
+        flag_option :porcelain                                     # --porcelain
+        value_option %i[receive_pack exec], inline: true           # --receive-pack=<git-receive-pack>
+        value_option :repo, inline: true                           # --repo=<repository>
+
+        # Safety
+        flag_option %i[force f]                                    # --force
+        flag_option %i[delete d]                                   # --delete
+        flag_option :prune                                         # --prune
+
+        # Output verbosity
+        flag_option %i[quiet q]                                    # --quiet
+        flag_option %i[verbose v]                                  # --verbose
+
+        # Tracking
+        flag_option %i[set_upstream u] # --set-upstream
+
+        # Push options (server-side)
+        value_option %i[push_option o], repeatable: true, inline: true # --push-option=<value>
+
+        # GPG signing
+        flag_or_value_option :signed, # --signed[=(true|false|if-asked)] / --no-signed
+                             negatable: true, inline: true
+
+        # Force safety
+        flag_or_value_option :force_with_lease,                    # --force-with-lease[=<refname>:<expect>]
+                             negatable: true, inline: true         # --no-force-with-lease
+        flag_option :force_if_includes, negatable: true            # --force-if-includes / --no-force-if-includes
+
+        # Hooks
+        flag_option :verify, negatable: true # --verify / --no-verify
+
+        # Submodules
+        flag_or_value_option :recurse_submodules, # --recurse-submodules=(...) / --no-recurse-submodules
+                             negatable: true, inline: true, type: [String, FalseClass]
+
+        # Transfer
+        flag_option :thin, negatable: true                         # --thin / --no-thin
+        flag_option :progress                                      # --progress
+
+        # Protocol and connectivity
+        flag_option %i[ipv4 4]                                     # --ipv4
+        flag_option %i[ipv6 6]                                     # --ipv6
+
+        # Execution options (not emitted as CLI flags)
+        execution_option :timeout
+
+        end_of_options
+
+        operand :repository                                        # [<repository>]
+        operand :refspec, repeatable: true                         # [<refspec>…]
+      end
+
+      # @!method call(*, **)
+      #
+      #   Execute the `git push` command
+      #
+      #   @overload call(repository = nil, *refspecs, **options)
+      #
+      #     @param repository [String, nil] The remote name or URL to push to
+      #
+      #       When nil, git uses the default remote configured for the current branch.
+      #
+      #     @param refspecs [Array<String>] Zero or more refspecs specifying which refs to push
+      #
+      #       Each may be a branch name or a full refspec pattern such as
+      #       `refs/heads/main:refs/heads/main`. When no refspecs are given, git uses
+      #       the push configuration for the current branch.
+      #
+      #     @param options [Hash] command options
+      #
+      #     @option options [Boolean] :all (nil) Push all branches
+      #
+      #       Alias: :branches
+      #
+      #     @option options [Boolean] :mirror (nil) Push all refs under `refs/` to the remote
+      #
+      #     @option options [Boolean] :tags (nil) Push all refs under `refs/tags/`
+      #
+      #     @option options [Boolean] :follow_tags (nil) Push annotated tags reachable from pushed commits
+      #
+      #       Pass `false` to emit `--no-follow-tags`.
+      #
+      #     @option options [Boolean] :atomic (nil) Use an atomic transaction to update remote refs
+      #
+      #       Pass `false` to emit `--no-atomic`.
+      #
+      #     @option options [Boolean] :dry_run (nil) Do not send updates, only report what would be pushed
+      #
+      #       Alias: :n
+      #
+      #     @option options [Boolean] :porcelain (nil) Produce machine-readable output
+      #
+      #     @option options [String] :receive_pack (nil) Path to the git-receive-pack program on the remote end
+      #
+      #       Alias: :exec
+      #
+      #     @option options [String] :repo (nil) Use this repository instead of the
+      #       positional repository argument
+      #
+      #       Equivalent to the positional `<repository>` argument. If both are given, the
+      #       positional argument takes precedence.
+      #
+      #     @option options [Boolean] :force (nil) Force updates, overriding the fast-forward check
+      #
+      #       Alias: :f
+      #
+      #     @option options [Boolean] :delete (nil) Delete all listed refs from the remote repository
+      #
+      #       Alias: :d
+      #
+      #     @option options [Boolean] :prune (nil) Remove remote branches that have no local counterpart
+      #
+      #     @option options [Boolean] :quiet (nil) Suppress all output
+      #
+      #       Alias: :q
+      #
+      #     @option options [Boolean] :verbose (nil) Run verbosely
+      #
+      #       Alias: :v
+      #
+      #     @option options [Boolean] :set_upstream (nil) Set upstream tracking for each successfully pushed branch
+      #
+      #       Alias: :u
+      #
+      #     @option options [String, Array<String>] :push_option (nil) Transmit one or more server-side options
+      #
+      #       Repeatable. Each occurrence emits a separate `--push-option=<value>` flag.
+      #
+      #       Alias: :o
+      #
+      #     @option options [Boolean, String] :signed (nil) GPG-sign the push certificate
+      #
+      #       When `true`, emits `--signed`. When a String (`'true'`, `'false'`, `'if-asked'`), passes
+      #       that value. When `false`, emits `--no-signed`.
+      #
+      #     @option options [Boolean, String] :force_with_lease (nil) Refuse force pushes unless the remote
+      #       ref matches the expected value
+      #
+      #       When `true`, emits `--force-with-lease`. When a String (e.g. `'main:abc123'`), emits
+      #       `--force-with-lease=<string>`. When `false`, emits `--no-force-with-lease`.
+      #
+      #     @option options [Boolean] :force_if_includes (nil) Force pushes only if commits being
+      #       pushed are already in the remote-tracking branch
+      #
+      #       Pass `false` to emit `--no-force-if-includes`.
+      #
+      #     @option options [Boolean] :verify (nil) Control pre-push hook execution
+      #
+      #       Pass `false` to emit `--no-verify`, bypassing the pre-push hook.
+      #
+      #     @option options [String, FalseClass] :recurse_submodules (nil) Control whether submodule
+      #       commits are pushed
+      #
+      #       Pass a String (`'check'`, `'on-demand'`, `'only'`, `'no'`) to emit
+      #       `--recurse-submodules=<value>`. When `false`, emits `--no-recurse-submodules`.
+      #       Note: passing `true` is not valid; git requires an explicit value for this option.
+      #
+      #     @option options [Boolean] :thin (nil) Send a "thin" pack to reduce network traffic
+      #
+      #       Pass `false` to emit `--no-thin`.
+      #
+      #     @option options [Boolean] :progress (nil) Force progress reporting even when stderr is not a terminal
+      #
+      #     @option options [Boolean] :ipv4 (nil) Use IPv4 addresses only
+      #
+      #       Alias: :"4"
+      #
+      #     @option options [Boolean] :ipv6 (nil) Use IPv6 addresses only
+      #
+      #       Alias: :"6"
+      #
+      #     @option options [Integer] :timeout (nil) Maximum seconds to wait for the command to complete
+      #
+      #     @return [Git::CommandLineResult] the result of calling `git push`
+      #
+      #     @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -28,6 +28,7 @@ require_relative 'commands/merge/start'
 require_relative 'commands/merge_base'
 require_relative 'commands/mv'
 require_relative 'commands/pull'
+require_relative 'commands/push'
 require_relative 'commands/reset'
 require_relative 'commands/rm'
 require_relative 'commands/show'
@@ -1720,29 +1721,104 @@ module Git
       Git::Commands::Fetch.new(self).call(*positionals, **opts, merge: true).stdout
     end
 
-    PUSH_OPTION_MAP = [
-      { keys: [:mirror],      flag: '--mirror',      type: :boolean },
-      { keys: [:delete],      flag: '--delete',      type: :boolean },
-      { keys: %i[force f], flag: '--force', type: :boolean },
-      { keys: [:push_option], flag: '--push-option', type: :repeatable_valued_space },
-      { keys: [:all],         type: :validate_only }, # For validation purposes
-      { keys: [:tags],        type: :validate_only }  # From the `push` method's logic
-    ].freeze
+    PUSH_ALLOWED_OPTS = %i[mirror delete force f push_option all tags].freeze
 
+    # Push refs to a remote repository
+    #
+    # @overload push(options = {})
+    #   Push using the current branch's default remote and push configuration
+    #
+    #   @param options [Hash] push options
+    #
+    #   @option options [Boolean] :all (nil) Push all branches
+    #
+    #   @option options [Boolean] :mirror (nil) Push all refs
+    #
+    #   @option options [Boolean] :tags (nil) Push all tags
+    #
+    #   @option options [Boolean] :force (nil) Force updates
+    #
+    #   @option options [Boolean] :delete (nil) Delete the named remote ref
+    #
+    #   @option options [String, Array<String>] :push_option (nil) Server-side push option values
+    #
+    #   @return [String] the stdout from the final `git push` invocation
+    #
+    #   @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    # @overload push(remote, options = {})
+    #   Push to the given remote using the current branch's default push configuration
+    #
+    #   @param remote [String] the remote name or URL to push to
+    #
+    #   @param options [Hash] push options
+    #
+    #   @option options [Boolean] :all (nil) Push all branches
+    #
+    #   @option options [Boolean] :mirror (nil) Push all refs
+    #
+    #   @option options [Boolean] :tags (nil) Push all tags
+    #
+    #   @option options [Boolean] :force (nil) Force updates
+    #
+    #   @option options [Boolean] :delete (nil) Delete the named remote ref
+    #
+    #   @option options [String, Array<String>] :push_option (nil) Server-side push option values
+    #
+    #   @return [String] the stdout from the final `git push` invocation
+    #
+    #   @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    # @overload push(remote, branch, options = {})
+    #   Push a branch or refspec to the given remote
+    #
+    #   @param remote [String] the remote name or URL to push to
+    #
+    #   @param branch [String] the branch name or refspec to push
+    #
+    #   @param options [Hash] push options
+    #
+    #   @option options [Boolean] :all (nil) Push all branches
+    #
+    #   @option options [Boolean] :mirror (nil) Push all refs
+    #
+    #   @option options [Boolean] :tags (nil) Push all tags
+    #
+    #   @option options [Boolean] :force (nil) Force updates
+    #
+    #   @option options [Boolean] :delete (nil) Delete the named remote ref
+    #
+    #   @option options [String, Array<String>] :push_option (nil) Server-side push option values
+    #
+    #   @return [String] the stdout from the final `git push` invocation
+    #
+    #   @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    #   @raise [ArgumentError] if `remote` is nil
+    #
+    # @overload push(remote, branch, tags)
+    #   Backward-compatible shorthand for `push(remote, branch, tags: tags)`
+    #
+    #   @param remote [String] the remote name or URL to push to
+    #
+    #   @param branch [String] the branch name or refspec to push
+    #
+    #   @param tags [Boolean] whether to push all tags
+    #
+    #   @return [String] the stdout from the final `git push` invocation
+    #
+    #   @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    #   @raise [ArgumentError] if `remote` is nil
+    #
     def push(remote = nil, branch = nil, opts = nil)
       remote, branch, opts = normalize_push_args(remote, branch, opts)
-      ArgsBuilder.validate!(opts, PUSH_OPTION_MAP)
+      validate_push_args!(remote, branch, opts)
 
-      raise ArgumentError, 'remote is required if branch is specified' if !remote && branch
+      first_result = push_refs(remote, branch, opts)
+      return first_result.stdout unless push_tags_separately?(opts)
 
-      args = build_push_args(remote, branch, opts)
-
-      if opts[:mirror]
-        command_capturing('push', *args)
-      else
-        command_capturing('push', *args)
-        command_capturing('push', '--tags', *(args - [branch].compact)) if opts[:tags]
-      end
+      push_tags(remote, opts).stdout
     end
 
     PULL_ALLOWED_OPTS = %i[allow_unrelated_histories].freeze
@@ -2512,15 +2588,22 @@ module Git
       [remote, branch, opts]
     end
 
-    def build_push_args(remote, branch, opts)
-      # Build the simple flags using the ArgsBuilder
-      args = build_args(opts, PUSH_OPTION_MAP)
+    def validate_push_args!(remote, branch, opts)
+      assert_valid_opts(opts, PUSH_ALLOWED_OPTS)
+      raise ArgumentError, 'remote is required if branch is specified' if !remote && branch
+    end
 
-      # Manually handle the flag with external dependencies and positional args
-      args << '--all' if opts[:all] && remote
-      args << remote if remote
-      args << branch if branch
-      args
+    def push_refs(remote, branch, opts)
+      positionals = [remote, branch].compact
+      Git::Commands::Push.new(self).call(*positionals, **opts.except(:tags))
+    end
+
+    def push_tags_separately?(opts)
+      opts[:tags] && !opts[:mirror]
+    end
+
+    def push_tags(remote, opts)
+      Git::Commands::Push.new(self).call(*[remote].compact, **opts)
     end
 
     def temp_file_name

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,13 +22,13 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (30/54 checklist items done, 24 remaining) |
+| Phase 2 | 🔄 In Progress | Migrating commands (31/54 checklist items done, 23 remaining) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate `push`** → `Git::Commands::Push`
+**Migrate `remote_add` / `remote_remove` / `remote_set_url` / `remote_set_branches`** → `Git::Commands::Remote`
 
 #### Workflow
 
@@ -895,6 +895,7 @@ The following tracks the migration status of commands from `Git::Lib` to
 | `ls_tree` / `full_tree` / `tree_depth` | `Git::Commands::LsTree` | `spec/unit/git/commands/ls_tree_spec.rb` | `git ls-tree` |
 | `fetch` | `Git::Commands::Fetch` | `spec/unit/git/commands/fetch_spec.rb` | `git fetch` |
 | `pull` | `Git::Commands::Pull` | `spec/unit/git/commands/pull_spec.rb` | `git pull` |
+| `push` | `Git::Commands::Push` | `spec/unit/git/commands/push_spec.rb` | `git push` |
 
 #### ⏳ Commands To Migrate
 
@@ -948,7 +949,7 @@ order: Basic Snapshotting → Branching & Merging → etc.
 
 - [x] `fetch` → `Git::Commands::Fetch` — `git fetch`
 - [x] `pull` → `Git::Commands::Pull` — `git pull`
-- [ ] `push` → `Git::Commands::Push` — `git push`
+- [x] `push` → `Git::Commands::Push` — `git push`
 - [ ] `remote_add` / `remote_remove` / `remote_set_url` / `remote_set_branches` →
   `Git::Commands::Remote` — `git remote`
 - [ ] `ls_remote` → `Git::Commands::LsRemote` — `git ls-remote`

--- a/spec/integration/git/commands/push_spec.rb
+++ b/spec/integration/git/commands/push_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/push'
+
+RSpec.describe Git::Commands::Push, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  let(:bare_dir) { Dir.mktmpdir('bare_repo') }
+
+  after do
+    FileUtils.rm_rf(bare_dir)
+  end
+
+  describe '#call' do
+    before do
+      write_file('file.txt', 'content')
+      repo.add('file.txt')
+      repo.commit('Initial commit')
+
+      Git.init(bare_dir, bare: true)
+      repo.add_remote('origin', bare_dir)
+    end
+
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult' do
+        result = command.call('origin', 'main')
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns result with exit status 0' do
+        result = command.call('origin', 'main')
+
+        expect(result.status.exitstatus).to eq(0)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError when remote does not exist' do
+        # git's error message phrasing varies by version — anchor on the stable input value
+        expect { command.call('nonexistent-remote', 'main') }
+          .to raise_error(Git::FailedError, /nonexistent-remote/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/push_spec.rb
+++ b/spec/unit/git/commands/push_spec.rb
@@ -1,0 +1,420 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/push'
+
+RSpec.describe Git::Commands::Push do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with no arguments' do
+      it 'runs git push with no positional arguments' do
+        expected_result = command_result
+        expect_command_capturing('push').and_return(expected_result)
+
+        result = command.call
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with a repository argument' do
+      it 'adds the end-of-options separator before the repository operand' do
+        expect_command_capturing('push', '--', 'origin').and_return(command_result)
+
+        command.call('origin')
+      end
+    end
+
+    context 'with a repository and refspec' do
+      it 'adds -- and then repository and refspec' do
+        expect_command_capturing('push', '--', 'origin', 'main').and_return(command_result)
+
+        command.call('origin', 'main')
+      end
+    end
+
+    context 'with a repository and multiple refspecs' do
+      it 'adds -- and then repository and all refspecs' do
+        expect_command_capturing('push', '--', 'origin', 'main', 'develop').and_return(command_result)
+
+        command.call('origin', 'main', 'develop')
+      end
+    end
+
+    context 'with the :verbose option' do
+      it 'adds --verbose to the command line' do
+        expect_command_capturing('push', '--verbose').and_return(command_result)
+
+        command.call(verbose: true)
+      end
+
+      it 'supports the :v alias' do
+        expect_command_capturing('push', '--verbose').and_return(command_result)
+
+        command.call(v: true)
+      end
+    end
+
+    context 'with the :quiet option' do
+      it 'adds --quiet to the command line' do
+        expect_command_capturing('push', '--quiet').and_return(command_result)
+
+        command.call(quiet: true)
+      end
+
+      it 'supports the :q alias' do
+        expect_command_capturing('push', '--quiet').and_return(command_result)
+
+        command.call(q: true)
+      end
+    end
+
+    context 'with the :all option' do
+      it 'adds --all when true' do
+        expect_command_capturing('push', '--all').and_return(command_result)
+
+        command.call(all: true)
+      end
+
+      it 'supports the :branches alias' do
+        expect_command_capturing('push', '--all').and_return(command_result)
+
+        command.call(branches: true)
+      end
+    end
+
+    context 'with the :prune option' do
+      it 'adds --prune to the command line' do
+        expect_command_capturing('push', '--prune').and_return(command_result)
+
+        command.call(prune: true)
+      end
+    end
+
+    context 'with the :mirror option' do
+      it 'adds --mirror to the command line' do
+        expect_command_capturing('push', '--mirror').and_return(command_result)
+
+        command.call(mirror: true)
+      end
+    end
+
+    context 'with the :delete option' do
+      it 'adds --delete to the command line' do
+        expect_command_capturing('push', '--delete').and_return(command_result)
+
+        command.call(delete: true)
+      end
+
+      it 'supports the :d alias' do
+        expect_command_capturing('push', '--delete').and_return(command_result)
+
+        command.call(d: true)
+      end
+    end
+
+    context 'with the :tags option' do
+      it 'adds --tags to the command line' do
+        expect_command_capturing('push', '--tags').and_return(command_result)
+
+        command.call(tags: true)
+      end
+    end
+
+    context 'with the :follow_tags option' do
+      it 'adds --follow-tags when true' do
+        expect_command_capturing('push', '--follow-tags').and_return(command_result)
+
+        command.call(follow_tags: true)
+      end
+
+      it 'adds --no-follow-tags when false' do
+        expect_command_capturing('push', '--no-follow-tags').and_return(command_result)
+
+        command.call(follow_tags: false)
+      end
+    end
+
+    context 'with the :atomic option' do
+      it 'adds --atomic when true' do
+        expect_command_capturing('push', '--atomic').and_return(command_result)
+
+        command.call(atomic: true)
+      end
+
+      it 'adds --no-atomic when false' do
+        expect_command_capturing('push', '--no-atomic').and_return(command_result)
+
+        command.call(atomic: false)
+      end
+    end
+
+    context 'with the :force option' do
+      it 'adds --force to the command line' do
+        expect_command_capturing('push', '--force').and_return(command_result)
+
+        command.call(force: true)
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('push', '--force').and_return(command_result)
+
+        command.call(f: true)
+      end
+    end
+
+    context 'with the :force_with_lease option' do
+      it 'adds --force-with-lease when true' do
+        expect_command_capturing('push', '--force-with-lease').and_return(command_result)
+
+        command.call(force_with_lease: true)
+      end
+
+      it 'adds --no-force-with-lease when false' do
+        expect_command_capturing('push', '--no-force-with-lease').and_return(command_result)
+
+        command.call(force_with_lease: false)
+      end
+
+      it 'adds --force-with-lease=<value> when given a string' do
+        expect_command_capturing('push', '--force-with-lease=main:abc123').and_return(command_result)
+
+        command.call(force_with_lease: 'main:abc123')
+      end
+    end
+
+    context 'with the :force_if_includes option' do
+      it 'adds --force-if-includes when true' do
+        expect_command_capturing('push', '--force-if-includes').and_return(command_result)
+
+        command.call(force_if_includes: true)
+      end
+
+      it 'adds --no-force-if-includes when false' do
+        expect_command_capturing('push', '--no-force-if-includes').and_return(command_result)
+
+        command.call(force_if_includes: false)
+      end
+    end
+
+    context 'with the :set_upstream option' do
+      it 'adds --set-upstream to the command line' do
+        expect_command_capturing('push', '--set-upstream').and_return(command_result)
+
+        command.call(set_upstream: true)
+      end
+
+      it 'supports the :u alias' do
+        expect_command_capturing('push', '--set-upstream').and_return(command_result)
+
+        command.call(u: true)
+      end
+    end
+
+    context 'with the :receive_pack option' do
+      it 'adds --receive-pack=<value> to the command line' do
+        expect_command_capturing('push', '--receive-pack=git-receive-pack').and_return(command_result)
+
+        command.call(receive_pack: 'git-receive-pack')
+      end
+
+      it 'supports the :exec alias' do
+        expect_command_capturing('push', '--receive-pack=git-receive-pack').and_return(command_result)
+
+        command.call(exec: 'git-receive-pack')
+      end
+    end
+
+    context 'with the :repo option' do
+      it 'adds --repo=<value> to the command line' do
+        expect_command_capturing('push', '--repo=origin').and_return(command_result)
+
+        command.call(repo: 'origin')
+      end
+
+      it 'includes both --repo and the positional repository when both are given' do
+        expect_command_capturing('push', '--repo=upstream', '--', 'origin', 'main').and_return(command_result)
+
+        command.call('origin', 'main', repo: 'upstream')
+      end
+    end
+
+    context 'with the :recurse_submodules option' do
+      it 'raises ArgumentError when true is passed' do
+        expect { command.call(recurse_submodules: true) }
+          .to raise_error(ArgumentError,
+                          /The :recurse_submodules option must be a String or FalseClass, but was a TrueClass/)
+      end
+
+      it 'adds --no-recurse-submodules when false' do
+        expect_command_capturing('push', '--no-recurse-submodules').and_return(command_result)
+
+        command.call(recurse_submodules: false)
+      end
+
+      it 'adds --recurse-submodules=<value> when given a string' do
+        expect_command_capturing('push', '--recurse-submodules=check').and_return(command_result)
+
+        command.call(recurse_submodules: 'check')
+      end
+    end
+
+    context 'with the :thin option' do
+      it 'adds --thin when true' do
+        expect_command_capturing('push', '--thin').and_return(command_result)
+
+        command.call(thin: true)
+      end
+
+      it 'adds --no-thin when false' do
+        expect_command_capturing('push', '--no-thin').and_return(command_result)
+
+        command.call(thin: false)
+      end
+    end
+
+    context 'with the :dry_run option' do
+      it 'adds --dry-run to the command line' do
+        expect_command_capturing('push', '--dry-run').and_return(command_result)
+
+        command.call(dry_run: true)
+      end
+
+      it 'supports the :n alias' do
+        expect_command_capturing('push', '--dry-run').and_return(command_result)
+
+        command.call(n: true)
+      end
+    end
+
+    context 'with the :porcelain option' do
+      it 'adds --porcelain to the command line' do
+        expect_command_capturing('push', '--porcelain').and_return(command_result)
+
+        command.call(porcelain: true)
+      end
+    end
+
+    context 'with the :progress option' do
+      it 'adds --progress to the command line' do
+        expect_command_capturing('push', '--progress').and_return(command_result)
+
+        command.call(progress: true)
+      end
+    end
+
+    context 'with the :verify option' do
+      it 'adds --verify when true' do
+        expect_command_capturing('push', '--verify').and_return(command_result)
+
+        command.call(verify: true)
+      end
+
+      it 'adds --no-verify when false' do
+        expect_command_capturing('push', '--no-verify').and_return(command_result)
+
+        command.call(verify: false)
+      end
+    end
+
+    context 'with the :signed option' do
+      it 'adds --signed when true' do
+        expect_command_capturing('push', '--signed').and_return(command_result)
+
+        command.call(signed: true)
+      end
+
+      it 'adds --no-signed when false' do
+        expect_command_capturing('push', '--no-signed').and_return(command_result)
+
+        command.call(signed: false)
+      end
+
+      it 'adds --signed=<value> when given a string' do
+        expect_command_capturing('push', '--signed=if-asked').and_return(command_result)
+
+        command.call(signed: 'if-asked')
+      end
+    end
+
+    context 'with the :push_option option' do
+      it 'adds --push-option=<value> with a single value' do
+        expect_command_capturing('push', '--push-option=ci.skip').and_return(command_result)
+
+        command.call(push_option: 'ci.skip')
+      end
+
+      it 'repeats --push-option for multiple values' do
+        expect_command_capturing(
+          'push', '--push-option=foo', '--push-option=bar'
+        ).and_return(command_result)
+
+        command.call(push_option: %w[foo bar])
+      end
+
+      it 'supports the :o alias' do
+        expect_command_capturing('push', '--push-option=ci.skip').and_return(command_result)
+
+        command.call(o: 'ci.skip')
+      end
+    end
+
+    context 'with the :ipv4 option' do
+      it 'adds --ipv4 to the command line' do
+        expect_command_capturing('push', '--ipv4').and_return(command_result)
+
+        command.call(ipv4: true)
+      end
+
+      it 'supports the :"4" alias' do
+        expect_command_capturing('push', '--ipv4').and_return(command_result)
+
+        command.call('4': true)
+      end
+    end
+
+    context 'with the :ipv6 option' do
+      it 'adds --ipv6 to the command line' do
+        expect_command_capturing('push', '--ipv6').and_return(command_result)
+
+        command.call(ipv6: true)
+      end
+
+      it 'supports the :"6" alias' do
+        expect_command_capturing('push', '--ipv6').and_return(command_result)
+
+        command.call('6': true)
+      end
+    end
+
+    context 'with combined options and operands' do
+      it 'emits options before the end-of-options separator and then operands' do
+        # Options render in DSL definition order: --tags is defined before --force
+        expect_command_capturing(
+          'push', '--tags', '--force', '--', 'origin', 'main'
+        ).and_return(command_result)
+
+        command.call('origin', 'main', force: true, tags: true)
+      end
+    end
+
+    context 'with the :timeout execution option' do
+      it 'passes timeout through to the execution context without emitting it as a CLI flag' do
+        expect_command_capturing('push', '--', 'origin', timeout: 30).and_return(command_result)
+
+        command.call('origin', timeout: 30)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(nonexistent_option: true) }
+          .to raise_error(ArgumentError, /Unsupported options: :nonexistent_option/)
+      end
+    end
+  end
+end

--- a/tests/units/test_push.rb
+++ b/tests/units/test_push.rb
@@ -14,22 +14,22 @@ class TestPush < Test::Unit::TestCase
   end
 
   test 'push with only a remote name' do
-    expected_command_line = ['push', 'origin', {}]
+    expected_command_line = ['push', '--', 'origin', {}]
     assert_command_line_eq(expected_command_line) { |git| git.push('origin') }
   end
 
   test 'push with a single push option' do
-    expected_command_line = ['push', '--push-option', 'foo', {}]
+    expected_command_line = ['push', '--push-option=foo', {}]
     assert_command_line_eq(expected_command_line) { |git| git.push(push_option: 'foo') }
   end
 
   test 'push with an array of push options' do
-    expected_command_line = ['push', '--push-option', 'foo', '--push-option', 'bar', '--push-option', 'baz', {}]
+    expected_command_line = ['push', '--push-option=foo', '--push-option=bar', '--push-option=baz', {}]
     assert_command_line_eq(expected_command_line) { |git| git.push(push_option: %w[foo bar baz]) }
   end
 
   test 'push with only a remote name and options' do
-    expected_command_line = ['push', '--force', 'origin', {}]
+    expected_command_line = ['push', '--force', '--', 'origin', {}]
     assert_command_line_eq(expected_command_line) { |git| git.push('origin', force: true) }
   end
 
@@ -41,38 +41,100 @@ class TestPush < Test::Unit::TestCase
   end
 
   test 'push with both remote and branch name' do
-    expected_command_line = ['push', 'origin', 'master', {}]
+    expected_command_line = ['push', '--', 'origin', 'master', {}]
     assert_command_line_eq(expected_command_line) { |git| git.push('origin', 'master') }
   end
 
   test 'push with force: true' do
-    expected_command_line = ['push', '--force', 'origin', 'master', {}]
+    expected_command_line = ['push', '--force', '--', 'origin', 'master', {}]
     assert_command_line_eq(expected_command_line) { |git| git.push('origin', 'master', force: true) }
   end
 
   test 'push with f: true' do
-    expected_command_line = ['push', '--force', 'origin', 'master', {}]
+    expected_command_line = ['push', '--force', '--', 'origin', 'master', {}]
     assert_command_line_eq(expected_command_line) { |git| git.push('origin', 'master', f: true) }
   end
 
   test 'push with mirror: true' do
-    expected_command_line = ['push', '--mirror', 'origin', 'master', {}]
+    expected_command_line = ['push', '--mirror', '--', 'origin', 'master', {}]
     assert_command_line_eq(expected_command_line) { |git| git.push('origin', 'master', mirror: true) }
   end
 
   test 'push with delete: true' do
-    expected_command_line = ['push', '--delete', 'origin', 'master', {}]
+    expected_command_line = ['push', '--delete', '--', 'origin', 'master', {}]
     assert_command_line_eq(expected_command_line) { |git| git.push('origin', 'master', delete: true) }
   end
 
-  test 'push with tags: true' do
-    expected_command_line = ['push', '--tags', 'origin', {}]
-    assert_command_line_eq(expected_command_line) { |git| git.push('origin', 'master', tags: true) }
+  test 'push with tags: true does a second tags push and returns its stdout' do
+    in_temp_dir do
+      git = Git.init('.', initial_branch: 'master')
+      push_cmd = Git::Commands::Push.new(git.lib)
+
+      status = Struct.new(:success?, :exitstatus, :signaled?).new(true, 0, false)
+      first_result = Git::CommandLineResult.new(%w[git push], status, 'first push', '')
+      second_result = Git::CommandLineResult.new(%w[git push], status, 'tags push', '')
+
+      Git::Commands::Push.expects(:new).with(git.lib).twice.returns(push_cmd)
+      push_cmd.expects(:call).with('origin', 'master').returns(first_result)
+      push_cmd.expects(:call).with('origin', tags: true).returns(second_result)
+
+      assert_equal('tags push', git.push('origin', 'master', tags: true))
+    end
+  end
+
+  test 'push with mirror: true and tags: true silently drops tags push' do
+    in_temp_dir do
+      git = Git.init('.', initial_branch: 'master')
+      push_cmd = Git::Commands::Push.new(git.lib)
+
+      status = Struct.new(:success?, :exitstatus, :signaled?).new(true, 0, false)
+      result = Git::CommandLineResult.new(%w[git push], status, 'mirror push', '')
+
+      Git::Commands::Push.expects(:new).with(git.lib).once.returns(push_cmd)
+      push_cmd.expects(:call).with('origin', 'master', mirror: true).returns(result)
+
+      assert_equal('mirror push', git.push('origin', 'master', mirror: true, tags: true))
+    end
+  end
+
+  test 'push with all: true and tags: true allows the mutually exclusive combination' do
+    in_temp_dir do
+      git = Git.init('.', initial_branch: 'master')
+      push_cmd = Git::Commands::Push.new(git.lib)
+
+      status = Struct.new(:success?, :exitstatus, :signaled?).new(true, 0, false)
+      first_result = Git::CommandLineResult.new(%w[git push], status, 'all push', '')
+      second_result = Git::CommandLineResult.new(%w[git push], status, 'all tags push', '')
+
+      Git::Commands::Push.expects(:new).with(git.lib).twice.returns(push_cmd)
+      push_cmd.expects(:call).with('origin', all: true).returns(first_result)
+      push_cmd.expects(:call).with('origin', all: true, tags: true).returns(second_result)
+
+      assert_equal('all tags push', git.push('origin', all: true, tags: true))
+    end
   end
 
   test 'push with all: true' do
-    expected_command_line = ['push', '--all', 'origin', {}]
+    expected_command_line = ['push', '--all', '--', 'origin', {}]
     assert_command_line_eq(expected_command_line) { |git| git.push('origin', all: true) }
+  end
+
+  test 'push rejects branches option because it was not supported by the legacy interface' do
+    in_temp_dir do
+      git = Git.init('.', initial_branch: 'master')
+
+      error = assert_raise(ArgumentError) { git.push('origin', branches: true) }
+      assert_equal('Unknown options: branches', error.message)
+    end
+  end
+
+  test 'push rejects timeout option because it was not supported by the legacy interface' do
+    in_temp_dir do
+      git = Git.init('.', initial_branch: 'master')
+
+      error = assert_raise(ArgumentError) { git.push('origin', timeout: 1) }
+      assert_equal('Unknown options: timeout', error.message)
+    end
   end
 
   test 'when push succeeds an error should not be raised' do


### PR DESCRIPTION
## Summary

Migrates `Git::Lib#push` to a new `Git::Commands::Push` class following the Strangler Fig architectural redesign pattern.

## Changes

- **Add `Git::Commands::Push`** — full `git push` option set defined via the arguments DSL (50 unit tests, 3 integration tests)
- **Delegate `Git::Lib#push`** to `Git::Commands::Push`; remove `PUSH_OPTION_MAP` and `build_push_args`; preserve `normalize_push_args` for legacy calling conventions
- **Maintain two-push legacy behavior** for `tags: true` (branch push + tags push without refspec)
- **Update legacy test expectations** to include `--` before positional operands
- **Update redesign tracker**: push migrated (31/54 done)
- **Fix `@option` types** for `:receive_pack` and `:repo` from `[String, nil]` to `[String]` per the `value_option` DSL-to-YARD type mapping

## Testing

- 50 new unit tests in `spec/unit/git/commands/push_spec.rb`
- 3 new integration tests in `spec/integration/git/commands/push_spec.rb`
- Updated legacy test expectations in `tests/units/test_push.rb`
