### PR TITLE
refactor(command): migrate archive to Git::Commands::Archive

### DIFF
--- a/lib/git/commands/archive.rb
+++ b/lib/git/commands/archive.rb
@@ -1,0 +1,158 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    # Archive creator for files from a named tree via `git archive`
+    #
+    # Produces an archive of the specified format containing the tree structure
+    # for the named tree, and writes it to stdout (or to a file when `out:` or
+    # `output:` is given). If `prefix:` is specified it is prepended to the
+    # filenames in the archive.
+    #
+    # @example Archive HEAD as a tar stream to a file
+    #   cmd = Git::Commands::Archive.new(execution_context)
+    #   File.open('release.tar', 'wb') do |f|
+    #     cmd.call('HEAD', format: 'tar', out: f)
+    #   end
+    #
+    # @example Archive a tag with a prefix
+    #   cmd = Git::Commands::Archive.new(execution_context)
+    #   cmd.call('v1.0', format: 'zip', prefix: 'myproject-1.0/', output: 'release.zip')
+    #
+    # @example Archive a subdirectory only
+    #   cmd = Git::Commands::Archive.new(execution_context)
+    #   cmd.call('HEAD', 'src/', format: 'tar', out: io)
+    #
+    # @see https://git-scm.com/docs/git-archive git-archive documentation
+    #
+    # @api private
+    #
+    class Archive < Base
+      arguments do
+        literal 'archive'
+
+        # Archive format — `tar` or `zip`; user-defined formats (e.g. `tar.gz`)
+        # are also supported when configured via `tar.<format>.command`
+        # @see https://git-scm.com/docs/git-archive#Documentation/git-archive.txt---formatltfmtgt
+        value_option :format, inline: true
+
+        # Report progress to stderr
+        # @see https://git-scm.com/docs/git-archive#Documentation/git-archive.txt---verbose
+        flag_option %i[verbose v]
+
+        # Prepend `<prefix>/` to each filename in the archive
+        # @see https://git-scm.com/docs/git-archive#Documentation/git-archive.txt---prefixltprefixgt
+        value_option :prefix, inline: true
+
+        # Write the archive to `<file>` instead of stdout
+        # @see https://git-scm.com/docs/git-archive#Documentation/git-archive.txt--oltfilegt
+        value_option %i[output o], inline: true
+
+        # Look for attributes in `.gitattributes` files in the working tree
+        # as well as in the tree being archived
+        # @see https://git-scm.com/docs/git-archive#Documentation/git-archive.txt---worktree-attributes
+        flag_option :worktree_attributes
+
+        # Instead of making an archive from the local repository, retrieve
+        # a tar archive from a remote repository
+        # @see https://git-scm.com/docs/git-archive#Documentation/git-archive.txt---remoteltrepogt
+        value_option :remote, inline: true
+
+        # Used with `--remote` to specify the path to `git-upload-archive`
+        # on the remote side
+        # @see https://git-scm.com/docs/git-archive#Documentation/git-archive.txt---execltgit-upload-archivegt
+        value_option :exec, inline: true
+
+        # Stream stdout to this IO object instead of buffering in memory.
+        # When provided, the command dispatches to the streaming execution path.
+        execution_option :out
+
+        conflicts :output, :out
+
+        end_of_options
+
+        # The tree or commit to produce an archive for
+        operand :tree_ish, required: true
+
+        # Limit the archive to these paths within the tree
+        operand :path, repeatable: true
+      end
+
+      # Execute the `git archive` command
+      #
+      # Archive output is binary. On the capturing path (no `out:` option),
+      # `normalize` and `chomp` are disabled so stdout bytes are returned
+      # unchanged. When `out:` is given, the streaming path is used and
+      # these options do not apply.
+      #
+      # @overload call(tree_ish, *path, **options)
+      #
+      #   @param tree_ish [String] the tree or commit to produce an archive for
+      #
+      #   @param path [Array<String>] limit the archive to these paths
+      #     within the tree
+      #
+      #   @param options [Hash] command options
+      #
+      #   @option options [String] :format (nil) archive format — `tar` or
+      #     `zip`; user-defined formats are also supported
+      #
+      #   @option options [Boolean] :verbose (nil) report progress to stderr
+      #
+      #     Alias: :v
+      #
+      #   @option options [String] :prefix (nil) prepend `<prefix>/` to each
+      #     filename in the archive
+      #
+      #   @option options [String] :output (nil) write the archive to
+      #     this file instead of stdout
+      #
+      #     Alias: :o
+      #
+      #   @option options [Boolean] :worktree_attributes (nil) look for
+      #     attributes in `.gitattributes` files in the working tree
+      #
+      #   @option options [String] :remote (nil) retrieve a tar archive from
+      #     a remote repository instead of the local one
+      #
+      #   @option options [String] :exec (nil) path to `git-upload-archive`
+      #     on the remote side (used with `:remote`)
+      #
+      #   @option options [IO] :out (nil) stream stdout to this IO object
+      #     instead of buffering in memory
+      #
+      #   @return [Git::CommandLineResult] the result of calling
+      #     `git archive`
+      #
+      #   @raise [ArgumentError] if unsupported options are provided
+      #
+      #   @raise [ArgumentError] if the tree_ish operand is missing
+      #
+      #   @raise [Git::FailedError] if the command returns a non-zero
+      #     exit status
+      def call(*, **)
+        bound = args_definition.bind(*, **)
+        result = execute_command(bound)
+        validate_exit_status!(result)
+        result
+      end
+
+      private
+
+      # Archive output is binary — disable normalize and chomp on the
+      # capturing path so stdout bytes are returned unchanged.
+      def execute_command(bound)
+        if bound.execution_options.key?(:out)
+          @execution_context.command_streaming(*bound, **bound.execution_options, raise_on_failure: false)
+        else
+          @execution_context.command_capturing(
+            *bound, **bound.execution_options,
+            normalize: false, chomp: false, raise_on_failure: false
+          )
+        end
+      end
+    end
+  end
+end

