### PR TITLE
Update CommitTree, Describe, and DiffFiles command classes per implementation skill

### DIFF
--- a/lib/git/commands/commit_tree.rb
+++ b/lib/git/commands/commit_tree.rb
@@ -10,21 +10,17 @@ module Git
     # new commit object id on stdout. The log message is provided via `-m` or `-F`
     # options; multiple instances of either are concatenated as separate paragraphs.
     #
-    # @example Create a simple commit with a message
+    # @example Typical usage
     #   commit_tree = Git::Commands::CommitTree.new(execution_context)
-    #   result = commit_tree.call('abc123', m: 'Initial commit')
+    #   commit_tree.call('abc123', m: 'Initial commit')
+    #   commit_tree.call('abc123', p: %w[parent1 parent2], m: 'Merge')
+    #   commit_tree.call('abc123', m: 'Signed', gpg_sign: true)
     #
-    # @example Create a merge commit with multiple parents
-    #   commit_tree = Git::Commands::CommitTree.new(execution_context)
-    #   result = commit_tree.call('abc123', p: %w[parent1 parent2], m: 'Merge')
-    #
-    # @example GPG-sign a commit
-    #   commit_tree = Git::Commands::CommitTree.new(execution_context)
-    #   result = commit_tree.call('abc123', m: 'Signed', gpg_sign: true)
-    #
-    # @see https://git-scm.com/docs/git-commit-tree git-commit-tree documentation
+    # @note `arguments` block audited against https://git-scm.com/docs/git-commit-tree/2.53.0
     #
     # @see Git::Commands
+    #
+    # @see https://git-scm.com/docs/git-commit-tree git-commit-tree
     #
     # @api private
     #
@@ -95,8 +91,10 @@ module Git
       #
       #     @raise [ArgumentError] if the tree operand is missing
       #
-      #     @raise [Git::FailedError] if the command returns a non-zero exit
+      #     @raise [Git::FailedError] if git exits with a non-zero exit
       #       status
+      #
+      #     @api public
     end
   end
 end

--- a/lib/git/commands/describe.rb
+++ b/lib/git/commands/describe.rb
@@ -11,118 +11,145 @@ module Git
     # tag name is shown. Otherwise, the tag name is suffixed with the number
     # of additional commits and the abbreviated commit SHA.
     #
+    # @example Typical usage
+    #   describe = Git::Commands::Describe.new(execution_context)
+    #   describe.call
+    #   describe.call('abc123')
+    #   describe.call(tags: true)
+    #   describe.call(dirty: true)
+    #   describe.call(dirty: '-dirty')
+    #
+    # @note `arguments` block audited against
+    #   https://git-scm.com/docs/git-describe/2.53.0
+    #
     # @see https://git-scm.com/docs/git-describe git-describe
+    #
     # @see Git::Commands
     #
     # @api private
     #
-    # @example Describe the current HEAD
-    #   describe = Git::Commands::Describe.new(execution_context)
-    #   result = describe.call
-    #
-    # @example Describe a specific commit
-    #   describe = Git::Commands::Describe.new(execution_context)
-    #   result = describe.call('abc123')
-    #
-    # @example Describe using any tag (not just annotated)
-    #   describe = Git::Commands::Describe.new(execution_context)
-    #   result = describe.call(tags: true)
-    #
-    # @example Describe with dirty-tree marker
-    #   describe = Git::Commands::Describe.new(execution_context)
-    #   result = describe.call(dirty: true)
-    #   result = describe.call(dirty: '-dirty')
-    #
     class Describe < Git::Commands::Base
       arguments do
         literal 'describe'
+
+        # Ref selection
         flag_option :all
         flag_option :tags
         flag_option :contains
-        flag_option :debug
-        flag_option :long
-        flag_option :always
-        flag_option :exact_match
-        flag_option :first_parent
+
+        # Abbreviation
+        flag_or_value_option :abbrev, inline: true
+
+        # Working tree state
         flag_or_value_option :dirty, inline: true
         flag_or_value_option :broken, inline: true
-        flag_or_value_option :abbrev, inline: true
+
+        # Match candidates
         value_option :candidates, inline: true
+        flag_option :exact_match
+
+        # Output control
+        flag_option :debug
+        flag_option :long
+
+        # Pattern filtering
         value_option :match, repeatable: true
         value_option :exclude, repeatable: true
+
+        # Fallback and history
+        flag_option :always
+        flag_option :first_parent
+
+        end_of_options
         operand :commit_ish, repeatable: true
       end
 
       # @!method call(*, **)
       #
-      #   Execute the git describe command
-      #
       #   @overload call(*commit_ish, **options)
       #
