### PR TITLE
refactor: add output-normalization hooks to Base and delegate write_staged_content to Show

### DIFF
--- a/lib/git/commands/archive.rb
+++ b/lib/git/commands/archive.rb
@@ -65,8 +65,7 @@ module Git
         # @see https://git-scm.com/docs/git-archive#Documentation/git-archive.txt---execltgit-upload-archivegt
         value_option :exec, inline: true
 
-        # Stream stdout to this IO object instead of buffering in memory.
-        # When provided, the command dispatches to the streaming execution path.
+        # Stream stdout to this IO object instead of buffering in memory
         execution_option :out
 
         conflicts :output, :out
@@ -86,73 +85,71 @@ module Git
       # `normalize` and `chomp` are disabled so stdout bytes are returned
       # unchanged. When `out:` is given, the streaming path is used and
       # these options do not apply.
+      # @!method call(*, **)
       #
-      # @overload call(tree_ish, *path, **options)
+      #   @overload call(tree_ish, *path, **options)
       #
-      #   @param tree_ish [String] the tree or commit to produce an archive for
+      #     @param tree_ish [String] the tree or commit to produce an archive for
       #
-      #   @param path [Array<String>] limit the archive to these paths
-      #     within the tree
+      #     @param path [Array<String>] limit the archive to these paths
+      #       within the tree
       #
-      #   @param options [Hash] command options
+      #     @param options [Hash] command options
       #
-      #   @option options [String] :format (nil) archive format — `tar` or
-      #     `zip`; user-defined formats are also supported
+      #     @option options [String] :format (nil) archive format — `tar` or
+      #       `zip`; user-defined formats are also supported
       #
-      #   @option options [Boolean] :verbose (nil) report progress to stderr
+      #     @option options [Boolean] :verbose (nil) report progress to stderr
       #
-      #     Alias: :v
+      #       Alias: :v
       #
-      #   @option options [String] :prefix (nil) prepend `<prefix>/` to each
-      #     filename in the archive
+      #     @option options [String] :prefix (nil) prepend `<prefix>/` to each
+      #       filename in the archive
       #
-      #   @option options [String] :output (nil) write the archive to
-      #     this file instead of stdout
+      #     @option options [String] :output (nil) write the archive to
+      #       this file instead of stdout
       #
-      #     Alias: :o
+      #       Alias: :o
       #
-      #   @option options [Boolean] :worktree_attributes (nil) look for
-      #     attributes in `.gitattributes` files in the working tree
+      #     @option options [Boolean] :worktree_attributes (nil) look for
+      #       attributes in `.gitattributes` files in the working tree
       #
-      #   @option options [String] :remote (nil) retrieve a tar archive from
-      #     a remote repository instead of the local one
+      #     @option options [String] :remote (nil) retrieve a tar archive from
+      #       a remote repository instead of the local one
       #
-      #   @option options [String] :exec (nil) path to `git-upload-archive`
-      #     on the remote side (used with `:remote`)
+      #     @option options [String] :exec (nil) path to `git-upload-archive`
+      #       on the remote side (used with `:remote`)
       #
-      #   @option options [IO] :out (nil) stream stdout to this IO object
-      #     instead of buffering in memory
+      #     @option options [IO, #write] :out the command output is sent to the
+      #       given IO object instead of being captured in the result; the
+      #       result's `.stdout` will be `''` in this case.
       #
-      #   @return [Git::CommandLineResult] the result of calling
-      #     `git archive`
+      #     @return [Git::CommandLineResult] the result of calling
+      #       `git archive`
       #
-      #   @raise [ArgumentError] if unsupported options are provided
+      #     @raise [ArgumentError] if unsupported options are provided
       #
-      #   @raise [ArgumentError] if the tree_ish operand is missing
+      #     @raise [ArgumentError] if the tree_ish operand is missing
       #