--- a/lib/git/commands/archive/list_formats.rb
+++ b/lib/git/commands/archive/list_formats.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+require 'git/commands/archive'
+
+module Git
+  module Commands
+    class Archive
+      # Format lister for `git archive --list`
+      #
+      # Lists all available archive formats supported by the current git
+      # installation. This is a standalone mode of `git archive` that does not
+      # require a tree-ish operand.
+      #
+      # @example List available archive formats
+      #   cmd = Git::Commands::Archive::ListFormats.new(execution_context)
+      #   result = cmd.call
+      #   result.stdout  # => "tar\ntgz\ntar.gz\nzip\n"
+      #
+      # @see Git::Commands::Archive
+      #
+      # @see https://git-scm.com/docs/git-archive git-archive documentation
+      #
+      # @api private
+      #
+      class ListFormats < Git::Commands::Base
+        arguments do
+          literal 'archive'
+          literal '--list'
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call
+        #
+        #     Execute `git archive --list` to show available formats
+        #
+        #     @return [Git::CommandLineResult] the result of calling
+        #       `git archive --list`
+        #
+        #     @raise [Git::FailedError] if the command returns a non-zero
+        #       exit status
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -3,6 +3,7 @@
 require_relative 'args_builder'
 require_relative 'commands/add'
 require_relative 'commands/am'
+require_relative 'commands/archive'
 require_relative 'commands/apply'
 require_relative 'commands/branch/create'
 require_relative 'commands/branch/delete'
@@ -1889,21 +1890,13 @@ module Git
       Git::Commands::CheckoutIndex.new(self).call(*paths.to_a, **keyword_opts)
     end
 
-    ARCHIVE_OPTION_MAP = [
-      { keys: [:prefix],     flag: '--prefix', type: :valued_equals },
-      { keys: [:remote],     flag: '--remote', type: :valued_equals },
-      # These options are used by helpers or handled manually
-      { keys: [:path],       type: :validate_only },
-      { keys: [:format],     type: :validate_only },
-      { keys: [:add_gzip],   type: :validate_only }
-    ].freeze
+    ARCHIVE_ALLOWED_OPTS = %i[prefix remote path format add_gzip].freeze
 
     # Creates an archive of the given tree-ish and writes it to a file
     #
-    # Runs `git archive` and streams its output directly to disk rather than
-    # accumulating it in memory. When `:add_gzip` is `true` or the format is
-    # `'tgz'`, the written archive is then read back into memory for gzip
-    # compression. Returns the path to the written archive file.
+    # Delegates to {Git::Commands::Archive} for CLI execution. Format coercion
+    # (`tgz` → `tar` + gzip), temp file management, and gzip post-processing
+    # remain in this adapter.
     #
     # @see https://git-scm.com/docs/git-archive git-archive
     #