-      #     @param commit_ish [Array<String>] zero or more commit-ish objects to describe.
+      #     Execute the `git describe` command
+      #
+      #     @param commit_ish [Array<String>] zero or more commit-ish objects
+      #       to describe
+      #
       #       When none are given, describes HEAD.
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :all (nil) Use any ref found in the `refs/`
-      #       namespace, not just tags.
+      #     @option options [Boolean] :all (false) use any ref found in the
+      #       `refs/` namespace, not just tags
       #
-      #     @option options [Boolean] :tags (nil) Use any tag found in the `refs/tags`
-      #       namespace, instead of only annotated tags.
+      #     @option options [Boolean] :tags (false) use any tag found in the
+      #       `refs/tags` namespace, instead of only annotated tags
       #
-      #     @option options [Boolean] :contains (nil) Find the tag that comes after
-      #       the commit and thus contains it, rather than the most recent tag
-      #       reachable from it.
+      #     @option options [Boolean] :contains (false) find the tag that
+      #       comes after the commit and thus contains it, rather than the
+      #       most recent tag reachable from it
       #
-      #     @option options [Boolean] :debug (nil) Verbosely display information
-      #       about the searching strategy being employed.
+      #     @option options [Boolean, String] :abbrev (nil) use this many
+      #       digits for the abbreviated commit object name
       #
-      #     @option options [Boolean] :long (nil) Always output the long format
-      #       (the tag, the number of commits, and the abbreviated object name)
-      #       even when it matches a tag exactly.
+      #       When `true`, emits bare `--abbrev` (which uses git's default
+      #       length). Pass a string to emit `--abbrev=<n>`.
       #
-      #     @option options [Boolean] :always (nil) Show uniquely abbreviated
-      #       commit object as fallback when the commit cannot be described.
+      #     @option options [Boolean, String] :dirty (nil) describe the
+      #       working tree
       #
-      #     @option options [Boolean] :exact_match (nil) Only output exact matches
-      #       (a tag directly references the supplied commit object). Maps to
-      #       `--exact-match`.
+      #       When `true`, appends `-dirty`; when a String, appends that
+      #       string as the dirty mark. Maps to `--dirty[=<mark>]`.
       #
-      #     @option options [Boolean] :first_parent (nil) Follow only the first
-      #       parent of a merge commit. Maps to `--first-parent`.
+      #     @option options [Boolean, String] :broken (nil) describe the
+      #       working tree, treating broken links as dirty
       #
-      #     @option options [Boolean, String] :abbrev (nil) Use this many digits (or
-      #       as many as needed to form a unique object name) for the abbreviated
-      #       commit object name. When `true`, emits bare `--abbrev` (which uses
-      #       git's default length). Maps to `--abbrev[=<n>]`.
+      #       When `true`, appends `-broken`; when a String, appends that
+      #       string as the broken mark. Maps to `--broken[=<mark>]`.
       #
-      #     @option options [String] :candidates (nil) Consider up to this many
-      #       candidates. Increasing above the default of 10 will take a slightly
+      #     @option options [Integer, String] :candidates (nil) consider up
+      #       to this many candidates
+      #
+      #       Increasing above the default of 10 will take a slightly
       #       longer time but may produce a more accurate result. Maps to
       #       `--candidates=<n>`.
       #
-      #     @option options [String, Array<String>] :match (nil) Only consider tags
-      #       matching the given `glob(7)` pattern. Pass an array to match against
-      #       multiple patterns. Maps to `--match <pattern>`.
+      #     @option options [Boolean] :exact_match (false) only output exact
+      #       matches (a tag directly references the supplied commit object)
       #
-      #     @option options [String, Array<String>] :exclude (nil) Do not consider
-      #       tags matching the given `glob(7)` pattern. Pass an array to exclude
-      #       multiple patterns. Maps to `--exclude <pattern>`.
+      #     @option options [Boolean] :debug (false) verbosely display
+      #       information about the searching strategy being employed
       #
-      #     @option options [Boolean, String] :dirty (nil) Describe the working
-      #       tree. When `true`, appends `-dirty`; when a String, appends that
-      #       string as the dirty mark. Maps to `--dirty[=<mark>]`.
+      #     @option options [Boolean] :long (false) always output the long
+      #       format (the tag, the number of commits, and the abbreviated
+      #       object name) even when it matches a tag exactly
       #
-      #     @option options [Boolean, String] :broken (nil) Describe the working
-      #       tree, treating broken links as dirty. When `true`, appends `-broken`;
-      #       when a String, appends that string as the broken mark. Maps to
-      #       `--broken[=<mark>]`.
+      #     @option options [String, Array<String>] :match (nil) only
+      #       consider tags matching the given `glob(7)` pattern
       #
