### PR TITLE
refactor: update stash and worktree commands for batch 3

### DIFF
--- a/lib/git/commands/stash/apply.rb
+++ b/lib/git/commands/stash/apply.rb
@@ -30,6 +30,7 @@ module Git
           literal 'stash'
           literal 'apply'
           flag_option :index
+          flag_option %i[quiet q]
           operand :stash
         end
 
@@ -45,6 +46,10 @@ module Git
         #
         #     @option options [Boolean] :index (nil) restore the index state as well
         #
+        #     @option options [Boolean] :quiet (nil) suppress feedback messages
+        #
+        #       Alias: :q
+        #
         #   @overload call(stash, **options)
         #
         #     Apply a specific stash
@@ -55,9 +60,13 @@ module Git
         #
         #     @option options [Boolean] :index (nil) restore the index state as well
         #
+        #     @option options [Boolean] :quiet (nil) suppress feedback messages
+        #
+        #       Alias: :q
+        #
         #   @return [Git::CommandLineResult] the result of calling `git stash apply`
         #
-        #   @raise [Git::FailedError] if the stash does not exist
+        #   @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/stash/branch.rb
+++ b/lib/git/commands/stash/branch.rb
@@ -56,7 +56,7 @@ module Git
         #
         #   @return [Git::CommandLineResult] the result of calling `git stash branch`
         #
-        #   @raise [Git::FailedError] if the branch already exists or stash doesn't exist
+        #   @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/stash/clear.rb
+++ b/lib/git/commands/stash/clear.rb
@@ -30,7 +30,9 @@ module Git
         #
         #     Clear all stash entries
         #
-        #     @return [Git::CommandLineResult] the result of calling `git stash clear`
+        #   @return [Git::CommandLineResult] the result of calling `git stash clear`
+        #
+        #   @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/stash/create.rb
+++ b/lib/git/commands/stash/create.rb
@@ -48,6 +48,8 @@ module Git
         #     @param message [String] optional message for the stash commit
         #
         #   @return [Git::CommandLineResult] the result of calling `git stash create`
+        #
+        #   @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/stash/drop.rb
+++ b/lib/git/commands/stash/drop.rb
@@ -26,6 +26,7 @@ module Git
         arguments do
           literal 'stash'
           literal 'drop'
+          flag_option %i[quiet q]
           operand :stash
         end
 
@@ -33,19 +34,31 @@ module Git
         #
         #   Drop a stash entry
         #
-        #   @overload call()
+        #   @overload call(**options)
         #
         #     Drop the latest stash
         #
-        #   @overload call(stash)
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :quiet (nil) suppress feedback messages
+        #
+        #       Alias: :q
+        #
+        #   @overload call(stash, **options)
         #
         #     Drop a specific stash
         #
         #     @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
         #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :quiet (nil) suppress feedback messages
+        #
+        #       Alias: :q
+        #
         #   @return [Git::CommandLineResult] the result of calling `git stash drop`
         #
-        #   @raise [Git::FailedError] if the stash does not exist
+        #   @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/stash/list.rb
+++ b/lib/git/commands/stash/list.rb
@@ -8,14 +8,16 @@ module Git
     module Stash
       # List all stash entries
       #
+      # @example List all stashes
+      #   Git::Commands::Stash::List.new(execution_context).call
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-stash/2.52.0
+      #
       # @see Git::Commands::Stash Git::Commands::Stash for usage examples
       #
       # @see https://git-scm.com/docs/git-stash git-stash documentation
       #
       # @api private
-      #
-      # @example List all stashes
-      #   Git::Commands::Stash::List.new(execution_context).call
       #
       class List < Git::Commands::Base
         arguments do
@@ -31,6 +33,8 @@ module Git
         #   @overload call()
         #
         #     @return [Git::CommandLineResult] the result of calling `git stash list`
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/stash/pop.rb
+++ b/lib/git/commands/stash/pop.rb
@@ -25,11 +25,14 @@ module Git
       # @example Pop and restore index state
       #   Git::Commands::Stash::Pop.new(execution_context).call(index: true)
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-stash/2.52.0
+      #
       class Pop < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'pop'
           flag_option :index
+          flag_option %i[quiet q]
           operand :stash
         end
 
@@ -45,6 +48,10 @@ module Git
         #
         #     @option options [Boolean] :index (nil) restore the index state as well
         #
+        #     @option options [Boolean] :quiet (nil) suppress feedback messages
+        #
+        #       Alias: :q
+        #
         #   @overload call(stash, **options)
         #
         #     Pop a specific stash
