### PR TITLE
refactor(commands): migrate Git::Lib worktree methods to Git::Commands::Worktree

### DIFF
--- a/lib/git/commands/base.rb
+++ b/lib/git/commands/base.rb
@@ -137,11 +137,32 @@ module Git
       end
 
       def execute_command(bound)
-        if bound.execution_options.key?(:out)
-          @execution_context.command_streaming(*bound, **bound.execution_options, raise_on_failure: false)
+        caller_env = bound.execution_options.fetch(:env, {}) || {}
+        merged_env = caller_env.merge(env)
+        exec_opts = bound.execution_options.except(:env)
+        exec_opts = exec_opts.merge(env: merged_env) unless merged_env.empty?
+
+        if exec_opts.key?(:out)
+          @execution_context.command_streaming(*bound, **exec_opts, raise_on_failure: false)
         else
-          @execution_context.command_capturing(*bound, **bound.execution_options, raise_on_failure: false)
+          @execution_context.command_capturing(*bound, **exec_opts, raise_on_failure: false)
         end
+      end
+
+      # Environment variable overrides to pass to the subprocess.
+      #
+      # Returns an empty hash by default. Subclasses may override this method
+      # to inject process-level environment changes required for correctness
+      # (e.g. unsetting `GIT_INDEX_FILE` for worktree management commands).
+      #
+      # The returned hash is merged with any environment overrides the caller
+      # supplies via the `env:` execution option — this hook's values win on
+      # conflict so that safety invariants cannot be accidentally overridden.
+      #
+      # @return [Hash] environment variable overrides (key: variable name, value: new value or nil to unset)
+      #
+      def env
+        {}
       end
 
       def allowed_exit_status_range

--- a/lib/git/commands/worktree.rb
+++ b/lib/git/commands/worktree.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Git
+  module Commands
+    # Implements `git worktree` subcommands for managing multiple working trees
+    #
+    # Split into subclasses because each subcommand has a distinct call shape
+    # and option set:
+    #
+    # - {Worktree::Add} — create a new linked worktree
+    # - {Worktree::List} — list all worktrees
+    # - {Worktree::Lock} — prevent a worktree from being pruned
+    # - {Worktree::Move} — move a worktree to a new location
+    # - {Worktree::Prune} — prune stale worktree administrative files
+    # - {Worktree::Remove} — remove a worktree
+    # - {Worktree::Repair} — repair worktree administrative files
+    # - {Worktree::Unlock} — allow a worktree to be pruned
+    #
+    # Management subcommands ({Add}, {Lock}, {Move}, {Prune}, {Remove},
+    # {Repair}, {Unlock}) inherit from {Worktree::ManagementBase}, which
+    # unconditionally unsets `GIT_INDEX_FILE` in the subprocess environment.
+    # Git worktrees maintain their own index files; leaving `GIT_INDEX_FILE`
+    # set causes silent corruption of both the main and the linked worktree
+    # indexes.
+    #
+    # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+    #
+    # @api private
+    #
+    module Worktree
+    end
+  end
+end

