### PR TITLE
refactor(commands): add Git::Commands::ConfigOptionSyntax classes and migrate Git::Lib

### DIFF
--- a/lib/git/commands/config_option_syntax.rb
+++ b/lib/git/commands/config_option_syntax.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Git
+  module Commands
+    # Implements the `git config` command using the option-based interface
+    #
+    # This module contains command classes for the pre-2.46.0 option-based
+    # `git config` interface (`--get`, `--list`, `--add`, etc.):
+    #
+    # **Read operations:**
+    # - {ConfigOptionSyntax::Get} — retrieve a single value (`--get`)
+    # - {ConfigOptionSyntax::GetAll} — retrieve all values for a multi-valued key (`--get-all`)
+    # - {ConfigOptionSyntax::GetRegexp} — retrieve values matching a name regex (`--get-regexp`)
+    # - {ConfigOptionSyntax::GetUrlmatch} — retrieve URL-matched values (`--get-urlmatch`)
+    # - {ConfigOptionSyntax::GetColor} — retrieve an ANSI color string (`--get-color`)
+    # - {ConfigOptionSyntax::GetColorBool} — query whether color output is enabled (`--get-colorbool`)
+    # - {ConfigOptionSyntax::List} — list all config entries (`--list`)
+    #
+    # **Write operations:**
+    # - {ConfigOptionSyntax::Set} — set a config value (implicit set mode)
+    # - {ConfigOptionSyntax::Add} — append a value to a multi-valued key (`--add`)
+    # - {ConfigOptionSyntax::ReplaceAll} — replace all matching values (`--replace-all`)
+    #
+    # **Delete operations:**
+    # - {ConfigOptionSyntax::Unset} — remove a single value (`--unset`)
+    # - {ConfigOptionSyntax::UnsetAll} — remove all matching values (`--unset-all`)
+    #
+    # **Section operations:**
+    # - {ConfigOptionSyntax::RenameSection} — rename a config section (`--rename-section`)
+    # - {ConfigOptionSyntax::RemoveSection} — remove a config section (`--remove-section`)
+    #
+    # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+    #
+    # @see Git::Commands
+    #
+    # @api private
+    #
+    module ConfigOptionSyntax
+    end
+  end
+end

--- a/lib/git/commands/config_option_syntax/add.rb
+++ b/lib/git/commands/config_option_syntax/add.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module ConfigOptionSyntax
+      # Append a value to a multi-valued config key
+      #
+      # Wraps `git config --add` to add a new line to a config key without
+      # altering existing values.
+      #
+      # @example Add a value to a multi-valued key
+      #   Git::Commands::ConfigOptionSyntax::Add.new(ctx).call(
+      #     'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*'
+      #   )
+      #
+      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      #
+      # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @api private
+      #
+      class Add < Git::Commands::Base
+        arguments do
+          literal 'config'
+          literal '--add'
+
+          # File-scope options
+          flag_option :global
+          flag_option :system
+          flag_option :local
+          flag_option :worktree
+          value_option %i[file f]
+          value_option :blob
+
+          # Type constraint
+          value_option :type, inline: true
+
+          # Operands
+          end_of_options
+          operand :name, required: true
+          operand :value, required: true
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name, value, **options)
+        #
+        #     Execute the `git config --add` command
+        #
+        #     @param name [String] the config key name
+        #
+        #     @param value [String] the value to append
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :global (nil) write to global config (`~/.gitconfig`)
+        #
+        #     @option options [Boolean] :system (nil) write to system config
+        #
+        #     @option options [Boolean] :local (nil) write to repository config (`.git/config`)
+        #
+        #     @option options [Boolean] :worktree (nil) write to worktree config
+        #
+        #     @option options [String] :file (nil) write to the specified file
+        #
+        #       Alias: :f
+        #
+        #     @option options [String] :blob (nil) read from the specified blob
+        #
+        #     @option options [String] :type (nil) ensure the value conforms to the given type
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git config --add`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/commands/config_option_syntax/get.rb
+++ b/lib/git/commands/config_option_syntax/get.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module ConfigOptionSyntax
+      # Retrieve a single config value by exact key name
+      #
+      # Wraps `git config --get` to return the value of the last-matching
+      # config entry for the given key name.
+      #
+      # @example Get a local config value
+      #   Git::Commands::ConfigOptionSyntax::Get.new(ctx).call('user.name')
+      #
+      # @example Get a global config value
+      #   Git::Commands::ConfigOptionSyntax::Get.new(ctx).call('user.name', global: true)
+      #
+      # @example Get a value with a type constraint
+      #   Git::Commands::ConfigOptionSyntax::Get.new(ctx).call('core.bare', type: 'bool')
+      #
+      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      #
+      # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @api private
+      #
+      class Get < Git::Commands::Base
+        arguments do
+          literal 'config'
+          literal '--get'
+
+          # File-scope options
+          flag_option :global
+          flag_option :system
+          flag_option :local
+          flag_option :worktree
+          value_option %i[file f]
+          value_option :blob
+
+          # General read options
+          flag_option :includes, negatable: true
+
+          # Type constraint
+          value_option :type, inline: true
+
+          # Output modifiers
+          flag_option :show_origin
+          flag_option :show_scope
+          flag_option %i[null z]
+          value_option :default
+
+          # Operands
+          end_of_options
+          operand :name, required: true
+          operand :value_regex
+        end
+
+        # git config --get exits 1 when the key is not found (not an error)
+        allow_exit_status 0..1
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name, value_regex = nil, **options)
+        #
+        #     Execute the `git config --get` command
+        #
+        #     @param name [String] the config key name to look up
+        #
+        #     @param value_regex [String, nil] (nil) optional regex to filter the value
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :global (nil) read from global config (`~/.gitconfig`)
+        #
+        #     @option options [Boolean] :system (nil) read from system config
+        #
+        #     @option options [Boolean] :local (nil) read from repository config (`.git/config`)
+        #
+        #     @option options [Boolean] :worktree (nil) read from worktree config
+        #
+        #     @option options [String] :file (nil) read from the specified file
+        #
+        #       Alias: :f
+        #
+        #     @option options [String] :blob (nil) read from the specified blob
+        #
+        #     @option options [Boolean] :includes (nil) respect include directives in config files
+        #
+        #     @option options [String] :type (nil) ensure the value conforms to the given type
+        #
+        #     @option options [Boolean] :show_origin (nil) show the origin of the config value
+        #
+        #     @option options [Boolean] :show_scope (nil) show the scope of the config value
+        #
+        #     @option options [Boolean] :null (nil) terminate values with NUL byte instead of newline
+        #
+        #       Alias: :z
+        #
+        #     @option options [String] :default (nil) default value when the key is not found
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git config --get`
+        #
+        #     @raise [Git::FailedError] if git exits outside the allowed status range (0..1)
+      end
+    end
+  end
+end

--- a/lib/git/commands/config_option_syntax/get_all.rb
+++ b/lib/git/commands/config_option_syntax/get_all.rb
@@ -1,0 +1,102 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module ConfigOptionSyntax
+      # Retrieve all values for a multi-valued config key
+      #
+      # Wraps `git config --get-all` to return all values matching the given
+      # key name, one per line.
+      #
+      # @example Get all values for a key
+      #   Git::Commands::ConfigOptionSyntax::GetAll.new(ctx).call('remote.origin.fetch')
+      #
+      # @example Get all values with a value pattern
+      #   Git::Commands::ConfigOptionSyntax::GetAll.new(ctx).call('remote.origin.fetch', '\\+refs/heads/.*')
+      #
+      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      #
+      # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @api private
+      #
+      class GetAll < Git::Commands::Base
+        arguments do
+          literal 'config'
+          literal '--get-all'
+
+          # File-scope options
+          flag_option :global
+          flag_option :system
+          flag_option :local
+          flag_option :worktree
+          value_option %i[file f]
+          value_option :blob
+
+          # General read options
+          flag_option :includes, negatable: true
+
+          # Type constraint
+          value_option :type, inline: true
+
+          # Output modifiers
+          flag_option :show_origin
+          flag_option :show_scope
+          flag_option %i[null z]
+
+          # Operands
+          end_of_options
+          operand :name, required: true
+          operand :value_regex
+        end
+
+        # git config --get-all exits 1 when the key is not found (not an error)
+        allow_exit_status 0..1
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name, value_regex = nil, **options)
+        #
+        #     Execute the `git config --get-all` command
+        #
+        #     @param name [String] the config key name to look up
+        #
+        #     @param value_regex [String, nil] optional regex to filter values
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :global (nil) read from global config (`~/.gitconfig`)
+        #
+        #     @option options [Boolean] :system (nil) read from system config
+        #
+        #     @option options [Boolean] :local (nil) read from repository config (`.git/config`)
+        #
+        #     @option options [Boolean] :worktree (nil) read from worktree config
+        #
+        #     @option options [String] :file (nil) read from the specified file
+        #
+        #       Alias: :f
+        #
+        #     @option options [String] :blob (nil) read from the specified blob
+        #
+        #     @option options [Boolean] :includes (nil) respect include directives in config files
+        #
+        #     @option options [String] :type (nil) ensure values conform to the given type
+        #
+        #     @option options [Boolean] :show_origin (nil) show the origin of each config value
+        #
+        #     @option options [Boolean] :show_scope (nil) show the scope of each config value
+        #
+        #     @option options [Boolean] :null (nil) terminate values with NUL byte instead of newline
+        #
+        #       Alias: :z
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git config --get-all`
+        #
+        #     @raise [Git::FailedError] if git exits outside the allowed status range (0..1)
+      end
+    end
+  end
+end

--- a/lib/git/commands/config_option_syntax/get_color.rb
+++ b/lib/git/commands/config_option_syntax/get_color.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module ConfigOptionSyntax
+      # Retrieve an ANSI color string from config
+      #
+      # Wraps `git config --get-color` to look up a color configuration
+      # and output the ANSI escape sequence for that color.
+      #
+      # @example Get a color config value
+      #   Git::Commands::ConfigOptionSyntax::GetColor.new(ctx).call('color.diff.new')
+      #
+      # @example Get a color config value with a default
+      #   Git::Commands::ConfigOptionSyntax::GetColor.new(ctx).call('color.diff.new', 'green')
+      #
+      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      #
+      # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @api private
+      #
+      class GetColor < Git::Commands::Base
+        arguments do
+          literal 'config'
+          literal '--get-color'
+
+          # File-scope options
+          flag_option :global
+          flag_option :system
+          flag_option :local
+          flag_option :worktree
+          value_option %i[file f]
+          value_option :blob
+
+          # General read options
+          flag_option :includes, negatable: true
+
+          # Operands
+          end_of_options
+          operand :name, required: true
+          operand :default
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name, default = nil, **options)
+        #
+        #     Execute the `git config --get-color` command
+        #
+        #     @param name [String] the color config key name to look up
+        #
+        #     @param default [String, nil] (nil) fallback color when the key is not set
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :global (nil) read from global config (`~/.gitconfig`)
+        #
+        #     @option options [Boolean] :system (nil) read from system config
+        #
+        #     @option options [Boolean] :local (nil) read from repository config (`.git/config`)
+        #
+        #     @option options [Boolean] :worktree (nil) read from worktree config
+        #
+        #     @option options [String] :file (nil) read from the specified file
+        #
+        #       Alias: :f
+        #
+        #     @option options [String] :blob (nil) read from the specified blob
+        #
+        #     @option options [Boolean] :includes (nil) respect include directives in config files
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git config --get-color`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/commands/config_option_syntax/get_color_bool.rb
+++ b/lib/git/commands/config_option_syntax/get_color_bool.rb
@@ -1,0 +1,85 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module ConfigOptionSyntax
+      # Query whether color output is enabled for a config key
+      #
+      # Wraps `git config --get-colorbool` to check whether color output
+      # should be used. This command has no subcommand equivalent even in
+      # git 2.46.0 — it exists only in the option-syntax interface.
+      #
+      # @example Query whether color is enabled for diff
+      #   Git::Commands::ConfigOptionSyntax::GetColorBool.new(ctx).call('color.diff')
+      #
+      # @example Query with explicit stdout-is-tty hint
+      #   Git::Commands::ConfigOptionSyntax::GetColorBool.new(ctx).call('color.diff', 'true')
+      #
+      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      #
+      # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @api private
+      #
+      class GetColorBool < Git::Commands::Base
+        arguments do
+          literal 'config'
+          literal '--get-colorbool'
+
+          # File-scope options
+          flag_option :global
+          flag_option :system
+          flag_option :local
+          flag_option :worktree
+          value_option %i[file f]
+          value_option :blob
+
+          # General read options
+          flag_option :includes, negatable: true
+
+          # Operands
+          end_of_options
+          operand :name, required: true
+          operand :stdout_is_tty
+        end
+
+        # git config --get-colorbool exits 0 for color=yes, 1 for color=no
+        allow_exit_status 0..1
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name, stdout_is_tty = nil, **options)
+        #
+        #     Execute the `git config --get-colorbool` command
+        #
+        #     @param name [String] the color config key name to query
+        #
+        #     @param stdout_is_tty [String, nil] (nil) hint whether stdout is a TTY (`"true"` or `"false"`)
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :global (nil) read from global config (`~/.gitconfig`)
+        #
+        #     @option options [Boolean] :system (nil) read from system config
+        #
+        #     @option options [Boolean] :local (nil) read from repository config (`.git/config`)
+        #
+        #     @option options [Boolean] :worktree (nil) read from worktree config
+        #
+        #     @option options [String] :file (nil) read from the specified file
+        #
+        #       Alias: :f
+        #
+        #     @option options [String] :blob (nil) read from the specified blob
+        #
+        #     @option options [Boolean] :includes (nil) respect include directives in config files
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git config --get-colorbool`
+        #
+        #     @raise [Git::FailedError] if git exits outside the allowed status range (0..1)
+      end
+    end
+  end
+end

--- a/lib/git/commands/config_option_syntax/get_regexp.rb
+++ b/lib/git/commands/config_option_syntax/get_regexp.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module ConfigOptionSyntax
+      # Retrieve config entries matching a name regex
+      #
+      # Wraps `git config --get-regexp` to return all config entries whose
+      # key name matches the given regular expression.
+      #
+      # @example Get all entries matching a pattern
+      #   Git::Commands::ConfigOptionSyntax::GetRegexp.new(ctx).call('remote\..*\.url')
+      #
+      # @example Get matching entries with value filter
+      #   Git::Commands::ConfigOptionSyntax::GetRegexp.new(ctx).call('remote\..*\.url', 'github')
+      #
+      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      #
+      # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @api private
+      #
+      class GetRegexp < Git::Commands::Base
+        arguments do
+          literal 'config'
+          literal '--get-regexp'
+
+          # File-scope options
+          flag_option :global
+          flag_option :system
+          flag_option :local
+          flag_option :worktree
+          value_option %i[file f]
+          value_option :blob
+
+          # General read options
+          flag_option :includes, negatable: true
+
+          # Type constraint
+          value_option :type, inline: true
+
+          # Output modifiers
+          flag_option :show_origin
+          flag_option :show_scope
+          flag_option %i[null z]
+          flag_option :name_only
+
+          # Operands
+          end_of_options
+          operand :name_regex, required: true
+          operand :value_regex
+        end
+
+        # git config --get-regexp exits 1 when no match is found (not an error)
+        allow_exit_status 0..1
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name_regex, value_regex = nil, **options)
+        #
+        #     Execute the `git config --get-regexp` command
+        #
+        #     @param name_regex [String] regex pattern to match config key names
+        #
+        #     @param value_regex [String, nil] optional regex to filter values
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :global (nil) read from global config (`~/.gitconfig`)
+        #
+        #     @option options [Boolean] :system (nil) read from system config
+        #
+        #     @option options [Boolean] :local (nil) read from repository config (`.git/config`)
+        #
+        #     @option options [Boolean] :worktree (nil) read from worktree config
+        #
+        #     @option options [String] :file (nil) read from the specified file
+        #
+        #       Alias: :f
+        #
+        #     @option options [String] :blob (nil) read from the specified blob
+        #
+        #     @option options [Boolean] :includes (nil) respect include directives in config files
+        #
+        #     @option options [String] :type (nil) ensure values conform to the given type
+        #
+        #     @option options [Boolean] :show_origin (nil) show the origin of each config entry
+        #
+        #     @option options [Boolean] :show_scope (nil) show the scope of each config entry
+        #
+        #     @option options [Boolean] :null (nil) terminate values with NUL byte instead of newline
+        #
+        #       Alias: :z
+        #
+        #     @option options [Boolean] :name_only (nil) output only the names of config keys
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git config --get-regexp`
+        #
+        #     @raise [Git::FailedError] if git exits outside the allowed status range (0..1)
+      end
+    end
+  end
+end

