### PR TITLE
Add `as:` option to `end_of_options` DSL method

### DIFF
--- a/lib/git/commands/arguments.rb
+++ b/lib/git/commands/arguments.rb
@@ -1019,18 +1019,23 @@ module Git
         @past_separator = true if flag_string == '--'
       end
 
-      # Conditionally emit '--' only when at least one following argument produces output
+      # Conditionally emit an options terminator only when at least one following
+      # argument produces output
       #
       # This is the canonical form for declaring the options/operands boundary in a
       # command definition. Unlike {#literal} with `'--'` which always emits the
-      # separator, `end_of_options` emits `--` only when at least one argument defined
-      # after it will be emitted as part of the CLI (for example operands or
-      # `value_option ... as_operand: true`). This avoids a trailing bare `--` when no
-      # pathspecs or other post-separator arguments are provided.
+      # separator, `end_of_options` emits its terminator string only when at least one
+      # argument defined after it will be emitted as part of the CLI (for example
+      # operands or `value_option ... as_operand: true`). This avoids a trailing bare
+      # terminator when no pathspecs or other post-separator arguments are provided.
       #
       # `end_of_options` also acts as an always-active validation boundary: operands
       # defined before it are always validated for option-like values (starting with
-      # `-`), regardless of whether `--` will ultimately be emitted.
+      # `-`), regardless of whether the terminator will ultimately be emitted.
+      #
+      # @param as [String] the CLI token to emit as the options terminator
+      #   (default `'--'`). Some commands use a different terminator; for example,
+      #   `git rev-parse` uses `'--end-of-options'`.
       #
       # @return [void]
       #
@@ -1050,11 +1055,21 @@ module Git
       #   args_def.bind(nil, 'file.txt').to_a      # => ['--', 'file.txt']
       #   args_def.bind(nil).to_a                  # => []
       #
-      def end_of_options
+      # @example Custom terminator (git rev-parse --end-of-options)
+      #   args_def = Arguments.define do
+      #     flag_option :verify
+      #     end_of_options as: '--end-of-options'
+      #     operand :args, repeatable: true
+      #   end
+      #   args_def.bind('HEAD').to_a               # => ['--end-of-options', 'HEAD']
+      #   args_def.bind.to_a                       # => []
+      #
+      def end_of_options(as: '--')
         raise ArgumentError, 'end_of_options cannot be declared twice' if @end_of_options_declared
 
         @ordered_definitions << { kind: :end_of_options }
         @end_of_options_declared = true
+        @end_of_options_as = as
         @past_separator = true
       end
 
@@ -1723,7 +1738,8 @@ module Git
       OPTION_TYPES_AFTER_SEPARATOR = %i[value_as_operand execution_option].freeze
 
       # Sentinel object placed in the build array by an :end_of_options definition.
-      # It is later replaced by '--' if any element follows it, or stripped if it is last.
+      # It is later replaced by the stored `as:` value (default `'--'`) if any element
+      # follows it, or stripped if it is last.
       # Uses Object identity comparison (== is not overridden) so it can never collide
       # with the literal string '--' or any other real argument value.
       END_OF_OPTIONS_MARKER = Object.new.freeze
@@ -1958,7 +1974,8 @@ module Git
         # :nocov:
       end
 
-      # Replace the END_OF_OPTIONS_MARKER with '--' if any element follows it, or strip it
+      # Replace the END_OF_OPTIONS_MARKER with the stored `as:` value if any element
+      # follows it, or strip it
       #
       # @param args [Array] the built argument array (may contain END_OF_OPTIONS_MARKER)
       # @return [Array<String>] the argument array with the marker resolved
@@ -1970,7 +1987,7 @@ module Git
         if idx == args.size - 1
           args.delete_at(idx) # nothing follows — strip
         else
-          args[idx] = '--'    # something follows — make it real
+          args[idx] = @end_of_options_as # something follows — make it real
         end
         args
       end

--- a/spec/unit/git/commands/arguments_spec.rb
+++ b/spec/unit/git/commands/arguments_spec.rb
@@ -5680,6 +5680,100 @@ RSpec.describe Git::Commands::Arguments do
         expect(args.bind('HEAD', '-file.txt').to_a).to eq(['HEAD', '--', '-file.txt'])
       end
     end
