### PR TITLE
feat: add Git::Commands::Version and delegate current_command_version

### DIFF
--- a/lib/git/commands.rb
+++ b/lib/git/commands.rb
@@ -47,6 +47,7 @@ require_relative 'commands/status'
 require_relative 'commands/symbolic_ref'
 require_relative 'commands/tag'
 require_relative 'commands/update_ref'
+require_relative 'commands/version'
 require_relative 'commands/worktree'
 require_relative 'commands/write_tree'
 

--- a/lib/git/commands/version.rb
+++ b/lib/git/commands/version.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require 'git/commands/base'
+
+module Git
+  module Commands
+    # Wrapper for the `git version` command
+    #
+    # Prints the git suite version.
+    #
+    # @example Basic usage
+    #   version = Git::Commands::Version.new(execution_context)
+    #   result = version.call
+    #   result.stdout #=> "git version 2.42.0"
+    #
+    # @see https://git-scm.com/docs/git-version git-version documentation
+    #
+    # @see Git::Commands
+    #
+    # @api private
+    #
+    class Version < Git::Commands::Base
+      arguments do
+        literal 'version'
+        flag_option :build_options
+      end
+
+      # @!method call(*, **)
+      #
+      #   @overload call(**options)
+      #
+      #     Execute the `git version` command
+      #
+      #     @param options [Hash] command options
+      #
+      #     @option options [Boolean] :build_options (nil) include build options in the output
+      #
+      #     @return [Git::CommandLineResult] the result of calling `git version`
+      #
+      #     @raise [Git::FailedError] if git exits with a non-zero status
+    end
+  end
+end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1873,7 +1873,7 @@ module Git
 
     # returns the current version of git, as an Array of Fixnums.
     def current_command_version
-      output = command_capturing('version').stdout
+      output = Git::Commands::Version.new(self).call.stdout
       version = output[/\d+(\.\d+)+/]
       version_parts = version.split('.').collect(&:to_i)
       version_parts.fill(0, version_parts.length...3)

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -22,21 +22,21 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase | Status | Description |
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
-| Phase 2 | 🔄 In Progress | Migrating commands (52/54 checklist items done, 2 remaining) |
+| Phase 2 | ✅ Complete | Migrating commands (all checklist items done) |
 | Phase 3 | ⏳ Not Started | Refactoring public interface |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Migrate `repository_default_branch`** → `Git::Commands::LsRemote` — `git ls-remote`
+**Begin Phase 3: Refactoring the Public Interface**
 
-The `repository_default_branch` method already delegates to `Git::Commands::LsRemote`,
-but the checklist item is not yet marked done. Review the delegation and mark the
-checklist item done.
+Phase 2 is complete — all commands have been migrated to `Git::Commands::*` classes.
+The next step is Phase 3: introducing `Git::Repository` as the public facade,
+populating it with delegate methods, and deprecating `Git::Base`.
 
 #### Workflow
 
-1. **Analyze**: Read the existing implementation in `lib/git/lib.rb` (search for `def repository_default_branch`). Understand all options and edge cases.
+1. **Analyze**: Review the Phase 3 plan below and the current state of `lib/git/repository.rb` and `lib/git/base.rb`.
 
 2. **Design**: Create command class following the pattern in
    `lib/git/commands/branch/delete.rb`. The interface for `#call` should only include
@@ -977,6 +977,7 @@ The following tracks the migration status of commands from `Git::Lib` to
 
 | `worktrees_all` / `worktree_add` / `worktree_remove` / `worktree_prune` | `Git::Commands::Worktree::List` / `Git::Commands::Worktree::Add` / `Git::Commands::Worktree::Remove` / `Git::Commands::Worktree::Prune` (+ `Lock`, `Unlock`, `Move`, `Repair`) | `spec/unit/git/commands/worktree/*_spec.rb` | `git worktree` |
 | `change_head_branch` | `Git::Commands::SymbolicRef::Update` (+ `Read`, `Delete`) | `spec/unit/git/commands/symbolic_ref/*_spec.rb` | `git symbolic-ref` |
+| `current_command_version` | `Git::Commands::Version` | `spec/unit/git/commands/version_spec.rb` | `git version` |
 
 #### ⏳ Commands To Migrate
 
