### PR TITLE
refactor(commands): backfill post-2.28.0 options — Batch 6 part 2 (checkout/files, checkout_index, clean, clone, commit)

### DIFF
--- a/lib/git/commands/checkout/files.rb
+++ b/lib/git/commands/checkout/files.rb
@@ -11,46 +11,40 @@ module Git
       # the index (when tree_ish is nil) or a specified tree-ish (commit,
       # branch, tag, etc.).
       #
+      # @example Restore working tree files
+      #   files = Git::Commands::Checkout::Files.new(execution_context)
+      #   files.call(pathspec: ['lib/foo.rb'])                             # from the index
+      #   files.call('HEAD~1', pathspec: ['lib/foo.rb'])                   # from a specific commit
+      #   files.call('main', pathspec: %w[lib/foo.rb lib/bar.rb])          # from a branch
+      #   files.call(pathspec: ['conflicted.txt'], ours: true)             # resolve conflict (ours)
+      #   files.call('main', pathspec_from_file: 'paths.txt')              # paths from a file
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-checkout/2.53.0
+      #
+      # @see Git::Commands::Checkout
+      #
       # @see https://git-scm.com/docs/git-checkout git-checkout
       #
-      # @see Git::Commands
-      #
       # @api private
-      #
-      # @example Restore a file from the index (discard uncommitted changes)
-      #   files = Git::Commands::Checkout::Files.new(execution_context)
-      #   files.call(pathspec: ['file.txt'])
-      #
-      # @example Restore a file from HEAD
-      #   files.call('HEAD', pathspec: ['file.txt'])
-      #
-      # @example Restore a file from a specific commit
-      #   files.call('HEAD~1', pathspec: ['file.txt'])
-      #
-      # @example Restore multiple files from a branch
-      #   files.call('main', pathspec: ['file1.txt', 'file2.txt'])
-      #
-      # @example Resolve merge conflict by choosing "ours" version
-      #   files.call(pathspec: ['conflicted.txt'], ours: true)
-      #
-      # @example Read paths from a file
-      #   files.call('main', pathspec_from_file: 'paths.txt')
       #
       class Files < Git::Commands::Base
         arguments do
           literal 'checkout'
-          flag_option %i[force f]
-          flag_option :ours
-          flag_option :theirs
-          flag_option %i[merge m]
-          value_option :conflict, inline: true
-          flag_option :overlay, negatable: true
-          value_option :pathspec_from_file, inline: true
-          flag_option :pathspec_file_nul
+          flag_option %i[force f]                                     # --force (alias: :f)
+          flag_option :ours                                           # --ours
+          flag_option :theirs                                         # --theirs
+          flag_option %i[merge m]                                     # --merge (alias: :m)
+          value_option :conflict, inline: true                        # --conflict=<style>
+          flag_option :overlay, negatable: true                       # --overlay / --no-overlay
+          flag_option :ignore_skip_worktree_bits                      # --ignore-skip-worktree-bits
+          value_option :pathspec_from_file, inline: true              # --pathspec-from-file=<file>
+          flag_option :pathspec_file_nul                              # --pathspec-file-nul
+
+          execution_option :chdir
 
           operand :tree_ish
           end_of_options
-          value_option :pathspec, as_operand: true, repeatable: true
+          value_option :pathspec, as_operand: true, repeatable: true  # <pathspec>...
         end
 
         # @!method call(*, **)
@@ -66,38 +60,48 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :force (nil) Ignore unmerged entries
+        #     @option options [Boolean] :force (false) ignore unmerged entries
         #
         #       Alias: `:f`
         #
-        #     @option options [Boolean] :ours (nil) For unmerged paths, use stage #2
+        #     @option options [Boolean] :ours (false) for unmerged paths, check out
+        #       stage #2 (our version)
         #
-        #     @option options [Boolean] :theirs (nil) For unmerged paths, use stage #3
+        #     @option options [Boolean] :theirs (false) for unmerged paths, check out
+        #       stage #3 (their version)
         #
-        #     @option options [Boolean] :merge (nil) Recreate the conflicted merge
+        #     @option options [Boolean] :merge (false) recreate the conflicted merge in
+        #       the specified paths; cannot be used when checking out from a tree-ish
         #
         #       Alias: `:m`
         #
-        #     @option options [String] :conflict (nil) Conflict marker style:
-        #       `merge`, `diff3`, or `zdiff3`
+        #     @option options [String] :conflict (nil) conflict marker style; valid
+        #       values are `'merge'`, `'diff3'`, and `'zdiff3'`
         #
-        #     @option options [Boolean] :overlay (nil) Use `true` for `--overlay`,
-        #       `false` for `--no-overlay`
+        #     @option options [Boolean] :overlay (nil) use `true` for `--overlay`
+        #       (never removes files from the index or working tree); use `false` for
+        #       `--no-overlay` (removes files not present in the tree-ish)
         #
-        #     @option options [String] :pathspec_from_file (nil) Read paths from file
-        #       (`'-'` for stdin)
+        #     @option options [Boolean] :ignore_skip_worktree_bits (false) in sparse
+        #       checkout mode, ignore sparse patterns and update all files matched by
+        #       pathspec
         #
-        #       Required unless `:pathspec` is provided
+        #     @option options [String] :pathspec_from_file (nil) read pathspec from
+        #       this file; pass `'-'` to read from stdin
         #
-        #     @option options [Boolean] :pathspec_file_nul (nil) NUL-separated paths in
-        #       pathspec file
+        #     @option options [Boolean] :pathspec_file_nul (false) with
+        #       `:pathspec_from_file`, separate pathspec elements with NUL instead of
+        #       newline
         #
-        #     @option options [Array<String>, String] :pathspec The files or directories
-        #       to restore
+        #     @option options [Array<String>, String] :pathspec (nil) the files or
+        #       directories to restore
         #
-        #       Required unless `:pathspec_from_file` is provided
+        #     @option options [String] :chdir (nil) change to this directory before
+        #       running git; not passed to the git CLI
         #
         #     @return [Git::CommandLineResult] the result of calling `git checkout`
+        #
+        #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
         #

--- a/lib/git/commands/checkout_index.rb
+++ b/lib/git/commands/checkout_index.rb
@@ -11,39 +11,33 @@ module Git
     # working directory from the current index, optionally scoped to a specific
     # path or prefix.
     #
+    # @example Typical usage
+    #   checkout_index = Git::Commands::CheckoutIndex.new(execution_context)
+    #   checkout_index.call(all: true)
+    #   checkout_index.call(all: true, force: true)
+    #   checkout_index.call('path/to/file.txt')
+    #   checkout_index.call(all: true, prefix: 'output/')
+    #
+    # @note `arguments` block audited against https://git-scm.com/docs/git-checkout-index/2.53.0
+    #
     # @see https://git-scm.com/docs/git-checkout-index git-checkout-index
     #
     # @see Git::Commands
     #
     # @api private
     #
-    # @example Copy all indexed files to the working directory
-    #   checkout_index = Git::Commands::CheckoutIndex.new(execution_context)
-    #   checkout_index.call(all: true)
-    #
-    # @example Force-overwrite existing files
-    #   checkout_index.call(all: true, force: true)
-    #
-    # @example Write files under an output prefix directory
-    #   checkout_index.call(all: true, prefix: 'output/')
-    #
-    # @example Checkout a specific file
-    #   checkout_index.call('path/to/file.txt')
-    #
-    # @example Checkout a specific file with force
-    #   checkout_index.call('path/to/file.txt', force: true)
-    #
     class CheckoutIndex < Git::Commands::Base
       arguments do
         literal 'checkout-index'
-        flag_option %i[index u]
-        flag_option %i[all a]
-        flag_option %i[force f]
-        flag_option %i[no_create n]
-        value_option :prefix, inline: true
-        value_option :stage, inline: true
-        flag_option :temp
-        flag_option :ignore_skip_worktree_bits
+        flag_option %i[index u]                  # --index (alias: :u)
+        flag_option %i[quiet q]                  # --quiet (alias: :q)
+        flag_option %i[all a]                    # --all (alias: :a)
+        flag_option %i[force f]                  # --force (alias: :f)
+        flag_option %i[no_create n]              # --no-create (alias: :n)
+        value_option :prefix, inline: true       # --prefix=<string>
+        value_option :stage, inline: true        # --stage=<number>|all
+        flag_option :temp                        # --temp
+        flag_option :ignore_skip_worktree_bits   # --ignore-skip-worktree-bits
         end_of_options
         operand :file, required: false, repeatable: true
       end
@@ -54,45 +48,53 @@ module Git
       #
       #     Execute the `git checkout-index` command
       #
-      #     @param file [Array<String>] Zero or more file paths to check out
+      #     @param file [Array<String>] zero or more file paths to check out
       #
       #       When empty, no files are checked out individually (use `:all` to check
       #       out everything).
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :index (nil) Update the index rather than
-      #       checking out files to the working directory
+      #     @option options [Boolean] :index (false) update stat information for the
+      #       checked out entries in the index file
       #
       #       Alias: `:u`
       #
-      #     @option options [Boolean] :all (nil) Check out all files in the index
+      #     @option options [Boolean] :quiet (false) suppress messages when files
+      #       exist or are not in the index
+      #
+      #       Alias: `:q`
+      #
+      #     @option options [Boolean] :all (false) check out all files in the index
       #
       #       Alias: `:a`
       #
