### PR TITLE
docs: align skill guidance with minimum git version policy

### DIFF
--- a/.github/skills/pr-readiness-review/SKILL.md
+++ b/.github/skills/pr-readiness-review/SKILL.md
@@ -90,7 +90,10 @@ Execute and report results for:
 
 ## 4. Verify Against Git Documentation
 
-- [ ] Read https://git-scm.com/docs/git-[command] for the implemented command
+- [ ] Determine the repository's minimum supported Git version from project metadata
+- [ ] Read version-matched upstream documentation for the implemented command
+- [ ] Inspect version-matched upstream source when docs are ambiguous about exact option forms
+- [ ] Use local `git <command> -h` output only as a supplemental check for the installed Git
 - [ ] Confirm all documented options are considered
 - [ ] All edge cases from git documentation are tested
 - [ ] Error handling matches git's actual behavior

--- a/.github/skills/review-arguments-dsl/CHECKLIST.md
+++ b/.github/skills/review-arguments-dsl/CHECKLIST.md
@@ -13,10 +13,11 @@
 | pathspec-style operands (keyword arg) | `end_of_options` + `value_option ... as_operand: true` | `end_of_options; value_option :pathspec, as_operand: true, repeatable: true` — caller passes `pathspec: ['f1', 'f2']` |
 | pathspec-style operands (positional arg) | `end_of_options` + `operand ...` | `end_of_options; operand :pathspec, repeatable: true` — caller passes positionals `cmd.call('f1', 'f2')` |
 
-### Recognizing `flag_or_value_option` from the git man page
+### Recognizing `flag_or_value_option` from version-matched git docs
 
-The git-scm.com man page uses **`[=<value>]`** (square-bracketed `=<value>`) to mark
-an option's value as optional. That notation maps directly to `flag_or_value_option`:
+Version-matched git documentation uses **`[=<value>]`** (square-bracketed
+`=<value>`) to mark an option's value as optional. That notation maps directly
+to `flag_or_value_option`:
 
 | Man-page signature | DSL method |
 | --- | --- |
@@ -33,7 +34,7 @@ supplied.
 ### Choosing the correct pathspec form
 
 The two pathspec-style rows above look similar but represent meaningfully different
-binding strategies. The choice is determined by the git-scm.com SYNOPSIS.
+binding strategies. The choice is determined by the version-matched git SYNOPSIS.
 
 **`--` present in the git SYNOPSIS → `value_option … as_operand: true` form**
 
@@ -142,7 +143,8 @@ truth and can be verified at a glance without auditing the `as:` string.
 
 ### Short-flag alias completeness
 
-Every option that the git man page documents with a short form must have an alias
+Every option that the version-matched git documentation documents with a short
+form must have an alias
 with the long name first:
 
 ```ruby
@@ -151,40 +153,43 @@ flag_option %i[extended_regexp E]      # -E / --extended-regexp
 flag_option %i[fixed_strings F]        # -F / --fixed-strings
 ```
 
-When reviewing, scan the man page's option headings for lines of the form `-X` /
-`--long-name` and verify each has a corresponding `%i[long_name X]` alias in the DSL.
+When reviewing, scan the version-matched docs' option headings for lines of the
+form `-X` / `--long-name` and verify each has a corresponding `%i[long_name X]`
+alias in the DSL.
 Missing short aliases are a completeness defect, not just a convenience omission —
 callers who pass the short key `:E` will get an `ArgumentError` rather than the
 expected flag.
 
 ### Spurious short-flag aliases
 
-**Never invent a short-flag alias that the man page does not document.** Check the
-actual man page (or `man git-<subcommand>`) before adding any alias entry. The
-canonical audit is: does the git man page show `-X, --long-name` on the same option
-heading? If not, do not add `:X` to the alias list.
+**Never invent a short-flag alias that the version-matched docs do not
+document.** Check the version-matched documentation (and tagged upstream source
+when needed) before adding any alias entry. The canonical audit is: do the
+minimum-version sources show `-X, --long-name` on the same option heading? If
+not, do not add `:X` to the alias list.
 
 A spurious alias looks correct to a reader but generates an unknown flag when git
 rejects it:
 
 ```ruby
-# ❌ Wrong — git push has no -t flag; man page shows --tags only
+# ❌ Wrong — git push has no -t flag; version-matched docs show --tags only
 flag_option %i[tags t]   # emits -t → git: error: unknown switch 't'
 
 # ✅ Correct
 flag_option :tags        # emits --tags only
 ```
 
