### PR TITLE
refactor(arguments): add `max_times:` to `flag_option` for count-limited repeatable flags

### DIFF
--- a/lib/git/commands/arguments.rb
+++ b/lib/git/commands/arguments.rb
@@ -629,9 +629,6 @@ module Git
       #
       # @param as [String, Array<String>, nil] custom argument(s) to output (e.g., '-r' or ['--amend', '--no-edit'])
       #
-      # @param type [Class, Array<Class>, nil] expected type(s) for validation. Raises ArgumentError with
-      #   descriptive message if value doesn't match.
-      #
       # @param negatable [Boolean] when true, outputs --no-flag when value is false (default: false)
       #
       # @param required [Boolean] whether the option must be provided (key must exist in opts)
@@ -639,9 +636,17 @@ module Git
       # @param allow_nil [Boolean] whether nil is allowed when required is true. Defaults to true.
       #   When false with required: true, raises ArgumentError if value is nil.
       #
+      # @param max_times [Integer, nil] maximum number of times the flag may be repeated (default: nil).
+      #   When set, the caller may pass a positive Integer up to this limit to emit the flag
+      #   multiple times (e.g. `force: 2` emits `--force --force`). Must be an Integer >= 2;
+      #   0 and 1 raise ArgumentError at definition time. When nil (the default), only boolean
+      #   values are accepted.
+      #
       # @return [void]
       #
       # @raise [ArgumentError] if defined after an `end_of_options` or `literal '--'` boundary
+      #
+      # @raise [ArgumentError] if max_times is not nil and not an Integer >= 2
       #
       # @example Basic flag
       #   args_def = Arguments.define do
@@ -657,11 +662,20 @@ module Git
       #   args_def.bind(full: true).to_a   # => ['--full']
       #   args_def.bind(full: false).to_a  # => ['--no-full']
       #
-      # @example With type validation
+      # @example Repeatable flag with max_times
       #   args_def = Arguments.define do
-      #     flag_option :force, type: [TrueClass, FalseClass]
+      #     flag_option :force, max_times: 2
       #   end
       #   args_def.bind(force: true).to_a  # => ['--force']
+      #   args_def.bind(force: 1).to_a     # => ['--force']
+      #   args_def.bind(force: 2).to_a     # => ['--force', '--force']
+      #
+      # @example Negatable flag with max_times
+      #   args_def = Arguments.define do
+      #     flag_option :force, negatable: true, max_times: 2
+      #   end
+      #   args_def.bind(force: false).to_a  # => ['--no-force']
+      #   args_def.bind(force: 2).to_a      # => ['--force', '--force']
       #
       # @example With required and allow_nil: false
       #   args_def = Arguments.define do
@@ -670,10 +684,12 @@ module Git
       #   args_def.bind() #=> raise ArgumentError, "Required options not provided: :force"
       #   args_def.bind(force: nil) #=> raise ArgumentError, "Required options cannot be nil: :force"
       #
-      def flag_option(names, as: nil, type: nil, negatable: false, required: false, allow_nil: true)
+      def flag_option(names, as: nil, negatable: false, required: false, allow_nil: true, max_times: nil)
         option_type = negatable ? :negatable_flag : :flag
-        register_option(names, type: option_type, as: as, expected_type: type, validator: nil,
-                               required: required, allow_nil: allow_nil)
+        validate_max_times!(Array(names).first, max_times)
+
+        register_option(names, type: option_type, as: as, expected_type: nil, validator: nil,
+                               required: required, allow_nil: allow_nil, max_times: max_times)
       end
 
       # Define a valued option (--flag value as separate arguments)
@@ -1890,6 +1906,14 @@ module Git
         @ordered_definitions << { kind: :option, name: primary }
       end
 
+      def validate_max_times!(option_name, max_times)
+        return if max_times.nil?
+
+        return if max_times.is_a?(Integer) && max_times >= 2
+
+        raise ArgumentError, "max_times for :#{option_name} must be an Integer >= 2"
+      end
+
       # Validate that flag-producing options are not defined after a '--' boundary
       #
       # @param type [Symbol] the option type
