### PR TITLE
Remove inline trailing comments from arguments DSL blocks

### DIFF
--- a/.github/skills/command-implementation/REFERENCE.md
+++ b/.github/skills/command-implementation/REFERENCE.md
@@ -91,9 +91,9 @@ class Diff::Raw < Git::Commands::Base; end      # literal '--raw'
 class Diff < Git::Commands::Base
   arguments do
     literal 'diff'
-    flag_option :patch    # facade passes patch: true when it needs patch output
-    flag_option :numstat  # facade passes numstat: true for stats
-    flag_option :raw      # facade passes raw: true for raw output
+    flag_option :patch
+    flag_option :numstat
+    flag_option :raw
     ...
   end
 end
@@ -325,10 +325,7 @@ module Git
       # @api private
       class Bar < Git::Commands::Base  # never name the class Object
         arguments do
-          # Trailing comments on DSL entries must show the emitted long flag:
-          #   flag_option %i[verbose v]  # --verbose (alias: :v)
-          # Never list short flags as separate emitted tokens:
-          #   flag_option %i[verbose v]  # -v / --verbose  ← wrong
+          # Group related options with section comments (e.g. # Output, # Safety)
         end
 
         # Optional: for commands where non-zero exits are valid

--- a/.github/skills/review-arguments-dsl/CHECKLIST.md
+++ b/.github/skills/review-arguments-dsl/CHECKLIST.md
@@ -284,42 +284,6 @@ matches the SYNOPSIS.
   N]`)
 - Ensure long name is first in alias arrays
 
-### Inline comment style
-
-Each DSL entry MAY have a trailing comment documenting the emitted CLI form. When
-present, the comment must reflect **what the DSL actually emits** — the primary
-(long) flag — not the git man-page synopsis notation.
-
-```ruby
-# ✅ Correct — shows the emitted long flag; alias noted separately
-flag_option %i[verbose v]          # --verbose (alias: :v)
-flag_option %i[all a]              # --all (alias: :a)
-flag_option :progress, negatable: true     # --progress / --no-progress
-flag_option :guess, negatable: true        # --guess / --no-guess
-flag_or_value_option :color, inline: true, negatable: true  # --color[=<when>] / --no-color
-value_option :format, inline: true # --format=<format>
-
-# ❌ Wrong — shows both short and long forms as if both are emitted;
-#            reader may assume -v and --verbose are two separate flags
-flag_option %i[verbose v], max_times: 2  # -v / -vv / --verbose
-flag_option %i[all a]                    # -a / --all
-
-# ❌ Wrong — negatable: true is declared but only the positive form is shown
-flag_option :progress, negatable: true   # --progress
-```
-
-The rule: **one comment → one emitted flag form**. Aliases are referenced as
-`(alias: :x)`, not listed as separate flag tokens. Flag any comment that lists a
-short flag as if it is independently emitted.
-
-**Negatable exception:** when `negatable: true` is present, the option has two
-distinct emitted forms. Show both separated by ` / `:
-
-- `flag_option :foo, negatable: true` → `# --foo / --no-foo`
-- `flag_or_value_option :foo, inline: true, negatable: true` → `# --foo[=<val>] / --no-foo`
-
-Flag any `negatable: true` entry whose trailing comment shows only the positive form
-as incorrect.
 - **Do not** flag uppercase short-flag aliases (e.g. `:A`, `:N`) as needing `as:` —
   the DSL preserves symbol case, so `:A` correctly produces `-A` without any override
 
@@ -392,9 +356,9 @@ Every option that the git documentation documents with a short form must have an
 alias with the long name first:
 
 ```ruby
-flag_option %i[regexp_ignore_case i]   # -i / --regexp-ignore-case
-flag_option %i[extended_regexp E]      # -E / --extended-regexp
-flag_option %i[fixed_strings F]        # -F / --fixed-strings
+flag_option %i[regexp_ignore_case i]
+flag_option %i[extended_regexp E]
+flag_option %i[fixed_strings F]
 ```
 
 When reviewing, scan the git command doc's option headings for lines of the form

--- a/lib/git/commands/add.rb
+++ b/lib/git/commands/add.rb
@@ -26,22 +26,22 @@ module Git
     class Add < Git::Commands::Base
       arguments do
         literal 'add'
-        flag_option %i[verbose v]                          # --verbose (alias: :v)
-        flag_option %i[dry_run n]                          # --dry-run (alias: :n)
-        flag_option %i[force f]                            # --force (alias: :f)
-        flag_option %i[all A], negatable: true             # --all / --no-all (alias: :A)
-        flag_option :ignore_removal, negatable: true       # --ignore-removal / --no-ignore-removal
-        flag_option %i[update u]                           # --update (alias: :u)
-        flag_option :sparse                                # --sparse
-        flag_option %i[intent_to_add N]                    # --intent-to-add (alias: :N)
-        flag_option :refresh                               # --refresh
-        flag_option :ignore_errors                         # --ignore-errors
-        flag_option :ignore_missing                        # --ignore-missing
-        flag_option :renormalize                           # --renormalize
-        flag_option :no_warn_embedded_repo                 # --no-warn-embedded-repo
-        value_option :chmod, inline: true                  # --chmod=<value>
-        value_option :pathspec_from_file, inline: true     # --pathspec-from-file=<file>
-        flag_option :pathspec_file_nul                     # --pathspec-file-nul
+        flag_option %i[verbose v]
+        flag_option %i[dry_run n]
+        flag_option %i[force f]
+        flag_option %i[all A], negatable: true
+        flag_option :ignore_removal, negatable: true
+        flag_option %i[update u]
+        flag_option :sparse
+        flag_option %i[intent_to_add N]
+        flag_option :refresh
+        flag_option :ignore_errors
+        flag_option :ignore_missing
+        flag_option :renormalize
+        flag_option :no_warn_embedded_repo
+        value_option :chmod, inline: true
+        value_option :pathspec_from_file, inline: true
+        flag_option :pathspec_file_nul
         end_of_options
         operand :pathspec, repeatable: true
       end

--- a/lib/git/commands/apply.rb
+++ b/lib/git/commands/apply.rb
@@ -31,57 +31,57 @@ module Git
         literal 'apply'
 
         # Informational flags (turn off actual apply)
-        flag_option :stat                                    # --stat
-        flag_option :numstat                                 # --numstat
-        flag_option :summary                                 # --summary
-        flag_option :check                                   # --check
+        flag_option :stat
+        flag_option :numstat
+        flag_option :summary
+        flag_option :check
 
         # Application mode
-        flag_option :index                                   # --index
-        flag_option %i[intent_to_add N]                      # --intent-to-add (alias: :N)
-        flag_option :three_way, as: '--3way'                 # --3way
+        flag_option :index
+        flag_option %i[intent_to_add N]
+        flag_option :three_way, as: '--3way'
 
         # 3-way merge conflict resolution
-        flag_option :ours                                    # --ours
-        flag_option :theirs                                  # --theirs
-        flag_option :union                                   # --union
+        flag_option :ours
+        flag_option :theirs
+        flag_option :union
 
         # Apply behavior
-        flag_option :apply                                   # --apply
-        flag_option :no_add                                  # --no-add
-        value_option :build_fake_ancestor, inline: true      # --build-fake-ancestor=<file>
-        flag_option %i[reverse R]                            # --reverse (alias: :R)
-        flag_option %i[allow_binary_replacement binary]      # --allow-binary-replacement (alias: :binary)
-        flag_option :reject                                  # --reject
-        flag_option :z                                       # -z
+        flag_option :apply
+        flag_option :no_add
+        value_option :build_fake_ancestor, inline: true
+        flag_option %i[reverse R]
+        flag_option %i[allow_binary_replacement binary]
+        flag_option :reject
+        flag_option :z
 
         # Strip/context levels
-        value_option :p, inline: true                        # -p<n>
-        value_option :C, inline: true                        # -C<n>
+        value_option :p, inline: true
+        value_option :C, inline: true
 
         # Patch parsing
-        flag_option :unidiff_zero                            # --unidiff-zero
-        flag_option :inaccurate_eof                          # --inaccurate-eof
-        flag_option :recount                                 # --recount
+        flag_option :unidiff_zero
+        flag_option :inaccurate_eof
+        flag_option :recount
 
         # Application scope
-        flag_option :cached # --cached
+        flag_option :cached
 
         # Whitespace handling
-        flag_option :ignore_space_change                     # --ignore-space-change
-        flag_option :ignore_whitespace                       # --ignore-whitespace
-        value_option :whitespace, inline: true               # --whitespace=<action>
+        flag_option :ignore_space_change
+        flag_option :ignore_whitespace
+        value_option :whitespace, inline: true
 
         # Path filtering
-        value_option :exclude, inline: true                  # --exclude=<path-pattern>
-        value_option :include, inline: true                  # --include=<path-pattern>
-        value_option :directory, inline: true                # --directory=<root>
+        value_option :exclude, inline: true
+        value_option :include, inline: true
+        value_option :directory, inline: true
 
         # Verbosity
-        flag_option %i[verbose v]                            # --verbose (alias: :v)
-        flag_option %i[quiet q]                              # --quiet (alias: :q)
-        flag_option :unsafe_paths                            # --unsafe-paths
-        flag_option :allow_empty                             # --allow-empty
+        flag_option %i[verbose v]
+        flag_option %i[quiet q]
+        flag_option :unsafe_paths
+        flag_option :allow_empty
 
         # Execution
         execution_option :chdir