--- a/lib/git/commands/worktree/add.rb
+++ b/lib/git/commands/worktree/add.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'git/commands/worktree/management_base'
+
+module Git
+  module Commands
+    module Worktree
+      # Creates a new linked worktree
+      #
+      # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      # @api private
+      #
+      # @example Add a worktree at a path (auto-creates a branch)
+      #   Git::Commands::Worktree::Add.new(execution_context).call('/tmp/feature')
+      #
+      # @example Add a worktree and check out an existing branch
+      #   Git::Commands::Worktree::Add.new(execution_context).call('/tmp/hotfix', 'main')
+      #
+      # @example Add a worktree with a new branch
+      #   Git::Commands::Worktree::Add.new(execution_context).call('/tmp/feat', b: 'feature/new')
+      #
+      # @example Add a detached-HEAD worktree locked at creation
+      #   Git::Commands::Worktree::Add.new(execution_context).call('/tmp/exp', detach: true, lock: true)
+      #
+      class Add < ManagementBase
+        arguments do
+          literal 'worktree'
+          literal 'add'
+          flag_option %i[force f]
+          flag_option :detach
+          flag_option :checkout, negatable: true
+          flag_option :guess_remote, negatable: true
+          flag_option :track, negatable: true
+          flag_option :lock
+          flag_option %i[quiet q]
+          value_option :b
+          value_option :B
+          end_of_options
+          operand :path, required: true
+          operand :commit_ish
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(path, commit_ish = nil, **options)
+        #
+        #     Create a new linked worktree and check out `commit_ish` into it
+        #
+        #     @param path [String] filesystem path for the new worktree
+        #
+        #     @param commit_ish [String, nil] (nil) branch, tag, or commit to check out
+        #
+        #       When omitted, git creates a new branch named after the final path
+        #       component and checks it out.
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :force (nil) override safety guards
+        #
+        #       Alias: :f
+        #
+        #     @option options [Boolean] :detach (nil) check out in detached-HEAD state
+        #
+        #     @option options [Boolean] :checkout (nil) control whether the working tree
+        #       is checked out after creation
+        #
+        #       When `false`, passes `--no-checkout`, suppressing the initial checkout.
+        #
+        #     @option options [Boolean] :guess_remote (nil) base new branch on a matching
+        #       remote-tracking branch when no `commit_ish` is given
+        #
+        #       When `false`, passes `--no-guess-remote`.
+        #
+        #     @option options [Boolean] :track (nil) mark the upstream branch for tracking
+        #
+        #       When `false`, passes `--no-track`.
+        #
+        #     @option options [Boolean] :lock (nil) lock the worktree immediately after creation
+        #
+        #     @option options [Boolean] :quiet (nil) suppress informational messages
+        #
+        #       Alias: :q
+        #
+        #     @option options [String] :b (nil) create a new branch with this name and check it out
+        #
+        #     @option options [String] :B (nil) create or reset a branch with this name and check it out
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git worktree add`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/commands/worktree/list.rb
+++ b/lib/git/commands/worktree/list.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module Worktree
+      # Lists all worktrees attached to the repository
+      #
+      # @example List all worktrees in porcelain format
+      #   Git::Commands::Worktree::List.new(execution_context).call(porcelain: true)
+      #
+      # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      # @api private
+      #
+      class List < Git::Commands::Base
+        arguments do
+          literal 'worktree'
+          literal 'list'
+          flag_option :porcelain
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(**options)
+        #
+        #     List all worktrees attached to the repository
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :porcelain (nil) produce machine-readable output
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git worktree list`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/commands/worktree/lock.rb
+++ b/lib/git/commands/worktree/lock.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'git/commands/worktree/management_base'
+
+module Git
+  module Commands
+    module Worktree
+      # Locks a worktree to prevent it from being pruned
+      #
+      # @example Lock a worktree
+      #   Git::Commands::Worktree::Lock.new(execution_context).call('/tmp/feature')
+      #
+      # @example Lock with a reason message
+      #   Git::Commands::Worktree::Lock.new(execution_context).call('/tmp/feature', reason: 'on NFS share')
+      #
+      # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      # @api private
+      #
+      class Lock < ManagementBase
+        arguments do
+          literal 'worktree'
+          literal 'lock'
+          value_option :reason
+          end_of_options
+          operand :worktree, required: true
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(worktree, **options)
+        #
+        #     Lock a worktree to prevent it from being pruned
+        #
+        #     @param worktree [String] path or unique suffix identifying the worktree to lock
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [String] :reason (nil) human-readable explanation stored alongside the lock
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git worktree lock`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/commands/worktree/management_base.rb
+++ b/lib/git/commands/worktree/management_base.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module Worktree
+      # Shared base class for worktree management subcommands
+      #
+      # Overrides the `env` method from {Git::Commands::Base} to unconditionally
+      # unset `GIT_INDEX_FILE` in the subprocess environment. Git worktrees
+      # maintain their own index files; passing a `GIT_INDEX_FILE` override when
+      # running management commands causes silent corruption of both the main
+      # worktree and linked worktree indexes.
+      #
+      # All worktree management subcommands ({Add}, {Lock}, {Move}, {Prune},
+      # {Remove}, {Repair}, {Unlock}) inherit from this class. The read-only
+      # {List} subcommand uses {Git::Commands::Base} directly.
+      #
+      # @example Defining a new worktree management subcommand
+      #   class Archive < Git::Commands::Worktree::ManagementBase
+      #     arguments do
+      #       literal 'worktree'
+      #       literal 'archive'
+      #       operand :path, required: true
+      #     end
+      #   end
+      #
+      # @see Git::Commands::Base
+      #
+      # @see Git::Commands::Worktree
+      #
+      # @api private
+      #
+      class ManagementBase < Git::Commands::Base
+        private
+
+        # Returns environment variable overrides that unset `GIT_INDEX_FILE`
+        #
+        # @return [Hash] the environment variable overrides, always
+        #   `{ 'GIT_INDEX_FILE' => nil }`
+        #
+        def env
+          { 'GIT_INDEX_FILE' => nil }
+        end
+      end
+    end
+  end
+end

--- a/lib/git/commands/worktree/move.rb
+++ b/lib/git/commands/worktree/move.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'git/commands/worktree/management_base'
+
+module Git
+  module Commands
+    module Worktree
+      # Moves a linked worktree to a new filesystem location
+      #
+      # @example Move a worktree to a new path
+      #   Git::Commands::Worktree::Move.new(execution_context).call('/tmp/old', '/tmp/new')
+      #
+      # @example Force-move a locked worktree
+      #   Git::Commands::Worktree::Move.new(execution_context).call('/tmp/feat', '/tmp/feat2', force: true)
+      #
+      # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      # @api private
+      #
+      class Move < ManagementBase
+        arguments do
+          literal 'worktree'
+          literal 'move'
+          flag_option %i[force f]
+          end_of_options
+          operand :worktree, required: true
+          operand :new_path, required: true
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(worktree, new_path, **options)
+        #
+        #     Move a linked worktree to a new filesystem location
+        #
+        #     @param worktree [String] path or unique suffix identifying the worktree to move
+        #
+        #     @param new_path [String] destination path for the worktree
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :force (nil) allow moving a locked worktree
+        #
+        #       Note: force-moving when the destination is also locked or missing (requires
+        #       `--force` twice) is not yet supported.
+        #       See {https://github.com/ruby-git/ruby-git/issues/1178 issue #1178}.
+        #
+        #       Alias: :f
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git worktree move`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/commands/worktree/prune.rb
+++ b/lib/git/commands/worktree/prune.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'git/commands/worktree/management_base'
+
+module Git
+  module Commands
+    module Worktree
+      # Prunes stale worktree administrative files
+      #
+      # @example Prune stale worktree info
+      #   Git::Commands::Worktree::Prune.new(execution_context).call
+      #
+      # @example Dry-run to see what would be pruned
+      #   Git::Commands::Worktree::Prune.new(execution_context).call(dry_run: true)
+      #
+      # @example Prune entries older than 2 weeks
+      #   Git::Commands::Worktree::Prune.new(execution_context).call(expire: '2.weeks.ago')
+      #
+      # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      # @api private
+      #
+      class Prune < ManagementBase
+        arguments do
+          literal 'worktree'
+          literal 'prune'
+          flag_option %i[dry_run n]
+          flag_option %i[verbose v]
+          value_option :expire
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(**options)
+        #
+        #     Prune stale worktree administrative files
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :dry_run (nil) report what would be removed
+        #       without removing anything
+        #
+        #       Alias: :n
+        #
+        #     @option options [Boolean] :verbose (nil) report all removals
+        #
+        #       Alias: :v
+        #
+        #     @option options [String] :expire (nil) only prune entries older than
+        #       this time expression
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git worktree prune`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/commands/worktree/remove.rb
+++ b/lib/git/commands/worktree/remove.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'git/commands/worktree/management_base'
+
+module Git
+  module Commands
+    module Worktree
+      # Removes a linked worktree
+      #
+      # @example Remove a clean worktree
+      #   Git::Commands::Worktree::Remove.new(execution_context).call('/tmp/feature')
+      #
+      # @example Force-remove an unclean worktree
+      #   Git::Commands::Worktree::Remove.new(execution_context).call('/tmp/feature', force: true)
+      #
+      # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      # @api private
+      #
+      class Remove < ManagementBase
+        arguments do
+          literal 'worktree'
+          literal 'remove'
+          flag_option %i[force f]
+          end_of_options
+          operand :worktree, required: true
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(worktree, **options)
+        #
+        #     Remove a linked worktree
+        #
+        #     @param worktree [String] path or unique suffix identifying the worktree to remove
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :force (nil) remove even if the worktree has uncommitted changes
+        #
+        #       Note: removing locked worktrees (requires `--force` twice) is not yet supported.
+        #       See {https://github.com/ruby-git/ruby-git/issues/1178 issue #1178}.
+        #
+        #       Alias: :f
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git worktree remove`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/commands/worktree/repair.rb
+++ b/lib/git/commands/worktree/repair.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'git/commands/worktree/management_base'
+
+module Git
+  module Commands
+    module Worktree
+      # Repairs worktree administrative files
+      #
+      # Resolves broken links between the repository and one or more linked
+      # worktrees. Useful after a worktree directory is moved manually.
+      #
+      # @example Repair all registered worktrees
+      #   Git::Commands::Worktree::Repair.new(execution_context).call
+      #
+      # @example Repair specific moved worktrees
+      #   Git::Commands::Worktree::Repair.new(execution_context).call('/tmp/moved1', '/tmp/moved2')
+      #
+      # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      # @api private
+      #
+      class Repair < ManagementBase
+        arguments do
+          literal 'worktree'
+          literal 'repair'
+          end_of_options
+          operand :path, repeatable: true
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(*path)
+        #
+        #     Repair worktree administrative files
+        #
+        #     @param path [Array<String>] paths to specific worktrees to repair
+        #
+        #       When omitted, all registered worktrees are repaired.
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git worktree repair`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/commands/worktree/unlock.rb
+++ b/lib/git/commands/worktree/unlock.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'git/commands/worktree/management_base'
+
+module Git
+  module Commands
+    module Worktree
+      # Unlocks a worktree so it can be pruned
+      #
+      # @example Unlock a worktree
+      #   Git::Commands::Worktree::Unlock.new(execution_context).call('/tmp/feature')
+      #
+      # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      # @api private
+      #
+      class Unlock < ManagementBase
+        arguments do
+          literal 'worktree'
+          literal 'unlock'
+          end_of_options
+          operand :worktree, required: true
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(worktree)
+        #
+        #     Unlock a worktree so it can be pruned
+        #
+        #     @param worktree [String] path or unique suffix identifying the worktree
+        #       to unlock
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git worktree unlock`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero status
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -74,6 +74,15 @@ require_relative 'commands/show_ref/exists'
 require_relative 'commands/show_ref/list'
 require_relative 'commands/show_ref/verify'
 require_relative 'commands/update_ref/update'