-      #   @raise [Git::FailedError] if the command returns a non-zero
-      #     exit status
-      def call(*, **)
-        bound = args_definition.bind(*, **)
-        result = execute_command(bound)
-        validate_exit_status!(result)
-        result
-      end
+      #     @raise [Git::FailedError] if the command returns a non-zero
+      #       exit status
 
-      private
+      # Archive output is intrinsically binary (tar, zip, etc.) — opt out of
+      # Ruby string normalization and trailing-newline chomping so that
+      # `result.stdout` bytes are returned unchanged. Only affects the
+      # capturing path; streaming via `out:` is never normalized or chomped
+      # regardless of these settings.
+      #
+      # @return [Boolean] `false`
+      #
+      def normalize_captured_stdout? = false
 
-      # Archive output is binary — disable normalize and chomp on the
-      # capturing path so stdout bytes are returned unchanged.
-      def execute_command(bound)
-        if bound.execution_options.key?(:out)
-          @execution_context.command_streaming(*bound, **bound.execution_options, raise_on_failure: false)
-        else
-          @execution_context.command_capturing(
-            *bound, **bound.execution_options,
-            normalize: false, chomp: false, raise_on_failure: false
-          )
-        end
-      end
+      # Archive output is binary, so preserve captured stdout byte-for-byte
+      # even when it ends with a newline.
+      #
+      # @return [Boolean] `false`
+      #
+      def chomp_captured_stdout? = false
     end
   end
 end

--- a/lib/git/commands/base.rb
+++ b/lib/git/commands/base.rb
@@ -137,16 +137,61 @@ module Git
       end
 
       def execute_command(bound)
-        caller_env = bound.execution_options.fetch(:env, {}) || {}
-        merged_env = caller_env.merge(env)
-        exec_opts = bound.execution_options.except(:env)
-        exec_opts = exec_opts.merge(env: merged_env) unless merged_env.empty?
+        exec_opts = execution_opts(bound)
 
         if exec_opts.key?(:out)
           @execution_context.command_streaming(*bound, **exec_opts, raise_on_failure: false)
         else
-          @execution_context.command_capturing(*bound, **exec_opts, raise_on_failure: false)
+          @execution_context.command_capturing(*bound, **capturing_opts(exec_opts), raise_on_failure: false)
         end
+      end
+
+      def execution_opts(bound)
+        caller_env = bound.execution_options.fetch(:env, {}) || {}
+        merged_env = caller_env.merge(env)
+        opts = bound.execution_options.except(:env)
+        merged_env.empty? ? opts : opts.merge(env: merged_env)
+      end
+
+      def capturing_opts(exec_opts)
+        opts = exec_opts
+        opts = opts.merge(normalize: false) unless normalize_captured_stdout?
+        opts = opts.merge(chomp: false) unless chomp_captured_stdout?
+        opts
+      end
+
+      # Whether {#execute_command} should apply Ruby string normalization to
+      # `result.stdout` on the capturing path.
+      #
+      # When `true` (the default), `command_capturing` normalizes the encoding of
+      # captured stdout. Override to return `false` in subclasses whose output is
+      # intrinsically binary (e.g. `git archive`), so that stdout bytes in
+      # `result.stdout` are returned unchanged.
+      #
+      # This hook only affects the **capturing** path — when an `out:` execution
+      # option is present, stdout is streamed directly to the caller-supplied IO
+      # object and is never normalized or chomped regardless of this setting.
+      #
+      # @return [Boolean]
+      def normalize_captured_stdout?
+        true
+      end
+
+      # Whether {#execute_command} should chomp trailing newlines from
+      # `result.stdout` on the capturing path.
+      #
+      # When `true` (the default), `command_capturing` strips the trailing
+      # newline from captured stdout. Override to return `false` in subclasses
+      # whose output must preserve trailing whitespace (e.g. `git show`, which
+      # can return blob content with significant trailing newlines).
+      #
+      # This hook only affects the **capturing** path — when an `out:` execution
+      # option is present, stdout is streamed directly to the caller-supplied IO
+      # object and is never chomped regardless of this setting.
+      #
+      # @return [Boolean]
+      def chomp_captured_stdout?
+        true
       end
 
       # Environment variable overrides to pass to the subprocess.

