### PR TITLE
refactor(commands): backfill post-2.28.0 options for worktree/remove, repair, unlock

### DIFF
--- a/.github/skills/command-implementation/REFERENCE.md
+++ b/.github/skills/command-implementation/REFERENCE.md
@@ -286,6 +286,8 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git ...`
         #
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
@@ -376,6 +378,8 @@ an explicit override.
 #   @option options [Boolean] :unordered (false) Unordered output
 #
 #   @return [Git::CommandLineResult] the result of calling `git cat-file --batch`
+#
+#   @raise [ArgumentError] if unsupported options are provided
 #
 #   @raise [Git::FailedError] if git exits with a non-zero exit status
 def call(*objects, **options)

--- a/lib/git/commands/worktree/remove.rb
+++ b/lib/git/commands/worktree/remove.rb
@@ -48,7 +48,9 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree remove`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/worktree/repair.rb
+++ b/lib/git/commands/worktree/repair.rb
@@ -17,6 +17,7 @@ module Git
       #   Git::Commands::Worktree::Repair.new(execution_context).call('/tmp/moved1', '/tmp/moved2')
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
+      #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
       #
       # @api private
@@ -25,13 +26,14 @@ module Git
         arguments do
           literal 'worktree'
           literal 'repair'
+          flag_option :relative_paths, negatable: true
           end_of_options
           operand :path, repeatable: true
         end
 
         # @!method call(*, **)
         #
-        #   @overload call(*path)
+        #   @overload call(*path, **options)
         #
         #     Repair worktree administrative files
         #
@@ -39,9 +41,20 @@ module Git
         #
         #       When omitted, all registered worktrees are repaired.
         #
+        #     @param options [Hash] command options
+        #
+        #     @option options [Boolean] :relative_paths (nil) link worktrees using relative paths
+        #
+        #       When `false`, passes `--no-relative-paths`, using absolute paths instead.
+        #       Also causes repair to update linking files if there is an absolute/relative
+        #       mismatch, even if the links are already correct. Overrides the
+        #       `worktree.useRelativePaths` config option.
+        #
         #     @return [Git::CommandLineResult] the result of calling `git worktree repair`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/worktree/unlock.rb
+++ b/lib/git/commands/worktree/unlock.rb
@@ -35,7 +35,7 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree unlock`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/spec/integration/git/commands/worktree/unlock_spec.rb
+++ b/spec/integration/git/commands/worktree/unlock_spec.rb
@@ -2,6 +2,8 @@
 
 require 'securerandom'
 require 'spec_helper'
+require 'git/commands/worktree/add'
+require 'git/commands/worktree/lock'
 require 'git/commands/worktree/unlock'
 
 RSpec.describe Git::Commands::Worktree::Unlock, :integration do
@@ -20,8 +22,8 @@ RSpec.describe Git::Commands::Worktree::Unlock, :integration do
       let(:worktree_path) { File.join(repo_dir, '..', "worktree-unlock-#{SecureRandom.hex(4)}") }
 
       before do
-        execution_context.command_capturing('worktree', 'add', worktree_path, env: { 'GIT_INDEX_FILE' => nil })
-        execution_context.command_capturing('worktree', 'lock', '--', worktree_path, env: { 'GIT_INDEX_FILE' => nil })
+        Git::Commands::Worktree::Add.new(execution_context).call(worktree_path)
+        Git::Commands::Worktree::Lock.new(execution_context).call(worktree_path)
       end
 
       after { FileUtils.rm_rf(worktree_path) }
@@ -33,9 +35,9 @@ RSpec.describe Git::Commands::Worktree::Unlock, :integration do
     end
 
     context 'when the command fails' do
-      it 'raises FailedError for a nonexistent path' do
+      it 'raises FailedError for a nonexistent worktree path' do
         expect { command.call('/nonexistent/path/xyz') }
-          .to raise_error(Git::FailedError, /nonexistent/)
+          .to raise_error(Git::FailedError)
       end
     end
   end

--- a/spec/unit/git/commands/worktree/repair_spec.rb
+++ b/spec/unit/git/commands/worktree/repair_spec.rb
@@ -38,5 +38,28 @@ RSpec.describe Git::Commands::Worktree::Repair do
         command.call('/tmp/moved1', '/tmp/moved2')
       end
     end
+
+    context 'with :relative_paths option' do
+      it 'adds --relative-paths when true' do
+        expect_command_capturing('worktree', 'repair', '--relative-paths', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call(relative_paths: true)
+      end
+
+      it 'adds --no-relative-paths when false' do
+        expect_command_capturing('worktree', 'repair', '--no-relative-paths', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call(relative_paths: false)
+      end
+
+      it 'combines --relative-paths with a path operand' do
+        expect_command_capturing('worktree', 'repair', '--relative-paths', '--', '/tmp/moved1', env: worktree_env)
+          .and_return(command_result(''))
+
+        command.call('/tmp/moved1', relative_paths: true)
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/worktree/unlock_spec.rb
+++ b/spec/unit/git/commands/worktree/unlock_spec.rb
@@ -22,17 +22,5 @@ RSpec.describe Git::Commands::Worktree::Unlock do
         expect(result).to eq(expected_result)
       end
     end
-
-    context 'input validation' do
-      it 'raises ArgumentError when no worktree is provided' do
-        expect { command.call }
-          .to raise_error(ArgumentError, /worktree is required/)
-      end
-
-      it 'raises ArgumentError for unsupported options' do
-        expect { command.call('/tmp/feature', foo: true) }
-          .to raise_error(ArgumentError, /Unsupported options/)
-      end
-    end
   end
 end


### PR DESCRIPTION
## Summary

Partially addresses #1196, Batch 3 — the remaining three `worktree` subcommands.

### Changes

#### `worktree/remove`

- **`@raise` wording** fixed: `non-zero status` → `non-zero exit status` (canonical REFERENCE.md wording)
- No new options: `git worktree remove` has had only `--force`/`-f` (max_times: 2) since 2.28.0; no options were added in subsequent releases

#### `worktree/repair`

- **New DSL entry** `flag_option :relative_paths, negatable: true` — the `--relative-paths` / `--no-relative-paths` option was introduced after 2.28.0 and causes repair to update linking files on absolute/relative mismatch; overrides the `worktree.useRelativePaths` config option
- **`@see` tag spacing** corrected: blank `#` comment line added between `@see` tags to match sibling command style
- **`@overload` signature** updated to `call(*path, **options)` to reflect the new option
- **`@raise` wording** fixed: `non-zero status` → `non-zero exit status`
- **Unit tests** added for `--relative-paths true`, `--no-relative-paths false`, and combined option + path

#### `worktree/unlock`

- **`@raise` wording** fixed: `non-zero status` → `non-zero exit status`
- **Unit spec** — removed redundant `input validation` context (required-operand rejection and unsupported-options tests retest DSL behaviour, not command behaviour; not present in sibling lock_spec.rb)
- **Integration spec** — replaced raw `execution_context.command_capturing(...)` setup calls with proper `Git::Commands::Worktree::Add` and `Git::Commands::Worktree::Lock` command class calls (consistent with the sibling lock integration spec pattern); aligned `FailedError` assertion to sibling pattern (no message regex)

### Quality gates

All quality gates pass:

```
bundle exec rake rubocop       # no offenses
bundle exec rake spec:unit:parallel        # 3392 examples, 0 failures
bundle exec rake spec:integration:parallel # 467 examples, 0 failures
bundle exec rake yard          # coverage above threshold, 0 doc failures
bundle exec rake test:parallel # 560 tests, 0 failures
bundle exec rake build         # gem built successfully
```