### PR TITLE
refactor(commands): update merge/* command classes (issue #1196 Batch 5)

### DIFF
--- a/lib/git/commands/merge/abort.rb
+++ b/lib/git/commands/merge/abort.rb
@@ -10,13 +10,17 @@ module Git
       # Aborts the current merge and reconstructs the pre-merge state.
       # If an autostash entry is present, applies it to the worktree.
       #
-      # @see https://git-scm.com/docs/git-merge git-merge
-      #
-      # @api private
-      #
       # @example Abort a merge
       #   abort_cmd = Git::Commands::Merge::Abort.new(execution_context)
       #   abort_cmd.call
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-merge/2.53.0
+      #
+      # @see Git::Commands::Merge
+      #
+      # @see https://git-scm.com/docs/git-merge git-merge
+      #
+      # @api private
       #
       class Abort < Git::Commands::Base
         arguments do
@@ -28,11 +32,12 @@ module Git
         #
         #   @overload call()
         #
-        #     Execute the git merge --abort command
+        #     Abort the current merge and reconstruct the pre-merge state
         #
-        #     @return [Git::CommandLineResult] the result of the command
+        #     @return [Git::CommandLineResult] the result of calling
+        #       `git merge --abort`
         #
-        #     @raise [Git::FailedError] if no merge is in progress
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/merge/continue.rb
+++ b/lib/git/commands/merge/continue.rb
@@ -7,16 +7,20 @@ module Git
     module Merge
       # Implements `git merge --continue` to complete a merge after conflict resolution
       #
-      # Completes the merge after conflicts have been resolved and staged.
-      # The editor is suppressed via GIT_EDITOR=true set in the execution environment.
-      #
-      # @see https://git-scm.com/docs/git-merge git-merge
-      #
-      # @api private
+      # After the user has resolved conflicts and staged the changes, the
+      # merge can be concluded with this command.
       #
       # @example Continue after resolving conflicts
       #   continue_cmd = Git::Commands::Merge::Continue.new(execution_context)
       #   continue_cmd.call
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-merge/2.53.0
+      #
+      # @see Git::Commands::Merge
+      #
+      # @see https://git-scm.com/docs/git-merge git-merge
+      #
+      # @api private
       #
       class Continue < Git::Commands::Base
         arguments do
@@ -28,11 +32,12 @@ module Git
         #
         #   @overload call()
         #
-        #     Execute the git merge --continue command
+        #     Resume the in-progress merge after conflicts have been resolved
         #
-        #     @return [Git::CommandLineResult] the result of the command
+        #     @return [Git::CommandLineResult] the result of calling
+        #       `git merge --continue`
         #
-        #     @raise [Git::FailedError] if no merge is in progress or conflicts remain unresolved
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/merge/quit.rb
+++ b/lib/git/commands/merge/quit.rb
@@ -11,13 +11,17 @@ module Git
       # working tree as-is. If an autostash entry is present, saves it to
       # the stash list.
       #
-      # @see https://git-scm.com/docs/git-merge git-merge
-      #
-      # @api private
-      #
       # @example Quit the merge, leaving working tree as-is
       #   quit_cmd = Git::Commands::Merge::Quit.new(execution_context)
       #   quit_cmd.call
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-merge/2.53.0
+      #
+      # @see Git::Commands::Merge
+      #
+      # @see https://git-scm.com/docs/git-merge git-merge
+      #
+      # @api private
       #
       class Quit < Git::Commands::Base
         arguments do
@@ -29,12 +33,13 @@ module Git
         #
         #   @overload call()
         #
-        #     Execute the git merge --quit command
+        #     Forget about the current merge in progress, leaving the index
+        #     and working tree as-is
         #
-        #     @return [Git::CommandLineResult] the result of the command
+        #     @return [Git::CommandLineResult] the result of calling
+        #       `git merge --quit`
         #
-        #     @raise [Git::FailedError] if the underlying git command exits non-zero
-        #       (for example, on Git versions before 2.35 when no merge is in progress)
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/merge/start.rb
+++ b/lib/git/commands/merge/start.rb
@@ -5,14 +5,10 @@ require 'git/commands/base'
 module Git
   module Commands
     module Merge
-      # Implements the `git merge` command for merging branches
+      # Implements `git merge` to incorporate changes from named commits
       #
-      # This command joins two or more development histories together by
-      # incorporating changes from named commits into the current branch.
-      #
-      # @see https://git-scm.com/docs/git-merge git-merge
-      #
-      # @api private
+      # Joins two or more development histories together by incorporating
+      # changes from the named commits into the current branch.
       #
       # @example Simple merge
       #   merge = Git::Commands::Merge::Start.new(execution_context)
@@ -30,43 +26,74 @@ module Git
       # @example Octopus merge (multiple branches)
       #   merge.call('branch1', 'branch2', 'branch3')
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-merge/2.53.0
+      #
+      # @see Git::Commands::Merge
+      #
+      # @see https://git-scm.com/docs/git-merge git-merge
+      #
+      # @api private
+      #
       class Start < Git::Commands::Base
         arguments do
           literal 'merge'
-          flag_option :edit, negatable: true
 
           # Commit behavior
           flag_option :commit, negatable: true
-          flag_option :squash
+          flag_option %i[edit e], negatable: true
+
+          # Commit message cleanup
+          value_option :cleanup, inline: true
 
           # Fast-forward behavior
           flag_option :ff, negatable: true
           flag_option :ff_only
 
-          # Message options
-          value_option :m
-          value_option %i[file F]
-          value_option :into_name, inline: true
-
-          # Strategy options
-          value_option %i[strategy s]
-          value_option %i[strategy_option X], repeatable: true
-
           # Signing
           flag_or_value_option %i[gpg_sign S], negatable: true, inline: true
 
+          # Log message
+          flag_or_value_option :log, negatable: true, inline: true
+
+          # Trailers
+          flag_option :signoff, negatable: true
+
+          # Stat display
+          flag_option :stat, negatable: true
+          flag_option :compact_summary
+
+          # Squash
+          flag_option :squash
+
           # Verification
           flag_option :verify, negatable: true
+
+          # Strategy options
+          value_option %i[strategy s], inline: true
+          value_option %i[strategy_option X], inline: true, repeatable: true
+
+          # Signature verification
           flag_option :verify_signatures, negatable: true
 
-          # History
-          flag_option :allow_unrelated_histories, negatable: true
-          flag_option :rerere_autoupdate, negatable: true
+          # Verbosity and progress
+          flag_option %i[quiet q]
+          flag_option %i[verbose v]
+          flag_option :progress, negatable: true
 
-          # Other
+          # Stash and history
           flag_option :autostash, negatable: true
-          flag_option :signoff, negatable: true
-          flag_or_value_option :log, negatable: true, inline: true
+          flag_option :allow_unrelated_histories, negatable: true
+
+          # Message options
+          value_option :m
+          value_option :into_name
+          value_option %i[file F], inline: true
+
+          # Conflict resolution
+          flag_option :rerere_autoupdate, negatable: true
+          flag_option :overwrite_ignore, negatable: true
+
+          end_of_options
 
           # Positional: commits to merge (variadic, required)
           operand :commit, repeatable: true, required: true
@@ -74,80 +101,131 @@ module Git
 
         # @!method call(*, **)
         #
-        #   Execute the git merge command
-        #
         #   @overload call(*commit, **options)
         #
-        #     @param commit [Array<String>] One or more branch names, commit SHAs,
-        #       or refs to merge into the current branch. Multiple commits create
-        #       an octopus merge.
+        #     Execute the git merge command
+        #
+        #     @param commit [Array<String>] one or more branch names, commit SHAs,
+        #       or refs to merge into the current branch; multiple commits create
+        #       an octopus merge
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :edit (nil) Open an editor for the merge commit message.
-        #       When false, adds --no-edit to suppress the editor. When true, adds --edit.
-        #       When nil, defers to git's default behavior.
+        #     @option options [Boolean] :commit (nil) perform merge and commit the result
         #
-        #     @option options [Boolean] :commit (nil) Perform merge and commit.
-        #       true for --commit, false for --no-commit
+        #       `true` → `--commit`, `false` → `--no-commit`
         #
-        #     @option options [Boolean] :squash (nil) Create a single commit on top
-        #       of current branch with the effect of merging another branch
+        #     @option options [Boolean] :edit (nil) open an editor for the merge commit message
         #
-        #     @option options [Boolean] :ff (nil) Fast-forward behavior.
-        #       true for --ff, false for --no-ff
+        #       `true` → `--edit`, `false` → `--no-edit`. Alias: `:e`
         #
-        #     @option options [Boolean] :ff_only (nil) Refuse to merge unless
-        #       fast-forward is possible
+        #     @option options [String] :cleanup (nil) how the merge message will be cleaned
+        #       up before committing
         #
-        #     @option options [String] :m (nil) Commit message for the merge commit.
+        #       Accepted values include `strip`, `whitespace`, `verbatim`,
+        #       `scissors`, and `default`. Emits `--cleanup=<mode>`.
         #
-        #     @option options [String] :file (nil) Read commit message from file.
-        #       Alias: :F
+        #     @option options [Boolean] :ff (nil) fast-forward behavior
         #
-        #     @option options [String] :into_name (nil) Prepare merge message as if
-        #       merging into this branch name
+        #       `true` → `--ff`, `false` → `--no-ff`
         #
-        #     @option options [String] :strategy (nil) Merge strategy to use
-        #       (e.g., 'ort', 'recursive', 'resolve', 'octopus', 'ours', 'subtree').
-        #       Alias: :s
+        #     @option options [Boolean] :ff_only (false) refuse to merge unless
+        #       fast-forward is possible; emits `--ff-only`
         #
-        #     @option options [String, Array<String>] :strategy_option (nil) Pass
-        #       option(s) to the merge strategy (e.g., 'ours', 'theirs', 'patience').
-        #       Can be a single value or array for multiple -X flags. Alias: :X
+        #     @option options [Boolean, String] :gpg_sign (nil) GPG-sign the resulting
+        #       merge commit
         #
-        #     @option options [Boolean, String] :gpg_sign (nil) GPG-sign the merge commit.
-        #       true for --gpg-sign, a String key ID for --gpg-sign=<keyid>, false for --no-gpg-sign.
-        #       Alias: :S
+        #       `true` → `--gpg-sign`, a String key ID → `--gpg-sign=<keyid>`,
+        #       `false` → `--no-gpg-sign`. Alias: `:S`
         #
-        #     @option options [Boolean] :verify (nil) Run pre-merge and commit-msg
-        #       hooks. true for --verify, false for --no-verify
+        #     @option options [Boolean, Integer] :log (nil) populate the merge message
+        #       with one-line commit descriptions
         #
-        #     @option options [Boolean] :verify_signatures (nil) Verify commit
-        #       signatures. true for --verify-signatures, false for
-        #       --no-verify-signatures
+        #       `true` → `--log`, `false` → `--no-log`,
+        #       an Integer `n` → `--log=<n>` to limit entries
         #
-        #     @option options [Boolean] :allow_unrelated_histories (nil) Allow
-        #       merging histories without common ancestor. true for
-        #       --allow-unrelated-histories, false for --no-allow-unrelated-histories
+        #     @option options [Boolean] :signoff (nil) add a Signed-off-by trailer
+        #       to the commit message
         #
-        #     @option options [Boolean] :rerere_autoupdate (nil) Allow rerere to
-        #       update index. true for --rerere-autoupdate, false for
-        #       --no-rerere-autoupdate
+        #       `true` → `--signoff`, `false` → `--no-signoff`
         #
-        #     @option options [Boolean] :autostash (nil) Automatically stash/unstash
-        #       before/after merge. true for --autostash, false for --no-autostash
+        #     @option options [Boolean] :stat (nil) show a diffstat at the end of the merge
         #
-        #     @option options [Boolean] :signoff (nil) Add Signed-off-by trailer.
-        #       true for --signoff, false for --no-signoff
+        #       `true` → `--stat`, `false` → `--no-stat`
         #
-        #     @option options [Boolean, Integer] :log (nil) Include one-line descriptions
-        #       from commits in merge message. true for --log, false for --no-log,
-        #       or an integer for --log=<n> to limit the number of entries.
+        #     @option options [Boolean] :compact_summary (false) show a compact summary
+        #       at the end of the merge; emits `--compact-summary`
         #
-        #     @return [Git::CommandLineResult] the result of the command
+        #     @option options [Boolean] :squash (false) produce working tree and index
+        #       state as if a real merge happened, but do not commit; emits `--squash`
         #
-        #     @raise [Git::FailedError] if the merge fails (e.g., conflicts)
+        #     @option options [Boolean] :verify (nil) run pre-merge and commit-msg hooks
+        #
+        #       `true` → `--verify`, `false` → `--no-verify`
+        #
+        #     @option options [String] :strategy (nil) merge strategy to use
+        #       (e.g., `'ort'`, `'recursive'`, `'resolve'`, `'octopus'`, `'ours'`, `'subtree'`)
+        #
+        #       Emits `--strategy=<strategy>`. Alias: `:s`
+        #
+        #     @option options [String, Array<String>] :strategy_option (nil) pass
+        #       option(s) to the merge strategy (e.g., `'ours'`, `'theirs'`, `'patience'`)
+        #
+        #       Can be a single value or an array for multiple `--strategy-option` flags.
+        #       Emits `--strategy-option=<option>`. Alias: `:X`
+        #
+        #     @option options [Boolean] :verify_signatures (nil) verify commit signatures
+        #       on the tip of the side branch
+        #
+        #       `true` → `--verify-signatures`, `false` → `--no-verify-signatures`
+        #
+        #     @option options [Boolean] :quiet (false) operate quietly; emits `--quiet`
+        #
+        #       Alias: `:q`
+        #
+        #     @option options [Boolean] :verbose (false) be verbose; emits `--verbose`
+        #
+        #       Alias: `:v`
+        #
+        #     @option options [Boolean] :progress (nil) turn progress reporting on or off
+        #
+        #       `true` → `--progress`, `false` → `--no-progress`
+        #
+        #     @option options [Boolean] :autostash (nil) automatically stash and unstash
+        #       the working tree before and after the operation
+        #
+        #       `true` → `--autostash`, `false` → `--no-autostash`
+        #
+        #     @option options [Boolean] :allow_unrelated_histories (nil) allow merging
+        #       histories that do not share a common ancestor
+        #
+        #       `true` → `--allow-unrelated-histories`,
+        #       `false` → `--no-allow-unrelated-histories`
+        #
+        #     @option options [String] :m (nil) commit message for the merge commit;
+        #       emits `-m <msg>`
+        #
+        #     @option options [String] :into_name (nil) prepare the default merge message
+        #       as if merging to the named branch; emits `--into-name <branch>`
+        #
+        #     @option options [String] :file (nil) read the commit message from the given
+        #       file; emits `--file=<file>`. Alias: `:F`
+        #
+        #     @option options [Boolean] :rerere_autoupdate (nil) allow rerere to update
+        #       the index with the auto-resolved conflict result
+        #
+        #       `true` → `--rerere-autoupdate`, `false` → `--no-rerere-autoupdate`
+        #
+        #     @option options [Boolean] :overwrite_ignore (nil) silently overwrite ignored
+        #       files from the merge result
+        #
+        #       `true` → `--overwrite-ignore`, `false` → `--no-overwrite-ignore`
+        #
+        #     @return [Git::CommandLineResult] the result of calling `git merge`
+        #
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/spec/unit/git/commands/merge/continue_spec.rb
+++ b/spec/unit/git/commands/merge/continue_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 require 'git/commands/merge/continue'
 
 RSpec.describe Git::Commands::Merge::Continue do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
   let(:execution_context) { double('ExecutionContext') }
   let(:command) { described_class.new(execution_context) }
 

--- a/spec/unit/git/commands/merge/start_spec.rb
+++ b/spec/unit/git/commands/merge/start_spec.rb
@@ -4,18 +4,16 @@ require 'spec_helper'
 require 'git/commands/merge/start'
 
 RSpec.describe Git::Commands::Merge::Start do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
   let(:execution_context) { double('ExecutionContext') }
   let(:command) { described_class.new(execution_context) }
 
   describe '#call' do
-    before do
-      allow(execution_context).to receive(:command_capturing).and_return(command_result)
-    end
-
     context 'with single branch to merge' do
       it 'calls git merge with the branch name' do
         expected_result = command_result
-        expect_command_capturing('merge', 'feature').and_return(expected_result)
+        expect_command_capturing('merge', '--', 'feature').and_return(expected_result)
 
         result = command.call('feature')
 
@@ -25,92 +23,340 @@ RSpec.describe Git::Commands::Merge::Start do
 
     context 'with multiple branches (octopus merge)' do
       it 'merges multiple branches' do
-        expect_command_capturing('merge', 'branch1', 'branch2')
+        expect_command_capturing('merge', '--', 'branch1', 'branch2').and_return(command_result)
         command.call('branch1', 'branch2')
       end
 
       it 'merges three branches' do
-        expect_command_capturing('merge', 'a', 'b', 'c')
+        expect_command_capturing('merge', '--', 'a', 'b', 'c').and_return(command_result)
         command.call('a', 'b', 'c')
-      end
-    end
-
-    context 'with the :edit option' do
-      it 'adds --no-edit when edit is false' do
-        expect_command_capturing('merge', '--no-edit', 'feature')
-        command.call('feature', edit: false)
-      end
-
-      it 'adds --edit when edit is true' do
-        expect_command_capturing('merge', '--edit', 'feature')
-        command.call('feature', edit: true)
-      end
-
-      it 'omits --edit/--no-edit when edit is nil' do
-        expect_command_capturing('merge', 'feature')
-        command.call('feature', edit: nil)
       end
     end
 
     context 'with :commit option' do
       context 'when true' do
         it 'adds --commit flag' do
-          expect_command_capturing('merge', '--commit', 'feature')
+          expect_command_capturing('merge', '--commit', '--', 'feature').and_return(command_result)
           command.call('feature', commit: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-commit flag' do
-          expect_command_capturing('merge', '--no-commit', 'feature')
+          expect_command_capturing('merge', '--no-commit', '--', 'feature').and_return(command_result)
           command.call('feature', commit: false)
         end
       end
     end
 
-    context 'with :squash option' do
-      it 'adds --squash flag' do
-        expect_command_capturing('merge', '--squash', 'feature')
-        command.call('feature', squash: true)
+    context 'with :edit option' do
+      it 'adds --no-edit when edit is false' do
+        expect_command_capturing('merge', '--no-edit', '--', 'feature').and_return(command_result)
+        command.call('feature', edit: false)
       end
 
-      it 'does not add flag when false' do
-        expect_command_capturing('merge', 'feature')
-        command.call('feature', squash: false)
+      it 'adds --edit when edit is true' do
+        expect_command_capturing('merge', '--edit', '--', 'feature').and_return(command_result)
+        command.call('feature', edit: true)
+      end
+
+      it 'omits --edit/--no-edit when edit is nil' do
+        expect_command_capturing('merge', '--', 'feature').and_return(command_result)
+        command.call('feature', edit: nil)
+      end
+
+      it 'supports the :e alias' do
+        expect_command_capturing('merge', '--edit', '--', 'feature').and_return(command_result)
+        command.call('feature', e: true)
       end
     end
 
-    context 'with :ff option (fast-forward)' do
+    context 'with :cleanup option' do
+      it 'adds --cleanup=<mode>' do
+        expect_command_capturing('merge', '--cleanup=strip', '--', 'feature').and_return(command_result)
+        command.call('feature', cleanup: 'strip')
+      end
+    end
+
+    context 'with :ff options' do
+      context 'with :ff option' do
+        context 'when true' do
+          it 'adds --ff flag' do
+            expect_command_capturing('merge', '--ff', '--', 'feature').and_return(command_result)
+            command.call('feature', ff: true)
+          end
+        end
+
+        context 'when false' do
+          it 'adds --no-ff flag' do
+            expect_command_capturing('merge', '--no-ff', '--', 'feature').and_return(command_result)
+            command.call('feature', ff: false)
+          end
+        end
+      end
+
+      context 'with :ff_only option' do
+        it 'adds --ff-only flag' do
+          expect_command_capturing('merge', '--ff-only', '--', 'feature').and_return(command_result)
+          command.call('feature', ff_only: true)
+        end
+
+        it 'does not add flag when false' do
+          expect_command_capturing('merge', '--', 'feature').and_return(command_result)
+          command.call('feature', ff_only: false)
+        end
+      end
+    end
+
+    context 'with :gpg_sign option' do
       context 'when true' do
-        it 'adds --ff flag' do
-          expect_command_capturing('merge', '--ff', 'feature')
-          command.call('feature', ff: true)
+        it 'adds --gpg-sign flag' do
+          expect_command_capturing('merge', '--gpg-sign', '--', 'feature').and_return(command_result)
+          command.call('feature', gpg_sign: true)
         end
       end
 
       context 'when false' do
-        it 'adds --no-ff flag' do
-          expect_command_capturing('merge', '--no-ff', 'feature')
-          command.call('feature', ff: false)
+        it 'adds --no-gpg-sign flag' do
+          expect_command_capturing('merge', '--no-gpg-sign', '--', 'feature').and_return(command_result)
+          command.call('feature', gpg_sign: false)
+        end
+      end
+
+      context 'when a key ID string' do
+        it 'adds --gpg-sign=<keyid>' do
+          expect_command_capturing('merge', '--gpg-sign=ABCDEF01', '--', 'feature').and_return(command_result)
+          command.call('feature', gpg_sign: 'ABCDEF01')
+        end
+      end
+
+      it 'supports the :S alias' do
+        expect_command_capturing('merge', '--gpg-sign', '--', 'feature').and_return(command_result)
+        command.call('feature', S: true)
+      end
+    end
+
+    context 'with :log option' do
+      context 'when true' do
+        it 'adds --log flag' do
+          expect_command_capturing('merge', '--log', '--', 'feature').and_return(command_result)
+          command.call('feature', log: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-log flag' do
+          expect_command_capturing('merge', '--no-log', '--', 'feature').and_return(command_result)
+          command.call('feature', log: false)
+        end
+      end
+
+      context 'when an integer' do
+        it 'adds --log=<n>' do
+          expect_command_capturing('merge', '--log=10', '--', 'feature').and_return(command_result)
+          command.call('feature', log: 10)
         end
       end
     end
 
-    context 'with :ff_only option' do
-      it 'adds --ff-only flag' do
-        expect_command_capturing('merge', '--ff-only', 'feature')
-        command.call('feature', ff_only: true)
+    context 'with :signoff option' do
+      context 'when true' do
+        it 'adds --signoff flag' do
+          expect_command_capturing('merge', '--signoff', '--', 'feature').and_return(command_result)
+          command.call('feature', signoff: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-signoff flag' do
+          expect_command_capturing('merge', '--no-signoff', '--', 'feature').and_return(command_result)
+          command.call('feature', signoff: false)
+        end
+      end
+    end
+
+    context 'with :stat option' do
+      context 'when true' do
+        it 'adds --stat flag' do
+          expect_command_capturing('merge', '--stat', '--', 'feature').and_return(command_result)
+          command.call('feature', stat: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-stat flag' do
+          expect_command_capturing('merge', '--no-stat', '--', 'feature').and_return(command_result)
+          command.call('feature', stat: false)
+        end
+      end
+    end
+
+    context 'with :compact_summary option' do
+      it 'adds --compact-summary flag' do
+        expect_command_capturing('merge', '--compact-summary', '--', 'feature').and_return(command_result)
+        command.call('feature', compact_summary: true)
       end
 
       it 'does not add flag when false' do
-        expect_command_capturing('merge', 'feature')
-        command.call('feature', ff_only: false)
+        expect_command_capturing('merge', '--', 'feature').and_return(command_result)
+        command.call('feature', compact_summary: false)
+      end
+    end
+
+    context 'with :squash option' do
+      it 'adds --squash flag' do
+        expect_command_capturing('merge', '--squash', '--', 'feature').and_return(command_result)
+        command.call('feature', squash: true)
+      end
+
+      it 'does not add flag when false' do
+        expect_command_capturing('merge', '--', 'feature').and_return(command_result)
+        command.call('feature', squash: false)
+      end
+    end
+
+    context 'with :verify option' do
+      context 'when true' do
+        it 'adds --verify flag' do
+          expect_command_capturing('merge', '--verify', '--', 'feature').and_return(command_result)
+          command.call('feature', verify: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-verify flag' do
+          expect_command_capturing('merge', '--no-verify', '--', 'feature').and_return(command_result)
+          command.call('feature', verify: false)
+        end
+      end
+    end
+
+    context 'with :strategy option' do
+      it 'adds --strategy=<name>' do
+        expect_command_capturing('merge', '--strategy=ours', '--', 'feature').and_return(command_result)
+        command.call('feature', strategy: 'ours')
+      end
+
+      it 'supports the :s alias' do
+        expect_command_capturing('merge', '--strategy=recursive', '--', 'feature').and_return(command_result)
+        command.call('feature', s: 'recursive')
+      end
+    end
+
+    context 'with :strategy_option option' do
+      it 'adds --strategy-option=<value>' do
+        expect_command_capturing('merge', '--strategy-option=ours', '--', 'feature').and_return(command_result)
+        command.call('feature', strategy_option: 'ours')
+      end
+
+      it 'supports the :X alias' do
+        expect_command_capturing('merge', '--strategy-option=theirs', '--', 'feature').and_return(command_result)
+        command.call('feature', X: 'theirs')
+      end
+
+      it 'supports multiple strategy options as an array' do
+        expect_command_capturing(
+          'merge', '--strategy-option=ours', '--strategy-option=patience', '--', 'feature'
+        ).and_return(command_result)
+        command.call('feature', strategy_option: %w[ours patience])
+      end
+    end
+
+    context 'with :verify_signatures option' do
+      context 'when true' do
+        it 'adds --verify-signatures flag' do
+          expect_command_capturing('merge', '--verify-signatures', '--', 'feature').and_return(command_result)
+          command.call('feature', verify_signatures: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-verify-signatures flag' do
+          expect_command_capturing('merge', '--no-verify-signatures', '--', 'feature').and_return(command_result)
+          command.call('feature', verify_signatures: false)
+        end
+      end
+    end
+
+    context 'with :quiet option' do
+      it 'adds --quiet flag' do
+        expect_command_capturing('merge', '--quiet', '--', 'feature').and_return(command_result)
+        command.call('feature', quiet: true)
+      end
+
+      it 'supports the :q alias' do
+        expect_command_capturing('merge', '--quiet', '--', 'feature').and_return(command_result)
+        command.call('feature', q: true)
+      end
+    end
+
+    context 'with :verbose option' do
+      it 'adds --verbose flag' do
+        expect_command_capturing('merge', '--verbose', '--', 'feature').and_return(command_result)
+        command.call('feature', verbose: true)
+      end
+
+      it 'supports the :v alias' do
+        expect_command_capturing('merge', '--verbose', '--', 'feature').and_return(command_result)
+        command.call('feature', v: true)
+      end
+    end
+
+    context 'with :progress option' do
+      context 'when true' do
+        it 'adds --progress flag' do
+          expect_command_capturing('merge', '--progress', '--', 'feature').and_return(command_result)
+          command.call('feature', progress: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-progress flag' do
+          expect_command_capturing('merge', '--no-progress', '--', 'feature').and_return(command_result)
+          command.call('feature', progress: false)
+        end
+      end
+    end
+
+    context 'with :autostash option' do
+      context 'when true' do
+        it 'adds --autostash flag' do
+          expect_command_capturing('merge', '--autostash', '--', 'feature').and_return(command_result)
+          command.call('feature', autostash: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-autostash flag' do
+          expect_command_capturing('merge', '--no-autostash', '--', 'feature').and_return(command_result)
+          command.call('feature', autostash: false)
+        end
+      end
+    end
+
+    context 'with :allow_unrelated_histories option' do
+      context 'when true' do
+        it 'adds --allow-unrelated-histories flag' do
+          expect_command_capturing(
+            'merge', '--allow-unrelated-histories', '--', 'feature'
+          ).and_return(command_result)
+          command.call('feature', allow_unrelated_histories: true)
+        end
+      end
+
+      context 'when false' do
+        it 'adds --no-allow-unrelated-histories flag' do
+          expect_command_capturing(
+            'merge', '--no-allow-unrelated-histories', '--', 'feature'
+          ).and_return(command_result)
+          command.call('feature', allow_unrelated_histories: false)
+        end
       end
     end
 
     context 'with :m option' do
       it 'adds -m flag with message' do
-        expect_command_capturing('merge', '-m', 'Merge feature', 'feature')
+        expect_command_capturing('merge', '-m', 'Merge feature', '--', 'feature').and_return(command_result)
         command.call('feature', m: 'Merge feature')
       end
 
@@ -120,201 +366,66 @@ RSpec.describe Git::Commands::Merge::Start do
       end
     end
 
-    context 'with :file option' do
-      it 'adds --file flag with file path' do
-        expect_command_capturing('merge', '--file', '/path/to/msg.txt', 'feature')
-        command.call('feature', file: '/path/to/msg.txt')
-      end
-
-      it 'works with :F alias' do
-        expect_command_capturing('merge', '--file', 'msg.txt', 'feature')
-        command.call('feature', F: 'msg.txt')
-      end
-    end
-
     context 'with :into_name option' do
       it 'adds --into-name flag with value' do
-        expect_command_capturing('merge', '--into-name=main', 'feature')
+        expect_command_capturing('merge', '--into-name', 'main', '--', 'feature').and_return(command_result)
         command.call('feature', into_name: 'main')
       end
     end
 
-    context 'with :strategy option' do
-      it 'adds --strategy flag with strategy name' do
-        expect_command_capturing('merge', '--strategy', 'ours', 'feature')
-        command.call('feature', strategy: 'ours')
+    context 'with :file option' do
+      it 'adds --file=<path>' do
+        expect_command_capturing('merge', '--file=/path/to/msg.txt', '--', 'feature').and_return(command_result)
+        command.call('feature', file: '/path/to/msg.txt')
       end
 
-      it 'works with :s alias' do
-        expect_command_capturing('merge', '--strategy', 'recursive', 'feature')
-        command.call('feature', s: 'recursive')
-      end
-    end
-
-    context 'with :strategy_option option' do
-      it 'adds --strategy-option flag with strategy option' do
-        expect_command_capturing('merge', '--strategy-option', 'ours', 'feature')
-        command.call('feature', strategy_option: 'ours')
-      end
-
-      it 'works with :X alias' do
-        expect_command_capturing('merge', '--strategy-option', 'theirs', 'feature')
-        command.call('feature', X: 'theirs')
-      end
-
-      it 'supports multiple strategy options' do
-        expect_command_capturing(
-          'merge', '--strategy-option', 'ours', '--strategy-option', 'patience', 'feature'
-        )
-        command.call('feature', strategy_option: %w[ours patience])
-      end
-    end
-
-    context 'with :verify option' do
-      context 'when true' do
-        it 'adds --verify flag' do
-          expect_command_capturing('merge', '--verify', 'feature')
-          command.call('feature', verify: true)
-        end
-      end
-
-      context 'when false' do
-        it 'adds --no-verify flag' do
-          expect_command_capturing('merge', '--no-verify', 'feature')
-          command.call('feature', verify: false)
-        end
-      end
-    end
-
-    context 'with :verify_signatures option' do
-      context 'when true' do
-        it 'adds --verify-signatures flag' do
-          expect_command_capturing('merge', '--verify-signatures', 'feature')
-          command.call('feature', verify_signatures: true)
-        end
-      end
-
-      context 'when false' do
-        it 'adds --no-verify-signatures flag' do
-          expect_command_capturing(
-            'merge', '--no-verify-signatures', 'feature'
-          )
-          command.call('feature', verify_signatures: false)
-        end
-      end
-    end
-
-    context 'with :gpg_sign option' do
-      context 'when true' do
-        it 'adds --gpg-sign flag' do
-          expect_command_capturing('merge', '--gpg-sign', 'feature')
-          command.call('feature', gpg_sign: true)
-        end
-      end
-
-      context 'when false' do
-        it 'adds --no-gpg-sign flag' do
-          expect_command_capturing('merge', '--no-gpg-sign', 'feature')
-          command.call('feature', gpg_sign: false)
-        end
-      end
-    end
-
-    context 'with :allow_unrelated_histories option' do
-      context 'when true' do
-        it 'adds --allow-unrelated-histories flag' do
-          expect_command_capturing(
-            'merge', '--allow-unrelated-histories', 'feature'
-          )
-          command.call('feature', allow_unrelated_histories: true)
-        end
-      end
-
-      context 'when false' do
-        it 'adds --no-allow-unrelated-histories flag' do
-          expect_command_capturing(
-            'merge', '--no-allow-unrelated-histories', 'feature'
-          )
-          command.call('feature', allow_unrelated_histories: false)
-        end
+      it 'supports the :F alias' do
+        expect_command_capturing('merge', '--file=msg.txt', '--', 'feature').and_return(command_result)
+        command.call('feature', F: 'msg.txt')
       end
     end
 
     context 'with :rerere_autoupdate option' do
       context 'when true' do
         it 'adds --rerere-autoupdate flag' do
-          expect_command_capturing('merge', '--rerere-autoupdate', 'feature')
+          expect_command_capturing('merge', '--rerere-autoupdate', '--', 'feature').and_return(command_result)
           command.call('feature', rerere_autoupdate: true)
         end
       end
 
       context 'when false' do
         it 'adds --no-rerere-autoupdate flag' do
-          expect_command_capturing(
-            'merge', '--no-rerere-autoupdate', 'feature'
-          )
+          expect_command_capturing('merge', '--no-rerere-autoupdate', '--', 'feature').and_return(command_result)
           command.call('feature', rerere_autoupdate: false)
         end
       end
     end
 
-    context 'with :autostash option' do
+    context 'with :overwrite_ignore option' do
       context 'when true' do
-        it 'adds --autostash flag' do
-          expect_command_capturing('merge', '--autostash', 'feature')
-          command.call('feature', autostash: true)
+        it 'adds --overwrite-ignore flag' do
+          expect_command_capturing('merge', '--overwrite-ignore', '--', 'feature').and_return(command_result)
+          command.call('feature', overwrite_ignore: true)
         end
       end
 
       context 'when false' do
-        it 'adds --no-autostash flag' do
-          expect_command_capturing('merge', '--no-autostash', 'feature')
-          command.call('feature', autostash: false)
-        end
-      end
-    end
-
-    context 'with :signoff option' do
-      context 'when true' do
-        it 'adds --signoff flag' do
-          expect_command_capturing('merge', '--signoff', 'feature')
-          command.call('feature', signoff: true)
-        end
-      end
-
-      context 'when false' do
-        it 'adds --no-signoff flag' do
-          expect_command_capturing('merge', '--no-signoff', 'feature')
-          command.call('feature', signoff: false)
-        end
-      end
-    end
-
-    context 'with :log option' do
-      context 'when true' do
-        it 'adds --log flag' do
-          expect_command_capturing('merge', '--log', 'feature')
-          command.call('feature', log: true)
-        end
-      end
-
-      context 'when false' do
-        it 'adds --no-log flag' do
-          expect_command_capturing('merge', '--no-log', 'feature')
-          command.call('feature', log: false)
+        it 'adds --no-overwrite-ignore flag' do
+          expect_command_capturing('merge', '--no-overwrite-ignore', '--', 'feature').and_return(command_result)
+          command.call('feature', overwrite_ignore: false)
         end
       end
     end
 
     context 'with multiple options combined' do
-      it 'includes all specified flags in correct order' do
+      it 'includes all specified flags in correct DSL order' do
         expect_command_capturing(
-          'merge', '--no-edit', '--no-commit', '--no-ff',
+          'merge',
+          '--no-commit', '--no-edit', '--no-ff',
+          '--strategy=ort', '--strategy-option=theirs',
           '-m', 'Merge feature branch',
-          '--strategy', 'ort',
-          '--strategy-option', 'theirs',
-          'feature'
-        )
+          '--', 'feature'
+        ).and_return(command_result)
         command.call(
           'feature',
           edit: false,
@@ -326,15 +437,10 @@ RSpec.describe Git::Commands::Merge::Start do
         )
       end
 
-      it 'combines squash with no-commit behavior' do
-        expect_command_capturing('merge', '--squash', 'feature')
-        command.call('feature', squash: true)
-      end
-
       it 'combines ff_only with allow_unrelated_histories' do
         expect_command_capturing(
-          'merge', '--ff-only', '--allow-unrelated-histories', 'feature'
-        )
+          'merge', '--ff-only', '--allow-unrelated-histories', '--', 'feature'
+        ).and_return(command_result)
         command.call('feature', ff_only: true, allow_unrelated_histories: true)
       end
     end


### PR DESCRIPTION
## Summary

Updates all four `merge/*` command classes (`Abort`, `Continue`, `Quit`, `Start`) to align with current project conventions and adds post-2.28.0 options to `Merge::Start`. This is the final batch of issue #1196 Batch 5.

Partially addresses #1196 (Batch 5: `merge/abort`, `merge/continue`, `merge/quit`, `merge/start`).

## Changes

### `merge/abort`, `merge/continue`, `merge/quit` (YARD + docs alignment)

- Fix YARD doc ordering: `@example` before `@note` / `@see` / `@api private`
- Add `@note` `` `arguments` block audited against https://git-scm.com/docs/git-merge/2.53.0 ``
- Add `@see Git::Commands::Merge` parent module cross-reference
- Fix `@return` and `@raise` to canonical project wording
- `merge/continue`: remove facade-layer policy sentence from class description

### `merge/start` (new options + DSL corrections)

- Add `@note` + `@see Git::Commands::Merge` links (same as siblings)
- Add 8 new options from the 2.53.0 docs:
  - `:cleanup` — `--cleanup=<mode>` (added in 2.29)
  - `:stat` (`stat: true` → `--stat`, `stat: false` → `--no-stat`)
  - `:compact_summary` — `--compact-summary`
  - `:quiet` / `:q` — `--quiet`
  - `:verbose` / `:v` — `--verbose`
  - `:progress` (`progress: true` → `--progress`, `progress: false` → `--no-progress`)
  - `:overwrite_ignore` (`overwrite_ignore: true` → `--overwrite-ignore`, `overwrite_ignore: false` → `--no-overwrite-ignore`)
- Add `:e` alias on `:edit`
- Add `inline: true` on `:strategy`, `:strategy_option`, `:file` (`=` notation in git docs)
- Remove `inline: true` from `:into_name` (space-separated notation in git docs)
- Add `end_of_options` before `operand :commit` (Rule 2: options precede operands)
- Rewrite `@!method call` YARD block: canonical wording, `@option` entries for all new options, `@raise [ArgumentError]` + `@raise [Git::FailedError]`

### Tests

- `start_spec`: update all `expect_command_capturing` calls to include `'--'` from `end_of_options`; add contexts for all 8 new options and the `:e` alias; update inline-option token form (`--strategy=`, `--file=`, etc.)
- `continue_spec`: add duck-type collaborator comment on double

## Quality gates

All tasks pass:
- `bundle exec rake spec:unit:parallel` — 3438 examples, 0 failures
- `bundle exec rake spec:integration:parallel` — 468 examples, 0 failures
- `bundle exec rake test:parallel` — 560 tests, 0 failures
- `bundle exec rake rubocop` — 578 files inspected, no offenses
- `bundle exec rake yard` — coverage 76.2% (threshold 75%), 0 doc failures
- `bundle exec rake build` — gem built successfully