--- a/lib/git/commands/show.rb
+++ b/lib/git/commands/show.rb
@@ -4,16 +4,11 @@ require 'git/commands/base'
 
 module Git
   module Commands
-    # Implements the `git show` command
+    # Wrapper for the `git show` command
     #
     # Displays information about git objects (commits, annotated tags, trees,
     # or blobs). Output format varies by object type and is intended for human
     # consumption rather than machine parsing.
-    #
-    # @see https://git-scm.com/docs/git-show git-show documentation
-    # @see Git::Commands
-    #
-    # @api private
     #
     # @example Show the HEAD commit
     #   show = Git::Commands::Show.new(execution_context)
@@ -31,6 +26,12 @@ module Git
     #   show = Git::Commands::Show.new(execution_context)
     #   result = show.call('v1.0', 'v2.0')
     #
+    # @see https://git-scm.com/docs/git-show git-show documentation
+    #
+    # @see Git::Commands
+    #
+    # @api private
+    #
     class Show < Git::Commands::Base
       arguments do
         literal 'show'
@@ -39,53 +40,48 @@ module Git
         # When provided, the command dispatches to the streaming execution path.
         execution_option :out
 
-        operand :objects, repeatable: true
+        operand :object, repeatable: true
       end
 
-      # Execute the `git show` command.
+      # @!method call(*, **)
       #
-      # @overload call(*objects)
+      #   @overload call(*object)
       #
-      #   Trailing newlines are preserved in the result stdout. Pass the result's
-      #   `.stdout` to callers that need the raw object content unchanged.
+      #     Trailing newlines are preserved in the result stdout. Pass the result's
+      #     `.stdout` to callers that need the raw object content unchanged.
       #
-      #   @param objects [Array<String>] zero or more object specifiers (refs, SHAs,
-      #     `objectish:path` expressions, etc.). When empty, defaults to `HEAD`.
+      #     @param object [Array<String>] zero or more object specifiers (refs, SHAs,
+      #       `objectish:path` expressions, etc.)
       #
-      #   @return [Git::CommandLineResult] the result of calling `git show`
+      #       When empty, defaults to `HEAD`
       #
-      #   @raise [Git::FailedError] if git exits with a non-zero exit status
+      #     @return [Git::CommandLineResult] the result of calling `git show`;
+      #       `result.stdout` will have trailing newlines preserved
       #
-      # @overload call(*objects, out:)
+      #     @raise [Git::FailedError] if git exits with a non-zero exit status
       #
-      #   Streams stdout directly to `out` without buffering in memory.
-      #   Use this form when showing large blobs to avoid memory pressure.
+      #   @overload call(*object, out:)
       #
-      #   @param objects [Array<String>] zero or more object specifiers
+      #     Streams stdout directly to `out` without buffering in memory.
+      #     Use this form when showing large blobs to avoid memory pressure.
       #
-      #   @param out [IO] the IO object to stream stdout into
+      #     @param object [Array<String>] zero or more object specifiers
       #
-      #   @return [Git::CommandLineResult] the result of calling `git show`;
-      #     `result.stdout` will be `''` — stdout was streamed to `out`
+      #     @param out [IO, #write] the command output is sent to the given IO object
       #
-      #   @raise [Git::FailedError] if git exits with a non-zero exit status
+      #       Instead of being captured in the result; the result's
+      #       `.stdout` will be `''` in this case.
       #
-      def call(*, **)
-        bound = args_definition.bind(*, **)
-        result = execute_command(bound)
-        validate_exit_status!(result)
-        result
-      end
+      #     @return [Git::CommandLineResult] the result of calling `git show`;
+      #       `result.stdout` will be `''` — stdout was streamed to `out`
+      #
+      #     @raise [Git::FailedError] if git exits with a non-zero exit status
 
       private
 
