### PR TITLE
feat: add Git::Commands::SymbolicRef command classes

### DIFF
--- a/lib/git/commands/symbolic_ref.rb
+++ b/lib/git/commands/symbolic_ref.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require_relative 'symbolic_ref/delete'
+require_relative 'symbolic_ref/read'
+require_relative 'symbolic_ref/update'
+
+module Git
+  module Commands
+    # Commands for reading, updating, and deleting symbolic refs via
+    # `git symbolic-ref`
+    #
+    # This module contains command classes split by invocation mode:
+    #
+    # - {SymbolicRef::Read} — read the target of a symbolic ref
+    # - {SymbolicRef::Update} — create or update a symbolic ref to point
+    #   at a given branch
+    # - {SymbolicRef::Delete} — delete a symbolic ref
+    #
+    # @api private
+    #
+    # @see https://git-scm.com/docs/git-symbolic-ref git-symbolic-ref documentation
+    #
+    # @example Read the current HEAD
+    #   cmd = Git::Commands::SymbolicRef::Read.new(lib)
+    #   cmd.call('HEAD')
+    #
+    # @example Update HEAD to point to a branch
+    #   cmd = Git::Commands::SymbolicRef::Update.new(lib)
+    #   cmd.call('HEAD', 'refs/heads/main')
+    #
+    # @example Delete a symbolic ref
+    #   cmd = Git::Commands::SymbolicRef::Delete.new(lib)
+    #   cmd.call('HEAD')
+    #
+    module SymbolicRef
+    end
+  end
+end

--- a/lib/git/commands/symbolic_ref/delete.rb
+++ b/lib/git/commands/symbolic_ref/delete.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module SymbolicRef
+      # Deletes a symbolic ref via `git symbolic-ref --delete`
+      #
+      # Removes the named symbolic ref. When `quiet: true`, exit status 1
+      # (non-symbolic ref) does not produce an error message.
+      #
+      # @example Delete a symbolic ref
+      #   cmd = Git::Commands::SymbolicRef::Delete.new(execution_context)
+      #   cmd.call('HEAD')
+      #
+      # @see Git::Commands::SymbolicRef
+      #
+      # @see https://git-scm.com/docs/git-symbolic-ref git-symbolic-ref documentation
+      #
+      # @api private
+      #
+      class Delete < Git::Commands::Base
+        arguments do
+          literal 'symbolic-ref'
+
+          # Delete the symbolic ref
+          literal '--delete'
+
+          # Suppress error message for non-symbolic (detached) refs
+          flag_option %i[quiet q]
+
+          end_of_options
+
+          # The symbolic ref name to delete (e.g. `HEAD`)
+          operand :name, required: true
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name, **options)
+        #
+        #     Execute the `git symbolic-ref --delete` command
+        #
+        #     @param name [String] the symbolic ref name to delete
+        #       (e.g. `HEAD`)
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :quiet (nil) suppress error message
+        #       when the name is not a symbolic ref
+        #
+        #       Alias: :q
+        #
+        #     @return [Git::CommandLineResult] the result of calling
+        #       `git symbolic-ref --delete`
+        #
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [ArgumentError] if the name operand is missing
+        #
+        #     @raise [Git::FailedError] if the command returns a non-zero
+        #       exit status
+      end
+    end
+  end
+end