--- a/lib/git/commands/archive.rb
+++ b/lib/git/commands/archive.rb
@@ -36,17 +36,17 @@ module Git
     class Archive < Base
       arguments do
         literal 'archive'
-        value_option :format, inline: true                              # --format=<fmt>
-        flag_option %i[list l]                                          # --list (alias: :l)
-        flag_option %i[verbose v]                                       # --verbose (alias: :v)
-        value_option :prefix, inline: true                              # --prefix=<prefix>
-        value_option %i[output o], inline: true                         # --output=<file> (alias: :o)
-        value_option :add_file, inline: true, repeatable: true          # --add-file=<file>
-        value_option :add_virtual_file, inline: true, repeatable: true  # --add-virtual-file=<path>:<content>
-        flag_option :worktree_attributes                                # --worktree-attributes
-        value_option :mtime, inline: true                               # --mtime=<time>
-        value_option :remote, inline: true                              # --remote=<repo>
-        value_option :exec, inline: true                                # --exec=<git-upload-archive>
+        value_option :format, inline: true
+        flag_option %i[list l]
+        flag_option %i[verbose v]
+        value_option :prefix, inline: true
+        value_option %i[output o], inline: true
+        value_option :add_file, inline: true, repeatable: true
+        value_option :add_virtual_file, inline: true, repeatable: true
+        flag_option :worktree_attributes
+        value_option :mtime, inline: true
+        value_option :remote, inline: true
+        value_option :exec, inline: true
         execution_option :out
         conflicts :output, :out
 

--- a/lib/git/commands/branch/list.rb
+++ b/lib/git/commands/branch/list.rb
@@ -36,21 +36,21 @@ module Git
           literal 'branch'
           literal '--list'
 
-          flag_or_value_option :color, inline: true, negatable: true     # --color[=<when>] / --no-color
-          flag_option %i[verbose v], max_times: 2                        # --verbose (alias: :v)
-          flag_or_value_option :abbrev, inline: true, negatable: true    # --abbrev[=<n>] / --no-abbrev
-          flag_or_value_option :column, inline: true, negatable: true    # --column[=<options>] / --no-column
-          value_option :sort, inline: true, repeatable: true             # --sort=<key>
-          flag_or_value_option :merged                                   # --merged [<commit>]
-          flag_or_value_option :no_merged                                # --no-merged [<commit>]
-          flag_or_value_option :contains                                 # --contains [<commit>]
-          flag_or_value_option :no_contains                              # --no-contains [<commit>]
-          value_option :points_at                                        # --points-at <object>
-          value_option :format, inline: true                             # --format=<format>
-          flag_option %i[remotes r]                                      # --remotes (alias: :r)
-          flag_option %i[all a]                                          # --all (alias: :a)
-          flag_option %i[ignore_case i]                                  # --ignore-case (alias: :i)
-          flag_option :omit_empty                                        # --omit-empty
+          flag_or_value_option :color, inline: true, negatable: true
+          flag_option %i[verbose v], max_times: 2
+          flag_or_value_option :abbrev, inline: true, negatable: true
+          flag_or_value_option :column, inline: true, negatable: true
+          value_option :sort, inline: true, repeatable: true
+          flag_or_value_option :merged
+          flag_or_value_option :no_merged
+          flag_or_value_option :contains
+          flag_or_value_option :no_contains
+          value_option :points_at
+          value_option :format, inline: true
+          flag_option %i[remotes r]
+          flag_option %i[all a]
+          flag_option %i[ignore_case i]
+          flag_option :omit_empty
 
           end_of_options
 

--- a/lib/git/commands/checkout/branch.rb
+++ b/lib/git/commands/checkout/branch.rb
@@ -30,23 +30,23 @@ module Git
       class Branch < Git::Commands::Base
         arguments do
           literal 'checkout'
-          flag_option %i[quiet q]                                          # --quiet (alias: :q)
-          flag_option :progress, negatable: true                           # --progress / --no-progress
-          flag_option %i[force f]                                          # --force (alias: :f)
-          value_option :b                                                  # -b <new-branch>
-          value_option :B                                                  # -B <new-branch>
-          flag_or_value_option %i[track t], negatable: true, inline: true  # --track[=(direct|inherit)] / --no-track
-          flag_option :guess, negatable: true                              # --guess / --no-guess
-          flag_option :l                                                   # -l
-          flag_option %i[detach d]                                         # --detach (alias: :d)
-          value_option :orphan                                             # --orphan <new-branch>
-          flag_option %i[merge m]                                          # --merge (alias: :m)
-          flag_option :ignore_other_worktrees                              # --ignore-other-worktrees
-          flag_option :overwrite_ignore, negatable: true                   # --overwrite-ignore / --no-overwrite-ignore
+          flag_option %i[quiet q]
+          flag_option :progress, negatable: true
+          flag_option %i[force f]
+          value_option :b
+          value_option :B
+          flag_or_value_option %i[track t], negatable: true, inline: true
+          flag_option :guess, negatable: true
+          flag_option :l
+          flag_option %i[detach d]
+          value_option :orphan
+          flag_option %i[merge m]
+          flag_option :ignore_other_worktrees
+          flag_option :overwrite_ignore, negatable: true
 
           # --recurse-submodules is technically available but has no effect on branch
           # switching in older git versions. Included for completeness per the man page.
-          flag_option :recurse_submodules, negatable: true # --recurse-submodules / --no-recurse-submodules
+          flag_option :recurse_submodules, negatable: true
 
           execution_option :chdir
 

--- a/lib/git/commands/checkout/files.rb
+++ b/lib/git/commands/checkout/files.rb
@@ -30,21 +30,21 @@ module Git
       class Files < Git::Commands::Base
         arguments do
           literal 'checkout'
-          flag_option %i[force f]                                     # --force (alias: :f)
-          flag_option :ours                                           # --ours
-          flag_option :theirs                                         # --theirs
-          flag_option %i[merge m]                                     # --merge (alias: :m)
-          value_option :conflict, inline: true                        # --conflict=<style>
-          flag_option :overlay, negatable: true                       # --overlay / --no-overlay
-          flag_option :ignore_skip_worktree_bits                      # --ignore-skip-worktree-bits
-          value_option :pathspec_from_file, inline: true              # --pathspec-from-file=<file>
-          flag_option :pathspec_file_nul                              # --pathspec-file-nul
+          flag_option %i[force f]
+          flag_option :ours
+          flag_option :theirs
+          flag_option %i[merge m]
+          value_option :conflict, inline: true
+          flag_option :overlay, negatable: true
+          flag_option :ignore_skip_worktree_bits
+          value_option :pathspec_from_file, inline: true
+          flag_option :pathspec_file_nul
 
           execution_option :chdir
 
           operand :tree_ish
           end_of_options
-          value_option :pathspec, as_operand: true, repeatable: true  # <pathspec>...
+          value_option :pathspec, as_operand: true, repeatable: true
         end
 
         # @!method call(*, **)

--- a/lib/git/commands/checkout_index.rb
+++ b/lib/git/commands/checkout_index.rb
@@ -29,15 +29,15 @@ module Git
     class CheckoutIndex < Git::Commands::Base
       arguments do
         literal 'checkout-index'
-        flag_option %i[index u]                  # --index (alias: :u)
-        flag_option %i[quiet q]                  # --quiet (alias: :q)
-        flag_option %i[all a]                    # --all (alias: :a)
-        flag_option %i[force f]                  # --force (alias: :f)
-        flag_option %i[no_create n]              # --no-create (alias: :n)
-        value_option :prefix, inline: true       # --prefix=<string>
-        value_option :stage, inline: true        # --stage=<number>|all
-        flag_option :temp                        # --temp
-        flag_option :ignore_skip_worktree_bits   # --ignore-skip-worktree-bits
+        flag_option %i[index u]
+        flag_option %i[quiet q]
+        flag_option %i[all a]
+        flag_option %i[force f]
+        flag_option %i[no_create n]
+        value_option :prefix, inline: true
+        value_option :stage, inline: true
+        flag_option :temp
+        flag_option :ignore_skip_worktree_bits
         end_of_options
         operand :file, required: false, repeatable: true
       end

--- a/lib/git/commands/clean.rb
+++ b/lib/git/commands/clean.rb
@@ -31,13 +31,13 @@ module Git
     class Clean < Git::Commands::Base
       arguments do
         literal 'clean'
-        flag_option :d # -d
-        flag_option %i[force f], max_times: 2 # --force (alias: :f)
-        flag_option %i[dry_run n] # --dry-run (alias: :n)
-        flag_option %i[quiet q] # --quiet (alias: :q)
-        value_option %i[exclude e], inline: true, repeatable: true # --exclude=<pattern> (alias: :e)
-        flag_option :x  # -x
-        flag_option :X  # -X
+        flag_option :d
+        flag_option %i[force f], max_times: 2
+        flag_option %i[dry_run n]
+        flag_option %i[quiet q]
+        value_option %i[exclude e], inline: true, repeatable: true
+        flag_option :x
+        flag_option :X
         execution_option :chdir
         end_of_options
         value_option :pathspec, as_operand: true, repeatable: true

--- a/lib/git/commands/clone.rb
+++ b/lib/git/commands/clone.rb
@@ -26,41 +26,41 @@ module Git
     class Clone < Git::Commands::Base
       arguments do
         literal 'clone'
