### PR TITLE
refactor(commands): add Git::Commands::DiffIndex command class

### DIFF
--- a/lib/git/commands/diff_index.rb
+++ b/lib/git/commands/diff_index.rb
@@ -1,0 +1,482 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    # Implements the `git diff-index` command
+    #
+    # Compares a tree object to either the index or the working tree.
+    #
+    # When `--cached` is given (`cached: true`) it compares the tree to the index
+    # (staged changes). Without `--cached` it compares the tree to the working tree,
+    # treating any file that differs from the index as changed even if the on-disk
+    # content is identical to the tree.
+    #
+    # @see https://git-scm.com/docs/git-diff-index git-diff-index documentation
+    #
+    # @see Git::Commands
+    #
+    # @api private
+    #
+    # @example Compare HEAD tree to the working tree (raw output)
+    #   # git diff-index HEAD
+    #   Git::Commands::DiffIndex.new(ctx).call('HEAD')
+    #
+    # @example Compare HEAD tree to the index (staged changes, raw output)
+    #   # git diff-index --cached HEAD
+    #   Git::Commands::DiffIndex.new(ctx).call('HEAD', cached: true)
+    #
+    # @example Compare HEAD tree to the index, showing a patch
+    #   # git diff-index --cached --patch HEAD
+    #   Git::Commands::DiffIndex.new(ctx).call('HEAD', cached: true, patch: true)
+    #
+    # @example Limit comparison to a specific path
+    #   # git diff-index --cached HEAD -- lib/
+    #   Git::Commands::DiffIndex.new(ctx).call('HEAD', 'lib/', cached: true)
+    #
+    class DiffIndex < Git::Commands::Base
+      arguments do
+        literal 'diff-index'
+
+        # diff-index-specific options
+        flag_option :m                                   # -m
+        flag_option :cached                              # --cached
+        flag_option :merge_base                          # --merge-base
+
+        # Output format selection
+        flag_option %i[patch p u]                        # --patch / -p / -u
+        flag_option %i[no_patch s]                       # --no-patch / -s
+        flag_option :raw                                 # --raw
+        flag_option :patch_with_raw                      # --patch-with-raw
+        value_option %i[unified U], inline: true         # --unified=<n> / -U<n>
+        value_option :output, inline: true               # --output=<file>
+        value_option :output_indicator_new, inline: true    # --output-indicator-new=<char>
+        value_option :output_indicator_old, inline: true    # --output-indicator-old=<char>
+        value_option :output_indicator_context, inline: true # --output-indicator-context=<char>
+
+        # Diff algorithm
+        flag_option :indent_heuristic, negatable: true   # --[no-]indent-heuristic
+        flag_option :minimal                             # --minimal
+        flag_option :patience                            # --patience
+        flag_option :histogram                           # --histogram
+        value_option :anchored, inline: true, repeatable: true # --anchored=<text> (repeatable)
+        value_option :diff_algorithm, inline: true # --diff-algorithm=<algo>
+
+        # Statistics output formats
+        flag_or_value_option :stat, inline: true         # --stat[=<width>[,<name-width>[,<count>]]]
+        value_option :stat_width, inline: true           # --stat-width=<width>
+        value_option :stat_name_width, inline: true      # --stat-name-width=<name-width>
+        value_option :stat_graph_width, inline: true     # --stat-graph-width=<graph-width>
+        value_option :stat_count, inline: true           # --stat-count=<count>
+        flag_option :compact_summary                     # --compact-summary
+        flag_option :numstat                             # --numstat
+        flag_option :shortstat                           # --shortstat
+        flag_or_value_option %i[dirstat X], inline: true # --dirstat[=<param>...] / -X[<param>...]
+        flag_option :cumulative                          # --cumulative
+        flag_or_value_option :dirstat_by_file, inline: true # --dirstat-by-file[=<param>...]
+        flag_option :summary                             # --summary
+        flag_option :patch_with_stat                     # --patch-with-stat
+
+        # Name and path display
+        flag_option :z                                   # -z
+        flag_option :name_only                           # --name-only
+        flag_option :name_status                         # --name-status
+        flag_or_value_option :submodule, inline: true    # --submodule[=<format>]
+
+        # Color output
+        flag_or_value_option :color, inline: true, negatable: true # --color[=<when>] / --no-color
+        flag_or_value_option :color_moved, inline: true, negatable: true # --color-moved[=<mode>] / --no-color-moved
+        value_option :color_moved_ws, inline: true       # --color-moved-ws=<mode>,...
+        flag_option :no_color_moved_ws                   # --no-color-moved-ws
+
+        # Word diff
+        flag_or_value_option :word_diff, inline: true    # --word-diff[=<mode>]
+        value_option :word_diff_regex, inline: true      # --word-diff-regex=<regex>
+        flag_or_value_option :color_words, inline: true  # --color-words[=<regex>]
+
+        # Whitespace handling
+        flag_option :ignore_cr_at_eol                    # --ignore-cr-at-eol
+        flag_option :ignore_space_at_eol                 # --ignore-space-at-eol
+        flag_option %i[ignore_space_change b]            # --ignore-space-change / -b
+        flag_option %i[ignore_all_space w]               # --ignore-all-space / -w
+        flag_option :ignore_blank_lines                  # --ignore-blank-lines
+        value_option %i[ignore_matching_lines I], inline: true, repeatable: true # --ignore-matching-lines / -I
+        flag_option :check                               # --check
+        value_option :ws_error_highlight, inline: true   # --ws-error-highlight=<kind>
+
+        # Rename/copy detection
+        flag_option :no_renames                          # --no-renames
+        flag_option :rename_empty, negatable: true       # --[no-]rename-empty
+        flag_option :full_index                          # --full-index
+        flag_option :binary                              # --binary
+        flag_or_value_option :abbrev, inline: true       # --abbrev[=<n>]
+        flag_or_value_option %i[break_rewrites B], inline: true  # --break-rewrites[=[<n>][/<m>]] / -B[<n>][/<m>]
+        flag_or_value_option %i[find_renames M], inline: true    # --find-renames[=<n>] / -M[<n>]
+        flag_or_value_option %i[find_copies C], inline: true     # --find-copies[=<n>] / -C[<n>]
+        flag_option :find_copies_harder                  # --find-copies-harder
+        flag_option %i[irreversible_delete D]            # --irreversible-delete / -D
+
+        # Pickaxe / filtering
+        value_option :l, inline: true                    # -l<num>
+        value_option :diff_filter, inline: true          # --diff-filter=[ACDMRTUXB*...]
+        value_option :S, inline: true                    # -S<string>
+        value_option :G, inline: true                    # -G<regex>
+        value_option :find_object, inline: true          # --find-object=<object-id>
+        flag_option :pickaxe_all                         # --pickaxe-all
+        flag_option :pickaxe_regex                       # --pickaxe-regex
+        value_option :O, inline: true                    # -O<orderfile>
+        value_option :skip_to, inline: true              # --skip-to=<file>
+        value_option :rotate_to, inline: true            # --rotate-to=<file>
+
+        # Miscellaneous diff options
+        flag_option :R # -R (swap inputs)
+        flag_or_value_option :relative, inline: true, negatable: true # --relative[=<path>] / --no-relative
+        flag_option %i[text a]                           # --text / -a
+        value_option :inter_hunk_context, inline: true   # --inter-hunk-context=<number>
+        flag_option %i[function_context W]               # --function-context / -W
+        flag_option :exit_code                           # --exit-code
+        flag_option :quiet                               # --quiet
+        flag_option :ext_diff, negatable: true           # --[no-]ext-diff
+        flag_option :textconv, negatable: true           # --[no-]textconv
+        flag_or_value_option :ignore_submodules, inline: true # --ignore-submodules[=<when>]
+        value_option :src_prefix, inline: true           # --src-prefix=<prefix>
+        value_option :dst_prefix, inline: true           # --dst-prefix=<prefix>
+        flag_option :no_prefix                           # --no-prefix
+        flag_option :default_prefix                      # --default-prefix
+        value_option :line_prefix, inline: true          # --line-prefix=<prefix>
+        flag_option :ita_invisible_in_index              # --ita-invisible-in-index
+        value_option :max_depth, inline: true            # --max-depth=<depth>
+
+        # Operands: git diff-index does not accept -- before <tree-ish>.
+        # end_of_options is placed between tree_ish and path so that -- is emitted
+        # only when path arguments are present, disambiguating paths from revisions.
+        operand :tree_ish, required: true   # <tree-ish> (required)
+        end_of_options                      # -- emitted only when paths follow
+        operand :path, repeatable: true     # [<path>...] (optional)
+      end
+
+      # git diff-index exits 1 when differences are found (e.g. with --exit-code)
+      allow_exit_status 0..1
+
+      # @!method call(*, **)
+      #
+      #   @api public
+      #
+      #   @overload call(tree_ish, **options)
+      #     Compare a tree to the index or working tree
+      #
+      #     @example Compare HEAD to the working tree
+      #       # git diff-index HEAD
+      #       DiffIndex.new(ctx).call('HEAD')
+      #
+      #     @example Compare HEAD to the index (staged changes only)
+      #       # git diff-index --cached HEAD
+      #       DiffIndex.new(ctx).call('HEAD', cached: true)
+      #
+      #     @param tree_ish [String] the tree object to compare against (e.g., `'HEAD'`, a commit SHA,
+      #       or a tag name)
+      #
+      #     @param options [Hash] command options
+      #
+      #     @option options [Boolean] :m (nil) Treat non-checked-out files as up to date
+      #
+      #       By default, files recorded in the index but not checked out are reported as
+      #       deleted. This flag makes `git diff-index` report all such files as up to date.
+      #
+      #     @option options [Boolean] :cached (nil) Compare the tree to the index only (staged
+      #       changes), without considering the working tree
+      #
+      #     @option options [Boolean] :merge_base (nil) Use the merge base between the tree-ish
+      #       and `HEAD` rather than the tree-ish directly
+      #
+      #       `tree_ish` must be a commit when this option is used.
+      #
+      #     @option options [Boolean] :patch (nil) Generate unified diff patch output
+      #
+      #       Alias: :p, :u
+      #
+      #     @option options [Boolean] :no_patch (nil) Suppress all diff output
+      #
+      #       Alias: :s
+      #
+      #     @option options [Boolean] :raw (nil) Generate diff in raw format (default output)
+      #
+      #     @option options [Boolean] :patch_with_raw (nil) Synonym for `patch: true, raw: true`
+      #
+      #     @option options [Integer, String] :unified (nil) Number of context lines around diff
+      #       hunks (e.g., `3`)
+      #
+      #       Alias: :U
+      #
+      #     @option options [String] :output (nil) Write diff output to a file instead of stdout
+      #
+      #     @option options [String] :output_indicator_new (nil) Character for new lines in patch output
+      #
+      #     @option options [String] :output_indicator_old (nil) Character for old lines in patch output
+      #
+      #     @option options [String] :output_indicator_context (nil) Character for context lines in patch output
+      #
+      #     @option options [Boolean] :indent_heuristic (nil) Shift hunk boundaries for readability
+      #
+      #       Pass `false` to emit `--no-indent-heuristic`.
+      #
+      #     @option options [Boolean] :minimal (nil) Spend extra time to minimize diff size
+      #
+      #     @option options [Boolean] :patience (nil) Use patience diff algorithm
+      #
+      #     @option options [Boolean] :histogram (nil) Use histogram diff algorithm
+      #
+      #     @option options [String, Array<String>] :anchored (nil) Anchor lines matching the given
+      #       text to prevent them from appearing as additions or deletions (repeatable)
+      #
+      #     @option options [String] :diff_algorithm (nil) diff algorithm to use
+      #
+      #       Accepted values: `'default'`, `'myers'`, `'minimal'`, `'patience'`, `'histogram'`.
+      #
+      #     @option options [Boolean, String] :stat (nil) Show a diffstat
+      #
+      #       Pass `true` for the default format, or a string like `'80,40,5'` for custom
+      #       `width,name-width,count` limits.
+      #
+      #     @option options [Integer, String] :stat_width (nil) Override diffstat total width
+      #
+      #     @option options [Integer, String] :stat_name_width (nil) Override diffstat filename column width
+      #
+      #     @option options [Integer, String] :stat_graph_width (nil) Override diffstat graph column width
+      #
+      #     @option options [Integer, String] :stat_count (nil) Limit diffstat to this many lines
+      #
+      #     @option options [Boolean] :compact_summary (nil) Include creation/deletion mode changes in stat
+      #
+      #     @option options [Boolean] :numstat (nil) Show per-file insertion/deletion counts (machine-friendly)
+      #
+      #     @option options [Boolean] :shortstat (nil) Show aggregate totals line only
+      #
+      #     @option options [Boolean, String] :dirstat (nil) Show distribution of changes per directory
+      #
+      #       Pass `true` for the default, or a string like `'lines,cumulative,10'` to pass params.
+      #
+      #       Alias: :X
+      #
+      #     @option options [Boolean] :cumulative (nil) Synonym for `dirstat: 'cumulative'`
+      #
+      #     @option options [Boolean, String] :dirstat_by_file (nil) Synonym for `dirstat: 'files,...'`
+      #
+      #     @option options [Boolean] :summary (nil) Show condensed extended header information
+      #
+      #     @option options [Boolean] :patch_with_stat (nil) Synonym for `patch: true, stat: true`
+      #
+      #     @option options [Boolean] :z (nil) Use NUL as output field terminator instead of newline
+      #
+      #     @option options [Boolean] :name_only (nil) Show only changed file names
+      #
+      #     @option options [Boolean] :name_status (nil) Show changed file names with status letters
+      #
+      #     @option options [Boolean, String] :submodule (nil) How to show submodule differences
+      #
+      #       Pass `true` for the default, or a string like `'log'` or `'diff'` for a format name.
+      #
+      #     @option options [Boolean, String] :color (nil) Control diff colorization
+      #
+      #       Pass `true` for `--color`, `false` for `--no-color`, or a string like `'always'`
+      #       or `'auto'` for a specific mode.
+      #
+      #     @option options [Boolean, String] :color_moved (nil) Color moved lines differently
+      #
+      #       Pass `true` for default, `false` for `--no-color-moved`, or a mode string such as
+      #       `'zebra'` or `'dimmed-zebra'`.
+      #
+      #     @option options [String] :color_moved_ws (nil) Whitespace handling for moved-line color detection
+      #
+      #       Comma-separated list of modes, e.g. `'ignore-space-at-eol,ignore-space-change'`.
+      #
+      #     @option options [Boolean] :no_color_moved_ws (nil) Synonym for `color_moved_ws: 'no'`
+      #
+      #     @option options [Boolean, String] :word_diff (nil) Show a word-level diff
+      #
+      #       Pass `true` for the default `plain` mode, or a string like `'color'`, `'porcelain'`,
+      #       or `'none'` for a specific mode.
+      #
+      #     @option options [String] :word_diff_regex (nil) Regular expression defining word boundaries for word diff
+      #
+      #     @option options [Boolean, String] :color_words (nil) Equivalent to `word_diff: 'color'`
+      #       plus an optional word regex
+      #
+      #     @option options [Boolean] :ignore_cr_at_eol (nil) Ignore carriage-return at end of line
+      #
+      #     @option options [Boolean] :ignore_space_at_eol (nil) Ignore whitespace changes at end of line
+      #
+      #     @option options [Boolean] :ignore_space_change (nil) Ignore changes in amount of whitespace
+      #
+      #       Alias: :b
+      #
+      #     @option options [Boolean] :ignore_all_space (nil) Ignore all whitespace when comparing lines
+      #
+      #       Alias: :w
+      #
+      #     @option options [Boolean] :ignore_blank_lines (nil) Ignore changes whose lines are all blank
+      #
+      #     @option options [String, Array<String>] :ignore_matching_lines (nil) Ignore changes whose lines all match
+      #       the given regex (repeatable)
+      #
+      #       Alias: :I
+      #
+      #     @option options [Boolean] :check (nil) Warn if changes introduce whitespace errors or
+      #       conflict markers
+      #
+      #     @option options [String] :ws_error_highlight (nil) Highlight whitespace errors in the
+      #       given diff line types (e.g. `'new'`, `'old,new'`, `'all'`)
+      #
+      #     @option options [Boolean] :no_renames (nil) Disable rename detection
+      #
+      #     @option options [Boolean] :rename_empty (nil) Use empty blobs as rename sources
+      #
+      #       Pass `false` to emit `--no-rename-empty`.
+      #
+      #     @option options [Boolean] :full_index (nil) Show full blob SHA in index line
+      #
+      #     @option options [Boolean] :binary (nil) Output binary diff suitable for `git apply`
+      #
+      #     @option options [Boolean, String] :abbrev (nil) Abbreviate blob names in raw output
+      #
+      #       Pass `true` for the default, or an integer string like `'10'` for a specific length.
+      #
+      #     @option options [Boolean, String] :break_rewrites (nil) Break total rewrites into
+      #       delete-and-create pairs
+      #
+      #       Pass `true` for defaults, or a threshold string like `'80%'` or `'50%/70%'` for custom
+      #       break and rename thresholds.
+      #
+      #       Alias: :B
+      #
+      #     @option options [Boolean, String] :find_renames (nil) Detect renames
+      #
+      #       Pass `true` for the default threshold, or a string like `'90%'` for a custom
+      #       similarity threshold.
+      #
+      #       Alias: :M
+      #
+      #     @option options [Boolean, String] :find_copies (nil) Detect copies as well as renames
+      #
+      #       Pass `true` for the default threshold, or a string like `'75%'` for a custom
+      #       similarity threshold.
+      #
+      #       Alias: :C
+      #
+      #     @option options [Boolean] :find_copies_harder (nil) Inspect all unmodified files as copy
+      #       sources (very expensive for large repos)
+      #
+      #     @option options [Boolean] :irreversible_delete (nil) Omit preimage for deleted files
+      #
+      #       Alias: :D
+      #
+      #     @option options [Integer, String] :l (nil) Limit the number of rename/copy candidates
+      #       considered during exhaustive detection
+      #
+      #     @option options [String] :diff_filter (nil) Select only certain kinds of changed files
+      #
+      #       A string of status letters such as `'A'`, `'M'`, `'D'`, `'ACDM'`, or lowercase
+      #       forms to exclude (e.g. `'ad'` excludes added and deleted).
+      #
+      #     @option options [String] :S (nil) Find changes that alter the occurrence count of the
+      #       given string (pickaxe)
+      #
+      #     @option options [String] :G (nil) Find changes whose patch text contains lines matching
+      #       the given regex (pickaxe)
+      #
+      #     @option options [String] :find_object (nil) Find changes involving the given object id
+      #
+      #     @option options [Boolean] :pickaxe_all (nil) Show all changes in a changeset when using
+      #       `-S` or `-G`
+      #
+      #     @option options [Boolean] :pickaxe_regex (nil) Treat the `-S` string as an extended POSIX
+      #       regular expression
+      #
+      #     @option options [String] :O (nil) Path to an orderfile controlling output file order
+      #
+      #     @option options [String] :skip_to (nil) Discard files before the named file in the output
+      #
+      #     @option options [String] :rotate_to (nil) Move files before the named file to end of output
+      #
+      #     @option options [Boolean] :R (nil) Swap the two diff inputs
+      #
+      #     @option options [Boolean, String] :relative (nil) Show paths relative to a directory
+      #
+      #       Pass `true` to use the current directory, `false` for `--no-relative`, or a path
+      #       string to name the directory explicitly.
+      #
+      #     @option options [Boolean] :text (nil) Treat all files as text
+      #
+      #       Alias: :a
+      #
+      #     @option options [Integer, String] :inter_hunk_context (nil) Show context between diff hunks
+      #       up to this many lines, fusing close hunks
+      #
+      #     @option options [Boolean] :function_context (nil) Show whole function as context for each change
+      #
+      #       Alias: :W
+      #
+      #     @option options [Boolean] :exit_code (nil) Exit with status 1 if differences are found,
+      #       0 if none
+      #
+      #     @option options [Boolean] :quiet (nil) Suppress all output
+      #
+      #       Implies `--exit-code`.
+      #
+      #     @option options [Boolean] :ext_diff (nil) Allow external diff helpers
+      #
+      #       Pass `false` to emit `--no-ext-diff`.
+      #
+      #     @option options [Boolean] :textconv (nil) Allow external text-conversion filters
+      #
+      #       Pass `false` to emit `--no-textconv`.
+      #
+      #     @option options [Boolean, String] :ignore_submodules (nil) Ignore submodule changes
+      #
+      #       Pass `true` for `--ignore-submodules` (equivalent to `'all'`), or a string such as
+      #       `'untracked'`, `'dirty'`, `'none'`, or `'all'`.
+      #
+      #     @option options [String] :src_prefix (nil) Source prefix for diff headers (e.g. `'a/'`)
+      #
+      #     @option options [String] :dst_prefix (nil) Destination prefix for diff headers (e.g. `'b/'`)
+      #
+      #     @option options [Boolean] :no_prefix (nil) Omit source and destination prefixes
+      #
+      #     @option options [Boolean] :default_prefix (nil) Use the default `a/` and `b/` prefixes
+      #
+      #     @option options [String] :line_prefix (nil) Prepend this prefix to every output line
+      #
+      #     @option options [Boolean] :ita_invisible_in_index (nil) Make `git add -N` entries appear as
+      #       new files in `git diff` and non-existent in `git diff --cached`
+      #
+      #     @option options [Integer, String] :max_depth (nil) Maximum directory depth to descend for
+      #       each pathspec (tree-to-tree diffs only)
+      #
+      #     @return [Git::CommandLineResult] the result of calling `git diff-index`
+      #
+      #     @raise [Git::FailedError] if git returns exit code >= 2
+      #
+      #   @overload call(tree_ish, *paths, **options)
+      #     Compare a tree to the index or working tree, limiting output to specific paths
+      #
+      #     @example Compare HEAD to the index for a single directory
+      #       # git diff-index --cached HEAD -- lib/
+      #       DiffIndex.new(ctx).call('HEAD', 'lib/', cached: true)
+      #
+      #     @example Compare HEAD to the working tree for multiple paths
+      #       # git diff-index HEAD -- lib/ spec/
+      #       DiffIndex.new(ctx).call('HEAD', 'lib/', 'spec/')
+      #
+      #     @param tree_ish [String] the tree object to compare against
+      #
+      #     @param paths [Array<String>] pathspecs limiting which files are compared
+      #
+      #     @param options [Hash] command options (same as the single-argument overload)
+      #
+      #     @return [Git::CommandLineResult] the result of calling `git diff-index`
+      #
+      #     @raise [Git::FailedError] if git returns exit code >= 2
+    end
+  end
+end

