### PR TITLE
refactor(stash): update apply, branch, clear, create, drop commands (batch 3 partial)

### DIFF
--- a/lib/git/commands/stash/apply.rb
+++ b/lib/git/commands/stash/apply.rb
@@ -30,6 +30,7 @@ module Git
           literal 'stash'
           literal 'apply'
           flag_option :index
+          flag_option %i[quiet q]
           operand :stash
         end
 
@@ -45,6 +46,10 @@ module Git
         #
         #     @option options [Boolean] :index (nil) restore the index state as well
         #
+        #     @option options [Boolean] :quiet (nil) suppress feedback messages
+        #
+        #       Alias: :q
+        #
         #   @overload call(stash, **options)
         #
         #     Apply a specific stash
@@ -55,9 +60,13 @@ module Git
         #
         #     @option options [Boolean] :index (nil) restore the index state as well
         #
+        #     @option options [Boolean] :quiet (nil) suppress feedback messages
+        #
+        #       Alias: :q
+        #
         #   @return [Git::CommandLineResult] the result of calling `git stash apply`
         #
-        #   @raise [Git::FailedError] if the stash does not exist
+        #   @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/stash/branch.rb
+++ b/lib/git/commands/stash/branch.rb
@@ -56,7 +56,7 @@ module Git
         #
         #   @return [Git::CommandLineResult] the result of calling `git stash branch`
         #
-        #   @raise [Git::FailedError] if the branch already exists or stash doesn't exist
+        #   @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/stash/clear.rb
+++ b/lib/git/commands/stash/clear.rb
@@ -30,7 +30,9 @@ module Git
         #
         #     Clear all stash entries
         #
-        #     @return [Git::CommandLineResult] the result of calling `git stash clear`
+        #   @return [Git::CommandLineResult] the result of calling `git stash clear`
+        #
+        #   @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/stash/create.rb
+++ b/lib/git/commands/stash/create.rb
@@ -48,6 +48,8 @@ module Git
         #     @param message [String] optional message for the stash commit
         #
         #   @return [Git::CommandLineResult] the result of calling `git stash create`
+        #
+        #   @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/stash/drop.rb
+++ b/lib/git/commands/stash/drop.rb
@@ -26,6 +26,7 @@ module Git
         arguments do
           literal 'stash'
           literal 'drop'
+          flag_option %i[quiet q]
           operand :stash
         end
 
@@ -33,19 +34,31 @@ module Git
         #
         #   Drop a stash entry
         #
-        #   @overload call()
+        #   @overload call(**options)
         #
         #     Drop the latest stash
         #
-        #   @overload call(stash)
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :quiet (nil) suppress feedback messages
+        #
+        #       Alias: :q
+        #
+        #   @overload call(stash, **options)
         #
         #     Drop a specific stash
         #
         #     @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
         #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :quiet (nil) suppress feedback messages
+        #
+        #       Alias: :q
+        #
         #   @return [Git::CommandLineResult] the result of calling `git stash drop`
         #
-        #   @raise [Git::FailedError] if the stash does not exist
+        #   @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/spec/unit/git/commands/stash/apply_spec.rb
+++ b/spec/unit/git/commands/stash/apply_spec.rb
@@ -54,5 +54,22 @@ RSpec.describe Git::Commands::Stash::Apply do
         command.call('stash@{1}', index: true)
       end
     end
+
+    context 'with :quiet option' do
+      it 'adds --quiet flag' do
+        expect_command_capturing('stash', 'apply', '--quiet').and_return(command_result(''))
+        command.call(quiet: true)
+      end
+
+      it 'does not add flag when false' do
+        expect_command_capturing('stash', 'apply').and_return(command_result(''))
+        command.call(quiet: false)
+      end
+
+      it ':q alias works' do
+        expect_command_capturing('stash', 'apply', '--quiet').and_return(command_result(''))
+        command.call(q: true)
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/stash/drop_spec.rb
+++ b/spec/unit/git/commands/stash/drop_spec.rb
@@ -35,5 +35,22 @@ RSpec.describe Git::Commands::Stash::Drop do
         command.call('1')
       end
     end
+
+    context 'with :quiet option' do
+      it 'adds --quiet flag' do
+        expect_command_capturing('stash', 'drop', '--quiet').and_return(command_result(''))
+        command.call(quiet: true)
+      end
+
+      it 'does not add flag when false' do
+        expect_command_capturing('stash', 'drop').and_return(command_result(''))
+        command.call(quiet: false)
+      end
+
+      it 'accepts :q alias' do
+        expect_command_capturing('stash', 'drop', '--quiet').and_return(command_result(''))
+        command.call(q: true)
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Partially addresses #1196 (batch 3: stash commands — first 5 of 10).

Updates `stash/apply`, `stash/branch`, `stash/clear`, `stash/create`, and `stash/drop`
command classes to fill missing DSL entries, fix `@raise` wording, and add YARD
documentation where absent.

## Changes

### `stash/apply`
- Add `flag_option %i[quiet q]` to arguments DSL (mirrors `[-q | --quiet]` in synopsis)
- Add `@option :quiet` (alias `:q`) to both `@overload` sections
- Fix `@raise` to canonical form: `if git exits with a non-zero exit status`
- Add unit tests for `:quiet` / `:q` option

### `stash/branch`
- Fix `@raise` to canonical form (previously named specific failure causes)

### `stash/clear`
- Add missing `@raise [Git::FailedError]` tag
- Move `@return` out of the `@overload` block to top-level `@!method` position

### `stash/create`
- Add missing `@raise [Git::FailedError]` tag

### `stash/drop`
- Add `flag_option %i[quiet q]` to arguments DSL
- Add `@option :quiet` (alias `:q`) to both `@overload` sections
- Fix `@raise` to canonical form
- Add unit tests for `:quiet` / `:q` option

## Test coverage

- 29 unit examples pass (0 failures)
- 12 integration examples pass (0 failures)
- Rubocop: 7 files, no offenses
- YARD: 0 undocumented command classes