-      #     @return [Git::CommandLineResult] the result of calling `git describe`
+      #       Pass an array to match against multiple patterns. Maps to
+      #       `--match <pattern>`.
+      #
+      #     @option options [String, Array<String>] :exclude (nil) do not
+      #       consider tags matching the given `glob(7)` pattern
+      #
+      #       Pass an array to exclude multiple patterns. Maps to
+      #       `--exclude <pattern>`.
+      #
+      #     @option options [Boolean] :always (false) show uniquely
+      #       abbreviated commit object as fallback when the commit cannot
+      #       be described
+      #
+      #     @option options [Boolean] :first_parent (false) follow only the
+      #       first parent of a merge commit
+      #
+      #     @return [Git::CommandLineResult] the result of calling
+      #       `git describe`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #
-      #     @raise [Git::FailedError] if the command returns a non-zero exit status
+      #     @raise [Git::FailedError] if git exits with a non-zero exit
+      #       status
+      #
+      #     @api public
     end
   end
 end

--- a/lib/git/commands/diff_files.rb
+++ b/lib/git/commands/diff_files.rb
@@ -10,27 +10,21 @@ module Git
     # have been modified but not yet staged. This is the plumbing equivalent of
     # checking for unstaged changes.
     #
-    # @see https://git-scm.com/docs/git-diff-files git-diff-files documentation
+    # @example Typical usage
+    #   diff_files = Git::Commands::DiffFiles.new(execution_context)
+    #   diff_files.call
+    #   diff_files.call(patch: true)
+    #   diff_files.call('lib/', 'spec/')
+    #   diff_files.call(q: true)
+    #
+    # @note `arguments` block audited against
+    #   https://git-scm.com/docs/git-diff-files/2.53.0
+    #
+    # @see https://git-scm.com/docs/git-diff-files git-diff-files
     #
     # @see Git::Commands
     #
     # @api private
-    #
-    # @example Show all unstaged changes (raw output)
-    #   # git diff-files
-    #   Git::Commands::DiffFiles.new(ctx).call
-    #
-    # @example Show unstaged changes as a patch
-    #   # git diff-files --patch
-    #   Git::Commands::DiffFiles.new(ctx).call(patch: true)
-    #
-    # @example Limit comparison to specific paths
-    #   # git diff-files -- lib/ spec/
-    #   Git::Commands::DiffFiles.new(ctx).call('lib/', 'spec/')
-    #
-    # @example Check quietly — only exit status (0 = clean, 1 = changes)
-    #   # git diff-files -q
-    #   Git::Commands::DiffFiles.new(ctx).call(q: true)
     #
     class DiffFiles < Git::Commands::Base
       arguments do
@@ -161,327 +155,353 @@ module Git
 
       # @!method call(*, **)
       #
-      #   @api public
-      #
       #   @overload call(**options)
       #     Compare the index to the working tree with no path restriction
       #
-      #     @example Show all unstaged changes in raw format
-      #       # git diff-files
-      #       DiffFiles.new(ctx).call
-      #
-      #     @example Show unstaged changes as a unified diff patch
-      #       # git diff-files --patch
-      #       DiffFiles.new(ctx).call(patch: true)
-      #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :q (nil) Do not complain about nonexistent files; only
+      #     @option options [Boolean] :q (false) do not complain about nonexistent files; only
       #       report exit status
       #
-      #     @option options [Boolean] :unmerged (nil) For unmerged entries, suppress diff output
+      #     @option options [Boolean] :unmerged (false) for unmerged entries, suppress diff output
       #       and show only "Unmerged"
       #
-      #     @option options [Boolean] :base (nil) For unmerged entries, diff against stage 1
+      #     @option options [Boolean] :base (false) for unmerged entries, diff against stage 1
       #       (common ancestor)
       #
       #       Short form: `-1`
       #
-      #     @option options [Boolean] :ours (nil) For unmerged entries, diff against stage 2
+      #     @option options [Boolean] :ours (false) for unmerged entries, diff against stage 2
       #       (our changes)
       #
       #       Short form: `-2`
       #
-      #     @option options [Boolean] :theirs (nil) For unmerged entries, diff against stage 3
+      #     @option options [Boolean] :theirs (false) for unmerged entries, diff against stage 3
       #       (their changes)
       #
       #       Short form: `-3`
       #
-      #     @option options [Boolean] :c (nil) For unmerged entries, show a combined diff of
+      #     @option options [Boolean] :c (false) for unmerged entries, show a combined diff of
       #       stage 2, stage 3, and the working tree
       #
-      #     @option options [Boolean] :cc (nil) Synonym for `c: true`
+      #     @option options [Boolean] :cc (false) synonym for `c: true`
       #
-      #     @option options [Boolean] :patch (nil) Generate unified diff patch output
+      #     @option options [Boolean] :patch (false) generate unified diff patch output
       #
       #       Alias: :p, :u
       #
-      #     @option options [Boolean] :no_patch (nil) Suppress all diff output
+      #     @option options [Boolean] :no_patch (false) suppress all diff output
       #
       #       Alias: :s
       #
-      #     @option options [Boolean] :raw (nil) Generate diff in raw format (default output)
+      #     @option options [Boolean] :raw (false) generate diff in raw format (default output)
       #