@@ -54,6 +61,10 @@ module Git
         #     @param options [Hash] command options
         #
         #     @option options [Boolean] :index (nil) restore the index state as well
+        #
+        #     @option options [Boolean] :quiet (nil) suppress feedback messages
+        #
+        #       Alias: :q
         #
         #   @return [Git::CommandLineResult] the result of calling `git stash pop`
         #

--- a/lib/git/commands/stash/push.rb
+++ b/lib/git/commands/stash/push.rb
@@ -29,6 +29,8 @@ module Git
       # @example Include untracked files
       #   Git::Commands::Stash::Push.new(execution_context).call(include_untracked: true)
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-stash/2.52.0
+      #
       class Push < Git::Commands::Base
         arguments do
           literal 'stash'
@@ -36,7 +38,8 @@ module Git
           flag_option %i[patch p]
           flag_option %i[staged S]
           flag_option %i[keep_index k], negatable: true
-          flag_option %i[include_untracked u]
+          flag_option %i[quiet q]
+          flag_option %i[include_untracked u], negatable: true
           flag_option %i[all a]
           value_option %i[message m]
           value_option :pathspec_from_file, inline: true
@@ -67,7 +70,14 @@ module Git
         #
         #       Alias: :k
         #
+        #     @option options [Boolean] :quiet (nil) Suppress feedback messages
+        #
+        #       Alias: :q
+        #
         #     @option options [Boolean] :include_untracked (nil) Include untracked files in the stash
+        #
+        #       Pass `true` to include untracked files (`--include-untracked`).
+        #       Pass `false` to explicitly exclude untracked files (`--no-include-untracked`).
         #
         #       Alias: :u
         #
@@ -87,7 +97,7 @@ module Git
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
         #
-        #   @api public
+        #   @api private
         #
       end
     end

--- a/lib/git/commands/stash/store.rb
+++ b/lib/git/commands/stash/store.rb
@@ -13,43 +13,53 @@ module Git
       # This command is typically used after {Create} to actually record
       # the stash in the reflog.
       #
-      # @see Git::Commands::Stash Git::Commands::Stash for usage examples
-      #
-      # @see https://git-scm.com/docs/git-stash git-stash documentation
-      #
-      # @api private
-      #
       # @example Store a stash commit
       #   Git::Commands::Stash::Store.new(execution_context).call('abc123def456')
       #
       # @example Store with a custom message
       #   Git::Commands::Stash::Store.new(execution_context).call('abc123def456', message: 'WIP: feature')
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-stash/2.52.0
+      #
+      # @see Git::Commands::Stash Git::Commands::Stash for usage examples
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      # @api private
+      #
       class Store < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'store'
-          value_option %i[message m]
+          value_option %i[message m]  # --message (alias: :m)
+          flag_option %i[quiet q]     # --quiet (alias: :q)
+
+          end_of_options
+
           operand :commit, required: true
         end
 
         # @!method call(*, **)
         #
-        #   Store a commit in the stash reflog
-        #
         #   @overload call(commit, **options)
+        #
+        #     Execute the `git stash store` command.
         #
         #     @param commit [String] the commit SHA to store in the stash (required)
         #
         #     @param options [Hash] command options
         #
-        #     @option options [String] :message (nil) description for the reflog entry.
+        #     @option options [String] :message (nil) description for the reflog entry
         #
         #       Alias: :m
         #
+        #     @option options [Boolean] :quiet (nil) suppress feedback messages
+        #
+        #       Alias: :q
+        #
         #     @return [Git::CommandLineResult] the result of calling `git stash store`
         #
-        #     @raise [Git::FailedError] if the commit is not a valid stash commit
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/worktree/add.rb
+++ b/lib/git/commands/worktree/add.rb
@@ -24,16 +24,21 @@ module Git
       # @example Add a detached-HEAD worktree locked at creation
       #   Git::Commands::Worktree::Add.new(execution_context).call('/tmp/exp', detach: true, lock: true)
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      #
       class Add < ManagementBase
         arguments do
           literal 'worktree'
           literal 'add'
           flag_option %i[force f], max_times: 2
-          flag_option :detach
+          flag_option %i[detach d]
           flag_option :checkout, negatable: true
           flag_option :guess_remote, negatable: true
+          flag_option :relative_paths, negatable: true
           flag_option :track, negatable: true
           flag_option :lock
+          value_option :reason
+          flag_option :orphan
           flag_option %i[quiet q]
           value_option :b
           value_option :B
@@ -66,6 +71,8 @@ module Git
         #
         #     @option options [Boolean] :detach (nil) check out in detached-HEAD state
         #