-      def execute_command(bound)
-        if bound.execution_options.key?(:out)
-          @execution_context.command_streaming(*bound, **bound.execution_options, raise_on_failure: false)
-        else
-          @execution_context.command_capturing(*bound, **bound.execution_options, chomp: false, raise_on_failure: false)
-        end
-      end
+      # @return [false] show output preserves trailing newlines, which are significant
+      #   for blob content
+      def chomp_captured_stdout? = false
     end
   end
 end

--- a/lib/git/commands/show.rb
+++ b/lib/git/commands/show.rb
@@ -34,6 +34,11 @@ module Git
     class Show < Git::Commands::Base
       arguments do
         literal 'show'
+
+        # Stream stdout to this IO object instead of buffering in memory.
+        # When provided, the command dispatches to the streaming execution path.
+        execution_option :out
+
         operand :objects, repeatable: true
       end
 
@@ -51,16 +56,35 @@ module Git
       #
       #   @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @overload call(*objects, out:)
+      #
+      #   Streams stdout directly to `out` without buffering in memory.
+      #   Use this form when showing large blobs to avoid memory pressure.
+      #
+      #   @param objects [Array<String>] zero or more object specifiers
+      #
+      #   @param out [IO] the IO object to stream stdout into
+      #
+      #   @return [Git::CommandLineResult] the result of calling `git show`;
+      #     `result.stdout` will be `''` — stdout was streamed to `out`
+      #
+      #   @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
       def call(*, **)
         bound = args_definition.bind(*, **)
-        result = @execution_context.command_capturing(
-          *bound,
-          **bound.execution_options,
-          chomp: false,
-          raise_on_failure: false
-        )
+        result = execute_command(bound)
         validate_exit_status!(result)
         result
+      end
+
+      private
+
+      def execute_command(bound)
+        if bound.execution_options.key?(:out)
+          @execution_context.command_streaming(*bound, **bound.execution_options, raise_on_failure: false)
+        else
+          @execution_context.command_capturing(*bound, **bound.execution_options, chomp: false, raise_on_failure: false)
+        end
       end
     end
   end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -2483,7 +2483,7 @@ module Git
     # @raise [Git::TimeoutError] if the command exceeds the configured timeout
     #
     def write_staged_content(path, stage, out_io)
-      command_streaming('show', ":#{stage}:#{path}", out: out_io)
+      Git::Commands::Show.new(self).call(":#{stage}:#{path}", out: out_io)
       out_io
     end
 

--- a/spec/integration/git/commands/show_spec.rb
+++ b/spec/integration/git/commands/show_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/commands/show'
+
+RSpec.describe Git::Commands::Show, :integration do
+  include_context 'in an empty repository'
+
+  subject(:command) { described_class.new(execution_context) }
+
+  before do
+    write_file('test.txt', "Hello, World!\n")
+    repo.add('test.txt')
+    repo.commit('Initial commit')
+  end
+
+  describe '#call' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult with commit information' do
+        result = command.call('HEAD')
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.success?).to be true
+        expect(result.stdout).not_to be_empty
+      end
+    end
+
+    context 'with out: streaming to a StringIO' do
+      it 'streams blob content into the IO object' do
+        io = StringIO.new
+        result = command.call('HEAD:test.txt', out: io)
+
+        expect(io.string).to eq("Hello, World!\n")
+        expect(result.stdout).to eq('')
+      end
+    end
+
+    context 'when the command fails' do
+      it 'raises FailedError for a nonexistent object' do
+        expect { command.call('nonexistent-ref-xyz') }
+          .to raise_error(Git::FailedError, /nonexistent-ref-xyz/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/commands/show_spec.rb
+++ b/spec/unit/git/commands/show_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 require 'git/commands/show'
 
 RSpec.describe Git::Commands::Show do
+  # Duck-type collaborator: command specs depend on the #command_capturing and
+  # #command_streaming interfaces, not a single concrete ExecutionContext class.
   let(:execution_context) { double('ExecutionContext') }
   let(:command) { described_class.new(execution_context) }
 
@@ -43,9 +45,18 @@ RSpec.describe Git::Commands::Show do
       end
     end
 
-    context 'with an unrecognised keyword argument' do
-      it 'raises ArgumentError' do
-        expect { command.call(foo: true) }.to raise_error(ArgumentError)
+    context 'with out: execution option (streaming)' do
+      it 'dispatches to command_streaming when out: is given' do
+        out_io = instance_double(File)
+        expect_command_streaming('show', ':2:path/to/file.txt', out: out_io).and_return(command_result)
+
+        command.call(':2:path/to/file.txt', out: out_io)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(foo: true) }.to raise_error(ArgumentError, /Unsupported options/)
       end
     end
   end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Two related refactors that eliminate duplicated output-handling logic from