-        value_option :template, inline: true # --template=<template-directory>
-        flag_option %i[local l], negatable: true # --local / --no-local (alias: :l)
-        flag_option %i[shared s] # --shared (alias: :s)
-        flag_option :no_hardlinks # --no-hardlinks
-        flag_option %i[quiet q] # --quiet (alias: :q)
-        flag_option %i[verbose v] # --verbose (alias: :v)
-        flag_option :progress # --progress
-        flag_option %i[no_checkout n] # --no-checkout (alias: :n)
-        flag_option :bare # --bare
-        flag_option :mirror # --mirror
-        value_option %i[origin o] # --origin <name> (alias: :o)
-        value_option %i[branch b] # --branch <name> (alias: :b)
-        value_option :revision, inline: true # --revision=<rev>
-        value_option %i[upload_pack u] # --upload-pack <upload-pack> (alias: :u)
-        value_option :reference, repeatable: true # --reference <repository>
-        value_option :reference_if_able, repeatable: true # --reference-if-able <repository>
-        flag_option :dissociate # --dissociate
-        value_option :separate_git_dir, inline: true # --separate-git-dir=<git-dir>
-        value_option :server_option, inline: true, repeatable: true # --server-option=<option>
-        value_option :depth # --depth <depth>
-        value_option :shallow_since, inline: true # --shallow-since=<date>
-        value_option :shallow_exclude, inline: true, repeatable: true # --shallow-exclude=<ref>
-        flag_option :single_branch, negatable: true # --single-branch / --no-single-branch
-        flag_option :tags, negatable: true # --tags / --no-tags
-        flag_or_value_option :recurse_submodules, inline: true, repeatable: true # --recurse-submodules[=<pathspec>]
-        flag_option :shallow_submodules, negatable: true # --shallow-submodules / --no-shallow-submodules
-        flag_option :remote_submodules, negatable: true # --remote-submodules / --no-remote-submodules
-        value_option %i[jobs j] # --jobs <n> (alias: :j)
-        flag_option :sparse # --sparse
-        flag_option :reject_shallow, negatable: true # --reject-shallow / --no-reject-shallow
-        value_option :filter, inline: true # --filter=<filter-spec>
-        flag_option :also_filter_submodules # --also-filter-submodules
-        value_option %i[config c], repeatable: true # --config <key>=<value> (alias: :c)
-        value_option :bundle_uri, inline: true # --bundle-uri=<uri>
-        value_option :ref_format, inline: true # --ref-format=<ref-format>
+        value_option :template, inline: true
+        flag_option %i[local l], negatable: true
+        flag_option %i[shared s]
+        flag_option :no_hardlinks
+        flag_option %i[quiet q]
+        flag_option %i[verbose v]
+        flag_option :progress
+        flag_option %i[no_checkout n]
+        flag_option :bare
+        flag_option :mirror
+        value_option %i[origin o]
+        value_option %i[branch b]
+        value_option :revision, inline: true
+        value_option %i[upload_pack u]
+        value_option :reference, repeatable: true
+        value_option :reference_if_able, repeatable: true
+        flag_option :dissociate
+        value_option :separate_git_dir, inline: true
+        value_option :server_option, inline: true, repeatable: true
+        value_option :depth
+        value_option :shallow_since, inline: true
+        value_option :shallow_exclude, inline: true, repeatable: true
+        flag_option :single_branch, negatable: true
+        flag_option :tags, negatable: true
+        flag_or_value_option :recurse_submodules, inline: true, repeatable: true
+        flag_option :shallow_submodules, negatable: true
+        flag_option :remote_submodules, negatable: true
+        value_option %i[jobs j]
+        flag_option :sparse
+        flag_option :reject_shallow, negatable: true
+        value_option :filter, inline: true
+        flag_option :also_filter_submodules
+        value_option %i[config c], repeatable: true
+        value_option :bundle_uri, inline: true
+        value_option :ref_format, inline: true
         end_of_options
         operand :repository, required: true
         operand :directory

--- a/lib/git/commands/commit.rb
+++ b/lib/git/commands/commit.rb
@@ -29,64 +29,64 @@ module Git
         literal 'commit'
 
         # Stage selection
-        flag_option %i[all a] # --all (alias: :a)
+        flag_option %i[all a]
 
         # Message source and editing
-        flag_option %i[edit e], negatable: true                          # --edit / --no-edit (alias: :e)
-        flag_option :amend                                               # --amend
-        value_option %i[reuse_message C], inline: true                   # --reuse-message=<commit> (alias: :C)
-        value_option :fixup, inline: true                                # --fixup=[amend:|reword:]<commit>
-        value_option :squash, inline: true                               # --squash=<commit>
-        value_option %i[message m], inline: true, allow_empty: true      # --message=<msg> (alias: :m)
-        value_option %i[file F], inline: true                            # --file=<file> (alias: :F)
-        value_option %i[template t], inline: true                        # --template=<file> (alias: :t)
+        flag_option %i[edit e], negatable: true
+        flag_option :amend
+        value_option %i[reuse_message C], inline: true
+        value_option :fixup, inline: true
+        value_option :squash, inline: true
+        value_option %i[message m], inline: true, allow_empty: true
+        value_option %i[file F], inline: true
+        value_option %i[template t], inline: true
 
         # Author / date
-        flag_option :reset_author                                        # --reset-author
-        value_option :author, inline: true                               # --author=<author>
-        value_option :date, inline: true, type: String                   # --date=<date>
+        flag_option :reset_author
+        value_option :author, inline: true
+        value_option :date, inline: true, type: String
 
         # Message cleanup and trailers
-        value_option :cleanup, inline: true                              # --cleanup=<mode>
-        value_option :trailer, repeatable: true                          # --trailer <token>[=<value>]
+        value_option :cleanup, inline: true
+        value_option :trailer, repeatable: true
 
         # Hooks
-        flag_option %i[verify n], negatable: true # --verify / --no-verify (alias: :n)
+        flag_option %i[verify n], negatable: true
 
         # Behavior
-        flag_option :allow_empty                                         # --allow-empty
-        flag_option :allow_empty_message                                 # --allow-empty-message
-        flag_option :no_post_rewrite                                     # --no-post-rewrite
-        flag_option %i[include i]                                        # --include (alias: :i)
-        flag_option %i[only o]                                           # --only (alias: :o)
+        flag_option :allow_empty
+        flag_option :allow_empty_message
+        flag_option :no_post_rewrite
+        flag_option %i[include i]
+        flag_option %i[only o]
 
         # Output / dry-run
-        flag_option :dry_run                                             # --dry-run
-        flag_option :short                                               # --short
-        flag_option :branch                                              # --branch
-        flag_option :porcelain                                           # --porcelain
-        flag_option :long                                                # --long
-        flag_option %i[null z]                                           # --null (alias: :z)
-        flag_option %i[verbose v], max_times: 2                          # --verbose (alias: :v, up to 2×)
-        flag_option %i[quiet q]                                          # --quiet (alias: :q)
-        flag_option :status, negatable: true                             # --status / --no-status
+        flag_option :dry_run
+        flag_option :short
+        flag_option :branch
+        flag_option :porcelain
+        flag_option :long
+        flag_option %i[null z]
+        flag_option %i[verbose v], max_times: 2
+        flag_option %i[quiet q]
+        flag_option :status, negatable: true
 
         # Verbose diff options
-        value_option %i[unified U], inline: true, type: Integer          # --unified=<n> (alias: :U)
-        value_option :inter_hunk_context, inline: true, type: Integer    # --inter-hunk-context=<n>
+        value_option %i[unified U], inline: true, type: Integer
+        value_option :inter_hunk_context, inline: true, type: Integer
 
         # Signoff
-        flag_option %i[signoff s], negatable: true # --signoff / --no-signoff (alias: :s)
+        flag_option %i[signoff s], negatable: true
 
         # GPG signing
-        flag_or_value_option %i[gpg_sign S], negatable: true, inline: true # --gpg-sign[=<keyid>] / --no-gpg-sign (:S)
+        flag_or_value_option %i[gpg_sign S], negatable: true, inline: true
 
         # Untracked files
-        flag_or_value_option %i[untracked_files u], inline: true # --untracked-files[=<mode>] (alias: :u)
+        flag_or_value_option %i[untracked_files u], inline: true
 
         # Pathspec from file
-        value_option :pathspec_from_file, inline: true                   # --pathspec-from-file=<file>
-        flag_option :pathspec_file_nul                                   # --pathspec-file-nul
+        value_option :pathspec_from_file, inline: true
+        flag_option :pathspec_file_nul
 
         # Path selection
         end_of_options

--- a/lib/git/commands/diff_files.rb
+++ b/lib/git/commands/diff_files.rb
@@ -37,123 +37,123 @@ module Git
         literal 'diff-files'
 
         # diff-files-specific options
-        flag_option :q                                   # -q (do not complain about nonexistent files)
-        flag_option :unmerged, as: '-0'                  # -0 (unmerged: suppress diff output)
-        flag_option :base                                # --base (-1: unmerged, diff against stage 1)
-        flag_option :ours                                # --ours (-2: unmerged, diff against stage 2)
-        flag_option :theirs                              # --theirs (-3: unmerged, diff against stage 3)
-        flag_option :c                                   # -c (combined diff: stage 2, stage 3, working tree)
-        flag_option :cc                                  # --cc (synonym for -c)
+        flag_option :q
+        flag_option :unmerged, as: '-0'
+        flag_option :base
+        flag_option :ours
+        flag_option :theirs
+        flag_option :c
+        flag_option :cc
 
         # Output format selection
