### PR TITLE
refactor(commands): backfill post-2.28.0 options for worktree/add, list, lock, move, prune

### DIFF
--- a/.github/skills/command-implementation/REFERENCE.md
+++ b/.github/skills/command-implementation/REFERENCE.md
@@ -377,7 +377,7 @@ an explicit override.
 #
 #   @return [Git::CommandLineResult] the result of calling `git cat-file --batch`
 #
-#   @raise [Git::FailedError] if git exits with a non-zero status
+#   @raise [Git::FailedError] if git exits with a non-zero exit status
 def call(*objects, **options)
   bound = args_definition.bind(*objects, **options)
   with_stdin(Array(bound.objects).map { |o| "#{o}\n" }.join) do |reader|

--- a/.github/skills/command-test-conventions/SKILL.md
+++ b/.github/skills/command-test-conventions/SKILL.md
@@ -504,6 +504,45 @@ RSpec.describe Git::Commands::Diff::Numstat, :integration do
 end
 ```
 
+#### Guard tests for options introduced after the minimum supported Git version
+
+When an integration test exercises an option that was introduced after the minimum
+supported Git version (2.28.0), guard the example with
+`skip: unless_git(minimum_version, feature_description)` to prevent failures on
+installations that do not yet have the required Git version. The `unless_git` helper
+is defined in `spec/spec_helper.rb`:
+
+- Returns `false` when the installed Git meets the minimum version (tests run normally).
+- Returns a human-readable skip reason string when the installed Git is too old
+  (RSpec skips the example).
+
+Apply the guard to individual `it` blocks when only some tests in a context require a
+newer version. Apply it to a `context` or `describe` block when **all** tests in that
+group require the same minimum version.
+
+```ruby
+# ✅ Different options introduced in different git versions — guard each `it` individually
+it 'returns a CommandLineResult with the :verbose option',
+   skip: unless_git('2.33.0', 'git worktree list --verbose') do
+  # ...
+end
+
+it 'returns a CommandLineResult with the :z option combined with :porcelain',
+   skip: unless_git('2.36.0', 'git worktree list --porcelain -z') do
+  # ...
+end
+
+# ✅ All tests in the group require the same version — guard the context/describe block
+RSpec.describe Git::Commands::ShowRef::Exists, :integration,
+               skip: unless_git('2.43.0', 'git show-ref --exists') do
+  # ...
+end
+```
+
+Determine the correct minimum version by checking version-matched upstream git
+documentation (e.g., `https://git-scm.com/docs/git-worktree/2.33.0`) rather than
+relying only on the locally installed git binary.
+
 #### Additional integration conventions
 
 **Always specify `initial_branch: 'main'` when calling `Git.init` in test setup.**

--- a/lib/git/commands/worktree/add.rb
+++ b/lib/git/commands/worktree/add.rb
@@ -29,14 +29,17 @@ module Git
           literal 'worktree'
           literal 'add'
           flag_option %i[force f], max_times: 2
-          flag_option :detach
-          flag_option :checkout, negatable: true
-          flag_option :guess_remote, negatable: true
-          flag_option :track, negatable: true
-          flag_option :lock
-          flag_option %i[quiet q]
           value_option :b
           value_option :B
+          flag_option %i[detach d]
+          flag_option :checkout, negatable: true
+          flag_option :guess_remote, negatable: true
+          flag_option :relative_paths, negatable: true
+          flag_option :track, negatable: true
+          flag_option :lock
+          flag_option :orphan
+          flag_option %i[quiet q]
+          value_option :reason
           end_of_options
           operand :path, required: true
           operand :commit_ish
@@ -64,7 +67,13 @@ module Git
         #
         #       Alias: :f
         #
+        #     @option options [String] :b (nil) create a new branch with this name and check it out
+        #
+        #     @option options [String] :B (nil) create or reset a branch with this name and check it out
+        #
         #     @option options [Boolean] :detach (nil) check out in detached-HEAD state
+        #
+        #       Alias: :d
         #
         #     @option options [Boolean] :checkout (nil) control whether the working tree
         #       is checked out after creation
@@ -76,23 +85,30 @@ module Git
         #
         #       When `false`, passes `--no-guess-remote`.
         #