--- a/lib/git/commands/symbolic_ref/read.rb
+++ b/lib/git/commands/symbolic_ref/read.rb
@@ -1,0 +1,84 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module SymbolicRef
+      # Reads the target of a symbolic ref via `git symbolic-ref`
+      #
+      # Given one argument, reads which branch head the given symbolic ref
+      # refers to and outputs its path, relative to the `.git/` directory.
+      #
+      # Exits with status 0 if the contents were printed correctly, or
+      # status 1 if the requested name is not a symbolic ref (e.g. a
+      # detached HEAD). When `quiet: true`, exit status 1 is silent
+      # (no error message on stderr).
+      #
+      # @example Read current HEAD
+      #   cmd = Git::Commands::SymbolicRef::Read.new(execution_context)
+      #   result = cmd.call('HEAD')
+      #   result.stdout  # => "refs/heads/main"
+      #
+      # @example Read HEAD with shortened output
+      #   cmd = Git::Commands::SymbolicRef::Read.new(execution_context)
+      #   result = cmd.call('HEAD', short: true)
+      #   result.stdout  # => "main"
+      #
+      # @see Git::Commands::SymbolicRef
+      #
+      # @see https://git-scm.com/docs/git-symbolic-ref git-symbolic-ref documentation
+      #
+      # @api private
+      #
+      class Read < Git::Commands::Base
+        arguments do
+          literal 'symbolic-ref'
+
+          # Suppress error message for non-symbolic (detached) refs
+          flag_option %i[quiet q]
+
+          # Shorten the ref output (e.g. `refs/heads/main` → `main`)
+          flag_option :short
+
+          end_of_options
+
+          # The symbolic ref name to read (e.g. `HEAD`)
+          operand :name, required: true
+        end
+
+        # Exit status 1 indicates the name is not a symbolic ref
+        # (e.g. detached HEAD) — this is not an error
+        allow_exit_status 0..1
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name, **options)
+        #
+        #     Execute the `git symbolic-ref` command to read a symbolic ref
+        #
+        #     @param name [String] the symbolic ref name to read
+        #       (e.g. `HEAD`)
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :quiet (nil) suppress error message
+        #       when the name is not a symbolic ref
+        #
+        #       Alias: :q
+        #
+        #     @option options [Boolean] :short (nil) shorten the ref output
+        #       (e.g. `refs/heads/main` → `main`)
+        #
+        #     @return [Git::CommandLineResult] the result of calling
+        #       `git symbolic-ref`
+        #
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [ArgumentError] if the name operand is missing
+        #
+        #     @raise [Git::FailedError] if git exits with status >= 2
+      end
+    end
+  end
+end

--- a/lib/git/commands/symbolic_ref/update.rb
+++ b/lib/git/commands/symbolic_ref/update.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    module SymbolicRef
+      # Creates or updates a symbolic ref via `git symbolic-ref`
+      #
+      # Given two arguments, creates or updates a symbolic ref `<name>` to
+      # point at the given branch `<ref>`.
+      #
+      # @example Update HEAD to point to a branch
+      #   cmd = Git::Commands::SymbolicRef::Update.new(execution_context)
+      #   cmd.call('HEAD', 'refs/heads/main')
+      #
+      # @example Update HEAD with a reflog message
+      #   cmd = Git::Commands::SymbolicRef::Update.new(execution_context)
+      #   cmd.call('HEAD', 'refs/heads/main', m: 'switching to main')
+      #
+      # @see Git::Commands::SymbolicRef
+      #
+      # @see https://git-scm.com/docs/git-symbolic-ref git-symbolic-ref documentation
+      #
+      # @api private
+      #
+      class Update < Git::Commands::Base
+        arguments do
+          literal 'symbolic-ref'
+
+          # Reflog message for the update
+          value_option :m
+
+          end_of_options
+
+          # The symbolic ref name to update (e.g. `HEAD`)
+          operand :name, required: true
+
+          # The target ref to point to (e.g. `refs/heads/main`)
+          operand :ref, required: true
+        end
+
+        # @!method call(*, **)
+        #
+        #   @overload call(name, ref, **options)
+        #
+        #     Execute the `git symbolic-ref` command to create or update a
+        #     symbolic ref
+        #
+        #     @param name [String] the symbolic ref name to update
+        #       (e.g. `HEAD`)
+        #
+        #     @param ref [String] the target ref to point to
+        #       (e.g. `refs/heads/main`)
+        #
+        #     @param options [Hash] command options
+        #
+        #     @option options [String] :m (nil) a reflog message for
+        #       the update
+        #
+        #     @return [Git::CommandLineResult] the result of calling
+        #       `git symbolic-ref`
+        #
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [ArgumentError] if the name or ref operand is missing
+        #
+        #     @raise [Git::FailedError] if the command returns a non-zero
+        #       exit status
+      end
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -62,6 +62,7 @@ require_relative 'commands/config_option_syntax/list'
 require_relative 'commands/config_option_syntax/set'
 require_relative 'commands/show'
 require_relative 'commands/status'
+require_relative 'commands/symbolic_ref/update'
 require_relative 'commands/tag/create'
 require_relative 'commands/tag/delete'
 require_relative 'commands/tag/list'
@@ -759,7 +760,7 @@ module Git
     end
 
     def change_head_branch(branch_name)