--- a/lib/git/commands/config_option_syntax/get_urlmatch.rb
+++ b/lib/git/commands/config_option_syntax/get_urlmatch.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module ConfigOptionSyntax
+      # Retrieve config values matching a URL
+      #
+      # Wraps `git config --get-urlmatch` to return config entries whose
+      # key name matches the given name and whose URL pattern matches the
+      # given URL.
+      #
+      # @example Get URL-matched config
+      #   Git::Commands::ConfigOptionSyntax::GetUrlmatch.new(ctx).call('http', 'https://example.com')
+      #
+      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      #
+      # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @api private
+      #
+      class GetUrlmatch < Git::Commands::Base
+        arguments do
+          literal 'config'
+          literal '--get-urlmatch'
+
+          # File-scope options
+          flag_option :global
+          flag_option :system
+          flag_option :local
+          flag_option :worktree
+          value_option %i[file f]
+          value_option :blob
+
+          # General read options
+          flag_option :includes, negatable: true
+
+          # Type constraint
+          value_option :type, inline: true
+
+          # Output modifier
+          flag_option %i[null z]
+
+          # Operands
+          end_of_options
+          operand :name, required: true
+          operand :url, required: true
+        end
+
+        # git config --get-urlmatch exits 1 when no match is found (not an error)
+        allow_exit_status 0..1
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name, url, **options)
+        #
+        #     Execute the `git config --get-urlmatch` command
+        #
+        #     @param name [String] the config key name (or section prefix) to look up
+        #
+        #     @param url [String] the URL to match against
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :global (nil) read from global config (`~/.gitconfig`)
+        #
+        #     @option options [Boolean] :system (nil) read from system config
+        #
+        #     @option options [Boolean] :local (nil) read from repository config (`.git/config`)
+        #
+        #     @option options [Boolean] :worktree (nil) read from worktree config
+        #
+        #     @option options [String] :file (nil) read from the specified file
+        #
+        #       Alias: :f
+        #
+        #     @option options [String] :blob (nil) read from the specified blob
+        #
+        #     @option options [Boolean] :includes (nil) respect include directives in config files
+        #
+        #     @option options [String] :type (nil) ensure values conform to the given type
+        #
+        #     @option options [Boolean] :null (nil) terminate values with NUL byte instead of newline
+        #
+        #       Alias: :z
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git config --get-urlmatch`
+        #
+        #     @raise [Git::FailedError] if git exits outside the allowed status range (0..1)
+      end
+    end
+  end
+end

--- a/lib/git/commands/config_option_syntax/list.rb
+++ b/lib/git/commands/config_option_syntax/list.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module ConfigOptionSyntax
+      # List all config entries
+      #
+      # Wraps `git config --list` to output all config entries visible
+      # from the current scope.
+      #
+      # @example List all config entries
+      #   Git::Commands::ConfigOptionSyntax::List.new(ctx).call
+      #
+      # @example List global config entries
+      #   Git::Commands::ConfigOptionSyntax::List.new(ctx).call(global: true)
+      #
+      # @example List entries from a specific file
+      #   Git::Commands::ConfigOptionSyntax::List.new(ctx).call(file: '/path/to/config')
+      #
+      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      #
+      # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @api private
+      #
+      class List < Git::Commands::Base
+        arguments do
+          literal 'config'
+          literal '--list'
+
+          # File-scope options
+          flag_option :global
+          flag_option :system
+          flag_option :local
+          flag_option :worktree
+          value_option %i[file f]
+          value_option :blob
+
+          # General read options
+          flag_option :includes, negatable: true
+
+          # Output modifiers
+          flag_option :show_origin
+          flag_option :show_scope
+          flag_option %i[null z]
+          flag_option :name_only
+
+          # Type constraint (not in --list SYNOPSIS but accepted in practice)
+          value_option :type, inline: true
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(**options)
+        #
+        #     Execute the `git config --list` command
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :global (nil) list only global config entries
+        #
+        #     @option options [Boolean] :system (nil) list only system config entries
+        #
+        #     @option options [Boolean] :local (nil) list only repository config entries
+        #
+        #     @option options [Boolean] :worktree (nil) list only worktree config entries
+        #
+        #     @option options [String] :file (nil) list entries from the specified file
+        #
+        #       Alias: :f
+        #
+        #     @option options [String] :blob (nil) list entries from the specified blob
+        #
+        #     @option options [Boolean] :includes (nil) respect include directives in config files
+        #
+        #     @option options [Boolean] :show_origin (nil) show the origin of each config entry
+        #
+        #     @option options [Boolean] :show_scope (nil) show the scope of each config entry
+        #
+        #     @option options [Boolean] :null (nil) terminate values with NUL byte instead of newline
+        #
+        #       Alias: :z
+        #
+        #     @option options [Boolean] :name_only (nil) output only the names of config keys
+        #
+        #     @option options [String] :type (nil) ensure values conform to the given type
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git config --list`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/commands/config_option_syntax/remove_section.rb
+++ b/lib/git/commands/config_option_syntax/remove_section.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module ConfigOptionSyntax
+      # Remove a config section
+      #
+      # Wraps `git config --remove-section` to remove an entire section
+      # from the config file.
+      #
+      # @example Remove a section
+      #   Git::Commands::ConfigOptionSyntax::RemoveSection.new(ctx).call('old-section')
+      #
+      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      #
+      # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @api private
+      #
+      class RemoveSection < Git::Commands::Base
+        arguments do
+          literal 'config'
+          literal '--remove-section'
+
+          # File-scope options
+          flag_option :global
+          flag_option :system
+          flag_option :local
+          flag_option :worktree
+          value_option %i[file f]
+          value_option :blob
+
+          # Operands
+          end_of_options
+          operand :name, required: true
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name, **options)
+        #
+        #     Execute the `git config --remove-section` command
+        #
+        #     @param name [String] the section name to remove
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :global (nil) operate on global config (`~/.gitconfig`)
+        #
+        #     @option options [Boolean] :system (nil) operate on system config
+        #
+        #     @option options [Boolean] :local (nil) operate on repository config (`.git/config`)
+        #
+        #     @option options [Boolean] :worktree (nil) operate on worktree config
+        #
+        #     @option options [String] :file (nil) operate on the specified file
+        #
+        #       Alias: :f
+        #
+        #     @option options [String] :blob (nil) read from the specified blob
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git config --remove-section`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/commands/config_option_syntax/rename_section.rb
+++ b/lib/git/commands/config_option_syntax/rename_section.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module ConfigOptionSyntax
+      # Rename a config section
+      #
+      # Wraps `git config --rename-section` to rename a section in the
+      # config file.
+      #
+      # @example Rename a section
+      #   Git::Commands::ConfigOptionSyntax::RenameSection.new(ctx).call('old-section', 'new-section')
+      #
+      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      #
+      # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @api private
+      #
+      class RenameSection < Git::Commands::Base
+        arguments do
+          literal 'config'
+          literal '--rename-section'
+
+          # File-scope options
+          flag_option :global
+          flag_option :system
+          flag_option :local
+          flag_option :worktree
+          value_option %i[file f]
+          value_option :blob
+
+          # Operands
+          end_of_options
+          operand :old_name, required: true
+          operand :new_name, required: true
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(old_name, new_name, **options)
+        #
+        #     Execute the `git config --rename-section` command
+        #
+        #     @param old_name [String] the current section name
+        #
+        #     @param new_name [String] the new section name
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :global (nil) operate on global config (`~/.gitconfig`)
+        #
+        #     @option options [Boolean] :system (nil) operate on system config
+        #
+        #     @option options [Boolean] :local (nil) operate on repository config (`.git/config`)
+        #
+        #     @option options [Boolean] :worktree (nil) operate on worktree config
+        #
+        #     @option options [String] :file (nil) operate on the specified file
+        #
+        #       Alias: :f
+        #
+        #     @option options [String] :blob (nil) read from the specified blob
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git config --rename-section`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/commands/config_option_syntax/replace_all.rb
+++ b/lib/git/commands/config_option_syntax/replace_all.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module ConfigOptionSyntax
+      # Replace all matching values for a config key
+      #
+      # Wraps `git config --replace-all` to replace all entries matching the
+      # given key and optional value regex with a new value.
+      #
+      # @example Replace all values for a key
+      #   Git::Commands::ConfigOptionSyntax::ReplaceAll.new(ctx).call('core.autocrlf', 'true')
+      #
+      # @example Replace values matching a pattern
+      #   Git::Commands::ConfigOptionSyntax::ReplaceAll.new(ctx).call('core.autocrlf', 'true', 'false')
+      #
+      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      #
+      # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @api private
+      #
+      class ReplaceAll < Git::Commands::Base
+        arguments do
+          literal 'config'
+          literal '--replace-all'
+
+          # File-scope options
+          flag_option :global
+          flag_option :system
+          flag_option :local
+          flag_option :worktree
+          value_option %i[file f]
+          value_option :blob
+
+          # Type constraint
+          value_option :type, inline: true
+
+          # Operands
+          end_of_options
+          operand :name, required: true
+          operand :value, required: true
+          operand :value_regex
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name, value, value_regex = nil, **options)
+        #
+        #     Execute the `git config --replace-all` command
+        #
+        #     @param name [String] the config key name
+        #
+        #     @param value [String] the new value to set
+        #
+        #     @param value_regex [String, nil] (nil) optional regex to match existing values to replace
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :global (nil) write to global config (`~/.gitconfig`)
+        #
+        #     @option options [Boolean] :system (nil) write to system config
+        #
+        #     @option options [Boolean] :local (nil) write to repository config (`.git/config`)
+        #
+        #     @option options [Boolean] :worktree (nil) write to worktree config
+        #
+        #     @option options [String] :file (nil) write to the specified file
+        #
+        #       Alias: :f
+        #
+        #     @option options [String] :blob (nil) read from the specified blob
+        #
+        #     @option options [String] :type (nil) ensure the value conforms to the given type
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git config --replace-all`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/commands/config_option_syntax/set.rb
+++ b/lib/git/commands/config_option_syntax/set.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module ConfigOptionSyntax
+      # Set a config value
+      #
+      # Wraps the implicit `git config <name> <value>` set mode to assign
+      # a value to a config key, optionally replacing only the entry
+      # matching a value regex.
+      #
+      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      #
+      # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @api private
+      #
+      # @example Set a local config value
+      #   Git::Commands::ConfigOptionSyntax::Set.new(ctx).call('user.name', 'Alice')
+      #
+      # @example Set a global config value
+      #   Git::Commands::ConfigOptionSyntax::Set.new(ctx).call('user.name', 'Alice', global: true)
+      #
+      # @example Set a value with a type constraint
+      #   Git::Commands::ConfigOptionSyntax::Set.new(ctx).call('core.bare', 'true', type: 'bool')
+      #
+      class Set < Git::Commands::Base
+        arguments do
+          literal 'config'
+
+          # File-scope options
+          flag_option :global
+          flag_option :system
+          flag_option :local
+          flag_option :worktree
+          value_option %i[file f]
+          value_option :blob
+
+          # Type constraint
+          value_option :type, inline: true
+
+          # Operands
+          end_of_options
+          operand :name, required: true
+          operand :value, required: true
+          operand :value_regex
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name, value, value_regex = nil, **options)
+        #
+        #     Execute the `git config <name> <value>` command
+        #
+        #     @param name [String] the config key name to set
+        #
+        #     @param value [String] the value to assign
+        #
+        #     @param value_regex [String, nil] (nil) optional regex to match the existing value to replace
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :global (nil) write to global config (`~/.gitconfig`)
+        #
+        #     @option options [Boolean] :system (nil) write to system config
+        #
+        #     @option options [Boolean] :local (nil) write to repository config (`.git/config`)
+        #
+        #     @option options [Boolean] :worktree (nil) write to worktree config
+        #
+        #     @option options [String] :file (nil) write to the specified file
+        #
+        #       Alias: :f
+        #
+        #     @option options [String] :blob (nil) read from the specified blob
+        #
+        #     @option options [String] :type (nil) ensure the value conforms to the given type
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git config`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/commands/config_option_syntax/unset.rb
+++ b/lib/git/commands/config_option_syntax/unset.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module ConfigOptionSyntax
+      # Remove a single config entry
+      #
+      # Wraps `git config --unset` to remove the entry matching the given
+      # key name and optional value regex.
+      #
+      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      #
+      # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @api private
+      #
+      # @example Unset a config key
+      #   Git::Commands::ConfigOptionSyntax::Unset.new(ctx).call('user.name')
+      #
+      # @example Unset a global config key
+      #   Git::Commands::ConfigOptionSyntax::Unset.new(ctx).call('user.name', global: true)
+      #
+      class Unset < Git::Commands::Base
+        arguments do
+          literal 'config'
+          literal '--unset'
+
+          # File-scope options
+          flag_option :global
+          flag_option :system
+          flag_option :local
+          flag_option :worktree
+          value_option %i[file f]
+          value_option :blob
+
+          # Operands
+          end_of_options
+          operand :name, required: true
+          operand :value_regex
+        end
+
+        # git config --unset exits 5 when trying to unset a non-existent or multi-valued key
+        allow_exit_status 0..5
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name, value_regex = nil, **options)
+        #
+        #     Execute the `git config --unset` command
+        #
+        #     @param name [String] the config key name to unset
+        #
+        #     @param value_regex [String, nil] (nil) optional regex to match the value to remove
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :global (nil) remove from global config (`~/.gitconfig`)
+        #
+        #     @option options [Boolean] :system (nil) remove from system config
+        #
+        #     @option options [Boolean] :local (nil) remove from repository config (`.git/config`)
+        #
+        #     @option options [Boolean] :worktree (nil) remove from worktree config
+        #
+        #     @option options [String] :file (nil) remove from the specified file
+        #
+        #       Alias: :f
+        #
+        #     @option options [String] :blob (nil) read from the specified blob
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git config --unset`
+        #
+        #     @raise [Git::FailedError] if git exits outside the allowed status range (0..5)
+      end
+    end
+  end
+end

--- a/lib/git/commands/config_option_syntax/unset_all.rb
+++ b/lib/git/commands/config_option_syntax/unset_all.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module ConfigOptionSyntax
+      # Remove all matching config entries
+      #
+      # Wraps `git config --unset-all` to remove all entries matching the
+      # given key name and optional value regex.
+      #
+      # @example Unset all values for a key
+      #   Git::Commands::ConfigOptionSyntax::UnsetAll.new(ctx).call('remote.origin.fetch')
+      #
+      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      #
+      # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @api private
+      #
+      class UnsetAll < Git::Commands::Base
+        arguments do
+          literal 'config'
+          literal '--unset-all'
+
+          # File-scope options
+          flag_option :global
+          flag_option :system
+          flag_option :local
+          flag_option :worktree
+          value_option %i[file f]
+          value_option :blob
+
+          # Operands
+          end_of_options
+          operand :name, required: true
+          operand :value_regex
+        end
+
+        # git config --unset-all exits 5 when trying to unset a non-existent key
+        allow_exit_status 0..5
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name, value_regex = nil, **options)
+        #
+        #     Execute the `git config --unset-all` command
+        #
+        #     @param name [String] the config key name to unset
+        #
+        #     @param value_regex [String, nil] optional regex to match values to remove
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :global (nil) remove from global config (`~/.gitconfig`)
+        #
+        #     @option options [Boolean] :system (nil) remove from system config
+        #
+        #     @option options [Boolean] :local (nil) remove from repository config (`.git/config`)
+        #
+        #     @option options [Boolean] :worktree (nil) remove from worktree config
+        #
+        #     @option options [String] :file (nil) remove from the specified file
+        #
+        #       Alias: :f
+        #
+        #     @option options [String] :blob (nil) read from the specified blob
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git config --unset-all`
+        #
+        #     @raise [Git::FailedError] if git exits outside the allowed status range (0..5)
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -57,6 +57,9 @@ require_relative 'commands/remote/show'
 require_relative 'commands/remote/update'
 require_relative 'commands/repack'
 require_relative 'commands/rm'