+        #     @option options [Boolean] :relative_paths (nil) link worktrees using relative paths
+        #
+        #       When `false`, passes `--no-relative-paths`, using absolute paths instead.
+        #       Overrides the `worktree.useRelativePaths` config option.
+        #
         #     @option options [Boolean] :track (nil) mark the upstream branch for tracking
         #
         #       When `false`, passes `--no-track`.
         #
         #     @option options [Boolean] :lock (nil) lock the worktree immediately after creation
         #
+        #     @option options [Boolean] :orphan (nil) create an empty worktree associated with a new unborn branch
+        #
         #     @option options [Boolean] :quiet (nil) suppress informational messages
         #
         #       Alias: :q
         #
-        #     @option options [String] :b (nil) create a new branch with this name and check it out
+        #     @option options [String] :reason (nil) explanation for why the worktree is locked
         #
-        #     @option options [String] :B (nil) create or reset a branch with this name and check it out
+        #       Only meaningful when used with `:lock`.
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree add`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/worktree/list.rb
+++ b/lib/git/commands/worktree/list.rb
@@ -20,6 +20,9 @@ module Git
           literal 'worktree'
           literal 'list'
           flag_option :porcelain
+          flag_option :z
+          flag_option %i[verbose v]
+          value_option :expire
         end
 
         # @!method call(*, **)
@@ -32,9 +35,18 @@ module Git
         #
         #     @option options [Boolean] :porcelain (nil) produce machine-readable output
         #
+        #     @option options [Boolean] :z (nil) NUL-terminate lines (use with `:porcelain`)
+        #
+        #     @option options [Boolean] :verbose (nil) output additional information about worktrees
+        #
+        #       Alias: :v
+        #
+        #     @option options [String] :expire (nil) annotate missing worktrees as prunable if older than
+        #       this time expression
+        #
         #     @return [Git::CommandLineResult] the result of calling `git worktree list`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/worktree/lock.rb
+++ b/lib/git/commands/worktree/lock.rb
@@ -42,7 +42,7 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree lock`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/worktree/move.rb
+++ b/lib/git/commands/worktree/move.rb
@@ -50,7 +50,7 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree move`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/worktree/prune.rb
+++ b/lib/git/commands/worktree/prune.rb
@@ -53,7 +53,7 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree prune`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/spec/integration/git/commands/worktree/list_spec.rb
+++ b/spec/integration/git/commands/worktree/list_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Git::Commands::Worktree::List, :integration do
       end
 
       it 'returns a CommandLineResult with the :z option combined with :porcelain',
-         skip: unless_git('2.36.0', 'git worktree list -z') do
+         skip: unless_git('2.36.0', 'git worktree list --porcelain -z') do
         result = command.call(porcelain: true, z: true)
         expect(result).to be_a(Git::CommandLineResult)
       end

--- a/spec/integration/git/commands/worktree/list_spec.rb
+++ b/spec/integration/git/commands/worktree/list_spec.rb
@@ -25,6 +25,24 @@ RSpec.describe Git::Commands::Worktree::List, :integration do
         result = command.call(porcelain: true)
         expect(result).to be_a(Git::CommandLineResult)
       end
+
+      it 'returns a CommandLineResult with the :verbose option',
+         skip: unless_git('2.33.0', 'git worktree list --verbose') do
+        result = command.call(verbose: true)
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns a CommandLineResult with the :z option combined with :porcelain',
+         skip: unless_git('2.36.0', 'git worktree list -z') do
+        result = command.call(porcelain: true, z: true)
+        expect(result).to be_a(Git::CommandLineResult)
+      end
+
+      it 'returns a CommandLineResult with the :expire option',
+         skip: unless_git('2.33.0', 'git worktree list --expire') do
+        result = command.call(expire: '2.weeks.ago')
+        expect(result).to be_a(Git::CommandLineResult)
+      end
     end
 
     context 'when the command fails' do

--- a/spec/unit/git/commands/worktree/add_spec.rb
+++ b/spec/unit/git/commands/worktree/add_spec.rb
@@ -62,6 +62,13 @@ RSpec.describe Git::Commands::Worktree::Add do
 
         command.call('/tmp/exp', detach: true)
       end