@@ -1930,16 +1923,16 @@ module Git
     # @raise [Git::FailedError] if `git archive` fails
     #
     def archive(sha, file = nil, opts = {})
-      ArgsBuilder.validate!(opts, ARCHIVE_OPTION_MAP)
+      assert_valid_opts(opts, ARCHIVE_ALLOWED_OPTS)
       file ||= temp_file_name
       format, gzip = parse_archive_format_options(opts)
 
-      args = build_args(opts, ARCHIVE_OPTION_MAP)
-      args.unshift("--format=#{format}")
-      args << sha
-      args.push('--', opts[:path]) if opts[:path]
+      command_opts = opts.slice(:prefix, :remote).merge(format: format)
+      path_args = opts[:path] ? [opts[:path]] : []
 
-      File.open(file, 'wb') { |f| command_streaming('archive', *args, out: f) }
+      File.open(file, 'wb') do |f|
+        Git::Commands::Archive.new(self).call(sha, *path_args, **command_opts, out: f)
+      end
       apply_gzip(file) if gzip
 
       file

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,15 +22,15 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (46/54 checklist items done, 8 remaining) |
+| Phase 2 | 🔄 In Progress | Migrating commands (47/54 checklist items done, 7 remaining) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate `archive`** → `Git::Commands::Archive` — `git archive`
+**Migrate `write_tree`** → `Git::Commands::WriteTree` — `git write-tree`
 
-Create `Git::Commands::Archive` to wrap `git archive`. Update `Git::Lib#archive` to
+Create `Git::Commands::WriteTree` to wrap `git write-tree`. Update `Git::Lib#write_tree` to
 delegate to the new command class and mark the checklist item done.
 
 #### Workflow
@@ -923,6 +923,7 @@ The following tracks the migration status of commands from `Git::Lib` to
 | N/A (new) | `Git::Commands::Stash::ShowRaw` | `spec/unit/git/commands/stash/show_raw_spec.rb` | `git stash show --raw` |
 | `cat_file_*` | `Git::Commands::CatFile::*` | `spec/unit/git/commands/cat_file/*_spec.rb` | `git cat-file` |
 | `checkout_index` | `Git::Commands::CheckoutIndex` | `spec/unit/git/commands/checkout_index_spec.rb` | `git checkout-index` |
+| `archive` | `Git::Commands::Archive` | `spec/unit/git/commands/archive_spec.rb` | `git archive` |
 | `grep` | `Git::Commands::Grep` | `spec/unit/git/commands/grep_spec.rb` | `git grep` |
 | `log_commits` / `full_log_commits` | `Git::Commands::Log` | `spec/unit/git/commands/log_spec.rb` | `git log` |
 | `show` | `Git::Commands::Show` | `spec/unit/git/commands/show_spec.rb` | `git show` |
@@ -1024,7 +1025,7 @@ order: Basic Snapshotting → Branching & Merging → etc.
 - [x] `commit_tree` → `Git::Commands::CommitTree` — `git commit-tree`
 - [x] `update_ref` → `Git::Commands::UpdateRef::*` — `git update-ref` (implemented as `Update`, `Delete`, and `Batch`)
 - [x] `checkout_index` → `Git::Commands::CheckoutIndex` — `git checkout-index`
-- [ ] `archive` → `Git::Commands::Archive` — `git archive`
+- [x] `archive` → `Git::Commands::Archive` — `git archive`
 - [ ] `write_tree` → `Git::Commands::WriteTree` — `git write-tree`
 
 **Administration:**

