### PR TITLE
test(commands): add unit tests for Git::Lib#branch_contains delegation

### DIFF
--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,21 +22,20 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (50/54 checklist items done, 4 remaining) |
+| Phase 2 | 🔄 In Progress | Migrating commands (51/54 checklist items done, 3 remaining) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate `branch_contains`** → part of `Git::Commands::Branch` — `git branch --contains`
+**Migrate `change_head_branch`** → `Git::Commands::SymbolicRef` — `git symbolic-ref`
 
-Add a `Git::Commands::Branch::Contains` class (or extend an existing Branch command) to wrap
-`git branch --contains [<commit>]`. Update `Git::Lib#branch_contains` to delegate to the new
-command class and mark the checklist item done.
+Create a `Git::Commands::SymbolicRef` class to wrap `git symbolic-ref`. Update
+`Git::Lib#change_head_branch` to delegate to the new command class and mark the checklist item done.
 
 #### Workflow
 
-1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def branch_contains`). Understand all options and edge cases.
+1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def change_head_branch`). Understand all options and edge cases.
 
 2. **Design**: Create command class following the pattern in
    `lib/git/commands/branch/delete.rb`. The interface for `#call` should only include
@@ -161,7 +160,10 @@ command class and mark the checklist item done.
 
 7. **Update Checklist**: Move the command from "Commands To Migrate" to "Migrated
    Commands" table in this document, and update the "Next Task" section to point to
-   the next command in the list.
+   the next command in the list. When updating "Next Task", also update the Workflow
+   steps below it — they contain method names and search strings specific to the
+   previous task (e.g. the `def <method>` reference in step 1) that must be changed
+   to match the new task.
 
 #### Reference Files
 
@@ -1060,7 +1062,7 @@ order: Basic Snapshotting → Branching & Merging → etc.
 **Other:**
 
 - [x] `worktree_add` / `worktree_remove` → `Git::Commands::Worktree` — `git worktree`
-- [ ] `branch_contains` → (part of `Git::Commands::Branch`)
+- [x] `branch_contains` → (part of `Git::Commands::Branch`)
 - [ ] `change_head_branch` → `Git::Commands::SymbolicRef` — `git symbolic-ref`
 - [ ] `repository_default_branch` → (part of `Git::Commands::LsRemote`)
 - [ ] `current_command_version` → `Git::Commands::Version` — `git version`

--- a/spec/unit/git/lib_command_spec.rb
+++ b/spec/unit/git/lib_command_spec.rb
@@ -1135,4 +1135,74 @@ RSpec.describe Git::Lib do
       end
     end
   end
+
+  describe '#branch_contains' do
+    let(:list_command) { instance_double(Git::Commands::Branch::List) }
+    let(:format_string) { Git::Parsers::Branch::FORMAT_STRING }
+
+    before do
+      allow(Git::Commands::Branch::List).to receive(:new).with(lib).and_return(list_command)
+    end
+
+    context 'when called with only a commit (no branch_name)' do
+      it 'delegates to Branch::List with contains: and format: and no pattern' do
+        allow(list_command).to receive(:call)
+          .with(contains: 'abc123', format: format_string)
+          .and_return(command_result("refs/heads/main|abc123|*|||\n"))
+
+        lib.branch_contains('abc123')
+
+        expect(list_command).to have_received(:call)
+          .with(contains: 'abc123', format: format_string)
+      end
+
+      it 'returns the stdout of the command' do
+        output = "refs/heads/main|abc123|*|||\n"
+        allow(list_command).to receive(:call).and_return(command_result(output))
+
+        result = lib.branch_contains('abc123')
+
+        expect(result).to eq(output)
+      end
+    end
+
+    context 'when called with an explicit branch_name pattern' do
+      it 'passes the branch_name as a positional pattern to Branch::List' do
+        allow(list_command).to receive(:call)
+          .with('feature/*', contains: 'abc123', format: format_string)
+          .and_return(command_result(''))
+
+        lib.branch_contains('abc123', 'feature/*')
+
+        expect(list_command).to have_received(:call)
+          .with('feature/*', contains: 'abc123', format: format_string)
+      end
+    end
+
+    context 'when branch_name is an empty string (default)' do
+      it 'does not pass a pattern argument' do
+        allow(list_command).to receive(:call)
+          .with(contains: 'abc123', format: format_string)
+          .and_return(command_result(''))
+
+        lib.branch_contains('abc123', '')
+
+        expect(list_command).to have_received(:call)
+          .with(contains: 'abc123', format: format_string)
+      end
+    end
+
+    context 'when branch_name is nil' do
+      it 'treats nil as empty string and does not pass a pattern' do
+        allow(list_command).to receive(:call)
+          .with(contains: 'abc123', format: format_string)
+          .and_return(command_result(''))
+
+        lib.branch_contains('abc123', nil)
+
+        expect(list_command).to have_received(:call)
+          .with(contains: 'abc123', format: format_string)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Git::Lib#branch_contains` already delegates to `Git::Commands::Branch::List`
using the `:contains` filter option — the command migration was already done but
lacked unit tests and the checklist entry was unchecked.

This PR adds the missing unit tests and marks the checklist item complete.

## Changes

### `spec/unit/git/lib_command_spec.rb`

Adds a `describe '#branch_contains'` block with 5 examples covering:

- Delegates to `Branch::List` with `contains:` and `format:` when no pattern given
- Returns the stdout from the command
- Passes an explicit `branch_name` as a positional pattern to `Branch::List`
- Omits the pattern argument when `branch_name` is an empty string (the default)
- Omits the pattern argument when `branch_name` is `nil`

### `redesign/3_architecture_implementation.md`

- Progress tracker updated: 50/54 → **51/54** migration items done
- `branch_contains` checklist entry marked `[x]`
- "Next Task" advanced to `change_head_branch` → `Git::Commands::SymbolicRef`

## Design note

`--contains` is a list-filter option on `git branch --list`, not an operation
selector, so no separate `Branch::Contains` class was created. The existing
`Git::Commands::Branch::List` class already exposes `contains:` as a
`flag_or_value_option` in its Arguments DSL.

## Test results

```
88 examples, 0 failures
```
