### PR TITLE
refactor: migrate read_tree to Git::Commands::ReadTree

### DIFF
--- a/lib/git/commands/read_tree.rb
+++ b/lib/git/commands/read_tree.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    # Implements the `git read-tree` command
+    #
+    # Reads tree information into the index. Optionally performs a merge
+    # (single-tree, two-way fast-forward, or three-way) with the `-m` flag,
+    # and updates the working tree files with `-u`.
+    #
+    # @example Read a single tree into the index
+    #   read_tree = Git::Commands::ReadTree.new(execution_context)
+    #   result = read_tree.call('HEAD')
+    #
+    # @example Read a tree under a prefix directory
+    #   read_tree = Git::Commands::ReadTree.new(execution_context)
+    #   result = read_tree.call('HEAD', prefix: 'subdir/')
+    #
+    # @example Perform a three-way merge
+    #   read_tree = Git::Commands::ReadTree.new(execution_context)
+    #   result = read_tree.call('base', 'ours', 'theirs', m: true, u: true)
+    #
+    # @example Empty the index
+    #   read_tree = Git::Commands::ReadTree.new(execution_context)
+    #   result = read_tree.call(empty: true)
+    #
+    # @see https://git-scm.com/docs/git-read-tree git-read-tree documentation
+    #
+    # @see Git::Commands
+    #
+    # @api private
+    #
+    class ReadTree < Git::Commands::Base
+      arguments do
+        literal 'read-tree'
+
+        # Merge mode — SYNOPSIS: [-m [--trivial] [--aggressive] | --reset | --prefix=<prefix>]
+        flag_option :m
+        flag_option :trivial
+        flag_option :aggressive
+        flag_option :reset
+        value_option :prefix, inline: true
+
+        # Working tree update — SYNOPSIS: [-u [--exclude-per-directory=<gitignore>] | -i]
+        flag_option :u
+        value_option :exclude_per_directory, inline: true
+        flag_option :i
+
+        # Dry run and progress
+        flag_option %i[dry_run n]
+        flag_option :v
+
+        # Filtering and output
+        value_option :index_output, inline: true
+        flag_option :recurse_submodules, negatable: true
+        flag_option :no_sparse_checkout
+        flag_option :empty
+
+        # Feedback control
+        flag_option %i[quiet q]
+
+        end_of_options
+
+        operand :tree_ish, repeatable: true
+      end
+
+      # @!method call(*, **)
+      #
+      #   @overload call(*tree_ish, **options)
+      #
+      #     Execute the `git read-tree` command
+      #
+      #     @param tree_ish [Array<String>] zero or more tree-ish objects to
+      #       read into the index
+      #
+      #       Pass one tree-ish for a simple read or single-tree merge, two
+      #       for a fast-forward (two-way) merge, or three for a three-way
+      #       merge. Omit when using the `:empty` option.
+      #
+      #     @param options [Hash] command options
+      #
+      #     @option options [Boolean] :m (nil) perform a merge, not just a
+      #       read
+      #
+      #     @option options [Boolean] :trivial (nil) restrict three-way merge
+      #       to happen only if there is no file-level merging required
+      #
+      #     @option options [Boolean] :aggressive (nil) resolve a few more
+      #       three-way merge cases internally beyond the trivial defaults
+      #
+      #     @option options [Boolean] :reset (nil) same as `-m`, except that
+      #       unmerged entries are discarded instead of failing
+      #
+      #     @option options [String] :prefix (nil) keep the current index
+      #       contents, and read the named tree-ish under the directory at
+      #       the given prefix
+      #
+      #       Maps to `--prefix=<prefix>`.
+      #
+      #     @option options [Boolean] :u (nil) after a successful merge,
+      #       update the files in the work tree with the result
+      #
+      #     @option options [String] :exclude_per_directory (nil) read
+      #       per-directory exclude file and allow untracked but explicitly
+      #       ignored files to be overwritten
+      #
+      #       Maps to `--exclude-per-directory=<gitignore>`.
+      #
+      #     @option options [Boolean] :i (nil) disable the check with the
+      #       working tree, meant for creating a merge of trees not directly
+      #       related to the current working tree status
+      #
+      #     @option options [Boolean] :dry_run (nil) check if the command
+      #       would error out, without updating the index or files for real
+      #
+      #       Alias: `:n`
+      #
+      #     @option options [Boolean] :v (nil) show the progress of checking
+      #       files out
+      #
+      #     @option options [String] :index_output (nil) write the resulting
+      #       index in the named file instead of `$GIT_INDEX_FILE`
+      #
+      #       Maps to `--index-output=<file>`.
+      #
+      #     @option options [Boolean] :recurse_submodules (nil) update the
+      #       content of all active submodules according to the commit
+      #       recorded in the superproject
+      #
+      #       When `false`, emits `--no-recurse-submodules`.
+      #
+      #     @option options [Boolean] :no_sparse_checkout (nil) disable
+      #       sparse checkout support even if `core.sparseCheckout` is true
+      #
+      #     @option options [Boolean] :empty (nil) empty the index instead of
+      #       reading tree object(s)
+      #
+      #     @option options [Boolean] :quiet (nil) suppress feedback messages
+      #
+      #       Alias: `:q`
+      #
+      #     @return [Git::CommandLineResult] the result of calling
+      #       `git read-tree`
+      #
+      #     @raise [Git::FailedError] if git exits with a non-zero exit
+      #       status
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -35,6 +35,7 @@ require_relative 'commands/mv'
 require_relative 'commands/name_rev'
 require_relative 'commands/pull'
 require_relative 'commands/push'
