### PR TITLE
chore: configure git and clean up build deps in Dockerfile

### DIFF
--- a/bin/git.dockerfile
+++ b/bin/git.dockerfile
@@ -8,6 +8,15 @@ RUN curl -sL "https://mirrors.edge.kernel.org/pub/software/scm/git/git-${GIT_VER
     cd "git-${GIT_VERSION}" && \
     make prefix=/usr/local NO_REGEX=NeedsStartEnd NO_TCLTK=YesPlease LIBC_CONTAINS_LIBINTL= all && \
     make prefix=/usr/local NO_REGEX=NeedsStartEnd NO_TCLTK=YesPlease LIBC_CONTAINS_LIBINTL= install && \
-    cd .. && rm -rf "git-${GIT_VERSION}"
+    cd .. && rm -rf "git-${GIT_VERSION}" && \
+    apk del --no-cache curl-dev build-base expat-dev openssl-dev zlib-dev && \
+    rm -rf /var/cache/apk/* && \
+    git config --global user.name "Git User" && \
+    git config --global user.email "git@example.com" && \
+    git config --global init.defaultBranch main && \
+    git config --global core.editor "vi" && \
+    git config --global core.pager ""
+
+WORKDIR /work
 
 ENTRYPOINT ["/bin/sh"]


### PR DESCRIPTION
Enhances the git Docker container with basic git configuration and build cleanup.

## Changes

- **Remove build-time dependencies** after compiling git (`apk del`, `rm -rf /var/cache/apk/*`) to reduce image size
- **Set default git identity** — `user.name` and `user.email` so commands that require an author (commit, merge, etc.) work out of the box
- **Set `init.defaultBranch` to `main`** — matches repository convention
- **Set `core.editor` to `vi`** and **disable the pager** — avoids interactive prompts that hang in non-TTY usage
- **Add `WORKDIR /work`** — provides a default working directory for the container