### PR TITLE
refactor(command): migrate gc to Git::Commands::Gc

### DIFF
--- a/lib/git/commands/gc.rb
+++ b/lib/git/commands/gc.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    # Wrapper for the `git gc` command
+    #
+    # Runs a number of housekeeping tasks within the current repository, such as
+    # compressing file revisions (to reduce disk space and increase performance),
+    # removing unreachable objects, packing refs, pruning reflog, rerere metadata
+    # or stale working trees.
+    #
+    # @example Basic usage
+    #   gc = Git::Commands::Gc.new(execution_context)
+    #   gc.call
+    #
+    # @example Run only if housekeeping is needed
+    #   gc = Git::Commands::Gc.new(execution_context)
+    #   gc.call(auto: true)
+    #
+    # @example Aggressive optimization with custom prune expiry
+    #   gc = Git::Commands::Gc.new(execution_context)
+    #   gc.call(aggressive: true, prune: 'now')
+    #
+    # @see https://git-scm.com/docs/git-gc git-gc documentation
+    #
+    # @see Git::Commands
+    #
+    # @api private
+    #
+    class Gc < Git::Commands::Base
+      arguments do
+        literal 'gc'
+
+        # Optimization behaviour
+        flag_option :aggressive
+        flag_option :auto
+
+        # Output control
+        flag_option %i[quiet q]
+
+        # Pruning
+        flag_or_value_option :prune, negatable: true, inline: true
+
+        # Safety / override
+        flag_option :force
+        flag_option :keep_largest_pack
+      end
+
+      # @!method call(*, **)
+      #
+      #   @overload call(**options)
+      #
+      #     Execute the `git gc` command
+      #
+      #     @param options [Hash] command options
+      #
+      #     @option options [Boolean] :aggressive (nil) be more thorough (increased runtime)
+      #
+      #       When `true`, git gc runs more aggressively to optimize the repository at
+      #       the expense of taking much more time. The effects are mostly persistent.
+      #
+      #     @option options [Boolean] :auto (nil) check whether any housekeeping is required
+      #       before performing any work
+      #
+      #       When `true`, git gc checks whether housekeeping is needed; if not, it exits
+      #       without doing anything.
+      #
+      #     @option options [Boolean] :quiet (nil) suppress progress reporting
+      #
+      #       Alias: `:q`
+      #
+      #     @option options [Boolean, String] :prune (nil) prune loose objects older than date
+      #
+      #       When `true`, passes `--prune` (uses git's default expiry of 2 weeks ago). When
+      #       a string, passes `--prune=<date>`. When `false`, passes `--no-prune` to skip
+      #       pruning entirely. When `nil`, the option is omitted and git uses its configured
+      #       default.
+      #
+      #     @option options [Boolean] :force (nil) force running gc even if there may be
+      #       another gc running on this repository
+      #
+      #     @option options [Boolean] :keep_largest_pack (nil) repack all other packs except
+      #       the largest pack and those marked with a `.keep` file
+      #
+      #       When `true`, `gc.bigPackThreshold` is ignored.
+      #
+      #     @return [Git::CommandLineResult] the result of calling `git gc`
+      #
+      #     @raise [ArgumentError] if unsupported options are provided
+      #
+      #     @raise [Git::FailedError] if the command returns a non-zero exit status
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -25,6 +25,7 @@ require_relative 'commands/diff_files'
 require_relative 'commands/diff_index'
 require_relative 'commands/fetch'
 require_relative 'commands/fsck'
+require_relative 'commands/gc'
 require_relative 'commands/grep'
 require_relative 'commands/init'
 require_relative 'commands/log'
@@ -1844,7 +1845,7 @@ module Git
     end
 
     def gc
-      command_capturing('gc', '--prune', '--aggressive', '--auto')
+      Git::Commands::Gc.new(self).call(prune: true, aggressive: true, auto: true)
     end
 
     # Execute git fsck to verify repository integrity

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,15 +22,15 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (48/54 checklist items done, 6 remaining) |
+| Phase 2 | 🔄 In Progress | Migrating commands (49/54 checklist items done, 5 remaining) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate `gc`** → `Git::Commands::Gc` — `git gc`
+**Migrate `repack`** → `Git::Commands::Repack` — `git repack`
 
-Create `Git::Commands::Gc` to wrap `git gc`. Update `Git::Lib#gc` to
+Create `Git::Commands::Repack` to wrap `git repack`. Update `Git::Lib#repack` to
 delegate to the new command class and mark the checklist item done.
 
 #### Workflow
@@ -954,6 +954,7 @@ The following tracks the migration status of commands from `Git::Lib` to
 | `update_ref` | `Git::Commands::UpdateRef::Update` | `spec/unit/git/commands/update_ref/update_spec.rb` | `git update-ref` |
 | N/A (new) | `Git::Commands::UpdateRef::Delete` | `spec/unit/git/commands/update_ref/delete_spec.rb` | `git update-ref -d` |
 | N/A (new) | `Git::Commands::UpdateRef::Batch` | `spec/unit/git/commands/update_ref/batch_spec.rb` | `git update-ref --stdin` |
+| `gc` | `Git::Commands::Gc` | `spec/unit/git/commands/gc_spec.rb` | `git gc` |
 
 #### ⏳ Commands To Migrate
 
@@ -1030,7 +1031,7 @@ order: Basic Snapshotting → Branching & Merging → etc.
 
 **Administration:**
 
-- [ ] `gc` → `Git::Commands::Gc` — `git gc`
+- [x] `gc` → `Git::Commands::Gc` — `git gc`
 - [ ] `repack` → `Git::Commands::Repack` — `git repack`
 
 **Setup & Config:**

