### PR TITLE
refactor(commands): update revert/skip and revert/start command classes

### DIFF
--- a/lib/git/commands/revert/skip.rb
+++ b/lib/git/commands/revert/skip.rb
@@ -14,6 +14,8 @@ module Git
       #   skip_cmd = Git::Commands::Revert::Skip.new(execution_context)
       #   skip_cmd.call
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-revert/2.53.0
+      #
       # @see Git::Commands::Revert
       #
       # @see https://git-scm.com/docs/git-revert git-revert
@@ -35,7 +37,7 @@ module Git
         #     @return [Git::CommandLineResult] the result of calling
         #       `git revert --skip`
         #
-        #     @raise [Git::FailedError] if no revert is in progress
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/revert/start.rb
+++ b/lib/git/commands/revert/start.rb
@@ -24,6 +24,8 @@ module Git
       # @example Revert a merge commit specifying the mainline parent
       #   revert.call('abc123', mainline: 1)
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-revert/2.53.0
+      #
       # @see Git::Commands::Revert
       #
       # @see https://git-scm.com/docs/git-revert git-revert
@@ -59,6 +61,9 @@ module Git
           # Conflict resolution
           flag_option :rerere_autoupdate, negatable: true
 
+          # Commit log message format
+          flag_option :reference
+
           end_of_options
 
           # Commits to revert
@@ -82,12 +87,12 @@ module Git
         #       `true` → `--edit`, `false` → `--no-edit`.
         #       Alias: `:e`
         #
-        #     @option options [Boolean] :no_commit (nil) apply changes to index
+        #     @option options [Boolean] :no_commit (false) apply changes to index
         #       and working tree without committing
         #
         #       Alias: `:n`
         #
-        #     @option options [Integer] :mainline (nil) parent number (starting
+        #     @option options [Integer, String] :mainline (nil) parent number (starting
         #       from 1) identifying the mainline when reverting a merge commit
         #
         #       Alias: `:m`
@@ -126,9 +131,14 @@ module Git
         #       `true` → `--rerere-autoupdate`,
         #       `false` → `--no-rerere-autoupdate`
         #
+        #     @option options [Boolean] :reference (false) use compact reference
+        #       format in the revert commit message instead of the full object name
+        #
         #     @return [Git::CommandLineResult] the result of calling `git revert`
         #
-        #     @raise [Git::FailedError] if the revert fails (e.g., conflicts)
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/spec/unit/git/commands/revert/skip_spec.rb
+++ b/spec/unit/git/commands/revert/skip_spec.rb
@@ -18,5 +18,12 @@ RSpec.describe Git::Commands::Revert::Skip do
 
       expect(result).to eq(expected_result)
     end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(invalid: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/revert/start_spec.rb
+++ b/spec/unit/git/commands/revert/start_spec.rb
@@ -141,6 +141,13 @@ RSpec.describe Git::Commands::Revert::Start do
       end
     end
 
+    context 'with :reference option' do
+      it 'adds --reference when true' do
+        expect_command_capturing('revert', '--reference', '--', 'abc123').and_return(command_result(''))
+        command.call('abc123', reference: true)
+      end
+    end
+
     context 'with :mainline option' do
       it 'adds --mainline <n>' do
         expect_command_capturing('revert', '--mainline', '1', '--', 'abc123').and_return(command_result(''))


### PR DESCRIPTION
Partially addresses #1196.

## Summary

Audits and updates `Git::Commands::Revert::Skip` and `Git::Commands::Revert::Start` to bring them in line with the project's command-implementation standards, matching the quality of the already-audited sibling classes (`Abort`, `Continue`, `Quit`).

## Changes

### `lib/git/commands/revert/skip.rb`
- Add missing `@note` audit annotation (`arguments` block audited against git-revert/2.53.0)
- Fix `@raise [Git::FailedError]` description to canonical wording

### `lib/git/commands/revert/start.rb`
- Add missing `@note` audit annotation (`arguments` block audited against git-revert/2.53.0)
- Add missing `--reference` flag to the arguments DSL (introduced in git 2.25.0, before the 2.28.0 minimum)
- Fix `@option :no_commit` default annotation (`false` not `nil` for non-negatable flags)
- Fix `@option :mainline` type annotation (`[Integer, String]` instead of `[Integer]`)
- Fix `@raise [Git::FailedError]` description to canonical wording
- Add `@option :reference` YARD documentation for the newly added DSL entry

### `spec/unit/git/commands/revert/skip_spec.rb`
- Add `input validation` context verifying `ArgumentError` is raised for unsupported options

### `spec/unit/git/commands/revert/start_spec.rb`
- Add `context 'with :reference option'` covering the new `--reference` flag

## Quality gates

All quality gates pass (rubocop, yard, spec:unit:parallel, spec:integration:parallel, test:parallel, build).