### PR TITLE
refactor: migrate repeatable command flags to max_times

### DIFF
--- a/.github/skills/command-yard-documentation/SKILL.md
+++ b/.github/skills/command-yard-documentation/SKILL.md
@@ -179,6 +179,7 @@ conflicting documentation for the method.
   | DSL method | YARD type |
   | --- | --- |
   | `flag_option` | `[Boolean]` |
+  | `flag_option ..., max_times: N` | `[Boolean, Integer]` |
   | `flag_or_value_option` | `[Boolean, String]` (or the specific value type) |
   | `value_option` | `[String]` (or a more specific type where known) |
   | `operand` (repeatable) | `[Array<String>]` |
@@ -219,6 +220,9 @@ When command declares non-default exit range:
       repository`, `the result of calling \`git show-ref\``, `if git exits with a non-zero
       status`)
 - [ ] consistent option wording and defaults across sibling commands
+- [ ] `max_times:` flags use `[Boolean, Integer]` type, not just `[Boolean]`, and
+      include a continuation paragraph explaining integer semantics (e.g. "When an
+      integer is given, the flag is repeated that many times")
 - [ ] no stale references to removed per-command implementation details
 - [ ] all other general formatting rules from [YARD
   Documentation](../yard-documentation/SKILL.md) are satisfied

--- a/.github/skills/review-arguments-dsl/CHECKLIST.md
+++ b/.github/skills/review-arguments-dsl/CHECKLIST.md
@@ -6,6 +6,7 @@
 | --- | --- | --- |
 | fixed flag always present | `literal` | `literal 'stash'` — **only** for operation selectors (subcommand names, mode flags like `--delete` that define what the class does) |
 | boolean flag | `flag_option` | `flag_option :cached` |
+| repeatable boolean flag | `flag_option ..., max_times: N` | `flag_option %i[force f], max_times: 2` |
 | boolean-or-value | `flag_or_value_option` | `flag_or_value_option :dirstat, inline: true` |
 | value option | `value_option` | `value_option :message` |
 | execution kwarg (not a CLI arg) | `execution_option` | `execution_option :timeout` |
@@ -136,33 +137,41 @@ This is intentional power — but it carries a cost: a reviewer can no longer ve
 the flag by reading the symbol name alone. The `as:` string must be audited
 separately, making it harder to spot typos and drift.
 
-Flag any use of `as:` unless one of these three conditions applies:
+Flag any use of `as:` unless one of these conditions applies:
 
 1. **Ruby keyword conflict** — the git flag's natural name is a Ruby keyword and
-   cannot be used as a symbol literal. The alias is renamed, and `as:` supplies the
-   real flag:
+  cannot be used as a symbol literal. The alias is renamed, and `as:` supplies the
+  real flag:
 
-   ```ruby
-   flag_option %i[begin_rev], as: '--begin'
-   ```
+  ```ruby
+  flag_option %i[begin_rev], as: '--begin'
+  ```
 
-2. **Combined short flag** — git accepts a repeated short flag in combined form (e.g.
-   `--force --force` → `-ff`) and there is no single long-form equivalent. This is
-   the only idiomatic way to express it:
+2. **The required argv cannot be expressed by the normal DSL mapping** — the
+  symbol name, aliases, and existing modifiers (`negatable:`, `inline:`,
+  `as_operand:`, `max_times:`, etc.) cannot produce the required token sequence,
+  so `as:` is the narrowest accurate escape hatch. Example:
 
-   ```ruby
-   flag_option %i[force_force ff], as: '-ff'
-   ```
+  ```ruby
+  flag_option :remotes, as: ['-r', '--remotes']
+  ```
 
-3. **Multi-token flag** — the option must emit two or more CLI tokens that cannot be
-   derived from a single symbol. Pass an array (valid on `flag_option` only):
+Outside these cases, `as:` is a red flag. A DSL entry that uses `as:` where a
+plain symbol, alias, or existing modifier would suffice should be corrected.
 
-   ```ruby
-   flag_option :double_force, as: ['--force', '--force']
-   ```
+#### Prefer first-class DSL features over `as:`
 
-Outside these three cases, `as:` is a red flag. A DSL entry that uses `as:` where a
-plain symbol or alias would suffice should be corrected.
+When the DSL now has a first-class way to express the behavior, `as:` is no longer
+justified. Repeated flags are the canonical example: use `max_times:` instead of
+encoding repetition manually.
+
+The following patterns should be flagged as errors because `max_times:` expresses
+them directly:
+
+- **Combined short flag used to emulate repetition** (e.g. `flag_option %i[force_force ff], as: '-ff'`) —
+  replace with `flag_option %i[force f], max_times: 2`
+- **Repeated identical tokens encoded as an array** (e.g. `flag_option :double_force, as: ['--force', '--force']`) —
+  replace with `flag_option %i[force f], max_times: 2`
 
 #### Single-char flags never need `as:`
 
@@ -355,6 +364,7 @@ correctly placed on their respective DSL methods:
 | `negatable:` | `flag_option`, `flag_or_value_option` |
 | `allow_empty:` | `value_option` |
 | `as_operand:` | `value_option` only — see pathspec table above |
+| `max_times:` | `flag_option` — limits how many times the flag is emitted; caller passes an integer up to N (e.g. `force: 2` emits `--force --force`) |
 | `end_of_options` | structural DSL method — required before the first `operand` (or `value_option ... as_operand: true`) whenever any option flags appear earlier in the block; pathspec operands always require it; see section 3 for the full placement rule |
 
 ## 5. Completeness
@@ -367,6 +377,23 @@ Cross-check against:
 
 Every supported **behavioral** option should be represented in `arguments do`, and
 every DSL entry should be covered by tests.
+
+### Repeatable boolean flags
+
+When the version-matched git documentation describes a flag that can be given multiple
+times to increase its effect (e.g. `--force` can be given twice for `git clean`), use
+`flag_option ..., max_times: N` where N is the documented maximum repetition count.
+The caller can then pass `true` (emit once) or an integer up to N (emit that many
+times).
+
+Flag these as errors:
+
+- Using `as:` to emulate repeated flags (e.g. `as: '-ff'` or
+  `as: ['--force', '--force']`) instead of `max_times:`
+- Using a separate symbol name for the repeated form (e.g. `:force_force`) instead of
+  `max_times:` on the same symbol
+- Missing `max_times:` when the version-matched docs explicitly describe repeatable
+  flag behavior
 
 ### Options excluded due to execution-model conflicts
 

--- a/.github/skills/review-arguments-dsl/SKILL.md
+++ b/.github/skills/review-arguments-dsl/SKILL.md
@@ -103,10 +103,11 @@ Key behaviors:
 - **`as:` override** — an escape hatch that emits the given string (or array of
   strings) verbatim instead of deriving a flag from the symbol name. Because it
   bypasses the DSL's automatic mapping it removes the guarantee that the flag can
-  be verified just by reading the symbol name, adding a manual audit burden. Use
-  it only when the DSL genuinely cannot produce the required output — see
-  section 2 for the three acceptable cases. Uppercase single-char symbols never
-  need `as:`.
+  be verified just by reading the symbol name, adding a manual audit burden. Treat
+  it as a red flag by default and allow it only when the DSL genuinely cannot
+  produce the required output any other way. Patterns now covered by first-class
+  DSL features, such as repeated flags via `max_times:`, should not use `as:`.
+  Uppercase single-char symbols never need `as:`.
 - **Aliases** — first alias is canonical and determines generated flag (long name
   first: `%i[force f]`, not `%i[f force]`)
 - **`skip_cli` operand behavior** — `operand ..., skip_cli: true` binds and validates

--- a/.github/skills/review-command-tests/SKILL.md
+++ b/.github/skills/review-command-tests/SKILL.md
@@ -90,6 +90,8 @@ Unit tests verify CLI argument building and command-layer behavior for each comm
   base invocation test — do not repeat it in every test.
 - Each positional operand variation (e.g., single value, multiple values)
 - Each flag option, including aliases (e.g., `:force` and `:f`)
+- `max_times:` flag options: test with `true` (emits once) and the maximum integer
+  (emits N times), plus each alias with `true`
 - Flag options combined with operands where meaningful (e.g., an option that modifies
   how operands are interpreted)
 - Value options with each accepted form (e.g., boolean `true` vs a string value like
@@ -197,6 +199,10 @@ Unit tests should exercise each **code path** through the command, not each poss
 - **Repeating the return value assertion.** The base invocation test asserts
   `expect(result).to eq(expected_result)` once as a contract check. Do not repeat
   this assertion in other tests — one check per file is sufficient.
+- **Intermediate integers for `max_times:` flags.** When a flag declares
+  `max_times: N`, test only `true` and the max integer N. Do not test intermediate
+  values (e.g. `force: 1` when `max_times: 2`) — the DSL handles all valid integers
+  uniformly and intermediate values exercise the same code path.
 - **String-variant pass-through tests.** Do not write multiple tests that pass
   different string values through the same positional argument or value option. Tests
   like "handles paths with spaces" and "handles paths with unicode" exercise the same

--- a/.github/skills/scaffold-new-command/SKILL.md
+++ b/.github/skills/scaffold-new-command/SKILL.md
@@ -247,6 +247,13 @@ module Git
         #
         #     @option options [Boolean] :simple_flag (nil) One-sentence description without period
         #
+        #     @option options [Boolean, Integer] :force (nil) Short description without period
+        #
+        #       When an integer is given, the flag is repeated that many times (up to the
+        #       configured `max_times:` limit).
+        #
+        #       Alias: :f
+        #
         #     @option options [Boolean, String, nil] :complex_flag (nil) Short description without period
         #
         #       Continuation: explain the `true`/`false`/string forms here, each separated by
@@ -471,6 +478,13 @@ not document — it will generate an unknown flag that older supported git may r
 Symmetrically, every option the version-matched docs document with a short form
 **must** have an
 alias in the DSL (long name first: `%i[dry_run n]`).
+
+**`as:` is an escape hatch, not a default tool:** treat `as:` as suspicious by
+default and use it only when the required argv cannot be expressed by the normal
+DSL mapping plus existing modifiers (`negatable:`, `inline:`, `as_operand:`,
+`max_times:`, etc.). If a plain symbol, alias, or first-class modifier can express
+the same behavior, prefer that. In particular, do not use `as:` to encode repeated
+flags now that `max_times:` exists.
 
 **`inline: true` for `=<value>` options:** when the version-matched docs show `--option=<value>`
 (with an `=`), the DSL entry must include `inline: true` regardless of whether the
@@ -697,6 +711,30 @@ end
 code path as the base invocation with no options. The "no arguments" test already
 covers this path. Do not write `command.call(prune: false)` or similar for flags
 that have no `--no-<flag>` form.
+
+**Test `max_times:` flags with both `true` and the maximum integer.** When a
+`flag_option` declares `max_times: N`, test two code paths: `option: true` (emits
+the flag once) and `option: N` (emits the flag N times). Also test every alias with
+`true`. Do not test intermediate integers (e.g. `force: 1` when `max_times: 2`) —
+the DSL handles all valid integers uniformly.
+
+```ruby
+# DSL: flag_option %i[force f], max_times: 2
+it 'adds --force when force: true' do
+  expect_command_capturing('clean', '--force').and_return(command_result)
+  command.call(force: true)
+end
+
+it 'emits --force twice when force: 2' do
+  expect_command_capturing('clean', '--force', '--force').and_return(command_result)
+  command.call(force: 2)
+end
+
+it 'supports the :f alias' do
+  expect_command_capturing('clean', '--force').and_return(command_result)
+  command.call(f: true)
+end
+```
 
 ### Integration tests
 

--- a/lib/git/commands/clean.rb
+++ b/lib/git/commands/clean.rb
@@ -23,7 +23,7 @@ module Git
     #   clean.call(force: true)
     #
     # @example Force cleaning of untracked nested git repositories
-    #   clean.call(force_force: true)
+    #   clean.call(force: 2)
     #
     # @example Recurse into untracked directories
     #   clean.call(d: true)
@@ -47,8 +47,7 @@ module Git
       arguments do
         literal 'clean'
         flag_option :d
-        flag_option %i[force f]
-        flag_option %i[force_force ff], as: '-ff'
+        flag_option %i[force f], max_times: 2
         flag_option %i[dry_run n]
         value_option %i[exclude e], inline: true, repeatable: true
         flag_option :x
@@ -67,13 +66,16 @@ module Git
       #
       #     @option options [Boolean] :d (nil) Recurse into untracked directories
       #
-      #     @option options [Boolean] :force (nil) Force the removal of untracked files
+      #     @option options [Boolean, Integer] :force (nil) Force the removal of untracked files
       #
       #       When `clean.requireForce` is not set to `false`, git-clean will refuse to
-      #       delete files or directories unless this option is given
+      #       delete files or directories unless this option is given.
       #
-      #     @option options [Boolean] :force_force (nil) Remove untracked nested git
-      #       repositories (directories with a `.git` subdirectory)
+      #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit `--force --force`,
+      #       which also removes untracked nested git repositories (directories with a
+      #       `.git` subdirectory).
+      #
+      #       Alias: :f
       #
       #     @option options [Boolean] :dry_run (nil) Don't actually remove anything, just
       #       show what would be done

--- a/lib/git/commands/worktree/add.rb
+++ b/lib/git/commands/worktree/add.rb
@@ -28,7 +28,7 @@ module Git
         arguments do
           literal 'worktree'
           literal 'add'
-          flag_option %i[force f]
+          flag_option %i[force f], max_times: 2
           flag_option :detach
           flag_option :checkout, negatable: true
           flag_option :guess_remote, negatable: true
@@ -57,7 +57,10 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :force (nil) override safety guards
+        #     @option options [Boolean, Integer] :force (nil) override safety guards
+        #
+        #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit
+        #       `--force --force`, which also allows adding worktrees for locked branches.
         #
         #       Alias: :f
         #

--- a/lib/git/commands/worktree/move.rb
+++ b/lib/git/commands/worktree/move.rb
@@ -23,7 +23,7 @@ module Git
         arguments do
           literal 'worktree'
           literal 'move'
-          flag_option %i[force f]
+          flag_option %i[force f], max_times: 2
           end_of_options
           operand :worktree, required: true
           operand :new_path, required: true
@@ -41,11 +41,10 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :force (nil) allow moving a locked worktree
+        #     @option options [Boolean, Integer] :force (nil) allow moving a locked worktree
         #
-        #       Note: force-moving when the destination is also locked or missing (requires
-        #       `--force` twice) is not yet supported.
-        #       See {https://github.com/ruby-git/ruby-git/issues/1178 issue #1178}.
+        #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit
+        #       `--force --force`, which also handles locked or missing destinations.
         #
         #       Alias: :f
         #

--- a/lib/git/commands/worktree/remove.rb
+++ b/lib/git/commands/worktree/remove.rb
@@ -23,7 +23,7 @@ module Git
         arguments do
           literal 'worktree'
           literal 'remove'
-          flag_option %i[force f]
+          flag_option %i[force f], max_times: 2
           end_of_options
           operand :worktree, required: true
         end
@@ -38,10 +38,11 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :force (nil) remove even if the worktree has uncommitted changes
+        #     @option options [Boolean, Integer] :force (nil) remove even if the worktree has
+        #       uncommitted changes
         #
-        #       Note: removing locked worktrees (requires `--force` twice) is not yet supported.
-        #       See {https://github.com/ruby-git/ruby-git/issues/1178 issue #1178}.
+        #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit `--force --force`,
+        #       which also removes locked worktrees.
         #
         #       Alias: :f
         #

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1227,35 +1227,6 @@ module Git
       Git::Commands::Clean.new(self).call(**opts).stdout
     end
 
-    def migrate_clean_legacy_options(opts)
-      opts = deprecate_clean_option(opts, :ff, ':ff option is deprecated. Use force: 2 instead.')
-      deprecate_clean_option(opts, :force_force, ':force_force option is deprecated. Use force: 2 instead.')
-    end
-
-    def deprecate_clean_option(opts, key, message)
-      return opts unless opts.key?(key)
-
-      Git::Deprecation.warn(message)
-      opts = opts.dup
-      deprecated_value = opts.delete(key)
-      return opts unless deprecated_value
-
-      opts[:force] = merge_clean_force_option(opts[:force])
-      opts
-    end
-
-    def merge_clean_force_option(existing_force)
-      [normalize_clean_force_option(existing_force), 2].max
-    end
-
-    def normalize_clean_force_option(value)
-      case value
-      when Integer then value
-      when true then 1
-      else 0
-      end
-    end
-
     REVERT_ALLOWED_OPTS = %i[no_edit].freeze
 
     def revert(commitish, opts = {})
@@ -2122,8 +2093,6 @@ module Git
 
     private
 
-<<<<<<< HEAD
-=======
     def migrate_clean_legacy_options(opts)
       opts = deprecate_clean_option(opts, :ff, ':ff option is deprecated. Use force: 2 instead.')
       deprecate_clean_option(opts, :force_force, ':force_force option is deprecated. Use force: 2 instead.')
@@ -2180,7 +2149,6 @@ module Git
       end
     end
 
->>>>>>> 481db6d (fixup! refactor(lib): update clean backward compat for force: 2)
     # Build a result hash from clone options for Git::Base.new
     #
     # Parses the clone directory from the git command's stderr output, which

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1223,12 +1223,37 @@ module Git
     # @return [String] the command output
     #
     def clean(opts = {})
-      if opts.key?(:ff)
-        Git::Deprecation.warn(':ff option is deprecated. Use :force_force instead.')
-        opts = opts.dup
-        opts[:force_force] = opts.delete(:ff)
-      end
+      opts = migrate_clean_legacy_options(opts)
       Git::Commands::Clean.new(self).call(**opts).stdout
+    end
+
+    def migrate_clean_legacy_options(opts)
+      opts = deprecate_clean_option(opts, :ff, ':ff option is deprecated. Use force: 2 instead.')
+      deprecate_clean_option(opts, :force_force, ':force_force option is deprecated. Use force: 2 instead.')
+    end
+
+    def deprecate_clean_option(opts, key, message)
+      return opts unless opts.key?(key)
+
+      Git::Deprecation.warn(message)
+      opts = opts.dup
+      deprecated_value = opts.delete(key)
+      return opts unless deprecated_value
+
+      opts[:force] = merge_clean_force_option(opts[:force])
+      opts
+    end
+
+    def merge_clean_force_option(existing_force)
+      [normalize_clean_force_option(existing_force), 2].max
+    end
+
+    def normalize_clean_force_option(value)
+      case value
+      when Integer then value
+      when true then 1
+      else 0
+      end
     end
 
     REVERT_ALLOWED_OPTS = %i[no_edit].freeze
@@ -2097,6 +2122,65 @@ module Git
 
     private
 
+<<<<<<< HEAD
+=======
+    def migrate_clean_legacy_options(opts)
+      opts = deprecate_clean_option(opts, :ff, ':ff option is deprecated. Use force: 2 instead.')
+      deprecate_clean_option(opts, :force_force, ':force_force option is deprecated. Use force: 2 instead.')
+    end
+
+    def deprecate_clean_option(opts, key, message)
+      return opts unless opts.key?(key)
+
+      opts = opts.dup
+      deprecated_value = opts.delete(key)
+      validate_deprecated_clean_option_value!(key, deprecated_value)
+
+      Git::Deprecation.warn(message)
+      return opts unless deprecated_value
+
+      opts[:force] = merge_clean_force_option(opts[:force], force_specified: force_option_specified?(opts))
+      opts
+    end
+
+    def force_option_specified?(opts)
+      opts.key?(:force) && !opts[:force].nil?
+    end
+
+    def validate_deprecated_clean_option_value!(key, value)
+      return if value.nil? || value == true || value == false
+
+      raise ArgumentError, "#{key} option only accepts true, false, or nil"
+    end
+
+    def merge_clean_force_option(existing_force, force_specified: false)
+      return 2 unless force_specified
+
+      normalized_force = normalize_clean_force_option(existing_force)
+
+      case normalized_force
+      when Integer then merge_integer_clean_force_option(normalized_force)
+      when false
+        2
+      else
+        normalized_force
+      end
+    end
+
+    def merge_integer_clean_force_option(normalized_force)
+      return normalized_force if normalized_force < 1
+
+      [normalized_force, 2].max
+    end
+
+    def normalize_clean_force_option(value)
+      case value
+      when true then 1
+      else value
+      end
+    end
+
+>>>>>>> 481db6d (fixup! refactor(lib): update clean backward compat for force: 2)
     # Build a result hash from clone options for Git::Base.new
     #
     # Parses the clone directory from the git command's stderr output, which

--- a/spec/unit/git/commands/clean_spec.rb
+++ b/spec/unit/git/commands/clean_spec.rb
@@ -26,22 +26,16 @@ RSpec.describe Git::Commands::Clean do
       end
     end
 
-    context 'with the :force_force argument' do
-      it 'adds -ff to the command line' do
-        expect_command_capturing('clean', '-ff').and_return(command_result)
-        command.call(force_force: true)
+    context 'with force: 2' do
+      it 'emits --force twice' do
+        expect_command_capturing('clean', '--force', '--force').and_return(command_result)
+        command.call(force: 2)
       end
-    end
 
-    context 'with both :force and :force_force arguments' do
-      it 'allows force: true with force_force: false' do
+      it 'accepts :f as an alias' do
         expect_command_capturing('clean', '--force').and_return(command_result)
-        command.call(force: true, force_force: false)
-      end
 
-      it 'allows force_force: true with force: false' do
-        expect_command_capturing('clean', '-ff').and_return(command_result)
-        command.call(force_force: true, force: false)
+        command.call(f: true)
       end
     end
 

--- a/spec/unit/git/commands/worktree/add_spec.rb
+++ b/spec/unit/git/commands/worktree/add_spec.rb
@@ -46,6 +46,13 @@ RSpec.describe Git::Commands::Worktree::Add do
 
         command.call('/tmp/feat', f: true)
       end
+
+      it 'emits --force twice when force: 2' do
+        expect_command_capturing('worktree', 'add', '--force', '--force', '--', '/tmp/feat', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/feat', force: 2)
+      end
     end
 
     context 'with :detach option' do

--- a/spec/unit/git/commands/worktree/move_spec.rb
+++ b/spec/unit/git/commands/worktree/move_spec.rb
@@ -39,8 +39,9 @@ RSpec.describe Git::Commands::Worktree::Move do
       end
 
       it 'emits --force twice when force: 2' do
-        expect_command_capturing('worktree', 'move', '--force', '--force', '--', '/tmp/old', '/tmp/new', env: worktree_env)
-          .and_return(command_result(''))
+        expect_command_capturing(
+          'worktree', 'move', '--force', '--force', '--', '/tmp/old', '/tmp/new', env: worktree_env
+        ).and_return(command_result(''))
 
         command.call('/tmp/old', '/tmp/new', force: 2)
       end

--- a/spec/unit/git/commands/worktree/move_spec.rb
+++ b/spec/unit/git/commands/worktree/move_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe Git::Commands::Worktree::Move do
 
         command.call('/tmp/old', '/tmp/new', f: true)
       end
+
+      it 'emits --force twice when force: 2' do
+        expect_command_capturing('worktree', 'move', '--force', '--force', '--', '/tmp/old', '/tmp/new', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/old', '/tmp/new', force: 2)
+      end
     end
   end
 end

--- a/spec/unit/git/commands/worktree/remove_spec.rb
+++ b/spec/unit/git/commands/worktree/remove_spec.rb
@@ -37,6 +37,13 @@ RSpec.describe Git::Commands::Worktree::Remove do
 
         command.call('/tmp/feature', f: true)
       end
+
+      it 'emits --force twice when force: 2' do
+        expect_command_capturing('worktree', 'remove', '--force', '--force', '--', '/tmp/feature', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/feature', force: 2)
+      end
     end
   end
 end

--- a/tests/units/test_deprecations.rb
+++ b/tests/units/test_deprecations.rb
@@ -202,11 +202,53 @@ class TestDeprecations < Test::Unit::TestCase
       git.add('tempfile.txt')
 
       Git::Deprecation.expects(:warn).with(
-        ':ff option is deprecated. Use :force_force instead.'
+        ':ff option is deprecated. Use force: 2 instead.'
       )
 
       # Call clean with deprecated :ff option
       git.lib.clean(ff: true)
+    end
+  end
+
+  def test_clean_ff_false_deprecation_preserves_non_force_behavior
+    Git::Deprecation.expects(:warn).with(
+      ':ff option is deprecated. Use force: 2 instead.'
+    )
+
+    expected_command_line = ['clean', {}]
+    assert_command_line_eq(expected_command_line) do |git|
+      git.clean(ff: false)
+    end
+  end
+
+  def test_clean_ff_rejects_non_boolean_values
+    error = assert_raise(ArgumentError) do
+      @git.clean(ff: 0)
+    end
+
+    assert_match(/ff option only accepts true, false, or nil/, error.message)
+  end
+
+  def test_clean_ff_does_not_mask_invalid_force_value
+    Git::Deprecation.expects(:warn).with(
+      ':ff option is deprecated. Use force: 2 instead.'
+    )
+
+    error = assert_raise(ArgumentError) do
+      @git.clean(ff: true, force: 0)
+    end
+
+    assert_match(/force.*positive Integer/, error.message)
+  end
+
+  def test_clean_ff_true_treats_force_nil_as_unspecified
+    Git::Deprecation.expects(:warn).with(
+      ':ff option is deprecated. Use force: 2 instead.'
+    )
+
+    expected_command_line = ['clean', '--force', '--force', {}]
+    assert_command_line_eq(expected_command_line) do |git|
+      git.clean(ff: true, force: nil)
     end
   end
 end

--- a/tests/units/test_index_ops.rb
+++ b/tests/units/test_index_ops.rb
@@ -75,7 +75,7 @@ class TestIndexOps < Test::Unit::TestCase
 
       assert(File.exist?('nested'))
 
-      g.clean(force_force: true, d: true)
+      g.clean(force: 2, d: true)
       assert(!File.exist?('nested'))
     end
   end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Implements PR 2 for #1178 by migrating the existing command classes that used ad hoc repeated-flag patterns over to `flag_option ..., max_times:`.

This changes the command DSL usage for repeated `--force` flags in `clean` and `worktree` commands, updates `Git::Lib#clean` backward-compatibility handling to steer callers to `force: 2`, and refreshes the command-related skills so scaffolding, DSL review, YARD review, and test review all document the new `max_times:` guidance consistently.

Key changes:

- migrate `Git::Commands::Clean` from the `force_force` workaround to `flag_option %i[force f], max_times: 2`
- add `max_times: 2` support for repeated `--force` in `worktree add`, `worktree move`, and `worktree remove`
- preserve backward compatibility in `Git::Lib#clean` by mapping legacy `:ff` and `:force_force` inputs to `force: 2` with deprecation warnings
- update unit and test-unit coverage for the new `force: 2` behavior
- update skill documentation to treat `as:` as an escape hatch and to direct repeated-flag cases to `max_times:`

Validation:

- `bundle exec rake default`
- `bundle exec rake default:parallel`
- `bundle exec rspec`
- `bundle exec rubocop`

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).