### PR TITLE
refactor(commands): audit and backfill options for am subcommands; add requires_git_version to Base

### DIFF
--- a/lib/git/commands/am/abort.rb
+++ b/lib/git/commands/am/abort.rb
@@ -14,6 +14,10 @@ module Git
       #   abort_cmd = Git::Commands::Am::Abort.new(execution_context)
       #   abort_cmd.call
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-am/2.53.0
+      #
+      # @see Git::Commands::Am
+      #
       # @see https://git-scm.com/docs/git-am git-am
       #
       # @api private
@@ -32,7 +36,7 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git am --abort`
         #
-        #     @raise [Git::FailedError] if no am session is in progress
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/am/apply.rb
+++ b/lib/git/commands/am/apply.rb
@@ -20,6 +20,8 @@ module Git
       # @example Apply with 3-way merge fallback
       #   am.call('patches.mbox', three_way: true, chdir: repo.workdir)
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-am/2.53.0
+      #
       # @see https://git-scm.com/docs/git-am git-am
       #
       # @api private
@@ -34,6 +36,8 @@ module Git
           flag_option :keep_non_patch
           flag_option :keep_cr, negatable: true
           flag_option %i[scissors c], negatable: true
+          value_option :quoted_cr
+          value_option :empty
           flag_option %i[message_id m], negatable: true
 
           # Output
@@ -59,6 +63,12 @@ module Git
 
           # Patch format
           value_option :patch_format
+
+          # Interactive mode
+          flag_option %i[interactive i]
+
+          # Hook verification
+          flag_option :verify, negatable: true
 
           # Date handling
           flag_option :committer_date_is_author_date
@@ -107,6 +117,17 @@ module Git
         #       body before a scissors line
         #
         #       `true` → `--scissors`, `false` → `--no-scissors`. Alias: `:c`
+        #
+        #     @option options [String] :quoted_cr (nil) how to handle CR in quoted
+        #       text passed to git-mailinfo
+        #
+        #       Valid actions: `'nowarn'`, `'warn'`, `'error'`.
+        #
+        #     @option options [String] :empty (nil) how to handle an e-mail message
+        #       lacking a patch
+        #
+        #       Valid values: `'stop'` (fail, default), `'drop'` (skip the message),
+        #       `'keep'` (create an empty commit).
         #
         #     @option options [Boolean] :message_id (nil) pass -m flag to
         #       git-mailinfo, adding the Message-ID header to the commit message
@@ -180,6 +201,17 @@ module Git
         #       Valid formats: `'mbox'`, `'mboxrd'`, `'stgit'`, `'stgit-series'`,
         #       `'hg'`.
         #
+        #     @option options [Boolean] :interactive (false) run interactively,
+        #       prompting before each patch is applied
+        #
+        #       Alias: `:i`
+        #
+        #     @option options [Boolean] :verify (nil) run pre-applypatch and
+        #       applypatch-msg hooks
+        #
+        #       `true` → `--verify`, `false` → `--no-verify` (bypass hooks).
+        #       Hooks are run by default when this option is omitted.
+        #
         #     @option options [Boolean] :committer_date_is_author_date (nil) use the
         #       author date as the committer date
         #
@@ -199,7 +231,9 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git am`
         #
-        #     @raise [Git::FailedError] if patches cannot be applied
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/am/continue.rb
+++ b/lib/git/commands/am/continue.rb
@@ -7,13 +7,14 @@ module Git
     module Am
       # Implements `git am --continue` to resume after resolving conflicts
       #
-      # After the user has resolved a conflict, the patch can be applied again
-      # with `--continue`. The editor is suppressed via `GIT_EDITOR=true` set
-      # in the execution environment.
+      # After the user has resolved a conflict in the working tree and updated
+      # the index, this command continues applying the remaining patches.
       #
       # @example Resume an am session after resolving conflicts
       #   continue_cmd = Git::Commands::Am::Continue.new(execution_context)
       #   continue_cmd.call
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-am/2.53.0
       #
       # @see Git::Commands::Am
       #
