### PR TITLE
chore: add clobber tasks for build and npm artifacts

### DIFF
--- a/tasks/gem_tasks.rake
+++ b/tasks/gem_tasks.rake
@@ -8,3 +8,7 @@ require 'bundler/gem_tasks'
 Rake::Task['release'].clear
 desc 'Customized release task to avoid creating a new tag'
 task release: 'release:rubygem_push'
+
+require 'rake/clean'
+CLOBBER << 'pkg'
+CLOBBER << 'Gemfile.lock'

--- a/tasks/npm_tasks.rake
+++ b/tasks/npm_tasks.rake
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+require 'rake/clean'
+
+CLOBBER << 'node_modules'
+CLOBBER << 'package-lock.json'
+CLOBBER << '.husky/_'


### PR DESCRIPTION
Add `CLOBBER` entries so `rake clobber` removes generated artifacts:

**gem_tasks.rake**
- `pkg/` — built gem packages
- `Gemfile.lock` — resolved bundle dependencies

**npm_tasks.rake** (new file)
- `node_modules/` — installed npm packages
- `package-lock.json` — resolved npm dependencies
- `.husky/_/` — generated husky git hooks

Each task file includes its own `require 'rake/clean'` so it is self-contained.