-      #     @option options [Boolean] :force (nil) Force checkout even if
-      #       file already exists in the output location
+      #     @option options [Boolean] :force (false) force overwrite of existing files
       #
       #       Alias: `:f`
       #
-      #     @option options [Boolean] :no_create (nil) Don't checkout new files,
+      #     @option options [Boolean] :no_create (false) don't checkout new files,
       #       only refresh files already checked out
       #
       #       Alias: `:n`
       #
-      #     @option options [String] :prefix (nil) Write the content to files under
-      #       the given directory prefix instead of the working directory root
+      #     @option options [String] :prefix (nil) write file content under the given
+      #       directory prefix instead of the working directory root
       #
-      #     @option options [String] :stage (nil) Check out from the named stage:
-      #       a number (1, 2, or 3) or the string `all`
+      #     @option options [String] :stage (nil) check out from the named stage
       #
-      #     @option options [Boolean] :temp (nil) Instead of checking the files out,
-      #       write the content to temporary files near the target location
+      #       Pass `'1'`, `'2'`, or `'3'` for a specific stage number, or `'all'` to
+      #       check out all stages (automatically implies `--temp`).
       #
-      #     @option options [Boolean] :ignore_skip_worktree_bits (nil) Ignore the
-      #       skip-worktree bits when checking out files
+      #     @option options [Boolean] :temp (false) write file content to temporary
+      #       files near the target location instead of checking them out
+      #
+      #     @option options [Boolean] :ignore_skip_worktree_bits (false) check out
+      #       all files, including those with the skip-worktree bit set
       #
       #     @return [Git::CommandLineResult] the result of calling `git checkout-index`
+      #
+      #     @raise [ArgumentError] if unsupported options are provided
       #
       #     @raise [Git::FailedError] if git exits with a non-zero exit status
       #

--- a/lib/git/commands/clean.rb
+++ b/lib/git/commands/clean.rb
@@ -6,52 +6,39 @@ module Git
   module Commands
     # Remove untracked files from the working tree
     #
-    # This command removes files from the working directory that are not tracked by Git.
-    # It respects standard ignore rules unless explicitly overridden.
+    # Cleans the working tree by recursively removing files that are not under
+    # version control. Only files unknown to Git are removed by default; with
+    # `:x` also removes ignored files; with `:X` removes only ignored files.
     #
-    # @see https://git-scm.com/docs/git-clean git-clean
+    # @example Typical usage
+    #   clean = Git::Commands::Clean.new(execution_context)
+    #   clean.call(force: true)
+    #   clean.call(force: true, d: true)
+    #   clean.call(force: 2)
+    #   clean.call(dry_run: true)
+    #   clean.call(force: true, exclude: '*.log')
+    #   clean.call(force: true, X: true)
+    #   clean.call(force: true, pathspec: ['tmp/', 'build/'])
+    #
+    # @note `arguments` block audited against https://git-scm.com/docs/git-clean/2.53.0
     #
     # @see Git::Commands
     #
+    # @see https://git-scm.com/docs/git-clean git-clean
+    #
     # @api private
-    #
-    # @example Clean untracked files
-    #   clean = Git::Commands::Clean.new(execution_context)
-    #   clean.call
-    #
-    # @example Force cleaning of untracked files
-    #   clean.call(force: true)
-    #
-    # @example Force cleaning of untracked nested git repositories
-    #   clean.call(force: 2)
-    #
-    # @example Recurse into untracked directories
-    #   clean.call(d: true)
-    #
-    # @example Don’t use the standard ignore rules
-    #   clean.call(x: true)
-    #
-    # @example Dry run — show what would be done without removing anything
-    #   clean.call(dry_run: true)
-    #
-    # @example Exclude files matching a pattern from cleaning
-    #   clean.call(force: true, exclude: '*.log')
-    #
-    # @example Remove only files ignored by Git
-    #   clean.call(force: true, X: true)
-    #
-    # @example Clean specific paths only
-    #   clean.call(force: true, pathspec: ['tmp/', 'build/'])
     #
     class Clean < Git::Commands::Base
       arguments do
         literal 'clean'
-        flag_option :d
-        flag_option %i[force f], max_times: 2
-        flag_option %i[dry_run n]
-        value_option %i[exclude e], inline: true, repeatable: true
-        flag_option :x
-        flag_option :X
+        flag_option :d # -d
+        flag_option %i[force f], max_times: 2 # --force (alias: :f)
+        flag_option %i[dry_run n] # --dry-run (alias: :n)
+        flag_option %i[quiet q] # --quiet (alias: :q)
+        value_option %i[exclude e], inline: true, repeatable: true # --exclude=<pattern> (alias: :e)
+        flag_option :x  # -x
+        flag_option :X  # -X
+        execution_option :chdir
         end_of_options
         value_option :pathspec, as_operand: true, repeatable: true
       end
@@ -64,9 +51,9 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :d (nil) Recurse into untracked directories
+      #     @option options [Boolean] :d (false) recurse into untracked directories
       #
-      #     @option options [Boolean, Integer] :force (nil) Force the removal of untracked files
+      #     @option options [Boolean, Integer] :force (false) force the removal of untracked files
       #
       #       When `clean.requireForce` is not set to `false`, git-clean will refuse to
       #       delete files or directories unless this option is given.
@@ -75,28 +62,35 @@ module Git
       #       which also removes untracked nested git repositories (directories with a
       #       `.git` subdirectory).
       #
-      #       Alias: :f
+      #       Alias: `:f`
       #
-      #     @option options [Boolean] :dry_run (nil) Don't actually remove anything, just
+      #     @option options [Boolean] :dry_run (false) don't actually remove anything, just
       #       show what would be done
       #
-      #     @option options [String, Array<String>] :exclude (nil) Use the given exclude pattern
-      #       in addition to the standard ignore rules
+      #       Alias: `:n`
       #
-      #       May be specified multiple times
+      #     @option options [Boolean] :quiet (false) be quiet, only report errors
       #
-      #     @option options [Boolean] :x (nil) Don't use the standard ignore rules
+      #       Alias: `:q`
       #
-      #       Mutually exclusive with `:X`
+      #     @option options [String, Array<String>] :exclude (nil) use the given exclude
+      #       pattern in addition to the standard ignore rules
       #
-      #     @option options [Boolean] :X (nil) Remove only files ignored by Git
+      #       May be specified multiple times. Alias: `:e`
       #
-      #       Mutually exclusive with `:x`
+      #     @option options [Boolean] :x (false) don't use the standard ignore rules
       #
-      #     @option options [String, Array<String>] :pathspec (nil) Limit cleaning to files
+      #     @option options [Boolean] :X (false) remove only files ignored by Git
+      #
+      #     @option options [String, Array<String>] :pathspec (nil) limit cleaning to files
       #       matching the given pathspec(s)
       #
+      #     @option options [String, nil] :chdir (nil) change to this directory before
+      #       running git; not passed to the git CLI
+      #
       #     @return [Git::CommandLineResult] the result of calling `git clean`
+      #
+      #     @raise [ArgumentError] if unsupported options are provided
       #
       #     @raise [Git::FailedError] if git exits with a non-zero exit status
       #

--- a/lib/git/commands/clone.rb
+++ b/lib/git/commands/clone.rb
@@ -6,55 +6,61 @@ module Git
   module Commands
     # Implements the `git clone` command
     #
-    # This command clones a repository into a newly created directory.
+    # Clones a repository into a newly created directory.
+    #
+    # @example Typical usage
+    #   clone = Git::Commands::Clone.new(execution_context)
+    #   clone.call('https://github.com/user/repo.git')
+    #   clone.call('https://github.com/user/repo.git', 'local-dir')
+    #   clone.call('https://github.com/user/repo.git', 'local-dir', bare: true)
+    #   clone.call('https://github.com/user/repo.git', 'local-dir', depth: 1)
+    #
+    # @note `arguments` block audited against https://git-scm.com/docs/git-clone/2.53.0
     #
     # @see https://git-scm.com/docs/git-clone git-clone
     #
+    # @see Git::Commands
+    #
     # @api private
-    #
-    # @example Basic usage
-    #   clone = Git::Commands::Clone.new(execution_context)
-    #   result = clone.call('https://github.com/user/repo.git', 'local-dir')
-    #
-    # @example With options
-    #   clone = Git::Commands::Clone.new(execution_context)
-    #   result = clone.call('https://github.com/user/repo.git', 'local-dir', bare: true, depth: 1)
     #
     class Clone < Git::Commands::Base
       arguments do
         literal 'clone'
