### PR TITLE
refactor(skills): add action-option-with-optional-value DSL pattern

### DIFF
--- a/.github/skills/review-arguments-dsl/CHECKLIST.md
+++ b/.github/skills/review-arguments-dsl/CHECKLIST.md
@@ -31,6 +31,48 @@ Common examples: `--branches[=<pattern>]`, `--tags[=<pattern>]`,
 **Do not** use `flag_option` for these — it silently drops the value when one is
 supplied.
 
+### Action-option-with-optional-value commands
+
+Some git commands express their **primary action** as an option with an optional
+value (man-page notation: `--flag[=<value>]`). The canonical example is
+`git am --show-current-patch[=(diff|raw)]` — there is no mode where the flag is
+*not* passed; the optional `=<value>` just refines the behavior.
+
+This situation is distinct from a normal `flag_or_value_option` used as a
+modifier: the option IS the command. Do **not** model this as `literal
+'--show-current-patch'` — that precludes passing the optional value.
+
+**DSL entry:**
+
+```ruby
+flag_or_value_option :show_current_patch, inline: true, type: [TrueClass, String]
+```
+
+**Required `#call` override** — the class must provide a positional `#call`
+override that maps the positional API onto the option keyword:
+
+```ruby
+def call(value = true, *, **)
+  super(*, **, option_name: value)
+end
+```
+
+Where:
+- `value = true` — `true` emits `--flag` alone; a String emits `--flag=value`
+- `*` — forwards any positional operands declared in the DSL (omit when none)
+- `**` — forwards keyword options; unknown keywords raise `ArgumentError`
+- `option_name: value` placed last so the positional arg always wins
+
+**Flag these as errors:**
+
+- Using `literal '--flag'` when the man page shows `--flag[=<value>]`
+- Omitting `type: [TrueClass, String]` — allows `false` to silently pass, which
+  emits nothing and produces no error
+- Omitting the `#call` override — forces callers to use the awkward keyword form
+  `.call(option_name: true)` instead of the natural `.call` or `.call('diff')`
+- Using `nil` as the default in the override instead of `true` (use
+  `value = true`, not `value = nil` with `|| true`)
+
 ### Choosing the correct pathspec form
 
 The two pathspec-style rows above look similar but represent meaningfully different

--- a/.github/skills/review-command-implementation/SKILL.md
+++ b/.github/skills/review-command-implementation/SKILL.md
@@ -170,6 +170,20 @@ adds no behavior and conflicts with the `@!method` directive.
    `Base#with_stdin`
 3. **Non-trivial option routing** — build different argument sets based on
    which options are present
+4. **Action-option-with-optional-value** — when the command's primary action is
+   expressed as an option with an optional value (man-page notation:
+   `--flag[=<value>]`). The DSL entry uses `flag_or_value_option :name, inline:
+   true, type: [TrueClass, String]` and the override maps a positional `call` API
+   onto the keyword:
+
+   ```ruby
+   def call(value = true, *, **)
+     super(*, **, option_name: value)
+   end
+   ```
+
+   See [Action-option-with-optional-value commands](../scaffold-new-command/SKILL.md#action-option-with-optional-value-commands)
+   for the full pattern and rationale.
 
 **When overriding:**
 

--- a/.github/skills/scaffold-new-command/SKILL.md
+++ b/.github/skills/scaffold-new-command/SKILL.md
@@ -22,6 +22,7 @@ docs using the `Git::Commands::Base` architecture.
   - [Namespace module template](#namespace-module-template)
 - [Command template (Base pattern)](#command-template-base-pattern)
   - [Overriding `call` — inline example](#overriding-call--inline-example)
+    - [Action-option-with-optional-value commands](#action-option-with-optional-value-commands)
     - [When to use `skip_cli` on `operand`](#when-to-use-skip_cli-on-operand)
 - [Options completeness — consult the man page first](#options-completeness--consult-the-man-page-first)
 - [Execution-model conflicts are intentionally omitted](#execution-model-conflicts-are-intentionally-omitted)
@@ -344,6 +345,46 @@ arguments do
   requires_one_of :objects, :batch_all_objects
 end
 ```
+
+#### Action-option-with-optional-value commands
+
+When a git command's primary action is an option with an optional value (man-page
+notation: `--flag[=<value>]`, e.g. `git am --show-current-patch[=(diff|raw)]`),
+use this pattern:
+
+**DSL:**
+```ruby
+arguments do
+  literal 'am'
+  flag_or_value_option :show_current_patch, inline: true, type: [TrueClass, String]
+end
+```
+
+**`#call` override** — required to give callers a natural positional API:
+```ruby
+# Show the patch currently being applied by `git am`
+#
+# @param value [true, String] When +true+ (default), emits +--show-current-patch+
+#   (git's default behavior). Pass +"diff"+ or +"raw"+ to emit
+#   +--show-current-patch=diff+ / +--show-current-patch=raw+.
+#
+# @return [Git::CommandLineResult] the result of the command
+#
+# @raise [Git::FailedError] if no am session is in progress
+#
+def call(value = true, *, **)
+  super(*, **, option_name: value)
+end
+```
+
+Where:
+- `value = true` — positional default; `true` emits `--flag`; a String emits `--flag=value`
+- `*` — forwards positional operands declared in the DSL (omit when the command has none)
+- `**` — forwards keyword options to the DSL binder; unknown keywords raise `ArgumentError`
+- `option_name: value` placed last so the positional arg always takes precedence
+
+The `type: [TrueClass, String]` on the DSL entry rejects `false` at bind time,
+removing the need for manual validation in the override.
 
 #### When to use `skip_cli` on `operand`
 


### PR DESCRIPTION
## Description

Documents the DSL pattern for git commands whose primary action is expressed as an option with an optional value (man-page notation: `--flag[=<value>]`), e.g. `git am --show-current-patch[=(diff|raw)]`.

**Changes:**
- `scaffold-new-command`: adds "Action-option-with-optional-value commands" section with DSL snippet, `#call` override template, and rationale
- `review-arguments-dsl`: adds matching checklist section listing common mistakes (using `literal` instead of `flag_or_value_option`, missing `type: [TrueClass, String]`, missing `#call` override, using `nil` default instead of `true`)
- `review-command-implementation`: adds case 4 to the `#call` override permitted-reasons list with cross-reference to the scaffold skill

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).