### PR TITLE
refactor: enforce command-layer neutrality and facade-owned policy

### DIFF
--- a/.github/skills/extract-command-from-lib/SKILL.md
+++ b/.github/skills/extract-command-from-lib/SKILL.md
@@ -431,6 +431,13 @@ A command class may expose many more options than the legacy `Git::Lib` method
 ever accepted. Without filtering, callers could accidentally pass options that
 happen to match command DSL names but were never part of the public contract.
 
+The facade is also where **policy options** are set as safe defaults — options
+that support non-interactive execution, control output format for parsing, or
+set other command-level defaults. The command class stays neutral; the facade
+makes the defaults explicit; callers may override when needed. Examples:
+`edit: false`, `verbose: true`, `progress: false`, `no_color: true`.
+See "Command-layer neutrality" in CONTRIBUTING.md.
+
 Declare an `<COMMAND>_ALLOWED_OPTS` constant listing only the options that were
 present in the original method. Call `assert_valid_opts` first to raise
 `ArgumentError` on unrecognised keys, then use `opts.slice` to filter before
@@ -446,7 +453,8 @@ def pull(remote = nil, branch = nil, opts = {})
   assert_valid_opts(opts, PULL_ALLOWED_OPTS)
   allowed_opts = opts.slice(*PULL_ALLOWED_OPTS)
   positional_args = [remote, branch].compact
-  Git::Commands::Pull.new(self).call(*positional_args, no_edit: true, **allowed_opts).stdout
+  # edit: false is the non-interactive default (see CONTRIBUTING.md)
+  Git::Commands::Pull.new(self).call(*positional_args, edit: false, **allowed_opts).stdout
 end
 ```
 

--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -104,6 +104,20 @@ Git::Base (facade)
 Command classes that need non-zero successful exits declare
 `allow_exit_status <Range>` with a rationale comment.
 
+### Command-layer neutrality
+
+Command classes are neutral, faithful representations of the git CLI. They declare
+options via the DSL but never embed policy choices (output-control flags, editor
+suppression, progress, verbose mode). The facade (`Git::Lib`) sets safe defaults
+at each call site; callers may override when needed. The execution layer
+(`GIT_EDITOR='true'`) is an unconditional safety net.
+
+> **Anti-pattern:** `literal '--no-edit'`, `literal '--verbose'`,
+> `literal '--no-progress'` inside a command class.
+>
+> **Correct pattern:** `flag_option :edit, negatable: true` in the command;
+> `edit: false` passed from the facade call site.
+
 ### Validation Boundaries
 
 Command classes use per-argument validation parameters (`required:`, `type:`,

--- a/.github/skills/refactor-command-to-commandlineresult/SKILL.md
+++ b/.github/skills/refactor-command-to-commandlineresult/SKILL.md
@@ -90,6 +90,11 @@ end
 
 - parser invocations
 - output transformation logic
+- `literal` entries for policy/output-control flags (e.g. `literal '--no-edit'`,
+  `literal '--verbose'`, `literal '--no-progress'`, `literal '--no-color'`) —
+  command classes are neutral, faithful representations of the git CLI; convert to
+  `flag_option` / `value_option` so the facade can pass the policy value. See
+  "Command-layer neutrality" in CONTRIBUTING.md.
 - manual `raise_on_failure` / manual exit-code checks (unless temporarily needed in
   an unmigrated class)
 - duplicated bind/execute logic

--- a/.github/skills/review-arguments-dsl/CHECKLIST.md
+++ b/.github/skills/review-arguments-dsl/CHECKLIST.md
@@ -374,13 +374,12 @@ Include ALL git options in the DSL by default — including output-format flags 
 `--patch`, `--numstat`, `--raw`, `--format=…`, `--pretty=…`, `--no-color`, etc.
 
 The only options that should be **excluded** are those that conflict with the
-subprocess execution model: options that require TTY input, open an external editor,
-or otherwise make the command incompatible with non-interactive subprocess execution:
+subprocess execution model: options that require TTY input or otherwise make the
+command incompatible with non-interactive subprocess execution:
 
 Examples of options to **exclude** (execution-model conflicts):
 
 - `--interactive` / `-i` — opens an interactive menu; requires a TTY
-- `--edit` / `-e` — opens an editor ($EDITOR); incompatible with subprocess
 - `--patch` (interactive form, e.g. `git add -p`) — requires TTY prompts
 - Any option whose git implementation requires stdin/TTY interaction the library
   cannot provide
@@ -404,12 +403,20 @@ Examples of options to **include** (no execution-model conflict):
 **Default assumption for `--verbose` and `--quiet`:** include unless their git
 implementation requires interactive I/O.
 
-**The `--no-edit` edge case:** `--no-edit` is a safe, non-interactive flag — it
-suppresses editor opening, which is the opposite of an execution-model conflict. If
-the facade always passes `--no-edit` to prevent interactive editor invocations (e.g.,
-for `git commit --amend --no-edit`), include `--no-edit` in the DSL using
-`flag_option :no_edit`. Do **not** hardcode it as `literal '--no-edit'` — that
-prevents callers from omitting it.
+Command classes are neutral — they never hardcode `literal` entries for
+output-control, editor-suppression, or progress flags. Declare these as
+`flag_option` / `value_option` so the facade can pass the policy value.
+
+> **Anti-pattern:** `literal '--no-edit'`, `literal '--verbose'`,
+> `literal '--no-progress'` inside a command class.
+>
+> **Correct pattern:** `flag_option :edit, negatable: true` in the command;
+> `edit: false` passed from the facade call site.
+
+**The `--edit` / `--no-edit` pair:** Model as `flag_option :edit, negatable: true`.
+The facade (`Git::Lib`) passes `edit: false` at each call site. Do **not** hardcode
+`literal '--no-edit'` — that prevents the facade from controlling the option — and do
+**not** exclude `--edit` from the DSL.
 
 **Output-format options belong at the facade call site, not as `literal` entries:**
 When a parser requires specific output flags (e.g. `--pretty=raw`, `--numstat`),

--- a/.github/skills/review-backward-compatibility/SKILL.md
+++ b/.github/skills/review-backward-compatibility/SKILL.md
@@ -249,6 +249,9 @@ end
 3. **Remove all new methods**: Don't try to make new methods backward compatible - just remove them
 4. **Minimize changes**: Only modify what's necessary for backward compatibility
 5. **Document conversions**: Make helper methods clear and well-named
+6. **Apply policy at the facade**: `Git::Lib` methods pass policy options explicitly
+   (e.g. `edit: false`, `verbose: true`, `progress: false`) — command classes stay
+   neutral. See "Command-layer neutrality" in CONTRIBUTING.md.
 
 ## Validation Checklist
 

--- a/.github/skills/review-command-implementation/SKILL.md
+++ b/.github/skills/review-command-implementation/SKILL.md
@@ -231,6 +231,11 @@ automatically during `args_definition.bind(...)` — do not set defaults manuall
 - [ ] DSL entries accurately describe subcommand interface
 - [ ] Option aliases and modifiers are used correctly
 - [ ] Ordering produces expected CLI argument order
+- [ ] No `literal` entries for output-control, editor-suppression, or progress flags
+      (e.g. `--no-edit`, `--verbose`, `--no-progress`, `--no-color`). Command classes
+      are neutral, faithful representations of the git CLI — these must be
+      `flag_option` / `value_option` so the facade can control them. See
+      "Command-layer neutrality" in CONTRIBUTING.md.
 - [ ] `operand ... skip_cli: true` is used only for domain inputs that must bind/validate
   but must not emit to argv (for example, stdin-fed object lists)
 - [ ] `execution_option` is used for execution kwargs (`timeout:`, `chdir:`), not `skip_cli`
@@ -268,6 +273,43 @@ For migration PRs, verify process constraints:
       `bundle exec rubocop`, `bundle exec rake yard`)
 
 ## Common Failures
+
+### Policy/output-control flag hardcoded as `literal` (neutrality violation)
+
+`literal` entries for output-control, editor-suppression, progress, or verbose
+flags inside a command class violate the neutrality principle. The command class
+must model the git CLI faithfully; the facade sets safe defaults and callers may
+override them.
+
+Symptom: the command class contains one or more of:
+
+```ruby
+# ❌ Any of these are neutrality violations
+literal '--no-edit'
+literal '--verbose'
+literal '--no-progress'
+literal '--no-color'
+literal '--porcelain'
+```
+
+Fix: convert each to a DSL option and pass the policy value from the facade:
+
+```ruby
+# ✅ In the command class — neutral DSL declaration
+flag_option :edit, negatable: true
+flag_option :progress, negatable: true
+flag_option :verbose
+value_option :format
+
+# ✅ In Git::Lib — facade passes the policy value explicitly
+Git::Commands::Pull.new(self).call(edit: false, progress: false)
+Git::Commands::Mv.new(self).call(*args, verbose: true)
+Git::Commands::Fsck.new(self).call(progress: false)
+```
+
+See "Command-layer neutrality" in CONTRIBUTING.md for the full policy.
+
+### Other common failures
 
 - lingering `ARGS = Arguments.define` constant and custom `#call`
 - command-specific duplicated exit-status checks instead of `allow_exit_status`