@@ -2044,11 +2068,7 @@ module Git
       end
 
       BUILDERS = {
-        flag: lambda do |args, arg_spec, value, _|
-          return unless value
-
-          arg_spec.is_a?(Array) ? args.concat(arg_spec) : args << arg_spec
-        end,
+        flag: :build_flag,
         negatable_flag: :build_negatable_flag,
         value: lambda do |args, arg_spec, value, definition|
           if definition[:repeatable]
@@ -2252,18 +2272,77 @@ module Git
         short_option?(arg_spec) ? '' : '='
       end
 
+      def build_flag(args, arg_spec, value, definition)
+        count = normalize_flag_value!(value, definition)
+        append_repeated_flag(args, arg_spec, count)
+      end
+
       # Build negatable flag with proper negation format
       #
       # For negation, always use double-dash format (--no-x) even for short options,
       # as this is the POSIX convention.
       #
-      def build_negatable_flag(args, arg_spec, value, _definition)
-        unless [true, false].include?(value)
-          raise ArgumentError,
-                "negatable_flag expects a boolean value, got #{value.inspect} (#{value.class})"
+      def build_negatable_flag(args, arg_spec, value, definition)
+        if value == false
+          args << negate_flag(arg_spec)
+          return
         end
 
-        args << (value ? arg_spec : negate_flag(arg_spec))
+        count = normalize_flag_value!(value, definition)
+        append_repeated_flag(args, arg_spec, count)
+      end
+
+      def append_repeated_flag(args, arg_spec, count)
+        return if count <= 0
+
+        count.times do
+          arg_spec.is_a?(Array) ? args.concat(arg_spec) : args << arg_spec
+        end
+      end
+
+      def normalize_flag_value!(value, definition)
+        return 1 if value == true
+        return 0 if value.nil? || value == false
+
+        option_name = definition[:aliases].first
+        max_times = definition[:max_times]
+
+        raise_flag_type_boolean_error!(value, definition) if max_times.nil?
+
+        return normalize_flag_integer_value!(value, option_name, max_times) if value.is_a?(Integer)
+
+        raise ArgumentError, "Invalid value for :#{option_name}: expected true, false, or a positive Integer"
+      end
+
+      def raise_flag_type_boolean_error!(value, definition)
+        if definition[:type] == :negatable_flag
+          raise_negatable_flag_boolean_error!(value)
+        else
+          raise_flag_boolean_error!(definition[:aliases].first, value)
+        end
+      end
+
+      def raise_flag_boolean_error!(option_name, value)
+        raise ArgumentError,
+              "flag_option :#{option_name} expects a boolean value, got #{value.inspect} (#{value.class})"
+      end
+
+      def raise_negatable_flag_boolean_error!(value)
+        raise ArgumentError,
+              "negatable_flag expects a boolean value, got #{value.inspect} (#{value.class})"
+      end
+
+      def normalize_flag_integer_value!(value, option_name, max_times)
+        raise ArgumentError, "Invalid value for :#{option_name}: expected a positive Integer" if value <= 0
+
+        raise_max_times_exceeded!(option_name, value, max_times) if value > max_times
+
+        value
+      end
+
+      def raise_max_times_exceeded!(option_name, value, max_times)
+        raise ArgumentError,
+              "#{option_name}: #{value} exceeds max_times: #{max_times} for :#{option_name}"
       end
 
       # Negate a flag by adding --no- prefix
@@ -3080,8 +3159,14 @@ module Git
             predicate_name = :"#{name}?"
             next if RESERVED_NAMES.include?(predicate_name)
 
-            define_singleton_method(predicate_name) { @options[name] }
+            define_singleton_method(predicate_name) { flag_predicate?(@options[name]) }
           end
+        end
+
+        def flag_predicate?(value)
+          return value.positive? if value.is_a?(Integer)
+
+          value == true
         end
       end
     end

--- a/spec/unit/git/commands/arguments_spec.rb
+++ b/spec/unit/git/commands/arguments_spec.rb
@@ -29,6 +29,156 @@ RSpec.describe Git::Commands::Arguments do
       it 'outputs nothing when option is not provided' do
         expect(args.bind.to_ary).to eq([])
       end
+
+      it 'raises an error for Integer value when max_times is not set' do
+        expect { args.bind(force: 1) }.to raise_error(ArgumentError, /flag_option :force expects a boolean value/)
+      end
+
+      it 'raises an error for String value' do
+        expect { args.bind(force: 'yes') }.to raise_error(ArgumentError, /flag_option :force expects a boolean value/)
+      end
+    end
+
+    context 'with flag options and max_times' do
+      let(:args) do
+        described_class.define do
+          flag_option :force, max_times: 2
+        end
+      end
+
+      it 'outputs nothing when value is nil' do
+        expect(args.bind(force: nil).to_ary).to eq([])
+      end
+
+      it 'outputs nothing when option is not provided' do
+        expect(args.bind.to_ary).to eq([])
+      end
+
+      it 'outputs nothing when value is false' do
+        expect(args.bind(force: false).to_ary).to eq([])
+      end
+
+      it 'outputs --flag when value is true' do
+        expect(args.bind(force: true).to_ary).to eq(['--force'])
+      end
+
+      it 'outputs --flag when value is 1' do
+        expect(args.bind(force: 1).to_ary).to eq(['--force'])
+      end
+
+      it 'outputs --flag twice when value is 2' do
+        expect(args.bind(force: 2).to_ary).to eq(['--force', '--force'])
+      end
+
+      it 'raises an error when value is 0' do
+        expect { args.bind(force: 0) }.to raise_error(ArgumentError, /force.*positive Integer/)
+      end
+
+      it 'raises an error when value exceeds max_times' do
+        expect { args.bind(force: 3) }.to raise_error(ArgumentError, /force: 3 exceeds max_times: 2 for :force/)
+      end
+
+      it 'raises an error when value is a float' do
+        expect { args.bind(force: 1.5) }.to raise_error(ArgumentError, /force.*positive Integer/)
+      end
+
+      it 'raises an error when value is negative' do
+        expect { args.bind(force: -1) }.to raise_error(ArgumentError, /force.*positive Integer/)
+      end
+    end
+
+    context 'with negatable flag options and max_times' do
+      let(:args) do
+        described_class.define do
+          flag_option :force, negatable: true, max_times: 2
+        end
+      end
+
+      it 'outputs --no-flag once when value is false' do
+        expect(args.bind(force: false).to_ary).to eq(['--no-force'])
+      end
+
+      it 'outputs --flag once when value is true' do
+        expect(args.bind(force: true).to_ary).to eq(['--force'])
+      end
+
+      it 'outputs --flag once when value is 1' do
+        expect(args.bind(force: 1).to_ary).to eq(['--force'])
+      end
+
+      it 'outputs repeated positive flags when value is an Integer' do
+        expect(args.bind(force: 2).to_ary).to eq(['--force', '--force'])
+      end
+
+      it 'raises an error when value is 0' do
+        expect { args.bind(force: 0) }.to raise_error(ArgumentError, /force.*positive Integer/)
+      end
+
+      it 'raises an error for non-boolean non-Integer value' do
+        expect { args.bind(force: 'yes') }.to raise_error(ArgumentError, /force.*true, false, or a positive Integer/)
+      end
+    end
+
+    context 'with negatable flag options without max_times' do
+      let(:args) do
+        described_class.define do
+          flag_option :force, negatable: true
+        end
+      end
+
+      it 'raises an error for Integer value' do
+        expect { args.bind(force: 1) }.to raise_error(ArgumentError, /negatable_flag expects a boolean value/)
+      end
+    end
+
+    context 'with invalid max_times definitions for flag options' do
+      it 'rejects max_times: 0' do
+        expect do
+          described_class.define do
+            flag_option :force, max_times: 0
+          end
+        end.to raise_error(ArgumentError, /max_times.*Integer >= 2/)
+      end
+
+      it 'rejects max_times: 1' do
+        expect do
+          described_class.define do
+            flag_option :force, max_times: 1
+          end
+        end.to raise_error(ArgumentError, /max_times.*Integer >= 2/)
+      end
+
+      it 'rejects non-Integer max_times' do
+        expect do
+          described_class.define do
+            flag_option :force, max_times: 2.5
+          end
+        end.to raise_error(ArgumentError, /max_times.*Integer >= 2/)
+      end
+    end
+
+    context 'with flag options using as: array and max_times' do
+      let(:args) do
+        described_class.define do
+          flag_option :recursive, as: ['-r', '--remotes'], max_times: 2
+        end
+      end
+
+      it 'repeats the full as: array output for each count' do
+        expect(args.bind(recursive: 2).to_ary).to eq(['-r', '--remotes', '-r', '--remotes'])
+      end
+    end
+
+    context 'with flag options using as: string and max_times' do
+      let(:args) do
+        described_class.define do
+          flag_option :force, as: '-ff', max_times: 2
+        end
+      end
+
+      it 'repeats the as: string output for each count' do
+        expect(args.bind(force: 2).to_ary).to eq(['-ff', '-ff'])
+      end
     end
 
     context 'with value options' do
@@ -4468,6 +4618,39 @@ RSpec.describe Git::Commands::Arguments do
         it '? accessor returns false when negatable flag is false' do
           bound = args.bind(verbose: false)
           expect(bound.verbose?).to be false
+        end
+      end
+
+      context 'with flag_option max_times' do
+        let(:args) do
+          described_class.define do
+            flag_option :force, max_times: 2
+          end
+        end
+
+        it '? accessor returns true for positive Integer value' do
+          bound = args.bind(force: 2)
+          expect(bound.force?).to be true
+        end
+
+        it '? accessor returns true when value is true' do
+          bound = args.bind(force: true)
+          expect(bound.force?).to be true
+        end
+
+        it '? accessor returns false when value is nil' do
+          bound = args.bind(force: nil)
+          expect(bound.force?).to be false
+        end
+
+        it '? accessor returns false when option is not provided' do
+          bound = args.bind
+          expect(bound.force?).to be false
+        end
+
+        it 'plain accessor returns the raw Integer value' do
+          bound = args.bind(force: 2)
+          expect(bound.force).to eq(2)
         end
       end
 


### PR DESCRIPTION
## Summary

Add a `max_times:` modifier to `flag_option` that lets callers pass a positive Integer (up to `max_times`) to emit a flag multiple times. This supports git flags with escalating effect (e.g. `git worktree remove --force --force`).

PR 1 of 2 for #1178. This PR covers the DSL change; PR 2 will update existing command classes to use `max_times:`.

## Changes

### `flag_option` DSL

- Add `max_times:` keyword (must be `Integer >= 2` or `nil`)
- Validate at definition time: `max_times: 0`, `max_times: 1`, and non-Integer values raise `ArgumentError`
- Remove unused `type:` parameter from `flag_option` (never used by any command class; accepted types are fully determined by `max_times:`)

### Builders

- Refactor `:flag` builder from a lambda to `build_flag` method that delegates to shared normalization
- Refactor `:negatable_flag` builder (`build_negatable_flag`) to share the same normalization path for non-`false` values
- Add `normalize_flag_value!` — returns a repeat count (1 for `true`, 0 for `nil`/`false`, validated integer otherwise)
- Add `append_repeated_flag` — emits the flag `count` times, handling both String and Array `as:` specs
- Add focused error-raising helpers for clear, context-specific error messages

### Bound accessors

- Update `flag_predicate?` to return `true` for positive integers, preserving `bound.force?` semantics when the caller passes `force: 2`

### Value contract

| Caller value | Non-negatable | `negatable: true` |
|---|---|---|
| `nil` / absent | no output | no output |
| `false` | no output | `--no-flag` once |
| `true` | flag once | flag once |
| `1..max_times` | flag N times | flag N times |
| `0`, negative, float, non-Integer | `ArgumentError` | `ArgumentError` |
| Integer without `max_times:` set | `ArgumentError` | `ArgumentError` |

### Tests

- 32 new specs covering all value contract cases, definition validation, `as:` string/array repetition, negatable combinations, and `Bound` predicate/accessor behavior