### PR TITLE
refactor(command): migrate Git::Lib#repack to Git::Commands::Repack

### DIFF
--- a/lib/git/commands/repack.rb
+++ b/lib/git/commands/repack.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    # Wrapper for the `git repack` command
+    #
+    # Packs unpacked objects in a repository into pack files, and can reorganize
+    # existing packs into a single, more efficient pack. Running `git repack -a -d`
+    # is the most common usage: pack all objects and delete redundant packs.
+    #
+    # @example Pack all objects and delete redundant packs
+    #   repack = Git::Commands::Repack.new(execution_context)
+    #   repack.call(a: true, d: true)
+    #
+    # @example Pack all objects with bitmap index
+    #   repack = Git::Commands::Repack.new(execution_context)
+    #   repack.call(a: true, d: true, write_bitmap_index: true)
+    #
+    # @example Control delta compression performance
+    #   repack = Git::Commands::Repack.new(execution_context)
+    #   repack.call(a: true, d: true, window: 250, depth: 50)
+    #
+    # @see https://git-scm.com/docs/git-repack git-repack documentation
+    #
+    # @see Git::Commands
+    #
+    # @api private
+    #
+    class Repack < Git::Commands::Base
+      arguments do
+        literal 'repack'
+
+        # SYNOPSIS order: [-a] [-A] [-d] [-f] [-F] [-l] [-n] [-q] [-b]
+        #   [--window=<n>] [--depth=<n>] [--threads=<n>] [--keep-pack=<pack-name>]
+        flag_option :a
+        flag_option :A
+        flag_option :d
+        flag_option :f
+        flag_option :F
+        flag_option :l
+        flag_option :n
+        flag_option :q
+        flag_option %i[write_bitmap_index b]
+        value_option :window, inline: true
+        value_option :depth, inline: true
+        value_option :threads, inline: true
+        value_option :keep_pack, inline: true, repeatable: true
+
+        # Non-SYNOPSIS options (OPTIONS section order)
+        value_option :window_memory, inline: true
+        value_option :max_pack_size, inline: true
+        flag_option :pack_kept_objects
+        value_option :unpack_unreachable, inline: true
+        flag_option %i[keep_unreachable k]
+        flag_option %i[delta_islands i]
+      end
+
+      # @!method call(*, **)
+      #
+      #   @overload call(**options)
+      #
+      #     Execute the `git repack` command
+      #
+      #     @param options [Hash] command options
+      #
+      #     @option options [Boolean] :a (nil) pack all objects into a single pack
+      #
+      #       When `true`, passes `-a`. Especially useful when packing a repository
+      #       used for private development. Use with `:d` to clean up objects.
+      #
+      #     @option options [Boolean] :A (nil) pack all objects, loosening unreachable
+      #       objects when combined with `:d`
+      #
+      #       When `true`, passes `-A`. Like `:a`, but any unreachable objects in a
+      #       previous pack become loose unpacked objects instead of being removed. The
+      #       loose unreachable objects are pruned by the next `git gc` invocation.
+      #
+      #     @option options [Boolean] :d (nil) delete redundant packs after repacking
+      #
+      #       When `true`, passes `-d`. After packing, removes any existing packs that
+      #       are made redundant by the newly created pack. Also runs `git prune-packed`.
+      #
+      #     @option options [Boolean] :f (nil) pass `--no-reuse-delta` to
+      #       `git pack-objects`
+      #
+      #       When `true`, passes `-f`. Forces reconstruction of all pack deltas.
+      #
+      #     @option options [Boolean] :F (nil) pass `--no-reuse-object` to
+      #       `git pack-objects`
+      #
+      #       When `true`, passes `-F`. Forces reconstruction of all object data, not
+      #       just deltas.
+      #
+      #     @option options [Boolean] :l (nil) pass `--local` to `git pack-objects`
+      #
+      #       When `true`, passes `-l`. Ignores objects that come from an alternates
+      #       object store.
+      #
+      #     @option options [Boolean] :n (nil) do not update server information
+      #
+      #       When `true`, passes `-n`. Skips running `git update-server-info`, which
+      #       updates local catalog files needed to publish the repository
+      #       over HTTP or FTP.
+      #
+      #     @option options [Boolean] :q (nil) suppress progress reporting
+      #
+      #       When `true`, passes `-q`.
+      #
+      #     @option options [Boolean] :write_bitmap_index (nil) write a reachability
+      #       bitmap index as part of the repack
+      #
+      #       When `true`, passes `--write-bitmap-index`. Only meaningful when used with
+      #       `:a`, `:A`. This option overrides the setting of `repack.writeBitmaps`.
+      #
+      #       Alias: `:b`
+      #
+      #     @option options [Integer, String] :window (nil) number of previous objects
+      #       used to generate delta compressions
+      #
+      #       Passed as `--window=<n>` to `git pack-objects`.
+      #
+      #     @option options [Integer, String] :depth (nil) maximum delta depth
+      #
+      #       Passed as `--depth=<n>` to `git pack-objects`.
+      #
+      #     @option options [Integer, String] :threads (nil) number of threads for
+      #       delta search
+      #
+      #       Passed as `--threads=<n>` to `git pack-objects`.
+      #
+      #     @option options [String, Array<String>] :keep_pack (nil) exclude named pack(s)
+      #       from repacking
+      #
+      #       Pass a pack file name (without leading directory, e.g. `'pack-abc123.pack'`)
+      #       or an array of pack file names. Each value is passed as a separate
+      #       `--keep-pack=<name>` argument.
+      #
+      #     @option options [Integer, String] :window_memory (nil) maximum memory usage
+      #       for delta window
+      #
+      #       Passed as `--window-memory=<n>` to `git pack-objects`. Accepts size
+      #       suffixes (`k`, `m`, `g`).
+      #
+      #     @option options [Integer, String] :max_pack_size (nil) maximum size of each
+      #       output pack file
+      #
+      #       Passed as `--max-pack-size=<n>`. Accepts size suffixes (`k`, `m`, `g`).
+      #
+      #     @option options [Boolean] :pack_kept_objects (nil) include objects in `.keep`
+      #       files when repacking
+      #
+      #       When `true`, passes `--pack-kept-objects`. Note that `.keep` packs are not
+      #       deleted after repacking. Generally only useful when also writing bitmaps
+      #       with `:write_bitmap_index`.
+      #
+      #     @option options [String] :unpack_unreachable (nil) control loosening of
+      #       unreachable objects by age
+      #
+      #       Passed as `--unpack-unreachable=<date>`. Objects older than the given date
+      #       are not loosened, since they would be immediately pruned by a follow-up
+      #       `git prune`.
+      #
+      #     @option options [Boolean] :keep_unreachable (nil) keep unreachable objects in
+      #       the new packfile rather than removing them
+      #
+      #       When `true`, passes `--keep-unreachable`. For use with `-ad`.
+      #
+      #       Alias: `:k`
+      #
+      #     @option options [Boolean] :delta_islands (nil) pass `--delta-islands` to
+      #       `git pack-objects`
+      #
+      #       Alias: `:i`
+      #
+      #     @return [Git::CommandLineResult] the result of calling `git repack`
+      #
+      #     @raise [Git::FailedError] if git exits with a non-zero exit status
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -55,6 +55,7 @@ require_relative 'commands/remote/set_url_add'
 require_relative 'commands/remote/set_url_delete'
 require_relative 'commands/remote/show'
 require_relative 'commands/remote/update'