-        value_option :template, inline: true
-        flag_option %i[local l], negatable: true
-        flag_option %i[shared s]
-        flag_option :no_hardlinks
-        flag_option %i[no_checkout n]
-        flag_option :bare
-        flag_option :mirror
-        value_option %i[origin o]
-        value_option %i[branch b]
-        value_option :revision, inline: true
-        value_option %i[upload_pack u]
-        value_option :reference, repeatable: true
-        value_option :reference_if_able, repeatable: true
-        flag_option :dissociate
-        value_option :separate_git_dir, inline: true
-        value_option :server_option, inline: true, repeatable: true
-        value_option :depth
-        value_option :shallow_since, inline: true
-        value_option :shallow_exclude, inline: true, repeatable: true
-        flag_option :single_branch, negatable: true
-        flag_option :tags, negatable: true
-        flag_or_value_option :recurse_submodules, inline: true, repeatable: true
-        flag_option :shallow_submodules, negatable: true
-        flag_option :remote_submodules, negatable: true
-        value_option %i[jobs j]
-        flag_option :sparse
-        flag_option :reject_shallow, negatable: true
-        value_option :filter, inline: true
-        flag_option :also_filter_submodules
-        value_option %i[config c], repeatable: true
-        value_option :bundle_uri, inline: true
-        value_option :ref_format, inline: true
+        value_option :template, inline: true # --template=<template-directory>
+        flag_option %i[local l], negatable: true # --local / --no-local (alias: :l)
+        flag_option %i[shared s] # --shared (alias: :s)
+        flag_option :no_hardlinks # --no-hardlinks
+        flag_option %i[quiet q] # --quiet (alias: :q)
+        flag_option %i[verbose v] # --verbose (alias: :v)
+        flag_option :progress # --progress
+        flag_option %i[no_checkout n] # --no-checkout (alias: :n)
+        flag_option :bare # --bare
+        flag_option :mirror # --mirror
+        value_option %i[origin o] # --origin <name> (alias: :o)
+        value_option %i[branch b] # --branch <name> (alias: :b)
+        value_option :revision, inline: true # --revision=<rev>
+        value_option %i[upload_pack u] # --upload-pack <upload-pack> (alias: :u)
+        value_option :reference, repeatable: true # --reference <repository>
+        value_option :reference_if_able, repeatable: true # --reference-if-able <repository>
+        flag_option :dissociate # --dissociate
+        value_option :separate_git_dir, inline: true # --separate-git-dir=<git-dir>
+        value_option :server_option, inline: true, repeatable: true # --server-option=<option>
+        value_option :depth # --depth <depth>
+        value_option :shallow_since, inline: true # --shallow-since=<date>
+        value_option :shallow_exclude, inline: true, repeatable: true # --shallow-exclude=<ref>
+        flag_option :single_branch, negatable: true # --single-branch / --no-single-branch
+        flag_option :tags, negatable: true # --tags / --no-tags
+        flag_or_value_option :recurse_submodules, inline: true, repeatable: true # --recurse-submodules[=<pathspec>]
+        flag_option :shallow_submodules, negatable: true # --shallow-submodules / --no-shallow-submodules
+        flag_option :remote_submodules, negatable: true # --remote-submodules / --no-remote-submodules
+        value_option %i[jobs j] # --jobs <n> (alias: :j)
+        flag_option :sparse # --sparse
+        flag_option :reject_shallow, negatable: true # --reject-shallow / --no-reject-shallow
+        value_option :filter, inline: true # --filter=<filter-spec>
+        flag_option :also_filter_submodules # --also-filter-submodules
+        value_option %i[config c], repeatable: true # --config <key>=<value> (alias: :c)
+        value_option :bundle_uri, inline: true # --bundle-uri=<uri>
+        value_option :ref_format, inline: true # --ref-format=<ref-format>
         end_of_options
         operand :repository, required: true
         operand :directory
@@ -64,125 +70,154 @@ module Git
 
       # @!method call(*, **)
       #
-      #   Execute the git clone command
-      #
       #   @overload call(repository, directory = nil, **options)
       #
-      #     @param repository [String] the URL of the repository to clone
+      #     Execute the `git clone` command
       #
-      #     @param directory [String, nil] the directory to clone into.
-      #       If nil, git derives the directory name from the repository URL.
+      #     @param repository [String] the URL or path of the repository to clone
+      #
+      #     @param directory [String, nil] the directory to clone into; git derives the
+      #       name from the repository URL when omitted
       #
       #     @param options [Hash] command options
       #
-      #     @option options [String] :template (nil) Directory from which templates will be used.
+      #     @option options [String] :template (nil) directory from which templates
+      #       will be used
       #
-      #     @option options [Boolean, nil] :local (nil) Bypass the normal Git-aware transport for local
-      #       clones. Use false to emit --no-local. Alias: :l
+      #     @option options [Boolean] :local (nil) bypass the normal Git-aware transport
+      #       for local clones; pass false to emit --no-local
       #
-      #     @option options [Boolean] :shared (nil) Set up a shared clone using alternates instead
-      #       of hardlinks. Alias: :s
+      #       Alias: `:l`
       #
-      #     @option options [Boolean] :no_hardlinks (nil) Force file-copy instead of hardlinks when
-      #       cloning from a local filesystem.
+      #     @option options [Boolean] :shared (false) set up a shared clone using
+      #       alternates instead of hardlinks
       #
-      #     @option options [Boolean] :no_checkout (nil) Skip checking out HEAD after the clone.
-      #       Alias: :n
+      #       Alias: `:s`
       #
-      #     @option options [Boolean] :bare (nil) Clone as a bare repository
+      #     @option options [Boolean] :no_hardlinks (false) force file-copy instead of
+      #       hardlinks when cloning from a local filesystem
       #
-      #     @option options [Boolean] :mirror (nil) Set up a mirror clone (implies --bare)
+      #     @option options [Boolean] :quiet (false) suppress progress output to stderr
       #
-      #     @option options [String] :origin (nil) Name of the remote (defaults to 'origin').
-      #       Alias: :o
+      #       Alias: `:q`
       #
-      #     @option options [String] :branch (nil) The branch to checkout after cloning.
-      #       Mutually exclusive with :revision. Alias: :b
+      #     @option options [Boolean] :verbose (false) run verbosely
       #
-      #     @option options [String] :revision (nil) Detach HEAD at the given revision after cloning.
-      #       Incompatible with :branch and :mirror.
+      #       Alias: `:v`
       #
-      #     @option options [String] :upload_pack (nil) Path to git-upload-pack on the remote (ssh only).
-      #       Alias: :u
+      #     @option options [Boolean] :progress (false) force progress status even when
+      #       stderr is not a terminal
       #
-      #     @option options [String, Array<String>] :reference (nil) Borrow objects from one or more
-      #       reference repositories.
+      #     @option options [Boolean] :no_checkout (false) skip checking out HEAD after
+      #       the clone
       #
-      #     @option options [String, Array<String>] :reference_if_able (nil) Like :reference but skip
-      #       with a warning if the reference directory does not exist. Repeatable.
+      #       Alias: `:n`
       #
-      #     @option options [Boolean] :dissociate (nil) Stop borrowing from reference repositories after
-      #       the clone is complete.
+      #     @option options [Boolean] :bare (false) clone as a bare repository
       #
-      #     @option options [String] :separate_git_dir (nil) Place the git directory at the given path
-      #       and create a gitfile symlink in the working tree.
+      #     @option options [Boolean] :mirror (false) set up a mirror clone (implies
+      #       --bare)
       #
-      #     @option options [String, Array<String>] :server_option (nil) Protocol-v2 server options.
-      #       Repeatable.
+      #     @option options [String] :origin (nil) name of the remote to use instead of
+      #       "origin"
       #
-      #     @option options [Integer, String] :depth (nil) Create a shallow clone with the specified
-      #       number of commits
+      #       Alias: `:o`
       #
-      #     @option options [String] :shallow_since (nil) Create a shallow clone with history after
-      #       the specified date.
+      #     @option options [String] :branch (nil) branch to check out after cloning
       #
-      #     @option options [String, Array<String>] :shallow_exclude (nil) Exclude commits reachable
-      #       from the specified remote branch or tag. Repeatable.
+      #       Alias: `:b`
       #
-      #     @option options [Boolean, nil] :single_branch (nil) Clone only the history leading to the
-      #       tip of a single branch. Use false to emit --no-single-branch.
+      #     @option options [String] :revision (nil) detach HEAD at the given revision
+      #       after cloning; incompatible with :branch and :mirror
       #
-      #     @option options [Boolean, nil] :tags (nil) Control whether tags are cloned. Use false to
-      #       emit --no-tags.
+      #     @option options [String] :upload_pack (nil) path to git-upload-pack on the
+      #       remote (ssh only)
       #
-      #     @option options [Boolean, String, Array<String>] :recurse_submodules (nil) Initialize all
-      #       submodules after cloning. When true, uses `--recurse-submodules`. When a string, passes
-      #       one pathspec. When an array of strings, emits repeated
-      #       `--recurse-submodules=<pathspec>` options.
+      #       Alias: `:u`
       #
-      #     @option options [Boolean, nil] :shallow_submodules (nil) Clone submodules with depth 1.
-      #       Use false to emit --no-shallow-submodules.
+      #     @option options [String, Array<String>] :reference (nil) borrow objects from
+      #       one or more reference repositories
       #
-      #     @option options [Boolean, nil] :remote_submodules (nil) Use submodule remote-tracking
-      #       branch status. Use false to emit --no-remote-submodules.
+      #     @option options [String, Array<String>] :reference_if_able (nil) like
+      #       :reference but skip with a warning when the reference does not exist
       #