+
+      it 'accepts :d alias' do
+        expect_command_capturing('worktree', 'add', '--detach', '--', '/tmp/exp', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/exp', d: true)
+      end
     end
 
     context 'with :checkout option' do
@@ -152,6 +159,41 @@ RSpec.describe Git::Commands::Worktree::Add do
           .and_return(command_result(''))
 
         command.call('/tmp/wt', track: false)
+      end
+    end
+
+    context 'with :relative_paths option' do
+      it 'adds --relative-paths when true' do
+        expect_command_capturing('worktree', 'add', '--relative-paths', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', relative_paths: true)
+      end
+
+      it 'adds --no-relative-paths when false' do
+        expect_command_capturing('worktree', 'add', '--no-relative-paths', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', relative_paths: false)
+      end
+    end
+
+    context 'with :orphan option' do
+      it 'adds --orphan flag' do
+        expect_command_capturing('worktree', 'add', '--orphan', '--', '/tmp/wt', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/wt', orphan: true)
+      end
+    end
+
+    context 'with :reason option' do
+      it 'adds --lock --reason with value (primary usage)' do
+        expect_command_capturing(
+          'worktree', 'add', '--lock', '--reason', 'archived', '--', '/tmp/wt', env: worktree_env
+        ).and_return(command_result(''))
+
+        command.call('/tmp/wt', lock: true, reason: 'archived')
       end
     end
   end

--- a/spec/unit/git/commands/worktree/list_spec.rb
+++ b/spec/unit/git/commands/worktree/list_spec.rb
@@ -29,5 +29,37 @@ RSpec.describe Git::Commands::Worktree::List do
         command.call(porcelain: true)
       end
     end
+
+    context 'with :z option' do
+      it 'includes the -z flag' do
+        expect_command_capturing('worktree', 'list', '-z').and_return(command_result(''))
+
+        command.call(z: true)
+      end
+    end
+
+    context 'with :verbose option' do
+      it 'includes the --verbose flag' do
+        expect_command_capturing('worktree', 'list', '--verbose').and_return(command_result(''))
+
+        command.call(verbose: true)
+      end
+    end
+
+    context 'with :v alias' do
+      it 'includes the --verbose flag' do
+        expect_command_capturing('worktree', 'list', '--verbose').and_return(command_result(''))
+
+        command.call(v: true)
+      end
+    end
+
+    context 'with :expire option' do
+      it 'includes the --expire flag with the given value' do
+        expect_command_capturing('worktree', 'list', '--expire', '2.weeks.ago').and_return(command_result(''))
+
+        command.call(expire: '2.weeks.ago')
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Backfill options added after git 2.28.0 for five `worktree` sub-command classes. Partially addresses #1196 (batch 3, first five commands).

## Changes

### `worktree/add`
- Add `--orphan` flag (`flag_option :orphan`) — creates an empty worktree with a new unborn branch
- Add `--relative-paths` / `--no-relative-paths` (`flag_option :relative_paths, negatable: true`) — link worktrees using relative paths
- Add `--reason <string>` (`value_option :reason`) — explanation for why the worktree is locked, usable with `--lock`
- Add `-d` as short alias for `--detach` (`flag_option %i[detach d]`)
- Reorder DSL entries to match the OPTIONS section order in the latest git docs
- Update YARD `@option` docs and unit tests for all new options

### `worktree/list`
- Add `-v` / `--verbose` (`flag_option %i[verbose v]`) — output additional information about worktrees
- Add `-z` (`flag_option :z`) — NUL-terminate lines (use with `--porcelain`)
- Add `--expire <time>` (`value_option :expire`) — annotate missing worktrees as prunable if older than the given time
- Update YARD `@option` docs, unit tests, and integration tests for all new options

### `worktree/lock`, `worktree/move`, `worktree/prune`
- No new options since git 2.28.0
- Normalize `@raise [Git::FailedError]` wording to canonical form (`non-zero exit status`)

## Batch 3 status after this PR

| Command | Status |
|---------|--------|
| `stash/*` (10 classes) | ✅ Done (#1211, #1212) |
| `worktree/add` | ✅ This PR |
| `worktree/list` | ✅ This PR |
| `worktree/lock` | ✅ This PR |
| `worktree/move` | ✅ This PR |
| `worktree/prune` | ✅ This PR |
| `worktree/remove`, `worktree/repair`, `worktree/unlock` | ⬜ Remaining |

## Quality gates

- `bundle exec rake rubocop` ✅
- `bundle exec rspec spec/unit/git/commands/worktree/` ✅ (51 examples, 0 failures)
- `bundle exec rspec spec/integration/git/commands/worktree/` ✅ (27 examples, 0 failures)
- `bundle exec rake yard` ✅
- `bundle exec rake build` ✅