+        #       Alias: :d
+        #
         #     @option options [Boolean] :checkout (nil) control whether the working tree
         #       is checked out after creation
         #
@@ -76,11 +83,26 @@ module Git
         #
         #       When `false`, passes `--no-guess-remote`.
         #
+        #     @option options [Boolean] :relative_paths (nil) link the new worktree using
+        #       relative paths instead of absolute paths
+        #
+        #       When `false`, passes `--no-relative-paths`.
+        #
         #     @option options [Boolean] :track (nil) mark the upstream branch for tracking
         #
         #       When `false`, passes `--no-track`.
         #
         #     @option options [Boolean] :lock (nil) lock the worktree immediately after creation
+        #
+        #     @option options [String] :reason (nil) explanation for the lock (used with :lock)
+        #
+        #       Sets the reason text stored with the lock. Only meaningful when :lock is also
+        #       passed.
+        #
+        #     @option options [Boolean] :orphan (nil) create the worktree on a new unborn branch
+        #
+        #       The new branch is named after the final component of :path unless :b or :B is
+        #       also given. Requires git 2.41.0 or later.
         #
         #     @option options [Boolean] :quiet (nil) suppress informational messages
         #
@@ -92,7 +114,9 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree add`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/worktree/list.rb
+++ b/lib/git/commands/worktree/list.rb
@@ -7,6 +7,12 @@ module Git
     module Worktree
       # Lists all worktrees attached to the repository
       #
+      # @example List all worktrees in default format
+      #   Git::Commands::Worktree::List.new(execution_context).call
+      #
+      # @example List worktrees with verbose output
+      #   Git::Commands::Worktree::List.new(execution_context).call(verbose: true)
+      #
       # @example List all worktrees in porcelain format
       #   Git::Commands::Worktree::List.new(execution_context).call(porcelain: true)
       #
@@ -19,7 +25,10 @@ module Git
         arguments do
           literal 'worktree'
           literal 'list'
+          flag_option %i[verbose v]
           flag_option :porcelain
+          flag_option :z
+          value_option :expire
         end
 
         # @!method call(*, **)
@@ -30,7 +39,19 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :porcelain (nil) produce machine-readable output
+        #     @option options [Boolean] :verbose (nil) output additional information about
+        #       each worktree, including lock reason and prunable status with detail
+        #
+        #       Alias: :v
+        #
+        #     @option options [Boolean] :porcelain (nil) produce machine-readable output;
+        #       format is stable across git versions regardless of user configuration
+        #
+        #     @option options [Boolean] :z (nil) terminate each line in porcelain output
+        #       with a NUL character instead of a newline; only meaningful with :porcelain
+        #
+        #     @option options [String] :expire (nil) annotate missing worktrees as prunable
+        #       if they are older than this time expression
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree list`
         #

--- a/lib/git/commands/worktree/lock.rb
+++ b/lib/git/commands/worktree/lock.rb
@@ -13,6 +13,8 @@ module Git
       # @example Lock with a reason message
       #   Git::Commands::Worktree::Lock.new(execution_context).call('/tmp/feature', reason: 'on NFS share')
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
@@ -23,7 +25,7 @@ module Git
         arguments do
           literal 'worktree'
           literal 'lock'
-          value_option :reason
+          value_option :reason # --reason
           end_of_options
           operand :worktree, required: true
         end
@@ -42,7 +44,7 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree lock`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/worktree/move.rb
+++ b/lib/git/commands/worktree/move.rb
@@ -11,7 +11,9 @@ module Git
       #   Git::Commands::Worktree::Move.new(execution_context).call('/tmp/old', '/tmp/new')
       #
       # @example Force-move a locked worktree
-      #   Git::Commands::Worktree::Move.new(execution_context).call('/tmp/feat', '/tmp/feat2', force: true)
+      #   Git::Commands::Worktree::Move.new(execution_context).call('/tmp/feat', '/tmp/feat2', force: 2)
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
@@ -41,14 +43,18 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, Integer] :force (nil) allow moving a locked worktree
+        #     @option options [Boolean, Integer] :force (nil) allow the move despite safety checks
         #
-        #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit
-        #       `--force --force`, which also handles locked or missing destinations.
+        #       Pass `true` or `1` to emit `--force` once, allowing the move when the
+        #       destination is already assigned to another worktree but is missing.
+        #       Pass `2` to emit `--force --force`, which also allows moving a locked
+        #       worktree or when the destination is locked.
         #
         #       Alias: :f
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree move`
+        #
+        #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero status
       end