-      #     @option options [Boolean] :patch_with_raw (nil) Synonym for `patch: true, raw: true`
+      #     @option options [Boolean] :patch_with_raw (false) synonym for `patch: true, raw: true`
       #
-      #     @option options [Integer, String] :unified (nil) Number of context lines around diff
+      #     @option options [Integer, String] :unified (nil) number of context lines around diff
       #       hunks
       #
       #       Alias: :U
       #
-      #     @option options [String] :output (nil) Write diff output to a file instead of stdout
+      #     @option options [String] :output (nil) write diff output to a file instead of stdout
       #
-      #     @option options [String] :output_indicator_new (nil) Character for new lines in patch output
+      #     @option options [String] :output_indicator_new (nil) character for new lines in patch output
       #
-      #     @option options [String] :output_indicator_old (nil) Character for old lines in patch output
+      #     @option options [String] :output_indicator_old (nil) character for old lines in patch output
       #
-      #     @option options [String] :output_indicator_context (nil) Character for context lines in patch output
+      #     @option options [String] :output_indicator_context (nil) character for context lines in
+      #       patch output
       #
-      #     @option options [Boolean] :indent_heuristic (nil) Shift hunk boundaries for readability
+      #     @option options [Boolean] :indent_heuristic (nil) shift hunk boundaries for readability
       #
       #       Pass `false` to emit `--no-indent-heuristic`.
       #
-      #     @option options [Boolean] :minimal (nil) Spend extra time to minimize diff size
+      #     @option options [Boolean] :minimal (false) spend extra time to minimize diff size
       #
-      #     @option options [Boolean] :patience (nil) Use patience diff algorithm
+      #     @option options [Boolean] :patience (false) use patience diff algorithm
       #
-      #     @option options [Boolean] :histogram (nil) Use histogram diff algorithm
+      #     @option options [Boolean] :histogram (false) use histogram diff algorithm
       #
-      #     @option options [String, Array<String>] :anchored (nil) Anchor lines matching the
+      #     @option options [String, Array<String>] :anchored (nil) anchor lines matching the
       #       given text (repeatable)
       #
-      #     @option options [String] :diff_algorithm (nil) Diff algorithm to use
+      #     @option options [String] :diff_algorithm (nil) diff algorithm to use
       #
       #       Accepted values: `'default'`, `'myers'`, `'minimal'`, `'patience'`, `'histogram'`.
       #
-      #     @option options [Boolean, String] :stat (nil) Show a diffstat
+      #     @option options [Boolean, String] :stat (nil) show a diffstat
       #
       #       Pass `true` for the default format, or a string like `'80,40,5'` for custom limits.
       #
-      #     @option options [Integer, String] :stat_width (nil) Override diffstat total width
+      #     @option options [Integer, String] :stat_width (nil) override diffstat total width
       #
-      #     @option options [Integer, String] :stat_name_width (nil) Override diffstat filename column width
+      #     @option options [Integer, String] :stat_name_width (nil) override diffstat filename
+      #       column width
       #
-      #     @option options [Integer, String] :stat_graph_width (nil) Override diffstat graph column width
+      #     @option options [Integer, String] :stat_graph_width (nil) override diffstat graph
+      #       column width
       #
-      #     @option options [Integer, String] :stat_count (nil) Limit diffstat to this many lines
+      #     @option options [Integer, String] :stat_count (nil) limit diffstat to this many lines
       #
-      #     @option options [Boolean] :compact_summary (nil) Include creation/deletion mode changes in stat
+      #     @option options [Boolean] :compact_summary (false) include creation/deletion mode
+      #       changes in stat
       #
-      #     @option options [Boolean] :numstat (nil) Show per-file insertion/deletion counts (machine-friendly)
+      #     @option options [Boolean] :numstat (false) show per-file insertion/deletion counts
+      #       (machine-friendly)
       #
-      #     @option options [Boolean] :shortstat (nil) Show aggregate totals line only
+      #     @option options [Boolean] :shortstat (false) show aggregate totals line only
       #
-      #     @option options [Boolean, String] :dirstat (nil) Show distribution of changes per directory
+      #     @option options [Boolean, String] :dirstat (nil) show distribution of changes per
+      #       directory
       #
       #       Pass `true` for the default, or a string like `'lines,cumulative,10'` for params.
       #
       #       Alias: :X
       #
-      #     @option options [Boolean] :cumulative (nil) Synonym for `dirstat: 'cumulative'`
+      #     @option options [Boolean] :cumulative (false) synonym for `dirstat: 'cumulative'`
       #
-      #     @option options [Boolean, String] :dirstat_by_file (nil) Synonym for `dirstat: 'files,...'`
+      #     @option options [Boolean, String] :dirstat_by_file (nil) synonym for
+      #       `dirstat: 'files,...'`
       #