--- a/spec/integration/git/commands/diff_index_spec.rb
+++ b/spec/integration/git/commands/diff_index_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/diff_index'
+
+RSpec.describe Git::Commands::DiffIndex, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    write_file('file.txt', "initial content\n")
+    repo.add('.')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult with exit code 0 when no working-tree changes exist' do
+        result = command.call('HEAD')
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'returns a CommandLineResult with exit code 0 when nothing is staged' do
+        result = command.call('HEAD', cached: true)
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'accepts a path operand and returns a CommandLineResult' do
+        result = command.call('HEAD', 'file.txt')
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'exits with status 1 when staged changes are present and --exit-code is given' do
+        write_file('file.txt', "changed\n")
+        repo.add('file.txt')
+        result = command.call('HEAD', cached: true, exit_code: true)
+        expect(result.status.exitstatus).to eq(1)
+      end
+
+      it 'exits with status 0 when no staged changes and --exit-code is given' do
+        result = command.call('HEAD', cached: true, exit_code: true)
+        expect(result.status.exitstatus).to eq(0)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for an invalid tree-ish' do
+        expect { command.call('nonexistent-sha-deadbeef') }
+          .to raise_error(Git::FailedError, /nonexistent-sha-deadbeef/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/diff_index_spec.rb
+++ b/spec/unit/git/commands/diff_index_spec.rb
@@ -1,0 +1,982 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/diff_index'
+
+RSpec.describe Git::Commands::DiffIndex do
+  # Duck-type collaborator: command specs depend on the #command_capturing
+  # interface, not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with required tree_ish operand only' do
+      it 'runs git diff-index with the tree_ish operand' do
+        expected_result = command_result('')
+        expect_command_capturing('diff-index', 'HEAD').and_return(expected_result)
+
+        result = command.call('HEAD')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with diff-index-specific options' do
+      it 'includes -m when m: true' do
+        expect_command_capturing('diff-index', '-m', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', m: true)
+      end
+
+      it 'includes --cached when cached: true' do
+        expect_command_capturing('diff-index', '--cached', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', cached: true)
+      end
+
+      it 'includes --merge-base when merge_base: true' do
+        expect_command_capturing('diff-index', '--merge-base', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', merge_base: true)
+      end
+    end
+
+    context 'with output format options' do
+      it 'includes --patch when patch: true' do
+        expect_command_capturing('diff-index', '--patch', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', patch: true)
+      end
+
+      it 'includes --no-patch when no_patch: true' do
+        expect_command_capturing('diff-index', '--no-patch', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', no_patch: true)
+      end
+
+      it 'includes --raw when raw: true' do
+        expect_command_capturing('diff-index', '--raw', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', raw: true)
+      end
+
+      it 'includes --numstat when numstat: true' do
+        expect_command_capturing('diff-index', '--numstat', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', numstat: true)
+      end
+
+      it 'includes --shortstat when shortstat: true' do
+        expect_command_capturing('diff-index', '--shortstat', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', shortstat: true)
+      end
+
+      it 'includes --stat when stat: true' do
+        expect_command_capturing('diff-index', '--stat', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', stat: true)
+      end
+
+      it 'passes an inline value to --stat= when stat: is a string' do
+        expect_command_capturing('diff-index', '--stat=80,40', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', stat: '80,40')
+      end
+
+      it 'includes --name-only when name_only: true' do
+        expect_command_capturing('diff-index', '--name-only', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', name_only: true)
+      end
+
+      it 'includes --name-status when name_status: true' do
+        expect_command_capturing('diff-index', '--name-status', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', name_status: true)
+      end
+    end
+
+    context 'with diff algorithm options' do
+      it 'adds --unified=3 when unified: 3' do
+        expect_command_capturing('diff-index', '--unified=3', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', unified: 3)
+      end
+
+      it 'adds --diff-algorithm=patience when diff_algorithm: "patience"' do
+        expect_command_capturing('diff-index', '--diff-algorithm=patience', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', diff_algorithm: 'patience')
+      end
+
+      it 'adds --minimal when minimal: true' do
+        expect_command_capturing('diff-index', '--minimal', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', minimal: true)
+      end
+
+      it 'adds --patience when patience: true' do
+        expect_command_capturing('diff-index', '--patience', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', patience: true)
+      end
+
+      it 'adds --histogram when histogram: true' do
+        expect_command_capturing('diff-index', '--histogram', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', histogram: true)
+      end
+    end
+
+    context 'with rename and copy detection options' do
+      it 'adds --find-renames when find_renames: true' do
+        expect_command_capturing('diff-index', '--find-renames', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', find_renames: true)
+      end
+
+      it 'adds --find-renames=90% when find_renames: "90%"' do
+        expect_command_capturing('diff-index', '--find-renames=90%', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', find_renames: '90%')
+      end
+
+      it 'adds --find-copies when find_copies: true' do
+        expect_command_capturing('diff-index', '--find-copies', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', find_copies: true)
+      end
+
+      it 'adds --find-copies-harder when find_copies_harder: true' do
+        expect_command_capturing('diff-index', '--find-copies-harder', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', find_copies_harder: true)
+      end
+
+      it 'adds --break-rewrites when break_rewrites: true' do
+        expect_command_capturing('diff-index', '--break-rewrites', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', break_rewrites: true)
+      end
+
+      it 'adds --irreversible-delete when irreversible_delete: true' do
+        expect_command_capturing('diff-index', '--irreversible-delete', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', irreversible_delete: true)
+      end
+
+      it 'adds --no-renames when no_renames: true' do
+        expect_command_capturing('diff-index', '--no-renames', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', no_renames: true)
+      end
+
+      it 'adds --full-index when full_index: true' do
+        expect_command_capturing('diff-index', '--full-index', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', full_index: true)
+      end
+
+      it 'adds --binary when binary: true' do
+        expect_command_capturing('diff-index', '--binary', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', binary: true)
+      end
+
+      it 'adds --abbrev when abbrev: true' do
+        expect_command_capturing('diff-index', '--abbrev', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', abbrev: true)
+      end
+
+      it 'adds --abbrev=8 when abbrev: 8' do
+        expect_command_capturing('diff-index', '--abbrev=8', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', abbrev: 8)
+      end
+
+      it 'adds --break-rewrites=60/50 when break_rewrites: "60/50"' do
+        expect_command_capturing('diff-index', '--break-rewrites=60/50', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', break_rewrites: '60/50')
+      end
+
+      it 'adds --find-copies=80% when find_copies: "80%"' do
+        expect_command_capturing('diff-index', '--find-copies=80%', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', find_copies: '80%')
+      end
+    end
+
+    context 'with output and format display options' do
+      it 'includes --patch-with-raw when patch_with_raw: true' do
+        expect_command_capturing('diff-index', '--patch-with-raw', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', patch_with_raw: true)
+      end
+
+      it 'includes --output=file.diff when output: "file.diff"' do
+        expect_command_capturing('diff-index', '--output=file.diff', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', output: 'file.diff')
+      end
+
+      it 'includes --output-indicator-new=> when output_indicator_new: ">"' do
+        expect_command_capturing('diff-index', '--output-indicator-new=>', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', output_indicator_new: '>')
+      end
+
+      it 'includes --output-indicator-old=< when output_indicator_old: "<"' do
+        expect_command_capturing('diff-index', '--output-indicator-old=<', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', output_indicator_old: '<')
+      end
+
+      it 'includes --output-indicator-context== when output_indicator_context: "="' do
+        expect_command_capturing('diff-index', '--output-indicator-context==', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', output_indicator_context: '=')
+      end
+
+      it 'includes -z when z: true' do
+        expect_command_capturing('diff-index', '-z', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', z: true)
+      end
+
+      it 'includes --submodule when submodule: true' do
+        expect_command_capturing('diff-index', '--submodule', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', submodule: true)
+      end
+
+      it 'includes --submodule=diff when submodule: "diff"' do
+        expect_command_capturing('diff-index', '--submodule=diff', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', submodule: 'diff')
+      end
+
+      it 'includes --patch-with-stat when patch_with_stat: true' do
+        expect_command_capturing('diff-index', '--patch-with-stat', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', patch_with_stat: true)
+      end
+
+      it 'includes --summary when summary: true' do
+        expect_command_capturing('diff-index', '--summary', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', summary: true)
+      end
+    end
+
+    context 'with statistics output options' do
+      it 'includes --compact-summary when compact_summary: true' do
+        expect_command_capturing('diff-index', '--compact-summary', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', compact_summary: true)
+      end
+
+      it 'includes --stat-width=80 when stat_width: 80' do
+        expect_command_capturing('diff-index', '--stat-width=80', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', stat_width: 80)
+      end
+
+      it 'includes --stat-name-width=40 when stat_name_width: 40' do
+        expect_command_capturing('diff-index', '--stat-name-width=40', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', stat_name_width: 40)
+      end
+
+      it 'includes --stat-graph-width=15 when stat_graph_width: 15' do
+        expect_command_capturing('diff-index', '--stat-graph-width=15', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', stat_graph_width: 15)
+      end
+
+      it 'includes --stat-count=5 when stat_count: 5' do
+        expect_command_capturing('diff-index', '--stat-count=5', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', stat_count: 5)
+      end
+
+      it 'includes --cumulative when cumulative: true' do
+        expect_command_capturing('diff-index', '--cumulative', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', cumulative: true)
+      end
+
+      it 'includes --dirstat when dirstat: true' do
+        expect_command_capturing('diff-index', '--dirstat', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', dirstat: true)
+      end
+
+      it 'includes --dirstat=cumulative,10 when dirstat: "cumulative,10"' do
+        expect_command_capturing('diff-index', '--dirstat=cumulative,10', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', dirstat: 'cumulative,10')
+      end
+
+      it 'includes --dirstat-by-file when dirstat_by_file: true' do
+        expect_command_capturing('diff-index', '--dirstat-by-file', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', dirstat_by_file: true)
+      end
+
+      it 'includes --dirstat-by-file=cumulative when dirstat_by_file: "cumulative"' do
+        expect_command_capturing('diff-index', '--dirstat-by-file=cumulative', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', dirstat_by_file: 'cumulative')
+      end
+    end
+
+    context 'with color and word diff options' do
+      it 'includes --color-moved when color_moved: true' do
+        expect_command_capturing('diff-index', '--color-moved', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', color_moved: true)
+      end
+
+      it 'includes --color-moved=zebra when color_moved: "zebra"' do
+        expect_command_capturing('diff-index', '--color-moved=zebra', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', color_moved: 'zebra')
+      end
+
+      it 'includes --no-color-moved when color_moved: false' do
+        expect_command_capturing('diff-index', '--no-color-moved', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', color_moved: false)
+      end
+
+      it 'includes --color-moved-ws=allow-indentation-change when color_moved_ws: "allow-indentation-change"' do
+        expect_command_capturing('diff-index', '--color-moved-ws=allow-indentation-change', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', color_moved_ws: 'allow-indentation-change')
+      end
+
+      it 'includes --no-color-moved-ws when no_color_moved_ws: true' do
+        expect_command_capturing('diff-index', '--no-color-moved-ws', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', no_color_moved_ws: true)
+      end
+
+      it 'includes --word-diff when word_diff: true' do
+        expect_command_capturing('diff-index', '--word-diff', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', word_diff: true)
+      end
+
+      it 'includes --word-diff=color when word_diff: "color"' do
+        expect_command_capturing('diff-index', '--word-diff=color', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', word_diff: 'color')
+      end
+
+      it 'includes --word-diff-regex=pattern when word_diff_regex: "pattern"' do
+        expect_command_capturing('diff-index', '--word-diff-regex=pattern', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', word_diff_regex: 'pattern')
+      end
+
+      it 'includes --color-words when color_words: true' do
+        expect_command_capturing('diff-index', '--color-words', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', color_words: true)
+      end
+
+      it 'includes --color-words=pattern when color_words: "pattern"' do
+        expect_command_capturing('diff-index', '--color-words=pattern', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', color_words: 'pattern')
+      end
+    end
+
+    context 'with whitespace handling options' do
+      it 'includes --ignore-cr-at-eol when ignore_cr_at_eol: true' do
+        expect_command_capturing('diff-index', '--ignore-cr-at-eol', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', ignore_cr_at_eol: true)
+      end
+
+      it 'includes --ignore-space-at-eol when ignore_space_at_eol: true' do
+        expect_command_capturing('diff-index', '--ignore-space-at-eol', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', ignore_space_at_eol: true)
+      end
+
+      it 'includes --ignore-space-change when ignore_space_change: true' do
+        expect_command_capturing('diff-index', '--ignore-space-change', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', ignore_space_change: true)
+      end
+
+      it 'includes --ignore-all-space when ignore_all_space: true' do
+        expect_command_capturing('diff-index', '--ignore-all-space', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', ignore_all_space: true)
+      end
+
+      it 'includes --ignore-blank-lines when ignore_blank_lines: true' do
+        expect_command_capturing('diff-index', '--ignore-blank-lines', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', ignore_blank_lines: true)
+      end
+
+      it 'includes --ignore-matching-lines=TODO when ignore_matching_lines: "TODO"' do
+        expect_command_capturing('diff-index', '--ignore-matching-lines=TODO', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', ignore_matching_lines: 'TODO')
+      end
+
+      it 'repeats --ignore-matching-lines= for each value in an array' do
+        expect_command_capturing('diff-index', '--ignore-matching-lines=TODO', '--ignore-matching-lines=FIXME', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', ignore_matching_lines: %w[TODO FIXME])
+      end
+
+      it 'includes --check when check: true' do
+        expect_command_capturing('diff-index', '--check', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', check: true)
+      end
+
+      it 'includes --ws-error-highlight=old,new when ws_error_highlight: "old,new"' do
+        expect_command_capturing('diff-index', '--ws-error-highlight=old,new', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', ws_error_highlight: 'old,new')
+      end
+    end
+
+    context 'with pickaxe and filtering options' do
+      it 'includes -l200 when l: 200' do
+        expect_command_capturing('diff-index', '-l200', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', l: 200)
+      end
+
+      it 'includes --diff-filter=ACMR when diff_filter: "ACMR"' do
+        expect_command_capturing('diff-index', '--diff-filter=ACMR', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', diff_filter: 'ACMR')
+      end
+
+      it 'includes -Ssearch when S: "search"' do
+        expect_command_capturing('diff-index', '-Ssearch', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', S: 'search')
+      end
+
+      it 'includes -Gpattern when G: "pattern"' do
+        expect_command_capturing('diff-index', '-Gpattern', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', G: 'pattern')
+      end
+
+      it 'includes --find-object=abc123 when find_object: "abc123"' do
+        expect_command_capturing('diff-index', '--find-object=abc123', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', find_object: 'abc123')
+      end
+
+      it 'includes --pickaxe-all when pickaxe_all: true' do
+        expect_command_capturing('diff-index', '--pickaxe-all', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', pickaxe_all: true)
+      end
+
+      it 'includes --pickaxe-regex when pickaxe_regex: true' do
+        expect_command_capturing('diff-index', '--pickaxe-regex', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', pickaxe_regex: true)
+      end
+
+      it 'includes -Oorder.txt when O: "order.txt"' do
+        expect_command_capturing('diff-index', '-Oorder.txt', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', O: 'order.txt')
+      end
+
+      it 'includes --skip-to=file.txt when skip_to: "file.txt"' do
+        expect_command_capturing('diff-index', '--skip-to=file.txt', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', skip_to: 'file.txt')
+      end
+
+      it 'includes --rotate-to=file.txt when rotate_to: "file.txt"' do
+        expect_command_capturing('diff-index', '--rotate-to=file.txt', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', rotate_to: 'file.txt')
+      end
+    end
+
+    context 'with miscellaneous diff options' do
+      it 'includes -R when R: true' do
+        expect_command_capturing('diff-index', '-R', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', R: true)
+      end
+
+      it 'includes --relative when relative: true' do
+        expect_command_capturing('diff-index', '--relative', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', relative: true)
+      end
+
+      it 'includes --relative=src/ when relative: "src/"' do
+        expect_command_capturing('diff-index', '--relative=src/', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', relative: 'src/')
+      end
+
+      it 'includes --no-relative when relative: false' do
+        expect_command_capturing('diff-index', '--no-relative', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', relative: false)
+      end
+
+      it 'includes --text when text: true' do
+        expect_command_capturing('diff-index', '--text', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', text: true)
+      end
+
+      it 'includes --function-context when function_context: true' do
+        expect_command_capturing('diff-index', '--function-context', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', function_context: true)
+      end
+
+      it 'includes --inter-hunk-context=3 when inter_hunk_context: 3' do
+        expect_command_capturing('diff-index', '--inter-hunk-context=3', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', inter_hunk_context: 3)
+      end
+
+      it 'includes --exit-code when exit_code: true' do
+        expect_command_capturing('diff-index', '--exit-code', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', exit_code: true)
+      end
+
+      it 'includes --quiet when quiet: true' do
+        expect_command_capturing('diff-index', '--quiet', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', quiet: true)
+      end
+
+      it 'includes --textconv when textconv: true' do
+        expect_command_capturing('diff-index', '--textconv', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', textconv: true)
+      end
+
+      it 'includes --no-textconv when textconv: false' do
+        expect_command_capturing('diff-index', '--no-textconv', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', textconv: false)
+      end
+
+      it 'includes --ignore-submodules when ignore_submodules: true' do
+        expect_command_capturing('diff-index', '--ignore-submodules', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', ignore_submodules: true)
+      end
+
+      it 'includes --ignore-submodules=all when ignore_submodules: "all"' do
+        expect_command_capturing('diff-index', '--ignore-submodules=all', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', ignore_submodules: 'all')
+      end
+
+      it 'includes --ita-invisible-in-index when ita_invisible_in_index: true' do
+        expect_command_capturing('diff-index', '--ita-invisible-in-index', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', ita_invisible_in_index: true)
+      end
+
+      it 'includes --max-depth=2 when max_depth: 2' do
+        expect_command_capturing('diff-index', '--max-depth=2', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', max_depth: 2)
+      end
+    end
+
+    context 'with prefix and line display options' do
+      it 'includes --src-prefix=a/ when src_prefix: "a/"' do
+        expect_command_capturing('diff-index', '--src-prefix=a/', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', src_prefix: 'a/')
+      end
+
+      it 'includes --dst-prefix=b/ when dst_prefix: "b/"' do
+        expect_command_capturing('diff-index', '--dst-prefix=b/', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', dst_prefix: 'b/')
+      end
+
+      it 'includes --no-prefix when no_prefix: true' do
+        expect_command_capturing('diff-index', '--no-prefix', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', no_prefix: true)
+      end
+
+      it 'includes --default-prefix when default_prefix: true' do
+        expect_command_capturing('diff-index', '--default-prefix', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', default_prefix: true)
+      end
+
+      it 'includes --line-prefix=| when line_prefix: "| "' do
+        expect_command_capturing('diff-index', '--line-prefix=| ', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', line_prefix: '| ')
+      end
+    end
+
+    context 'with repeatable options' do
+      it 'includes --anchored=context when anchored: "context"' do
+        expect_command_capturing('diff-index', '--anchored=context', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', anchored: 'context')
+      end
+
+      it 'repeats --anchored= for each value in an array' do
+        expect_command_capturing('diff-index', '--anchored=ctx1', '--anchored=ctx2', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', anchored: %w[ctx1 ctx2])
+      end
+    end
+
+    context 'with path operands' do
+      it 'appends a single path after the tree_ish operand with -- separator' do
+        expect_command_capturing('diff-index', 'HEAD', '--', 'lib/')
+          .and_return(command_result(''))
+
+        command.call('HEAD', 'lib/')
+      end
+
+      it 'appends multiple paths after the tree_ish operand with -- separator' do
+        expect_command_capturing('diff-index', 'HEAD', '--', 'lib/', 'spec/')
+          .and_return(command_result(''))
+
+        command.call('HEAD', 'lib/', 'spec/')
+      end
+
+      it 'places options before tree_ish and paths after the -- separator' do
+        expect_command_capturing('diff-index', '--cached', 'HEAD', '--', 'lib/')
+          .and_return(command_result(''))
+
+        command.call('HEAD', 'lib/', cached: true)
+      end
+    end
+
+    context 'with DSL option aliases' do
+      it 'supports :p as alias for :patch' do
+        expect_command_capturing('diff-index', '--patch', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', p: true)
+      end
+
+      it 'supports :u as alias for :patch' do
+        expect_command_capturing('diff-index', '--patch', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', u: true)
+      end
+
+      it 'supports :s as alias for :no_patch' do
+        expect_command_capturing('diff-index', '--no-patch', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', s: true)
+      end
+
+      it 'supports :M as alias for :find_renames' do
+        expect_command_capturing('diff-index', '--find-renames', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', M: true)
+      end
+
+      it 'supports :C as alias for :find_copies' do
+        expect_command_capturing('diff-index', '--find-copies', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', C: true)
+      end
+
+      it 'supports :B as alias for :break_rewrites' do
+        expect_command_capturing('diff-index', '--break-rewrites', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', B: true)
+      end
+
+      it 'supports :D as alias for :irreversible_delete' do
+        expect_command_capturing('diff-index', '--irreversible-delete', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', D: true)
+      end
+
+      it 'supports :X as alias for :dirstat' do
+        expect_command_capturing('diff-index', '--dirstat', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', X: true)
+      end
+
+      it 'supports :W as alias for :function_context' do
+        expect_command_capturing('diff-index', '--function-context', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', W: true)
+      end
+
+      it 'supports :b as alias for :ignore_space_change' do
+        expect_command_capturing('diff-index', '--ignore-space-change', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', b: true)
+      end
+
+      it 'supports :w as alias for :ignore_all_space' do
+        expect_command_capturing('diff-index', '--ignore-all-space', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', w: true)
+      end
+
+      it 'supports :a as alias for :text' do
+        expect_command_capturing('diff-index', '--text', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', a: true)
+      end
+
+      it 'supports :U as alias for :unified' do
+        expect_command_capturing('diff-index', '--unified=5', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', U: 5)
+      end
+
+      it 'supports :I as alias for :ignore_matching_lines' do
+        expect_command_capturing('diff-index', '--ignore-matching-lines=TODO', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', I: 'TODO')
+      end
+    end
+
+    context 'with negatable options' do
+      it 'adds --indent-heuristic when indent_heuristic: true' do
+        expect_command_capturing('diff-index', '--indent-heuristic', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', indent_heuristic: true)
+      end
+
+      it 'adds --no-indent-heuristic when indent_heuristic: false' do
+        expect_command_capturing('diff-index', '--no-indent-heuristic', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', indent_heuristic: false)
+      end
+
+      it 'adds --color when color: true' do
+        expect_command_capturing('diff-index', '--color', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', color: true)
+      end
+
+      it 'adds --no-color when color: false' do
+        expect_command_capturing('diff-index', '--no-color', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', color: false)
+      end
+
+      it 'adds --color=always when color: "always"' do
+        expect_command_capturing('diff-index', '--color=always', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', color: 'always')
+      end
+
+      it 'adds --ext-diff when ext_diff: true' do
+        expect_command_capturing('diff-index', '--ext-diff', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', ext_diff: true)
+      end
+
+      it 'adds --no-ext-diff when ext_diff: false' do
+        expect_command_capturing('diff-index', '--no-ext-diff', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', ext_diff: false)
+      end
+
+      it 'adds --rename-empty when rename_empty: true' do
+        expect_command_capturing('diff-index', '--rename-empty', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', rename_empty: true)
+      end
+
+      it 'adds --no-rename-empty when rename_empty: false' do
+        expect_command_capturing('diff-index', '--no-rename-empty', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', rename_empty: false)
+      end
+    end
+
+    context 'exit code handling' do
+      it 'returns successfully with exit code 0 when no differences' do
+        expect_command_capturing('diff-index', 'HEAD')
+          .and_return(command_result('', exitstatus: 0))
+
+        result = command.call('HEAD')
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'returns successfully with exit code 1 (within allowed range)' do
+        expect_command_capturing('diff-index', 'HEAD')
+          .and_return(command_result('', exitstatus: 1))
+
+        result = command.call('HEAD')
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.exitstatus).to eq(1)
+      end
+
+      it 'raises FailedError when git exits with code 2 or higher' do
+        expect_command_capturing('diff-index', 'HEAD')
+          .and_return(command_result('', stderr: 'fatal: bad revision', exitstatus: 128))
+
+        expect { command.call('HEAD') }.to raise_error(Git::FailedError, /fatal: bad revision/)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when tree_ish is not provided' do
+        expect { command.call }.to raise_error(ArgumentError, /tree_ish/)
+      end
+
+      it 'raises ArgumentError for unsupported option keys' do
+        expect { command.call('HEAD', totally_unknown: true) }.to raise_error(ArgumentError, /totally_unknown/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Adds `Git::Commands::DiffIndex`, a new command class implementing `git diff-index` using the `Git::Commands::Base` Arguments DSL architecture.

# Description

Implements `git diff-index` as a `Git::Commands::Base` subclass. The command compares a tree object against either the index (`--cached`) or the working tree.

The Arguments DSL covers the full option surface of `git diff-index`:
- diff-index-specific flags (`-m`, `--cached`, `--merge-base`)
- All output format options (patch, raw, numstat, shortstat, stat, name-only, name-status, etc.)
- Diff algorithm options including repeatable `--anchored`
- Statistics variants (stat-width, stat-name-width, dirstat, dirstat-by-file, etc.)
- Color and word-diff options (color-moved with negatable form, word-diff, color-words)
- Whitespace handling (ignore-cr-at-eol, ignore-space-change, repeatable ignore-matching-lines, etc.)
- Rename/copy detection (find-renames, find-copies, break-rewrites, abbrev, etc.)
- Pickaxe/filtering options (-S, -G, --find-object, --diff-filter, etc.)
- Miscellaneous options (--relative with negatable, --textconv with negatable, --exit-code, etc.)
- Prefix options (--src-prefix, --dst-prefix, --no-prefix, --default-prefix, --line-prefix)

`allow_exit_status 0..1` is declared because `git diff-index` exits 1 when differences are found (e.g. with `--exit-code`).

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD)