+require_relative 'commands/read_tree'
 require_relative 'commands/reset'
 require_relative 'commands/rev_parse'
 require_relative 'commands/revert'
@@ -1856,14 +1857,12 @@ module Git
     end
     # rubocop:enable Style/ArgumentsForwarding
 
-    READ_TREE_OPTION_MAP = [
-      { keys: [:prefix], flag: '--prefix', type: :valued_equals }
-    ].freeze
+    READ_TREE_ALLOWED_OPTS = %i[prefix].freeze
 
     def read_tree(treeish, opts = {})
-      ArgsBuilder.validate!(opts, READ_TREE_OPTION_MAP)
-      flags = build_args(opts, READ_TREE_OPTION_MAP)
-      command_capturing('read-tree', *flags, treeish)
+      assert_valid_opts(opts, READ_TREE_ALLOWED_OPTS)
+      allowed_opts = opts.slice(*READ_TREE_ALLOWED_OPTS)
+      Git::Commands::ReadTree.new(self).call(treeish, **allowed_opts)
     end
 
     def write_tree

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,20 +22,20 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (43/54 checklist items done, 11 remaining) |
+| Phase 2 | 🔄 In Progress | Migrating commands (44/54 checklist items done, 10 remaining) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate `read_tree`** → `Git::Commands::ReadTree` — `git read-tree`
+**Migrate `commit_tree`** → `Git::Commands::CommitTree` — `git commit-tree`
 
-Create `Git::Commands::ReadTree` to wrap `git read-tree`. Update `Git::Lib#read_tree` to
+Create `Git::Commands::CommitTree` to wrap `git commit-tree`. Update `Git::Lib#commit_tree` to
 delegate to the new command class and mark the checklist item done.
 
 #### Workflow
 
-1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def read_tree`). Understand all options and edge cases.
+1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def commit_tree`). Understand all options and edge cases.
 
 2. **Design**: Create command class following the pattern in
    `lib/git/commands/branch/delete.rb`. The interface for `#call` should only include
@@ -1016,7 +1016,7 @@ order: Basic Snapshotting → Branching & Merging → etc.
 - [x] `rev_parse` → `Git::Commands::RevParse` — `git rev-parse`
 - [x] `name_rev` → `Git::Commands::NameRev` — `git name-rev`
 - [x] `cat_file_*` → `Git::Commands::CatFile::*` — `git cat-file` (implemented as `Full`, `Meta`, `Pretty`, and `Typed`, with `Git::Lib#cat_file_*` delegating through these classes)
-- [ ] `read_tree` → `Git::Commands::ReadTree` — `git read-tree`
+- [x] `read_tree` → `Git::Commands::ReadTree` — `git read-tree`
 - [ ] `commit_tree` → `Git::Commands::CommitTree` — `git commit-tree`
 - [ ] `update_ref` → `Git::Commands::UpdateRef` — `git update-ref`
 - [x] `checkout_index` → `Git::Commands::CheckoutIndex` — `git checkout-index`