-      #     @option options [Integer] :jobs (nil) Number of submodules fetched concurrently.
-      #       Alias: :j
+      #     @option options [Boolean] :dissociate (false) stop borrowing from reference
+      #       repositories after the clone is complete
       #
-      #     @option options [Boolean] :sparse (nil) Enable sparse checkout with top-level files only.
+      #     @option options [String] :separate_git_dir (nil) place the git directory at
+      #       the given path and create a gitfile symlink in the working tree
       #
-      #     @option options [Boolean, nil] :reject_shallow (nil) Fail if source is shallow.
-      #       Use false to emit --no-reject-shallow.
+      #     @option options [String, Array<String>] :server_option (nil) protocol-v2
+      #       server options
       #
-      #     @option options [String] :filter (nil) Specify partial clone filter
-      #       (e.g., 'blob:none', 'tree:0'). Required when :also_filter_submodules is set.
+      #     @option options [Integer, String] :depth (nil) create a shallow clone with
+      #       the specified number of commits
       #
-      #     @option options [Boolean] :also_filter_submodules (nil) Apply the partial clone filter
-      #       to submodules. Requires :filter and :recurse_submodules.
+      #     @option options [String] :shallow_since (nil) create a shallow clone with
+      #       history after the specified date
       #
-      #     @option options [String, Array<String>] :config (nil) Configuration options to set.
-      #       Alias: :c
+      #     @option options [String, Array<String>] :shallow_exclude (nil) exclude
+      #       commits reachable from the specified remote branch or tag
       #
-      #     @option options [String] :bundle_uri (nil) Fetch a bundle from the given URI before
-      #       fetching from the remote. Incompatible with :depth, :shallow_since, and
-      #       :shallow_exclude.
+      #     @option options [Boolean] :single_branch (nil) clone only the history for
+      #       one branch; pass false to emit --no-single-branch
       #
-      #     @option options [String] :ref_format (nil) Specify the ref storage format
-      #       (e.g., 'files', 'reftable').
+      #     @option options [Boolean] :tags (nil) control whether tags are cloned; pass
+      #       false to emit --no-tags
+      #
+      #     @option options [Boolean, String, Array<String>] :recurse_submodules (nil)
+      #       initialize submodules after cloning; pass true for all submodules or a
+      #       pathspec string/array for a subset
+      #
+      #     @option options [Boolean] :shallow_submodules (nil) clone submodules with
+      #       depth 1; pass false to emit --no-shallow-submodules
+      #
+      #     @option options [Boolean] :remote_submodules (nil) use submodule
+      #       remote-tracking branch status; pass false to emit --no-remote-submodules
+      #
+      #     @option options [Integer, String] :jobs (nil) number of submodules fetched
+      #       concurrently
+      #
+      #       Alias: `:j`
+      #
+      #     @option options [Boolean] :sparse (false) enable sparse checkout with
+      #       top-level files only
+      #
+      #     @option options [Boolean] :reject_shallow (nil) fail if source is shallow;
+      #       pass false to emit --no-reject-shallow
+      #
+      #     @option options [String] :filter (nil) specify a partial clone filter
+      #       (e.g., 'blob:none', 'tree:0')
+      #
+      #     @option options [Boolean] :also_filter_submodules (false) apply the partial
+      #       clone filter to submodules; requires :filter and :recurse_submodules
+      #
+      #     @option options [String, Array<String>] :config (nil) set configuration
+      #       variables in the newly-created repository
+      #
+      #       Alias: `:c`
+      #
+      #     @option options [String] :bundle_uri (nil) fetch a bundle from the given URI
+      #       before fetching from the remote
+      #
+      #     @option options [String] :ref_format (nil) specify the ref storage format
+      #       (e.g., 'files', 'reftable')
       #
       #     @option options [Numeric, nil] :timeout (nil) the number of seconds to wait
-      #       for the command to complete. If nil, uses the global timeout from
-      #       {Git::Config}. If 0, no timeout is enforced.
+      #       for the command to complete; if nil, uses the global timeout from
+      #       {Git::Config}; if 0, no timeout is enforced
       #
-      #     @option options [String, nil] :chdir (nil) the directory to run the git clone
-      #       command in. When given, the clone is created relative to this directory.
+      #     @option options [String, nil] :chdir (nil) the working directory in which to
+      #       run the git clone command
       #
       #     @return [Git::CommandLineResult] the result of calling `git clone`
       #
-      #     @raise [ArgumentError] if argument validation fails (e.g., unsupported options
-      #       are provided or option values are invalid)
+      #     @raise [ArgumentError] if unsupported options are provided
       #
       #     @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      #   @api public
+      #
     end
   end
 end

--- a/lib/git/commands/commit.rb
+++ b/lib/git/commands/commit.rb
@@ -9,81 +9,265 @@ module Git
     # This command records changes to the repository by creating a new commit
     # with the staged changes.
     #
-    # @see https://git-scm.com/docs/git-commit git-commit
-    #
-    # @api private
-    #
-    # @example Basic usage
+    # @example Typical usage
     #   commit = Git::Commands::Commit.new(execution_context)
     #   commit.call(message: 'Initial commit')
-    #
-    # @example With options
-    #   commit = Git::Commands::Commit.new(execution_context)
     #   commit.call(message: 'Add feature', all: true, author: 'Jane <jane@example.com>')
+    #   commit.call(amend: true, verify: false)  # emits --no-verify
+    #   commit.call('src/foo.rb', message: 'Update foo')
     #
-    # @example Amending the previous commit
-    #   commit = Git::Commands::Commit.new(execution_context)
-    #   commit.call(amend: true)
+    # @note `arguments` block audited against https://git-scm.com/docs/git-commit/2.53.0
+    #
+    # @see https://git-scm.com/docs/git-commit git-commit
+    #
+    # @see Git::Commands
+    #
+    # @api private
     #
     class Commit < Git::Commands::Base
       arguments do
         literal 'commit'
-        flag_option :edit, negatable: true
-        flag_option %i[all a]
-        flag_option :amend
-        value_option %i[message m], inline: true, allow_empty: true
-        flag_option :allow_empty
-        flag_option :allow_empty_message
-        flag_option :no_verify
-        value_option :author, inline: true
-        value_option :date, inline: true, type: String
-        flag_or_value_option %i[gpg_sign S], negatable: true, inline: true
+
+        # Stage selection
+        flag_option %i[all a] # --all (alias: :a)
+
+        # Message source and editing
+        flag_option %i[edit e], negatable: true                          # --edit / --no-edit (alias: :e)
+        flag_option :amend                                               # --amend
+        value_option %i[reuse_message C], inline: true                   # --reuse-message=<commit> (alias: :C)
+        value_option :fixup, inline: true                                # --fixup=[amend:|reword:]<commit>
+        value_option :squash, inline: true                               # --squash=<commit>
+        value_option %i[message m], inline: true, allow_empty: true      # --message=<msg> (alias: :m)
+        value_option %i[file F], inline: true                            # --file=<file> (alias: :F)
+        value_option %i[template t], inline: true                        # --template=<file> (alias: :t)
+
+        # Author / date
+        flag_option :reset_author                                        # --reset-author
+        value_option :author, inline: true                               # --author=<author>
+        value_option :date, inline: true, type: String                   # --date=<date>
+
+        # Message cleanup and trailers
+        value_option :cleanup, inline: true                              # --cleanup=<mode>
+        value_option :trailer, repeatable: true                          # --trailer <token>[=<value>]
+
+        # Hooks
+        flag_option %i[verify n], negatable: true # --verify / --no-verify (alias: :n)
+
+        # Behavior
+        flag_option :allow_empty                                         # --allow-empty
+        flag_option :allow_empty_message                                 # --allow-empty-message
+        flag_option :no_post_rewrite                                     # --no-post-rewrite
+        flag_option %i[include i]                                        # --include (alias: :i)
+        flag_option %i[only o]                                           # --only (alias: :o)
+
+        # Output / dry-run
+        flag_option :dry_run                                             # --dry-run
+        flag_option :short                                               # --short
+        flag_option :branch                                              # --branch
+        flag_option :porcelain                                           # --porcelain
+        flag_option :long                                                # --long
+        flag_option %i[null z]                                           # --null (alias: :z)
+        flag_option %i[verbose v], max_times: 2                          # --verbose (alias: :v, up to 2×)
+        flag_option %i[quiet q]                                          # --quiet (alias: :q)
+        flag_option :status, negatable: true                             # --status / --no-status
+
+        # Verbose diff options
+        value_option %i[unified U], inline: true, type: Integer          # --unified=<n> (alias: :U)
+        value_option :inter_hunk_context, inline: true, type: Integer    # --inter-hunk-context=<n>
+
+        # Signoff
+        flag_option %i[signoff s], negatable: true # --signoff / --no-signoff (alias: :s)
+
+        # GPG signing
+        flag_or_value_option %i[gpg_sign S], negatable: true, inline: true # --gpg-sign[=<keyid>] / --no-gpg-sign (:S)
+
+        # Untracked files
+        flag_or_value_option %i[untracked_files u], inline: true # --untracked-files[=<mode>] (alias: :u)
+
+        # Pathspec from file
+        value_option :pathspec_from_file, inline: true                   # --pathspec-from-file=<file>
+        flag_option :pathspec_file_nul                                   # --pathspec-file-nul
+
+        # Path selection
+        end_of_options
+        operand :pathspec, repeatable: true
       end
 
       # @!method call(*, **)
       #
