### PR TITLE
docs: improve command-implementation skill discoverability

### DIFF
--- a/.github/skills/command-implementation/SKILL.md
+++ b/.github/skills/command-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: command-implementation
-description: "Scaffolds new and reviews existing Git::Commands::* classes with unit tests, integration tests, and YARD docs using the Base architecture. Use when creating a new command from scratch, updating an existing command, or reviewing a command class for correctness."
+description: "Scaffolds new, reviews existing Git::Commands::* classes with unit tests, integration tests, and YARD docs using the Base architecture. Use when creating a new command class from scratch, updating an existing command class, or reviewing a command class for correctness."
 ---
 
 # Command Implementation

--- a/.github/skills/command-implementation/SKILL.md
+++ b/.github/skills/command-implementation/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: command-implementation
-description: "Scaffolds new, reviews existing Git::Commands::* classes with unit tests, integration tests, and YARD docs using the Base architecture. Use when creating a new command class from scratch, updating an existing command class, or reviewing a command class for correctness."
+description: "Scaffolds new and reviews existing Git::Commands::* classes with unit tests, integration tests, and YARD docs using the Base architecture. Use when creating a new command class from scratch, updating an existing command class, or reviewing a command class for correctness."
 ---
 
 # Command Implementation


### PR DESCRIPTION
Adds "class" to the "updating an existing command" trigger phrase in the \`command-implementation\` skill's frontmatter description, so the skill is reliably selected when users say "update command class".

**Before:**
> Use when creating a new command from scratch, **updating an existing command**, or reviewing a command class for correctness.

**After:**
> Use when creating a new command class from scratch, **updating an existing command class**, or reviewing a command class for correctness.