-        flag_option %i[patch p u]                        # --patch / -p / -u
-        flag_option %i[no_patch s]                       # --no-patch / -s
-        flag_option :raw                                 # --raw
-        flag_option :patch_with_raw                      # --patch-with-raw
-        value_option %i[unified U], inline: true         # --unified=<n> / -U<n>
-        value_option :output, inline: true               # --output=<file>
-        value_option :output_indicator_new, inline: true    # --output-indicator-new=<char>
-        value_option :output_indicator_old, inline: true    # --output-indicator-old=<char>
-        value_option :output_indicator_context, inline: true # --output-indicator-context=<char>
+        flag_option %i[patch p u]
+        flag_option %i[no_patch s]
+        flag_option :raw
+        flag_option :patch_with_raw
+        value_option %i[unified U], inline: true
+        value_option :output, inline: true
+        value_option :output_indicator_new, inline: true
+        value_option :output_indicator_old, inline: true
+        value_option :output_indicator_context, inline: true
 
         # Diff algorithm
-        flag_option :indent_heuristic, negatable: true   # --[no-]indent-heuristic
-        flag_option :minimal                             # --minimal
-        flag_option :patience                            # --patience
-        flag_option :histogram                           # --histogram
-        value_option :anchored, inline: true, repeatable: true # --anchored=<text> (repeatable)
-        value_option :diff_algorithm, inline: true # --diff-algorithm=<algo>
+        flag_option :indent_heuristic, negatable: true
+        flag_option :minimal
+        flag_option :patience
+        flag_option :histogram
+        value_option :anchored, inline: true, repeatable: true
+        value_option :diff_algorithm, inline: true
 
         # Statistics output formats
-        flag_or_value_option :stat, inline: true         # --stat[=<width>[,<name-width>[,<count>]]]
-        value_option :stat_width, inline: true           # --stat-width=<width>
-        value_option :stat_name_width, inline: true      # --stat-name-width=<name-width>
-        value_option :stat_graph_width, inline: true     # --stat-graph-width=<graph-width>
-        value_option :stat_count, inline: true           # --stat-count=<count>
-        flag_option :compact_summary                     # --compact-summary
-        flag_option :numstat                             # --numstat
-        flag_option :shortstat                           # --shortstat
-        flag_or_value_option %i[dirstat X], inline: true # --dirstat[=<param>...] / -X[<param>...]
-        flag_option :cumulative                          # --cumulative
-        flag_or_value_option :dirstat_by_file, inline: true # --dirstat-by-file[=<param>...]
-        flag_option :summary                             # --summary
-        flag_option :patch_with_stat                     # --patch-with-stat
+        flag_or_value_option :stat, inline: true
+        value_option :stat_width, inline: true
+        value_option :stat_name_width, inline: true
+        value_option :stat_graph_width, inline: true
+        value_option :stat_count, inline: true
+        flag_option :compact_summary
+        flag_option :numstat
+        flag_option :shortstat
+        flag_or_value_option %i[dirstat X], inline: true
+        flag_option :cumulative
+        flag_or_value_option :dirstat_by_file, inline: true
+        flag_option :summary
+        flag_option :patch_with_stat
 
         # Name and path display
-        flag_option :z                                   # -z
-        flag_option :name_only                           # --name-only
-        flag_option :name_status                         # --name-status
-        flag_or_value_option :submodule, inline: true    # --submodule[=<format>]
+        flag_option :z
+        flag_option :name_only
+        flag_option :name_status
+        flag_or_value_option :submodule, inline: true
 
         # Color output
-        flag_or_value_option :color, inline: true, negatable: true # --color[=<when>] / --no-color
-        flag_or_value_option :color_moved, inline: true, negatable: true # --color-moved[=<mode>] / --no-color-moved
-        value_option :color_moved_ws, inline: true       # --color-moved-ws=<mode>,...
-        flag_option :no_color_moved_ws                   # --no-color-moved-ws
+        flag_or_value_option :color, inline: true, negatable: true
+        flag_or_value_option :color_moved, inline: true, negatable: true
+        value_option :color_moved_ws, inline: true
+        flag_option :no_color_moved_ws
 
         # Word diff
-        flag_or_value_option :word_diff, inline: true    # --word-diff[=<mode>]
-        value_option :word_diff_regex, inline: true      # --word-diff-regex=<regex>
-        flag_or_value_option :color_words, inline: true  # --color-words[=<regex>]
+        flag_or_value_option :word_diff, inline: true
+        value_option :word_diff_regex, inline: true
+        flag_or_value_option :color_words, inline: true
 
         # Whitespace handling
-        flag_option :ignore_cr_at_eol                    # --ignore-cr-at-eol
-        flag_option :ignore_space_at_eol                 # --ignore-space-at-eol
-        flag_option %i[ignore_space_change b]            # --ignore-space-change / -b
-        flag_option %i[ignore_all_space w]               # --ignore-all-space / -w
-        flag_option :ignore_blank_lines                  # --ignore-blank-lines
-        value_option %i[ignore_matching_lines I], inline: true, repeatable: true # --ignore-matching-lines / -I
-        flag_option :check                               # --check
-        value_option :ws_error_highlight, inline: true   # --ws-error-highlight=<kind>
+        flag_option :ignore_cr_at_eol
+        flag_option :ignore_space_at_eol
+        flag_option %i[ignore_space_change b]
+        flag_option %i[ignore_all_space w]
+        flag_option :ignore_blank_lines
+        value_option %i[ignore_matching_lines I], inline: true, repeatable: true
+        flag_option :check
+        value_option :ws_error_highlight, inline: true
 
         # Rename/copy detection
-        flag_option :no_renames                          # --no-renames
-        flag_option :rename_empty, negatable: true       # --[no-]rename-empty
-        flag_option :full_index                          # --full-index
-        flag_option :binary                              # --binary
-        flag_or_value_option :abbrev, inline: true       # --abbrev[=<n>]
-        flag_or_value_option %i[break_rewrites B], inline: true  # --break-rewrites[=[<n>][/<m>]] / -B[<n>][/<m>]
-        flag_or_value_option %i[find_renames M], inline: true    # --find-renames[=<n>] / -M[<n>]
-        flag_or_value_option %i[find_copies C], inline: true     # --find-copies[=<n>] / -C[<n>]
-        flag_option :find_copies_harder                  # --find-copies-harder
-        flag_option %i[irreversible_delete D]            # --irreversible-delete / -D
+        flag_option :no_renames
+        flag_option :rename_empty, negatable: true
+        flag_option :full_index
+        flag_option :binary
+        flag_or_value_option :abbrev, inline: true
+        flag_or_value_option %i[break_rewrites B], inline: true
+        flag_or_value_option %i[find_renames M], inline: true
+        flag_or_value_option %i[find_copies C], inline: true
+        flag_option :find_copies_harder
+        flag_option %i[irreversible_delete D]
 
         # Pickaxe / filtering
-        value_option :l, inline: true                    # -l<num>
-        value_option :diff_filter, inline: true          # --diff-filter=[ACDMRTUXB*...]
-        value_option :S, inline: true                    # -S<string>
-        value_option :G, inline: true                    # -G<regex>
-        value_option :find_object, inline: true          # --find-object=<object-id>
-        flag_option :pickaxe_all                         # --pickaxe-all
-        flag_option :pickaxe_regex                       # --pickaxe-regex
-        value_option :O, inline: true                    # -O<orderfile>
-        value_option :skip_to, inline: true              # --skip-to=<file>
-        value_option :rotate_to, inline: true            # --rotate-to=<file>
+        value_option :l, inline: true
+        value_option :diff_filter, inline: true
+        value_option :S, inline: true
+        value_option :G, inline: true
+        value_option :find_object, inline: true
+        flag_option :pickaxe_all
+        flag_option :pickaxe_regex
+        value_option :O, inline: true
+        value_option :skip_to, inline: true
+        value_option :rotate_to, inline: true
 
         # Miscellaneous diff options
-        flag_option :R # -R (swap inputs)
-        flag_or_value_option :relative, inline: true, negatable: true # --relative[=<path>] / --no-relative
-        flag_option %i[text a]                           # --text / -a
-        value_option :inter_hunk_context, inline: true   # --inter-hunk-context=<number>
-        flag_option %i[function_context W]               # --function-context / -W
-        flag_option :exit_code                           # --exit-code
-        flag_option :quiet                               # --quiet
-        flag_option :ext_diff, negatable: true           # --[no-]ext-diff
-        flag_option :textconv, negatable: true           # --[no-]textconv
-        flag_or_value_option :ignore_submodules, inline: true # --ignore-submodules[=<when>]
-        value_option :src_prefix, inline: true           # --src-prefix=<prefix>
-        value_option :dst_prefix, inline: true           # --dst-prefix=<prefix>
-        flag_option :no_prefix                           # --no-prefix
-        flag_option :default_prefix                      # --default-prefix
-        value_option :line_prefix, inline: true          # --line-prefix=<prefix>
-        flag_option :ita_invisible_in_index              # --ita-invisible-in-index
-        value_option :max_depth, inline: true            # --max-depth=<depth>
+        flag_option :R
+        flag_or_value_option :relative, inline: true, negatable: true
+        flag_option %i[text a]
+        value_option :inter_hunk_context, inline: true
+        flag_option %i[function_context W]
+        flag_option :exit_code
+        flag_option :quiet
+        flag_option :ext_diff, negatable: true
+        flag_option :textconv, negatable: true
+        flag_or_value_option :ignore_submodules, inline: true
+        value_option :src_prefix, inline: true
+        value_option :dst_prefix, inline: true
+        flag_option :no_prefix
+        flag_option :default_prefix
+        value_option :line_prefix, inline: true
+        flag_option :ita_invisible_in_index
+        value_option :max_depth, inline: true
 
         # Operands: git diff-files has no required <tree-ish>; options precede end_of_options.
         # end_of_options emits -- only when path arguments are present, protecting paths
         # that start with '-' from being misinterpreted as flags.