-      #   Execute the git commit command
+      #   @overload call(*pathspec, **options)
       #
-      #   @overload call(**options)
+      #     Execute the `git commit` command.
+      #
+      #     @param pathspec [Array<String>] zero or more paths to commit
+      #
+      #       When given, only changes to the listed paths are committed, ignoring
+      #       staged changes for other paths.
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :edit (nil) Open an editor for the commit message. When false,
-      #       adds --no-edit to suppress the editor. When true, adds --edit. When nil, defers to
-      #       git's default behavior.
+      #     @option options [Boolean] :all (false) automatically stage modified and deleted
+      #       files before committing
       #
-      #     @option options [Boolean] :all (nil) Automatically stage all modified and deleted files
-      #       before committing.
-      #       Alias: :a
+      #       Alias: `:a`
       #
-      #     @option options [Boolean] :amend (nil) Amend the previous commit instead of creating a new one
+      #     @option options [Boolean, nil] :edit (nil) open an editor for the commit message
       #
-      #     @option options [String] :message (nil) The commit message.
-      #       Alias: :m
+      #       When `false`, adds `--no-edit` to suppress the editor. When `true`, adds
+      #       `--edit`. When `nil`, defers to git's default behavior.
       #
-      #     @option options [Boolean] :allow_empty (nil) Allow creating a commit with no changes
+      #       Alias: `:e`
       #
-      #     @option options [Boolean] :allow_empty_message (nil) Allow creating a commit with an empty message
+      #     @option options [Boolean] :amend (false) replace the tip of the current branch
+      #       with a new commit
       #
-      #     @option options [Boolean] :no_verify (nil) Bypass the pre-commit and commit-msg hooks
+      #     @option options [String] :reuse_message (nil) reuse the log message and
+      #       authorship from the given commit without invoking an editor
       #
-      #     @option options [String] :author (nil) Override the commit author in the format 'Name <email>'
+      #       Alias: `:C`
       #
-      #     @option options [String] :date (nil) Override the author date. Must be a string in a format
-      #       that git understands (e.g., '2023-01-15T10:30:00', 'now', 'yesterday')
+      #     @option options [String] :fixup (nil) create a fixup or amend commit targeting
+      #       the given commit
       #
-      #     @option options [Boolean, String, false] :gpg_sign (nil) GPG-sign the commit. When true, uses the
-      #       default key. When a string, uses the specified key ID. When false, adds --no-gpg-sign
-      #       to override any commit.gpgsign configuration.
-      #       Alias: :S
+      #       Pass `<commit>` for a plain "fixup!" commit, `amend:<commit>` to also replace
+      #       the log message, or `reword:<commit>` to replace only the log message.
+      #
+      #     @option options [String] :squash (nil) construct a "squash!" commit message for
+      #       use with `git rebase --autosquash`
+      #
+      #     @option options [String] :message (nil) use the given string as the commit message
+      #
+      #       Alias: `:m`
+      #
+      #     @option options [String] :file (nil) read the commit message from the given file;
+      #       use `-` to read from standard input
+      #
+      #       Alias: `:F`
+      #
+      #     @option options [String] :template (nil) start the editor with the contents of
+      #       the given file as the commit message template
+      #
+      #       Alias: `:t`
+      #
+      #     @option options [Boolean] :reset_author (false) when used with `:reuse_message`
+      #       or `:amend`, declare the committer as the new author
+      #
+      #     @option options [String] :author (nil) override the commit author
+      #
+      #     @option options [String] :date (nil) override the author date
+      #
+      #     @option options [String] :cleanup (nil) how to clean up the commit message before
+      #       committing; one of `strip`, `whitespace`, `verbatim`, `scissors`, or `default`
+      #
+      #     @option options [String, Array<String>] :trailer (nil) add one or more
+      #       `<token>[=<value>]` trailers to the commit message
+      #
+      #     @option options [Boolean, nil] :verify (nil) run pre-commit and commit-msg hooks
+      #
+      #       When `false`, adds `--no-verify` to bypass the hooks. When `true`, adds
+      #       `--verify` to explicitly re-enable them. When `nil`, defers to git's default.
+      #
+      #       Alias: `:n`
+      #
+      #     @option options [Boolean] :allow_empty (false) allow committing with no changes
+      #
+      #     @option options [Boolean] :allow_empty_message (false) allow committing with an
+      #       empty message
+      #
+      #     @option options [Boolean] :no_post_rewrite (false) bypass the post-rewrite hook
+      #
+      #     @option options [Boolean] :include (false) stage the listed paths before
+      #       committing in addition to already-staged contents
+      #
+      #       Alias: `:i`
+      #
+      #     @option options [Boolean] :only (false) commit only the listed paths from the
+      #       working tree, ignoring staged changes for other paths
+      #
+      #       Alias: `:o`
+      #
+      #     @option options [Boolean] :dry_run (false) do not create a commit; show what
+      #       would be committed
+      #
+      #     @option options [Boolean] :short (false) show short-format dry-run output;
+      #       implies `:dry_run`
+      #
+      #     @option options [Boolean] :branch (false) show branch and tracking info in
+      #       short-format dry-run output
+      #
+      #     @option options [Boolean] :porcelain (false) show porcelain-format dry-run
+      #       output; implies `:dry_run`
+      #
+      #     @option options [Boolean] :long (false) show long-format dry-run output;
+      #       implies `:dry_run`
+      #
+      #     @option options [Boolean] :null (false) terminate dry-run output entries with
+      #       NUL instead of LF
+      #
+      #       Alias: `:z`
+      #
+      #     @option options [Boolean, Integer] :verbose (false) show unified diff between
+      #       HEAD and what would be committed at the bottom of the commit message template
+      #
+      #       Pass `2` to also show the unified diff between staged and working-tree changes.
+      #
+      #       Alias: `:v`
+      #
+      #     @option options [Boolean] :quiet (false) suppress commit summary message
+      #
+      #       Alias: `:q`
+      #
+      #     @option options [Boolean, nil] :status (nil) include `git status` output in the
+      #       commit message template
+      #
+      #       When `false`, adds `--no-status`. When `true`, adds `--status`. When `nil`,
+      #       defers to git's default (controlled by `commit.status` config).
+      #
+      #     @option options [Integer] :unified (nil) generate verbose diff with the given
+      #       number of context lines
+      #
+      #       Alias: `:U`
+      #
+      #     @option options [Integer] :inter_hunk_context (nil) show context between diff
+      #       hunks up to the given number of lines (for use with `:verbose`)
+      #
+      #     @option options [Boolean, nil] :signoff (nil) add a `Signed-off-by` trailer to
+      #       the commit message
+      #
+      #       When `false`, adds `--no-signoff`. When `nil`, defers to git's default.
+      #
+      #       Alias: `:s`
+      #
+      #     @option options [Boolean, String, nil] :gpg_sign (nil) GPG-sign the commit
+      #
+      #       When `true`, uses the default key. When a `String`, uses the specified key ID.
+      #       When `false`, adds `--no-gpg-sign` to override `commit.gpgSign` config.
+      #       When `nil`, defers to git's default.
+      #
+      #       Alias: `:S`
+      #
+      #     @option options [Boolean, String] :untracked_files (nil) show untracked files
+      #       in the dry-run status output
+      #
+      #       When `true`, uses git's default mode (`all`). Pass a `String` (`"no"`,
+      #       `"normal"`, or `"all"`) to set the mode explicitly.
+      #
+      #       Alias: `:u`
+      #
+      #     @option options [String] :pathspec_from_file (nil) read pathspec from the given
+      #       file instead of the command line
+      #
+      #     @option options [Boolean] :pathspec_file_nul (false) pathspec elements in
+      #       `:pathspec_from_file` are NUL-separated instead of newline-separated
       #
       #     @return [Git::CommandLineResult] the result of calling `git commit`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #
-      #     @raise [ArgumentError] if :date is not a String
+      #     @raise [Git::FailedError] if git exits with a non-zero exit status
       #
-      #     @raise [Git::FailedError] if the command returns a non-zero exit status
+      #   @api public
+      #
     end
   end
 end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1197,20 +1197,8 @@ module Git
     #
     def commit(message, opts = {})
       opts = opts.merge(message: message) if message
-
-      # TODO: deprecate :no_gpg_sign in favor of :gpg_sign => false
-      # This adapter was added to maintain backward compatibility
-      if opts[:no_gpg_sign]
-        Git::Deprecation.warn(':no_gpg_sign option is deprecated. Use :gpg_sign => false instead.')
-
-        raise ArgumentError, 'cannot specify :gpg_sign and :no_gpg_sign' if opts.key?(:gpg_sign)
-
-        opts.delete(:no_gpg_sign)
-        opts[:gpg_sign] = false
-      end
-
+      deprecate_commit_no_gpg_sign_option!(opts)
       deprecate_commit_add_all_option!(opts)
-
       Git::Commands::Commit.new(self).call(edit: false, **opts).stdout
     end
 
@@ -2255,6 +2243,17 @@ module Git
 
       Git::Deprecation.warn('The :add_all option for Git::Lib#commit is deprecated, use :all instead')
       opts[:all] = opts.delete(:add_all)