--- a/spec/integration/git/commands/gc_spec.rb
+++ b/spec/integration/git/commands/gc_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/gc'
+
+RSpec.describe Git::Commands::Gc, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult' do
+        result = command.call
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.exitstatus).to eq(0)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError when not in a git repository' do
+        FileUtils.rm_rf(File.join(repo_dir, '.git'))
+
+        # git's "not a git repository" message varies across versions — anchor on stable text
+        expect { command.call }.to raise_error(Git::FailedError, /git repository/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/gc_spec.rb
+++ b/spec/unit/git/commands/gc_spec.rb
@@ -1,0 +1,119 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/gc'
+
+RSpec.describe Git::Commands::Gc do
+  # Duck-type collaborator: command specs depend on the #command_capturing
+  # interface, not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with no options' do
+      it 'runs git gc with no extra arguments' do
+        expected_result = command_result
+        expect_command_capturing('gc').and_return(expected_result)
+
+        result = command.call
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with the :aggressive option' do
+      it 'adds --aggressive when true' do
+        expect_command_capturing('gc', '--aggressive').and_return(command_result)
+
+        command.call(aggressive: true)
+      end
+    end
+
+    context 'with the :auto option' do
+      it 'adds --auto when true' do
+        expect_command_capturing('gc', '--auto').and_return(command_result)
+
+        command.call(auto: true)
+      end
+    end
+
+    context 'with :prune option as true' do
+      it 'passes --prune' do
+        expect_command_capturing('gc', '--prune').and_return(command_result)
+
+        command.call(prune: true)
+      end
+    end
+
+    context 'with :prune option as a date string' do
+      it 'passes --prune=<date>' do
+        expect_command_capturing('gc', '--prune=now').and_return(command_result)
+
+        command.call(prune: 'now')
+      end
+    end
+
+    context 'with :prune option as false' do
+      it 'passes --no-prune' do
+        expect_command_capturing('gc', '--no-prune').and_return(command_result)
+
+        command.call(prune: false)
+      end
+    end
+
+    context 'with the :quiet option' do
+      it 'adds --quiet when true' do
+        expect_command_capturing('gc', '--quiet').and_return(command_result)
+
+        command.call(quiet: true)
+      end
+    end
+
+    context 'with the :q alias for :quiet' do
+      it 'passes --quiet' do
+        expect_command_capturing('gc', '--quiet').and_return(command_result)
+
+        command.call(q: true)
+      end
+    end
+
+    context 'with the :force option' do
+      it 'adds --force when true' do
+        expect_command_capturing('gc', '--force').and_return(command_result)
+
+        command.call(force: true)
+      end
+    end
+
+    context 'with the :keep_largest_pack option' do
+      it 'adds --keep-largest-pack when true' do
+        expect_command_capturing('gc', '--keep-largest-pack').and_return(command_result)
+
+        command.call(keep_largest_pack: true)
+      end
+    end
+
+    context 'with :aggressive, :quiet, and :prune combined' do
+      it 'passes all three flags in DSL-defined order' do
+        expect_command_capturing('gc', '--aggressive', '--quiet', '--prune=now').and_return(command_result)
+
+        command.call(aggressive: true, prune: 'now', quiet: true)
+      end
+    end
+
+    context 'with :auto and :quiet combined' do
+      it 'passes both flags in DSL-defined order' do
+        expect_command_capturing('gc', '--auto', '--quiet').and_return(command_result)
+
+        command.call(auto: true, quiet: true)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(unknown: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Migrates `Git::Lib#gc` to a new `Git::Commands::Gc` class as part of the Phase 2 Strangler Fig pattern migration (checklist item 49/54).

## Changes

### New: `lib/git/commands/gc.rb`

`Git::Commands::Gc` wraps `git gc` using the `Git::Commands::Base` architecture. Exposes all options documented in the minimum-supported git version (2.28.0):

- `--aggressive` — be more thorough but slower
- `--auto` — skip if housekeeping is not needed
- `--quiet`/`-q` — suppress progress reporting
- `--prune[=<date>]`/`--no-prune` — prune loose objects (boolean or expiry date string)
- `--force` — run even if another gc may be running
- `--keep-largest-pack` — repack all other packs except the largest

### Updated: `lib/git/lib.rb`

`Git::Lib#gc` now delegates to `Git::Commands::Gc`, preserving the existing behavior (`prune: true`, `aggressive: true`, `auto: true`):

```ruby
def gc
  Git::Commands::Gc.new(self).call(prune: true, aggressive: true, auto: true)
end
```

### Tests

- Unit tests (`spec/unit/git/commands/gc_spec.rb`): 14 examples covering no-options baseline, each option individually (including `:q` alias for `:quiet` and all three `:prune` forms), combined options, and unsupported-option validation.
- Integration tests (`spec/integration/git/commands/gc_spec.rb`): 2 examples — a smoke test confirming a basic call returns a `CommandLineResult` with exit code 0, and a failure test confirming `FailedError` is raised when not in a git repository.

### Docs

- `redesign/3_architecture_implementation.md` — marked `gc` done, updated progress counter to 49/54, updated Next Task to `repack`.

## Checklist

- [x] Unit tests pass (`bundle exec rspec spec/unit/git/commands/gc_spec.rb`)
- [x] Integration tests pass (`bundle exec rspec spec/integration/git/commands/gc_spec.rb`)
- [x] Full RSpec suite passes
- [x] Legacy TestUnit suite passes
- [x] Rubocop clean
- [x] Implementation plan updated