-      #     @option options [Boolean] :summary (nil) Show condensed extended header information
+      #     @option options [Boolean] :summary (false) show condensed extended header information
       #
-      #     @option options [Boolean] :patch_with_stat (nil) Synonym for `patch: true, stat: true`
+      #     @option options [Boolean] :patch_with_stat (false) synonym for
+      #       `patch: true, stat: true`
       #
-      #     @option options [Boolean] :z (nil) Use NUL as output field terminator instead of newline
+      #     @option options [Boolean] :z (false) use NUL as output field terminator instead of
+      #       newline
       #
-      #     @option options [Boolean] :name_only (nil) Show only changed file names
+      #     @option options [Boolean] :name_only (false) show only changed file names
       #
-      #     @option options [Boolean] :name_status (nil) Show changed file names with status letters
+      #     @option options [Boolean] :name_status (false) show changed file names with status
+      #       letters
       #
-      #     @option options [Boolean, String] :submodule (nil) How to show submodule differences
+      #     @option options [Boolean, String] :submodule (nil) how to show submodule differences
       #
-      #       Pass `true` for the default, or a string like `'log'` or `'diff'` for a format name.
+      #       Pass `true` for the default, or a string like `'log'` or `'diff'` for a format
+      #       name.
       #
-      #     @option options [Boolean, String] :color (nil) Control diff colorization
+      #     @option options [Boolean, String] :color (nil) control diff colorization
       #
-      #       Pass `true` for `--color`, `false` for `--no-color`, or a string like `'always'` or
-      #       `'auto'` for a specific mode.
+      #       Pass `true` for `--color`, `false` for `--no-color`, or a string like `'always'`
+      #       or `'auto'` for a specific mode.
       #
-      #     @option options [Boolean, String] :color_moved (nil) Color moved lines differently
+      #     @option options [Boolean, String] :color_moved (nil) color moved lines differently
       #
-      #       Pass `true` for default, `false` for `--no-color-moved`, or a mode string such as
-      #       `'zebra'` or `'dimmed-zebra'`.
+      #       Pass `true` for default, `false` for `--no-color-moved`, or a mode string such
+      #       as `'zebra'` or `'dimmed-zebra'`.
       #
-      #     @option options [String] :color_moved_ws (nil) Whitespace handling for moved-line color detection
+      #     @option options [String] :color_moved_ws (nil) whitespace handling for moved-line
+      #       color detection
       #
-      #       Comma-separated list of modes, e.g. `'ignore-space-at-eol,ignore-space-change'`.
+      #       Comma-separated list of modes, e.g.
+      #       `'ignore-space-at-eol,ignore-space-change'`.
       #
-      #     @option options [Boolean] :no_color_moved_ws (nil) Synonym for `color_moved_ws: 'no'`
+      #     @option options [Boolean] :no_color_moved_ws (false) synonym for
+      #       `color_moved_ws: 'no'`
       #
-      #     @option options [Boolean, String] :word_diff (nil) Show a word-level diff
+      #     @option options [Boolean, String] :word_diff (nil) show a word-level diff
       #
-      #       Pass `true` for the default `plain` mode, or a string like `'color'`, `'porcelain'`,
-      #       or `'none'` for a specific mode.
+      #       Pass `true` for the default `plain` mode, or a string like `'color'`,
+      #       `'porcelain'`, or `'none'` for a specific mode.
       #
-      #     @option options [String] :word_diff_regex (nil) Regular expression defining word boundaries
-      #       for word diff
+      #     @option options [String] :word_diff_regex (nil) regular expression defining word
+      #       boundaries for word diff
       #
-      #     @option options [Boolean, String] :color_words (nil) Equivalent to `word_diff: 'color'`
-      #       plus an optional word regex
+      #     @option options [Boolean, String] :color_words (nil) equivalent to
+      #       `word_diff: 'color'` plus an optional word regex
       #
-      #     @option options [Boolean] :ignore_cr_at_eol (nil) Ignore carriage-return at end of line
+      #     @option options [Boolean] :ignore_cr_at_eol (false) ignore carriage-return at end
+      #       of line
       #
-      #     @option options [Boolean] :ignore_space_at_eol (nil) Ignore whitespace changes at end of line
+      #     @option options [Boolean] :ignore_space_at_eol (false) ignore whitespace changes
+      #       at end of line
       #
-      #     @option options [Boolean] :ignore_space_change (nil) Ignore changes in amount of whitespace
+      #     @option options [Boolean] :ignore_space_change (false) ignore changes in amount of
+      #       whitespace
       #
       #       Alias: :b
       #
-      #     @option options [Boolean] :ignore_all_space (nil) Ignore all whitespace when comparing lines
+      #     @option options [Boolean] :ignore_all_space (false) ignore all whitespace when
+      #       comparing lines
       #
       #       Alias: :w
       #