@@ -35,8 +36,7 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git am --continue`
         #
-        #     @raise [Git::FailedError] if no am session is in progress or
-        #       conflicts remain unresolved
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/am/quit.rb
+++ b/lib/git/commands/am/quit.rb
@@ -5,7 +5,7 @@ require 'git/commands/base'
 module Git
   module Commands
     module Am
-      # Wrapper for `git am --quit` that aborts the in-progress am session
+      # Implements `git am --quit` to abort the in-progress am session
       #
       # Aborts the in-progress patch application but keeps the current HEAD
       # position (does not restore the branch to its pre-am state).
@@ -13,6 +13,10 @@ module Git
       # @example Quit an am session without restoring HEAD
       #   quit_cmd = Git::Commands::Am::Quit.new(execution_context)
       #   quit_cmd.call
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-am/2.53.0
+      #
+      # @see Git::Commands::Am
       #
       # @see https://git-scm.com/docs/git-am git-am
       #
@@ -32,7 +36,7 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git am --quit`
         #
-        #     @raise [Git::FailedError] if no am session is in progress
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/am/retry.rb
+++ b/lib/git/commands/am/retry.rb
@@ -5,7 +5,7 @@ require 'git/commands/base'
 module Git
   module Commands
     module Am
-      # Command that retries the current in-progress `git am` patch
+      # Implements `git am --retry` to retry the most-recently-failed patch
       #
       # Tries to apply the last conflicting patch again. Generally only useful
       # when retrying with extra options (e.g. `--3way`), or in scripts where
@@ -15,10 +15,7 @@ module Git
       #   retry_cmd = Git::Commands::Am::Retry.new(execution_context)
       #   retry_cmd.call
       #
-      # @note Requires git 2.46 or later
-      #
-      #   Earlier versions do not recognise the `--retry` flag; the option was
-      #   introduced in git 2.46.0.
+      # @note `arguments` block audited against https://git-scm.com/docs/git-am/2.53.0
       #
       # @see Git::Commands::Am
       #
@@ -32,15 +29,18 @@ module Git
           literal '--retry'
         end
 
+        # git am --retry was introduced in git 2.46.0
+        requires_git_version '2.46.0'
+
         # @!method call(*, **)
         #
         #   @overload call()
         #
-        #     Retry applying the current patch
+        #     Retry applying the most-recently-failed patch
         #
-        #     @return [Git::CommandLineResult] the result of calling `git am`
+        #     @return [Git::CommandLineResult] the result of calling `git am --retry`
         #
-        #     @raise [Git::FailedError] if no am session is in progress
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/am/show_current_patch.rb
+++ b/lib/git/commands/am/show_current_patch.rb
@@ -5,7 +5,7 @@ require 'git/commands/base'
 module Git
   module Commands
     module Am
-      # Wrapper for the `git am --show-current-patch` command
+      # Implements the `git am --show-current-patch` command
       #
       # Shows the message currently being applied when `git am` has stopped due to
       # conflicts.
@@ -13,6 +13,8 @@ module Git
       # @example Show the current patch
       #   show_cmd = Git::Commands::Am::ShowCurrentPatch.new(execution_context)
       #   show_cmd.call
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-am/2.53.0
       #
       # @see Git::Commands::Am
       #
@@ -23,25 +25,38 @@ module Git
       class ShowCurrentPatch < Git::Commands::Base
         arguments do
           literal 'am'
-          flag_or_value_option :show_current_patch, inline: true, type: [TrueClass, String]
+          flag_or_value_option :show_current_patch, inline: true
         end
 
-        # @overload call(format = true, **options)
+        # @overload call(*, show_current_patch: true, **options)
         #
         #   Execute the `git am --show-current-patch` command
         #