+require_relative 'commands/worktree'
+require_relative 'commands/worktree/add'
+require_relative 'commands/worktree/list'
+require_relative 'commands/worktree/lock'
+require_relative 'commands/worktree/move'
+require_relative 'commands/worktree/prune'
+require_relative 'commands/worktree/remove'
+require_relative 'commands/worktree/repair'
+require_relative 'commands/worktree/unlock'
 require_relative 'commands/write_tree'
 
 require 'git/command_line'
@@ -770,7 +779,7 @@ module Git
       # HEAD b8c63206f8d10f57892060375a86ae911fad356e
       # detached
       #
-      command_capturing('worktree', 'list', '--porcelain').stdout.split("\n").each do |w|
+      Git::Commands::Worktree::List.new(self).call(porcelain: true).stdout.split("\n").each do |w|
         s = w.split
         directory = s[1] if s[0] == 'worktree'
         arr << [directory, s[1]] if s[0] == 'HEAD'
@@ -778,23 +787,20 @@ module Git
       arr
     end
 
-    # Environment override to exclude GIT_INDEX_FILE for worktree commands
-    # Git worktrees manage their own index files and setting GIT_INDEX_FILE
-    # causes corruption of both the main worktree and new worktree indexes.
-    WORKTREE_ENV = { 'GIT_INDEX_FILE' => nil }.freeze
-
     def worktree_add(dir, commitish = nil)