-        end_of_options                      # -- emitted only when paths follow
-        operand :path, repeatable: true     # [<path>...] (optional)
+        end_of_options
+        operand :path, repeatable: true
       end
 
       # git diff-files exits 1 when differences are found (not an error)

--- a/lib/git/commands/diff_index.rb
+++ b/lib/git/commands/diff_index.rb
@@ -40,120 +40,120 @@ module Git
         literal 'diff-index'
 
         # diff-index-specific options
-        flag_option :m                                   # -m
-        flag_option :cached                              # --cached
-        flag_option :merge_base                          # --merge-base
+        flag_option :m
+        flag_option :cached
+        flag_option :merge_base
 
         # Output format selection
-        flag_option %i[patch p u]                        # --patch / -p / -u
-        flag_option %i[no_patch s]                       # --no-patch / -s
-        flag_option :raw                                 # --raw
-        flag_option :patch_with_raw                      # --patch-with-raw
-        value_option %i[unified U], inline: true         # --unified=<n> / -U<n>
-        value_option :output, inline: true               # --output=<file>
-        value_option :output_indicator_new, inline: true    # --output-indicator-new=<char>
-        value_option :output_indicator_old, inline: true    # --output-indicator-old=<char>
-        value_option :output_indicator_context, inline: true # --output-indicator-context=<char>
+        flag_option %i[patch p u]
+        flag_option %i[no_patch s]
+        flag_option :raw
+        flag_option :patch_with_raw
+        value_option %i[unified U], inline: true
+        value_option :output, inline: true
+        value_option :output_indicator_new, inline: true
+        value_option :output_indicator_old, inline: true
+        value_option :output_indicator_context, inline: true
 
         # Diff algorithm
-        flag_option :indent_heuristic, negatable: true   # --[no-]indent-heuristic
-        flag_option :minimal                             # --minimal
-        flag_option :patience                            # --patience
-        flag_option :histogram                           # --histogram
-        value_option :anchored, inline: true, repeatable: true # --anchored=<text> (repeatable)
-        value_option :diff_algorithm, inline: true # --diff-algorithm=<algo>
+        flag_option :indent_heuristic, negatable: true
+        flag_option :minimal
+        flag_option :patience
+        flag_option :histogram
+        value_option :anchored, inline: true, repeatable: true
+        value_option :diff_algorithm, inline: true
 
         # Statistics output formats
-        flag_or_value_option :stat, inline: true         # --stat[=<width>[,<name-width>[,<count>]]]
-        value_option :stat_width, inline: true           # --stat-width=<width>
-        value_option :stat_name_width, inline: true      # --stat-name-width=<name-width>
-        value_option :stat_graph_width, inline: true     # --stat-graph-width=<graph-width>
-        value_option :stat_count, inline: true           # --stat-count=<count>
-        flag_option :compact_summary                     # --compact-summary
-        flag_option :numstat                             # --numstat
-        flag_option :shortstat                           # --shortstat
-        flag_or_value_option %i[dirstat X], inline: true # --dirstat[=<param>...] / -X[<param>...]
-        flag_option :cumulative                          # --cumulative
-        flag_or_value_option :dirstat_by_file, inline: true # --dirstat-by-file[=<param>...]
-        flag_option :summary                             # --summary
-        flag_option :patch_with_stat                     # --patch-with-stat
+        flag_or_value_option :stat, inline: true
+        value_option :stat_width, inline: true
+        value_option :stat_name_width, inline: true
+        value_option :stat_graph_width, inline: true
+        value_option :stat_count, inline: true
+        flag_option :compact_summary
+        flag_option :numstat
+        flag_option :shortstat
+        flag_or_value_option %i[dirstat X], inline: true
+        flag_option :cumulative
+        flag_or_value_option :dirstat_by_file, inline: true
+        flag_option :summary
+        flag_option :patch_with_stat
 
         # Name and path display
-        flag_option :z                                   # -z
-        flag_option :name_only                           # --name-only
-        flag_option :name_status                         # --name-status
-        flag_or_value_option :submodule, inline: true    # --submodule[=<format>]
+        flag_option :z
+        flag_option :name_only
+        flag_option :name_status
+        flag_or_value_option :submodule, inline: true
 
         # Color output
-        flag_or_value_option :color, inline: true, negatable: true # --color[=<when>] / --no-color
-        flag_or_value_option :color_moved, inline: true, negatable: true # --color-moved[=<mode>] / --no-color-moved
-        value_option :color_moved_ws, inline: true       # --color-moved-ws=<mode>,...
-        flag_option :no_color_moved_ws                   # --no-color-moved-ws
+        flag_or_value_option :color, inline: true, negatable: true
+        flag_or_value_option :color_moved, inline: true, negatable: true
+        value_option :color_moved_ws, inline: true
+        flag_option :no_color_moved_ws
 
         # Word diff
-        flag_or_value_option :word_diff, inline: true    # --word-diff[=<mode>]
-        value_option :word_diff_regex, inline: true      # --word-diff-regex=<regex>
-        flag_or_value_option :color_words, inline: true  # --color-words[=<regex>]
+        flag_or_value_option :word_diff, inline: true
+        value_option :word_diff_regex, inline: true
+        flag_or_value_option :color_words, inline: true
 
         # Whitespace handling
-        flag_option :ignore_cr_at_eol                    # --ignore-cr-at-eol
-        flag_option :ignore_space_at_eol                 # --ignore-space-at-eol
-        flag_option %i[ignore_space_change b]            # --ignore-space-change / -b
-        flag_option %i[ignore_all_space w]               # --ignore-all-space / -w
-        flag_option :ignore_blank_lines                  # --ignore-blank-lines
-        value_option %i[ignore_matching_lines I], inline: true, repeatable: true # --ignore-matching-lines / -I
-        flag_option :check                               # --check
-        value_option :ws_error_highlight, inline: true   # --ws-error-highlight=<kind>
+        flag_option :ignore_cr_at_eol
+        flag_option :ignore_space_at_eol
+        flag_option %i[ignore_space_change b]
+        flag_option %i[ignore_all_space w]
+        flag_option :ignore_blank_lines
+        value_option %i[ignore_matching_lines I], inline: true, repeatable: true
+        flag_option :check
+        value_option :ws_error_highlight, inline: true
 
         # Rename/copy detection
-        flag_option :no_renames                          # --no-renames
-        flag_option :rename_empty, negatable: true       # --[no-]rename-empty
-        flag_option :full_index                          # --full-index
-        flag_option :binary                              # --binary
-        flag_or_value_option :abbrev, inline: true       # --abbrev[=<n>]
-        flag_or_value_option %i[break_rewrites B], inline: true  # --break-rewrites[=[<n>][/<m>]] / -B[<n>][/<m>]
-        flag_or_value_option %i[find_renames M], inline: true    # --find-renames[=<n>] / -M[<n>]
-        flag_or_value_option %i[find_copies C], inline: true     # --find-copies[=<n>] / -C[<n>]
-        flag_option :find_copies_harder                  # --find-copies-harder
-        flag_option %i[irreversible_delete D]            # --irreversible-delete / -D
+        flag_option :no_renames
+        flag_option :rename_empty, negatable: true
+        flag_option :full_index
+        flag_option :binary
+        flag_or_value_option :abbrev, inline: true
+        flag_or_value_option %i[break_rewrites B], inline: true
+        flag_or_value_option %i[find_renames M], inline: true
+        flag_or_value_option %i[find_copies C], inline: true
+        flag_option :find_copies_harder
+        flag_option %i[irreversible_delete D]
 
         # Pickaxe / filtering
-        value_option :l, inline: true                    # -l<num>
-        value_option :diff_filter, inline: true          # --diff-filter=[ACDMRTUXB*...]
-        value_option :S, inline: true                    # -S<string>
-        value_option :G, inline: true                    # -G<regex>
-        value_option :find_object, inline: true          # --find-object=<object-id>
-        flag_option :pickaxe_all                         # --pickaxe-all
-        flag_option :pickaxe_regex                       # --pickaxe-regex
-        value_option :O, inline: true                    # -O<orderfile>
-        value_option :skip_to, inline: true              # --skip-to=<file>
-        value_option :rotate_to, inline: true            # --rotate-to=<file>
+        value_option :l, inline: true
+        value_option :diff_filter, inline: true
+        value_option :S, inline: true
+        value_option :G, inline: true
+        value_option :find_object, inline: true
+        flag_option :pickaxe_all
+        flag_option :pickaxe_regex
+        value_option :O, inline: true
+        value_option :skip_to, inline: true
+        value_option :rotate_to, inline: true
 
         # Miscellaneous diff options