-      #     @option options [Boolean] :ignore_blank_lines (nil) Ignore changes whose lines are all blank
+      #     @option options [Boolean] :ignore_blank_lines (false) ignore changes whose lines
+      #       are all blank
       #
-      #     @option options [String, Array<String>] :ignore_matching_lines (nil) Ignore changes whose
-      #       lines all match the given regex (repeatable)
+      #     @option options [String, Array<String>] :ignore_matching_lines (nil) ignore changes
+      #       whose lines all match the given regex (repeatable)
       #
       #       Alias: :I
       #
-      #     @option options [Boolean] :check (nil) Warn if changes introduce whitespace errors or
-      #       conflict markers
+      #     @option options [Boolean] :check (false) warn if changes introduce whitespace errors
+      #       or conflict markers
       #
-      #     @option options [String] :ws_error_highlight (nil) Highlight whitespace errors in the
-      #       given diff line types (e.g. `'new'`, `'old,new'`, `'all'`)
+      #     @option options [String] :ws_error_highlight (nil) highlight whitespace errors in
+      #       the given diff line types (e.g. `'new'`, `'old,new'`, `'all'`)
       #
-      #     @option options [Boolean] :no_renames (nil) Disable rename detection
+      #     @option options [Boolean] :no_renames (false) disable rename detection
       #
-      #     @option options [Boolean] :rename_empty (nil) Use empty blobs as rename sources
+      #     @option options [Boolean] :rename_empty (nil) use empty blobs as rename sources
       #
       #       Pass `false` to emit `--no-rename-empty`.
       #
-      #     @option options [Boolean] :full_index (nil) Show full blob SHA in index line
+      #     @option options [Boolean] :full_index (false) show full blob SHA in index line
       #
-      #     @option options [Boolean] :binary (nil) Output binary diff suitable for `git apply`
+      #     @option options [Boolean] :binary (false) output binary diff suitable for
+      #       `git apply`
       #
-      #     @option options [Boolean, String] :abbrev (nil) Abbreviate blob names in raw output
+      #     @option options [Boolean, String] :abbrev (nil) abbreviate blob names in raw output
       #
-      #       Pass `true` for the default, or an integer string like `'10'` for a specific length.
+      #       Pass `true` for the default, or an integer string like `'10'` for a specific
+      #       length.
       #
-      #     @option options [Boolean, String] :break_rewrites (nil) Break total rewrites into
+      #     @option options [Boolean, String] :break_rewrites (nil) break total rewrites into
       #       delete-and-create pairs
       #
       #       Alias: :B
       #
-      #     @option options [Boolean, String] :find_renames (nil) Detect renames
+      #     @option options [Boolean, String] :find_renames (nil) detect renames
       #
       #       Pass `true` for the default threshold, or a string like `'90%'` for a custom
       #       similarity threshold.
       #
       #       Alias: :M
       #
-      #     @option options [Boolean, String] :find_copies (nil) Detect copies as well as renames
+      #     @option options [Boolean, String] :find_copies (nil) detect copies as well as
+      #       renames
       #
       #       Pass `true` for the default threshold, or a string like `'75%'` for a custom
       #       similarity threshold.
       #
       #       Alias: :C
       #
-      #     @option options [Boolean] :find_copies_harder (nil) Inspect all unmodified files as
-      #       copy sources (very expensive for large repos)
+      #     @option options [Boolean] :find_copies_harder (false) inspect all unmodified files
+      #       as copy sources (very expensive for large repos)
       #
-      #     @option options [Boolean] :irreversible_delete (nil) Omit preimage for deleted files
+      #     @option options [Boolean] :irreversible_delete (false) omit preimage for deleted
+      #       files
       #
       #       Alias: :D
       #
-      #     @option options [Integer, String] :l (nil) Limit the number of rename/copy candidates
-      #       considered during exhaustive detection
+      #     @option options [Integer, String] :l (nil) limit the number of rename/copy
+      #       candidates considered during exhaustive detection
       #
-      #     @option options [String] :diff_filter (nil) Select only certain kinds of changed files
+      #     @option options [String] :diff_filter (nil) select only certain kinds of changed
+      #       files
       #
       #       A string of status letters such as `'A'`, `'M'`, `'D'`, `'ACDM'`, or lowercase
       #       to exclude.
       #
-      #     @option options [String] :S (nil) Find changes that alter the occurrence count of the
-      #       given string (pickaxe)
+      #     @option options [String] :S (nil) find changes that alter the occurrence count of
+      #       the given string (pickaxe)
       #
-      #     @option options [String] :G (nil) Find changes whose patch text contains lines matching
-      #       the given regex (pickaxe)
+      #     @option options [String] :G (nil) find changes whose patch text contains lines
+      #       matching the given regex (pickaxe)
       #