--- a/lib/git/commands/worktree/prune.rb
+++ b/lib/git/commands/worktree/prune.rb
@@ -16,6 +16,8 @@ module Git
       # @example Prune entries older than 2 weeks
       #   Git::Commands::Worktree::Prune.new(execution_context).call(expire: '2.weeks.ago')
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
@@ -53,7 +55,9 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree prune`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/worktree/remove.rb
+++ b/lib/git/commands/worktree/remove.rb
@@ -48,7 +48,7 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree remove`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/worktree/repair.rb
+++ b/lib/git/commands/worktree/repair.rb
@@ -16,7 +16,10 @@ module Git
       # @example Repair specific moved worktrees
       #   Git::Commands::Worktree::Repair.new(execution_context).call('/tmp/moved1', '/tmp/moved2')
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
+      #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
       #
       # @api private
@@ -25,13 +28,14 @@ module Git
         arguments do
           literal 'worktree'
           literal 'repair'
+          flag_option :relative_paths, negatable: true # --relative-paths / --no-relative-paths
           end_of_options
           operand :path, repeatable: true
         end
 
         # @!method call(*, **)
         #
-        #   @overload call(*path)
+        #   @overload call(*path, **options)
         #
         #     Repair worktree administrative files
         #
@@ -39,9 +43,17 @@ module Git
         #
         #       When omitted, all registered worktrees are repaired.
         #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :relative_paths (nil) use relative or absolute paths for linking
+        #
+        #       Pass `true` for `--relative-paths`, `false` for `--no-relative-paths`.
+        #
         #     @return [Git::CommandLineResult] the result of calling `git worktree repair`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/worktree/unlock.rb