--- a/spec/integration/git/commands/archive/list_formats_spec.rb
+++ b/spec/integration/git/commands/archive/list_formats_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/archive/list_formats'
+
+RSpec.describe Git::Commands::Archive::ListFormats, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult with output' do
+        result = command.call
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.stdout).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/archive_spec.rb
+++ b/spec/integration/git/commands/archive_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/archive'
+
+RSpec.describe Git::Commands::Archive, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    write_file('file.txt', "content\n")
+    repo.add('file.txt')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'captures binary-identical archive content in stdout' do
+        # Stream to a file for the reference bytes
+        streamed_bytes = Tempfile.create(%w[archive .tar]) do |f|
+          f.binmode
+          command.call('HEAD', format: 'tar', out: f)
+          f.flush
+          f.rewind
+          f.read
+        end
+
+        # Capture in-memory and compare byte-for-byte
+        result = command.call('HEAD', format: 'tar')
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.stdout).to eq(streamed_bytes)
+      end
+
+      it 'streams output to a file when out: is given' do
+        Tempfile.create(%w[archive .tar]) do |f|
+          f.binmode
+          result = command.call('HEAD', format: 'tar', out: f)
+          f.flush
+          expect(f.size).to be > 0
+          expect(result.stdout).to eq('')
+        end
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for a nonexistent tree-ish' do
+        # git's error message phrasing varies by version — anchor on the stable input value
+        expect { command.call('nonexistent-ref', format: 'tar') }
+          .to raise_error(Git::FailedError, /nonexistent-ref/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/archive/list_formats_spec.rb
+++ b/spec/unit/git/commands/archive/list_formats_spec.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/archive/list_formats'
+
+RSpec.describe Git::Commands::Archive::ListFormats do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    it 'runs git archive --list' do
+      expected_result = command_result
+      expect_command_capturing('archive', '--list').and_return(expected_result)
+
+      result = command.call
+
+      expect(result).to eq(expected_result)
+    end
+  end
+end

--- a/spec/unit/git/commands/archive_spec.rb
+++ b/spec/unit/git/commands/archive_spec.rb
@@ -1,0 +1,165 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/archive'
+
+RSpec.describe Git::Commands::Archive do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with only the tree_ish operand' do
+      it 'runs git archive with the tree-ish' do
+        expected_result = command_result
+        expect_command_capturing('archive', '--', 'HEAD', normalize: false, chomp: false)
+          .and_return(expected_result)
+
+        result = command.call('HEAD')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with path operands' do
+      it 'includes paths after the tree-ish' do
+        expect_command_capturing('archive', '--', 'HEAD', 'src/', normalize: false, chomp: false)
+          .and_return(command_result)
+
+        command.call('HEAD', 'src/')
+      end
+
+      it 'includes multiple paths' do
+        expect_command_capturing('archive', '--', 'HEAD', 'src/', 'lib/', normalize: false, chomp: false)
+          .and_return(command_result)
+
+        command.call('HEAD', 'src/', 'lib/')
+      end
+    end
+
+    context 'with the :format option' do
+      it 'adds --format=<value> to the command line' do
+        expect_command_capturing('archive', '--format=tar', '--', 'HEAD', normalize: false, chomp: false)
+          .and_return(command_result)
+
+        command.call('HEAD', format: 'tar')
+      end
+    end
+
+    context 'with the :prefix option' do
+      it 'adds --prefix=<value> to the command line' do
+        expect_command_capturing('archive', '--prefix=myproject/', '--', 'HEAD', normalize: false, chomp: false)
+          .and_return(command_result)
+
+        command.call('HEAD', prefix: 'myproject/')
+      end
+    end
+
+    context 'with the :output option' do
+      it 'adds --output=<value> to the command line' do
+        expect_command_capturing('archive', '--output=release.zip', '--', 'HEAD', normalize: false, chomp: false)
+          .and_return(command_result)
+
+        command.call('HEAD', output: 'release.zip')
+      end
+
+      it 'supports the :o alias' do
+        expect_command_capturing('archive', '--output=release.tar', '--', 'HEAD', normalize: false, chomp: false)
+          .and_return(command_result)
+
+        command.call('HEAD', o: 'release.tar')
+      end
+    end
+
+    context 'with the :worktree_attributes option' do
+      it 'adds --worktree-attributes to the command line' do
+        expect_command_capturing('archive', '--worktree-attributes', '--', 'HEAD', normalize: false, chomp: false)
+          .and_return(command_result)
+
+        command.call('HEAD', worktree_attributes: true)
+      end
+    end
+
+    context 'with the :remote option' do
+      it 'adds --remote=<value> to the command line' do
+        expect_command_capturing(
+          'archive', '--remote=git://example.com/repo.git', '--', 'HEAD',
+          normalize: false, chomp: false
+        ).and_return(command_result)
+
+        command.call('HEAD', remote: 'git://example.com/repo.git')
+      end
+    end
+
+    context 'with the :exec option' do
+      it 'adds --exec=<value> to the command line' do
+        expect_command_capturing(
+          'archive', '--exec=/usr/bin/git-upload-archive', '--', 'HEAD',
+          normalize: false, chomp: false
+        ).and_return(command_result)
+
+        command.call('HEAD', exec: '/usr/bin/git-upload-archive')
+      end
+    end
+
+    context 'with the :verbose option' do
+      it 'adds --verbose when true' do
+        expect_command_capturing('archive', '--verbose', '--', 'HEAD', normalize: false, chomp: false)
+          .and_return(command_result)
+
+        command.call('HEAD', verbose: true)
+      end
+
+      it 'supports the :v alias' do
+        expect_command_capturing('archive', '--verbose', '--', 'HEAD', normalize: false, chomp: false)
+          .and_return(command_result)
+
+        command.call('HEAD', v: true)
+      end
+    end
+
+    context 'with out: execution option (streaming)' do
+      it 'dispatches to command_streaming when out: is given' do
+        out_io = instance_double(File)
+        expect_command_streaming('archive', '--', 'HEAD', out: out_io).and_return(command_result)
+
+        command.call('HEAD', out: out_io)
+      end
+    end
+
+    context 'with multiple options combined' do
+      it 'includes all specified options in definition order' do
+        expect_command_capturing(
+          'archive',
+          '--format=tar',
+          '--verbose',
+          '--prefix=release-1.0/',
+          '--remote=git://example.com/repo.git',
+          '--', 'v1.0', 'src/',
+          normalize: false, chomp: false
+        ).and_return(command_result)
+
+        command.call('v1.0', 'src/', format: 'tar', prefix: 'release-1.0/',
+                                     remote: 'git://example.com/repo.git', verbose: true)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when tree_ish is missing' do
+        expect { command.call }
+          .to raise_error(ArgumentError, /tree_ish is required/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('HEAD', unknown: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+
+      it 'raises ArgumentError when both output: and out: are given' do
+        expect { command.call('HEAD', output: 'release.tar', out: instance_double(File)) }
+          .to raise_error(ArgumentError, /cannot specify :output and :out/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/lib_command_spec.rb
+++ b/spec/unit/git/lib_command_spec.rb
@@ -663,7 +663,7 @@ RSpec.describe Git::Lib do
         lib.archive('HEAD', out_file.path)
 
         expect(streaming_command_line).to have_received(:run).with(
-          'archive', anything, anything,
+          'archive', '--format=zip', '--', 'HEAD',
           hash_including(out: instance_of(File))
         )
       end


### PR DESCRIPTION
## Summary

Migrate `git archive` from a direct `command_streaming` call in `Git::Lib` to a dedicated `Git::Commands::Archive` class following the Strangler Fig architecture redesign.

## Changes

### New: `Git::Commands::Archive` (`lib/git/commands/archive.rb`)

Full `Git::Commands::Base` subclass wrapping `git archive` with arguments DSL support for all documented options:

- `--format=<fmt>` (tar, zip, user-defined formats)
- `--prefix=<prefix>/`
- `--output=<file>` / `-o <file>`
- `--worktree-attributes`
- `--remote=<repo>`
- `--exec=<git-upload-archive>`
- `--verbose` / `-v`
- Execution option `out:` for streaming stdout to an IO object (mutually exclusive with `--output`)
- Positional operands: `tree_ish` (required) and `path` (repeatable)

### New: `Git::Commands::Archive::ListFormats` (`lib/git/commands/archive/list_formats.rb`)

Separate `Git::Commands::Base` subclass wrapping `git archive --list` as a standalone command. This mode lists available archive formats and does not accept a tree-ish or path operands.

### Updated: `Git::Lib#archive` (`lib/git/lib.rb`)

- Delegates CLI execution to `Git::Commands::Archive`
- Removes `ARCHIVE_OPTION_MAP` and manual argument building
- Retains format coercion (`tgz` → `tar` + gzip), temp file management, and gzip post-processing in the adapter layer

### Tests

- **Unit tests** (`spec/unit/git/commands/archive_spec.rb`): spec covering argument building for all options, operands, aliases, combinations, and input validation (including `output:`/`out:` conflict)
- **Unit tests** (`spec/unit/git/commands/archive/list_formats_spec.rb`): spec for the `ListFormats` command
- **Integration tests** (`spec/integration/git/commands/archive_spec.rb`): End-to-end tests verifying archive creation against a real git repository
- **Integration tests** (`spec/integration/git/commands/archive/list_formats_spec.rb`): End-to-end tests for `ListFormats`

### Tracking

- Updated `redesign/3_architecture_implementation.md`: marked `archive` as complete (47/54), set next task to `write_tree`