--- a/spec/integration/git/commands/read_tree_spec.rb
+++ b/spec/integration/git/commands/read_tree_spec.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/read_tree'
+
+RSpec.describe Git::Commands::ReadTree, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    write_file('file.txt', "content\n")
+    repo.add('file.txt')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult' do
+        result = command.call('HEAD')
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for an invalid tree-ish' do
+        # git's error message phrasing varies by version — anchor on the stable input value
+        expect { command.call('nonexistent-ref') }
+          .to raise_error(Git::FailedError, /nonexistent-ref/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/read_tree_spec.rb
+++ b/spec/unit/git/commands/read_tree_spec.rb
@@ -1,0 +1,204 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/read_tree'
+
+RSpec.describe Git::Commands::ReadTree do
+  # Duck-type collaborator: command specs depend on the #command_capturing
+  # interface, not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with a single tree-ish' do
+      it 'runs git read-tree with the tree-ish as a positional argument' do
+        expected_result = command_result
+        expect_command_capturing('read-tree', '--', 'HEAD').and_return(expected_result)
+
+        result = command.call('HEAD')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with multiple tree-ishes' do
+      it 'passes all tree-ishes as positional arguments' do
+        expect_command_capturing('read-tree', '--', 'abc123', 'def456', 'ghi789')
+          .and_return(command_result)
+
+        command.call('abc123', 'def456', 'ghi789')
+      end
+    end
+
+    context 'with the :m option' do
+      it 'adds -m to the command line' do
+        expect_command_capturing('read-tree', '-m', '--', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', m: true)
+      end
+    end
+
+    context 'with the :reset option' do
+      it 'adds --reset to the command line' do
+        expect_command_capturing('read-tree', '--reset', '--', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', reset: true)
+      end
+    end
+
+    context 'with the :prefix option' do
+      it 'adds --prefix=<value> as an inline value' do
+        expect_command_capturing('read-tree', '--prefix=subdir/', '--', 'HEAD')
+          .and_return(command_result)
+
+        command.call('HEAD', prefix: 'subdir/')
+      end
+    end
+
+    context 'with the :u option' do
+      it 'adds -u to the command line' do
+        expect_command_capturing('read-tree', '-u', '--', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', u: true)
+      end
+    end
+
+    context 'with the :i option' do
+      it 'adds -i to the command line' do
+        expect_command_capturing('read-tree', '-i', '--', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', i: true)
+      end
+    end
+
+    context 'with the :dry_run option' do
+      it 'adds --dry-run to the command line' do
+        expect_command_capturing('read-tree', '--dry-run', '--', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', dry_run: true)
+      end
+    end
+
+    context 'with the :n alias' do
+      it 'supports the :n alias for :dry_run' do
+        expect_command_capturing('read-tree', '--dry-run', '--', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', n: true)
+      end
+    end
+
+    context 'with the :v option' do
+      it 'adds -v to the command line' do
+        expect_command_capturing('read-tree', '-v', '--', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', v: true)
+      end
+    end
+
+    context 'with the :trivial option' do
+      it 'adds --trivial to the command line' do
+        expect_command_capturing('read-tree', '--trivial', '--', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', trivial: true)
+      end
+    end
+
+    context 'with the :aggressive option' do
+      it 'adds --aggressive to the command line' do
+        expect_command_capturing('read-tree', '--aggressive', '--', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', aggressive: true)
+      end
+    end
+
+    context 'with the :exclude_per_directory option' do
+      it 'adds --exclude-per-directory=<value> as an inline value' do
+        expect_command_capturing('read-tree', '--exclude-per-directory=.gitignore', '--', 'HEAD')
+          .and_return(command_result)
+
+        command.call('HEAD', exclude_per_directory: '.gitignore')
+      end
+    end
+
+    context 'with the :index_output option' do
+      it 'adds --index-output=<value> as an inline value' do
+        expect_command_capturing('read-tree', '--index-output=/tmp/index', '--', 'HEAD')
+          .and_return(command_result)
+
+        command.call('HEAD', index_output: '/tmp/index')
+      end
+    end
+
+    context 'with the :recurse_submodules option' do
+      it 'adds --recurse-submodules when true' do
+        expect_command_capturing('read-tree', '--recurse-submodules', '--', 'HEAD')
+          .and_return(command_result)
+
+        command.call('HEAD', recurse_submodules: true)
+      end
+
+      it 'adds --no-recurse-submodules when false' do
+        expect_command_capturing('read-tree', '--no-recurse-submodules', '--', 'HEAD')
+          .and_return(command_result)
+
+        command.call('HEAD', recurse_submodules: false)
+      end
+    end
+
+    context 'with the :no_sparse_checkout option' do
+      it 'adds --no-sparse-checkout to the command line' do
+        expect_command_capturing('read-tree', '--no-sparse-checkout', '--', 'HEAD')
+          .and_return(command_result)
+
+        command.call('HEAD', no_sparse_checkout: true)
+      end
+    end
+
+    context 'with the :empty option' do
+      it 'adds --empty to the command line' do
+        expect_command_capturing('read-tree', '--empty').and_return(command_result)
+
+        command.call(empty: true)
+      end
+    end
+
+    context 'with the :quiet option' do
+      it 'adds --quiet to the command line' do
+        expect_command_capturing('read-tree', '--quiet', '--', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', quiet: true)
+      end
+    end
+
+    context 'with the :q alias' do
+      it 'supports the :q alias for :quiet' do
+        expect_command_capturing('read-tree', '--quiet', '--', 'HEAD').and_return(command_result)
+
+        command.call('HEAD', q: true)
+      end
+    end
+
+    context 'with multiple options combined' do
+      it 'includes all specified flags in definition order' do
+        expect_command_capturing(
+          'read-tree',
+          '-m',
+          '--trivial', '--aggressive',
+          '-u',
+          '--quiet',
+          '--',
+          'base', 'ours', 'theirs'
+        ).and_return(command_result)
+
+        command.call('base', 'ours', 'theirs', m: true, trivial: true, aggressive: true, u: true, quiet: true)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('HEAD', unknown: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/tests/units/test_tree_ops.rb
+++ b/tests/units/test_tree_ops.rb
@@ -5,14 +5,14 @@ require 'test_helper'
 class TestTreeOps < Test::Unit::TestCase
   def test_read_tree
     treeish = 'testbranch1'
-    expected_command_line = ['read-tree', treeish, {}]
+    expected_command_line = ['read-tree', '--', treeish, {}]
     assert_command_line_eq(expected_command_line) { |git| git.read_tree(treeish) }
   end
 
   def test_read_tree_with_prefix
     treeish = 'testbranch1'
     prefix = 'foo'
-    expected_command_line = ['read-tree', "--prefix=#{prefix}", treeish, {}]
+    expected_command_line = ['read-tree', "--prefix=#{prefix}", '--', treeish, {}]
     assert_command_line_eq(expected_command_line) { |git| git.read_tree(treeish, prefix: prefix) }
   end
 


### PR DESCRIPTION
## Summary

Migrate the `git read-tree` command from a direct `command_capturing` call in `Git::Lib#read_tree` to the new `Git::Commands::ReadTree` class, following the Phase 2 Strangler Fig migration pattern.

## Changes

- **New command class** `Git::Commands::ReadTree` with full `git read-tree` option set from the v2.28.0 man page:
  - Merge modes: `-m`, `--reset`
  - Working tree update: `-u`, `-i`
  - Merge strategies: `--trivial`, `--aggressive`
  - Path/output control: `--prefix=`, `--exclude-per-directory=`, `--index-output=`
  - Dry run: `-n`/`--dry-run`
  - Submodules: `--[no-]recurse-submodules`
  - Sparse checkout: `--no-sparse-checkout`
  - Index clearing: `--empty`
  - Feedback: `-v`, `-q`/`--quiet`
- **Lib delegation**: `Git::Lib#read_tree` now delegates to the command class with only `:prefix` allowed, preserving the existing public API contract
- **Unit tests**: 22 examples covering all options, aliases, combined flags, and input validation
- **Integration tests**: 2 examples verifying real git execution (success and failure paths)
- **Checklist update**: Marked `read_tree` as migrated (44/54 done), updated next task to `commit_tree`

## Verification

All quality gates pass:
- `bundle exec rspec` — 3281 examples, 0 failures
- `bundle exec rake test` — 557 tests, 0 failures
- `bundle exec rubocop` — no offenses
- `bundle exec rake yard` — documentation valid