-      #     @option options [String] :find_object (nil) Find changes involving the given object id
+      #     @option options [String] :find_object (nil) find changes involving the given
+      #       object id
       #
-      #     @option options [Boolean] :pickaxe_all (nil) Show all changes in a changeset when using
-      #       `-S` or `-G`
+      #     @option options [Boolean] :pickaxe_all (false) show all changes in a changeset
+      #       when using `-S` or `-G`
       #
-      #     @option options [Boolean] :pickaxe_regex (nil) Treat the `-S` string as an extended POSIX
-      #       regular expression
+      #     @option options [Boolean] :pickaxe_regex (false) treat the `-S` string as an
+      #       extended POSIX regular expression
       #
-      #     @option options [String] :O (nil) Path to an orderfile controlling output file order
+      #     @option options [String] :O (nil) path to an orderfile controlling output file
+      #       order
       #
-      #     @option options [String] :skip_to (nil) Discard files before the named file in the output
+      #     @option options [String] :skip_to (nil) discard files before the named file in
+      #       the output
       #
-      #     @option options [String] :rotate_to (nil) Move files before the named file to end of output
+      #     @option options [String] :rotate_to (nil) move files before the named file to end
+      #       of output
       #
-      #     @option options [Boolean] :R (nil) Swap the two diff inputs
+      #     @option options [Boolean] :R (false) swap the two diff inputs
       #
-      #     @option options [Boolean, String] :relative (nil) Show paths relative to a directory
+      #     @option options [Boolean, String] :relative (nil) show paths relative to a
+      #       directory
       #
-      #       Pass `true` to use the current directory, `false` for `--no-relative`, or a path
-      #       string to name the directory explicitly.
+      #       Pass `true` to use the current directory, `false` for `--no-relative`, or a
+      #       path string to name the directory explicitly.
       #
-      #     @option options [Boolean] :text (nil) Treat all files as text
+      #     @option options [Boolean] :text (false) treat all files as text
       #
       #       Alias: :a
       #
-      #     @option options [Integer, String] :inter_hunk_context (nil) Show context between diff hunks
-      #       up to this many lines, fusing close hunks
+      #     @option options [Integer, String] :inter_hunk_context (nil) show context between
+      #       diff hunks up to this many lines, fusing close hunks
       #
-      #     @option options [Boolean] :function_context (nil) Show whole function as context for each change
+      #     @option options [Boolean] :function_context (false) show whole function as context
+      #       for each change
       #
       #       Alias: :W
       #
-      #     @option options [Boolean] :exit_code (nil) Exit with status 1 if differences are found,
-      #       0 if none
+      #     @option options [Boolean] :exit_code (false) exit with status 1 if differences
+      #       are found, 0 if none
       #
-      #     @option options [Boolean] :quiet (nil) Suppress all output
+      #     @option options [Boolean] :quiet (false) suppress all output
       #
       #       Implies `--exit-code`.
       #
-      #     @option options [Boolean] :ext_diff (nil) Allow external diff helpers
+      #     @option options [Boolean] :ext_diff (nil) allow external diff helpers
       #
       #       Pass `false` to emit `--no-ext-diff`.
       #
-      #     @option options [Boolean] :textconv (nil) Allow external text-conversion filters
+      #     @option options [Boolean] :textconv (nil) allow external text-conversion filters
       #
       #       Pass `false` to emit `--no-textconv`.
       #
-      #     @option options [Boolean, String] :ignore_submodules (nil) Ignore submodule changes
+      #     @option options [Boolean, String] :ignore_submodules (nil) ignore submodule changes
       #
-      #       Pass `true` for `--ignore-submodules` (equivalent to `'all'`), or a string such as
-      #       `'untracked'`, `'dirty'`, `'none'`, or `'all'`.
+      #       Pass `true` for `--ignore-submodules` (equivalent to `'all'`), or a string such
+      #       as `'untracked'`, `'dirty'`, `'none'`, or `'all'`.
       #
-      #     @option options [String] :src_prefix (nil) Source prefix for diff headers (e.g. `'a/'`)
+      #     @option options [String] :src_prefix (nil) source prefix for diff headers
+      #       (e.g. `'a/'`)
       #
-      #     @option options [String] :dst_prefix (nil) Destination prefix for diff headers (e.g. `'b/'`)
+      #     @option options [String] :dst_prefix (nil) destination prefix for diff headers
+      #       (e.g. `'b/'`)
       #
-      #     @option options [Boolean] :no_prefix (nil) Omit source and destination prefixes
+      #     @option options [Boolean] :no_prefix (false) omit source and destination prefixes
       #
-      #     @option options [Boolean] :default_prefix (nil) Use the default `a/` and `b/` prefixes
+      #     @option options [Boolean] :default_prefix (false) use the default `a/` and `b/`
+      #       prefixes
       #
-      #     @option options [String] :line_prefix (nil) Prepend this prefix to every output line
+      #     @option options [String] :line_prefix (nil) prepend this prefix to every output
+      #       line
       #
