### PR TITLE
refactor(commands): backfill post-2.28.0 options for stash/list, pop, push, show, store (#1196 batch 3 partial)

### DIFF
--- a/.github/skills/command-test-conventions/SKILL.md
+++ b/.github/skills/command-test-conventions/SKILL.md
@@ -310,6 +310,11 @@ Unit test descriptions should be concise and action-oriented. Use descriptions l
 "includes the --cached flag", "passes both commits as operands", "combines commit
 with pathspecs".
 
+**Always use the emitted long-flag form in descriptions, never a short alias.** The
+DSL canonicalises aliases to the long form (e.g. `:q` → `--quiet`, `:f` → `--force`).
+Writing `'adds -q flag'` in an `it` description is misleading because the actual token
+asserted in the expectation is `'--quiet'`. Use `'adds --quiet flag'` instead.
+
 > **Exception to RSpec Unit Testing Standards Rules 11–12 (subject and let
 > ordering):** Command unit tests intentionally omit `subject` within `describe
 > '#call'`. Because each test exercises a different argument combination, there is no

--- a/.github/skills/command-yard-documentation/SKILL.md
+++ b/.github/skills/command-yard-documentation/SKILL.md
@@ -165,7 +165,7 @@ conflicting documentation for the method.
 | `flag_option ..., negatable: true` | `[Boolean]` — document both `true` (→ `--flag`) and `false` (→ `--no-flag`) forms |
 | `flag_or_value_option` | `[Boolean, String]` (or the specific value type) |
 | `flag_or_value_option ..., negatable: true` | `[Boolean, String]` — document `true` (→ `--flag`), string (→ `--flag=value`), and `false` (→ `--no-flag`) forms |
-| `value_option` | `[String]` (or a more specific type where known) |
+| `value_option` | `[String]` — `value_option` does not enforce types; it accepts any non-nil value and converts it to a string. Use `[String]` unless callers are expected to pass a narrower type, in which case widen the annotation to reflect reality (e.g. `[Integer, String]` for options documented as taking `<n>` lines/bytes). Never use a bare numeric type such as `[Integer]` alone — that misrepresents what the implementation accepts. |
 | `operand` (repeatable) | `[Array<String>]` |
 | `operand` (single) | `[String]` |
 

--- a/.github/skills/review-command-tests/SKILL.md
+++ b/.github/skills/review-command-tests/SKILL.md
@@ -326,6 +326,11 @@ Unit test descriptions should be concise and action-oriented. Use descriptions l
 "includes the --cached flag", "passes both commits as operands", "combines commit
 with pathspecs".
 
+**Always use the emitted long-flag form in descriptions, never a short alias.** The
+DSL canonicalises aliases to the long form (e.g. `:q` → `--quiet`, `:f` → `--force`).
+Writing `'adds -q flag'` in an `it` description is misleading because the actual token
+asserted in the expectation is `'--quiet'`. Use `'adds --quiet flag'` instead.
+
 > **Exception to RSpec Unit Testing Standards Rules 11–12 (subject and let
 > ordering):** Command unit tests intentionally omit `subject` within `describe
 > '#call'`. Because each test exercises a different argument combination, there is no

--- a/lib/git/commands/stash/list.rb
+++ b/lib/git/commands/stash/list.rb
@@ -8,6 +8,8 @@ module Git
     module Stash
       # List all stash entries
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-stash/2.53.0
+      #
       # @see Git::Commands::Stash Git::Commands::Stash for usage examples
       #
       # @see https://git-scm.com/docs/git-stash git-stash documentation

--- a/lib/git/commands/stash/pop.rb
+++ b/lib/git/commands/stash/pop.rb
@@ -10,6 +10,8 @@ module Git
       # Like {Apply}, but removes the stash from the stash list after
       # applying, unless there are conflicts.
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-stash/2.53.0
+      #
       # @see Git::Commands::Stash Git::Commands::Stash for usage examples
       #
       # @see https://git-scm.com/docs/git-stash git-stash documentation
@@ -25,11 +27,15 @@ module Git
       # @example Pop and restore index state
       #   Git::Commands::Stash::Pop.new(execution_context).call(index: true)
       #
+      # @example Pop quietly
+      #   Git::Commands::Stash::Pop.new(execution_context).call(quiet: true)
+      #
       class Pop < Git::Commands::Base
         arguments do
           literal 'stash'
           literal 'pop'
           flag_option :index
+          flag_option %i[quiet q]
           operand :stash
         end
 
@@ -45,6 +51,10 @@ module Git
         #
         #     @option options [Boolean] :index (nil) restore the index state as well
         #
+        #     @option options [Boolean] :quiet (nil) suppress informational messages
+        #
+        #       Alias: :q
+        #
         #   @overload call(stash, **options)
         #
         #     Pop a specific stash
@@ -54,6 +64,10 @@ module Git
         #     @param options [Hash] command options
         #
         #     @option options [Boolean] :index (nil) restore the index state as well
+        #
+        #     @option options [Boolean] :quiet (nil) suppress informational messages
+        #
+        #       Alias: :q
         #
         #   @return [Git::CommandLineResult] the result of calling `git stash pop`
         #

--- a/lib/git/commands/stash/push.rb
+++ b/lib/git/commands/stash/push.rb
@@ -11,6 +11,8 @@ module Git
       # to HEAD (in the working tree and index). The command takes
       # various options to customize what gets stashed.
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-stash/2.53.0
+      #
       # @see Git::Commands::Stash Git::Commands::Stash for usage examples
       #
       # @see https://git-scm.com/docs/git-stash git-stash documentation
@@ -36,6 +38,7 @@ module Git
           flag_option %i[patch p]
           flag_option %i[staged S]
           flag_option %i[keep_index k], negatable: true
+          flag_option %i[quiet q]
           flag_option %i[include_untracked u]
           flag_option %i[all a]
           value_option %i[message m]
@@ -55,39 +58,41 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :patch (nil) Interactively select hunks to stash
+        #     @option options [Boolean] :patch (nil) interactively select hunks to stash
         #
         #       Alias: :p
         #
-        #     @option options [Boolean] :staged (nil) Stash only staged changes
+        #     @option options [Boolean] :staged (nil) stash only staged changes
         #
         #       Alias: :S
         #
-        #     @option options [Boolean] :keep_index (nil) Keep staged changes in the index
+        #     @option options [Boolean] :keep_index (nil) keep staged changes in the index
         #
         #       Alias: :k
         #
-        #     @option options [Boolean] :include_untracked (nil) Include untracked files in the stash
+        #     @option options [Boolean] :quiet (nil) suppress informational messages
+        #
+        #       Alias: :q
+        #
+        #     @option options [Boolean] :include_untracked (nil) include untracked files in the stash
         #
         #       Alias: :u
         #
-        #     @option options [Boolean] :all (nil) Include untracked and ignored files in the stash
+        #     @option options [Boolean] :all (nil) include untracked and ignored files in the stash
         #
         #       Alias: :a
         #
-        #     @option options [String] :message (nil) Descriptive message for the stash
+        #     @option options [String] :message (nil) descriptive message for the stash
         #
         #       Alias: :m
         #
-        #     @option options [String] :pathspec_from_file (nil) Read pathspecs from the given file
+        #     @option options [String] :pathspec_from_file (nil) read pathspecs from the given file
         #
-        #     @option options [Boolean] :pathspec_file_nul (nil) Pathspecs in the file are NUL-separated
+        #     @option options [Boolean] :pathspec_file_nul (nil) pathspecs in the file are NUL-separated
         #
         #     @return [Git::CommandLineResult] the result of calling `git stash push`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
-        #
-        #   @api public
         #
       end
     end

--- a/lib/git/commands/stash/show.rb
+++ b/lib/git/commands/stash/show.rb
@@ -5,9 +5,15 @@ require 'git/commands/base'
 module Git
   module Commands
     module Stash
-      # Implements the `git stash show` command
+      # Show the changes recorded in a stash entry as a diff
       #
-      # Shows the changes recorded in a stash entry as a diff.
+      # Shows the changes recorded in the stash entry as a diff between the
+      # stashed contents and the commit back when the stash entry was first
+      # created.
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-stash/2.53.0
+      #
+      # @see Git::Commands::Stash Git::Commands::Stash for usage examples
       #
       # @see https://git-scm.com/docs/git-stash git-stash documentation
       #
@@ -32,12 +38,14 @@ module Git
           flag_option :numstat
           flag_option :raw
           flag_option :shortstat
+          value_option %i[unified U], inline: true
 
           flag_option %i[include_untracked u], negatable: true
           flag_option :only_untracked
           flag_or_value_option %i[find_renames M], inline: true
           flag_or_value_option %i[find_copies C], inline: true
           flag_option :find_copies_harder
+          value_option :inter_hunk_context, inline: true
           flag_or_value_option :dirstat, inline: true
           operand :stash
         end
@@ -60,6 +68,10 @@ module Git
         #
         #     @option options [Boolean] :shortstat (nil) include aggregate totals line
         #
+        #     @option options [Integer, String] :unified (nil) generate diff with <n> lines of context
+        #
+        #       Alias: :U
+        #
         #     @option options [Boolean] :include_untracked (nil) include untracked files
         #
         #       Alias: :u
@@ -73,6 +85,9 @@ module Git
         #       optionally pass a threshold. Alias: :C
         #
         #     @option options [Boolean] :find_copies_harder (nil) inspect all files as copy sources; expensive
+        #
+        #     @option options [Integer, String] :inter_hunk_context (nil) show context between diff hunks, up to
+        #       <n> lines, fusing hunks that are close to each other
         #
         #     @option options [Boolean, String] :dirstat (nil) include directory statistics
         #
@@ -94,6 +109,10 @@ module Git
         #
         #     @option options [Boolean] :shortstat (nil) include aggregate totals line
         #
+        #     @option options [Integer, String] :unified (nil) generate diff with <n> lines of context
+        #
+        #       Alias: :U
+        #
         #     @option options [Boolean] :include_untracked (nil) include untracked files
         #
         #       Alias: :u
@@ -107,6 +126,9 @@ module Git
         #       optionally pass a threshold. Alias: :C
         #
         #     @option options [Boolean] :find_copies_harder (nil) inspect all files as copy sources; expensive
+        #
+        #     @option options [Integer, String] :inter_hunk_context (nil) show context between diff hunks, up to
+        #       <n> lines, fusing hunks that are close to each other
         #
         #     @option options [Boolean, String] :dirstat (nil) include directory statistics
         #

--- a/lib/git/commands/stash/store.rb
+++ b/lib/git/commands/stash/store.rb
@@ -13,6 +13,8 @@ module Git
       # This command is typically used after {Create} to actually record
       # the stash in the reflog.
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-stash/2.53.0
+      #
       # @see Git::Commands::Stash Git::Commands::Stash for usage examples
       #
       # @see https://git-scm.com/docs/git-stash git-stash documentation
@@ -30,6 +32,7 @@ module Git
           literal 'stash'
           literal 'store'
           value_option %i[message m]
+          flag_option %i[quiet q]
           operand :commit, required: true
         end
 
@@ -43,9 +46,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [String] :message (nil) description for the reflog entry.
+        #     @option options [String] :message (nil) description for the reflog entry
         #
         #       Alias: :m
+        #
+        #     @option options [Boolean] :quiet (nil) suppress output
+        #
+        #       Alias: :q
         #
         #     @return [Git::CommandLineResult] the result of calling `git stash store`
         #

--- a/spec/unit/git/commands/stash/pop_spec.rb
+++ b/spec/unit/git/commands/stash/pop_spec.rb
@@ -48,10 +48,34 @@ RSpec.describe Git::Commands::Stash::Pop do
       end
     end
 
+    context 'with :quiet option' do
+      it 'adds --quiet flag' do
+        expect_command_capturing('stash', 'pop', '--quiet').and_return(command_result(''))
+        command.call(quiet: true)
+      end
+
+      it 'does not add flag when false' do
+        expect_command_capturing('stash', 'pop').and_return(command_result(''))
+        command.call(quiet: false)
+      end
+    end
+
+    context 'with :q short option alias' do
+      it 'adds --quiet flag' do
+        expect_command_capturing('stash', 'pop', '--quiet').and_return(command_result(''))
+        command.call(q: true)
+      end
+    end
+
     context 'with stash reference and options' do
       it 'combines stash reference with index option' do
         expect_command_capturing('stash', 'pop', '--index', 'stash@{1}').and_return(command_result(''))
         command.call('stash@{1}', index: true)
+      end
+
+      it 'combines stash reference with quiet option' do
+        expect_command_capturing('stash', 'pop', '--quiet', 'stash@{1}').and_return(command_result(''))
+        command.call('stash@{1}', quiet: true)
       end
     end
   end

--- a/spec/unit/git/commands/stash/push_spec.rb
+++ b/spec/unit/git/commands/stash/push_spec.rb
@@ -72,6 +72,18 @@ RSpec.describe Git::Commands::Stash::Push do
       end
     end
 
+    context 'with :quiet option' do
+      it 'adds --quiet flag to suppress output' do
+        expect_command_capturing('stash', 'push', '--quiet').and_return(command_result(''))
+        command.call(quiet: true)
+      end
+
+      it 'accepts :q alias' do
+        expect_command_capturing('stash', 'push', '--quiet').and_return(command_result(''))
+        command.call(q: true)
+      end
+    end
+
     context 'with :include_untracked option' do
       it 'adds -u flag to include untracked files' do
         expect_command_capturing('stash', 'push', '--include-untracked').and_return(command_result(''))

--- a/spec/unit/git/commands/stash/show_spec.rb
+++ b/spec/unit/git/commands/stash/show_spec.rb
@@ -65,6 +65,22 @@ RSpec.describe Git::Commands::Stash::Show do
       end
     end
 
+    context 'with :unified option' do
+      it 'adds --unified=<n> for context lines' do
+        expect_command_capturing('stash', 'show', '--unified=5')
+          .and_return(command_result(''))
+
+        command.call(unified: 5)
+      end
+
+      it 'accepts :U alias' do
+        expect_command_capturing('stash', 'show', '--unified=3')
+          .and_return(command_result(''))
+
+        command.call(U: 3)
+      end
+    end
+
     context 'with specific stash reference' do
       it 'passes stash reference to command' do
         expect_command_capturing('stash', 'show', '--numstat', '--shortstat', 'stash@{2}')
@@ -103,6 +119,15 @@ RSpec.describe Git::Commands::Stash::Show do
           .and_return(command_result(numstat_output))
 
         command.call(numstat: true, shortstat: true, only_untracked: true)
+      end
+    end
+
+    context 'with :inter_hunk_context option' do
+      it 'adds --inter-hunk-context=<n>' do
+        expect_command_capturing('stash', 'show', '--inter-hunk-context=2')
+          .and_return(command_result(''))
+
+        command.call(inter_hunk_context: 2)
       end
     end
 

--- a/spec/unit/git/commands/stash/store_spec.rb
+++ b/spec/unit/git/commands/stash/store_spec.rb
@@ -50,6 +50,31 @@ RSpec.describe Git::Commands::Stash::Store do
       end
     end
 
+    context 'with :quiet option' do
+      it 'adds --quiet flag' do
+        expect_command_capturing('stash', 'store', '--quiet', 'abc123')
+          .and_return(command_result(''))
+
+        command.call('abc123', quiet: true)
+      end
+
+      it 'does not add flag when false' do
+        expect_command_capturing('stash', 'store', 'abc123')
+          .and_return(command_result(''))
+
+        command.call('abc123', quiet: false)
+      end
+    end
+
+    context 'with :q short option alias' do
+      it 'adds --quiet flag' do
+        expect_command_capturing('stash', 'store', '--quiet', 'abc123')
+          .and_return(command_result(''))
+
+        command.call('abc123', q: true)
+      end
+    end
+
     context 'with full SHA' do
       it 'handles 40-character SHA' do
         sha = 'a' * 40


### PR DESCRIPTION
## Summary

Partially addresses #1196 (batch 3: `stash/*` + `worktree/*`) — five more stash subcommands.

Adds options introduced after git 2.28.0 to five `Git::Commands::Stash::*` command classes. Each new option gets a DSL entry, unit tests, and YARD documentation. No `requires_git_version` annotation — git handles unsupported-option errors on older installations.

All arguments blocks have been audited against the git-stash documentation at version 2.53.0.

## Changes

### `stash/list`

- Add audit `@note` vs. git-stash 2.53.0
- No new DSL options (format literal is locked for parser compatibility)

### `stash/pop`

- **DSL**: add `flag_option %i[quiet q]` (synopsis: `pop [--index] [-q | --quiet] [<stash>]`)
- **YARD**: add `@option :quiet` with alias `:q` to both `@overload` blocks; add `@example` for quiet
- **Tests**: add contexts for `:quiet`, `:q` alias, and quiet+stash-reference combination
- Add audit `@note` vs. git-stash 2.53.0

### `stash/push`

- **DSL**: add `flag_option %i[quiet q]` (synopsis: `push [-q | --quiet] ...`)
- **YARD**: add `@option :quiet` with alias `:q`; lowercase option descriptions; remove misplaced `@api public` tag
- **Tests**: add context for `:quiet` and `:q` alias
- Add audit `@note` vs. git-stash 2.53.0

### `stash/show`

- **Class description**: replace "Implements the `git stash show` command" with a noun-phrase description
- **DSL**: add `value_option %i[unified U], inline: true` (`-U<n>` / `--unified=<n>`) and `value_option :inter_hunk_context, inline: true` (`--inter-hunk-context=<n>`)
- **YARD**: add `@see Git::Commands::Stash` line; add `@option :unified` and `@option :inter_hunk_context` to both overloads
- **Tests**: add contexts for `:unified` (with `:U` alias) and `:inter_hunk_context`
- Add audit `@note` vs. git-stash 2.53.0

### `stash/store`

- **DSL**: add `flag_option %i[quiet q]` (synopsis: `store [(-m | --message) <message>] [-q | --quiet] <commit>`)
- **YARD**: add `@option :quiet` with alias `:q`
- **Tests**: add contexts for `:quiet` and `:q` alias
- Add audit `@note` vs. git-stash 2.53.0

## Test results

```
91 stash unit examples, 0 failures
rubocop: 578 files inspected, no offenses detected
```