-        flag_option :R # -R (swap inputs)
-        flag_or_value_option :relative, inline: true, negatable: true # --relative[=<path>] / --no-relative
-        flag_option %i[text a]                           # --text / -a
-        value_option :inter_hunk_context, inline: true   # --inter-hunk-context=<number>
-        flag_option %i[function_context W]               # --function-context / -W
-        flag_option :exit_code                           # --exit-code
-        flag_option :quiet                               # --quiet
-        flag_option :ext_diff, negatable: true           # --[no-]ext-diff
-        flag_option :textconv, negatable: true           # --[no-]textconv
-        flag_or_value_option :ignore_submodules, inline: true # --ignore-submodules[=<when>]
-        value_option :src_prefix, inline: true           # --src-prefix=<prefix>
-        value_option :dst_prefix, inline: true           # --dst-prefix=<prefix>
-        flag_option :no_prefix                           # --no-prefix
-        flag_option :default_prefix                      # --default-prefix
-        value_option :line_prefix, inline: true          # --line-prefix=<prefix>
-        flag_option :ita_invisible_in_index              # --ita-invisible-in-index
-        value_option :max_depth, inline: true            # --max-depth=<depth>
+        flag_option :R
+        flag_or_value_option :relative, inline: true, negatable: true
+        flag_option %i[text a]
+        value_option :inter_hunk_context, inline: true
+        flag_option %i[function_context W]
+        flag_option :exit_code
+        flag_option :quiet
+        flag_option :ext_diff, negatable: true
+        flag_option :textconv, negatable: true
+        flag_or_value_option :ignore_submodules, inline: true
+        value_option :src_prefix, inline: true
+        value_option :dst_prefix, inline: true
+        flag_option :no_prefix
+        flag_option :default_prefix
+        value_option :line_prefix, inline: true
+        flag_option :ita_invisible_in_index
+        value_option :max_depth, inline: true
 
         # Operands: git diff-index does not accept -- before <tree-ish>.
         # end_of_options is placed between tree_ish and path so that -- is emitted
         # only when path arguments are present, disambiguating paths from revisions.
-        operand :tree_ish, required: true   # <tree-ish> (required)
-        end_of_options                      # -- emitted only when paths follow
-        operand :path, repeatable: true     # [<path>...] (optional)
+        operand :tree_ish, required: true
+        end_of_options
+        operand :path, repeatable: true
       end
 
       # git diff-index exits 1 when differences are found (e.g. with --exit-code)

--- a/lib/git/commands/fetch.rb
+++ b/lib/git/commands/fetch.rb
@@ -39,67 +39,67 @@ module Git
         literal 'fetch'
 
         # Remotes and fetching scope
-        flag_option :all, negatable: true              # --all / --no-all
-        flag_option %i[append a]                       # --append; alias: :a
-        flag_option :atomic                            # --atomic
+        flag_option :all, negatable: true
+        flag_option %i[append a]
+        flag_option :atomic
 
         # Shallow clone controls
-        value_option :depth                            # --depth <n>
-        value_option :deepen                           # --deepen <n>
-        value_option :shallow_since, inline: true      # --shallow-since=<date>
-        value_option :shallow_exclude,                 # --shallow-exclude=<ref>
+        value_option :depth
+        value_option :deepen
+        value_option :shallow_since, inline: true
+        value_option :shallow_exclude,
                      inline: true, repeatable: true
-        flag_option :unshallow                         # --unshallow
-        flag_option :update_shallow                    # --update-shallow
+        flag_option :unshallow
+        flag_option :update_shallow
 
         # Output and behavior
-        flag_option :dry_run                           # --dry-run
-        flag_option :write_fetch_head, negatable: true # --write-fetch-head / --no-write-fetch-head
-        flag_option :refetch                           # --refetch
-        flag_option :prefetch                          # --prefetch
+        flag_option :dry_run
+        flag_option :write_fetch_head, negatable: true
+        flag_option :refetch
+        flag_option :prefetch
 
         # Safety and update control
-        flag_option %i[force f]                        # --force; alias: :f
-        flag_option %i[keep k]                         # --keep; alias: :k
-        flag_option :multiple                          # --multiple
+        flag_option %i[force f]
+        flag_option %i[keep k]
+        flag_option :multiple
 
         # Pruning
-        flag_option %i[prune p]                        # --prune; alias: :p
-        flag_option %i[prune_tags P]                   # --prune-tags; alias: :P
+        flag_option %i[prune p]
+        flag_option %i[prune_tags P]
 
         # Tag handling
-        flag_option %i[tags t], negatable: true # --tags / --no-tags; alias: :t
+        flag_option %i[tags t], negatable: true
 
         # Submodules
-        flag_or_value_option :recurse_submodules, # --recurse-submodules[=(yes|on-demand|no)]
+        flag_or_value_option :recurse_submodules,
                              inline: true, negatable: true
 
         # Parallelism
-        value_option %i[jobs j] # --jobs <n>; alias: :j
+        value_option %i[jobs j]
 
         # Tracking
-        flag_option :set_upstream                      # --set-upstream
-        flag_option %i[update_head_ok u]               # --update-head-ok; alias: :u
+        flag_option :set_upstream
+        flag_option %i[update_head_ok u]
 
         # Output verbosity
-        flag_option %i[quiet q]                        # --quiet; alias: :q
-        flag_option %i[verbose v]                      # --verbose; alias: :v
-        flag_option :progress                          # --progress
+        flag_option %i[quiet q]
+        flag_option %i[verbose v]
+        flag_option :progress
 
         # Protocol and connectivity
-        value_option %i[server_option o], # --server-option=<opt>; alias: :o
+        value_option %i[server_option o],
                      inline: true, repeatable: true
-        flag_option :show_forced_updates, negatable: true # --show-forced-updates / --no-show-forced-updates
-        flag_option :ipv4                              # --ipv4
-        flag_option :ipv6                              # --ipv6
+        flag_option :show_forced_updates, negatable: true
+        flag_option :ipv4
+        flag_option :ipv6
 
         # Execution-only options (not emitted as CLI flags)
         execution_option :timeout
         execution_option :merge
 
         end_of_options
-        operand :repository                            # [<repository>]
-        operand :refspecs, repeatable: true            # [<refspec>...]
+        operand :repository
+        operand :refspecs, repeatable: true
       end
 
       # @!method call(*, **)

--- a/lib/git/commands/ls_files.rb
+++ b/lib/git/commands/ls_files.rb
@@ -32,41 +32,41 @@ module Git
     class LsFiles < Git::Commands::Base
       arguments do
         literal 'ls-files'
-        flag_option :z                                     # -z
-        flag_option :t                                     # -t
-        flag_option :v                                     # -v
-        flag_option :f                                     # -f
-        flag_option %i[cached c]                           # --cached (alias: :c)
-        flag_option %i[deleted d]                          # --deleted (alias: :d)
-        flag_option %i[others o]                           # --others (alias: :o)
-        flag_option %i[ignored i]                          # --ignored (alias: :i)
-        flag_option %i[stage s]                            # --stage (alias: :s)
-        flag_option %i[unmerged u]                         # --unmerged (alias: :u)
-        flag_option %i[killed k]                           # --killed (alias: :k)
-        flag_option %i[modified m]                         # --modified (alias: :m)
-        flag_option :resolve_undo                          # --resolve-undo
-        flag_option :directory                             # --directory
-        flag_option :no_empty_directory                    # --no-empty-directory
-        flag_option :eol                                   # --eol
-        flag_option :sparse                                # --sparse
-        flag_option :deduplicate                           # --deduplicate
-        value_option %i[exclude x], inline: true           # --exclude=<pattern> (alias: :x)
-        value_option %i[exclude_from X], inline: true      # --exclude-from=<file> (alias: :X)
-        value_option :exclude_per_directory, inline: true  # --exclude-per-directory=<file>
-        flag_option :exclude_standard                      # --exclude-standard
-        flag_option :error_unmatch                         # --error-unmatch
-        value_option :with_tree, inline: true              # --with-tree=<tree-ish>
-        flag_option :full_name                             # --full-name
-        flag_option :recurse_submodules                    # --recurse-submodules
-        flag_or_value_option :abbrev, inline: true         # --abbrev[=<n>]
-        flag_option :debug                                 # --debug
-        value_option :format, inline: true                 # --format=<format>
+        flag_option :z
+        flag_option :t
+        flag_option :v
+        flag_option :f
+        flag_option %i[cached c]
+        flag_option %i[deleted d]
+        flag_option %i[others o]
+        flag_option %i[ignored i]
+        flag_option %i[stage s]
+        flag_option %i[unmerged u]
+        flag_option %i[killed k]
+        flag_option %i[modified m]
+        flag_option :resolve_undo
+        flag_option :directory
+        flag_option :no_empty_directory
+        flag_option :eol
+        flag_option :sparse
+        flag_option :deduplicate
+        value_option %i[exclude x], inline: true
+        value_option %i[exclude_from X], inline: true
+        value_option :exclude_per_directory, inline: true
+        flag_option :exclude_standard
+        flag_option :error_unmatch
+        value_option :with_tree, inline: true
+        flag_option :full_name
+        flag_option :recurse_submodules
+        flag_or_value_option :abbrev, inline: true
+        flag_option :debug
+        value_option :format, inline: true
 
-        end_of_options                                     # --
+        end_of_options
 
-        operand :file, repeatable: true                    # [<file>...]
+        operand :file, repeatable: true
 
-        execution_option :chdir                            # NOT a git flag — routes to process spawn options only
+        execution_option :chdir
       end
 
       # @!method call(*, **)

--- a/lib/git/commands/ls_remote.rb
+++ b/lib/git/commands/ls_remote.rb
@@ -39,29 +39,29 @@ module Git
       arguments do
         literal 'ls-remote'
 
-        flag_option %i[heads h]                                       # --heads; alias: :h
-        flag_option %i[tags t]                                        # --tags; alias: :t
-        flag_option :refs                                             # --refs
+        flag_option %i[heads h]
+        flag_option %i[tags t]
+        flag_option :refs
 
         # Connectivity