+require_relative 'commands/repack'
 require_relative 'commands/rm'
 require_relative 'commands/show'
 require_relative 'commands/status'
@@ -1841,7 +1842,7 @@ module Git
     end
 
     def repack
-      command_capturing('repack', '-a', '-d')
+      Git::Commands::Repack.new(self).call(a: true, d: true)
     end
 
     def gc

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,20 +22,19 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (49/54 checklist items done, 5 remaining) |
+| Phase 2 | 🔄 In Progress | Migrating commands (50/54 checklist items done, 4 remaining) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate `repack`** → `Git::Commands::Repack` — `git repack`
+**Migrate `config_get` / `config_set` / `global_config_*` / `config_list`** → `Git::Commands::Config` — `git config`
 
-Create `Git::Commands::Repack` to wrap `git repack`. Update `Git::Lib#repack` to
-delegate to the new command class and mark the checklist item done.
+Create `Git::Commands::Config` to wrap `git config`. Update `Git::Lib#config_get`, `Git::Lib#config_set`, `Git::Lib#global_config_*`, and `Git::Lib#config_list` to delegate to the new command class and mark the checklist item done.
 
 #### Workflow
 
-1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def commit_tree`). Understand all options and edge cases.
+1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def config_get`). Understand all options and edge cases.
 
 2. **Design**: Create command class following the pattern in
    `lib/git/commands/branch/delete.rb`. The interface for `#call` should only include
@@ -955,6 +954,7 @@ The following tracks the migration status of commands from `Git::Lib` to
 | N/A (new) | `Git::Commands::UpdateRef::Delete` | `spec/unit/git/commands/update_ref/delete_spec.rb` | `git update-ref -d` |
 | N/A (new) | `Git::Commands::UpdateRef::Batch` | `spec/unit/git/commands/update_ref/batch_spec.rb` | `git update-ref --stdin` |
 | `gc` | `Git::Commands::Gc` | `spec/unit/git/commands/gc_spec.rb` | `git gc` |
+| `repack` | `Git::Commands::Repack` | `spec/unit/git/commands/repack_spec.rb` | `git repack` |
 
 #### ⏳ Commands To Migrate
 