-Flag any alias whose short character cannot be found in the man page's option
+Flag any alias whose short character cannot be found in the version-matched
+docs' option
 headings as an error (not just a style issue).
 
 ## 3. Correct ordering
 
-Mirror the order options appear in the git-scm.com SYNOPSIS for the command. This
-keeps the DSL self-documenting and makes it easy to verify completeness against the
-man page.
+Mirror the order options appear in the version-matched git SYNOPSIS for the
+command. This keeps the DSL self-documenting and makes it easy to verify
+completeness against the docs.
 
-Within a group where the man page does not impose an order (e.g., a block of short
+Within a group where the docs do not impose an order (e.g., a block of short
 flags), prefer:
 
 1. literals
@@ -195,7 +200,8 @@ flags), prefer:
 
 ## 4. Correct modifiers
 
-Derive `required:` and `repeatable:` directly from the git-scm.com SYNOPSIS notation
+Derive `required:` and `repeatable:` directly from the version-matched git
+SYNOPSIS notation
 for operands:
 
 | SYNOPSIS notation | `required:` | `repeatable:` |

--- a/.github/skills/review-arguments-dsl/SKILL.md
+++ b/.github/skills/review-arguments-dsl/SKILL.md
@@ -14,6 +14,7 @@ methods and modifiers.
 - [How to use this skill](#how-to-use-this-skill)
 - [Related skills](#related-skills)
 - [Input](#input)
+- [Version-Aware Verification Sources](#version-aware-verification-sources)
 - [Architecture Context (Base Pattern)](#architecture-context-base-pattern)
 - [How Arguments Work](#how-arguments-work)
 - [What to Check](#what-to-check)
@@ -23,7 +24,7 @@ methods and modifiers.
 ## How to use this skill
 
 Attach this file to your Copilot Chat context, then invoke it with one or more
-command source files and the relevant git man page or documentation. Examples:
+command source files and the relevant version-matched git documentation. Examples:
 
 ```text
 Using the Review Arguments DSL skill, review
@@ -34,8 +35,8 @@ lib/git/commands/diff/numstat.rb against `git diff --numstat` docs.
 Review Arguments DSL: lib/git/commands/stash/push.rb
 ```
 
-The invocation needs the command file(s) to review. Providing the git man page
-or CLI documentation helps verify flag accuracy.
+The invocation needs the command file(s) to review. Providing version-matched
+git documentation helps verify flag accuracy.
 
 ## Related skills
 
@@ -49,7 +50,34 @@ or CLI documentation helps verify flag accuracy.
 Required:
 1. One or more command source files containing a `class < Git::Commands::Base` and an
    `arguments do` block
-2. The git man page or documentation for the subcommand
+2. Version-matched git documentation for the subcommand
+
+## Version-Aware Verification Sources
+
+Before auditing any DSL entry, determine the project's minimum supported Git
+version from the repository metadata. In this repository, that version is
+declared in `git.gemspec` (`git 2.28.0 or greater`).
+
+Use sources in this order:
+
+1. **Version-matched upstream documentation** for the minimum supported Git
+  version. Prefer the tagged upstream documentation or versioned man page for
+  that exact release.
+2. **Version-matched upstream source** for the same release when the docs are
+  ambiguous or abbreviated and exact parser behavior matters (for example:
+  long-option spelling, short aliases, negation support, optional values, or
+  `--option[=<value>]` forms).
+3. **Local `git <command> -h` output** only as a supplemental check for the
+  installed Git version on the current machine.
+
+Do **not** rely exclusively on local help output. The installed Git may be
+newer than the repository's minimum supported version and can advertise options
+or flag forms that are not safe to model in the DSL for older supported Git
+releases.
+
+When local help disagrees with the minimum-supported-version sources, prefer the
+minimum-supported-version behavior for the DSL and call out the newer-version
+difference explicitly in the review output.
 
 ## Architecture Context (Base Pattern)
 
@@ -84,7 +112,8 @@ Key behaviors:
 - **`skip_cli` operand behavior** — `operand ..., skip_cli: true` binds and validates
   like any other operand and remains accessible on `Bound`, but is intentionally
   excluded from argv emission
-- **Operand naming** — use the parameter name from the git-scm.com man page, in
+- **Operand naming** — use the parameter name from the version-matched git
+  documentation, in
   singular form (e.g., `<file>` → `:file`, `<tag>` → `:tag`). The `repeatable: true`
   modifier already communicates that multiple values are accepted; pluralising the
   name is unnecessary and diverges from the docs.

--- a/.github/skills/review-command-implementation/SKILL.md
+++ b/.github/skills/review-command-implementation/SKILL.md
@@ -14,6 +14,7 @@ contains no duplicated execution behavior.
 - [Prerequisites](#prerequisites)
 - [Related skills](#related-skills)
 - [Input](#input)
+- [Version-Aware Review Scope](#version-aware-review-scope)
 - [Architecture Contract (Current)](#architecture-contract-current)
 - [What to Check](#what-to-check)
   - [1. Class shape](#1-class-shape)
@@ -59,6 +60,22 @@ Before starting, you **MUST** load the following skill(s) in their entirety:
 ## Input
 
 Required: one or more command source files from `lib/git/commands/`.
+
+## Version-Aware Review Scope
+
+Before judging whether a command implementation or its DSL surface is correct,
+determine the repository's minimum supported Git version from project metadata.
+In this repository, `git.gemspec` declares `git 2.28.0 or greater`.
+
+For compatibility-sensitive conclusions, use sources in this order:
+
+1. Version-matched upstream documentation for the minimum supported Git version
+2. Version-matched upstream source when parser behavior is ambiguous in docs
+3. Local `git <command> -h` output only as a supplemental check for the installed Git
+
+Do not fail or require implementation changes solely because the locally
+installed Git advertises newer options or flag forms that are not confirmed for
+the minimum supported version.
 
 ## Architecture Contract (Current)
 

--- a/.github/skills/review-command-tests/SKILL.md
+++ b/.github/skills/review-command-tests/SKILL.md
@@ -13,6 +13,7 @@ conventions.
 - [Contents](#contents)
 - [How to use this skill](#how-to-use-this-skill)
 - [Related skills](#related-skills)
+- [Version-Aware Test Scope](#version-aware-test-scope)
 - [Unit tests](#unit-tests)
   - [Cover these cases](#cover-these-cases)
   - [Expectations for command invocation](#expectations-for-command-invocation)
@@ -59,6 +60,22 @@ it, MUST-level structural, naming, stubbing, and coverage checks will not be app
   structure, phased rollout gates, and internal compatibility contracts
 - [Review Command YARD Documentation](../review-command-yard-documentation/SKILL.md)
   — documentation completeness for command classes
+
+## Version-Aware Test Scope
+
+Before deciding that test coverage is missing for an option, alias, or flag
+form, determine the repository's minimum supported Git version from project
+metadata. In this repository, `git.gemspec` declares `git 2.28.0 or greater`.
+
+Coverage expectations for CLI forms must be based on the minimum supported Git
+version, not only on the locally installed Git. Use version-matched upstream
+documentation first, version-matched upstream source when needed, and local
+`git <command> -h` output only as a supplemental check.
+
+Do not require tests for newer-version-only forms that are not supported by the
+minimum supported Git version. Symmetrically, if the local Git omits or
+abbreviates a form that is supported in the minimum version, tests should still
+cover the minimum-version behavior.
 
 ## Unit tests
 

--- a/.github/skills/review-command-yard-documentation/SKILL.md
+++ b/.github/skills/review-command-yard-documentation/SKILL.md
@@ -15,6 +15,7 @@ the `Git::Commands::Base` pattern.
 - [Prerequisites](#prerequisites)
 - [Related skills](#related-skills)
 - [Input](#input)
+- [Version-Aware Documentation Scope](#version-aware-documentation-scope)
 - [Required documentation model](#required-documentation-model)
   - [No `def call` override (simple commands)](#no-def-call-override-simple-commands)
   - [Explicit `def call` override](#explicit-def-call-override)
@@ -72,6 +73,21 @@ One or more command files from `lib/git/commands/` containing:
 - optional `allow_exit_status`
 - either a `# @!method call(*, **)` YARD directive (when no `def call` override) or
   YARD doc comments directly above an explicit `def call` override
+
+## Version-Aware Documentation Scope
+
+Before deciding whether YARD documentation is accurate or incomplete, determine
+the repository's minimum supported Git version from project metadata. In this
+repository, `git.gemspec` declares `git 2.28.0 or greater`.
+
+Option names, aliases, negated forms, and accepted values documented in YARD
+must be validated against the minimum supported Git version first. Use
+version-matched upstream documentation as the primary source, inspect
+version-matched upstream source when exact parser behavior is ambiguous, and use
+local `git <command> -h` output only as a supplemental check.
+
+Do not flag docs as missing solely because the locally installed Git advertises
+newer forms that are unavailable in the minimum supported version.
 
 ## Required documentation model
 

--- a/.github/skills/review-cross-command-consistency/SKILL.md
+++ b/.github/skills/review-cross-command-consistency/SKILL.md
@@ -13,6 +13,7 @@ documentation, testing, and exit-status conventions under the `Base` architectur
 - [How to use this skill](#how-to-use-this-skill)
 - [Prerequisites](#prerequisites)
 - [Related skills](#related-skills)
+- [Version-Aware Comparison Scope](#version-aware-comparison-scope)
 - [What to Check](#what-to-check)
   - [1. Class structure consistency](#1-class-structure-consistency)
   - [2. Arguments DSL consistency](#2-arguments-dsl-consistency)
@@ -54,6 +55,19 @@ Before starting, you **MUST** load the following skill(s) in their entirety:
 - [Review Arguments DSL](../review-arguments-dsl/SKILL.md) — verifying DSL entries match git CLI
 - [Review Command Tests](../review-command-tests/SKILL.md) — unit/integration test expectations for command classes
 - [Review Command YARD Documentation](../review-command-yard-documentation/SKILL.md) — documentation completeness for command classes
+
+## Version-Aware Comparison Scope
+
+Before flagging siblings as inconsistent for option names, aliases, negated
+forms, or documented values, determine the repository's minimum supported Git
+version from project metadata. In this repository, `git.gemspec` declares
+`git 2.28.0 or greater`.
+
+Consistency judgments for CLI surface area must be based on the minimum
+supported Git version, not only on the locally installed Git. Use
+version-matched upstream documentation first, version-matched upstream source
+when exact parser behavior is ambiguous, and local `git <command> -h` output
+only as a supplemental check.
 
 ## What to Check
 

--- a/.github/skills/scaffold-new-command/SKILL.md
+++ b/.github/skills/scaffold-new-command/SKILL.md
@@ -372,13 +372,34 @@ Key points:
 - **Extract helpers** like `run_batch` to stay within Rubocop `Metrics/MethodLength`
   and `Metrics/AbcSize` thresholds. Aim to keep `call` under ~10 lines.
 
-## Options completeness — consult the man page first
+## Options completeness — consult version-matched docs first
 
-**Before writing any DSL entries**, fetch the git-scm.com man page for the
-subcommand and enumerate every option it documents:
+**Before writing any DSL entries**, determine the project's minimum supported
+Git version from the repository metadata, then fetch documentation for that
+exact version of the subcommand and enumerate every option it documents.
+
+For this repository, the minimum supported Git version is declared in
+`git.gemspec` (`git 2.28.0 or greater`).
+
+Use sources in this order:
+
+1. **Version-matched upstream documentation** for the minimum supported Git
+  version.
+2. **Version-matched upstream source** for that same release when exact parser
+  behavior is ambiguous in the docs.
+3. **Local `git <command> -h` output** only as a supplemental check for the
+  installed Git version.
+
+Do **not** scaffold from local help output alone. The installed Git may be
+newer than the minimum supported version and may expose flags, negated forms,
+or aliases that are unavailable in older supported releases.
+
+Useful documentation URLs often look like:
 
 ```text
 https://git-scm.com/docs/git-<subcommand>
+https://git-scm.com/docs/git-<subcommand>/<version>
+https://raw.githubusercontent.com/git/git/v<version>/Documentation/git-<subcommand>.txt
 ```
 
 For each option, make one of two decisions:
@@ -389,27 +410,31 @@ For each option, make one of two decisions:
 | **Exclude (execution-model conflict)** | Requires TTY input, opens an external editor, or otherwise makes the command incompatible with non-interactive subprocess execution | Omit — see "Execution-model conflicts are intentionally omitted" below |
 
 Group related options with a comment in the DSL (e.g. `# Ref inclusion`, `# Date
-filtering`, `# Commit ordering`). Follow the section groupings from the man page —
+filtering`, `# Commit ordering`). Follow the section groupings from the
+version-matched documentation —
 this makes it easy for a reviewer to cross-check against the docs.
 
-**Pairs and opposites:** when the man page documents `--foo` / `--no-foo` as
+**Pairs and opposites:** when the version-matched docs document `--foo` /
+`--no-foo` as
 explicit flags, model them as a single `flag_option :foo, negatable: true` rather
 than two separate entries. This prevents contradictory combinations and makes the
 three-state semantics (`true` / `false` / `nil`) explicit.
 
-**Short-flag aliases — cross-check the man page:** before adding any short-flag
+**Short-flag aliases — cross-check the version-matched docs/source:** before adding any short-flag
 alias (e.g. `%i[dry_run n]`), verify the alias character appears on the same option
-heading in the man page (`-n, --dry-run`). Do **not** invent an alias that the man
-page does not document — it will generate an unknown flag that git rejects.
-Symmetrically, every option the man page documents with a short form **must** have an
+heading in the documentation or parser for the minimum supported version
+(`-n, --dry-run`). Do **not** invent an alias that the minimum-version sources do
+not document — it will generate an unknown flag that older supported git may reject.
+Symmetrically, every option the version-matched docs document with a short form
+**must** have an
 alias in the DSL (long name first: `%i[dry_run n]`).
 
-**`inline: true` for `=<value>` options:** when the man page shows `--option=<value>`
+**`inline: true` for `=<value>` options:** when the version-matched docs show `--option=<value>`
 (with an `=`), the DSL entry must include `inline: true` regardless of whether the
 DSL method is `value_option` or `flag_or_value_option`. Without it, the value is
 emitted as a separate token (`--option value`) instead of the expected inline form
 (`--option=value`). Check every `value_option` and `flag_or_value_option` entry
-against the man page signature.
+against the minimum-version signature.
 
 **Constraint declarations are generally not used in command classes.** Do not add
 `conflicts`, `requires`, `requires_one_of`, `requires_exactly_one_of`,
@@ -430,8 +455,10 @@ See `redesign/3_architecture_implementation.md` Insight 6 for the full policy.
 
 This step is required. A command class that only exposes the options that happen
 to be used today in `Git::Lib` is incomplete — callers of the future API should
-not need to re-open the man page just because the scaffold only covered current
-usage.
+not need to re-open the docs just because the scaffold only covered current
+usage. If local help output shows more options than the minimum-version sources,
+do not scaffold those newer forms into the DSL unless the repository's minimum
+supported Git version has also been raised.
 
 ## Execution-model conflicts are intentionally omitted
 


### PR DESCRIPTION
## Summary
- update skill guidance to validate command options against the repository's minimum supported Git version first
- treat local `git <command> -h` output as a supplemental check instead of the primary source of truth
- propagate the same verification policy across scaffolding, reviews, and PR readiness workflows

## Why
The previous guidance could cause skills to model or review CLI options using the locally installed Git version instead of the repository's supported compatibility floor. This change aligns the skills with the project's Git 2.28.0+ support policy.

## Testing
- not run; documentation-only skill updates

## Scope
- `.github/skills/scaffold-new-command/SKILL.md`
- `.github/skills/review-arguments-dsl/SKILL.md`
- `.github/skills/review-arguments-dsl/CHECKLIST.md`
- `.github/skills/review-command-implementation/SKILL.md`
- `.github/skills/review-command-tests/SKILL.md`
- `.github/skills/review-command-yard-documentation/SKILL.md`
- `.github/skills/review-cross-command-consistency/SKILL.md`
- `.github/skills/pr-readiness-review/SKILL.md`