command subclasses and wire `Git::Lib#write_staged_content` through the proper
command layer.

## Output-normalization hooks in `Base` (commit 2)

`Git::Commands::Archive` previously overrode `execute_command` solely to pass
`normalize: false` and `chomp: false` to `command_capturing`. That is
boilerplate that belongs in the base class. Similarly, `Show` previously
overrode `execute_command` to pass `chomp: false`, also duplicating the
env-merging logic.

`Base#execute_command` now checks two new template methods before calling
`command_capturing`:

**`normalize_captured_stdout?`** (default: `true`)
When it returns `false`, `normalize: false` is merged automatically.

```ruby
def normalize_captured_stdout? = false
```

**`chomp_captured_stdout?`** (default: `true`)
When it returns `false`, `chomp: false` is merged automatically, preserving
trailing newlines in the returned stdout.

```ruby
def chomp_captured_stdout? = false
```

Both hooks **only affect the capturing path** — when an `out:` execution option
is present, stdout is streamed directly to the caller-supplied IO object and is
never normalized or chomped regardless of these settings.

`Archive` declares both `normalize_captured_stdout? = false` and
`chomp_captured_stdout? = false` — binary archive output (tar, zip, etc.) must
be returned byte-for-byte unchanged, with no encoding normalization or trailing
newline stripping.

`Show` declares `chomp_captured_stdout? = false` — blob and commit output may
have significant trailing newlines that must be preserved for callers.

## `write_staged_content` delegation (commit 1)

`Git::Lib#write_staged_content` was calling `command_streaming` directly,
bypassing the `Git::Commands::Show` layer entirely. This change:

- Adds an `execution_option :out` to `Git::Commands::Show` so it supports the
  streaming execution path.
- Rewrites the `Lib` method to delegate:
  `Git::Commands::Show.new(self).call(":#{stage}:#{path}", out: out_io)`

The public behaviour is unchanged — `write_staged_content` still streams the
staged blob content into `out_io`.

## Test changes

- **Show unit tests:** added duck-type collaborator comment, streaming (`out:`)
  test, renamed validation context to `'input validation'`, added message
  pattern to `ArgumentError` assertion (Rule 22).
- **Show integration test:** new file — smoke test, streaming (`out:`) with
  `StringIO`, and `FailedError` for a nonexistent ref.
- **Archive unit tests:** all `expect_command_capturing` expectations include
  `normalize: false, chomp: false` to reflect both binary-output hooks
  (`normalize_captured_stdout?` and `chomp_captured_stdout?`).

## Related issues

- Closes #1187 — facade `chomp` behaviour after `Show` command change: resolved
  by the `chomp_captured_stdout?` hook
- #1185 — `UpdateRef::Batch` also bypasses `Base#execute_command` (future work)
- #1186 — `CatFile::Batch#run_batch` duplicates `Base#execute_command` (future work)

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD)