-      return command_capturing('worktree', 'add', dir, commitish, env: WORKTREE_ENV).stdout unless commitish.nil?
-
-      command_capturing('worktree', 'add', dir, env: WORKTREE_ENV).stdout
+      if commitish.nil?
+        Git::Commands::Worktree::Add.new(self).call(dir).stdout
+      else
+        Git::Commands::Worktree::Add.new(self).call(dir, commitish).stdout
+      end
     end
 
     def worktree_remove(dir)
-      command_capturing('worktree', 'remove', dir, env: WORKTREE_ENV).stdout
+      Git::Commands::Worktree::Remove.new(self).call(dir).stdout
     end
 
     def worktree_prune
-      command_capturing('worktree', 'prune', env: WORKTREE_ENV).stdout
+      Git::Commands::Worktree::Prune.new(self).call.stdout
     end
 
     def list_files(ref_dir)

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,19 +22,21 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (51/54 checklist items done, 3 remaining) |
+| Phase 2 | 🔄 In Progress | Migrating commands (50/54 checklist items done, 4 remaining) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate `worktree_add` / `worktree_remove`** → `Git::Commands::Worktree` — `git worktree`
+**Migrate `branch_contains`** → part of `Git::Commands::Branch` — `git branch --contains`
 
-Create `Git::Commands::Worktree::Add` and `Git::Commands::Worktree::Remove` (and any other relevant subcommands such as `List`, `Lock`, `Unlock`, `Move`, `Prune`) to wrap `git worktree`. Update `Git::Lib#worktree_add` and `Git::Lib#worktree_remove` to delegate to the new command classes and mark the checklist item done.
+Add a `Git::Commands::Branch::Contains` class (or extend an existing Branch command) to wrap
+`git branch --contains [<commit>]`. Update `Git::Lib#branch_contains` to delegate to the new
+command class and mark the checklist item done.
 
 #### Workflow
 
-1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def worktree_add`). Understand all options and edge cases.
+1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def branch_contains`). Understand all options and edge cases.
 
 2. **Design**: Create command class following the pattern in
    `lib/git/commands/branch/delete.rb`. The interface for `#call` should only include
@@ -970,6 +972,8 @@ The following tracks the migration status of commands from `Git::Lib` to
 | N/A (new) | `Git::Commands::ConfigOptionSyntax::Unset` | `spec/unit/git/commands/config_option_syntax/unset_spec.rb` | `git config --unset` |
 | N/A (new) | `Git::Commands::ConfigOptionSyntax::UnsetAll` | `spec/unit/git/commands/config_option_syntax/unset_all_spec.rb` | `git config --unset-all` |
 
+| `worktrees_all` / `worktree_add` / `worktree_remove` / `worktree_prune` | `Git::Commands::Worktree::List` / `Git::Commands::Worktree::Add` / `Git::Commands::Worktree::Remove` / `Git::Commands::Worktree::Prune` (+ `Lock`, `Unlock`, `Move`, `Repair`) | `spec/unit/git/commands/worktree/*_spec.rb` | `git worktree` |
+
 #### ⏳ Commands To Migrate
 
 Commands are listed in recommended migration order within each group. Migrate in
@@ -1055,7 +1059,7 @@ order: Basic Snapshotting → Branching & Merging → etc.
 
 **Other:**
 
-- [ ] `worktree_add` / `worktree_remove` → `Git::Commands::Worktree` — `git worktree`
+- [x] `worktree_add` / `worktree_remove` → `Git::Commands::Worktree` — `git worktree`
 - [ ] `branch_contains` → (part of `Git::Commands::Branch`)
 - [ ] `change_head_branch` → `Git::Commands::SymbolicRef` — `git symbolic-ref`
 - [ ] `repository_default_branch` → (part of `Git::Commands::LsRemote`)