-      #     @option options [Boolean] :ita_invisible_in_index (nil) Make `git add -N` entries appear as
-      #       new files in `git diff` and non-existent in `git diff --cached`
+      #     @option options [Boolean] :ita_invisible_in_index (false) make `git add -N` entries
+      #       appear as new files in `git diff` and non-existent in `git diff --cached`
       #
-      #     @option options [Integer, String] :max_depth (nil) Maximum directory depth to descend for
-      #       pathspecs
+      #     @option options [Integer, String] :max_depth (nil) maximum directory depth to
+      #       descend for pathspecs
       #
       #     @return [Git::CommandLineResult] the result of calling `git diff-files`
       #
-      #     @raise [Git::FailedError] if git exits with code >= 2
+      #     @raise [ArgumentError] if unsupported options are provided
       #
-      #   @overload call(*paths, **options)
+      #     @raise [Git::FailedError] if git exits outside the allowed range
+      #       (exit code > 1)
+      #
+      #     @api public
+      #
+      #   @overload call(*path, **options)
       #     Compare the index to the working tree, limiting output to specific paths
       #
-      #     @example Show unstaged changes in a specific directory
-      #       # git diff-files -- lib/
-      #       DiffFiles.new(ctx).call('lib/')
-      #
-      #     @example Show unstaged changes for multiple paths
-      #       # git diff-files -- lib/ spec/
-      #       DiffFiles.new(ctx).call('lib/', 'spec/')
-      #
-      #     @param paths [Array<String>] pathspecs limiting which files are compared
+      #     @param path [Array<String>] pathspecs limiting which files are compared
       #
       #     @param options [Hash] command options (same as the no-path overload)
       #
       #     @return [Git::CommandLineResult] the result of calling `git diff-files`
       #
-      #     @raise [Git::FailedError] if git exits with code >= 2
+      #     @raise [ArgumentError] if unsupported options are provided
+      #
+      #     @raise [Git::FailedError] if git exits outside the allowed range
+      #       (exit code > 1)
+      #
+      #     @api public
     end
   end
 end

--- a/spec/unit/git/commands/describe_spec.rb
+++ b/spec/unit/git/commands/describe_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe Git::Commands::Describe do
 
     context 'with a commit-ish' do
       it 'passes a single commit-ish as a positional argument' do
-        expect_command_capturing('describe', 'abc123').and_return(command_result('v1.0-3-gabc123'))
+        expect_command_capturing('describe', '--', 'abc123').and_return(command_result('v1.0-3-gabc123'))
 
         command.call('abc123')
       end
 
       it 'passes multiple commit-ishes as positional arguments' do
-        expect_command_capturing('describe', 'abc123', 'def456').and_return(command_result("v1.0\nv1.1"))
+        expect_command_capturing('describe', '--', 'abc123', 'def456').and_return(command_result("v1.0\nv1.1"))
 
         command.call('abc123', 'def456')
       end
@@ -200,10 +200,10 @@ RSpec.describe Git::Commands::Describe do
         expect_command_capturing(
           'describe',
           '--tags',
-          '--long',
           '--abbrev=7',
+          '--long',
           '--match', 'v[0-9]*',
-          'HEAD'
+          '--', 'HEAD'
         ).and_return(command_result('v1.0-0-g1234567'))
 
         command.call('HEAD', tags: true, long: true, abbrev: '7', match: 'v[0-9]*')
@@ -213,9 +213,9 @@ RSpec.describe Git::Commands::Describe do
         expect_command_capturing(
           'describe',
           '--tags',
-          '--long',
+          '--abbrev=7',
           '--dirty',
-          '--abbrev=7'
+          '--long'
         ).and_return(command_result('v1.0-0-g1234567-dirty'))
 
         command.call(tags: true, long: true, abbrev: '7', dirty: true)


### PR DESCRIPTION
## Summary

Update three command classes from Batch 6 (top-level A–L) of #1196: `commit_tree`, `describe`, and `diff_files`.

Each class was updated per the command implementation skill:
- Add `@note` annotation audited against git 2.53.0
- Add `@see` cross-references
- Consolidate `@example` into a single idiomatic multi-call block
- Reorder DSL entries to match git SYNOPSIS/OPTIONS ordering
- Add section comments grouping related DSL options
- Fix `flag_option` YARD defaults from `(nil)` to `(false)` per DSL-to-YARD mapping
- Add `end_of_options` before operands where applicable
- Add `@raise` and `@api public` to YARD call docs
- Update unit tests for new DSL emission order and new options

## Commits

- `commit_tree` — update DSL, YARD, and tests
- `describe` — reorder DSL, add `end_of_options`, update tests
- `diff_files` (aka `diff-files`) — update DSL, YARD, and tests

Partially addresses #1196 (Batch 6, row 3).