+require_relative 'commands/config_option_syntax/get'
+require_relative 'commands/config_option_syntax/list'
+require_relative 'commands/config_option_syntax/set'
 require_relative 'commands/show'
 require_relative 'commands/status'
 require_relative 'commands/tag/create'
@@ -1147,19 +1150,25 @@ module Git
     end
 
     def config_get(name)
-      command_capturing('config', '--get', name, chdir: @git_dir).stdout
+      result = Git::Commands::ConfigOptionSyntax::Get.new(self).call(name)
+      raise Git::FailedError, result if result.status.exitstatus != 0
+
+      result.stdout
     end
 
     def global_config_get(name)
-      command_capturing('config', '--global', '--get', name).stdout
+      result = Git::Commands::ConfigOptionSyntax::Get.new(self).call(name, global: true)
+      raise Git::FailedError, result if result.status.exitstatus != 0
+
+      result.stdout
     end
 
     def config_list
-      parse_config_list command_capturing('config', '--list', chdir: @git_dir).stdout.split("\n")
+      parse_config_list Git::Commands::ConfigOptionSyntax::List.new(self).call.stdout.split("\n")
     end
 
     def global_config_list
-      parse_config_list command_capturing('config', '--global', '--list').stdout.split("\n")
+      parse_config_list Git::Commands::ConfigOptionSyntax::List.new(self).call(global: true).stdout.split("\n")
     end
 
     def parse_config_list(lines)
@@ -1172,7 +1181,7 @@ module Git
     end
 
     def parse_config(file)
-      parse_config_list command_capturing('config', '--list', '--file', file).stdout.split("\n")
+      parse_config_list Git::Commands::ConfigOptionSyntax::List.new(self).call(file: file).stdout.split("\n")
     end
 
     # Shows objects
@@ -1187,18 +1196,15 @@ module Git
 
     ## WRITE COMMANDS ##
 
-    CONFIG_SET_OPTION_MAP = [
-      { keys: [:file], flag: '--file', type: :valued_space }
-    ].freeze
+    CONFIG_SET_ALLOWED_OPTS = %i[file].freeze
 
     def config_set(name, value, options = {})
-      ArgsBuilder.validate!(options, CONFIG_SET_OPTION_MAP)
-      flags = build_args(options, CONFIG_SET_OPTION_MAP)
-      command_capturing('config', *flags, name, value)
+      assert_valid_opts(options, CONFIG_SET_ALLOWED_OPTS)
+      Git::Commands::ConfigOptionSyntax::Set.new(self).call(name, value, **options.slice(*CONFIG_SET_ALLOWED_OPTS))
     end
 
     def global_config_set(name, value)
-      command_capturing('config', '--global', name, value)
+      Git::Commands::ConfigOptionSyntax::Set.new(self).call(name, value, global: true)
     end
 
     # Update the index from the current worktree to prepare the for the next commit

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,19 +22,19 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (50/54 checklist items done, 4 remaining) |
+| Phase 2 | 🔄 In Progress | Migrating commands (51/54 checklist items done, 3 remaining) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate `config_get` / `config_set` / `global_config_*` / `config_list`** → `Git::Commands::Config` — `git config`
+**Migrate `worktree_add` / `worktree_remove`** → `Git::Commands::Worktree` — `git worktree`
 
-Create `Git::Commands::Config` to wrap `git config`. Update `Git::Lib#config_get`, `Git::Lib#config_set`, `Git::Lib#global_config_*`, and `Git::Lib#config_list` to delegate to the new command class and mark the checklist item done.
+Create `Git::Commands::Worktree::Add` and `Git::Commands::Worktree::Remove` (and any other relevant subcommands such as `List`, `Lock`, `Unlock`, `Move`, `Prune`) to wrap `git worktree`. Update `Git::Lib#worktree_add` and `Git::Lib#worktree_remove` to delegate to the new command classes and mark the checklist item done.
 
 #### Workflow
 
-1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def config_get`). Understand all options and edge cases.
+1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def worktree_add`). Understand all options and edge cases.
 
 2. **Design**: Create command class following the pattern in
    `lib/git/commands/branch/delete.rb`. The interface for `#call` should only include
@@ -955,6 +955,20 @@ The following tracks the migration status of commands from `Git::Lib` to
 | N/A (new) | `Git::Commands::UpdateRef::Batch` | `spec/unit/git/commands/update_ref/batch_spec.rb` | `git update-ref --stdin` |
 | `gc` | `Git::Commands::Gc` | `spec/unit/git/commands/gc_spec.rb` | `git gc` |
 | `repack` | `Git::Commands::Repack` | `spec/unit/git/commands/repack_spec.rb` | `git repack` |
+| `config_get` / `global_config_get` | `Git::Commands::ConfigOptionSyntax::Get` | `spec/unit/git/commands/config_option_syntax/get_spec.rb` | `git config --get` |
+| `config_list` / `global_config_list` / `parse_config` | `Git::Commands::ConfigOptionSyntax::List` | `spec/unit/git/commands/config_option_syntax/list_spec.rb` | `git config --list` |
+| `config_set` / `global_config_set` | `Git::Commands::ConfigOptionSyntax::Set` | `spec/unit/git/commands/config_option_syntax/set_spec.rb` | `git config` (set value) |
+| N/A (new) | `Git::Commands::ConfigOptionSyntax::Add` | `spec/unit/git/commands/config_option_syntax/add_spec.rb` | `git config --add` |
+| N/A (new) | `Git::Commands::ConfigOptionSyntax::GetAll` | `spec/unit/git/commands/config_option_syntax/get_all_spec.rb` | `git config --get-all` |
+| N/A (new) | `Git::Commands::ConfigOptionSyntax::GetColor` | `spec/unit/git/commands/config_option_syntax/get_color_spec.rb` | `git config --get-color` |
+| N/A (new) | `Git::Commands::ConfigOptionSyntax::GetColorBool` | `spec/unit/git/commands/config_option_syntax/get_color_bool_spec.rb`, `spec/integration/git/commands/config_option_syntax/get_color_bool_spec.rb` | `git config --get-colorbool` |
+| N/A (new) | `Git::Commands::ConfigOptionSyntax::GetRegexp` | `spec/unit/git/commands/config_option_syntax/get_regexp_spec.rb` | `git config --get-regexp` |
+| N/A (new) | `Git::Commands::ConfigOptionSyntax::GetUrlmatch` | `spec/unit/git/commands/config_option_syntax/get_urlmatch_spec.rb` | `git config --get-urlmatch` |
+| N/A (new) | `Git::Commands::ConfigOptionSyntax::RemoveSection` | `spec/unit/git/commands/config_option_syntax/remove_section_spec.rb` | `git config --remove-section` |
+| N/A (new) | `Git::Commands::ConfigOptionSyntax::RenameSection` | `spec/unit/git/commands/config_option_syntax/rename_section_spec.rb` | `git config --rename-section` |
+| N/A (new) | `Git::Commands::ConfigOptionSyntax::ReplaceAll` | `spec/unit/git/commands/config_option_syntax/replace_all_spec.rb` | `git config --replace-all` |
+| N/A (new) | `Git::Commands::ConfigOptionSyntax::Unset` | `spec/unit/git/commands/config_option_syntax/unset_spec.rb` | `git config --unset` |
+| N/A (new) | `Git::Commands::ConfigOptionSyntax::UnsetAll` | `spec/unit/git/commands/config_option_syntax/unset_all_spec.rb` | `git config --unset-all` |
 
 #### ⏳ Commands To Migrate
 