+++ b/lib/git/commands/worktree/unlock.rb
@@ -10,6 +10,8 @@ module Git
       # @example Unlock a worktree
       #   Git::Commands::Worktree::Unlock.new(execution_context).call('/tmp/feature')
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
@@ -35,7 +37,7 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree unlock`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/spec/integration/git/commands/worktree/add_spec.rb
+++ b/spec/integration/git/commands/worktree/add_spec.rb
@@ -49,6 +49,42 @@ RSpec.describe Git::Commands::Worktree::Add, :integration do
           expect(File.directory?(worktree_path)).to be(true)
         end
       end
+
+      context 'with --lock and --reason' do
+        let(:worktree_path) { File.join(repo_dir, '..', "worktree-locked-#{SecureRandom.hex(4)}") }
+
+        after { FileUtils.rm_rf(worktree_path) }
+
+        it 'creates a locked worktree with the given reason' do
+          result = command.call(worktree_path, lock: true, reason: 'on portable device')
+          expect(result).to be_a(Git::CommandLineResult)
+          expect(File.directory?(worktree_path)).to be(true)
+        end
+      end
+
+      context 'with --relative-paths' do
+        let(:worktree_path) { File.join(repo_dir, '..', "worktree-relative-#{SecureRandom.hex(4)}") }
+
+        after { FileUtils.rm_rf(worktree_path) }
+
+        it 'creates the worktree successfully' do
+          result = command.call(worktree_path, relative_paths: true)
+          expect(result).to be_a(Git::CommandLineResult)
+          expect(File.directory?(worktree_path)).to be(true)
+        end
+      end
+
+      context 'with --orphan', skip: unless_git('2.41', 'git worktree add --orphan') do
+        let(:worktree_path) { File.join(repo_dir, '..', "worktree-orphan-#{SecureRandom.hex(4)}") }
+
+        after { FileUtils.rm_rf(worktree_path) }
+
+        it 'creates a worktree on a new unborn branch' do
+          result = command.call(worktree_path, orphan: true)
+          expect(result).to be_a(Git::CommandLineResult)
+          expect(File.directory?(worktree_path)).to be(true)
+        end
+      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/worktree/list_spec.rb
+++ b/spec/integration/git/commands/worktree/list_spec.rb
@@ -21,8 +21,23 @@ RSpec.describe Git::Commands::Worktree::List, :integration do
         expect(result).to be_a(Git::CommandLineResult)
       end
 
+      it 'returns a CommandLineResult with the :verbose option' do
+        result = command.call(verbose: true)
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
       it 'returns a CommandLineResult with the :porcelain option' do
         result = command.call(porcelain: true)
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns a CommandLineResult with :porcelain and :z options combined' do
+        result = command.call(porcelain: true, z: true)
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns a CommandLineResult with the :expire option' do
+        result = command.call(expire: '1.week.ago')
         expect(result).to be_a(Git::CommandLineResult)
       end
     end

--- a/spec/integration/git/commands/worktree/remove_spec.rb
+++ b/spec/integration/git/commands/worktree/remove_spec.rb
@@ -2,6 +2,7 @@
 
 require 'securerandom'
 require 'spec_helper'
+require 'git/commands/worktree/add'
 require 'git/commands/worktree/remove'
 
 RSpec.describe Git::Commands::Worktree::Remove, :integration do
@@ -19,9 +20,7 @@ RSpec.describe Git::Commands::Worktree::Remove, :integration do
     context 'when the command succeeds' do
       let(:worktree_path) { File.join(repo_dir, '..', "worktree-remove-#{SecureRandom.hex(4)}") }
 
-      before do
-        execution_context.command_capturing('worktree', 'add', '--', worktree_path, env: { 'GIT_INDEX_FILE' => nil })
-      end
+      before { Git::Commands::Worktree::Add.new(execution_context).call(worktree_path) }
       after { FileUtils.rm_rf(worktree_path) }
 
       it 'returns a CommandLineResult' do

--- a/spec/integration/git/commands/worktree/repair_spec.rb
+++ b/spec/integration/git/commands/worktree/repair_spec.rb
@@ -29,11 +29,9 @@ RSpec.describe Git::Commands::Worktree::Repair, :integration do
 
     context 'when the command fails' do
       it 'raises FailedError outside a git repository' do
-        Dir.mktmpdir do |tmpdir|
-          non_repo = Git.init(tmpdir, initial_branch: 'main')
-          FileUtils.rm_rf(File.join(tmpdir, '.git'))
-          non_git_command = described_class.new(non_repo.lib)
-          expect { non_git_command.call }
+        Dir.chdir(repo_dir) do
+          FileUtils.rm_rf(File.join(repo_dir, '.git'))
+          expect { command.call }
             .to raise_error(Git::FailedError, /not a git repository/)
         end
       end

--- a/spec/integration/git/commands/worktree/unlock_spec.rb
+++ b/spec/integration/git/commands/worktree/unlock_spec.rb
@@ -3,6 +3,8 @@
 require 'securerandom'
 require 'spec_helper'
 require 'git/commands/worktree/unlock'
+require 'git/commands/worktree/add'
+require 'git/commands/worktree/lock'
 
 RSpec.describe Git::Commands::Worktree::Unlock, :integration do
   include_context 'in an empty repository'
@@ -20,8 +22,8 @@ RSpec.describe Git::Commands::Worktree::Unlock, :integration do
       let(:worktree_path) { File.join(repo_dir, '..', "worktree-unlock-#{SecureRandom.hex(4)}") }
 
       before do
-        execution_context.command_capturing('worktree', 'add', worktree_path, env: { 'GIT_INDEX_FILE' => nil })
-        execution_context.command_capturing('worktree', 'lock', '--', worktree_path, env: { 'GIT_INDEX_FILE' => nil })
+        Git::Commands::Worktree::Add.new(execution_context).call(worktree_path)
+        Git::Commands::Worktree::Lock.new(execution_context).call(worktree_path)
       end
 
       after { FileUtils.rm_rf(worktree_path) }

--- a/spec/unit/git/commands/stash/apply_spec.rb
+++ b/spec/unit/git/commands/stash/apply_spec.rb
@@ -54,5 +54,22 @@ RSpec.describe Git::Commands::Stash::Apply do
         command.call('stash@{1}', index: true)
       end
     end
+
+    context 'with :quiet option' do
+      it 'adds --quiet flag' do
+        expect_command_capturing('stash', 'apply', '--quiet').and_return(command_result(''))
+        command.call(quiet: true)
+      end
+
+      it 'does not add flag when false' do
+        expect_command_capturing('stash', 'apply').and_return(command_result(''))
+        command.call(quiet: false)
+      end
+
+      it ':q alias works' do
+        expect_command_capturing('stash', 'apply', '--quiet').and_return(command_result(''))
+        command.call(q: true)
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/stash/drop_spec.rb
+++ b/spec/unit/git/commands/stash/drop_spec.rb
@@ -35,5 +35,22 @@ RSpec.describe Git::Commands::Stash::Drop do
         command.call('1')
       end
     end
+
+    context 'with :quiet option' do
+      it 'adds --quiet flag' do
+        expect_command_capturing('stash', 'drop', '--quiet').and_return(command_result(''))
+        command.call(quiet: true)
+      end
+
+      it 'does not add flag when false' do
+        expect_command_capturing('stash', 'drop').and_return(command_result(''))
+        command.call(quiet: false)
+      end
+
+      it 'accepts :q alias' do
+        expect_command_capturing('stash', 'drop', '--quiet').and_return(command_result(''))
+        command.call(q: true)
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/stash/list_spec.rb
+++ b/spec/unit/git/commands/stash/list_spec.rb
@@ -5,26 +5,30 @@ require 'git/commands/stash/list'
 require 'git/parsers/stash'
 
 RSpec.describe Git::Commands::Stash::List do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
   let(:execution_context) { double('ExecutionContext') }
   let(:command) { described_class.new(execution_context) }
 
-  let(:stash_output) do
-    "abc1234567890abcdef1234567890abcdef123456\x1fabc1234\x1fstash@{0}\x1f" \
-      "WIP on main: abc1234 Initial commit\x1fTest Author\x1fauthor@test.com\x1f" \
-      "2026-01-24T10:00:00-08:00\x1fTest Committer\x1fcommitter@test.com\x1f2026-01-24T10:00:00-08:00"
-  end
-
   describe '#call' do
-    it 'runs stash list with format' do
-      format_arg = "--format=#{Git::Parsers::Stash::STASH_FORMAT}"
+    context 'with no options' do
+      it 'runs stash list with the stash format' do
+        format_arg = "--format=#{Git::Parsers::Stash::STASH_FORMAT}"
+        expected_result = command_result('stash output')
 
-      expect_command_capturing('stash', 'list', format_arg)
-        .and_return(command_result(stash_output))
+        expect_command_capturing('stash', 'list', format_arg)
+          .and_return(expected_result)
 
-      result = command.call
+        result = command.call
 
-      expect(result).to be_a(Git::CommandLineResult)
-      expect(result.stdout).to eq(stash_output)
+        expect(result).to eq(expected_result)
+      end
+    end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(foo: true) }.to raise_error(ArgumentError, /unsupported/i)
+      end
     end
   end
 end

--- a/spec/unit/git/commands/stash/pop_spec.rb
+++ b/spec/unit/git/commands/stash/pop_spec.rb
@@ -5,6 +5,8 @@ require 'git/commands/stash/pop'
 
 RSpec.describe Git::Commands::Stash::Pop do
   let(:execution_context) { double('ExecutionContext') }
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
   let(:command) { described_class.new(execution_context) }
 
   describe '#call' do
@@ -52,6 +54,23 @@ RSpec.describe Git::Commands::Stash::Pop do
       it 'combines stash reference with index option' do
         expect_command_capturing('stash', 'pop', '--index', 'stash@{1}').and_return(command_result(''))
         command.call('stash@{1}', index: true)
+      end
+    end
+
+    context 'with :quiet option' do
+      it 'adds --quiet flag' do
+        expect_command_capturing('stash', 'pop', '--quiet').and_return(command_result(''))
+        command.call(quiet: true)
+      end
+
+      it 'does not add flag when false' do
+        expect_command_capturing('stash', 'pop').and_return(command_result(''))
+        command.call(quiet: false)
+      end
+
+      it ':q alias works' do
+        expect_command_capturing('stash', 'pop', '--quiet').and_return(command_result(''))
+        command.call(q: true)
       end
     end
   end

--- a/spec/unit/git/commands/stash/push_spec.rb
+++ b/spec/unit/git/commands/stash/push_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 require 'git/commands/stash/push'
 
 RSpec.describe Git::Commands::Stash::Push do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
   let(:execution_context) { double('ExecutionContext') }
   let(:command) { described_class.new(execution_context) }
 
@@ -72,10 +74,27 @@ RSpec.describe Git::Commands::Stash::Push do
       end
     end
 
+    context 'with :quiet option' do
+      it 'adds --quiet flag' do
+        expect_command_capturing('stash', 'push', '--quiet').and_return(command_result(''))
+        command.call(quiet: true)
+      end
+
+      it 'accepts :q alias' do
+        expect_command_capturing('stash', 'push', '--quiet').and_return(command_result(''))
+        command.call(q: true)
+      end
+    end
+
     context 'with :include_untracked option' do
       it 'adds -u flag to include untracked files' do
         expect_command_capturing('stash', 'push', '--include-untracked').and_return(command_result(''))
         command.call(include_untracked: true)
+      end
+
+      it 'adds --no-include-untracked flag when false' do
+        expect_command_capturing('stash', 'push', '--no-include-untracked').and_return(command_result(''))
+        command.call(include_untracked: false)
       end
 
       it 'accepts :u alias' do

--- a/spec/unit/git/commands/stash/store_spec.rb
+++ b/spec/unit/git/commands/stash/store_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 require 'git/commands/stash/store'
 
 RSpec.describe Git::Commands::Stash::Store do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
   let(:execution_context) { double('ExecutionContext') }
   let(:command) { described_class.new(execution_context) }
 
@@ -11,7 +13,7 @@ RSpec.describe Git::Commands::Stash::Store do
     context 'with commit SHA only' do
       it 'calls git stash store with commit' do
         expected_result = command_result('')
-        expect_command_capturing('stash', 'store', 'abc123def456789')
+        expect_command_capturing('stash', 'store', '--', 'abc123def456789')
           .and_return(expected_result)
 
         result = command.call('abc123def456789')
@@ -22,41 +24,33 @@ RSpec.describe Git::Commands::Stash::Store do
 
     context 'with :message option' do
       it 'adds --message flag with value' do
-        expect_command_capturing('stash', 'store', '--message', 'WIP: my changes', 'abc123')
+        expect_command_capturing('stash', 'store', '--message', 'WIP: my changes', '--', 'abc123')
           .and_return(command_result(''))
 
         command.call('abc123', message: 'WIP: my changes')
       end
 
       it 'accepts :m alias' do
-        expect_command_capturing('stash', 'store', '--message', 'WIP', 'abc123')
+        expect_command_capturing('stash', 'store', '--message', 'WIP', '--', 'abc123')
           .and_return(command_result(''))
 
         command.call('abc123', m: 'WIP')
       end
-
-      it 'handles message with special characters' do
-        expect_command_capturing('stash', 'store', '--message', 'Fix "bug" in code', 'abc123')
-          .and_return(command_result(''))
-
-        command.call('abc123', message: 'Fix "bug" in code')
-      end
-
-      it 'handles message with spaces' do
-        expect_command_capturing('stash', 'store', '--message', 'work in progress', 'abc123')
-          .and_return(command_result(''))
-
-        command.call('abc123', message: 'work in progress')
-      end
     end
 
-    context 'with full SHA' do
-      it 'handles 40-character SHA' do
-        sha = 'a' * 40
-        expect_command_capturing('stash', 'store', sha)
+    context 'with :quiet option' do
+      it 'adds --quiet flag' do
+        expect_command_capturing('stash', 'store', '--quiet', '--', 'abc123')
           .and_return(command_result(''))
 
-        command.call(sha)
+        command.call('abc123', quiet: true)
+      end
+
+      it 'accepts :q alias' do
+        expect_command_capturing('stash', 'store', '--quiet', '--', 'abc123')
+          .and_return(command_result(''))
+
+        command.call('abc123', q: true)
       end
     end
   end

--- a/spec/unit/git/commands/worktree/add_spec.rb
+++ b/spec/unit/git/commands/worktree/add_spec.rb
@@ -62,6 +62,13 @@ RSpec.describe Git::Commands::Worktree::Add do
 
         command.call('/tmp/exp', detach: true)
       end
+
+      it 'accepts :d alias' do
+        expect_command_capturing('worktree', 'add', '--detach', '--', '/tmp/exp', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/exp', d: true)
+      end
     end
 
     context 'with :checkout option' do
@@ -86,6 +93,24 @@ RSpec.describe Git::Commands::Worktree::Add do
           .and_return(command_result(''))
 
         command.call('/tmp/wt', lock: true)
+      end
+    end
+
+    context 'with :reason option' do
+      it 'adds --reason with the given string' do
+        expect_command_capturing('worktree', 'add', '--reason', 'on portable drive', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', reason: 'on portable drive')
+      end
+    end
+
+    context 'with :orphan option' do
+      it 'adds --orphan flag' do
+        expect_command_capturing('worktree', 'add', '--orphan', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', orphan: true)
       end
     end
 
@@ -136,6 +161,22 @@ RSpec.describe Git::Commands::Worktree::Add do
           .and_return(command_result(''))
 
         command.call('/tmp/wt', guess_remote: false)
+      end
+    end
+
+    context 'with :relative_paths option' do
+      it 'adds --relative-paths when true' do
+        expect_command_capturing('worktree', 'add', '--relative-paths', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', relative_paths: true)
+      end
+
+      it 'adds --no-relative-paths when false' do
+        expect_command_capturing('worktree', 'add', '--no-relative-paths', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', relative_paths: false)
       end
     end
 

--- a/spec/unit/git/commands/worktree/list_spec.rb
+++ b/spec/unit/git/commands/worktree/list_spec.rb
@@ -21,12 +21,46 @@ RSpec.describe Git::Commands::Worktree::List do
       end
     end
 
+    context 'with :verbose option' do
+      it 'includes the --verbose flag' do
+        expect_command_capturing('worktree', 'list', '--verbose')
+          .and_return(command_result("/repo  abc1234 [main]\n"))
+
+        command.call(verbose: true)
+      end
+
+      it 'accepts the :v alias' do
+        expect_command_capturing('worktree', 'list', '--verbose')
+          .and_return(command_result("/repo  abc1234 [main]\n"))
+
+        command.call(v: true)
+      end
+    end
+
     context 'with :porcelain option' do
       it 'includes the --porcelain flag' do
         expect_command_capturing('worktree', 'list', '--porcelain')
           .and_return(command_result("worktree /repo\nHEAD abc1234\nbranch refs/heads/main\n\n"))
 
         command.call(porcelain: true)
+      end
+    end
+
+    context 'with :z option' do
+      it 'includes the -z flag' do
+        expect_command_capturing('worktree', 'list', '-z')
+          .and_return(command_result("worktree /repo\0HEAD abc1234\0branch refs/heads/main\0\0"))
+
+        command.call(z: true)
+      end
+    end
+
+    context 'with :expire option' do
+      it 'includes the --expire flag with value' do
+        expect_command_capturing('worktree', 'list', '--expire', '2.weeks.ago')
+          .and_return(command_result("/repo  abc1234 [main]\n"))
+
+        command.call(expire: '2.weeks.ago')
       end
     end
   end

--- a/spec/unit/git/commands/worktree/lock_spec.rb
+++ b/spec/unit/git/commands/worktree/lock_spec.rb
@@ -32,5 +32,17 @@ RSpec.describe Git::Commands::Worktree::Lock do
         command.call('/tmp/feature', reason: 'on NFS share')
       end
     end
+
+    context 'input validation' do
+      it 'raises ArgumentError when no worktree is provided' do
+        expect { command.call }
+          .to raise_error(ArgumentError, /worktree is required/)
+      end
+
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('/tmp/feature', foo: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/worktree/repair_spec.rb
+++ b/spec/unit/git/commands/worktree/repair_spec.rb
@@ -38,5 +38,23 @@ RSpec.describe Git::Commands::Worktree::Repair do
         command.call('/tmp/moved1', '/tmp/moved2')
       end
     end
+
+    context 'with --relative-paths' do
+      it 'passes the flag' do
+        expect_command_capturing('worktree', 'repair', '--relative-paths', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call(relative_paths: true)
+      end
+    end
+
+    context 'with --no-relative-paths' do
+      it 'passes the negated flag' do
+        expect_command_capturing('worktree', 'repair', '--no-relative-paths', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call(relative_paths: false)
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/worktree/unlock_spec.rb
+++ b/spec/unit/git/commands/worktree/unlock_spec.rb
@@ -22,17 +22,5 @@ RSpec.describe Git::Commands::Worktree::Unlock do
         expect(result).to eq(expected_result)
       end
     end
-
-    context 'input validation' do
-      it 'raises ArgumentError when no worktree is provided' do
-        expect { command.call }
-          .to raise_error(ArgumentError, /worktree is required/)
-      end
-
-      it 'raises ArgumentError for unsupported options' do
-        expect { command.call('/tmp/feature', foo: true) }
-          .to raise_error(ArgumentError, /Unsupported options/)
-      end
-    end
   end
 end


### PR DESCRIPTION
Partially addresses issue 1196.

This PR expands the batch 3 command refresh across both stash and worktree command classes.

Updated stash commands:
- Apply
- Branch
- Clear
- Create
- Drop
- List
- Pop
- Push
- Store

Updated worktree commands:
- Add
- List
- Lock
- Move
- Prune
- Remove
- Repair
- Unlock

Highlights:
- fill out missing command DSL options and aliases
- align YARD docs with the current git CLI behavior
- add or refine focused unit and integration coverage
- keep worktree management commands on the shared ManagementBase behavior

Validation:
- bundle exec rspec spec/unit/git/commands/worktree/add_spec.rb spec/unit/git/commands/worktree/list_spec.rb spec/unit/git/commands/worktree/lock_spec.rb spec/unit/git/commands/worktree/move_spec.rb spec/unit/git/commands/worktree/prune_spec.rb spec/integration/git/commands/worktree/add_spec.rb spec/integration/git/commands/worktree/list_spec.rb spec/integration/git/commands/worktree/lock_spec.rb spec/integration/git/commands/worktree/move_spec.rb spec/integration/git/commands/worktree/prune_spec.rb
- bundle exec rake test:parallel
- bundle exec rake spec:unit:parallel
- bundle exec rake spec:integration:parallel
- bundle exec rake rubocop
- bundle exec rake yard
- bundle exec rake build