-        value_option :upload_pack, inline: true # --upload-pack=<exec>
+        value_option :upload_pack, inline: true
 
-        flag_option %i[quiet q]                                       # --quiet; alias: :q
-        flag_option :exit_code                                        # --exit-code
-        flag_option :get_url                                          # --get-url
-        value_option :sort, inline: true                              # --sort=<key>
-        flag_option :symref                                           # --symref
+        flag_option %i[quiet q]
+        flag_option :exit_code
+        flag_option :get_url
+        value_option :sort, inline: true
+        flag_option :symref
 
-        value_option %i[server_option o],                             # --server-option=<option>
-                     inline: true, repeatable: true                   # alias: :o
+        value_option %i[server_option o],
+                     inline: true, repeatable: true
 
         # Execution-only options (not emitted as CLI flags)
         execution_option :timeout
 
         end_of_options
 
-        operand :repository # [<repository>]
-        operand :pattern, repeatable: true # [<patterns>...]
+        operand :repository
+        operand :pattern, repeatable: true
       end
 
       # Exit status 2 means no matching refs were found (used with --exit-code)

--- a/lib/git/commands/ls_tree.rb
+++ b/lib/git/commands/ls_tree.rb
@@ -35,25 +35,25 @@ module Git
         literal 'ls-tree'
 
         # Listing behavior
-        flag_option :d                                  # -d
-        flag_option :r                                  # -r
-        flag_option :t                                  # -t
-        flag_option %i[long l]                          # --long / -l (show object size)
-        flag_option :z                                  # -z (NUL termination)
+        flag_option :d
+        flag_option :r
+        flag_option :t
+        flag_option %i[long l]
+        flag_option :z
 
         # Output format
-        flag_option %i[name_only name_status]           # --name-only (alias: :name_status)
-        flag_option :object_only                        # --object-only
-        flag_option :full_name                          # --full-name
-        flag_option :full_tree                          # --full-tree
-        flag_or_value_option :abbrev, inline: true      # --abbrev[=<n>]
-        value_option :format, inline: true              # --format=<format>
+        flag_option %i[name_only name_status]
+        flag_option :object_only
+        flag_option :full_name
+        flag_option :full_tree
+        flag_or_value_option :abbrev, inline: true
+        value_option :format, inline: true
 
-        operand :tree_ish, required: true               # <tree-ish>
+        operand :tree_ish, required: true
 
-        end_of_options                                  # --
+        end_of_options
 
-        operand :path, repeatable: true                 # [<path>...]
+        operand :path, repeatable: true
       end
 
       # @!method call(*, **)

--- a/lib/git/commands/pull.rb
+++ b/lib/git/commands/pull.rb
@@ -43,68 +43,68 @@ module Git
         literal 'pull'
 
         # General options
-        flag_option %i[quiet q]                                              # --quiet
-        flag_option %i[verbose v]                                            # --verbose
-        flag_or_value_option :recurse_submodules, # --recurse-submodules[=yes|on-demand|no] / --no-recurse-submodules
+        flag_option %i[quiet q]
+        flag_option %i[verbose v]
+        flag_or_value_option :recurse_submodules,
                              negatable: true, inline: true
 
         # Merge options
-        flag_option :commit, negatable: true                                 # --commit / --no-commit
-        flag_option :edit, negatable: true                                   # --edit / --no-edit
-        value_option :cleanup, inline: true                                  # --cleanup=<mode>
-        flag_option :ff_only                                                 # --ff-only
-        flag_option :ff, negatable: true                                     # --ff / --no-ff
-        flag_or_value_option %i[gpg_sign S], negatable: true, inline: true # --gpg-sign[=<key-id>] / --no-gpg-sign
-        flag_or_value_option :log, negatable: true, inline: true             # --log[=<n>] / --no-log
-        flag_option :signoff, negatable: true                                # --signoff / --no-signoff
-        flag_option :stat                                                    # --stat
-        flag_option %i[no_stat n]                                            # --no-stat
-        flag_option :compact_summary                                         # --compact-summary
-        flag_option :squash, negatable: true                                 # --squash / --no-squash
-        flag_option :verify, negatable: true                                 # --verify / --no-verify
-        value_option %i[strategy s], inline: true # --strategy=<strategy>
-        value_option %i[strategy_option X], inline: true, repeatable: true # --strategy-option=<option>
-        flag_option :verify_signatures, negatable: true # --verify-signatures / --no-verify-signatures
-        flag_option :summary, negatable: true                                # --summary / --no-summary
-        flag_option :autostash, negatable: true                              # --autostash / --no-autostash
-        flag_option :allow_unrelated_histories                               # --allow-unrelated-histories
-        flag_or_value_option %i[rebase r], negatable: true, inline: true # --rebase[=<mode>] / --no-rebase
+        flag_option :commit, negatable: true
+        flag_option :edit, negatable: true
+        value_option :cleanup, inline: true
+        flag_option :ff_only
+        flag_option :ff, negatable: true
+        flag_or_value_option %i[gpg_sign S], negatable: true, inline: true
+        flag_or_value_option :log, negatable: true, inline: true
+        flag_option :signoff, negatable: true
+        flag_option :stat
+        flag_option %i[no_stat n]
+        flag_option :compact_summary
+        flag_option :squash, negatable: true
+        flag_option :verify, negatable: true
+        value_option %i[strategy s], inline: true
+        value_option %i[strategy_option X], inline: true, repeatable: true
+        flag_option :verify_signatures, negatable: true
+        flag_option :summary, negatable: true
+        flag_option :autostash, negatable: true
+        flag_option :allow_unrelated_histories
+        flag_or_value_option %i[rebase r], negatable: true, inline: true
 
         # Fetch options
-        flag_option :all, negatable: true                                    # --all / --no-all
-        flag_option %i[append a]                                             # --append
-        flag_option :atomic                                                  # --atomic
-        value_option :depth, inline: true # --depth=<depth>
-        value_option :deepen, inline: true                                   # --deepen=<depth>
-        value_option :shallow_since, inline: true                            # --shallow-since=<date>
-        value_option :shallow_exclude, inline: true, repeatable: true        # --shallow-exclude=<ref>
-        flag_option :unshallow                                               # --unshallow
-        flag_option :update_shallow                                          # --update-shallow
-        value_option :negotiation_tip, inline: true, repeatable: true        # --negotiation-tip=<commit|glob>
-        flag_option :negotiate_only                                          # --negotiate-only
-        flag_option :dry_run                                                 # --dry-run
-        flag_option :porcelain                                               # --porcelain
-        flag_option %i[force f]                                              # --force
-        flag_option %i[keep k]                                               # --keep
-        flag_option :prefetch                                                # --prefetch
-        flag_option %i[prune p]                                              # --prune
-        flag_option %i[tags t], negatable: true                              # --tags / --no-tags
-        value_option :refmap, inline: true, repeatable: true                 # --refmap=<refspec>
-        value_option %i[jobs j], inline: true # --jobs=<n>
-        flag_option :set_upstream                                            # --set-upstream
-        value_option :upload_pack                                            # --upload-pack <path>
-        flag_option :progress, negatable: true                               # --[no-]progress
-        value_option %i[server_option o], inline: true, repeatable: true     # --server-option=<option>
-        flag_option :show_forced_updates, negatable: true # --show-forced-updates / --no-show-forced-updates
-        flag_option %i[ipv4 4]                                               # --ipv4
-        flag_option %i[ipv6 6]                                               # --ipv6
+        flag_option :all, negatable: true
+        flag_option %i[append a]
+        flag_option :atomic
+        value_option :depth, inline: true
+        value_option :deepen, inline: true
+        value_option :shallow_since, inline: true
+        value_option :shallow_exclude, inline: true, repeatable: true
+        flag_option :unshallow
+        flag_option :update_shallow
+        value_option :negotiation_tip, inline: true, repeatable: true
+        flag_option :negotiate_only
+        flag_option :dry_run
+        flag_option :porcelain
+        flag_option %i[force f]
+        flag_option %i[keep k]
+        flag_option :prefetch
+        flag_option %i[prune p]
+        flag_option %i[tags t], negatable: true
+        value_option :refmap, inline: true, repeatable: true
+        value_option %i[jobs j], inline: true
+        flag_option :set_upstream
+        value_option :upload_pack
+        flag_option :progress, negatable: true
+        value_option %i[server_option o], inline: true, repeatable: true
+        flag_option :show_forced_updates, negatable: true
+        flag_option %i[ipv4 4]
+        flag_option %i[ipv6 6]
 
         # Execution options (not emitted as CLI flags)
         execution_option :timeout
 
         end_of_options
-        operand :repository                                                  # [<repository>]
-        operand :refspec, repeatable: true                                   # [<refspec>…]
+        operand :repository
+        operand :refspec, repeatable: true
       end
 
       # @!method call(*, **)

--- a/lib/git/commands/push.rb
+++ b/lib/git/commands/push.rb
@@ -42,64 +42,64 @@ module Git
         literal 'push'
 
         # Push scope (SYNOPSIS order: [--all | --branches | --mirror | --tags])
-        flag_option %i[all branches]                               # --all
-        flag_option :mirror                                        # --mirror
-        flag_option :tags                                          # --tags
-        flag_option :follow_tags, negatable: true                  # --follow-tags / --no-follow-tags
-        flag_option :atomic, negatable: true                       # --atomic / --no-atomic
+        flag_option %i[all branches]
+        flag_option :mirror
+        flag_option :tags
+        flag_option :follow_tags, negatable: true
+        flag_option :atomic, negatable: true
 
         # Transfer options