--- a/.github/skills/review-command-tests/SKILL.md
+++ b/.github/skills/review-command-tests/SKILL.md
@@ -216,6 +216,44 @@ conditions. Command specs should test that the command **uses** the DSL correctl
 (i.e., the right arguments reach `execution_context.command_capturing`), not re-test
 the DSL's own behavior.
 
+**Policy vs. interface testing:** Command classes are neutral, faithful
+representations of the git CLI. Their unit tests verify CLI argument building (the
+neutral interface), not policy enforcement. Tests should **not** hardcode policy
+assumptions — for example, a command spec should not always pass `edit: false` or
+expect `--no-edit` unless the test is specifically exercising that option.
+
+> **Anti-pattern:** every `it` block in a command spec passes `edit: false`,
+> `progress: false`, or `no_color: true` — this tests the facade's policy, not
+> the command's interface.
+>
+> **Correct pattern:** test each option independently (`it 'passes --no-edit
+> when edit is false'`); test the default (no option passed) separately. Policy
+> enforcement (which options the facade passes and why) is tested at the facade
+> layer (`lib_command_spec.rb`).
+
+**Where to test policy enforcement:** Policy tests belong in the facade layer,
+not in command specs. When a `Git::Lib` method sets policy defaults like
+`edit: false` or `progress: false`, the corresponding `lib_command_spec.rb`
+(or `lib_spec.rb`) test should verify those defaults reach the command:
+
+```ruby
+# spec/unit/git/lib_command_spec.rb — facade policy-default test
+describe '#pull' do
+  it 'defaults to edit: false for non-interactive execution' do
+    expect_any_instance_of(Git::Commands::Pull)
+      .to receive(:call).with(anything, edit: false).and_call_original
+    lib.pull('origin', 'main')
+  end
+end
+```
+
+This separation ensures:
+- Command specs verify the **neutral interface** (every option works correctly)
+- Facade specs verify the **policy** (the right options are passed and why)
+- An AI sees exactly where each concern is tested and does not conflate them
+
+See "Command-layer neutrality" in CONTRIBUTING.md.
+
 ### `#initialize` — omit from command specs
 
 **Do not write a `describe '#initialize'` block in command specs.** This is a

--- a/.github/skills/review-cross-command-consistency/SKILL.md
+++ b/.github/skills/review-cross-command-consistency/SKILL.md
@@ -85,6 +85,11 @@ only as a supplemental check.
 - [ ] shared options use same alias/modifier patterns
 - [ ] shared entries appear in same relative order
 - [ ] command-specific differences are intentional and documented
+- [ ] no `literal` entries for policy/output-control flags (`--no-edit`, `--verbose`,
+      `--no-progress`, `--no-color`, etc.) — command classes are neutral, faithful
+      representations of the git CLI; all siblings use `flag_option` /
+      `value_option` for these, leaving policy decisions to the facade. See
+      "Command-layer neutrality" in CONTRIBUTING.md.
 
 ### 3. Exit-status consistency
 