-        #   @param format [true, String] optional format: `'diff'` emits
-        #     `--show-current-patch=diff` (diff portion only); `'raw'` emits
-        #     `--show-current-patch=raw` (full raw email)
+        #   @param show_current_patch [true, String] patch format selector
         #
-        #     When omitted, emits `--show-current-patch` and git defaults to `raw`.
+        #     Pass `true` (default) to emit `--show-current-patch` (git defaults to
+        #     `raw` format); pass `'diff'` to emit `--show-current-patch=diff` (diff
+        #     portion only) or `'raw'` for `--show-current-patch=raw` (full raw email).
+        #     Passing `false` or `nil` raises `ArgumentError`.
         #
-        #   @return [Git::CommandLineResult] the result of calling `git am --show-current-patch`
+        #   @param options [Hash] command options
         #
-        #   @raise [Git::FailedError] if no am session is in progress
+        #   @return [Git::CommandLineResult] the result of calling
+        #     `git am --show-current-patch`
         #
-        def call(format = true, **) # rubocop:disable Style/OptionalBooleanParameter
-          super(**, show_current_patch: format)
+        #   @raise [ArgumentError] if `show_current_patch` is `false` or `nil`
+        #
+        #   @raise [ArgumentError] if unsupported options are provided
+        #
+        #   @raise [Git::FailedError] if git exits with a non-zero exit status
+        #
+        def call(*, show_current_patch: true, **)
+          unless show_current_patch
+            raise ArgumentError,
+                  ":show_current_patch must be true or a non-empty String, got #{show_current_patch.inspect}"
+          end
+
+          super
         end
       end
     end

--- a/lib/git/commands/am/skip.rb
+++ b/lib/git/commands/am/skip.rb
@@ -13,6 +13,10 @@ module Git
       #   skip_cmd = Git::Commands::Am::Skip.new(execution_context)
       #   skip_cmd.call
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-am/2.53.0
+      #
+      # @see Git::Commands::Am
+      #
       # @see https://git-scm.com/docs/git-am git-am
       #
       # @api private
@@ -29,9 +33,9 @@ module Git
         #
         #     Skip the current patch and continue with remaining patches
         #
-        #     @return [Git::CommandLineResult] the result of calling `git am`
+        #     @return [Git::CommandLineResult] the result of calling `git am --skip`
         #
-        #     @raise [Git::FailedError] if no am session is in progress
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/base.rb
+++ b/lib/git/commands/base.rb
@@ -88,6 +88,38 @@ module Git
 
           @allowed_exit_status_range = range
         end
+
+        # @return [String, nil] minimum git version required by this command, or +nil+ if
+        #   the command is available in all supported git versions
+        attr_reader :minimum_git_version
+
+        # Declare the minimum git version required for this command.
+        #
+        # Use this when the command (or the specific sub-action this class wraps) was
+        # introduced in a git version later than +Git::MINIMUM_GIT_VERSION+. When
+        # not declared, the command is assumed to be available in all supported git
+        # versions.
+        #
+        # @note This macro stores the version string for documentation and introspection.
+        #   It does not enforce the requirement at runtime — git itself will return a
+        #   native "unknown option" error when the option is not available.
+        #
+        # @example git-am --retry requires git 2.46.0
+        #   requires_git_version '2.46.0'
+        #
+        # @param version [String] minimum git version in +'major.minor.patch'+ format
+        #
+        # @raise [ArgumentError] if version is not a valid +'major.minor.patch'+ string
+        #
+        # @return [void]
+        def requires_git_version(version)
+          unless version.is_a?(String) && version.match?(/\A\d+\.\d+\.\d+\z/)
+            raise ArgumentError,
+                  "requires_git_version expects a 'major.minor.patch' string, got: #{version.inspect}"
+          end
+
+          @minimum_git_version = version
+        end
       end
 
       # @param execution_context [Git::ExecutionContext, Git::Lib] context that provides