@@ -1032,7 +1032,7 @@ order: Basic Snapshotting → Branching & Merging → etc.
 **Administration:**
 
 - [x] `gc` → `Git::Commands::Gc` — `git gc`
-- [ ] `repack` → `Git::Commands::Repack` — `git repack`
+- [x] `repack` → `Git::Commands::Repack` — `git repack`
 
 **Setup & Config:**
 

--- a/spec/integration/git/commands/repack_spec.rb
+++ b/spec/integration/git/commands/repack_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/repack'
+
+RSpec.describe Git::Commands::Repack, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult' do
+        result = command.call
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'returns a CommandLineResult with :a and :d options' do
+        result = command.call(a: true, d: true)
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.exitstatus).to eq(0)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError when not in a git repository' do
+        FileUtils.rm_rf(File.join(repo_dir, '.git'))
+
+        # git's "not a git repository" message varies across versions — anchor on stable text
+        expect { command.call }.to raise_error(Git::FailedError, /git repository/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/repack_spec.rb
+++ b/spec/unit/git/commands/repack_spec.rb
@@ -1,0 +1,233 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/repack'
+
+RSpec.describe Git::Commands::Repack do
+  # Duck-type collaborator: command specs depend on the #command_capturing
+  # interface, not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with no options' do
+      it 'runs git repack with no extra arguments' do
+        expected_result = command_result
+        expect_command_capturing('repack').and_return(expected_result)
+
+        result = command.call
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with the :a option' do
+      it 'passes -a when true' do
+        expect_command_capturing('repack', '-a').and_return(command_result)
+
+        command.call(a: true)
+      end
+    end
+
+    context 'with the :A option' do
+      it 'passes -A when true' do
+        expect_command_capturing('repack', '-A').and_return(command_result)
+
+        command.call(A: true)
+      end
+    end
+
+    context 'with the :d option' do
+      it 'passes -d when true' do
+        expect_command_capturing('repack', '-d').and_return(command_result)
+
+        command.call(d: true)
+      end
+    end
+
+    context 'with the :l option' do
+      it 'passes -l when true' do
+        expect_command_capturing('repack', '-l').and_return(command_result)
+
+        command.call(l: true)
+      end
+    end
+
+    context 'with the :f option' do
+      it 'passes -f when true' do
+        expect_command_capturing('repack', '-f').and_return(command_result)
+
+        command.call(f: true)
+      end
+    end
+
+    context 'with the :F option' do
+      it 'passes -F when true' do
+        expect_command_capturing('repack', '-F').and_return(command_result)
+
+        command.call(F: true)
+      end
+    end
+
+    context 'with the :q option' do
+      it 'passes -q when true' do
+        expect_command_capturing('repack', '-q').and_return(command_result)
+
+        command.call(q: true)
+      end
+    end
+
+    context 'with the :n option' do
+      it 'passes -n when true' do
+        expect_command_capturing('repack', '-n').and_return(command_result)
+
+        command.call(n: true)
+      end
+    end
+
+    context 'with the :write_bitmap_index option' do
+      it 'passes --write-bitmap-index when true' do
+        expect_command_capturing('repack', '--write-bitmap-index').and_return(command_result)
+
+        command.call(write_bitmap_index: true)
+      end
+    end
+
+    context 'with the :b alias for :write_bitmap_index' do
+      it 'passes --write-bitmap-index' do
+        expect_command_capturing('repack', '--write-bitmap-index').and_return(command_result)
+
+        command.call(b: true)
+      end
+    end
+
+    context 'with the :pack_kept_objects option' do
+      it 'passes --pack-kept-objects when true' do
+        expect_command_capturing('repack', '--pack-kept-objects').and_return(command_result)
+
+        command.call(pack_kept_objects: true)
+      end
+    end
+
+    context 'with the :keep_pack option as a single pack name' do
+      it 'passes --keep-pack=<name>' do
+        expect_command_capturing('repack', '--keep-pack=pack-abc123.pack').and_return(command_result)
+
+        command.call(keep_pack: 'pack-abc123.pack')
+      end
+    end
+
+    context 'with the :keep_pack option as multiple pack names' do
+      it 'repeats --keep-pack for each pack name' do
+        expect_command_capturing(
+          'repack', '--keep-pack=pack-abc123.pack', '--keep-pack=pack-def456.pack'
+        ).and_return(command_result)
+
+        command.call(keep_pack: %w[pack-abc123.pack pack-def456.pack])
+      end
+    end
+
+    context 'with the :unpack_unreachable option' do
+      it 'passes --unpack-unreachable=<date>' do
+        expect_command_capturing('repack', '--unpack-unreachable=2.weeks.ago').and_return(command_result)
+
+        command.call(unpack_unreachable: '2.weeks.ago')
+      end
+    end
+
+    context 'with the :keep_unreachable option' do
+      it 'passes --keep-unreachable when true' do
+        expect_command_capturing('repack', '--keep-unreachable').and_return(command_result)
+
+        command.call(keep_unreachable: true)
+      end
+    end
+
+    context 'with the :k alias for :keep_unreachable' do
+      it 'passes --keep-unreachable' do
+        expect_command_capturing('repack', '--keep-unreachable').and_return(command_result)
+
+        command.call(k: true)
+      end
+    end
+
+    context 'with the :delta_islands option' do
+      it 'passes --delta-islands when true' do
+        expect_command_capturing('repack', '--delta-islands').and_return(command_result)
+
+        command.call(delta_islands: true)
+      end
+    end
+
+    context 'with the :i alias for :delta_islands' do
+      it 'passes --delta-islands' do
+        expect_command_capturing('repack', '--delta-islands').and_return(command_result)
+
+        command.call(i: true)
+      end
+    end
+
+    context 'with the :window option' do
+      it 'passes --window=<n>' do
+        expect_command_capturing('repack', '--window=250').and_return(command_result)
+
+        command.call(window: 250)
+      end
+    end
+
+    context 'with the :window_memory option' do
+      it 'passes --window-memory=<value>' do
+        expect_command_capturing('repack', '--window-memory=1g').and_return(command_result)
+
+        command.call(window_memory: '1g')
+      end
+    end
+
+    context 'with the :max_pack_size option' do
+      it 'passes --max-pack-size=<value>' do
+        expect_command_capturing('repack', '--max-pack-size=2g').and_return(command_result)
+
+        command.call(max_pack_size: '2g')
+      end
+    end
+
+    context 'with the :depth option' do
+      it 'passes --depth=<n>' do
+        expect_command_capturing('repack', '--depth=50').and_return(command_result)
+
+        command.call(depth: 50)
+      end
+    end
+
+    context 'with the :threads option' do
+      it 'passes --threads=<n>' do
+        expect_command_capturing('repack', '--threads=4').and_return(command_result)
+
+        command.call(threads: 4)
+      end
+    end
+
+    context 'with :a, :d, and :q combined' do
+      it 'passes all flags in DSL-defined order' do
+        expect_command_capturing('repack', '-a', '-d', '-q').and_return(command_result)
+
+        command.call(a: true, d: true, q: true)
+      end
+    end
+
+    context 'with :a and :write_bitmap_index combined' do
+      it 'passes both flags in DSL-defined order' do
+        expect_command_capturing('repack', '-a', '--write-bitmap-index').and_return(command_result)
+
+        command.call(a: true, write_bitmap_index: true)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(unknown: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Migrates `Git::Lib#repack` to a new `Git::Commands::Repack` class following the
Strangler Fig architectural redesign pattern.

## What changed

- **New class** `Git::Commands::Repack` wraps `git repack` using the `Commands::Base`
  architecture with the Arguments DSL. Supports all options documented in
  git-repack(1) for git 2.28.0:
  - Core flags: `-a`, `-A`, `-d`, `-f`, `-F`, `-l`, `-n`, `-q`, `-b`/`--write-bitmap-index`
  - Performance tuning: `--window`, `--depth`, `--threads`, `--window-memory`,
    `--max-pack-size`
  - Reachability control: `--keep-pack`, `--pack-kept-objects`,
    `--unpack-unreachable`, `--keep-unreachable`/`-k`, `--delta-islands`/`-i`
- **Updated** `Git::Lib#repack` to delegate to the new command class, preserving
  the existing behaviour (`all: true`, `delete: true`).
- **Updated** `redesign/3_architecture_implementation.md` to mark `repack` as
  migrated (50/54 checklist items done).

## Why

Part of the ongoing Phase 2 architectural migration (Strangler Fig pattern) that
moves individual git commands out of the monolithic `Git::Lib` class into focused
`Git::Commands::*` classes with a consistent DSL-driven interface.

## Test coverage

- **Unit tests** (`spec/unit/git/commands/repack_spec.rb`): 27 examples covering
  every option, repeatable `--keep-pack`, alias pairs (`:b`/`:write_bitmap_index`,
  `:k`/`:keep_unreachable`, `:i`/`:delta_islands`), combined option scenarios, and
  error handling.
- **Integration tests** (`spec/integration/git/commands/repack_spec.rb`): 3
  examples — smoke test (default call), option variation (`:a`+`:d`), and
  `FailedError` when the repository is destroyed. Per project policy, integration
  tests are minimal; option-level coverage is handled by unit tests.
- All 3,042 unit specs, 365 integration specs, and 557 minitest tests pass
  (`bundle exec rake default`, exit 0). No RuboCop offenses.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD)