-      command_capturing('symbolic-ref', 'HEAD', "refs/heads/#{branch_name}")
+      Git::Commands::SymbolicRef::Update.new(self).call('HEAD', "refs/heads/#{branch_name}")
     end
 
     def branches_all

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,20 +22,21 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (51/54 checklist items done, 3 remaining) |
+| Phase 2 | 🔄 In Progress | Migrating commands (52/54 checklist items done, 2 remaining) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate `change_head_branch`** → `Git::Commands::SymbolicRef` — `git symbolic-ref`
+**Migrate `repository_default_branch`** → `Git::Commands::LsRemote` — `git ls-remote`
 
-Create a `Git::Commands::SymbolicRef` class to wrap `git symbolic-ref`. Update
-`Git::Lib#change_head_branch` to delegate to the new command class and mark the checklist item done.
+The `repository_default_branch` method already delegates to `Git::Commands::LsRemote`,
+but the checklist item is not yet marked done. Review the delegation and mark the
+checklist item done.
 
 #### Workflow
 
-1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def change_head_branch`). Understand all options and edge cases.
+1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def repository_default_branch`). Understand all options and edge cases.
 
 2. **Design**: Create command class following the pattern in
    `lib/git/commands/branch/delete.rb`. The interface for `#call` should only include
@@ -975,6 +976,7 @@ The following tracks the migration status of commands from `Git::Lib` to
 | N/A (new) | `Git::Commands::ConfigOptionSyntax::UnsetAll` | `spec/unit/git/commands/config_option_syntax/unset_all_spec.rb` | `git config --unset-all` |
 
 | `worktrees_all` / `worktree_add` / `worktree_remove` / `worktree_prune` | `Git::Commands::Worktree::List` / `Git::Commands::Worktree::Add` / `Git::Commands::Worktree::Remove` / `Git::Commands::Worktree::Prune` (+ `Lock`, `Unlock`, `Move`, `Repair`) | `spec/unit/git/commands/worktree/*_spec.rb` | `git worktree` |
+| `change_head_branch` | `Git::Commands::SymbolicRef::Update` (+ `Read`, `Delete`) | `spec/unit/git/commands/symbolic_ref/*_spec.rb` | `git symbolic-ref` |
 
 #### ⏳ Commands To Migrate
 
@@ -1063,7 +1065,7 @@ order: Basic Snapshotting → Branching & Merging → etc.
 
 - [x] `worktree_add` / `worktree_remove` → `Git::Commands::Worktree` — `git worktree`
 - [x] `branch_contains` → (part of `Git::Commands::Branch`)
-- [ ] `change_head_branch` → `Git::Commands::SymbolicRef` — `git symbolic-ref`
+- [x] `change_head_branch` → `Git::Commands::SymbolicRef` — `git symbolic-ref`
 - [ ] `repository_default_branch` → (part of `Git::Commands::LsRemote`)
 - [ ] `current_command_version` → `Git::Commands::Version` — `git version`
 

--- a/spec/integration/git/commands/symbolic_ref/delete_spec.rb
+++ b/spec/integration/git/commands/symbolic_ref/delete_spec.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/symbolic_ref/delete'
+
+RSpec.describe Git::Commands::SymbolicRef::Delete, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'deletes the symbolic ref' do
+        # Create a custom symbolic ref to delete (not HEAD, which would break the repo)
+        execution_context.command_capturing('symbolic-ref', 'refs/heads/sym-link', 'refs/heads/main')
+
+        result = command.call('refs/heads/sym-link')
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.exitstatus).to eq(0)
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for a nonexistent ref' do
+        expect { command.call('refs/heads/nonexistent') }
+          .to raise_error(Git::FailedError, /nonexistent/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/symbolic_ref/read_spec.rb
+++ b/spec/integration/git/commands/symbolic_ref/read_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/symbolic_ref/read'
+
+RSpec.describe Git::Commands::SymbolicRef::Read, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns the full ref path' do
+        result = command.call('HEAD')
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.stdout.strip).to eq('refs/heads/main')
+      end
+
+      it 'returns the shortened ref name with :short' do
+        result = command.call('HEAD', short: true)
+
+        expect(result.stdout.strip).to eq('main')
+      end
+
+      context 'when HEAD is detached' do
+        before do
+          write_file('initial.txt', 'content')
+          repo.add('initial.txt')
+          repo.commit('initial')
+          execution_context.command_capturing('checkout', '--detach', 'HEAD')
+        end
+
+        it 'returns exit status 1 without raising' do
+          result = command.call('HEAD', quiet: true)
+
+          expect(result.status.exitstatus).to eq(1)
+        end
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError when not in a git repository' do
+        FileUtils.rm_rf(File.join(repo_dir, '.git'))
+
+        # git's "not a git repository" message varies across versions — anchor on stable text
+        expect { command.call('HEAD') }.to raise_error(Git::FailedError, /git repository/)
+      end
+    end
+  end
+end