--- a/spec/integration/git/commands/worktree/add_spec.rb
+++ b/spec/integration/git/commands/worktree/add_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'spec_helper'
+require 'git/commands/worktree/add'
+
+RSpec.describe Git::Commands::Worktree::Add, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      context 'with a path' do
+        let(:worktree_path) { File.join(repo_dir, '..', "worktree-#{SecureRandom.hex(4)}") }
+
+        after { FileUtils.rm_rf(worktree_path) }
+
+        it 'returns a CommandLineResult' do
+          result = command.call(worktree_path)
+          expect(result).to be_a(Git::CommandLineResult)
+        end
+
+        it 'creates the worktree directory on disk' do
+          command.call(worktree_path)
+          expect(File.directory?(worktree_path)).to be(true)
+        end
+
+        it 'creates a .git file in the worktree' do
+          command.call(worktree_path)
+          expect(File.exist?(File.join(worktree_path, '.git'))).to be(true)
+        end
+      end
+
+      context 'with --detach' do
+        let(:worktree_path) { File.join(repo_dir, '..', "worktree-detach-#{SecureRandom.hex(4)}") }
+
+        after { FileUtils.rm_rf(worktree_path) }
+
+        it 'creates a detached HEAD worktree' do
+          result = command.call(worktree_path, detach: true)
+          expect(result).to be_a(Git::CommandLineResult)
+          expect(File.directory?(worktree_path)).to be(true)
+        end
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for a nonexistent commit-ish' do
+        worktree_path = File.join(repo_dir, '..', "worktree-fail-#{SecureRandom.hex(4)}")
+        expect { command.call(worktree_path, 'nonexistent-branch-xyz') }
+          .to raise_error(Git::FailedError, /nonexistent-branch-xyz/)
+      ensure
+        FileUtils.rm_rf(worktree_path)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/worktree/list_spec.rb
+++ b/spec/integration/git/commands/worktree/list_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/worktree/list'
+
+RSpec.describe Git::Commands::Worktree::List, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult with no options' do
+        result = command.call
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns a CommandLineResult with the :porcelain option' do
+        result = command.call(porcelain: true)
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError when not in a git repository' do
+        FileUtils.rm_rf(File.join(repo_dir, '.git'))
+        expect { command.call }.to raise_error(Git::FailedError, /not a git repository/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/worktree/lock_spec.rb
+++ b/spec/integration/git/commands/worktree/lock_spec.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'spec_helper'
+require 'git/commands/worktree/add'
+require 'git/commands/worktree/lock'
+
+RSpec.describe Git::Commands::Worktree::Lock, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      let(:worktree_path) { File.join(repo_dir, '..', "worktree-lock-#{SecureRandom.hex(4)}") }
+
+      before { Git::Commands::Worktree::Add.new(execution_context).call(worktree_path) }
+      after { FileUtils.rm_rf(worktree_path) }
+
+      it 'returns a CommandLineResult' do
+        result = command.call(worktree_path)
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'locks the worktree with a reason' do
+        result = command.call(worktree_path, reason: 'on NFS share')
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for a nonexistent worktree path' do
+        expect { command.call('/nonexistent/path/xyz') }
+          .to raise_error(Git::FailedError)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/worktree/move_spec.rb
+++ b/spec/integration/git/commands/worktree/move_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'spec_helper'
+require 'git/commands/worktree/move'
+
+RSpec.describe Git::Commands::Worktree::Move, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      let(:src_path) { File.join(repo_dir, '..', "worktree-src-#{SecureRandom.hex(4)}") }
+      let(:dst_path) { File.join(repo_dir, '..', "worktree-dst-#{SecureRandom.hex(4)}") }
+
+      before do
+        execution_context.command_capturing(
+          'worktree', 'add', '--', src_path,
+          env: { 'GIT_INDEX_FILE' => nil }
+        )
+      end
+
+      after do
+        FileUtils.rm_rf(src_path)
+        FileUtils.rm_rf(dst_path)
+      end
+
+      it 'returns a CommandLineResult' do
+        result = command.call(src_path, dst_path)
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for a nonexistent worktree path' do
+        expect { command.call('/nonexistent/path/xyz', '/tmp/dst') }
+          .to raise_error(Git::FailedError, /nonexistent/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/worktree/prune_spec.rb
+++ b/spec/integration/git/commands/worktree/prune_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/worktree/prune'
+
+RSpec.describe Git::Commands::Worktree::Prune, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult' do
+        result = command.call
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns a CommandLineResult with --dry-run' do
+        result = command.call(dry_run: true)
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns a CommandLineResult with --verbose' do
+        result = command.call(verbose: true)
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError when not in a git repository' do
+        FileUtils.rm_rf(File.join(repo_dir, '.git'))
+        expect { command.call }
+          .to raise_error(Git::FailedError, /not a git repository/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/worktree/remove_spec.rb
+++ b/spec/integration/git/commands/worktree/remove_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'spec_helper'
+require 'git/commands/worktree/remove'
+
+RSpec.describe Git::Commands::Worktree::Remove, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      let(:worktree_path) { File.join(repo_dir, '..', "worktree-remove-#{SecureRandom.hex(4)}") }
+
+      before do
+        execution_context.command_capturing('worktree', 'add', '--', worktree_path, env: { 'GIT_INDEX_FILE' => nil })
+      end
+      after { FileUtils.rm_rf(worktree_path) }
+
+      it 'returns a CommandLineResult' do
+        result = command.call(worktree_path)
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'removes the worktree directory from disk' do
+        command.call(worktree_path)
+        expect(File.directory?(worktree_path)).to be(false)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for a nonexistent worktree path' do
+        expect { command.call('/nonexistent/path/xyz') }
+          .to raise_error(Git::FailedError, /nonexistent/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/worktree/repair_spec.rb
+++ b/spec/integration/git/commands/worktree/repair_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/worktree/repair'
+
+RSpec.describe Git::Commands::Worktree::Repair, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult' do
+        # git worktree repair inspects the CWD to detect linked worktree context;
+        # run from within the repo directory so it does not mistakenly scan the
+        # test runner's CWD.
+        Dir.chdir(repo_dir) do
+          result = command.call
+          expect(result).to be_a(Git::CommandLineResult)
+        end
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError outside a git repository' do
+        Dir.mktmpdir do |tmpdir|
+          non_repo = Git.init(tmpdir, initial_branch: 'main')
+          FileUtils.rm_rf(File.join(tmpdir, '.git'))
+          non_git_command = described_class.new(non_repo.lib)
+          expect { non_git_command.call }
+            .to raise_error(Git::FailedError, /not a git repository/)
+        end
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/worktree/unlock_spec.rb
+++ b/spec/integration/git/commands/worktree/unlock_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'spec_helper'
+require 'git/commands/worktree/unlock'
+
+RSpec.describe Git::Commands::Worktree::Unlock, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      let(:worktree_path) { File.join(repo_dir, '..', "worktree-unlock-#{SecureRandom.hex(4)}") }
+
+      before do
+        execution_context.command_capturing('worktree', 'add', worktree_path, env: { 'GIT_INDEX_FILE' => nil })
+        execution_context.command_capturing('worktree', 'lock', '--', worktree_path, env: { 'GIT_INDEX_FILE' => nil })
+      end
+
+      after { FileUtils.rm_rf(worktree_path) }
+
+      it 'returns a CommandLineResult' do
+        result = command.call(worktree_path)
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for a nonexistent path' do
+        expect { command.call('/nonexistent/path/xyz') }
+          .to raise_error(Git::FailedError, /nonexistent/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/worktree/add_spec.rb
+++ b/spec/unit/git/commands/worktree/add_spec.rb
@@ -1,0 +1,151 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/worktree/add'
+
+RSpec.describe Git::Commands::Worktree::Add do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+  let(:worktree_env) { { 'GIT_INDEX_FILE' => nil } }
+
+  describe '#call' do
+    context 'with path only' do
+      it 'runs worktree add with the path' do
+        expected_result = command_result('')
+        expect_command_capturing('worktree', 'add', '--', '/tmp/feature', env: worktree_env)
+          .and_return(expected_result)
+
+        result = command.call('/tmp/feature')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with path and commit-ish' do
+      it 'passes the commit-ish after path' do
+        expect_command_capturing('worktree', 'add', '--', '/tmp/hotfix', 'main', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/hotfix', 'main')
+      end
+    end
+
+    context 'with :force option' do
+      it 'adds --force flag' do
+        expect_command_capturing('worktree', 'add', '--force', '--', '/tmp/feat', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/feat', force: true)
+      end
+
+      it 'accepts :f alias' do
+        expect_command_capturing('worktree', 'add', '--force', '--', '/tmp/feat', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/feat', f: true)
+      end
+    end
+
+    context 'with :detach option' do
+      it 'adds --detach flag' do
+        expect_command_capturing('worktree', 'add', '--detach', '--', '/tmp/exp', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/exp', detach: true)
+      end
+    end
+
+    context 'with :checkout option' do
+      it 'adds --checkout when true' do
+        expect_command_capturing('worktree', 'add', '--checkout', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', checkout: true)
+      end
+
+      it 'adds --no-checkout when false' do
+        expect_command_capturing('worktree', 'add', '--no-checkout', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', checkout: false)
+      end
+    end
+
+    context 'with :lock option' do
+      it 'adds --lock flag' do
+        expect_command_capturing('worktree', 'add', '--lock', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', lock: true)
+      end
+    end
+
+    context 'with :quiet option' do
+      it 'adds --quiet flag' do
+        expect_command_capturing('worktree', 'add', '--quiet', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', quiet: true)
+      end
+
+      it 'accepts :q alias' do
+        expect_command_capturing('worktree', 'add', '--quiet', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', q: true)
+      end
+    end
+
+    context 'with :b option' do
+      it 'adds -b with branch name' do
+        expect_command_capturing('worktree', 'add', '-b', 'feature/new', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', b: 'feature/new')
+      end
+    end
+
+    context 'with :B option' do
+      it 'adds -B with branch name' do
+        expect_command_capturing('worktree', 'add', '-B', 'feature/new', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', B: 'feature/new')
+      end
+    end
+
+    context 'with :guess_remote option' do
+      it 'adds --guess-remote when true' do
+        expect_command_capturing('worktree', 'add', '--guess-remote', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', guess_remote: true)
+      end
+
+      it 'adds --no-guess-remote when false' do
+        expect_command_capturing('worktree', 'add', '--no-guess-remote', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', guess_remote: false)
+      end
+    end
+
+    context 'with :track option' do
+      it 'adds --track when true' do
+        expect_command_capturing('worktree', 'add', '--track', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', track: true)
+      end
+
+      it 'adds --no-track when false' do
+        expect_command_capturing('worktree', 'add', '--no-track', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', track: false)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/worktree/list_spec.rb
+++ b/spec/unit/git/commands/worktree/list_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/worktree/list'
+
+RSpec.describe Git::Commands::Worktree::List do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with no options' do
+      it 'runs worktree list with no flags' do
+        expected_result = command_result("/repo  abc1234 [main]\n")
+        expect_command_capturing('worktree', 'list').and_return(expected_result)
+
+        result = command.call
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with :porcelain option' do
+      it 'includes the --porcelain flag' do
+        expect_command_capturing('worktree', 'list', '--porcelain')
+          .and_return(command_result("worktree /repo\nHEAD abc1234\nbranch refs/heads/main\n\n"))
+
+        command.call(porcelain: true)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/worktree/lock_spec.rb
+++ b/spec/unit/git/commands/worktree/lock_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/worktree/lock'
+
+RSpec.describe Git::Commands::Worktree::Lock do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+  let(:worktree_env) { { 'GIT_INDEX_FILE' => nil } }
+
+  describe '#call' do
+    context 'with worktree path only' do
+      it 'runs worktree lock with the path' do
+        expected_result = command_result('')
+        expect_command_capturing('worktree', 'lock', '--', '/tmp/feature', env: worktree_env)
+          .and_return(expected_result)
+
+        result = command.call('/tmp/feature')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with :reason option' do
+      it 'adds --reason with value' do
+        expect_command_capturing(
+          'worktree', 'lock', '--reason', 'on NFS share', '--', '/tmp/feature', env: worktree_env
+        ).and_return(command_result(''))
+
+        command.call('/tmp/feature', reason: 'on NFS share')
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/worktree/move_spec.rb
+++ b/spec/unit/git/commands/worktree/move_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/worktree/move'
+
+RSpec.describe Git::Commands::Worktree::Move do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+  let(:worktree_env) { { 'GIT_INDEX_FILE' => nil } }
+
+  describe '#call' do
+    context 'with worktree and new path' do
+      it 'runs worktree move with both paths' do
+        expected_result = command_result('')
+        expect_command_capturing('worktree', 'move', '--', '/tmp/old', '/tmp/new', env: worktree_env)
+          .and_return(expected_result)
+
+        result = command.call('/tmp/old', '/tmp/new')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with :force option' do
+      it 'adds --force flag' do
+        expect_command_capturing('worktree', 'move', '--force', '--', '/tmp/old', '/tmp/new', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/old', '/tmp/new', force: true)
+      end
+
+      it 'accepts :f alias' do
+        expect_command_capturing('worktree', 'move', '--force', '--', '/tmp/old', '/tmp/new', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/old', '/tmp/new', f: true)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/worktree/prune_spec.rb
+++ b/spec/unit/git/commands/worktree/prune_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/worktree/prune'
+
+RSpec.describe Git::Commands::Worktree::Prune do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+  let(:worktree_env) { { 'GIT_INDEX_FILE' => nil } }
+
+  describe '#call' do
+    context 'with no options' do
+      it 'runs worktree prune with no flags' do
+        expected_result = command_result('')
+        expect_command_capturing('worktree', 'prune', env: worktree_env)
+          .and_return(expected_result)
+
+        result = command.call
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with :dry_run option' do
+      it 'adds --dry-run flag' do
+        expect_command_capturing('worktree', 'prune', '--dry-run', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call(dry_run: true)
+      end
+
+      it 'accepts :n alias' do
+        expect_command_capturing('worktree', 'prune', '--dry-run', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call(n: true)
+      end
+    end
+
+    context 'with :verbose option' do
+      it 'adds --verbose flag' do
+        expect_command_capturing('worktree', 'prune', '--verbose', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call(verbose: true)
+      end
+
+      it 'accepts :v alias' do
+        expect_command_capturing('worktree', 'prune', '--verbose', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call(v: true)
+      end
+    end
+
+    context 'with :expire option' do
+      it 'adds --expire with value' do
+        expect_command_capturing('worktree', 'prune', '--expire', '2.weeks.ago', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call(expire: '2.weeks.ago')
+      end
+    end
+
+    context 'with multiple options' do
+      it 'includes all specified flags in correct order' do
+        expect_command_capturing('worktree', 'prune', '--dry-run', '--verbose', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call(dry_run: true, verbose: true)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/worktree/remove_spec.rb
+++ b/spec/unit/git/commands/worktree/remove_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/worktree/remove'
+
+RSpec.describe Git::Commands::Worktree::Remove do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+  let(:worktree_env) { { 'GIT_INDEX_FILE' => nil } }
+
+  describe '#call' do
+    context 'with worktree path' do
+      it 'runs worktree remove with the path' do
+        expected_result = command_result('')
+        expect_command_capturing('worktree', 'remove', '--', '/tmp/feature', env: worktree_env)
+          .and_return(expected_result)
+
+        result = command.call('/tmp/feature')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with :force option' do
+      it 'adds --force flag' do
+        expect_command_capturing('worktree', 'remove', '--force', '--', '/tmp/feature', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/feature', force: true)
+      end
+
+      it 'accepts :f alias' do
+        expect_command_capturing('worktree', 'remove', '--force', '--', '/tmp/feature', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/feature', f: true)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/worktree/repair_spec.rb
+++ b/spec/unit/git/commands/worktree/repair_spec.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/worktree/repair'
+
+RSpec.describe Git::Commands::Worktree::Repair do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+  let(:worktree_env) { { 'GIT_INDEX_FILE' => nil } }
+
+  describe '#call' do
+    context 'with no arguments' do
+      it 'runs worktree repair with no operands' do
+        expected_result = command_result('')
+        expect_command_capturing('worktree', 'repair', env: worktree_env)
+          .and_return(expected_result)
+
+        result = command.call
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with specific paths' do
+      it 'passes each path as an operand' do
+        expect_command_capturing('worktree', 'repair', '--', '/tmp/moved1', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/moved1')
+      end
+
+      it 'passes multiple paths' do
+        expect_command_capturing('worktree', 'repair', '--', '/tmp/moved1', '/tmp/moved2', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/moved1', '/tmp/moved2')
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/worktree/unlock_spec.rb
+++ b/spec/unit/git/commands/worktree/unlock_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/worktree/unlock'
+
+RSpec.describe Git::Commands::Worktree::Unlock do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+  let(:worktree_env) { { 'GIT_INDEX_FILE' => nil } }
+
+  describe '#call' do
+    context 'with worktree path' do
+      it 'runs worktree unlock with the path' do
+        expected_result = command_result('')
+        expect_command_capturing('worktree', 'unlock', '--', '/tmp/feature', env: worktree_env)
+          .and_return(expected_result)
+
+        result = command.call('/tmp/feature')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError when no worktree is provided' do
+        expect { command.call }
+          .to raise_error(ArgumentError, /worktree is required/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('/tmp/feature', foo: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/tests/units/test_command_line_env_overrides.rb
+++ b/tests/units/test_command_line_env_overrides.rb
@@ -93,15 +93,6 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
     end
   end
 
-  test 'WORKTREE_ENV constant should exclude GIT_INDEX_FILE from environment' do
-    # WORKTREE_ENV is used by worktree commands to prevent index corruption
-    # by setting GIT_INDEX_FILE to nil (which unsets it per Process.spawn semantics)
-    worktree_env = Git::Lib::WORKTREE_ENV
-
-    assert_nil worktree_env['GIT_INDEX_FILE']
-    assert worktree_env.frozen?, 'WORKTREE_ENV should be frozen'
-  end
-
   test 'env_overrides should allow both adding and excluding variables simultaneously' do
     in_temp_dir do |_path|
       git = Git.init('test_project')


### PR DESCRIPTION
## Summary

Migrates `git worktree` operations from direct `command_capturing` calls in `Git::Lib` to a new family of `Git::Commands::Worktree::*` command classes, following the Strangler Fig architecture redesign (Phase 2).

## Changes

### New command classes (`lib/git/commands/worktree/`)

| Class | Git subcommand |
|-------|---------------|
| `Git::Commands::Worktree::Add` | `git worktree add` |
| `Git::Commands::Worktree::List` | `git worktree list` |
| `Git::Commands::Worktree::Lock` | `git worktree lock` |
| `Git::Commands::Worktree::Unlock` | `git worktree unlock` |
| `Git::Commands::Worktree::Move` | `git worktree move` |
| `Git::Commands::Worktree::Prune` | `git worktree prune` |
| `Git::Commands::Worktree::Remove` | `git worktree remove` |
| `Git::Commands::Worktree::Repair` | `git worktree repair` |

A shared `Git::Commands::Worktree::ManagementBase` intermediate class overrides `#env` to inject `GIT_INDEX_FILE=nil`, replacing the `WORKTREE_ENV` constant previously used in `Git::Lib`. This ensures all worktree mutation commands unset the index file regardless of how they are called.

### `lib/git/lib.rb`

Delegated `#worktrees_all`, `#worktree_add`, `#worktree_remove`, and `#worktree_prune` to the new command classes.

### Tests

- Unit specs for all 8 new command classes under `spec/unit/git/commands/worktree/`
- Integration specs for all 8 new command classes under `spec/integration/git/commands/worktree/`

## Checklist

- [x] All new command classes follow `Git::Commands::Base` architecture
- [x] `ManagementBase` centralises `GIT_INDEX_FILE` env override
- [x] `Git::Lib` delegation preserves existing public API behaviour
- [x] Unit and integration tests for every new command class
- [x] Redesign implementation doc updated (checklist item marked done, next task set)