--- a/spec/unit/git/commands/am/abort_spec.rb
+++ b/spec/unit/git/commands/am/abort_spec.rb
@@ -18,5 +18,12 @@ RSpec.describe Git::Commands::Am::Abort do
 
       expect(result).to eq(expected_result)
     end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(invalid: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/am/apply_spec.rb
+++ b/spec/unit/git/commands/am/apply_spec.rb
@@ -263,6 +263,48 @@ RSpec.describe Git::Commands::Am::Apply do
       end
     end
 
+    context 'with :interactive option' do
+      it 'adds --interactive flag' do
+        expect_command_capturing('am', '--interactive').and_return(command_result)
+        command.call(interactive: true)
+      end
+
+      it 'accepts :i alias' do
+        expect_command_capturing('am', '--interactive').and_return(command_result)
+        command.call(i: true)
+      end
+    end
+
+    context 'with :verify option' do
+      context 'when false' do
+        it 'adds --no-verify flag' do
+          expect_command_capturing('am', '--no-verify', '--', 'patches.mbox').and_return(command_result)
+          command.call('patches.mbox', verify: false)
+        end
+      end
+
+      context 'when true' do
+        it 'adds --verify flag' do
+          expect_command_capturing('am', '--verify', '--', 'patches.mbox').and_return(command_result)
+          command.call('patches.mbox', verify: true)
+        end
+      end
+    end
+
+    context 'with :quoted_cr option' do
+      it 'adds --quoted-cr flag' do
+        expect_command_capturing('am', '--quoted-cr', 'warn', '--', 'patches.mbox').and_return(command_result)
+        command.call('patches.mbox', quoted_cr: 'warn')
+      end
+    end
+
+    context 'with :empty option' do
+      it 'adds --empty flag' do
+        expect_command_capturing('am', '--empty', 'drop', '--', 'patches.mbox').and_return(command_result)
+        command.call('patches.mbox', empty: 'drop')
+      end
+    end
+
     context 'with :committer_date_is_author_date option' do
       it 'adds --committer-date-is-author-date flag' do
         expect_command_capturing('am', '--committer-date-is-author-date', '--',

--- a/spec/unit/git/commands/am/continue_spec.rb
+++ b/spec/unit/git/commands/am/continue_spec.rb
@@ -18,5 +18,12 @@ RSpec.describe Git::Commands::Am::Continue do
 
       expect(result).to eq(expected_result)
     end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(invalid: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/am/quit_spec.rb
+++ b/spec/unit/git/commands/am/quit_spec.rb
@@ -18,5 +18,12 @@ RSpec.describe Git::Commands::Am::Quit do
 
       expect(result).to eq(expected_result)
     end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(invalid: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/am/show_current_patch_spec.rb
+++ b/spec/unit/git/commands/am/show_current_patch_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Git::Commands::Am::ShowCurrentPatch do
       it 'includes --show-current-patch=diff' do
         expect_command_capturing('am', '--show-current-patch=diff').and_return(command_result)
 
-        command.call('diff')
+        command.call(show_current_patch: 'diff')
       end
     end
 
@@ -33,6 +33,16 @@ RSpec.describe Git::Commands::Am::ShowCurrentPatch do
       it 'raises ArgumentError for an unsupported option' do
         expect { command.call(unknown: true) }
           .to raise_error(ArgumentError, /Unsupported options: :unknown/)
+      end
+
+      it 'raises ArgumentError when show_current_patch is false' do
+        expect { command.call(show_current_patch: false) }
+          .to raise_error(ArgumentError, /:show_current_patch must be true or a non-empty String/)
+      end
+
+      it 'raises ArgumentError when show_current_patch is nil' do
+        expect { command.call(show_current_patch: nil) }
+          .to raise_error(ArgumentError, /:show_current_patch must be true or a non-empty String/)
       end
     end
   end

--- a/spec/unit/git/commands/am/skip_spec.rb
+++ b/spec/unit/git/commands/am/skip_spec.rb
@@ -18,5 +18,12 @@ RSpec.describe Git::Commands::Am::Skip do
 
       expect(result).to eq(expected_result)
     end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(invalid: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/base_spec.rb
+++ b/spec/unit/git/commands/base_spec.rb
@@ -32,6 +32,34 @@ RSpec.describe Git::Commands::Base do
     end
   end
 
+  describe '.requires_git_version' do
+    let(:command_class) do
+      Class.new(described_class) do
+        arguments { literal 'status' }
+      end
+    end
+
+    it 'stores the version string in minimum_git_version' do
+      command_class.requires_git_version '2.46.0'
+
+      expect(command_class.minimum_git_version).to eq('2.46.0')
+    end
+
+    it 'raises ArgumentError for a non-semver string' do
+      expect { command_class.requires_git_version '2.46' }
+        .to raise_error(ArgumentError, /major\.minor\.patch/)
+    end
+
+    it 'raises ArgumentError for a non-string value' do
+      expect { command_class.requires_git_version 2 }
+        .to raise_error(ArgumentError, /major\.minor\.patch/)
+    end
+
+    it 'defaults minimum_git_version to nil when not declared' do
+      expect(command_class.minimum_git_version).to be_nil
+    end
+  end
+
   describe '.allow_exit_status' do
     let(:command_class) do
       Class.new(described_class) do


### PR DESCRIPTION
Partially addresses #1196 (batch 5 — am subcommands).

## Changes

### `Git::Commands::Base` — new `requires_git_version` macro

- Add `requires_git_version(version)` class-level macro that records the minimum git
  version required for a command
- Stores the version string in `@minimum_git_version` for documentation and
  introspection; does not enforce at runtime (git itself returns a native "unknown
  option" error on old versions)
- Validates the `'major.minor.patch'` format and raises `ArgumentError` for bad input

### `am/apply` — backfill missing options

- Add `value_option :quoted_cr` (`--quoted-cr=<action>`, introduced in git 2.29.0)
- Add `value_option :empty` (`--empty=(stop|drop|keep)`, introduced in git 2.32.0)
- Add `flag_option %i[interactive i]` (`--interactive` / `-i`)
- Add `flag_option :verify, negatable: true` (`--verify` / `--no-verify`)
- Add `@note` audit annotation referencing git-am 2.53.0 docs
- Add YARD `@option` documentation for all four new options
- Fix `@raise` tags: add `ArgumentError`, standardize `FailedError` wording
- Add unit tests for all four new options

### `am/abort`, `am/continue`, `am/quit`, `am/skip`

- Add `@note` audit annotation referencing git-am 2.53.0 docs
- Add `@see Git::Commands::Am` cross-reference
- Fix `@raise` tags: add `ArgumentError`, standardize `FailedError` wording
- Add input-validation unit test (unsupported options raises `ArgumentError`)

### `am/continue`

- Tighten class description: remove implementation detail about `GIT_EDITOR`

### `am/quit`

- Replace "Wrapper for" with "Implements" in class summary

### `am/retry`

- Replace class summary with canonical "Implements" wording
- Replace old "Requires git 2.46 or later" `@note` block with standard audit annotation
- Add `requires_git_version '2.46.0'` (flag was introduced in 2.46.0)
- Fix `@overload` description and `@return` to reference `git am --retry`
- Fix `@raise` tags: add `ArgumentError`, standardize `FailedError` wording

### `am/show_current_patch`

- Replace "Wrapper for" with "Implements" in class summary
- Add `@note` audit annotation
- Fix `@raise` tags: add `ArgumentError`, standardize `FailedError` wording
- Tighten unit test suite: remove duplicate `raw`-format test (same code path as `diff`)
- Add type-validation test rejecting `false` as a format value