--- a/spec/integration/git/commands/symbolic_ref/update_spec.rb
+++ b/spec/integration/git/commands/symbolic_ref/update_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/symbolic_ref/update'
+
+RSpec.describe Git::Commands::SymbolicRef::Update, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'changes the symbolic ref target' do
+        result = command.call('HEAD', 'refs/heads/new-branch')
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.exitstatus).to eq(0)
+
+        head_content = File.read(File.join(repo_dir, '.git', 'HEAD')).strip
+        expect(head_content).to eq('ref: refs/heads/new-branch')
+      end
+
+      it 'updates the symbolic ref with the :m option' do
+        result = command.call('HEAD', 'refs/heads/feature', m: 'switching to feature')
+
+        expect(result.status.exitstatus).to eq(0)
+
+        head_content = File.read(File.join(repo_dir, '.git', 'HEAD')).strip
+        expect(head_content).to eq('ref: refs/heads/feature')
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError when not in a git repository' do
+        FileUtils.rm_rf(File.join(repo_dir, '.git'))
+
+        # git's "not a git repository" message varies across versions — anchor on stable text
+        expect { command.call('HEAD', 'refs/heads/main') }
+          .to raise_error(Git::FailedError, /git repository/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/symbolic_ref/delete_spec.rb
+++ b/spec/unit/git/commands/symbolic_ref/delete_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/symbolic_ref/delete'
+
+RSpec.describe Git::Commands::SymbolicRef::Delete do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with a name operand' do
+      it 'runs git symbolic-ref --delete with the name' do
+        expected_result = command_result
+        expect_command_capturing('symbolic-ref', '--delete', '--', 'HEAD')
+          .and_return(expected_result)
+
+        result = command.call('HEAD')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with the :quiet option' do
+      it 'adds --quiet to the command line' do
+        expect_command_capturing('symbolic-ref', '--delete', '--quiet', '--', 'HEAD')
+          .and_return(command_result)
+
+        command.call('HEAD', quiet: true)
+      end
+    end
+
+    context 'with the :q alias' do
+      it 'adds --quiet to the command line' do
+        expect_command_capturing('symbolic-ref', '--delete', '--quiet', '--', 'HEAD')
+          .and_return(command_result)
+
+        command.call('HEAD', q: true)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('HEAD', unknown: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+
+      it 'raises ArgumentError when the name operand is missing' do
+        expect { command.call }
+          .to raise_error(ArgumentError, /name is required/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/symbolic_ref/read_spec.rb
+++ b/spec/unit/git/commands/symbolic_ref/read_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/symbolic_ref/read'
+
+RSpec.describe Git::Commands::SymbolicRef::Read do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with a name operand' do
+      it 'runs git symbolic-ref with the name' do
+        expected_result = command_result('refs/heads/main')
+        expect_command_capturing('symbolic-ref', '--', 'HEAD')
+          .and_return(expected_result)
+
+        result = command.call('HEAD')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with the :quiet option' do
+      it 'adds --quiet to the command line' do
+        expect_command_capturing('symbolic-ref', '--quiet', '--', 'HEAD')
+          .and_return(command_result('refs/heads/main'))
+
+        command.call('HEAD', quiet: true)
+      end
+    end
+
+    context 'with the :q alias' do
+      it 'adds --quiet to the command line' do
+        expect_command_capturing('symbolic-ref', '--quiet', '--', 'HEAD')
+          .and_return(command_result('refs/heads/main'))
+
+        command.call('HEAD', q: true)
+      end
+    end
+
+    context 'with the :short option' do
+      it 'adds --short to the command line' do
+        expect_command_capturing('symbolic-ref', '--short', '--', 'HEAD')
+          .and_return(command_result('main'))
+
+        command.call('HEAD', short: true)
+      end
+    end
+
+    context 'with multiple options combined' do
+      it 'includes all specified options in definition order' do
+        expect_command_capturing('symbolic-ref', '--quiet', '--short', '--', 'HEAD')
+          .and_return(command_result('main'))
+
+        command.call('HEAD', quiet: true, short: true)
+      end
+    end
+
+    context 'exit code handling' do
+      it 'returns normally on exit code 0' do
+        expect_command_capturing('symbolic-ref', '--', 'HEAD')
+          .and_return(command_result(exitstatus: 0))
+
+        result = command.call('HEAD')
+
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'returns normally on exit code 1 (not a symbolic ref)' do
+        expect_command_capturing('symbolic-ref', '--', 'HEAD')
+          .and_return(command_result(exitstatus: 1))
+
+        result = command.call('HEAD')
+
+        expect(result.status.exitstatus).to eq(1)
+      end
+
+      it 'raises Git::FailedError on exit code 2' do
+        expect_command_capturing('symbolic-ref', '--', 'HEAD')
+          .and_return(command_result(exitstatus: 2))
+
+        expect { command.call('HEAD') }.to raise_error(Git::FailedError, /git/)
+      end
+
+      it 'raises Git::FailedError on exit code 128' do
+        expect_command_capturing('symbolic-ref', '--', 'HEAD')
+          .and_return(command_result(exitstatus: 128))
+
+        expect { command.call('HEAD') }.to raise_error(Git::FailedError, /git/)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('HEAD', unknown: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+
+      it 'raises ArgumentError when the name operand is missing' do
+        expect { command.call }
+          .to raise_error(ArgumentError, /name is required/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/symbolic_ref/update_spec.rb
+++ b/spec/unit/git/commands/symbolic_ref/update_spec.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/symbolic_ref/update'
+
+RSpec.describe Git::Commands::SymbolicRef::Update do
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with name and ref operands' do
+      it 'runs git symbolic-ref with both positional arguments' do
+        expected_result = command_result
+        expect_command_capturing('symbolic-ref', '--', 'HEAD', 'refs/heads/main')
+          .and_return(expected_result)
+
+        result = command.call('HEAD', 'refs/heads/main')
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with the :m option' do
+      it 'adds -m <reason> to the command line' do
+        expect_command_capturing('symbolic-ref', '-m', 'switching to main', '--', 'HEAD', 'refs/heads/main')
+          .and_return(command_result)
+
+        command.call('HEAD', 'refs/heads/main', m: 'switching to main')
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('HEAD', 'refs/heads/main', unknown: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+
+      it 'raises ArgumentError when the name operand is missing' do
+        expect { command.call }
+          .to raise_error(ArgumentError, /name is required/)
+      end
+
+      it 'raises ArgumentError when the ref operand is missing' do
+        expect { command.call('HEAD') }
+          .to raise_error(ArgumentError, /ref is required/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Migrate `git symbolic-ref` to the new `Git::Commands::*` architecture by creating three subcommand classes and delegating `Git::Lib#change_head_branch` to the new implementation.

## Changes

### New command classes

- **`Git::Commands::SymbolicRef::Read`** — reads the target of a symbolic ref (`--quiet`, `--short`), with `allow_exit_status 0..1` for detached HEAD
- **`Git::Commands::SymbolicRef::Update`** — creates or updates a symbolic ref (`-m` for reflog message)
- **`Git::Commands::SymbolicRef::Delete`** — deletes a symbolic ref (`--delete`, `--quiet`)
- **`Git::Commands::SymbolicRef`** — namespace module with autoloads

### Delegation

- `Git::Lib#change_head_branch` now delegates to `Git::Commands::SymbolicRef::Update`

### Tests

- 19 unit test examples covering argument building, exit code handling, and input validation
- 7 integration test examples covering smoke tests and error handling against real git

### Documentation

- Updated migration checklist (52/54 commands migrated)
- Set next task to `repository_default_branch`

## Files changed

```
lib/git/commands/symbolic_ref.rb           (new — namespace module)
lib/git/commands/symbolic_ref/delete.rb    (new)
lib/git/commands/symbolic_ref/read.rb      (new)
lib/git/commands/symbolic_ref/update.rb    (new)
lib/git/lib.rb                             (delegation)
redesign/3_architecture_implementation.md  (checklist update)
spec/integration/git/commands/symbolic_ref/ (3 new specs)
spec/unit/git/commands/symbolic_ref/       (3 new specs)
```