@@ -1066,8 +1067,8 @@ order: Basic Snapshotting → Branching & Merging → etc.
 - [x] `worktree_add` / `worktree_remove` → `Git::Commands::Worktree` — `git worktree`
 - [x] `branch_contains` → (part of `Git::Commands::Branch`)
 - [x] `change_head_branch` → `Git::Commands::SymbolicRef` — `git symbolic-ref`
-- [ ] `repository_default_branch` → (part of `Git::Commands::LsRemote`)
-- [ ] `current_command_version` → `Git::Commands::Version` — `git version`
+- [x] `repository_default_branch` → (part of `Git::Commands::LsRemote`)
+- [x] `current_command_version` → `Git::Commands::Version` — `git version`
 
 ## Phase 3: Refactoring the Public Interface
 

--- a/spec/integration/git/commands/version_spec.rb
+++ b/spec/integration/git/commands/version_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/version'
+
+RSpec.describe Git::Commands::Version, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult' do
+        result = command.call
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.exitstatus).to eq(0)
+        expect(result.stdout).to match(/\Agit version \d+\.\d+/)
+        expect(result.stderr).to be_empty
+      end
+    end
+
+    context 'with unsupported options' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(unsupported: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/version_spec.rb
+++ b/spec/unit/git/commands/version_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/version'
+
+RSpec.describe Git::Commands::Version do
+  # Duck-type collaborator: command specs depend on the #command_capturing
+  # interface, not a single concrete ExecutionContext class.
+  let(:execution_context) { double('ExecutionContext') }
+  let(:command) { described_class.new(execution_context) }
+
+  describe '#call' do
+    context 'with no arguments' do
+      it 'runs git version and returns the result' do
+        expected_result = command_result('git version 2.42.0')
+        expect_command_capturing('version').and_return(expected_result)
+
+        result = command.call
+
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'with :build_options option' do
+      it 'includes the --build-options flag' do
+        expect_command_capturing('version', '--build-options').and_return(command_result)
+        command.call(build_options: true)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(unsupported: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
+  end
+end

--- a/tests/units/test_lib_meets_required_version.rb
+++ b/tests/units/test_lib_meets_required_version.rb
@@ -33,12 +33,12 @@ class TestLibMeetsRequiredVersion < Test::Unit::TestCase
 
     lib.instance_variable_set(:@next_version_index, 0)
 
-    lib.define_singleton_method(:command_capturing) do |cmd, *_opts|
+    lib.define_singleton_method(:command_capturing) do |cmd, *_opts, **_kwargs|
       raise ArgumentError unless cmd == 'version'
 
       version_string = versions_to_test[@next_version_index][:version_string]
       @next_version_index += 1
-      status = Struct.new(:success?).new(true)
+      status = Struct.new(:success?, :exitstatus).new(true, 0)
       Git::CommandLineResult.new(['git', cmd], status, version_string, '')
     end
 


### PR DESCRIPTION
## Summary

Migrates `current_command_version` from `Git::Lib` to a proper
`Git::Commands::Version` class, completing Phase 2 of the architectural redesign.

## Changes

### `lib/git/commands/version.rb` (new)

A `Git::Commands::Base` subclass that wraps `git version`. Uses the Arguments
DSL with `literal 'version'` and `flag_option :build_options` to support the
`--build-options` flag.

### `spec/unit/git/commands/version_spec.rb` (new)

Unit test verifying the command invokes `command_capturing` with `'version'` and
returns the result unchanged, plus coverage for `--build-options` and unsupported
option validation.

### `spec/integration/git/commands/version_spec.rb` (new)

Integration test verifying the command runs against real git, returns exit status 0,
produces output matching `/\Agit version \d+\.\d+/`, and emits no stderr output.

### `lib/git/commands.rb`

Adds `require_relative 'commands/version'` in alphabetical order (between
`update_ref` and `worktree`).

### `lib/git/lib.rb`

Updates `Git::Lib#current_command_version` to delegate to `Git::Commands::Version`
instead of calling `command_capturing('version')` directly.

### `redesign/3_architecture_implementation.md`

- Marks Phase 2 as ✅ Complete (all checklist items done)
- Adds `current_command_version` row to the Migrated Commands table
- Ticks the last checklist item
- Updates the Next Task section to point to Phase 3

## Test results

```
3784 examples, 0 failures
```

No rubocop offenses on new files.