--- a/.github/skills/scaffold-new-command/SKILL.md
+++ b/.github/skills/scaffold-new-command/SKILL.md
@@ -35,6 +35,7 @@ docs using the `Git::Commands::Base` architecture.
   - [Step 1 — Review Arguments DSL](#step-1--review-arguments-dsl)
   - [Step 2 — Review Command Tests](#step-2--review-command-tests)
   - [Step 3 — Command YARD Documentation](#step-3--command-yard-documentation)
+- [Facade delegation and policy options](#facade-delegation-and-policy-options)
 - [Phased rollout, compatibility, and quality gates](#phased-rollout-compatibility-and-quality-gates)
 
 ## How to use this skill
@@ -449,7 +450,7 @@ For each option, make one of two decisions:
 | Decision | Reason | Action |
 |---|---|---|
 | **Include** | All behavioral options — including output-format flags (`--pretty=`, `--patch`, `--numstat`, `--name-only`, etc.) and filtering/selection flags | Add to `arguments do` |
-| **Exclude (execution-model conflict)** | Requires TTY input, opens an external editor, or otherwise makes the command incompatible with non-interactive subprocess execution | Omit — see "Execution-model conflicts are intentionally omitted" below |
+| **Exclude (execution-model conflict)** | Requires TTY input or otherwise makes the command incompatible with non-interactive subprocess execution | Omit — see "Execution-model conflicts are intentionally omitted" below |
 
 Group related options with a comment in the DSL (e.g. `# Ref inclusion`, `# Date
 filtering`, `# Commit ordering`). Follow the section groupings from the
@@ -504,6 +505,15 @@ supported Git version has also been raised.
 
 ## Execution-model conflicts are intentionally omitted
 
+Command classes are neutral — they never hardcode policy choices (output-control,
+editor suppression, progress, verbose). Those belong to the facade (`Git::Lib`).
+
+> **Anti-pattern:** `literal '--no-edit'`, `literal '--verbose'`,
+> `literal '--no-progress'` inside a command class.
+>
+> **Correct pattern:** `flag_option :edit, negatable: true` in the command;
+> `edit: false` passed from the facade call site.
+
 Include **all** git options in the DSL by default — including output-format flags
 such as `--patch`, `--numstat`, `--raw`, `--format=…`, `--pretty=…`, `--no-color`,
 etc. The facade passes these explicitly when a parser requires a specific format;
@@ -513,7 +523,6 @@ The **only** options to exclude are those that conflict with non-interactive
 subprocess execution:
 
 - `--interactive` / `-i` — opens an interactive menu; requires a TTY
-- `--edit` / `-e` — opens `$EDITOR`; incompatible with subprocess execution
 - `--patch` (interactive form, e.g. `git add -p`) — requires TTY prompts
 - Any option whose git implementation requires stdin/TTY interaction the
   library cannot provide
@@ -523,12 +532,13 @@ subprocess execution:
 > (exclude). In `git diff --patch` it selects a non-interactive output format
 > (include). Evaluate per-command, not globally.
 
+**`--edit` / `--no-edit`:** Model as `flag_option :edit, negatable: true`. The
+command class is neutral; the facade passes `edit: false` at each call site. Do
+**not** hardcode `literal '--no-edit'`. See "Command-layer neutrality" in
+CONTRIBUTING.md.
+
 **`--verbose`/`-v` and `--quiet`/`-q`:** include these unless their git
 implementation requires interactive I/O.
-
-**The `--no-edit` edge case:** `--no-edit` suppresses editor opening — it is the
-opposite of an execution-model conflict. Use `flag_option :no_edit`; do **not**
-hardcode it as `literal '--no-edit'`, which prevents callers from omitting it.
 
 ## `end_of_options` placement
 
@@ -815,6 +825,46 @@ against the unit and integration spec files. Fix all issues before proceeding.
 
 Load and apply **[Command YARD Documentation](../command-yard-documentation/SKILL.md)**
 against the command class. Fix all issues before proceeding.
+
+## Facade delegation and policy options
+
+The command class is only half the story. After scaffolding the command, you must
+also write (or update) the `Git::Lib` method that **delegates** to it. The facade
+sets safe policy defaults at each call site — `edit: false`, `verbose: true`,
+`progress: false`, etc. — not as `literal` entries inside the command class.
+Callers may override these defaults when needed.
+See "Command-layer neutrality" in CONTRIBUTING.md.
+
+```ruby
+# lib/git/lib.rb — facade method for `git pull`
+
+PULL_ALLOWED_OPTS = %i[allow_unrelated_histories].freeze
+
+def pull(remote = nil, branch = nil, opts = {})
+  raise ArgumentError, 'You must specify a remote if a branch is specified' if remote.nil? && !branch.nil?
+
+  assert_valid_opts(opts, PULL_ALLOWED_OPTS)
+  allowed_opts = opts.slice(*PULL_ALLOWED_OPTS)
+  positional_args = [remote, branch].compact
+  # edit: false is the non-interactive default (see CONTRIBUTING.md)
+  Git::Commands::Pull.new(self).call(*positional_args, edit: false, **allowed_opts).stdout
+end
+```
+
+Key points for the facade method:
+
+- **Filter options** — declare an `ALLOWED_OPTS` constant listing only the options
+  the public API accepted at v4.3.0. Use `assert_valid_opts` + `opts.slice` to
+  prevent accidental API expansion.
+- **Pass policy options as safe defaults** — `edit: false`, `progress: false`, etc.
+  Place them before `**opts` so the caller can override when needed.
+  Add a comment explaining *why* (e.g., `# non-interactive default`).
+- **Return the legacy type** — typically `.stdout` or a parsed struct, not
+  `CommandLineResult`.
+
+See [Extract Command from Lib](../extract-command-from-lib/SKILL.md) for the
+complete delegation workflow and additional patterns (stdout passthrough,
+parsed return values, opts-hash normalization).
 
 ## Phased rollout, compatibility, and quality gates
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,7 @@
 - [Branch strategy](#branch-strategy)
 - [AI-assisted contributions](#ai-assisted-contributions)
 - [Design philosophy](#design-philosophy)
+- [Command-layer neutrality](#command-layer-neutrality)
 - [Wrapping a git command](#wrapping-a-git-command)
   - [Method placement](#method-placement)
   - [Method naming](#method-naming)
@@ -153,6 +154,35 @@ avoiding extensions or alterations that could lead to unexpected behaviors.
 By following this philosophy, the `git` gem allows users to leverage their existing
 knowledge of Git while benefiting from the expressiveness and power of Ruby's syntax
 and paradigms.
+
+## Command-layer neutrality
+
+Command classes (`Git::Commands::*`) are **faithful, neutral representations of the
+git CLI**. They declare every option via the DSL but never embed policy choices —
+output-control flags, editor suppression, progress output, verbose mode, etc.
+Policy decisions belong to the facade (`Git::Lib`), which sets safe defaults at
+each call site. Callers may override those defaults when they have a legitimate
+reason (e.g., running in a TTY-attached environment where an editor is desired).
+
+This principle serves two purposes: it keeps the command layer a reusable, unbiased
+interface to git, and it supports this gem's **non-interactive execution model** (git
+is never allowed to prompt for input, open an editor, or wait for TTY interaction
+by default). The execution layer provides an unconditional safety net regardless of
+what the caller passes.
+
+The three architectural layers each play a distinct role:
+
+| Layer | Responsibility | Mechanism |
+|---|---|---|
+| **Command** (`Git::Commands::*`) | Neutral git CLI interface | Declares options via DSL (e.g. `flag_option :edit, negatable: true`) — no policy |
+| **Facade** (`Git::Lib`) | Safe defaults | Sets policy options at each call site (e.g. `edit: false`); callers may override |
+| **Execution** (`Git::CommandLine`) | Unconditional safety net | `GIT_EDITOR='true'` in every subprocess environment |
+
+> **Anti-pattern:** `literal '--no-edit'`, `literal '--verbose'`,
+> `literal '--no-progress'` inside a command class — embeds policy in the wrong layer.
+>
+> **Correct pattern:** `flag_option :edit, negatable: true` in the command;
+> `edit: false` passed from the facade call site.
 
 ## Wrapping a git command
 

--- a/lib/git/commands/commit.rb
+++ b/lib/git/commands/commit.rb
@@ -28,8 +28,7 @@ module Git
     class Commit < Git::Commands::Base
       arguments do
         literal 'commit'
-        # Always suppress editor (non-interactive use)
-        literal '--no-edit'
+        flag_option :edit, negatable: true
         flag_option %i[all a]
         flag_option :amend
         value_option %i[message m], inline: true, allow_empty: true
@@ -48,6 +47,10 @@ module Git
       #   @overload call(**options)
       #
       #     @param options [Hash] command options
+      #
+      #     @option options [Boolean] :edit (nil) Open an editor for the commit message. When false,
+      #       adds --no-edit to suppress the editor. When true, adds --edit. When nil, defers to
+      #       git's default behavior.
       #
       #     @option options [Boolean] :all (nil) Automatically stage all modified and deleted files
       #       before committing.

--- a/lib/git/commands/fsck.rb
+++ b/lib/git/commands/fsck.rb
@@ -30,7 +30,7 @@ module Git
     class Fsck < Git::Commands::Base
       arguments do
         literal 'fsck'
-        literal '--no-progress'
+        flag_option :progress, negatable: true
         flag_option :tags
         flag_option :root
         flag_option :unreachable
@@ -57,20 +57,23 @@ module Git
       #   @overload call(*object, **options)
       #
       #     @example Check repository integrity
-      #       # git fsck --no-progress
+      #       # git fsck
       #       result = fsck.call
       #
       #     @example Check specific objects
-      #       # git fsck --no-progress abc1234 def5678
+      #       # git fsck abc1234 def5678
       #       result = fsck.call('abc1234', 'def5678')
       #
       #     @example With options
-      #       # git fsck --no-progress --unreachable --strict
+      #       # git fsck --unreachable --strict
       #       result = fsck.call(unreachable: true, strict: true)
       #
       #     @param object [Array<String>] optional object identifiers to check
       #
       #     @param options [Hash] command options
+      #
+      #     @option options [Boolean] :progress (nil) Show progress status (e.g. `--progress`).
+      #       Pass `false` to suppress progress output (e.g. `--no-progress`)
       #
       #     @option options [Boolean] :tags (nil) report tags
       #

--- a/lib/git/commands/merge/start.rb
+++ b/lib/git/commands/merge/start.rb
@@ -33,8 +33,7 @@ module Git
       class Start < Git::Commands::Base
         arguments do
           literal 'merge'
-          # Always suppress editor (non-interactive use)
-          literal '--no-edit'
+          flag_option :edit, negatable: true
 
           # Commit behavior
           flag_option :commit, negatable: true
@@ -84,6 +83,10 @@ module Git
         #       an octopus merge.
         #
         #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :edit (nil) Open an editor for the merge commit message.
+        #       When false, adds --no-edit to suppress the editor. When true, adds --edit.
+        #       When nil, defers to git's default behavior.
         #
         #     @option options [Boolean] :commit (nil) Perform merge and commit.
         #       true for --commit, false for --no-commit

--- a/lib/git/commands/mv.rb
+++ b/lib/git/commands/mv.rb
@@ -28,7 +28,7 @@ module Git
     class Mv < Git::Commands::Base
       arguments do
         literal 'mv'
-        literal '--verbose'
+        flag_option %i[verbose v]
         flag_option %i[force f]
         flag_option %i[dry_run n]
         flag_option :k
@@ -50,6 +50,10 @@ module Git
       #     @param destination [String] the destination file or directory
       #
       #     @param options [Hash] command options
+      #
+      #     @option options [Boolean] :verbose (nil) Report the names of files as they are moved
+      #
+      #       Alias: `:v`
       #
       #     @option options [Boolean] :force (nil) Force renaming or moving even if the destination exists
       #

--- a/lib/git/commands/pull.rb
+++ b/lib/git/commands/pull.rb
@@ -36,7 +36,7 @@ module Git
     #
     # @example Pull and suppress the merge-commit editor
     #   pull = Git::Commands::Pull.new(execution_context)
-    #   pull.call('origin', no_edit: true)
+    #   pull.call('origin', edit: false)
     #
     class Pull < Git::Commands::Base
       arguments do
@@ -50,7 +50,7 @@ module Git
 
         # Merge options
         flag_option :commit, negatable: true                                 # --commit / --no-commit
-        flag_option :no_edit                                                 # --no-edit
+        flag_option :edit, negatable: true                                   # --edit / --no-edit
         value_option :cleanup, inline: true                                  # --cleanup=<mode>
         flag_option :ff_only                                                 # --ff-only
         flag_option :ff, negatable: true                                     # --ff / --no-ff
@@ -93,7 +93,7 @@ module Git
         value_option %i[jobs j], inline: true # --jobs=<n>
         flag_option :set_upstream                                            # --set-upstream
         value_option :upload_pack                                            # --upload-pack <path>
-        flag_option :progress                                                # --progress
+        flag_option :progress, negatable: true                               # --[no-]progress
         value_option %i[server_option o], inline: true, repeatable: true     # --server-option=<option>
         flag_option :show_forced_updates, negatable: true # --show-forced-updates / --no-show-forced-updates
         flag_option %i[ipv4 4]                                               # --ipv4
@@ -143,10 +143,9 @@ module Git
       #
       #       `true` for `--commit`, `false` for `--no-commit`.
       #
-      #     @option options [Boolean] :no_edit (nil) Suppress the editor for the auto-generated
-      #       merge commit message
-      #
-      #       Corresponds to `--no-edit`. The counterpart `--edit`/`-e` is not supported.
+      #     @option options [Boolean] :edit (nil) Open an editor for the merge commit message.
+      #       When false, adds --no-edit to suppress the editor. When true, adds --edit.
+      #       When nil, defers to git's default behavior.
       #
       #     @option options [String] :cleanup (nil) Merge-message cleanup mode
       #
@@ -308,8 +307,10 @@ module Git
       #
       #     @option options [String] :upload_pack (nil) Path to `git-upload-pack` on the remote
       #
-      #     @option options [Boolean] :progress (nil) Force progress reporting even if stderr
-      #       is not a terminal
+      #     @option options [Boolean] :progress (nil) Control progress reporting
+      #
+      #       `true` for `--progress` (force progress even if stderr is not a terminal),
+      #       `false` for `--no-progress` (suppress progress output).
       #
       #     @option options [String, Array<String>] :server_option (nil) Transmit the given
       #       string to the server when communicating using protocol version 2

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -738,7 +738,7 @@ module Git
     # @return [String] the command output
     #
     def mv(source, destination, options = {})
-      Git::Commands::Mv.new(self).call(*Array(source), destination, **options).stdout
+      Git::Commands::Mv.new(self).call(*Array(source), destination, verbose: true, **options).stdout
     end
 
     def full_tree(sha)
@@ -1284,7 +1284,7 @@ module Git
 
       deprecate_commit_add_all_option!(opts)
 
-      Git::Commands::Commit.new(self).call(**opts).stdout
+      Git::Commands::Commit.new(self).call(edit: false, **opts).stdout
     end
 
     # @return [String] the command output
@@ -1529,7 +1529,7 @@ module Git
       # Map legacy option names to new interface
       opts = translate_merge_options(opts)
 
-      Git::Commands::Merge::Start.new(self).call(*Array(branch), **opts).stdout
+      Git::Commands::Merge::Start.new(self).call(*Array(branch), edit: false, **opts).stdout
     end
 
     # Find common ancestor commit(s) for merge
@@ -1829,7 +1829,7 @@ module Git
       assert_valid_opts(opts, PULL_ALLOWED_OPTS)
       allowed_opts = opts.slice(*PULL_ALLOWED_OPTS)
       positional_args = [remote, branch].compact
-      Git::Commands::Pull.new(self).call(*positional_args, no_edit: true, **allowed_opts).stdout
+      Git::Commands::Pull.new(self).call(*positional_args, edit: false, progress: false, **allowed_opts).stdout
     end
 
     # Return the SHA of a tag reference
@@ -1866,7 +1866,7 @@ module Git
     #
     # rubocop:disable Style/ArgumentsForwarding
     def fsck(*objects, **opts)
-      result = Git::Commands::Fsck.new(self).call(*objects, **opts)
+      result = Git::Commands::Fsck.new(self).call(*objects, progress: false, **opts)
       Git::Parsers::Fsck.parse(result.stdout)
     end
     # rubocop:enable Style/ArgumentsForwarding

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -795,6 +795,39 @@ future work:
     `literal "--format=…"` in `Branch::List` and `Tag::List` were moved to
     their respective facade call sites.
 
+17. **Command classes are neutral; the facade owns policy**
+
+    Command classes are faithful, neutral representations of the git CLI. They
+    never hardcode `literal` entries for output-control, editor-suppression, or
+    progress flags. The facade (`Git::Lib`) sets safe defaults at each call site
+    (e.g. `edit: false`, `progress: false`); callers may override when needed.
+    The execution layer (`GIT_EDITOR='true'`) is an unconditional safety net.
+
+    ```ruby
+    # ❌ Anti-pattern: policy embedded in command class
+    class Pull < Git::Commands::Base
+      arguments do
+        literal 'pull'
+        literal '--no-edit'      # ← wrong layer
+        literal '--no-progress'  # ← same problem
+      end
+    end
+
+    # ✅ Correct: command is neutral; facade passes policy options
+    class Pull < Git::Commands::Base
+      arguments do
+        literal 'pull'
+        flag_option :edit, negatable: true
+        flag_option :progress, negatable: true
+      end
+    end
+
+    # lib/git/lib.rb — facade sets safe defaults:
+    Git::Commands::Pull.new(self).call(edit: false, progress: false)
+    ```
+
+    See "Command-layer neutrality" in CONTRIBUTING.md for the full policy.
+
 - **1. Migrate the First Command (`add`)**:
 
   - **Write Unit Tests First**: Write comprehensive RSpec unit tests for the

--- a/spec/unit/git/commands/arguments_spec.rb
+++ b/spec/unit/git/commands/arguments_spec.rb
@@ -1312,9 +1312,9 @@ RSpec.describe Git::Commands::Arguments do
     context 'with as: parameter arrays' do
       it 'supports arrays for flag type' do
         args = described_class.define do
-          flag_option :amend, as: ['--amend', '--no-edit']
+          flag_option :dry_run, as: ['--dry-run', '--porcelain']
         end
-        expect(args.bind(amend: true).to_ary).to eq(['--amend', '--no-edit'])
+        expect(args.bind(dry_run: true).to_ary).to eq(['--dry-run', '--porcelain'])
       end
 
       it 'rejects arrays for flag negatable: true type' do

--- a/spec/unit/git/commands/commit_spec.rb
+++ b/spec/unit/git/commands/commit_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Commit do
     context 'with a simple message' do
       it 'commits with the given message' do
         expected_result = command_result
-        expect_command_capturing('commit', '--no-edit', '--message=Initial commit').and_return(expected_result)
+        expect_command_capturing('commit', '--message=Initial commit').and_return(expected_result)
 
         result = command.call(message: 'Initial commit')
 
@@ -18,23 +18,43 @@ RSpec.describe Git::Commands::Commit do
       end
     end
 
+    context 'with the :edit option' do
+      it 'adds --no-edit when edit is false' do
+        expect_command_capturing('commit', '--no-edit', '--message=Msg').and_return(command_result)
+
+        command.call(edit: false, message: 'Msg')
+      end
+
+      it 'adds --edit when edit is true' do
+        expect_command_capturing('commit', '--edit', '--message=Msg').and_return(command_result)
+
+        command.call(edit: true, message: 'Msg')
+      end
+
+      it 'omits --edit/--no-edit when edit is nil' do
+        expect_command_capturing('commit', '--message=Msg').and_return(command_result)
+
+        command.call(edit: nil, message: 'Msg')
+      end
+    end
+
     context 'with the :all option' do
       it 'includes the --all flag' do
-        expect_command_capturing('commit', '--no-edit', '--all',
+        expect_command_capturing('commit', '--all',
                                  '--message=Add all changes').and_return(command_result)
 
         command.call(message: 'Add all changes', all: true)
       end
 
       it 'also accepts :a as an alias' do
-        expect_command_capturing('commit', '--no-edit', '--all',
+        expect_command_capturing('commit', '--all',
                                  '--message=Add all changes').and_return(command_result)
 
         command.call(message: 'Add all changes', a: true)
       end
 
       it 'does not include the flag when false' do
-        expect_command_capturing('commit', '--no-edit', '--message=Message').and_return(command_result)
+        expect_command_capturing('commit', '--message=Message').and_return(command_result)
 
         command.call(message: 'Message', all: false)
       end
@@ -42,7 +62,7 @@ RSpec.describe Git::Commands::Commit do
 
     context 'with the :allow_empty option' do
       it 'includes the --allow-empty flag' do
-        expect_command_capturing('commit', '--no-edit', '--message=Empty commit',
+        expect_command_capturing('commit', '--message=Empty commit',
                                  '--allow-empty').and_return(command_result)
 
         command.call(message: 'Empty commit', allow_empty: true)
@@ -51,7 +71,7 @@ RSpec.describe Git::Commands::Commit do
 
     context 'with the :allow_empty_message option' do
       it 'includes the --allow-empty-message flag without a message' do
-        expect_command_capturing('commit', '--no-edit', '--allow-empty-message').and_return(command_result)
+        expect_command_capturing('commit', '--allow-empty-message').and_return(command_result)
 
         command.call(allow_empty_message: true)
       end
@@ -59,7 +79,7 @@ RSpec.describe Git::Commands::Commit do
 
     context 'with the :no_verify option' do
       it 'includes the --no-verify flag' do
-        expect_command_capturing('commit', '--no-edit', '--message=Skip hooks',
+        expect_command_capturing('commit', '--message=Skip hooks',
                                  '--no-verify').and_return(command_result)
 
         command.call(message: 'Skip hooks', no_verify: true)
@@ -70,7 +90,6 @@ RSpec.describe Git::Commands::Commit do
       it 'includes the --author flag with the specified value' do
         expect_command_capturing(
           'commit',
-          '--no-edit',
           '--message=Authored commit',
           '--author=John Doe <john@example.com>'
         ).and_return(command_result)
@@ -83,7 +102,6 @@ RSpec.describe Git::Commands::Commit do
       it 'includes the --date flag with the specified value' do
         expect_command_capturing(
           'commit',
-          '--no-edit',
           '--message=Dated commit',
           '--date=2023-01-15T10:30:00'
         ).and_return(command_result)
@@ -93,14 +111,14 @@ RSpec.describe Git::Commands::Commit do
     end
 
     context 'with the :amend option' do
-      it 'includes --no-edit always; also includes --amend when true' do
-        expect_command_capturing('commit', '--no-edit', '--amend').and_return(command_result)
+      it 'includes --amend when true' do
+        expect_command_capturing('commit', '--amend').and_return(command_result)
 
         command.call(amend: true)
       end
 
-      it 'does not include --amend when false; --no-edit still present' do
-        expect_command_capturing('commit', '--no-edit', '--message=Normal commit').and_return(command_result)
+      it 'does not include --amend when false' do
+        expect_command_capturing('commit', '--message=Normal commit').and_return(command_result)
 
         command.call(message: 'Normal commit', amend: false)
       end
@@ -109,7 +127,7 @@ RSpec.describe Git::Commands::Commit do
     context 'with GPG signing options' do
       context 'when :gpg_sign is true' do
         it 'includes --gpg-sign flag' do
-          expect_command_capturing('commit', '--no-edit', '--message=Signed commit',
+          expect_command_capturing('commit', '--message=Signed commit',
                                    '--gpg-sign').and_return(command_result)
 
           command.call(message: 'Signed commit', gpg_sign: true)
@@ -120,7 +138,6 @@ RSpec.describe Git::Commands::Commit do
         it 'includes --gpg-sign with the key ID' do
           expect_command_capturing(
             'commit',
-            '--no-edit',
             '--message=Signed commit',
             '--gpg-sign=ABCD1234'
           ).and_return(command_result)
@@ -131,7 +148,7 @@ RSpec.describe Git::Commands::Commit do
 
       context 'when :gpg_sign is false' do
         it 'includes --no-gpg-sign flag' do
-          expect_command_capturing('commit', '--no-edit', '--message=Unsigned commit',
+          expect_command_capturing('commit', '--message=Unsigned commit',
                                    '--no-gpg-sign').and_return(command_result)
 
           command.call(message: 'Unsigned commit', gpg_sign: false)
@@ -143,7 +160,6 @@ RSpec.describe Git::Commands::Commit do
       it 'includes all specified flags' do
         expect_command_capturing(
           'commit',
-          '--no-edit',
           '--all',
           '--message=Combined options',
           '--no-verify',

--- a/spec/unit/git/commands/fsck_spec.rb
+++ b/spec/unit/git/commands/fsck_spec.rb
@@ -15,9 +15,9 @@ RSpec.describe Git::Commands::Fsck do
 
   describe '#call' do
     context 'with default arguments' do
-      it 'runs fsck with --no-progress' do
+      it 'runs fsck with no extra flags' do
         expected_result = command_result('')
-        expect_command_capturing('fsck', '--no-progress').and_return(expected_result)
+        expect_command_capturing('fsck').and_return(expected_result)
 
         result = command.call
 
@@ -25,9 +25,23 @@ RSpec.describe Git::Commands::Fsck do
       end
     end
 
+    context 'with the :progress option' do
+      it 'includes --progress when true' do
+        expect_command_capturing('fsck', '--progress').and_return(command_result(''))
+
+        command.call(progress: true)
+      end
+
+      it 'includes --no-progress when false' do
+        expect_command_capturing('fsck', '--no-progress').and_return(command_result(''))
+
+        command.call(progress: false)
+      end
+    end
+
     context 'with specific objects' do
       it 'includes the object identifiers' do
-        expect_command_capturing('fsck', '--no-progress', 'abc1234', 'def5678').and_return(command_result(''))
+        expect_command_capturing('fsck', 'abc1234', 'def5678').and_return(command_result(''))
 
         command.call('abc1234', 'def5678')
       end
@@ -35,7 +49,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :unreachable option' do
       it 'includes the --unreachable flag' do
-        expect_command_capturing('fsck', '--no-progress', '--unreachable').and_return(command_result(''))
+        expect_command_capturing('fsck', '--unreachable').and_return(command_result(''))
 
         command.call(unreachable: true)
       end
@@ -43,7 +57,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :strict option' do
       it 'includes the --strict flag' do
-        expect_command_capturing('fsck', '--no-progress', '--strict').and_return(command_result(''))
+        expect_command_capturing('fsck', '--strict').and_return(command_result(''))
 
         command.call(strict: true)
       end
@@ -51,7 +65,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :connectivity_only option' do
       it 'includes the --connectivity-only flag' do
-        expect_command_capturing('fsck', '--no-progress', '--connectivity-only').and_return(command_result(''))
+        expect_command_capturing('fsck', '--connectivity-only').and_return(command_result(''))
 
         command.call(connectivity_only: true)
       end
@@ -59,7 +73,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :root option' do
       it 'includes the --root flag' do
-        expect_command_capturing('fsck', '--no-progress', '--root').and_return(command_result(''))
+        expect_command_capturing('fsck', '--root').and_return(command_result(''))
 
         command.call(root: true)
       end
@@ -67,7 +81,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :tags option' do
       it 'includes the --tags flag' do
-        expect_command_capturing('fsck', '--no-progress', '--tags').and_return(command_result(''))
+        expect_command_capturing('fsck', '--tags').and_return(command_result(''))
 
         command.call(tags: true)
       end
@@ -75,7 +89,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :cache option' do
       it 'includes the --cache flag' do
-        expect_command_capturing('fsck', '--no-progress', '--cache').and_return(command_result(''))
+        expect_command_capturing('fsck', '--cache').and_return(command_result(''))
 
         command.call(cache: true)
       end
@@ -83,7 +97,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :no_reflogs option' do
       it 'includes the --no-reflogs flag' do
-        expect_command_capturing('fsck', '--no-progress', '--no-reflogs').and_return(command_result(''))
+        expect_command_capturing('fsck', '--no-reflogs').and_return(command_result(''))
 
         command.call(no_reflogs: true)
       end
@@ -91,7 +105,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with the :lost_found option' do
       it 'includes the --lost-found flag' do
-        expect_command_capturing('fsck', '--no-progress', '--lost-found').and_return(command_result(''))
+        expect_command_capturing('fsck', '--lost-found').and_return(command_result(''))
 
         command.call(lost_found: true)
       end
@@ -100,13 +114,13 @@ RSpec.describe Git::Commands::Fsck do
     context 'with boolean_negatable options' do
       context ':dangling' do
         it 'includes --dangling when true' do
-          expect_command_capturing('fsck', '--no-progress', '--dangling').and_return(command_result(''))
+          expect_command_capturing('fsck', '--dangling').and_return(command_result(''))
 
           command.call(dangling: true)
         end
 
         it 'includes --no-dangling when false' do
-          expect_command_capturing('fsck', '--no-progress', '--no-dangling').and_return(command_result(''))
+          expect_command_capturing('fsck', '--no-dangling').and_return(command_result(''))
 
           command.call(dangling: false)
         end
@@ -114,13 +128,13 @@ RSpec.describe Git::Commands::Fsck do
 
       context ':full' do
         it 'includes --full when true' do
-          expect_command_capturing('fsck', '--no-progress', '--full').and_return(command_result(''))
+          expect_command_capturing('fsck', '--full').and_return(command_result(''))
 
           command.call(full: true)
         end
 
         it 'includes --no-full when false' do
-          expect_command_capturing('fsck', '--no-progress', '--no-full').and_return(command_result(''))
+          expect_command_capturing('fsck', '--no-full').and_return(command_result(''))
 
           command.call(full: false)
         end
@@ -128,13 +142,13 @@ RSpec.describe Git::Commands::Fsck do
 
       context ':name_objects' do
         it 'includes --name-objects when true' do
-          expect_command_capturing('fsck', '--no-progress', '--name-objects').and_return(command_result(''))
+          expect_command_capturing('fsck', '--name-objects').and_return(command_result(''))
 
           command.call(name_objects: true)
         end
 
         it 'includes --no-name-objects when false' do
-          expect_command_capturing('fsck', '--no-progress', '--no-name-objects').and_return(command_result(''))
+          expect_command_capturing('fsck', '--no-name-objects').and_return(command_result(''))
 
           command.call(name_objects: false)
         end
@@ -142,13 +156,13 @@ RSpec.describe Git::Commands::Fsck do
 
       context ':references' do
         it 'includes --references when true' do
-          expect_command_capturing('fsck', '--no-progress', '--references').and_return(command_result(''))
+          expect_command_capturing('fsck', '--references').and_return(command_result(''))
 
           command.call(references: true)
         end
 
         it 'includes --no-references when false' do
-          expect_command_capturing('fsck', '--no-progress', '--no-references').and_return(command_result(''))
+          expect_command_capturing('fsck', '--no-references').and_return(command_result(''))
 
           command.call(references: false)
         end
@@ -157,7 +171,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with multiple options combined' do
       it 'includes all specified flags' do
-        expect_command_capturing('fsck', '--no-progress', '--unreachable', '--full',
+        expect_command_capturing('fsck', '--unreachable', '--full',
                                  '--strict').and_return(command_result(''))
 
         command.call(unreachable: true, strict: true, full: true)
@@ -166,7 +180,7 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'with objects and options combined' do
       it 'includes both objects and flags' do
-        expect_command_capturing('fsck', '--no-progress', '--strict', 'abc1234').and_return(command_result(''))
+        expect_command_capturing('fsck', '--strict', 'abc1234').and_return(command_result(''))
 
         command.call('abc1234', strict: true)
       end
@@ -174,28 +188,28 @@ RSpec.describe Git::Commands::Fsck do
 
     context 'exit code handling' do
       it 'handles exit code 0 (no issues)' do
-        mock_command('fsck', '--no-progress')
+        mock_command('fsck')
         result = command.call
         expect(result).to be_a(Git::CommandLineResult)
       end
 
       it 'handles exit code 1 (errors found)' do
         output = "missing tree 1234567890abcdef1234567890abcdef12345678\n"
-        mock_command('fsck', '--no-progress', stdout: output, exitstatus: 1)
+        mock_command('fsck', stdout: output, exitstatus: 1)
         result = command.call
         expect(result).to be_a(Git::CommandLineResult)
       end
 
       it 'handles exit code 2 (missing objects)' do
         output = "missing blob abcdef1234567890abcdef1234567890abcdef12\n"
-        mock_command('fsck', '--no-progress', stdout: output, exitstatus: 2)
+        mock_command('fsck', stdout: output, exitstatus: 2)
         result = command.call
         expect(result).to be_a(Git::CommandLineResult)
       end
 
       it 'handles exit code 4 (warnings)' do
         output = "warning in commit 1234567890abcdef1234567890abcdef12345678: bad date\n"
-        mock_command('fsck', '--no-progress', stdout: output, exitstatus: 4)
+        mock_command('fsck', stdout: output, exitstatus: 4)
         result = command.call
         expect(result).to be_a(Git::CommandLineResult)
       end
@@ -206,7 +220,7 @@ RSpec.describe Git::Commands::Fsck do
           missing tree 1111111111111111111111111111111111111111
           missing blob 2222222222222222222222222222222222222222
         OUTPUT
-        mock_command('fsck', '--no-progress', stdout: output, exitstatus: 3)
+        mock_command('fsck', stdout: output, exitstatus: 3)
         result = command.call
         expect(result).to be_a(Git::CommandLineResult)
       end
@@ -216,7 +230,7 @@ RSpec.describe Git::Commands::Fsck do
           missing tree 1111111111111111111111111111111111111111
           warning in commit 2222222222222222222222222222222222222222: bad date
         OUTPUT
-        mock_command('fsck', '--no-progress', stdout: output, exitstatus: 5)
+        mock_command('fsck', stdout: output, exitstatus: 5)
         result = command.call
         expect(result).to be_a(Git::CommandLineResult)
       end
@@ -226,7 +240,7 @@ RSpec.describe Git::Commands::Fsck do
           missing blob 1111111111111111111111111111111111111111
           warning in commit 2222222222222222222222222222222222222222: bad date
         OUTPUT
-        mock_command('fsck', '--no-progress', stdout: output, exitstatus: 6)
+        mock_command('fsck', stdout: output, exitstatus: 6)
         result = command.call
         expect(result).to be_a(Git::CommandLineResult)
       end
@@ -237,13 +251,13 @@ RSpec.describe Git::Commands::Fsck do
           missing blob 2222222222222222222222222222222222222222
           warning in commit 3333333333333333333333333333333333333333: bad date
         OUTPUT
-        mock_command('fsck', '--no-progress', stdout: output, exitstatus: 7)
+        mock_command('fsck', stdout: output, exitstatus: 7)
         result = command.call
         expect(result).to be_a(Git::CommandLineResult)
       end
 
       it 'raises for exit code > 7 (fatal errors)' do
-        mock_command('fsck', '--no-progress', stderr: 'fatal: not a git repository', exitstatus: 128)
+        mock_command('fsck', stderr: 'fatal: not a git repository', exitstatus: 128)
         expect { command.call }.to raise_error(Git::FailedError)
       end
     end

--- a/spec/unit/git/commands/merge/start_spec.rb
+++ b/spec/unit/git/commands/merge/start_spec.rb
@@ -13,9 +13,9 @@ RSpec.describe Git::Commands::Merge::Start do
     end
 
     context 'with single branch to merge' do
-      it 'calls git merge with --no-edit and the branch name' do
+      it 'calls git merge with the branch name' do
         expected_result = command_result
-        expect_command_capturing('merge', '--no-edit', 'feature').and_return(expected_result)
+        expect_command_capturing('merge', 'feature').and_return(expected_result)
 
         result = command.call('feature')
 
@@ -25,27 +25,44 @@ RSpec.describe Git::Commands::Merge::Start do
 
     context 'with multiple branches (octopus merge)' do
       it 'merges multiple branches' do
-        expect_command_capturing('merge', '--no-edit', 'branch1', 'branch2')
+        expect_command_capturing('merge', 'branch1', 'branch2')
         command.call('branch1', 'branch2')
       end
 
       it 'merges three branches' do
-        expect_command_capturing('merge', '--no-edit', 'a', 'b', 'c')
+        expect_command_capturing('merge', 'a', 'b', 'c')
         command.call('a', 'b', 'c')
+      end
+    end
+
+    context 'with the :edit option' do
+      it 'adds --no-edit when edit is false' do
+        expect_command_capturing('merge', '--no-edit', 'feature')
+        command.call('feature', edit: false)
+      end
+
+      it 'adds --edit when edit is true' do
+        expect_command_capturing('merge', '--edit', 'feature')
+        command.call('feature', edit: true)
+      end
+
+      it 'omits --edit/--no-edit when edit is nil' do
+        expect_command_capturing('merge', 'feature')
+        command.call('feature', edit: nil)
       end
     end
 
     context 'with :commit option' do
       context 'when true' do
         it 'adds --commit flag' do
-          expect_command_capturing('merge', '--no-edit', '--commit', 'feature')
+          expect_command_capturing('merge', '--commit', 'feature')
           command.call('feature', commit: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-commit flag' do
-          expect_command_capturing('merge', '--no-edit', '--no-commit', 'feature')
+          expect_command_capturing('merge', '--no-commit', 'feature')
           command.call('feature', commit: false)
         end
       end
@@ -53,12 +70,12 @@ RSpec.describe Git::Commands::Merge::Start do
 
     context 'with :squash option' do
       it 'adds --squash flag' do
-        expect_command_capturing('merge', '--no-edit', '--squash', 'feature')
+        expect_command_capturing('merge', '--squash', 'feature')
         command.call('feature', squash: true)
       end
 
       it 'does not add flag when false' do
-        expect_command_capturing('merge', '--no-edit', 'feature')
+        expect_command_capturing('merge', 'feature')
         command.call('feature', squash: false)
       end
     end
@@ -66,14 +83,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :ff option (fast-forward)' do
       context 'when true' do
         it 'adds --ff flag' do
-          expect_command_capturing('merge', '--no-edit', '--ff', 'feature')
+          expect_command_capturing('merge', '--ff', 'feature')
           command.call('feature', ff: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-ff flag' do
-          expect_command_capturing('merge', '--no-edit', '--no-ff', 'feature')
+          expect_command_capturing('merge', '--no-ff', 'feature')
           command.call('feature', ff: false)
         end
       end
@@ -81,19 +98,19 @@ RSpec.describe Git::Commands::Merge::Start do
 
     context 'with :ff_only option' do
       it 'adds --ff-only flag' do
-        expect_command_capturing('merge', '--no-edit', '--ff-only', 'feature')
+        expect_command_capturing('merge', '--ff-only', 'feature')
         command.call('feature', ff_only: true)
       end
 
       it 'does not add flag when false' do
-        expect_command_capturing('merge', '--no-edit', 'feature')
+        expect_command_capturing('merge', 'feature')
         command.call('feature', ff_only: false)
       end
     end
 
     context 'with :m option' do
       it 'adds -m flag with message' do
-        expect_command_capturing('merge', '--no-edit', '-m', 'Merge feature', 'feature')
+        expect_command_capturing('merge', '-m', 'Merge feature', 'feature')
         command.call('feature', m: 'Merge feature')
       end
 
@@ -105,49 +122,49 @@ RSpec.describe Git::Commands::Merge::Start do
 
     context 'with :file option' do
       it 'adds --file flag with file path' do
-        expect_command_capturing('merge', '--no-edit', '--file', '/path/to/msg.txt', 'feature')
+        expect_command_capturing('merge', '--file', '/path/to/msg.txt', 'feature')
         command.call('feature', file: '/path/to/msg.txt')
       end
 
       it 'works with :F alias' do
-        expect_command_capturing('merge', '--no-edit', '--file', 'msg.txt', 'feature')
+        expect_command_capturing('merge', '--file', 'msg.txt', 'feature')
         command.call('feature', F: 'msg.txt')
       end
     end
 
     context 'with :into_name option' do
       it 'adds --into-name flag with value' do
-        expect_command_capturing('merge', '--no-edit', '--into-name=main', 'feature')
+        expect_command_capturing('merge', '--into-name=main', 'feature')
         command.call('feature', into_name: 'main')
       end
     end
 
     context 'with :strategy option' do
       it 'adds --strategy flag with strategy name' do
-        expect_command_capturing('merge', '--no-edit', '--strategy', 'ours', 'feature')
+        expect_command_capturing('merge', '--strategy', 'ours', 'feature')
         command.call('feature', strategy: 'ours')
       end
 
       it 'works with :s alias' do
-        expect_command_capturing('merge', '--no-edit', '--strategy', 'recursive', 'feature')
+        expect_command_capturing('merge', '--strategy', 'recursive', 'feature')
         command.call('feature', s: 'recursive')
       end
     end
 
     context 'with :strategy_option option' do
       it 'adds --strategy-option flag with strategy option' do
-        expect_command_capturing('merge', '--no-edit', '--strategy-option', 'ours', 'feature')
+        expect_command_capturing('merge', '--strategy-option', 'ours', 'feature')
         command.call('feature', strategy_option: 'ours')
       end
 
       it 'works with :X alias' do
-        expect_command_capturing('merge', '--no-edit', '--strategy-option', 'theirs', 'feature')
+        expect_command_capturing('merge', '--strategy-option', 'theirs', 'feature')
         command.call('feature', X: 'theirs')
       end
 
       it 'supports multiple strategy options' do
         expect_command_capturing(
-          'merge', '--no-edit', '--strategy-option', 'ours', '--strategy-option', 'patience', 'feature'
+          'merge', '--strategy-option', 'ours', '--strategy-option', 'patience', 'feature'
         )
         command.call('feature', strategy_option: %w[ours patience])
       end
@@ -156,14 +173,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :verify option' do
       context 'when true' do
         it 'adds --verify flag' do
-          expect_command_capturing('merge', '--no-edit', '--verify', 'feature')
+          expect_command_capturing('merge', '--verify', 'feature')
           command.call('feature', verify: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-verify flag' do
-          expect_command_capturing('merge', '--no-edit', '--no-verify', 'feature')
+          expect_command_capturing('merge', '--no-verify', 'feature')
           command.call('feature', verify: false)
         end
       end
@@ -172,7 +189,7 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :verify_signatures option' do
       context 'when true' do
         it 'adds --verify-signatures flag' do
-          expect_command_capturing('merge', '--no-edit', '--verify-signatures', 'feature')
+          expect_command_capturing('merge', '--verify-signatures', 'feature')
           command.call('feature', verify_signatures: true)
         end
       end
@@ -180,7 +197,7 @@ RSpec.describe Git::Commands::Merge::Start do
       context 'when false' do
         it 'adds --no-verify-signatures flag' do
           expect_command_capturing(
-            'merge', '--no-edit', '--no-verify-signatures', 'feature'
+            'merge', '--no-verify-signatures', 'feature'
           )
           command.call('feature', verify_signatures: false)
         end
@@ -190,14 +207,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :gpg_sign option' do
       context 'when true' do
         it 'adds --gpg-sign flag' do
-          expect_command_capturing('merge', '--no-edit', '--gpg-sign', 'feature')
+          expect_command_capturing('merge', '--gpg-sign', 'feature')
           command.call('feature', gpg_sign: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-gpg-sign flag' do
-          expect_command_capturing('merge', '--no-edit', '--no-gpg-sign', 'feature')
+          expect_command_capturing('merge', '--no-gpg-sign', 'feature')
           command.call('feature', gpg_sign: false)
         end
       end
@@ -207,7 +224,7 @@ RSpec.describe Git::Commands::Merge::Start do
       context 'when true' do
         it 'adds --allow-unrelated-histories flag' do
           expect_command_capturing(
-            'merge', '--no-edit', '--allow-unrelated-histories', 'feature'
+            'merge', '--allow-unrelated-histories', 'feature'
           )
           command.call('feature', allow_unrelated_histories: true)
         end
@@ -216,7 +233,7 @@ RSpec.describe Git::Commands::Merge::Start do
       context 'when false' do
         it 'adds --no-allow-unrelated-histories flag' do
           expect_command_capturing(
-            'merge', '--no-edit', '--no-allow-unrelated-histories', 'feature'
+            'merge', '--no-allow-unrelated-histories', 'feature'
           )
           command.call('feature', allow_unrelated_histories: false)
         end
@@ -226,7 +243,7 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :rerere_autoupdate option' do
       context 'when true' do
         it 'adds --rerere-autoupdate flag' do
-          expect_command_capturing('merge', '--no-edit', '--rerere-autoupdate', 'feature')
+          expect_command_capturing('merge', '--rerere-autoupdate', 'feature')
           command.call('feature', rerere_autoupdate: true)
         end
       end
@@ -234,7 +251,7 @@ RSpec.describe Git::Commands::Merge::Start do
       context 'when false' do
         it 'adds --no-rerere-autoupdate flag' do
           expect_command_capturing(
-            'merge', '--no-edit', '--no-rerere-autoupdate', 'feature'
+            'merge', '--no-rerere-autoupdate', 'feature'
           )
           command.call('feature', rerere_autoupdate: false)
         end
@@ -244,14 +261,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :autostash option' do
       context 'when true' do
         it 'adds --autostash flag' do
-          expect_command_capturing('merge', '--no-edit', '--autostash', 'feature')
+          expect_command_capturing('merge', '--autostash', 'feature')
           command.call('feature', autostash: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-autostash flag' do
-          expect_command_capturing('merge', '--no-edit', '--no-autostash', 'feature')
+          expect_command_capturing('merge', '--no-autostash', 'feature')
           command.call('feature', autostash: false)
         end
       end
@@ -260,14 +277,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :signoff option' do
       context 'when true' do
         it 'adds --signoff flag' do
-          expect_command_capturing('merge', '--no-edit', '--signoff', 'feature')
+          expect_command_capturing('merge', '--signoff', 'feature')
           command.call('feature', signoff: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-signoff flag' do
-          expect_command_capturing('merge', '--no-edit', '--no-signoff', 'feature')
+          expect_command_capturing('merge', '--no-signoff', 'feature')
           command.call('feature', signoff: false)
         end
       end
@@ -276,14 +293,14 @@ RSpec.describe Git::Commands::Merge::Start do
     context 'with :log option' do
       context 'when true' do
         it 'adds --log flag' do
-          expect_command_capturing('merge', '--no-edit', '--log', 'feature')
+          expect_command_capturing('merge', '--log', 'feature')
           command.call('feature', log: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-log flag' do
-          expect_command_capturing('merge', '--no-edit', '--no-log', 'feature')
+          expect_command_capturing('merge', '--no-log', 'feature')
           command.call('feature', log: false)
         end
       end
@@ -300,6 +317,7 @@ RSpec.describe Git::Commands::Merge::Start do
         )
         command.call(
           'feature',
+          edit: false,
           commit: false,
           ff: false,
           m: 'Merge feature branch',
@@ -309,13 +327,13 @@ RSpec.describe Git::Commands::Merge::Start do
       end
 
       it 'combines squash with no-commit behavior' do
-        expect_command_capturing('merge', '--no-edit', '--squash', 'feature')
+        expect_command_capturing('merge', '--squash', 'feature')
         command.call('feature', squash: true)
       end
 
       it 'combines ff_only with allow_unrelated_histories' do
         expect_command_capturing(
-          'merge', '--no-edit', '--ff-only', '--allow-unrelated-histories', 'feature'
+          'merge', '--ff-only', '--allow-unrelated-histories', 'feature'
         )
         command.call('feature', ff_only: true, allow_unrelated_histories: true)
       end

--- a/spec/unit/git/commands/mv_spec.rb
+++ b/spec/unit/git/commands/mv_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Git::Commands::Mv do
     context 'with a single file to move' do
       it 'moves the file to the destination' do
         expected_result = command_result
-        expect_command_capturing('mv', '--verbose', '--', 'old_name.rb', 'new_name.rb').and_return(expected_result)
+        expect_command_capturing('mv', '--', 'old_name.rb', 'new_name.rb').and_return(expected_result)
 
         result = command.call('old_name.rb', 'new_name.rb')
 
@@ -21,16 +21,32 @@ RSpec.describe Git::Commands::Mv do
     context 'with multiple source files' do
       it 'moves all files to the destination directory' do
         expect_command_capturing(
-          'mv', '--verbose', '--', 'file1.rb', 'file2.rb', 'file3.rb', 'destination_dir/'
+          'mv', '--', 'file1.rb', 'file2.rb', 'file3.rb', 'destination_dir/'
         ).and_return(command_result)
 
         command.call('file1.rb', 'file2.rb', 'file3.rb', 'destination_dir/')
       end
     end
 
+    context 'with the :verbose option' do
+      it 'includes the --verbose flag' do
+        expect_command_capturing('mv', '--verbose', '--', 'source.rb',
+                                 'dest.rb').and_return(command_result)
+
+        command.call('source.rb', 'dest.rb', verbose: true)
+      end
+
+      it 'also accepts :v as an alias' do
+        expect_command_capturing('mv', '--verbose', '--', 'source.rb',
+                                 'dest.rb').and_return(command_result)
+
+        command.call('source.rb', 'dest.rb', v: true)
+      end
+    end
+
     context 'with the :force option' do
       it 'includes the --force flag' do
-        expect_command_capturing('mv', '--verbose', '--force', '--', 'source.rb',
+        expect_command_capturing('mv', '--force', '--', 'source.rb',
                                  'dest.rb').and_return(command_result)
 
         command.call('source.rb', 'dest.rb', force: true)
@@ -39,7 +55,7 @@ RSpec.describe Git::Commands::Mv do
 
     context 'with the :dry_run option' do
       it 'includes the --dry-run flag' do
-        expect_command_capturing('mv', '--verbose', '--dry-run', '--', 'source.rb',
+        expect_command_capturing('mv', '--dry-run', '--', 'source.rb',
                                  'dest.rb').and_return(command_result)
 
         command.call('source.rb', 'dest.rb', dry_run: true)
@@ -48,7 +64,7 @@ RSpec.describe Git::Commands::Mv do
 
     context 'with the :k option' do
       it 'includes the -k flag' do
-        expect_command_capturing('mv', '--verbose', '-k', '--', 'source.rb', 'dest.rb').and_return(command_result)
+        expect_command_capturing('mv', '-k', '--', 'source.rb', 'dest.rb').and_return(command_result)
 
         command.call('source.rb', 'dest.rb', k: true)
       end
@@ -57,7 +73,7 @@ RSpec.describe Git::Commands::Mv do
     context 'with multiple options combined' do
       it 'includes all specified flags' do
         expect_command_capturing(
-          'mv', '--verbose', '--force', '--dry-run', '--', 'source.rb', 'dest.rb'
+          'mv', '--force', '--dry-run', '--', 'source.rb', 'dest.rb'
         ).and_return(command_result)
 
         command.call('source.rb', 'dest.rb', force: true, dry_run: true)
@@ -65,7 +81,7 @@ RSpec.describe Git::Commands::Mv do
 
       it 'handles force and k together' do
         expect_command_capturing(
-          'mv', '--verbose', '--force', '-k', '--', 'file1.rb', 'file2.rb', 'dest_dir/'
+          'mv', '--force', '-k', '--', 'file1.rb', 'file2.rb', 'dest_dir/'
         ).and_return(command_result)
 
         command.call('file1.rb', 'file2.rb', 'dest_dir/', force: true, k: true)
@@ -74,7 +90,7 @@ RSpec.describe Git::Commands::Mv do
 
     context 'with paths containing special characters' do
       it 'handles paths with spaces' do
-        expect_command_capturing('mv', '--verbose', '--', 'old file.rb', 'new file.rb').and_return(command_result)
+        expect_command_capturing('mv', '--', 'old file.rb', 'new file.rb').and_return(command_result)
 
         command.call('old file.rb', 'new file.rb')
       end
@@ -82,14 +98,14 @@ RSpec.describe Git::Commands::Mv do
 
     context 'with directory paths' do
       it 'moves a directory to a new location' do
-        expect_command_capturing('mv', '--verbose', '--', 'old_dir/', 'new_dir/').and_return(command_result)
+        expect_command_capturing('mv', '--', 'old_dir/', 'new_dir/').and_return(command_result)
 
         command.call('old_dir/', 'new_dir/')
       end
 
       it 'moves files into an existing directory' do
         expect_command_capturing(
-          'mv', '--verbose', '--', 'file1.rb', 'file2.rb', 'existing_dir/'
+          'mv', '--', 'file1.rb', 'file2.rb', 'existing_dir/'
         ).and_return(command_result)
 
         command.call('file1.rb', 'file2.rb', 'existing_dir/')

--- a/spec/unit/git/commands/pull_spec.rb
+++ b/spec/unit/git/commands/pull_spec.rb
@@ -684,11 +684,17 @@ RSpec.describe Git::Commands::Pull do
       end
     end
 
-    context 'with the :no_edit option' do
-      it 'adds --no-edit to the command line' do
+    context 'with the :edit option' do
+      it 'adds --edit when true' do
+        expect_command_capturing('pull', '--edit').and_return(command_result)
+
+        command.call(edit: true)
+      end
+
+      it 'adds --no-edit when false' do
         expect_command_capturing('pull', '--no-edit').and_return(command_result)
 
-        command.call(no_edit: true)
+        command.call(edit: false)
       end
     end
 

--- a/spec/unit/git/lib_command_spec.rb
+++ b/spec/unit/git/lib_command_spec.rb
@@ -420,6 +420,7 @@ RSpec.describe Git::Lib do
     it 'parses the command output into a FsckResult' do
       fsck_output = "dangling blob 1234567890abcdef1234567890abcdef12345678\n"
       allow(fsck_command).to receive(:call)
+        .with(progress: false)
         .and_return(command_result(fsck_output))
 
       result = lib.fsck
@@ -432,12 +433,12 @@ RSpec.describe Git::Lib do
 
     it 'forwards objects and options to the command' do
       allow(fsck_command).to receive(:call)
-        .with('abc1234', strict: true)
+        .with('abc1234', progress: false, strict: true)
         .and_return(command_result(''))
 
       result = lib.fsck('abc1234', strict: true)
 
-      expect(fsck_command).to have_received(:call).with('abc1234', strict: true)
+      expect(fsck_command).to have_received(:call).with('abc1234', progress: false, strict: true)
       expect(result).to be_a(Git::FsckResult)
     end
   end

--- a/tests/units/test_pull.rb
+++ b/tests/units/test_pull.rb
@@ -138,7 +138,7 @@ class TestPull < Test::Unit::TestCase
   end
 
   test 'pull with allow_unrelated_histories: true' do
-    expected_command_line = ['pull', '--no-edit', '--allow-unrelated-histories', '--', 'origin', 'feature1', {}]
+    expected_command_line = ['pull', '--no-edit', '--allow-unrelated-histories', '--no-progress', '--', 'origin', 'feature1', {}]
     assert_command_line_eq(expected_command_line) do |git|
       git.pull('origin', 'feature1', allow_unrelated_histories: true)
     end


### PR DESCRIPTION
## Summary

Establish and enforce the architectural principle that **command classes are neutral, faithful representations of the git CLI** while **the facade layer owns all policy decisions**.

This applies to non-interactivity (`edit: false`), output control (`no_color: true`), verbosity (`verbose: true`), progress suppression (`progress: false`), and any future policy options.

## Problem

Several command classes hardcoded policy flags as `literal` entries (e.g. `literal '--no-edit'`, `literal '--verbose'`, `literal '--no-progress'`). This embedded policy decisions in the wrong layer — preventing the facade from controlling those options and violating the separation between the neutral CLI interface and the gem's behavioral choices.

The documentation and AI skills didn't consistently explain which layer owns what.

## Design principle

Two architectural rules are now documented and enforced:

1. **Command classes are neutral** — they declare options via DSL (`flag_option :edit, negatable: true`) but never hardcode policy values. A command class is a faithful model of the git CLI, nothing more.
2. **The facade owns all policy** — `Git::Lib` methods pass policy options explicitly at each call site (`edit: false`, `verbose: true`, `progress: false`, `no_color: true`). This makes every policy choice visible and auditable.

A third safety layer (`GIT_EDITOR='true'` in every subprocess environment) remains as a universal backstop for editor-related interactivity.

## Changes

### Code changes (commands + facade)

- **`commit.rb`** — replace `literal '--no-edit'` with `flag_option :edit, negatable: true`
- **`merge/start.rb`** — replace `literal '--no-edit'` with `flag_option :edit, negatable: true`
- **`pull.rb`** — replace `literal '--no-edit'` with `flag_option :edit, negatable: true`; add `flag_option :progress, negatable: true`
- **`mv.rb`** — replace `literal '--verbose'` with `flag_option :verbose`
- **`fsck.rb`** — replace `literal '--no-progress'` with `flag_option :progress, negatable: true`
- **`lib.rb`** — update facade call sites to pass `edit: false`, `verbose: true`, `progress: false` explicitly
- **Unit specs** — updated to match new DSL shapes and test each option independently

### Documentation changes

- **CONTRIBUTING.md** — new "Non-interactive execution model" section with three-layer table, principle/anti-pattern/correct-pattern block
- **project-context skill** — new "Non-interactivity policy" subsection in Layer Responsibilities
- **scaffold-new-command skill** — new "Facade delegation and policy options" section with concrete `Git::Lib` delegation example
- **review-arguments-dsl checklist** — principle block, anti-pattern examples, `--edit`/`--no-edit` guidance
- **extract-command-from-lib skill** — policy paragraph in delegation-with-option-filtering section
- **review-command-implementation skill** — elevated neutrality violation to top-level Common Failures entry with symptom/fix code blocks
- **review-command-tests skill** — "Policy vs. interface testing" anti-pattern block; new "Where to test policy enforcement" section with facade test example
- **review-cross-command-consistency skill** — DSL consistency check for policy flags
- **review-backward-compatibility skill** — new Key Principle #6 (apply policy at facade)
- **refactor-command-to-commandlineresult skill** — "What to remove" bullet for literal policy flags
- **redesign/3_architecture_implementation.md** — new insight documenting the policy

## Testing

All existing tests pass. Unit specs now test each policy-relevant option independently rather than baking policy assumptions into every test case.