-        flag_option %i[dry_run n]                                  # --dry-run
-        flag_option :porcelain                                     # --porcelain
-        value_option %i[receive_pack exec], inline: true           # --receive-pack=<git-receive-pack>
-        value_option :repo, inline: true                           # --repo=<repository>
+        flag_option %i[dry_run n]
+        flag_option :porcelain
+        value_option %i[receive_pack exec], inline: true
+        value_option :repo, inline: true
 
         # Safety
-        flag_option %i[force f]                                    # --force
-        flag_option %i[delete d]                                   # --delete
-        flag_option :prune                                         # --prune
+        flag_option %i[force f]
+        flag_option %i[delete d]
+        flag_option :prune
 
         # Output verbosity
-        flag_option %i[quiet q]                                    # --quiet
-        flag_option %i[verbose v]                                  # --verbose
+        flag_option %i[quiet q]
+        flag_option %i[verbose v]
 
         # Tracking
-        flag_option %i[set_upstream u] # --set-upstream
+        flag_option %i[set_upstream u]
 
         # Push options (server-side)
-        value_option %i[push_option o], repeatable: true, inline: true # --push-option=<value>
+        value_option %i[push_option o], repeatable: true, inline: true
 
         # GPG signing
-        flag_or_value_option :signed, # --signed[=(true|false|if-asked)] / --no-signed
+        flag_or_value_option :signed,
                              negatable: true, inline: true
 
         # Force safety
-        flag_or_value_option :force_with_lease,                    # --force-with-lease[=<refname>:<expect>]
-                             negatable: true, inline: true         # --no-force-with-lease
-        flag_option :force_if_includes, negatable: true            # --force-if-includes / --no-force-if-includes
+        flag_or_value_option :force_with_lease,
+                             negatable: true, inline: true
+        flag_option :force_if_includes, negatable: true
 
         # Hooks
-        flag_option :verify, negatable: true # --verify / --no-verify
+        flag_option :verify, negatable: true
 
         # Submodules
-        flag_or_value_option :recurse_submodules, # --recurse-submodules=(...) / --no-recurse-submodules
+        flag_or_value_option :recurse_submodules,
                              negatable: true, inline: true, type: [String, FalseClass]
 
         # Transfer
-        flag_option :thin, negatable: true                         # --thin / --no-thin
-        flag_option :progress                                      # --progress
+        flag_option :thin, negatable: true
+        flag_option :progress
 
         # Protocol and connectivity
-        flag_option %i[ipv4 4]                                     # --ipv4
-        flag_option %i[ipv6 6]                                     # --ipv6
+        flag_option %i[ipv4 4]
+        flag_option %i[ipv6 6]
 
         # Execution options (not emitted as CLI flags)
         execution_option :timeout
 
         end_of_options
 
-        operand :repository                                        # [<repository>]
-        operand :refspec, repeatable: true                         # [<refspec>…]
+        operand :repository
+        operand :refspec, repeatable: true
       end
 
       # @!method call(*, **)

--- a/lib/git/commands/remote/add.rb
+++ b/lib/git/commands/remote/add.rb
@@ -34,11 +34,11 @@ module Git
         arguments do
           literal 'remote'
           literal 'add'
-          value_option %i[track t], repeatable: true  # --track=<branch> (alias: :t)
-          value_option %i[master m]                   # --master=<branch> (alias: :m)
-          flag_option %i[fetch f]                     # --fetch (alias: :f)
-          flag_option :tags, negatable: true          # --tags / --no-tags
-          value_option :mirror, inline: true          # --mirror=<mode>
+          value_option %i[track t], repeatable: true
+          value_option %i[master m]
+          flag_option %i[fetch f]
+          flag_option :tags, negatable: true
+          value_option :mirror, inline: true
 
           end_of_options
 

--- a/lib/git/commands/remote/get_url.rb
+++ b/lib/git/commands/remote/get_url.rb
@@ -33,8 +33,8 @@ module Git
         arguments do
           literal 'remote'
           literal 'get-url'
-          flag_option :push  # --push
-          flag_option :all   # --all
+          flag_option :push
+          flag_option :all
 
           end_of_options
 

--- a/lib/git/commands/remote/list.rb
+++ b/lib/git/commands/remote/list.rb
@@ -28,7 +28,7 @@ module Git
       class List < Git::Commands::Base
         arguments do
           literal 'remote'
-          flag_option %i[verbose v] # --verbose (alias: :v)
+          flag_option %i[verbose v]
         end
 
         # @!method call(*, **)

--- a/lib/git/commands/remote/prune.rb
+++ b/lib/git/commands/remote/prune.rb
@@ -29,7 +29,7 @@ module Git
         arguments do
           literal 'remote'
           literal 'prune'
-          flag_option %i[dry_run n] # --dry-run (alias: :n)
+          flag_option %i[dry_run n]
 
           end_of_options
 

--- a/lib/git/commands/remote/rename.rb
+++ b/lib/git/commands/remote/rename.rb
@@ -34,7 +34,7 @@ module Git
         arguments do
           literal 'remote'
           literal 'rename'
-          flag_option :progress, negatable: true # --[no-]progress
+          flag_option :progress, negatable: true
 
           end_of_options
 

--- a/lib/git/commands/remote/set_branches.rb
+++ b/lib/git/commands/remote/set_branches.rb
@@ -30,7 +30,7 @@ module Git
         arguments do
           literal 'remote'
           literal 'set-branches'
-          flag_option :add # --add
+          flag_option :add
 
           end_of_options
 

--- a/lib/git/commands/remote/set_head.rb
+++ b/lib/git/commands/remote/set_head.rb
@@ -34,8 +34,8 @@ module Git
           literal 'remote'
           literal 'set-head'
           operand :name, required: true
-          flag_option %i[auto a]    # --auto (alias: :a)
-          flag_option %i[delete d]  # --delete (alias: :d)
+          flag_option %i[auto a]
+          flag_option %i[delete d]
           operand :branch
         end
 

--- a/lib/git/commands/remote/set_url.rb
+++ b/lib/git/commands/remote/set_url.rb
@@ -35,7 +35,7 @@ module Git
         arguments do
           literal 'remote'
           literal 'set-url'
-          flag_option :push # --push
+          flag_option :push
 
           end_of_options
 

--- a/lib/git/commands/remote/set_url_add.rb
+++ b/lib/git/commands/remote/set_url_add.rb
@@ -30,7 +30,7 @@ module Git
           literal 'remote'
           literal 'set-url'
           literal '--add'
-          flag_option :push # --push
+          flag_option :push
 
           end_of_options
 

--- a/lib/git/commands/remote/set_url_delete.rb
+++ b/lib/git/commands/remote/set_url_delete.rb
@@ -31,7 +31,7 @@ module Git
           literal 'remote'
           literal 'set-url'
           literal '--delete'
-          flag_option :push # --push
+          flag_option :push
 
           end_of_options
 

--- a/lib/git/commands/remote/show.rb
+++ b/lib/git/commands/remote/show.rb
@@ -33,9 +33,9 @@ module Git
       class Show < Git::Commands::Base
         arguments do
           literal 'remote'
-          flag_option %i[verbose v]                   # --verbose (alias: :v)
+          flag_option %i[verbose v]
           literal 'show'
-          flag_option :n                              # -n
+          flag_option :n
 
           end_of_options
 

--- a/lib/git/commands/remote/update.rb
+++ b/lib/git/commands/remote/update.rb
@@ -34,9 +34,9 @@ module Git
       class Update < Git::Commands::Base
         arguments do
           literal 'remote'
-          flag_option %i[verbose v]  # --verbose (alias: :v)
+          flag_option %i[verbose v]
           literal 'update'
-          flag_option %i[prune p]    # --prune (alias: :p)
+          flag_option %i[prune p]
 
           end_of_options
 

--- a/lib/git/commands/repack.rb
+++ b/lib/git/commands/repack.rb
@@ -32,8 +32,6 @@ module Git
       arguments do
         literal 'repack'
 
-        # SYNOPSIS order: [-a] [-A] [-d] [-f] [-F] [-l] [-n] [-q] [-b]
-        #   [--window=<n>] [--depth=<n>] [--threads=<n>] [--keep-pack=<pack-name>]
         flag_option :a
         flag_option :A
         flag_option :d


### PR DESCRIPTION
Remove 560 inline trailing comments (e.g. `# --all (alias: :a)`) from arguments DSL definitions across 30 command classes and update skill files to stop enforcing the convention.

## Motivation

These comments were:
- A **strict information subset** of the YARD documentation — they added no unique information
- **Inconsistently applied** — only 30 of 125 command classes had them
- A **false verification layer** — reviewers could check comments against the DSL without noticing either was wrong

The DSL is self-documenting: `default_arg_spec` derives flag names from kwarg names deterministically, and YARD docs provide the authoritative reference for every option.

## Changes

**Command classes (30 files):** Strip all inline trailing comments from `arguments do` blocks. Group heading comments (e.g. `# Stage selection`, `# Hooks`) are preserved.

**Skill files (3 files):**
- `review-arguments-dsl/CHECKLIST.md` — delete the "Inline comment style" audit section that enforced the removed convention; remove flag-form comments from alias examples
- `command-implementation/REFERENCE.md` — replace inline comment examples in the scaffolding template with group comment guidance; remove flag-documentation comments from code examples