@@ -1036,8 +1050,8 @@ order: Basic Snapshotting → Branching & Merging → etc.
 
 **Setup & Config:**
 
-- [ ] `config_get` / `config_set` / `global_config_*` / `config_list` →
-  `Git::Commands::Config` — `git config`
+- [x] `config_get` / `config_set` / `global_config_*` / `config_list` →
+  `Git::Commands::ConfigOptionSyntax::*` — `git config`
 
 **Other:**
 

--- a/spec/integration/git/commands/config_option_syntax/add_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/add_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/add'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::Add, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult' do
+        result = command.call('test.multi', 'value1')
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for an invalid config key' do
+        # git's error message phrasing varies by version — anchor on the stable input value
+        expect { command.call('invalidkey', 'value') }
+          .to raise_error(Git::FailedError, /invalidkey/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/config_option_syntax/get_all_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_all_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/get_all'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::GetAll, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult' do
+        result = command.call('user.name')
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns the configured value in stdout' do
+        result = command.call('user.name', local: true)
+
+        expect(result.stdout.strip).to eq('Test User')
+      end
+
+      it 'returns result with exit status 1 when the key is not found' do
+        result = command.call('nonexistent.key')
+
+        expect(result.status.exitstatus).to eq(1)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError when given a malformed config file' do
+        malformed_config = File.join(repo_dir, 'malformed.config')
+        File.write(malformed_config, "[incomplete-section\n")
+
+        expect { command.call('user.name', file: malformed_config) }
+          .to raise_error(Git::FailedError, /malformed\.config/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/config_option_syntax/get_color_bool_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_color_bool_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/get_color_bool'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::GetColorBool, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult with exit status 0 when color is enabled' do
+        repo.config('color.test', 'always')
+        result = command.call('color.test')
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'returns exit status 1 when color is disabled' do
+        repo.config('color.test', 'never')
+        result = command.call('color.test')
+
+        expect(result.status.exitstatus).to eq(1)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError when --local is used outside a git repository' do
+        FileUtils.rm_rf(File.join(repo_dir, '.git'))
+
+        expect { command.call('color.diff', local: true) }
+          .to raise_error(Git::FailedError, /fatal/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/config_option_syntax/get_color_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_color_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/get_color'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::GetColor, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      before do
+        repo.config('color.test.slot', 'red')
+      end
+
+      it 'returns a CommandLineResult' do
+        result = command.call('color.test.slot')
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns result with exit status 0' do
+        result = command.call('color.test.slot')
+
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'returns exit status 0 when a default is provided for an unset key' do
+        result = command.call('color.nonexistent.slot', 'green')
+
+        expect(result.status.exitstatus).to eq(0)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError when --local is used outside a git repository' do
+        FileUtils.rm_rf(File.join(repo_dir, '.git'))
+
+        expect { command.call('color.test', local: true) }
+          .to raise_error(Git::FailedError)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/config_option_syntax/get_regexp_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_regexp_spec.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/get_regexp'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::GetRegexp, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult' do
+        result = command.call('user\\..*')
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns exit status 0 when entries match' do
+        result = command.call('user\\..*')
+
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'returns exit status 1 when no entries match' do
+        result = command.call('nonexistent\\..*')
+
+        expect(result.status.exitstatus).to eq(1)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError when --local is used outside a git repository' do
+        FileUtils.rm_rf(File.join(repo_dir, '.git'))
+
+        expect { command.call('user\\..*', local: true) }
+          .to raise_error(Git::FailedError, /local/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/config_option_syntax/get_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/get'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::Get, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult' do
+        result = command.call('user.name')
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns exit code 0 when the key exists' do
+        result = command.call('user.name')
+
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'returns exit code 1 when the key is not found' do
+        result = command.call('nonexistent.key')
+
+        expect(result.status.exitstatus).to eq(1)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for an invalid type argument' do
+        expect { command.call('user.name', type: 'invalid_type') }
+          .to raise_error(Git::FailedError)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/config_option_syntax/get_urlmatch_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_urlmatch_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/get_urlmatch'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::GetUrlmatch, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      before do
+        repo.config('http.https://example.com.proxy', 'http://proxy.example.com')
+      end
+
+      it 'returns a CommandLineResult' do
+        result = command.call('http.proxy', 'https://example.com')
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns exit code 1 when no URL match exists' do
+        result = command.call('http.proxy', 'https://nomatch.example.com')
+
+        expect(result.status.exitstatus).to eq(1)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for an invalid type argument' do
+        expect { command.call('http.proxy', 'https://example.com', type: 'invalid_type') }
+          .to raise_error(Git::FailedError, /invalid_type/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/config_option_syntax/list_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/list_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/list'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::List, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult' do
+        result = command.call
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError when the config file does not exist' do
+        # git's error message phrasing varies by version — anchor on the stable input value
+        expect { command.call(file: 'nonexistent.conf') }
+          .to raise_error(Git::FailedError, /nonexistent\.conf/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/config_option_syntax/remove_section_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/remove_section_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/get'
+require 'git/commands/config_option_syntax/remove_section'
+require 'git/commands/config_option_syntax/set'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::RemoveSection, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      before do
+        set = Git::Commands::ConfigOptionSyntax::Set.new(execution_context)
+        set.call('testsection.key', 'value')
+      end
+
+      it 'returns a CommandLineResult' do
+        result = command.call('testsection')
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns result with exit status 0' do
+        result = command.call('testsection')
+
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'removes the section entirely' do
+        command.call('testsection')
+
+        get = Git::Commands::ConfigOptionSyntax::Get.new(execution_context)
+        result = get.call('testsection.key')
+        expect(result.status.exitstatus).to eq(1)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError when the section does not exist' do
+        expect { command.call('nonexistent-section') }
+          .to raise_error(Git::FailedError)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/config_option_syntax/rename_section_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/rename_section_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/rename_section'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::RenameSection, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      before do
+        repo.config('oldsection.key', 'value')
+      end
+
+      it 'returns a CommandLineResult' do
+        result = command.call('oldsection', 'newsection')
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns result with exit status 0' do
+        result = command.call('oldsection', 'newsection')
+
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'renames the section' do
+        command.call('oldsection', 'newsection')
+
+        expect(repo.config('newsection.key')).to eq('value')
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for a nonexistent section' do
+        expect { command.call('nonexistent', 'newsection') }
+          .to raise_error(Git::FailedError, /nonexistent/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/config_option_syntax/replace_all_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/replace_all_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/replace_all'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::ReplaceAll, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      before do
+        execution_context.command_capturing('config', '--add', 'test.multi', 'old1')
+        execution_context.command_capturing('config', '--add', 'test.multi', 'old2')
+      end
+
+      it 'returns a CommandLineResult' do
+        result = command.call('test.multi', 'new-value')
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for an invalid key name' do
+        expect { command.call('invalidkey', 'value') }
+          .to raise_error(Git::FailedError, /invalidkey/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/config_option_syntax/set_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/set_spec.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/set'
+require 'git/commands/config_option_syntax/get'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::Set, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult' do
+        result = command.call('test.key', 'test-value')
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns result with exit status 0' do
+        result = command.call('test.key', 'test-value')
+
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'persists the value' do
+        command.call('test.key', 'test-value')
+
+        get = Git::Commands::ConfigOptionSyntax::Get.new(execution_context)
+        expect(get.call('test.key').stdout.strip).to eq('test-value')
+      end
+
+      it 'validates the value against the type when :type option is given' do
+        command.call('test.flag', 'yes', type: 'bool')
+
+        get = Git::Commands::ConfigOptionSyntax::Get.new(execution_context)
+        expect(get.call('test.flag').stdout.strip).to eq('true')
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError when the key has no section' do
+        expect { command.call('invalid', 'value') }.to raise_error(Git::FailedError, /does not contain a section/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/config_option_syntax/unset_all_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/unset_all_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/add'
+require 'git/commands/config_option_syntax/unset_all'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::UnsetAll, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      before do
+        add = Git::Commands::ConfigOptionSyntax::Add.new(execution_context)
+        add.call('test.multi', 'value1')
+        add.call('test.multi', 'value2')
+      end
+
+      it 'returns a CommandLineResult' do
+        result = command.call('test.multi')
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns exit status 0 when the key exists' do
+        result = command.call('test.multi')
+
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'returns exit status 5 when the key does not exist' do
+        result = command.call('nonexistent.key')
+
+        expect(result.status.exitstatus).to eq(5)
+      end
+    end
+
+    context 'when the command fails' do
+      before { FileUtils.rm_rf(File.join(repo_dir, '.git')) }
+
+      it 'raises FailedError outside a git repository' do
+        expect { command.call('test.key') }
+          .to raise_error(Git::FailedError, /test\.key/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/config_option_syntax/unset_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/unset_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/unset'
+require 'git/commands/config_option_syntax/set'
+require 'git/commands/config_option_syntax/get'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::Unset, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      before do
+        set = Git::Commands::ConfigOptionSyntax::Set.new(execution_context)
+        set.call('test.key', 'test-value')
+      end
+
+      it 'returns a CommandLineResult' do
+        result = command.call('test.key')
+
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns result with exit status 0' do
+        result = command.call('test.key')
+
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'removes the config entry' do
+        command.call('test.key')
+
+        get = Git::Commands::ConfigOptionSyntax::Get.new(execution_context)
+        result = get.call('test.key')
+        expect(result.status.exitstatus).to eq(1)
+      end
+
+      it 'returns exit status 5 when the key does not exist' do
+        result = command.call('nonexistent.key')
+
+        expect(result.status.exitstatus).to eq(5)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError outside a git repository' do
+        execution_context # ensure repo is initialized before removing .git
+        FileUtils.rm_rf(File.join(repo_dir, '.git'))
+
+        expect { command.call('test.key') }.to raise_error(Git::FailedError, /test\.key/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/lib/config_spec.rb
+++ b/spec/integration/git/lib/config_spec.rb
@@ -1,0 +1,126 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Backward-compatibility integration tests for Git::Lib config methods.
+# These verify that the public API of Git::Lib is preserved after the methods
+# were delegated to Git::Commands::ConfigOptionSyntax::* classes.
+RSpec.describe Git::Lib, :integration do
+  include_context 'in an empty repository'
+
+  subject(:lib) { repo.lib }
+
+  # --- config_get ---
+
+  describe '#config_get' do
+    it 'returns the value for an existing key' do
+      lib.config_set('user.name', 'Test User')
+      expect(lib.config_get('user.name')).to eq('Test User')
+    end
+
+    it 'raises Git::FailedError for a missing key' do
+      expect { lib.config_get('section.missing.key') }
+        .to raise_error(Git::FailedError)
+    end
+  end
+
+  # --- config_list ---
+
+  describe '#config_list' do
+    it 'returns a Hash of all local config entries' do
+      lib.config_set('user.name', 'Test User')
+      lib.config_set('user.email', 'test@example.com')
+      result = lib.config_list
+      expect(result).to be_a(Hash)
+      expect(result['user.name']).to eq('Test User')
+      expect(result['user.email']).to eq('test@example.com')
+    end
+  end
+
+  # --- parse_config ---
+
+  describe '#parse_config' do
+    it 'returns a Hash of all entries in the given file' do
+      config_file = File.join(repo_dir, 'my.config')
+      File.write(config_file, "[section]\n\tkey = value\n")
+      result = lib.parse_config(config_file)
+      expect(result).to be_a(Hash)
+      expect(result['section.key']).to eq('value')
+    end
+  end
+
+  # --- config_set ---
+
+  describe '#config_set' do
+    it 'writes a local config value readable by config_get' do
+      lib.config_set('section.key', 'hello')
+      expect(lib.config_get('section.key')).to eq('hello')
+    end
+
+    it 'writes to the specified file when file: is given' do
+      config_file = File.join(repo_dir, 'custom.config')
+      lib.config_set('section.key', 'file_value', file: config_file)
+      result = lib.parse_config(config_file)
+      expect(result['section.key']).to eq('file_value')
+    end
+  end
+
+  # --- global config methods ---
+  #
+  # GIT_CONFIG_GLOBAL is redirected to a temp file for the duration of each
+  # example so the real ~/.gitconfig is never read or modified.
+
+  describe '#global_config_get' do
+    around do |example|
+      with_isolated_global_config { example.run }
+    end
+
+    it 'returns the value for an existing key' do
+      lib.global_config_set('user.name', 'Global User')
+      expect(lib.global_config_get('user.name')).to eq('Global User')
+    end
+
+    it 'raises Git::FailedError for a missing key' do
+      expect { lib.global_config_get('section.missing.key') }
+        .to raise_error(Git::FailedError)
+    end
+  end
+
+  describe '#global_config_list' do
+    around do |example|
+      with_isolated_global_config { example.run }
+    end
+
+    it 'returns a Hash of global config entries' do
+      lib.global_config_set('user.name', 'Global User')
+      lib.global_config_set('user.email', 'global@example.com')
+      result = lib.global_config_list
+      expect(result).to be_a(Hash)
+      expect(result['user.name']).to eq('Global User')
+      expect(result['user.email']).to eq('global@example.com')
+    end
+  end
+
+  describe '#global_config_set' do
+    around do |example|
+      with_isolated_global_config { example.run }
+    end
+
+    it 'writes a global config value readable by global_config_get' do
+      lib.global_config_set('user.name', 'Global User')
+      expect(lib.global_config_get('user.name')).to eq('Global User')
+    end
+  end
+
+  # Helpers
+
+  def with_isolated_global_config
+    global_config = File.join(repo_dir, 'global.config')
+    FileUtils.touch(global_config)
+    saved = ENV.fetch('GIT_CONFIG_GLOBAL', nil)
+    ENV['GIT_CONFIG_GLOBAL'] = global_config
+    yield
+  ensure
+    saved.nil? ? ENV.delete('GIT_CONFIG_GLOBAL') : ENV['GIT_CONFIG_GLOBAL'] = saved
+  end
+end

--- a/spec/unit/git/commands/config_option_syntax/add_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/add_spec.rb
@@ -1,0 +1,106 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/add'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::Add do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with name and value arguments' do
+      it 'runs git config --add with name and value' do
+        expected_result = command_result
+        expect_command_capturing('config', '--add', '--', 'remote.origin.fetch',
+                                 '+refs/heads/*:refs/remotes/origin/*').and_return(expected_result)
+
+        result = command.call('remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*')
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with the :global option' do
+      it 'adds --global to the command line' do
+        expect_command_capturing('config', '--add', '--global', '--', 'user.name', 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', global: true)
+      end
+    end
+
+    context 'with the :system option' do
+      it 'adds --system to the command line' do
+        expect_command_capturing('config', '--add', '--system', '--', 'user.name', 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', system: true)
+      end
+    end
+
+    context 'with the :local option' do
+      it 'adds --local to the command line' do
+        expect_command_capturing('config', '--add', '--local', '--', 'user.name', 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', local: true)
+      end
+    end
+
+    context 'with the :worktree option' do
+      it 'adds --worktree to the command line' do
+        expect_command_capturing('config', '--add', '--worktree', '--', 'user.name', 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', worktree: true)
+      end
+    end
+
+    context 'with the :file option' do
+      it 'adds --file with the path' do
+        expect_command_capturing('config', '--add', '--file', '/path/to/config', '--', 'user.name',
+                                 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', file: '/path/to/config')
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('config', '--add', '--file', '/path/to/config', '--', 'user.name',
+                                 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', f: '/path/to/config')
+      end
+    end
+
+    context 'with the :blob option' do
+      it 'adds --blob with the value' do
+        expect_command_capturing('config', '--add', '--blob', 'HEAD:.gitmodules', '--', 'user.name',
+                                 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', blob: 'HEAD:.gitmodules')
+      end
+    end
+
+    context 'with the :type option' do
+      it 'adds --type=<value> inline' do
+        expect_command_capturing('config', '--add', '--type=int', '--', 'core.bigFileThreshold',
+                                 '512m').and_return(command_result)
+
+        command.call('core.bigFileThreshold', '512m', type: 'int')
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when name is missing' do
+        expect { command.call }.to raise_error(ArgumentError, /name/)
+      end
+
+      it 'raises ArgumentError when value is missing' do
+        expect { command.call('user.name') }.to raise_error(ArgumentError, /value/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect do
+          command.call('user.name', 'Alice', unknown: true)
+        end.to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/config_option_syntax/get_all_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/get_all_spec.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/get_all'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::GetAll do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with a name argument' do
+      it 'runs git config --get-all with the name' do
+        expected_result = command_result
+        expect_command_capturing('config', '--get-all', '--', 'remote.origin.fetch').and_return(expected_result)
+
+        result = command.call('remote.origin.fetch')
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with a name and value_regex' do
+      it 'adds the value_regex after the name' do
+        expect_command_capturing('config', '--get-all', '--', 'remote.origin.fetch',
+                                 '\\+refs/heads/.*').and_return(command_result)
+
+        command.call('remote.origin.fetch', '\\+refs/heads/.*')
+      end
+    end
+
+    context 'with the :global option' do
+      it 'adds --global to the command line' do
+        expect_command_capturing('config', '--get-all', '--global', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', global: true)
+      end
+    end
+
+    context 'with the :system option' do
+      it 'adds --system to the command line' do
+        expect_command_capturing('config', '--get-all', '--system', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', system: true)
+      end
+    end
+
+    context 'with the :local option' do
+      it 'adds --local to the command line' do
+        expect_command_capturing('config', '--get-all', '--local', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', local: true)
+      end
+    end
+
+    context 'with the :worktree option' do
+      it 'adds --worktree to the command line' do
+        expect_command_capturing('config', '--get-all', '--worktree', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', worktree: true)
+      end
+    end
+
+    context 'with the :file option' do
+      it 'adds --file with the path' do
+        expect_command_capturing('config', '--get-all', '--file', '/path/to/config', '--',
+                                 'user.name').and_return(command_result)
+
+        command.call('user.name', file: '/path/to/config')
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('config', '--get-all', '--file', '/path/to/config', '--',
+                                 'user.name').and_return(command_result)
+
+        command.call('user.name', f: '/path/to/config')
+      end
+    end
+
+    context 'with the :blob option' do
+      it 'adds --blob with the value' do
+        expect_command_capturing('config', '--get-all', '--blob', 'HEAD:.gitmodules', '--',
+                                 'user.name').and_return(command_result)
+
+        command.call('user.name', blob: 'HEAD:.gitmodules')
+      end
+    end
+
+    context 'with the :includes option' do
+      it 'adds --includes to the command line' do
+        expect_command_capturing('config', '--get-all', '--includes', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', includes: true)
+      end
+
+      it 'adds --no-includes to the command line' do
+        expect_command_capturing('config', '--get-all', '--no-includes', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', includes: false)
+      end
+    end
+
+    context 'with the :type option' do
+      it 'adds --type=<value> inline' do
+        expect_command_capturing('config', '--get-all', '--type=bool', '--', 'core.bare').and_return(command_result)
+
+        command.call('core.bare', type: 'bool')
+      end
+    end
+
+    context 'with the :show_origin option' do
+      it 'adds --show-origin to the command line' do
+        expect_command_capturing('config', '--get-all', '--show-origin', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', show_origin: true)
+      end
+    end
+
+    context 'with the :show_scope option' do
+      it 'adds --show-scope to the command line' do
+        expect_command_capturing('config', '--get-all', '--show-scope', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', show_scope: true)
+      end
+    end
+
+    context 'with the :null option' do
+      it 'adds --null to the command line' do
+        expect_command_capturing('config', '--get-all', '--null', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', null: true)
+      end
+
+      it 'supports the :z alias' do
+        expect_command_capturing('config', '--get-all', '--null', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', z: true)
+      end
+    end
+
+    context 'exit code handling' do
+      it 'returns result for exit code 0 (key found)' do
+        expect_command_capturing('config', '--get-all', '--', 'user.name')
+          .and_return(command_result('Alice', exitstatus: 0))
+
+        result = command.call('user.name')
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'returns result for exit code 1 (key not found)' do
+        expect_command_capturing('config', '--get-all', '--', 'nonexistent.key')
+          .and_return(command_result('', exitstatus: 1))
+
+        result = command.call('nonexistent.key')
+        expect(result.status.exitstatus).to eq(1)
+      end
+
+      it 'raises FailedError when git exits with code 2' do
+        expect_command_capturing('config', '--get-all', '--', 'user.name')
+          .and_return(command_result('', stderr: 'error: bad config', exitstatus: 2))
+
+        expect { command.call('user.name') }.to raise_error(Git::FailedError, /bad config/)
+      end
+
+      it 'raises FailedError when git exits with code 128' do
+        expect_command_capturing('config', '--get-all', '--', 'user.name')
+          .and_return(command_result('', stderr: 'fatal: not a git repository', exitstatus: 128))
+
+        expect { command.call('user.name') }.to raise_error(Git::FailedError, /not a git repository/)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when name is missing' do
+        expect { command.call }.to raise_error(ArgumentError, /name/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('user.name', unknown: true) }.to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/config_option_syntax/get_color_bool_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/get_color_bool_spec.rb
@@ -1,0 +1,137 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/get_color_bool'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::GetColorBool do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with a name argument' do
+      it 'runs git config --get-colorbool with the name' do
+        expected_result = command_result
+        expect_command_capturing('config', '--get-colorbool', '--', 'color.diff').and_return(expected_result)
+
+        result = command.call('color.diff')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with a name and stdout_is_tty' do
+      it 'adds the stdout_is_tty after the name' do
+        expect_command_capturing('config', '--get-colorbool', '--', 'color.diff', 'true').and_return(command_result)
+
+        command.call('color.diff', 'true')
+      end
+    end
+
+    context 'with the :global option' do
+      it 'adds --global to the command line' do
+        expect_command_capturing('config', '--get-colorbool', '--global', '--', 'color.diff').and_return(command_result)
+
+        command.call('color.diff', global: true)
+      end
+    end
+
+    context 'with the :system option' do
+      it 'adds --system to the command line' do
+        expect_command_capturing('config', '--get-colorbool', '--system', '--', 'color.diff').and_return(command_result)
+
+        command.call('color.diff', system: true)
+      end
+    end
+
+    context 'with the :local option' do
+      it 'adds --local to the command line' do
+        expect_command_capturing('config', '--get-colorbool', '--local', '--', 'color.diff').and_return(command_result)
+
+        command.call('color.diff', local: true)
+      end
+    end
+
+    context 'with the :worktree option' do
+      it 'adds --worktree to the command line' do
+        expect_command_capturing('config', '--get-colorbool', '--worktree', '--',
+                                 'color.diff').and_return(command_result)
+
+        command.call('color.diff', worktree: true)
+      end
+    end
+
+    context 'with the :file option' do
+      it 'adds --file with the path' do
+        expect_command_capturing('config', '--get-colorbool', '--file', '/path/to/config', '--',
+                                 'color.diff').and_return(command_result)
+
+        command.call('color.diff', file: '/path/to/config')
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('config', '--get-colorbool', '--file', '/path/to/config', '--',
+                                 'color.diff').and_return(command_result)
+
+        command.call('color.diff', f: '/path/to/config')
+      end
+    end
+
+    context 'with the :blob option' do
+      it 'adds --blob with the value' do
+        expect_command_capturing('config', '--get-colorbool', '--blob', 'HEAD:.gitmodules', '--',
+                                 'color.diff').and_return(command_result)
+
+        command.call('color.diff', blob: 'HEAD:.gitmodules')
+      end
+    end
+
+    context 'with the :includes option' do
+      it 'adds --includes to the command line' do
+        expect_command_capturing('config', '--get-colorbool', '--includes', '--',
+                                 'color.diff').and_return(command_result)
+
+        command.call('color.diff', includes: true)
+      end
+
+      it 'adds --no-includes to the command line' do
+        expect_command_capturing('config', '--get-colorbool', '--no-includes', '--',
+                                 'color.diff').and_return(command_result)
+
+        command.call('color.diff', includes: false)
+      end
+    end
+
+    context 'exit code handling' do
+      it 'returns result for exit code 0' do
+        result = command_result(exitstatus: 0)
+        expect_command_capturing('config', '--get-colorbool', '--', 'color.diff').and_return(result)
+
+        expect(command.call('color.diff')).to eq(result)
+      end
+
+      it 'returns result for exit code 1 (color=no)' do
+        result = command_result(exitstatus: 1)
+        expect_command_capturing('config', '--get-colorbool', '--', 'color.diff').and_return(result)
+
+        expect(command.call('color.diff')).to eq(result)
+      end
+
+      it 'raises FailedError for exit code 2' do
+        result = command_result(stderr: 'fatal: bad config', exitstatus: 2)
+        expect_command_capturing('config', '--get-colorbool', '--', 'color.diff').and_return(result)
+
+        expect { command.call('color.diff') }.to raise_error(Git::FailedError, /fatal: bad config/)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when name is missing' do
+        expect { command.call }.to raise_error(ArgumentError, /name/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('color.diff', unknown: true) }.to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/config_option_syntax/get_color_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/get_color_spec.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/get_color'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::GetColor do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with a name argument' do
+      it 'runs git config --get-color with the name' do
+        expected_result = command_result
+        expect_command_capturing('config', '--get-color', '--', 'color.diff.new').and_return(expected_result)
+
+        result = command.call('color.diff.new')
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with a name and default' do
+      it 'adds the default after the name' do
+        expect_command_capturing('config', '--get-color', '--', 'color.diff.new', 'green').and_return(command_result)
+
+        command.call('color.diff.new', 'green')
+      end
+    end
+
+    context 'with the :global option' do
+      it 'adds --global to the command line' do
+        expect_command_capturing('config', '--get-color', '--global', '--', 'color.diff.new').and_return(command_result)
+
+        command.call('color.diff.new', global: true)
+      end
+    end
+
+    context 'with the :system option' do
+      it 'adds --system to the command line' do
+        expect_command_capturing('config', '--get-color', '--system', '--', 'color.diff.new').and_return(command_result)
+
+        command.call('color.diff.new', system: true)
+      end
+    end
+
+    context 'with the :local option' do
+      it 'adds --local to the command line' do
+        expect_command_capturing('config', '--get-color', '--local', '--', 'color.diff.new').and_return(command_result)
+
+        command.call('color.diff.new', local: true)
+      end
+    end
+
+    context 'with the :worktree option' do
+      it 'adds --worktree to the command line' do
+        expect_command_capturing('config', '--get-color', '--worktree', '--',
+                                 'color.diff.new').and_return(command_result)
+
+        command.call('color.diff.new', worktree: true)
+      end
+    end
+
+    context 'with the :file option' do
+      it 'adds --file with the path' do
+        expect_command_capturing('config', '--get-color', '--file', '/path/to/config', '--',
+                                 'color.diff.new').and_return(command_result)
+
+        command.call('color.diff.new', file: '/path/to/config')
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('config', '--get-color', '--file', '/path/to/config', '--',
+                                 'color.diff.new').and_return(command_result)
+
+        command.call('color.diff.new', f: '/path/to/config')
+      end
+    end
+
+    context 'with the :blob option' do
+      it 'adds --blob with the value' do
+        expect_command_capturing('config', '--get-color', '--blob', 'HEAD:.gitmodules', '--',
+                                 'color.diff.new').and_return(command_result)
+
+        command.call('color.diff.new', blob: 'HEAD:.gitmodules')
+      end
+    end
+
+    context 'with the :includes option' do
+      it 'adds --includes when true' do
+        expect_command_capturing('config', '--get-color', '--includes', '--',
+                                 'color.diff.new').and_return(command_result)
+
+        command.call('color.diff.new', includes: true)
+      end
+
+      it 'adds --no-includes when false' do
+        expect_command_capturing('config', '--get-color', '--no-includes', '--',
+                                 'color.diff.new').and_return(command_result)
+
+        command.call('color.diff.new', includes: false)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when name is missing' do
+        expect { command.call }.to raise_error(ArgumentError, /name/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('color.diff.new', unknown: true) }.to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/config_option_syntax/get_regexp_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/get_regexp_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/get_regexp'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::GetRegexp do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with a name_regex argument' do
+      it 'runs git config --get-regexp with the name regex' do
+        expected_result = command_result
+        expect_command_capturing('config', '--get-regexp', '--', 'remote\..*\.url').and_return(expected_result)
+
+        result = command.call('remote\..*\.url')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with a name_regex and value_regex' do
+      it 'adds the value_regex after the name regex' do
+        expect_command_capturing('config', '--get-regexp', '--', 'remote\..*\.url', 'github').and_return(command_result)
+
+        command.call('remote\..*\.url', 'github')
+      end
+    end
+
+    context 'with the :global option' do
+      it 'adds --global to the command line' do
+        expect_command_capturing('config', '--get-regexp', '--global', '--', 'user\..*').and_return(command_result)
+
+        command.call('user\..*', global: true)
+      end
+    end
+
+    context 'with the :system option' do
+      it 'adds --system to the command line' do
+        expect_command_capturing('config', '--get-regexp', '--system', '--', 'user\..*').and_return(command_result)
+
+        command.call('user\..*', system: true)
+      end
+    end
+
+    context 'with the :local option' do
+      it 'adds --local to the command line' do
+        expect_command_capturing('config', '--get-regexp', '--local', '--', 'user\..*').and_return(command_result)
+
+        command.call('user\..*', local: true)
+      end
+    end
+
+    context 'with the :worktree option' do
+      it 'adds --worktree to the command line' do
+        expect_command_capturing('config', '--get-regexp', '--worktree', '--', 'user\..*').and_return(command_result)
+
+        command.call('user\..*', worktree: true)
+      end
+    end
+
+    context 'with the :file option' do
+      it 'adds --file with the path' do
+        expect_command_capturing('config', '--get-regexp', '--file', '/path/to/config', '--',
+                                 'user\..*').and_return(command_result)
+
+        command.call('user\..*', file: '/path/to/config')
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('config', '--get-regexp', '--file', '/path/to/config', '--',
+                                 'user\..*').and_return(command_result)
+
+        command.call('user\..*', f: '/path/to/config')
+      end
+    end
+
+    context 'with the :blob option' do
+      it 'adds --blob with the value' do
+        expect_command_capturing('config', '--get-regexp', '--blob', 'HEAD:.gitmodules', '--',
+                                 'user\..*').and_return(command_result)
+
+        command.call('user\..*', blob: 'HEAD:.gitmodules')
+      end
+    end
+
+    context 'with the :includes option' do
+      it 'adds --includes when true' do
+        expect_command_capturing('config', '--get-regexp', '--includes', '--', 'user\..*').and_return(command_result)
+
+        command.call('user\..*', includes: true)
+      end
+
+      it 'adds --no-includes when false' do
+        expect_command_capturing('config', '--get-regexp', '--no-includes', '--', 'user\..*').and_return(command_result)
+
+        command.call('user\..*', includes: false)
+      end
+    end
+
+    context 'with the :type option' do
+      it 'adds --type=<value> inline' do
+        expect_command_capturing('config', '--get-regexp', '--type=bool', '--', 'core\..*').and_return(command_result)
+
+        command.call('core\..*', type: 'bool')
+      end
+    end
+
+    context 'with the :show_origin option' do
+      it 'adds --show-origin to the command line' do
+        expect_command_capturing('config', '--get-regexp', '--show-origin', '--', 'user\..*').and_return(command_result)
+
+        command.call('user\..*', show_origin: true)
+      end
+    end
+
+    context 'with the :show_scope option' do
+      it 'adds --show-scope to the command line' do
+        expect_command_capturing('config', '--get-regexp', '--show-scope', '--', 'user\..*').and_return(command_result)
+
+        command.call('user\..*', show_scope: true)
+      end
+    end
+
+    context 'with the :null option' do
+      it 'adds --null to the command line' do
+        expect_command_capturing('config', '--get-regexp', '--null', '--', 'user\..*').and_return(command_result)
+
+        command.call('user\..*', null: true)
+      end
+
+      it 'supports the :z alias' do
+        expect_command_capturing('config', '--get-regexp', '--null', '--', 'user\..*').and_return(command_result)
+
+        command.call('user\..*', z: true)
+      end
+    end
+
+    context 'with the :name_only option' do
+      it 'adds --name-only to the command line' do
+        expect_command_capturing('config', '--get-regexp', '--name-only', '--', 'user\..*').and_return(command_result)
+
+        command.call('user\..*', name_only: true)
+      end
+    end
+
+    context 'exit code handling' do
+      it 'returns the result for exit code 0' do
+        result = command_result(exitstatus: 0)
+        expect_command_capturing('config', '--get-regexp', '--', 'user\..*').and_return(result)
+
+        expect { command.call('user\..*') }.not_to raise_error
+      end
+
+      it 'returns the result for exit code 1 (no match found)' do
+        result = command_result(exitstatus: 1)
+        expect_command_capturing('config', '--get-regexp', '--', 'nonexistent\..*').and_return(result)
+
+        expect { command.call('nonexistent\..*') }.not_to raise_error
+      end
+
+      it 'raises FailedError for exit code 2 (error)' do
+        result = command_result(stderr: 'fatal: bad config', exitstatus: 2)
+        expect_command_capturing('config', '--get-regexp', '--', 'user\..*').and_return(result)
+
+        expect { command.call('user\..*') }.to raise_error(Git::FailedError, /fatal: bad config/)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when name_regex is missing' do
+        expect { command.call }.to raise_error(ArgumentError, /name_regex/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('user\..*', unknown: true) }.to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/config_option_syntax/get_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/get_spec.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/get'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::Get do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with a name argument' do
+      it 'runs git config --get with the name' do
+        expected_result = command_result
+        expect_command_capturing('config', '--get', '--', 'user.name').and_return(expected_result)
+
+        result = command.call('user.name')
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with a name and value_regex' do
+      it 'adds the value_regex after the name' do
+        expect_command_capturing('config', '--get', '--', 'user.name', 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice')
+      end
+    end
+
+    context 'with the :global option' do
+      it 'adds --global to the command line' do
+        expect_command_capturing('config', '--get', '--global', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', global: true)
+      end
+    end
+
+    context 'with the :system option' do
+      it 'adds --system to the command line' do
+        expect_command_capturing('config', '--get', '--system', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', system: true)
+      end
+    end
+
+    context 'with the :local option' do
+      it 'adds --local to the command line' do
+        expect_command_capturing('config', '--get', '--local', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', local: true)
+      end
+    end
+
+    context 'with the :worktree option' do
+      it 'adds --worktree to the command line' do
+        expect_command_capturing('config', '--get', '--worktree', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', worktree: true)
+      end
+    end
+
+    context 'with the :file option' do
+      it 'adds --file with the path' do
+        expect_command_capturing('config', '--get', '--file', '/path/to/config', '--',
+                                 'user.name').and_return(command_result)
+
+        command.call('user.name', file: '/path/to/config')
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('config', '--get', '--file', '/path/to/config', '--',
+                                 'user.name').and_return(command_result)
+
+        command.call('user.name', f: '/path/to/config')
+      end
+    end
+
+    context 'with the :blob option' do
+      it 'adds --blob with the value' do
+        expect_command_capturing('config', '--get', '--blob', 'HEAD:.gitmodules', '--',
+                                 'user.name').and_return(command_result)
+
+        command.call('user.name', blob: 'HEAD:.gitmodules')
+      end
+    end
+
+    context 'with the :includes option' do
+      it 'adds --includes when true' do
+        expect_command_capturing('config', '--get', '--includes', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', includes: true)
+      end
+
+      it 'adds --no-includes when false' do
+        expect_command_capturing('config', '--get', '--no-includes', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', includes: false)
+      end
+    end
+
+    context 'with the :type option' do
+      it 'adds --type=<value> inline' do
+        expect_command_capturing('config', '--get', '--type=bool', '--', 'core.bare').and_return(command_result)
+
+        command.call('core.bare', type: 'bool')
+      end
+    end
+
+    context 'with the :show_origin option' do
+      it 'adds --show-origin to the command line' do
+        expect_command_capturing('config', '--get', '--show-origin', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', show_origin: true)
+      end
+    end
+
+    context 'with the :show_scope option' do
+      it 'adds --show-scope to the command line' do
+        expect_command_capturing('config', '--get', '--show-scope', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', show_scope: true)
+      end
+    end
+
+    context 'with the :null option' do
+      it 'adds --null to the command line' do
+        expect_command_capturing('config', '--get', '--null', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', null: true)
+      end
+
+      it 'supports the :z alias' do
+        expect_command_capturing('config', '--get', '--null', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', z: true)
+      end
+    end
+
+    context 'with the :default option' do
+      it 'adds --default with the value' do
+        expect_command_capturing('config', '--get', '--default', 'fallback', '--',
+                                 'user.name').and_return(command_result)
+
+        command.call('user.name', default: 'fallback')
+      end
+    end
+
+    context 'exit code handling' do
+      it 'returns result for exit code 0' do
+        result = command_result(exitstatus: 0)
+        expect_command_capturing('config', '--get', '--', 'user.name').and_return(result)
+
+        expect(command.call('user.name')).to eq(result)
+      end
+
+      it 'returns result for exit code 1 (key not found)' do
+        result = command_result(exitstatus: 1)
+        expect_command_capturing('config', '--get', '--', 'nonexistent.key').and_return(result)
+
+        expect(command.call('nonexistent.key')).to eq(result)
+      end
+
+      it 'raises FailedError for exit code 2' do
+        result = command_result(exitstatus: 2)
+        expect_command_capturing('config', '--get', '--', 'user.name').and_return(result)
+
+        expect { command.call('user.name') }.to raise_error(Git::FailedError)
+      end
+
+      it 'raises FailedError for exit code 128' do
+        result = command_result(exitstatus: 128)
+        expect_command_capturing('config', '--get', '--', 'user.name').and_return(result)
+
+        expect { command.call('user.name') }.to raise_error(Git::FailedError)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when name is missing' do
+        expect { command.call }.to raise_error(ArgumentError, /name/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('user.name', unknown: true) }.to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/config_option_syntax/get_urlmatch_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/get_urlmatch_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/get_urlmatch'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::GetUrlmatch do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with name and url arguments' do
+      it 'runs git config --get-urlmatch with name and url' do
+        expected_result = command_result
+        expect_command_capturing('config', '--get-urlmatch', '--', 'http', 'https://example.com').and_return(expected_result)
+
+        result = command.call('http', 'https://example.com')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with the :global option' do
+      it 'adds --global to the command line' do
+        expect_command_capturing('config', '--get-urlmatch', '--global', '--', 'http', 'https://example.com').and_return(command_result)
+
+        command.call('http', 'https://example.com', global: true)
+      end
+    end
+
+    context 'with the :system option' do
+      it 'adds --system to the command line' do
+        expect_command_capturing('config', '--get-urlmatch', '--system', '--', 'http', 'https://example.com').and_return(command_result)
+
+        command.call('http', 'https://example.com', system: true)
+      end
+    end
+
+    context 'with the :local option' do
+      it 'adds --local to the command line' do
+        expect_command_capturing('config', '--get-urlmatch', '--local', '--', 'http', 'https://example.com').and_return(command_result)
+
+        command.call('http', 'https://example.com', local: true)
+      end
+    end
+
+    context 'with the :worktree option' do
+      it 'adds --worktree to the command line' do
+        expect_command_capturing('config', '--get-urlmatch', '--worktree', '--', 'http', 'https://example.com').and_return(command_result)
+
+        command.call('http', 'https://example.com', worktree: true)
+      end
+    end
+
+    context 'with the :file option' do
+      it 'adds --file with the path' do
+        expect_command_capturing('config', '--get-urlmatch', '--file', '/path/to/config', '--', 'http', 'https://example.com').and_return(command_result)
+
+        command.call('http', 'https://example.com', file: '/path/to/config')
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('config', '--get-urlmatch', '--file', '/path/to/config', '--', 'http', 'https://example.com').and_return(command_result)
+
+        command.call('http', 'https://example.com', f: '/path/to/config')
+      end
+    end
+
+    context 'with the :blob option' do
+      it 'adds --blob with the value' do
+        expect_command_capturing('config', '--get-urlmatch', '--blob', 'HEAD:.gitmodules', '--', 'http', 'https://example.com').and_return(command_result)
+
+        command.call('http', 'https://example.com', blob: 'HEAD:.gitmodules')
+      end
+    end
+
+    context 'with the :includes option' do
+      it 'adds --includes to the command line' do
+        expect_command_capturing('config', '--get-urlmatch', '--includes', '--', 'http', 'https://example.com').and_return(command_result)
+
+        command.call('http', 'https://example.com', includes: true)
+      end
+
+      it 'adds --no-includes to the command line' do
+        expect_command_capturing('config', '--get-urlmatch', '--no-includes', '--', 'http', 'https://example.com').and_return(command_result)
+
+        command.call('http', 'https://example.com', includes: false)
+      end
+    end
+
+    context 'with the :type option' do
+      it 'adds --type=<value> inline' do
+        expect_command_capturing('config', '--get-urlmatch', '--type=bool', '--', 'http', 'https://example.com').and_return(command_result)
+
+        command.call('http', 'https://example.com', type: 'bool')
+      end
+    end
+
+    context 'with the :null option' do
+      it 'adds --null to the command line' do
+        expect_command_capturing('config', '--get-urlmatch', '--null', '--', 'http', 'https://example.com').and_return(command_result)
+
+        command.call('http', 'https://example.com', null: true)
+      end
+
+      it 'supports the :z alias' do
+        expect_command_capturing('config', '--get-urlmatch', '--null', '--', 'http', 'https://example.com').and_return(command_result)
+
+        command.call('http', 'https://example.com', z: true)
+      end
+    end
+
+    context 'exit code handling' do
+      it 'returns result for exit code 1 (no match found)' do
+        result = command_result(exitstatus: 1)
+        expect_command_capturing('config', '--get-urlmatch', '--', 'http', 'https://example.com').and_return(result)
+
+        expect(command.call('http', 'https://example.com')).to eq(result)
+      end
+
+      it 'raises FailedError for exit code 2' do
+        result = command_result(exitstatus: 2)
+        expect_command_capturing('config', '--get-urlmatch', '--', 'http', 'https://example.com').and_return(result)
+
+        expect { command.call('http', 'https://example.com') }.to raise_error(Git::FailedError, /git/)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when name is missing' do
+        expect { command.call }.to raise_error(ArgumentError, /name/)
+      end
+
+      it 'raises ArgumentError when url is missing' do
+        expect { command.call('http') }.to raise_error(ArgumentError, /url/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect do
+          command.call('http', 'https://example.com', unknown: true)
+        end.to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/config_option_syntax/list_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/list_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/list'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::List do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with no arguments' do
+      it 'runs git config --list' do
+        expected_result = command_result
+        expect_command_capturing('config', '--list').and_return(expected_result)
+
+        result = command.call
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with the :global option' do
+      it 'adds --global to the command line' do
+        expect_command_capturing('config', '--list', '--global').and_return(command_result)
+
+        command.call(global: true)
+      end
+    end
+
+    context 'with the :system option' do
+      it 'adds --system to the command line' do
+        expect_command_capturing('config', '--list', '--system').and_return(command_result)
+
+        command.call(system: true)
+      end
+    end
+
+    context 'with the :local option' do
+      it 'adds --local to the command line' do
+        expect_command_capturing('config', '--list', '--local').and_return(command_result)
+
+        command.call(local: true)
+      end
+    end
+
+    context 'with the :worktree option' do
+      it 'adds --worktree to the command line' do
+        expect_command_capturing('config', '--list', '--worktree').and_return(command_result)
+
+        command.call(worktree: true)
+      end
+    end
+
+    context 'with the :file option' do
+      it 'adds --file with the path' do
+        expect_command_capturing('config', '--list', '--file', '/path/to/config').and_return(command_result)
+
+        command.call(file: '/path/to/config')
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('config', '--list', '--file', '/path/to/config').and_return(command_result)
+
+        command.call(f: '/path/to/config')
+      end
+    end
+
+    context 'with the :blob option' do
+      it 'adds --blob with the value' do
+        expect_command_capturing('config', '--list', '--blob', 'HEAD:.gitmodules').and_return(command_result)
+
+        command.call(blob: 'HEAD:.gitmodules')
+      end
+    end
+
+    context 'with the :type option' do
+      it 'adds --type=<value> inline' do
+        expect_command_capturing('config', '--list', '--type=bool').and_return(command_result)
+
+        command.call(type: 'bool')
+      end
+    end
+
+    context 'with the :includes option' do
+      it 'adds --includes when true' do
+        expect_command_capturing('config', '--list', '--includes').and_return(command_result)
+
+        command.call(includes: true)
+      end
+
+      it 'adds --no-includes when false' do
+        expect_command_capturing('config', '--list', '--no-includes').and_return(command_result)
+
+        command.call(includes: false)
+      end
+    end
+
+    context 'with the :show_origin option' do
+      it 'adds --show-origin to the command line' do
+        expect_command_capturing('config', '--list', '--show-origin').and_return(command_result)
+
+        command.call(show_origin: true)
+      end
+    end
+
+    context 'with the :show_scope option' do
+      it 'adds --show-scope to the command line' do
+        expect_command_capturing('config', '--list', '--show-scope').and_return(command_result)
+
+        command.call(show_scope: true)
+      end
+    end
+
+    context 'with the :null option' do
+      it 'adds --null to the command line' do
+        expect_command_capturing('config', '--list', '--null').and_return(command_result)
+
+        command.call(null: true)
+      end
+
+      it 'supports the :z alias' do
+        expect_command_capturing('config', '--list', '--null').and_return(command_result)
+
+        command.call(z: true)
+      end
+    end
+
+    context 'with the :name_only option' do
+      it 'adds --name-only to the command line' do
+        expect_command_capturing('config', '--list', '--name-only').and_return(command_result)
+
+        command.call(name_only: true)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(unknown: true) }.to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/config_option_syntax/remove_section_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/remove_section_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/remove_section'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::RemoveSection do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with a name argument' do
+      it 'runs git config --remove-section with the name' do
+        expected_result = command_result
+        expect_command_capturing('config', '--remove-section', '--', 'old-section').and_return(expected_result)
+
+        result = command.call('old-section')
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with the :global option' do
+      it 'adds --global to the command line' do
+        expect_command_capturing('config', '--remove-section', '--global', '--',
+                                 'old-section').and_return(command_result)
+
+        command.call('old-section', global: true)
+      end
+    end
+
+    context 'with the :system option' do
+      it 'adds --system to the command line' do
+        expect_command_capturing('config', '--remove-section', '--system', '--',
+                                 'old-section').and_return(command_result)
+
+        command.call('old-section', system: true)
+      end
+    end
+
+    context 'with the :local option' do
+      it 'adds --local to the command line' do
+        expect_command_capturing('config', '--remove-section', '--local', '--',
+                                 'old-section').and_return(command_result)
+
+        command.call('old-section', local: true)
+      end
+    end
+
+    context 'with the :worktree option' do
+      it 'adds --worktree to the command line' do
+        expect_command_capturing('config', '--remove-section', '--worktree', '--',
+                                 'old-section').and_return(command_result)
+
+        command.call('old-section', worktree: true)
+      end
+    end
+
+    context 'with the :file option' do
+      it 'adds --file with the path' do
+        expect_command_capturing('config', '--remove-section', '--file', '/path/to/config', '--',
+                                 'old-section').and_return(command_result)
+
+        command.call('old-section', file: '/path/to/config')
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('config', '--remove-section', '--file', '/path/to/config', '--',
+                                 'old-section').and_return(command_result)
+
+        command.call('old-section', f: '/path/to/config')
+      end
+    end
+
+    context 'with the :blob option' do
+      it 'adds --blob with the value' do
+        expect_command_capturing('config', '--remove-section', '--blob', 'HEAD:.gitmodules', '--',
+                                 'old-section').and_return(command_result)
+
+        command.call('old-section', blob: 'HEAD:.gitmodules')
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when name is missing' do
+        expect { command.call }.to raise_error(ArgumentError, /name/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('old-section', unknown: true) }.to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/config_option_syntax/rename_section_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/rename_section_spec.rb
@@ -1,0 +1,99 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/rename_section'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::RenameSection do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with old_name and new_name arguments' do
+      it 'runs git config --rename-section with old and new names' do
+        expected_result = command_result
+        expect_command_capturing('config', '--rename-section', '--', 'old-section',
+                                 'new-section').and_return(expected_result)
+
+        result = command.call('old-section', 'new-section')
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with the :global option' do
+      it 'adds --global to the command line' do
+        expect_command_capturing('config', '--rename-section', '--global', '--', 'old-section',
+                                 'new-section').and_return(command_result)
+
+        command.call('old-section', 'new-section', global: true)
+      end
+    end
+
+    context 'with the :system option' do
+      it 'adds --system to the command line' do
+        expect_command_capturing('config', '--rename-section', '--system', '--', 'old-section',
+                                 'new-section').and_return(command_result)
+
+        command.call('old-section', 'new-section', system: true)
+      end
+    end
+
+    context 'with the :local option' do
+      it 'adds --local to the command line' do
+        expect_command_capturing('config', '--rename-section', '--local', '--', 'old-section',
+                                 'new-section').and_return(command_result)
+
+        command.call('old-section', 'new-section', local: true)
+      end
+    end
+
+    context 'with the :worktree option' do
+      it 'adds --worktree to the command line' do
+        expect_command_capturing('config', '--rename-section', '--worktree', '--', 'old-section',
+                                 'new-section').and_return(command_result)
+
+        command.call('old-section', 'new-section', worktree: true)
+      end
+    end
+
+    context 'with the :file option' do
+      it 'adds --file with the path' do
+        expect_command_capturing('config', '--rename-section', '--file', '/path/to/config', '--', 'old-section',
+                                 'new-section').and_return(command_result)
+
+        command.call('old-section', 'new-section', file: '/path/to/config')
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('config', '--rename-section', '--file', '/path/to/config', '--', 'old-section',
+                                 'new-section').and_return(command_result)
+
+        command.call('old-section', 'new-section', f: '/path/to/config')
+      end
+    end
+
+    context 'with the :blob option' do
+      it 'adds --blob with the value' do
+        expect_command_capturing('config', '--rename-section', '--blob', 'HEAD:.gitmodules', '--', 'old-section',
+                                 'new-section').and_return(command_result)
+
+        command.call('old-section', 'new-section', blob: 'HEAD:.gitmodules')
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when old_name is missing' do
+        expect { command.call }.to raise_error(ArgumentError, /old_name/)
+      end
+
+      it 'raises ArgumentError when new_name is missing' do
+        expect { command.call('old-section') }.to raise_error(ArgumentError, /new_name/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect do
+          command.call('old-section', 'new-section', unknown: true)
+        end.to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/config_option_syntax/replace_all_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/replace_all_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/replace_all'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::ReplaceAll do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with name and value arguments' do
+      it 'runs git config --replace-all with name and value' do
+        expected_result = command_result
+        expect_command_capturing('config', '--replace-all', '--', 'core.autocrlf', 'true').and_return(expected_result)
+
+        result = command.call('core.autocrlf', 'true')
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with name, value, and value_regex' do
+      it 'adds the value_regex after the value' do
+        expect_command_capturing('config', '--replace-all', '--', 'core.autocrlf', 'true',
+                                 'false').and_return(command_result)
+
+        command.call('core.autocrlf', 'true', 'false')
+      end
+    end
+
+    context 'with the :global option' do
+      it 'adds --global to the command line' do
+        expect_command_capturing('config', '--replace-all', '--global', '--', 'user.name',
+                                 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', global: true)
+      end
+    end
+
+    context 'with the :system option' do
+      it 'adds --system to the command line' do
+        expect_command_capturing('config', '--replace-all', '--system', '--', 'user.name',
+                                 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', system: true)
+      end
+    end
+
+    context 'with the :local option' do
+      it 'adds --local to the command line' do
+        expect_command_capturing('config', '--replace-all', '--local', '--', 'user.name',
+                                 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', local: true)
+      end
+    end
+
+    context 'with the :worktree option' do
+      it 'adds --worktree to the command line' do
+        expect_command_capturing('config', '--replace-all', '--worktree', '--', 'user.name',
+                                 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', worktree: true)
+      end
+    end
+
+    context 'with the :file option' do
+      it 'adds --file with the path' do
+        expect_command_capturing('config', '--replace-all', '--file', '/path/to/config', '--', 'user.name',
+                                 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', file: '/path/to/config')
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('config', '--replace-all', '--file', '/path/to/config', '--', 'user.name',
+                                 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', f: '/path/to/config')
+      end
+    end
+
+    context 'with the :blob option' do
+      it 'adds --blob with the value' do
+        expect_command_capturing('config', '--replace-all', '--blob', 'HEAD:.gitmodules', '--', 'user.name',
+                                 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', blob: 'HEAD:.gitmodules')
+      end
+    end
+
+    context 'with the :type option' do
+      it 'adds --type=<value> inline' do
+        expect_command_capturing('config', '--replace-all', '--type=bool', '--', 'core.bare',
+                                 'true').and_return(command_result)
+
+        command.call('core.bare', 'true', type: 'bool')
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when name is missing' do
+        expect { command.call }.to raise_error(ArgumentError, /name/)
+      end
+
+      it 'raises ArgumentError when value is missing' do
+        expect { command.call('user.name') }.to raise_error(ArgumentError, /value/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect do
+          command.call('user.name', 'Alice', unknown: true)
+        end.to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/config_option_syntax/set_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/set_spec.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/set'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::Set do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with name and value arguments' do
+      it 'runs git config with name and value' do
+        expected_result = command_result
+        expect_command_capturing('config', '--', 'user.name', 'Alice').and_return(expected_result)
+
+        result = command.call('user.name', 'Alice')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with name, value, and value_regex' do
+      it 'adds the value_regex after the value' do
+        expect_command_capturing('config', '--', 'user.name', 'Alice', 'Bob').and_return(command_result)
+
+        command.call('user.name', 'Alice', 'Bob')
+      end
+    end
+
+    context 'with the :global option' do
+      it 'adds --global to the command line' do
+        expect_command_capturing('config', '--global', '--', 'user.name', 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', global: true)
+      end
+    end
+
+    context 'with the :system option' do
+      it 'adds --system to the command line' do
+        expect_command_capturing('config', '--system', '--', 'user.name', 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', system: true)
+      end
+    end
+
+    context 'with the :local option' do
+      it 'adds --local to the command line' do
+        expect_command_capturing('config', '--local', '--', 'user.name', 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', local: true)
+      end
+    end
+
+    context 'with the :worktree option' do
+      it 'adds --worktree to the command line' do
+        expect_command_capturing('config', '--worktree', '--', 'user.name', 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', worktree: true)
+      end
+    end
+
+    context 'with the :file option' do
+      it 'adds --file with the path' do
+        expect_command_capturing('config', '--file', '/path/to/config', '--', 'user.name',
+                                 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', file: '/path/to/config')
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('config', '--file', '/path/to/config', '--', 'user.name',
+                                 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', f: '/path/to/config')
+      end
+    end
+
+    context 'with the :blob option' do
+      it 'adds --blob with the value' do
+        expect_command_capturing('config', '--blob', 'HEAD:.gitmodules', '--', 'user.name',
+                                 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', blob: 'HEAD:.gitmodules')
+      end
+    end
+
+    context 'with the :type option' do
+      it 'adds --type=<value> inline' do
+        expect_command_capturing('config', '--type=bool', '--', 'core.bare', 'true').and_return(command_result)
+
+        command.call('core.bare', 'true', type: 'bool')
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when name is missing' do
+        expect { command.call }.to raise_error(ArgumentError, /name/)
+      end
+
+      it 'raises ArgumentError when value is missing' do
+        expect { command.call('user.name') }.to raise_error(ArgumentError, /value/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect do
+          command.call('user.name', 'Alice', unknown: true)
+        end.to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/config_option_syntax/unset_all_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/unset_all_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/unset_all'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::UnsetAll do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with a name argument' do
+      it 'runs git config --unset-all with the name' do
+        expected_result = command_result
+        expect_command_capturing('config', '--unset-all', '--', 'remote.origin.fetch').and_return(expected_result)
+
+        result = command.call('remote.origin.fetch')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with a name and value_regex' do
+      it 'adds the value_regex after the name' do
+        expect_command_capturing('config', '--unset-all', '--', 'remote.origin.fetch',
+                                 '\\+refs/heads/.*').and_return(command_result)
+
+        command.call('remote.origin.fetch', '\\+refs/heads/.*')
+      end
+    end
+
+    context 'with the :global option' do
+      it 'adds --global to the command line' do
+        expect_command_capturing('config', '--unset-all', '--global', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', global: true)
+      end
+    end
+
+    context 'with the :system option' do
+      it 'adds --system to the command line' do
+        expect_command_capturing('config', '--unset-all', '--system', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', system: true)
+      end
+    end
+
+    context 'with the :local option' do
+      it 'adds --local to the command line' do
+        expect_command_capturing('config', '--unset-all', '--local', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', local: true)
+      end
+    end
+
+    context 'with the :worktree option' do
+      it 'adds --worktree to the command line' do
+        expect_command_capturing('config', '--unset-all', '--worktree', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', worktree: true)
+      end
+    end
+
+    context 'with the :file option' do
+      it 'adds --file with the path' do
+        expect_command_capturing('config', '--unset-all', '--file', '/path/to/config', '--',
+                                 'user.name').and_return(command_result)
+
+        command.call('user.name', file: '/path/to/config')
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('config', '--unset-all', '--file', '/path/to/config', '--',
+                                 'user.name').and_return(command_result)
+
+        command.call('user.name', f: '/path/to/config')
+      end
+    end
+
+    context 'with the :blob option' do
+      it 'adds --blob with the value' do
+        expect_command_capturing('config', '--unset-all', '--blob', 'HEAD:.gitmodules', '--',
+                                 'user.name').and_return(command_result)
+
+        command.call('user.name', blob: 'HEAD:.gitmodules')
+      end
+    end
+
+    context 'exit code handling' do
+      it 'returns normally on exit status 5 (key not found)' do
+        result = command_result(exitstatus: 5)
+        expect_command_capturing('config', '--unset-all', '--', 'nonexistent.key').and_return(result)
+
+        expect(command.call('nonexistent.key')).to eq(result)
+      end
+
+      it 'raises Git::FailedError on exit status 6' do
+        result = command_result(exitstatus: 6)
+        expect_command_capturing('config', '--unset-all', '--', 'user.name').and_return(result)
+
+        expect { command.call('user.name') }.to raise_error(Git::FailedError, /git/)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when name is missing' do
+        expect { command.call }.to raise_error(ArgumentError, /name/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('user.name', unknown: true) }.to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/config_option_syntax/unset_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/unset_spec.rb
@@ -1,0 +1,112 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/config_option_syntax/unset'
+
+RSpec.describe Git::Commands::ConfigOptionSyntax::Unset do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with a name argument' do
+      it 'runs git config --unset with the name' do
+        expected_result = command_result
+        expect_command_capturing('config', '--unset', '--', 'user.name').and_return(expected_result)
+
+        result = command.call('user.name')
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with a name and value_regex' do
+      it 'adds the value_regex after the name' do
+        expect_command_capturing('config', '--unset', '--', 'user.name', 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice')
+      end
+    end
+
+    context 'with the :global option' do
+      it 'adds --global to the command line' do
+        expect_command_capturing('config', '--unset', '--global', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', global: true)
+      end
+    end
+
+    context 'with the :system option' do
+      it 'adds --system to the command line' do
+        expect_command_capturing('config', '--unset', '--system', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', system: true)
+      end
+    end
+
+    context 'with the :local option' do
+      it 'adds --local to the command line' do
+        expect_command_capturing('config', '--unset', '--local', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', local: true)
+      end
+    end
+
+    context 'with the :worktree option' do
+      it 'adds --worktree to the command line' do
+        expect_command_capturing('config', '--unset', '--worktree', '--', 'user.name').and_return(command_result)
+
+        command.call('user.name', worktree: true)
+      end
+    end
+
+    context 'with the :file option' do
+      it 'adds --file with the path' do
+        expect_command_capturing('config', '--unset', '--file', '/path/to/config', '--',
+                                 'user.name').and_return(command_result)
+
+        command.call('user.name', file: '/path/to/config')
+      end
+
+      it 'supports the :f alias' do
+        expect_command_capturing('config', '--unset', '--file', '/path/to/config', '--',
+                                 'user.name').and_return(command_result)
+
+        command.call('user.name', f: '/path/to/config')
+      end
+    end
+
+    context 'with the :blob option' do
+      it 'adds --blob with the value' do
+        expect_command_capturing('config', '--unset', '--blob', 'HEAD:.gitmodules', '--',
+                                 'user.name').and_return(command_result)
+
+        command.call('user.name', blob: 'HEAD:.gitmodules')
+      end
+    end
+
+    context 'exit code handling' do
+      it 'returns result for exit code 5 (non-existent key)' do
+        result = command_result(exitstatus: 5)
+        expect_command_capturing('config', '--unset', '--', 'nonexistent.key').and_return(result)
+
+        expect(command.call('nonexistent.key')).to eq(result)
+      end
+
+      it 'raises FailedError for exit code 6 (outside allowed range)' do
+        result = command_result(exitstatus: 6)
+        expect_command_capturing('config', '--unset', '--', 'user.name').and_return(result)
+
+        expect { command.call('user.name') }.to raise_error(Git::FailedError, /git/)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when name is missing' do
+        expect { command.call }.to raise_error(ArgumentError, /name/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('user.name', unknown: true) }.to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements the `Git::Commands::ConfigOptionSyntax` command namespace as part of the Phase 2 architectural redesign (Strangler Fig pattern), and migrates the relevant `Git::Lib` config methods to delegate to the new command classes.

## Commits

### `refactor(commands)`: Add `Git::Commands::ConfigOptionSyntax` classes

Adds 14 new command classes covering the full `git config` option-syntax surface:

| Class | Git command |
|---|---|
| `ConfigOptionSyntax::Get` | `git config --get` |
| `ConfigOptionSyntax::GetAll` | `git config --get-all` |
| `ConfigOptionSyntax::GetColor` | `git config --get-color` |
| `ConfigOptionSyntax::GetColorBool` | `git config --get-color-bool` |
| `ConfigOptionSyntax::GetRegexp` | `git config --get-regexp` |
| `ConfigOptionSyntax::GetUrlmatch` | `git config --get-urlmatch` |
| `ConfigOptionSyntax::List` | `git config --list` |
| `ConfigOptionSyntax::Set` | `git config` (set value) |
| `ConfigOptionSyntax::Add` | `git config --add` |
| `ConfigOptionSyntax::ReplaceAll` | `git config --replace-all` |
| `ConfigOptionSyntax::Unset` | `git config --unset` |
| `ConfigOptionSyntax::UnsetAll` | `git config --unset-all` |
| `ConfigOptionSyntax::RemoveSection` | `git config --remove-section` |
| `ConfigOptionSyntax::RenameSection` | `git config --rename-section` |

Each class includes comprehensive YARD documentation, unit specs, and integration specs.

### `refactor(lib)`: Migrate `Git::Lib` config methods to `ConfigOptionSyntax` commands

Delegates the following `Git::Lib` methods to the new command classes:

- `config_get` / `global_config_get` → `ConfigOptionSyntax::Get`
- `config_list` / `global_config_list` / `parse_config` → `ConfigOptionSyntax::List`
- `config_set` / `global_config_set` → `ConfigOptionSyntax::Set`

Also replaces the `CONFIG_SET_OPTION_MAP` / `ArgsBuilder.validate!` pattern with `assert_valid_opts` and `options.slice` for consistency with other adapter methods. Adds `tests/units/test_lib_config_methods.rb` covering the migrated methods.

### `docs(redesign)`: Update implementation plan

Marks the config migration complete in `redesign/3_architecture_implementation.md`, adds all 14 `ConfigOptionSyntax::*` entries to the Migrated Commands table, advances the progress tracker to 51/54, and sets the next task to `worktree`.

## Checklist

- [x] All tests pass (`rake default:parallel`)
- [x] No RuboCop violations
- [x] Unit and integration specs added for all new command classes
- [x] `Git::Lib` adapter methods remain backward compatible
- [x] Implementation plan updated