+
+    context 'with as: option' do
+      context 'when as: is specified' do
+        let(:args) do
+          described_class.define do
+            flag_option :verify
+            end_of_options as: '--end-of-options'
+            operand :args, repeatable: true
+          end
+        end
+
+        it 'emits the custom as: value when a following operand has a value' do
+          expect(args.bind('HEAD').to_a).to eq(['--end-of-options', 'HEAD'])
+        end
+
+        it 'omits the custom as: value when no following operand has a value' do
+          expect(args.bind.to_a).to eq([])
+        end
+
+        it 'allows post-boundary operands to contain "--"' do
+          expect(args.bind('HEAD', '--', 'file.txt').to_a).to eq(['--end-of-options', 'HEAD', '--', 'file.txt'])
+        end
+
+        it 'allows post-boundary operands to contain hyphen-prefixed values' do
+          expect(args.bind('-f').to_a).to eq(['--end-of-options', '-f'])
+        end
+
+        it 'passes flags before end_of_options' do
+          expect(args.bind('HEAD', verify: true).to_a).to eq(['--verify', '--end-of-options', 'HEAD'])
+        end
+      end
+
+      context 'when as: is explicitly "--"' do
+        let(:args) do
+          described_class.define do
+            operand :commit
+            end_of_options as: '--'
+            operand :paths, repeatable: true
+          end
+        end
+
+        it 'behaves identically to the default (no as: argument)' do
+          expect(args.bind('HEAD', 'file.txt').to_a).to eq(['HEAD', '--', 'file.txt'])
+        end
+
+        it 'omits -- when no following operand has a value' do
+          expect(args.bind('HEAD').to_a).to eq(['HEAD'])
+        end
+      end
+
+      context 'boundary semantics with as:' do
+        let(:args) do
+          described_class.define do
+            operand :commit
+            end_of_options as: '--end-of-options'
+            operand :paths, repeatable: true
+          end
+        end
+
+        it 'still validates pre-boundary operands as option-like' do
+          expect { args.bind('--bad') }.to raise_error(
+            ArgumentError, "operand :commit value '--bad' looks like a command-line option"
+          )
+        end
+
+        it 'does not validate post-boundary operands' do
+          expect(args.bind('HEAD', '--something').to_a).to eq(['HEAD', '--end-of-options', '--something'])
+        end
+      end
+
+      context 'duplicate guard with as:' do
+        it 'raises ArgumentError if end_of_options is declared twice with as:' do
+          expect do
+            described_class.define do
+              end_of_options as: '--end-of-options'
+              end_of_options as: '--end-of-options'
+            end
+          end.to raise_error(ArgumentError, 'end_of_options cannot be declared twice')
+        end
+      end
+
+      context 'marker does not leak with as:' do
+        let(:args) do
+          described_class.define do
+            flag_option :force
+            end_of_options as: '--end-of-options'
+          end
+        end
+
+        it 'does not emit the custom as: value when nothing follows' do
+          expect(args.bind(force: true).to_a).to eq(['--force'])
+        end
+      end
+    end
   end
 
   describe Git::Commands::Arguments::Bound do


### PR DESCRIPTION
## Summary

Add an `as:` keyword parameter to the `end_of_options` DSL method so command
definitions can specify the CLI token used as the options terminator.

Fixes #1164

## Motivation

Some git commands use a different string as their options terminator. For example,
`git rev-parse` uses `--end-of-options` to stop processing flags, while `--` serves
a completely different purpose (separating verified arguments from those echoed back
unchanged). With the current DSL there is no way to model this distinction.

## Changes

### `lib/git/commands/arguments.rb`

- `end_of_options` now accepts `as: '--'` (default preserves all existing behavior)
- The `as:` value is stored in the ordered definition entry and as `@end_of_options_as`
- `resolve_end_of_options_marker` uses the stored `as:` value instead of a hardcoded `'--'`
- YARD docs updated with `@param as`, updated description, and a new example

### `spec/unit/git/commands/arguments_spec.rb`

11 new tests covering:

- Custom `as:` value emission and omission
- Post-boundary operands accepting `--` and hyphen-prefixed values without raising
- Flags before `end_of_options` with custom `as:`
- Explicit `as: '--'` behaving identically to the default
- Boundary validation still enforced with custom `as:`
- Duplicate guard with `as:`
- Marker not leaking when nothing follows

## Example

```ruby
args_def = Arguments.define do
  flag_option :verify
  end_of_options as: '--end-of-options'
  operand :args, repeatable: true
end

args_def.bind('HEAD').to_a                      # => ['--end-of-options', 'HEAD']
args_def.bind('HEAD', '--', 'file.txt').to_a    # => ['--end-of-options', 'HEAD', '--', 'file.txt']
args_def.bind.to_a                              # => []
args_def.bind('HEAD', verify: true).to_a        # => ['--verify', '--end-of-options', 'HEAD']
```