+    end
+
+    # TODO: deprecate :no_gpg_sign in favor of :gpg_sign => false
+    def deprecate_commit_no_gpg_sign_option!(opts)
+      return unless opts[:no_gpg_sign]
+
+      Git::Deprecation.warn(':no_gpg_sign option is deprecated. Use :gpg_sign => false instead.')
+      raise ArgumentError, 'cannot specify :gpg_sign and :no_gpg_sign' if opts.key?(:gpg_sign)
+
+      opts.delete(:no_gpg_sign)
+      opts[:gpg_sign] = false
     end
 
     # Extracts execution context options from clone options.

--- a/spec/unit/git/commands/checkout/files_spec.rb
+++ b/spec/unit/git/commands/checkout/files_spec.rb
@@ -138,6 +138,20 @@ RSpec.describe Git::Commands::Checkout::Files do
       end
     end
 
+    context 'with :ignore_skip_worktree_bits option' do
+      it 'adds --ignore-skip-worktree-bits flag' do
+        expect_command_capturing('checkout', '--ignore-skip-worktree-bits', '--', 'file.txt').and_return(command_result)
+        command.call(pathspec: ['file.txt'], ignore_skip_worktree_bits: true)
+      end
+    end
+
+    context 'with :chdir execution option' do
+      it 'passes chdir to the execution context, not to the git CLI' do
+        expect_command_capturing('checkout', '--', 'file.txt', chdir: '/some/dir').and_return(command_result)
+        command.call(pathspec: ['file.txt'], chdir: '/some/dir')
+      end
+    end
+
     context 'with multiple options combined' do
       it 'includes all specified flags in correct order' do
         expect_command_capturing('checkout',

--- a/spec/unit/git/commands/checkout_index_spec.rb
+++ b/spec/unit/git/commands/checkout_index_spec.rb
@@ -19,6 +19,20 @@ RSpec.describe Git::Commands::CheckoutIndex do
       end
     end
 
+    context 'with the :quiet option' do
+      it 'includes --quiet when true' do
+        expect_command_capturing('checkout-index', '--quiet').and_return(command_result)
+
+        command.call(quiet: true)
+      end
+
+      it 'accepts :q as an alias' do
+        expect_command_capturing('checkout-index', '--quiet').and_return(command_result)
+
+        command.call(q: true)
+      end
+    end
+
     context 'with the :all option' do
       it 'includes --all when true' do
         expect_command_capturing('checkout-index', '--all').and_return(command_result)

--- a/spec/unit/git/commands/clean_spec.rb
+++ b/spec/unit/git/commands/clean_spec.rb
@@ -61,6 +61,28 @@ RSpec.describe Git::Commands::Clean do
       end
     end
 
+    context 'with the :quiet option' do
+      it 'adds --quiet to the command line' do
+        expect_command_capturing('clean', '--quiet').and_return(command_result)
+
+        command.call(quiet: true)
+      end
+
+      it 'accepts :q as an alias' do
+        expect_command_capturing('clean', '--quiet').and_return(command_result)
+
+        command.call(q: true)
+      end
+    end
+
+    context 'with the :chdir execution option' do
+      it 'passes chdir to the execution context, not to the git CLI' do
+        expect_command_capturing('clean', chdir: '/some/dir').and_return(command_result)
+
+        command.call(chdir: '/some/dir')
+      end
+    end
+
     context 'with the :exclude option' do
       it 'adds --exclude=<pattern> to the command line' do
         expect_command_capturing('clean', '--exclude=*.log').and_return(command_result)

--- a/spec/unit/git/commands/clone_spec.rb
+++ b/spec/unit/git/commands/clone_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'git/commands/clone'
 
 RSpec.describe Git::Commands::Clone do
   let(:execution_context) { double('ExecutionContext') }
@@ -224,6 +225,42 @@ RSpec.describe Git::Commands::Clone do
                                  directory).and_return(command_result)
 
         command.call(repository_url, directory, no_hardlinks: true)
+      end
+    end
+
+    context 'with the :quiet option' do
+      it 'includes --quiet when true' do
+        expect_command_capturing('clone', '--quiet', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, quiet: true)
+      end
+
+      it 'accepts :q as an alias' do
+        expect_command_capturing('clone', '--quiet', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, q: true)
+      end
+    end
+
+    context 'with the :verbose option' do
+      it 'includes --verbose when true' do
+        expect_command_capturing('clone', '--verbose', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, verbose: true)
+      end
+
+      it 'accepts :v as an alias' do
+        expect_command_capturing('clone', '--verbose', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, v: true)
+      end
+    end
+
+    context 'with the :progress option' do
+      it 'includes --progress when true' do
+        expect_command_capturing('clone', '--progress', '--', repository_url, directory).and_return(command_result)
+
+        command.call(repository_url, directory, progress: true)
       end
     end
 

--- a/spec/unit/git/commands/commit_spec.rb
+++ b/spec/unit/git/commands/commit_spec.rb
@@ -1,112 +1,59 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'git/commands/commit'
 
 RSpec.describe Git::Commands::Commit do
   let(:execution_context) { double('ExecutionContext') }
   let(:command) { described_class.new(execution_context) }
 
   describe '#call' do
-    context 'with a simple message' do
-      it 'commits with the given message' do
+    context 'with no arguments' do
+      it 'runs git commit without any flags' do
         expected_result = command_result
-        expect_command_capturing('commit', '--message=Initial commit').and_return(expected_result)
+        expect_command_capturing('commit').and_return(expected_result)
 
-        result = command.call(message: 'Initial commit')
+        result = command.call
 
         expect(result).to eq(expected_result)
       end
     end
 
-    context 'with the :edit option' do
-      it 'adds --no-edit when edit is false' do
-        expect_command_capturing('commit', '--no-edit', '--message=Msg').and_return(command_result)
-
-        command.call(edit: false, message: 'Msg')
-      end
-
-      it 'adds --edit when edit is true' do
-        expect_command_capturing('commit', '--edit', '--message=Msg').and_return(command_result)
-
-        command.call(edit: true, message: 'Msg')
-      end
-
-      it 'omits --edit/--no-edit when edit is nil' do
-        expect_command_capturing('commit', '--message=Msg').and_return(command_result)
-
-        command.call(edit: nil, message: 'Msg')
-      end
-    end
+    # Stage selection
 
     context 'with the :all option' do
-      it 'includes the --all flag' do
-        expect_command_capturing('commit', '--all',
-                                 '--message=Add all changes').and_return(command_result)
+      it 'includes --all when true' do
+        expect_command_capturing('commit', '--all').and_return(command_result)
 
-        command.call(message: 'Add all changes', all: true)
+        command.call(all: true)
       end
 
-      it 'also accepts :a as an alias' do
-        expect_command_capturing('commit', '--all',
-                                 '--message=Add all changes').and_return(command_result)
+      it 'accepts :a as an alias' do
+        expect_command_capturing('commit', '--all').and_return(command_result)
 
-        command.call(message: 'Add all changes', a: true)
-      end
-
-      it 'does not include the flag when false' do
-        expect_command_capturing('commit', '--message=Message').and_return(command_result)
-
-        command.call(message: 'Message', all: false)
+        command.call(a: true)
       end
     end
 
-    context 'with the :allow_empty option' do
-      it 'includes the --allow-empty flag' do
-        expect_command_capturing('commit', '--message=Empty commit',
-                                 '--allow-empty').and_return(command_result)
+    # Message source and editing
 
-        command.call(message: 'Empty commit', allow_empty: true)
+    context 'with the :edit option' do
+      it 'includes --edit when true' do
+        expect_command_capturing('commit', '--edit').and_return(command_result)
+
+        command.call(edit: true)
       end
-    end
 
-    context 'with the :allow_empty_message option' do
-      it 'includes the --allow-empty-message flag without a message' do
-        expect_command_capturing('commit', '--allow-empty-message').and_return(command_result)
+      it 'includes --no-edit when false' do
+        expect_command_capturing('commit', '--no-edit').and_return(command_result)
 
-        command.call(allow_empty_message: true)
+        command.call(edit: false)
       end
-    end
 
-    context 'with the :no_verify option' do
-      it 'includes the --no-verify flag' do
-        expect_command_capturing('commit', '--message=Skip hooks',
-                                 '--no-verify').and_return(command_result)
+      it 'accepts :e as an alias' do
+        expect_command_capturing('commit', '--edit').and_return(command_result)
 
-        command.call(message: 'Skip hooks', no_verify: true)
-      end
-    end
-
-    context 'with the :author option' do
-      it 'includes the --author flag with the specified value' do
-        expect_command_capturing(
-          'commit',
-          '--message=Authored commit',
-          '--author=John Doe <john@example.com>'
-        ).and_return(command_result)
-
-        command.call(message: 'Authored commit', author: 'John Doe <john@example.com>')
-      end
-    end
-
-    context 'with the :date option' do
-      it 'includes the --date flag with the specified value' do
-        expect_command_capturing(
-          'commit',
-          '--message=Dated commit',
-          '--date=2023-01-15T10:30:00'
-        ).and_return(command_result)
-
-        command.call(message: 'Dated commit', date: '2023-01-15T10:30:00')
+        command.call(e: true)
       end
     end
 
@@ -116,81 +63,508 @@ RSpec.describe Git::Commands::Commit do
 
         command.call(amend: true)
       end
+    end
 
-      it 'does not include --amend when false' do
-        expect_command_capturing('commit', '--message=Normal commit').and_return(command_result)
+    context 'with the :reuse_message option' do
+      it 'includes --reuse-message=<commit>' do
+        expect_command_capturing('commit', '--reuse-message=abc123').and_return(command_result)
 
-        command.call(message: 'Normal commit', amend: false)
+        command.call(reuse_message: 'abc123')
+      end
+
+      it 'accepts :C as an alias' do
+        expect_command_capturing('commit', '--reuse-message=abc123').and_return(command_result)
+
+        command.call(C: 'abc123')
       end
     end
 
-    context 'with GPG signing options' do
-      context 'when :gpg_sign is true' do
-        it 'includes --gpg-sign flag' do
-          expect_command_capturing('commit', '--message=Signed commit',
-                                   '--gpg-sign').and_return(command_result)
+    context 'with the :fixup option' do
+      it 'includes --fixup=<commit>' do
+        expect_command_capturing('commit', '--fixup=abc123').and_return(command_result)
 
-          command.call(message: 'Signed commit', gpg_sign: true)
-        end
+        command.call(fixup: 'abc123')
       end
 
-      context 'when :gpg_sign is a key ID' do
-        it 'includes --gpg-sign with the key ID' do
-          expect_command_capturing(
-            'commit',
-            '--message=Signed commit',
-            '--gpg-sign=ABCD1234'
-          ).and_return(command_result)
+      it 'supports the amend: prefix form' do
+        expect_command_capturing('commit', '--fixup=amend:abc123').and_return(command_result)
 
-          command.call(message: 'Signed commit', gpg_sign: 'ABCD1234')
-        end
-      end
-
-      context 'when :gpg_sign is false' do
-        it 'includes --no-gpg-sign flag' do
-          expect_command_capturing('commit', '--message=Unsigned commit',
-                                   '--no-gpg-sign').and_return(command_result)
-
-          command.call(message: 'Unsigned commit', gpg_sign: false)
-        end
+        command.call(fixup: 'amend:abc123')
       end
     end
+
+    context 'with the :squash option' do
+      it 'includes --squash=<commit>' do
+        expect_command_capturing('commit', '--squash=abc123').and_return(command_result)
+
+        command.call(squash: 'abc123')
+      end
+    end
+
+    context 'with the :message option' do
+      it 'includes --message=<msg>' do
+        expect_command_capturing('commit', '--message=Initial commit').and_return(command_result)
+
+        command.call(message: 'Initial commit')
+      end
+
+      it 'accepts :m as an alias' do
+        expect_command_capturing('commit', '--message=Fix bug').and_return(command_result)
+
+        command.call(m: 'Fix bug')
+      end
+
+      it 'allows an empty message' do
+        expect_command_capturing('commit', '--message=').and_return(command_result)
+
+        command.call(message: '')
+      end
+    end
+
+    context 'with the :file option' do
+      it 'includes --file=<file>' do
+        expect_command_capturing('commit', '--file=msg.txt').and_return(command_result)
+
+        command.call(file: 'msg.txt')
+      end
+
+      it 'accepts :F as an alias' do
+        expect_command_capturing('commit', '--file=msg.txt').and_return(command_result)
+
+        command.call(F: 'msg.txt')
+      end
+    end
+
+    context 'with the :template option' do
+      it 'includes --template=<file>' do
+        expect_command_capturing('commit', '--template=tmpl.txt').and_return(command_result)
+
+        command.call(template: 'tmpl.txt')
+      end
+
+      it 'accepts :t as an alias' do
+        expect_command_capturing('commit', '--template=tmpl.txt').and_return(command_result)
+
+        command.call(t: 'tmpl.txt')
+      end
+    end
+
+    # Author / date
+
+    context 'with the :reset_author option' do
+      it 'includes --reset-author when true' do
+        expect_command_capturing('commit', '--reset-author').and_return(command_result)
+
+        command.call(reset_author: true)
+      end
+    end
+
+    context 'with the :author option' do
+      it 'includes --author=<value>' do
+        expect_command_capturing('commit', '--author=Jane <jane@example.com>').and_return(command_result)
+
+        command.call(author: 'Jane <jane@example.com>')
+      end
+    end
+
+    context 'with the :date option' do
+      it 'includes --date=<value>' do
+        expect_command_capturing('commit', '--date=2024-01-01T00:00:00').and_return(command_result)
+
+        command.call(date: '2024-01-01T00:00:00')
+      end
+    end
+
+    # Message cleanup and trailers
+
+    context 'with the :cleanup option' do
+      it 'includes --cleanup=<mode>' do
+        expect_command_capturing('commit', '--cleanup=strip').and_return(command_result)
+
+        command.call(cleanup: 'strip')
+      end
+    end
+
+    context 'with the :trailer option' do
+      it 'includes --trailer <value>' do
+        expect_command_capturing('commit', '--trailer',
+                                 'Signed-off-by: Dev <dev@example.com>').and_return(command_result)
+
+        command.call(trailer: 'Signed-off-by: Dev <dev@example.com>')
+      end
+
+      it 'repeats --trailer for each value in an array' do
+        expect_command_capturing(
+          'commit',
+          '--trailer', 'Signed-off-by: Dev <dev@example.com>',
+          '--trailer', 'Reviewed-by: Rev <rev@example.com>'
+        ).and_return(command_result)
+
+        command.call(trailer: ['Signed-off-by: Dev <dev@example.com>', 'Reviewed-by: Rev <rev@example.com>'])
+      end
+    end
+
+    # Hooks
+
+    context 'with the :verify option' do
+      it 'includes --no-verify when false' do
+        expect_command_capturing('commit', '--no-verify').and_return(command_result)
+
+        command.call(verify: false)
+      end
+
+      it 'includes --verify when true' do
+        expect_command_capturing('commit', '--verify').and_return(command_result)
+
+        command.call(verify: true)
+      end
+
+      it 'accepts :n as an alias' do
+        expect_command_capturing('commit', '--verify').and_return(command_result)
+
+        command.call(n: true)
+      end
+    end
+
+    # Behavior
+
+    context 'with the :allow_empty option' do
+      it 'includes --allow-empty when true' do
+        expect_command_capturing('commit', '--allow-empty').and_return(command_result)
+
+        command.call(allow_empty: true)
+      end
+    end
+
+    context 'with the :allow_empty_message option' do
+      it 'includes --allow-empty-message when true' do
+        expect_command_capturing('commit', '--allow-empty-message').and_return(command_result)
+
+        command.call(allow_empty_message: true)
+      end
+    end
+
+    context 'with the :no_post_rewrite option' do
+      it 'includes --no-post-rewrite when true' do
+        expect_command_capturing('commit', '--no-post-rewrite').and_return(command_result)
+
+        command.call(no_post_rewrite: true)
+      end
+    end
+
+    context 'with the :include option' do
+      it 'includes --include when true' do
+        expect_command_capturing('commit', '--include').and_return(command_result)
+
+        command.call(include: true)
+      end
+
+      it 'accepts :i as an alias' do
+        expect_command_capturing('commit', '--include').and_return(command_result)
+
+        command.call(i: true)
+      end
+    end
+
+    context 'with the :only option' do
+      it 'includes --only when true' do
+        expect_command_capturing('commit', '--only').and_return(command_result)
+
+        command.call(only: true)
+      end
+
+      it 'accepts :o as an alias' do
+        expect_command_capturing('commit', '--only').and_return(command_result)
+
+        command.call(o: true)
+      end
+    end
+
+    # Output / dry-run
+
+    context 'with the :dry_run option' do
+      it 'includes --dry-run when true' do
+        expect_command_capturing('commit', '--dry-run').and_return(command_result)
+
+        command.call(dry_run: true)
+      end
+    end
+
+    context 'with the :short option' do
+      it 'includes --short when true' do
+        expect_command_capturing('commit', '--short').and_return(command_result)
+
+        command.call(short: true)
+      end
+    end
+
+    context 'with the :branch option' do
+      it 'includes --branch when true' do
+        expect_command_capturing('commit', '--branch').and_return(command_result)
+
+        command.call(branch: true)
+      end
+    end
+
+    context 'with the :porcelain option' do
+      it 'includes --porcelain when true' do
+        expect_command_capturing('commit', '--porcelain').and_return(command_result)
+
+        command.call(porcelain: true)
+      end
+    end
+
+    context 'with the :long option' do
+      it 'includes --long when true' do
+        expect_command_capturing('commit', '--long').and_return(command_result)
+
+        command.call(long: true)
+      end
+    end
+
+    context 'with the :null option' do
+      it 'includes --null when true' do
+        expect_command_capturing('commit', '--null').and_return(command_result)
+
+        command.call(null: true)
+      end
+
+      it 'accepts :z as an alias' do
+        expect_command_capturing('commit', '--null').and_return(command_result)
+
+        command.call(z: true)
+      end
+    end
+
+    context 'with the :verbose option' do
+      it 'includes --verbose once when true' do
+        expect_command_capturing('commit', '--verbose').and_return(command_result)
+
+        command.call(verbose: true)
+      end
+
+      it 'includes --verbose twice when given 2' do
+        expect_command_capturing('commit', '--verbose', '--verbose').and_return(command_result)
+
+        command.call(verbose: 2)
+      end
+
+      it 'accepts :v as an alias' do
+        expect_command_capturing('commit', '--verbose').and_return(command_result)
+
+        command.call(v: true)
+      end
+    end
+
+    context 'with the :quiet option' do
+      it 'includes --quiet when true' do
+        expect_command_capturing('commit', '--quiet').and_return(command_result)
+
+        command.call(quiet: true)
+      end
+
+      it 'accepts :q as an alias' do
+        expect_command_capturing('commit', '--quiet').and_return(command_result)
+
+        command.call(q: true)
+      end
+    end
+
+    context 'with the :status option' do
+      it 'includes --status when true' do
+        expect_command_capturing('commit', '--status').and_return(command_result)
+
+        command.call(status: true)
+      end
+
+      it 'includes --no-status when false' do
+        expect_command_capturing('commit', '--no-status').and_return(command_result)
+
+        command.call(status: false)
+      end
+    end
+
+    # Verbose diff options
+
+    context 'with the :unified option' do
+      it 'includes --unified=<n>' do
+        expect_command_capturing('commit', '--unified=5').and_return(command_result)
+
+        command.call(unified: 5)
+      end
+
+      it 'accepts :U as an alias' do
+        expect_command_capturing('commit', '--unified=5').and_return(command_result)
+
+        command.call(U: 5)
+      end
+    end
+
+    context 'with the :inter_hunk_context option' do
+      it 'includes --inter-hunk-context=<n>' do
+        expect_command_capturing('commit', '--inter-hunk-context=3').and_return(command_result)
+
+        command.call(inter_hunk_context: 3)
+      end
+    end
+
+    # Signoff
+
+    context 'with the :signoff option' do
+      it 'includes --signoff when true' do
+        expect_command_capturing('commit', '--signoff').and_return(command_result)
+
+        command.call(signoff: true)
+      end
+
+      it 'includes --no-signoff when false' do
+        expect_command_capturing('commit', '--no-signoff').and_return(command_result)
+
+        command.call(signoff: false)
+      end
+
+      it 'accepts :s as an alias' do
+        expect_command_capturing('commit', '--signoff').and_return(command_result)
+
+        command.call(s: true)
+      end
+    end
+
+    # GPG signing
+
+    context 'with the :gpg_sign option' do
+      it 'includes --gpg-sign when true' do
+        expect_command_capturing('commit', '--gpg-sign').and_return(command_result)
+
+        command.call(gpg_sign: true)
+      end
+
+      it 'includes --gpg-sign=<keyid> when a String' do
+        expect_command_capturing('commit', '--gpg-sign=DEADBEEF').and_return(command_result)
+
+        command.call(gpg_sign: 'DEADBEEF')
+      end
+
+      it 'includes --no-gpg-sign when false' do
+        expect_command_capturing('commit', '--no-gpg-sign').and_return(command_result)
+
+        command.call(gpg_sign: false)
+      end
+
+      it 'accepts :S as an alias' do
+        expect_command_capturing('commit', '--gpg-sign').and_return(command_result)
+
+        command.call(S: true)
+      end
+    end
+
+    # Untracked files
+
+    context 'with the :untracked_files option' do
+      it 'includes --untracked-files when true' do
+        expect_command_capturing('commit', '--untracked-files').and_return(command_result)
+
+        command.call(untracked_files: true)
+      end
+
+      it 'includes --untracked-files=<mode> when a String' do
+        expect_command_capturing('commit', '--untracked-files=no').and_return(command_result)
+
+        command.call(untracked_files: 'no')
+      end
+
+      it 'accepts :u as an alias' do
+        expect_command_capturing('commit', '--untracked-files').and_return(command_result)
+
+        command.call(u: true)
+      end
+    end
+
+    # Pathspec from file
+
+    context 'with the :pathspec_from_file option' do
+      it 'includes --pathspec-from-file=<file>' do
+        expect_command_capturing('commit', '--pathspec-from-file=paths.txt').and_return(command_result)
+
+        command.call(pathspec_from_file: 'paths.txt')
+      end
+    end
+
+    context 'with the :pathspec_file_nul option' do
+      it 'includes --pathspec-file-nul when true' do
+        expect_command_capturing(
+          'commit',
+          '--pathspec-from-file=paths.txt',
+          '--pathspec-file-nul'
+        ).and_return(command_result)
+
+        command.call(pathspec_from_file: 'paths.txt', pathspec_file_nul: true)
+      end
+    end
+
+    # Path selection (positional pathspec operand)
+
+    context 'with pathspec positional arguments' do
+      it 'appends -- and a single path' do
+        expect_command_capturing('commit', '--', 'src/foo.rb').and_return(command_result)
+
+        command.call('src/foo.rb')
+      end
+
+      it 'appends -- and multiple paths' do
+        expect_command_capturing('commit', '--', 'src/foo.rb', 'src/bar.rb').and_return(command_result)
+
+        command.call('src/foo.rb', 'src/bar.rb')
+      end
+
+      it 'omits -- when no paths are given' do
+        expect_command_capturing('commit').and_return(command_result)
+
+        command.call
+      end
+    end
+
+    # Combined options
 
     context 'with multiple options combined' do
-      it 'includes all specified flags' do
+      it 'includes all specified flags in DSL order' do
         expect_command_capturing(
           'commit',
           '--all',
-          '--message=Combined options',
-          '--no-verify',
-          '--author=Jane <jane@example.com>'
+          '--amend',
+          '--message=Fix typo',
+          '--no-verify'
         ).and_return(command_result)
 
-        command.call(
-          message: 'Combined options',
-          all: true,
-          no_verify: true,
-          author: 'Jane <jane@example.com>'
-        )
+        command.call(all: true, amend: true, message: 'Fix typo', verify: false)
       end
     end
 
+    context 'with options and pathspec combined' do
+      it 'places flags before -- and paths after' do
+        expect_command_capturing(
+          'commit',
+          '--message=Targeted commit',
+          '--',
+          'src/foo.rb'
+        ).and_return(command_result)
+
+        command.call('src/foo.rb', message: 'Targeted commit')
+      end
+    end
+
+    # Input validation
+
     context 'input validation' do
-      it 'raises ArgumentError when date is not a string' do
-        expect { command.call(message: 'Commit', date: Time.now) }.to(
+      it 'raises ArgumentError when :date is not a String' do
+        expect { command.call(date: Time.now) }.to(
           raise_error(ArgumentError, /The :date option must be a String, but was a Time/)
         )
       end
 
       it 'raises ArgumentError for unsupported options' do
-        expect { command.call(message: 'Commit', invalid_option: true) }.to(
+        expect { command.call(invalid_option: true) }.to(
           raise_error(ArgumentError, /Unsupported options: :invalid_option/)
-        )
-      end
-
-      it 'raises ArgumentError when :add_all is provided (removed alias)' do
-        expect { command.call(message: 'Commit', add_all: true) }.to(
-          raise_error(ArgumentError, /Unsupported options: :add_all/)
         )
       end
     end

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -74,9 +74,9 @@ class TestLib < Test::Unit::TestCase
       @lib.commit('commit without no verify and pre-commit file')
     end
 
-    # Error is not raised when no_verify is passed
+    # Error is not raised when verify: false is passed
     assert_nothing_raised do
-      @lib.commit('commit with no verify and pre-commit file', no_verify: true)
+      @lib.commit('commit with no verify and pre-commit file', verify: false)
     end
 
     # Restore pre-commit hook


### PR DESCRIPTION
## Summary

Partially addresses #1196 (Batch 6, second group): backfills post-2.28.0 options into five command classes, audited against git 2.53.0 / git-scm.com docs.

**Commands updated:**
- `checkout/files` — adds `:ignore_skip_worktree_bits`, execution_option `:chdir`; fixes YARD defaults
- `checkout_index` — adds missing `:quiet`/`:q`; fixes YARD defaults and `@option` descriptions
- `clean` — adds missing `:quiet`/`:q`, execution_option `:chdir`; fixes YARD defaults
- `clone` — adds missing `:quiet`/`:q`, `:verbose`/`:v`, `:progress`; fixes negatable YARD defaults; reorganizes alias continuation paragraphs
- `commit` — adds 23 missing options (grouped by section); replaces `:no_verify` with negatable `:verify`; adds `end_of_options` + repeatable `:pathspec`; rewrites unit spec with 72 examples

## Changes per class

All five classes receive:
- `@note` annotation audited against git 2.53.0
- `@see Git::Commands` cross-reference
- Single idiomatic multi-call `@example` block
- Trailing inline DSL comments documenting emitted CLI tokens
- `(false)` YARD defaults for `flag_option` (was `nil`)
- `@raise [ArgumentError]` and `@api public` on `call` docs

## Checklist

- [x] All new options have unit tests confirming correct CLI token emission
- [x] YARD `@option` documentation added for each new option
- [x] `bundle exec rake default` passes

## Related

- Parent tracking issue: #1196
- Previous Batch 6 PR (add, apply, archive, checkout, checkout/branch): #1226