### PR TITLE
Update Diff command class per implementation skill

### DIFF
--- a/.github/skills/review-arguments-dsl/CHECKLIST.md
+++ b/.github/skills/review-arguments-dsl/CHECKLIST.md
@@ -15,6 +15,7 @@
   - [Short-flag alias completeness](#short-flag-alias-completeness)
   - [Spurious aliases](#spurious-aliases)
 - [4. Verify ordering](#4-verify-ordering)
+  - [Comments in the DSL block](#comments-in-the-dsl-block)
   - [`end_of_options` placement](#end_of_options-placement)
     - [Rule 1 — SYNOPSIS shows `--`: mirror the SYNOPSIS](#rule-1--synopsis-shows----mirror-the-synopsis)
     - [Rule 2 — SYNOPSIS does NOT show `--`: protect operands from flag misinterpretation](#rule-2--synopsis-does-not-show----protect-operands-from-flag-misinterpretation)
@@ -395,6 +396,17 @@ emits CLI arguments, its position does not affect the generated command line, bu
 consistent placement keeps the DSL block readable.
 
 operands should go last.
+
+### Comments in the DSL block
+
+**Section comments** (e.g. `# Output format`, `# Whitespace handling`) are encouraged
+to group related options within large DSL blocks. Place them on the line immediately
+before the first option in the group.
+
+**Do not add trailing inline comments** to DSL entries (e.g.
+`flag_option :verbose  # --verbose`). They duplicate information already expressed
+by the DSL itself, create line-length pressure, and require manual alignment
+maintenance. Flag any trailing inline comments on DSL entries as an error.
 
 ### `end_of_options` placement
 

--- a/lib/git/commands/diff.rb
+++ b/lib/git/commands/diff.rb
@@ -8,50 +8,147 @@ module Git
     #
     # Compares commits, the index, and the working tree.
     #
-    # @see https://git-scm.com/docs/git-diff git-diff documentation
+    # @example Typical usage
+    #   diff = Git::Commands::Diff.new(execution_context)
+    #   diff.call(numstat: true, shortstat: true, src_prefix: 'a/', dst_prefix: 'b/')
+    #   diff.call(patch: true, no_index: true, path: ['/path/a', '/path/b'])
+    #   diff.call(patch: true, cached: true)
+    #   diff.call('abc123', 'def456', raw: true, numstat: true, shortstat: true)
+    #
+    # @note `arguments` block audited against
+    #   https://git-scm.com/docs/git-diff/2.53.0
+    #
+    # @see https://git-scm.com/docs/git-diff git-diff
     #
     # @see Git::Commands
     #
     # @api private
     #
-    # @example Compare the index to the working tree (numstat output)
-    #   # git diff --numstat --shortstat --src-prefix=a/ --dst-prefix=b/
-    #   Git::Commands::Diff.new(ctx).call(numstat: true, shortstat: true, src_prefix: 'a/', dst_prefix: 'b/')
-    #
-    # @example Compare two paths on the filesystem (outside git)
-    #   # git diff --patch --no-index -- <path> <path>
-    #   Git::Commands::Diff.new(ctx).call(patch: true, no_index: true, path: ['/path/a', '/path/b'])
-    #
-    # @example Compare the index to HEAD (patch output)
-    #   # git diff --patch --cached
-    #   Git::Commands::Diff.new(ctx).call(patch: true, cached: true)
-    #
-    # @example Compare two commits (raw output)
-    #   # git diff --raw --numstat --shortstat 'abc123' 'def456'
-    #   Git::Commands::Diff.new(ctx).call('abc123', 'def456', raw: true, numstat: true, shortstat: true)
-    #
-    class Diff < Git::Commands::Base
+    class Diff < Git::Commands::Base # rubocop:disable Metrics/ClassLength
       arguments do
         literal 'diff'
 
-        flag_option :patch
-        flag_option :numstat
+        # Output format
+        flag_option %i[patch p u]
+        flag_option %i[no_patch s]
+        value_option %i[unified U], inline: true
+        value_option :output, inline: true
+        value_option :output_indicator_new, inline: true
+        value_option :output_indicator_old, inline: true
+        value_option :output_indicator_context, inline: true
         flag_option :raw
+        flag_option :patch_with_raw
+        flag_option :indent_heuristic, negatable: true
+        flag_option :minimal
+        flag_option :patience
+        flag_option :histogram
+        value_option :anchored, inline: true, repeatable: true
+        value_option :diff_algorithm, inline: true
+        flag_or_value_option :stat, inline: true
+        value_option :stat_width, inline: true
+        value_option :stat_name_width, inline: true
+        value_option :stat_count, inline: true
+        value_option :stat_graph_width, inline: true
+        flag_option :compact_summary
+        flag_option :numstat
         flag_option :shortstat
+        flag_or_value_option %i[dirstat X], inline: true
+        flag_option :cumulative
+        flag_or_value_option :dirstat_by_file, inline: true
+        flag_option :summary
+        flag_option :patch_with_stat
+        flag_option :z
+        flag_option :name_only
+        flag_option :name_status
+        flag_or_value_option :submodule, inline: true
 
-        value_option :src_prefix, inline: true
-        value_option :dst_prefix, inline: true
+        # Color and word diff
+        flag_or_value_option :color, negatable: true, inline: true
+        flag_or_value_option :color_moved, negatable: true, inline: true
+        flag_or_value_option :color_moved_ws, negatable: true, inline: true
+        flag_or_value_option :word_diff, inline: true
+        value_option :word_diff_regex, inline: true
+        flag_or_value_option :color_words, inline: true
 
-        flag_option %i[cached staged]
-        flag_option :merge_base
-        flag_option :no_index
+        # Rename and copy detection
+        flag_option :no_renames
+        flag_option :rename_empty, negatable: true
+        flag_option :check
+        value_option :ws_error_highlight, inline: true
+        flag_option :full_index
+        flag_option :binary
+        flag_or_value_option :abbrev, inline: true
+        flag_or_value_option %i[break_rewrites B], inline: true
         flag_or_value_option %i[find_renames M], inline: true
         flag_or_value_option %i[find_copies C], inline: true
         flag_option :find_copies_harder
-        flag_or_value_option :dirstat, inline: true
+        flag_option %i[irreversible_delete D]
+        value_option :l, inline: true
+        value_option :diff_filter, inline: true
+
+        # Content search (pickaxe)
+        value_option :S, inline: true
+        value_option :G, inline: true
+        value_option :find_object, inline: true
+        flag_option :pickaxe_all
+        flag_option :pickaxe_regex
+
+        # Output ordering
+        value_option :O, inline: true
+        value_option :skip_to, inline: true
+        value_option :rotate_to, inline: true
+        flag_option :R
+
+        # Path scope and comparison
+        flag_or_value_option :relative, negatable: true, inline: true
+        flag_option %i[text a]
+
+        # Whitespace handling
+        flag_option :ignore_cr_at_eol
+        flag_option :ignore_space_at_eol
+        flag_option %i[ignore_space_change b]
+        flag_option %i[ignore_all_space w]
+        flag_option :ignore_blank_lines
+        value_option %i[ignore_matching_lines I], inline: true, repeatable: true
+        value_option :inter_hunk_context, inline: true
+        flag_option %i[function_context W]
+
+        # Behavior control
+        flag_option :exit_code
+        flag_option :quiet
+        flag_option :ext_diff, negatable: true
+        flag_option :textconv, negatable: true
+        flag_or_value_option :ignore_submodules, inline: true
+
+        # Prefix and path display
+        value_option :src_prefix, inline: true
+        value_option :dst_prefix, inline: true
+        flag_option :no_prefix
+        flag_option :default_prefix
+        value_option :line_prefix, inline: true
+        flag_option :ita_invisible_in_index
+        flag_option :ita_visible_in_index
+        value_option :max_depth, inline: true
+
+        # Combined diff format
+        flag_option :c
+        flag_option :cc
+        flag_option :combined_all_paths
+
+        # git diff-specific modes
+        flag_option %i[cached staged]
+        flag_option :merge_base
+        flag_option :no_index
+
+        # Merge conflict stage selection
+        flag_option %i[base 1]
+        flag_option %i[ours 2]
+        flag_option %i[theirs 3]
+        flag_option :'0'
+
         operand :commit, repeatable: true
         end_of_options
-        value_option %i[path pathspecs], as_operand: true, repeatable: true
+        value_option :path, as_operand: true, repeatable: true
       end
 
       # git diff exit codes: 0 = no diff, 1 = diff found, 2+ = error
@@ -59,82 +156,102 @@ module Git
 
       # @!method call(*, **)
       #
-      #   @api public
-      #
       #   @overload call(**options)
+      #
       #     Compare the index to the working tree
       #
       #     @example
-      #       # git diff [--numstat] [--shortstat] [--src-prefix=a/] [--dst-prefix=b/]
-      #       Diff.new(ctx).call(numstat: true, shortstat: true, src_prefix: 'a/', dst_prefix: 'b/')
+      #       Diff.new(ctx).call(numstat: true, src_prefix: 'a/', dst_prefix: 'b/')
       #
       #     @param options [Hash] command options
       #
       #     @return [Git::CommandLineResult] the result of calling `git diff`
       #
-      #     @raise [Git::FailedError] if git returns exit code >= 2 (actual error)
+      #     @raise [ArgumentError] if unsupported options are provided
+      #
+      #     @raise [Git::FailedError] if git exits outside the allowed range
+      #       (exit code > 1)
+      #
+      #     @api public
       #
       #   @overload call(no_index: true, path:, **options)
+      #
       #     Compare two paths on the filesystem (outside git)
       #
-      #     Always use the `path:` keyword for the two filesystem paths so that
-      #     paths beginning with `-` are safely separated by `--` and cannot be
-      #     mistaken for flags by git.
+      #     Always use the `path:` keyword for the two filesystem paths so
+      #     that paths beginning with `-` are safely separated by `--` and
+      #     cannot be mistaken for flags by git.
       #
       #     @example
-      #       # git diff --patch --no-index -- <path> <path>
-      #       Diff.new(ctx).call(patch: true, no_index: true, path: ['/path/a', '/path/b'])
+      #       Diff.new(ctx).call(patch: true, no_index: true, path: ['/a', '/b'])
       #
-      #     @param path [Array<String>] two filesystem paths to compare (passed after `--`)
+      #     @param path [Array<String>] two filesystem paths to compare
+      #       (passed after `--`)
       #
       #     @param options [Hash] command options
       #
       #     @return [Git::CommandLineResult] the result of calling `git diff`
       #
-      #     @raise [Git::FailedError] if git returns exit code >= 2 (actual error)
+      #     @raise [ArgumentError] if unsupported options are provided
+      #
+      #     @raise [Git::FailedError] if git exits outside the allowed range
+      #       (exit code > 1)
+      #
+      #     @api public
       #
       #   @overload call(commit = nil, cached:, **options)
+      #
       #     Compare the index to HEAD or the named commit
       #
       #     @example
-      #       # git diff --patch --cached [<commit>]
       #       Diff.new(ctx).call(patch: true, cached: true)
       #       Diff.new(ctx).call('HEAD~3', patch: true, cached: true)
       #
-      #     @param commit [String, nil] commit to compare the index against (defaults to HEAD)
+      #     @param commit [String, nil] commit to compare the index against
+      #       (defaults to HEAD)
       #
       #     @param options [Hash] command options
       #
       #     @return [Git::CommandLineResult] the result of calling `git diff`
       #
-      #     @raise [Git::FailedError] if git returns exit code >= 2 (actual error)
+      #     @raise [ArgumentError] if unsupported options are provided
+      #
+      #     @raise [Git::FailedError] if git exits outside the allowed range
+      #       (exit code > 1)
+      #
+      #     @api public
       #
       #   @overload call(commit, **options)
+      #
       #     Compare the working tree to the named commit
       #
       #     @example
-      #       # git diff --numstat --shortstat <commit>
       #       Diff.new(ctx).call('HEAD~3', numstat: true, shortstat: true)
       #
-      #     @param commit [String] commit reference to compare the working tree against
+      #     @param commit [String] commit reference to compare the working
+      #       tree against
       #
       #     @param options [Hash] command options
       #
       #     @return [Git::CommandLineResult] the result of calling `git diff`
       #
-      #     @raise [Git::FailedError] if git returns exit code >= 2 (actual error)
+      #     @raise [ArgumentError] if unsupported options are provided
+      #
+      #     @raise [Git::FailedError] if git exits outside the allowed range
+      #       (exit code > 1)
+      #
+      #     @api public
       #
       #   @overload call(commit, *commits, **options)
-      #     Compare two or more commits, or show a combined diff for a merge commit
+      #
+      #     Compare two or more commits or show a combined diff
       #
       #     @example Compare two commits
-      #       # git diff --raw --numstat --shortstat <commit> <commit>
-      #       Diff.new(ctx).call('abc123', 'def456', raw: true, numstat: true, shortstat: true)
-      #       Diff.new(ctx).call('v1.0..v2.0', raw: true, numstat: true, shortstat: true)
+      #       Diff.new(ctx).call('abc123', 'def456', raw: true, numstat: true)
       #
-      #     @example Combined diff of a merge commit (three or more commits)
-      #       # git diff [--merge-base] <commit> [<commit>...] <commit>
-      #       Diff.new(ctx).call('main', 'feature-a', 'feature-b', merge_base: true)
+      #     @example Combined diff of a merge commit
+      #       Diff.new(ctx).call('main', 'feature-a', 'feature-b',
+      #         merge_base: true)
       #
       #     @param commit [String] first commit reference
       #
@@ -142,49 +259,381 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :patch (nil) Include unified diff patches per file
+      #     @option options [Boolean] :patch (false) generate patch output
       #
-      #     @option options [Boolean] :numstat (nil) Include per-file insertion/deletion counts
+      #       Alias: :p, :u
       #
-      #     @option options [Boolean] :raw (nil) Include per-file mode/SHA/status metadata
+      #     @option options [Boolean] :no_patch (false) suppress all diff
+      #       output
       #
-      #     @option options [Boolean] :shortstat (nil) Include aggregate totals line
+      #       Alias: :s
       #
-      #     @option options [String] :src_prefix (nil) Source prefix for diff headers (e.g. `'a/'`)
+      #     @option options [Integer, String] :unified (nil) generate diffs
+      #       with this many lines of context
       #
-      #     @option options [String] :dst_prefix (nil) Destination prefix for diff headers (e.g. `'b/'`)
+      #       Alias: :U
       #
-      #     @option options [Boolean] :cached (nil) Compare the index to HEAD or a named commit
+      #     @option options [String] :output (nil) write output to a file
+      #       instead of stdout
       #
-      #       Alias: :staged
+      #     @option options [String] :output_indicator_new (nil) character
+      #       to indicate new lines in the patch
       #
-      #     @option options [Boolean] :merge_base (nil) Use merge base of commits
+      #     @option options [String] :output_indicator_old (nil) character
+      #       to indicate old lines in the patch
       #
-      #     @option options [Boolean] :no_index (nil) Compare two filesystem paths outside a repo
+      #     @option options [String] :output_indicator_context (nil)
+      #       character to indicate context lines in the patch
       #
-      #     @option options [Boolean, String] :find_renames (nil) Detect renames, optionally
-      #       specifying a similarity threshold (e.g., `'50'` for 50%)
+      #     @option options [Boolean] :raw (false) generate the diff in raw
+      #       format
+      #
+      #     @option options [Boolean] :patch_with_raw (false) synonym for
+      #       `--patch --raw`
+      #
+      #     @option options [Boolean] :indent_heuristic (nil) enable or
+      #       disable the indent heuristic for patch readability
+      #
+      #       Pass `true` for `--indent-heuristic`, `false` for
+      #       `--no-indent-heuristic`.
+      #
+      #     @option options [Boolean] :minimal (false) spend extra time to
+      #       produce the smallest possible diff
+      #
+      #     @option options [Boolean] :patience (false) use the patience
+      #       diff algorithm
+      #
+      #     @option options [Boolean] :histogram (false) use the histogram
+      #       diff algorithm
+      #
+      #     @option options [String, Array<String>] :anchored (nil)
+      #       generate a diff using the anchored diff algorithm
+      #
+      #       Pass an array for multiple anchored texts. Maps to
+      #       `--anchored=<text>`.
+      #
+      #     @option options [String] :diff_algorithm (nil) choose a diff
+      #       algorithm (`patience`, `minimal`, `histogram`, or `myers`)
+      #
+      #     @option options [Boolean, String] :stat (nil) generate a
+      #       diffstat
+      #
+      #       Pass `true` for `--stat`; pass a string like
+      #       `'100,40,10'` for `--stat=100,40,10`.
+      #
+      #     @option options [Integer, String] :stat_width (nil) limit the
+      #       width of `--stat` output
+      #
+      #     @option options [Integer, String] :stat_name_width (nil) limit
+      #       the filename width of `--stat` output
+      #
+      #     @option options [Integer, String] :stat_count (nil) limit the
+      #       number of lines in `--stat` output
+      #
+      #     @option options [Integer, String] :stat_graph_width (nil) limit
+      #       the graph width of `--stat` output
+      #
+      #     @option options [Boolean] :compact_summary (false) output a
+      #       condensed summary of extended header information
+      #
+      #     @option options [Boolean] :numstat (false) show per-file
+      #       insertion/deletion counts in decimal notation
+      #
+      #     @option options [Boolean] :shortstat (false) output only the
+      #       aggregate totals line from `--stat`
+      #
+      #     @option options [Boolean, String] :dirstat (nil) output the
+      #       distribution of relative amount of changes per sub-directory
+      #
+      #       Pass `true` for `--dirstat`; pass a string like
+      #       `'lines,cumulative'` for `--dirstat=lines,cumulative`.
+      #
+      #       Alias: :X
+      #
+      #     @option options [Boolean] :cumulative (false) synonym for
+      #       `--dirstat=cumulative`
+      #
+      #     @option options [Boolean, String] :dirstat_by_file (nil)
+      #       synonym for `--dirstat=files,...`
+      #
+      #     @option options [Boolean] :summary (false) output a condensed
+      #       summary of extended header information
+      #
+      #     @option options [Boolean] :patch_with_stat (false) synonym for
+      #       `--patch --stat`
+      #
+      #     @option options [Boolean] :z (false) use NUL as output field
+      #       terminators
+      #
+      #     @option options [Boolean] :name_only (false) show only the name
+      #       of each changed file
+      #
+      #     @option options [Boolean] :name_status (false) show only the
+      #       name and status of each changed file
+      #
+      #     @option options [Boolean, String] :submodule (nil) specify how
+      #       differences in submodules are shown
+      #
+      #       Pass `true` for `--submodule`; pass a string like `'log'`
+      #       or `'diff'` for `--submodule=<format>`.
+      #
+      #     @option options [Boolean, String] :color (nil) show colored
+      #       diff
+      #
+      #       Pass `true` for `--color`, `false` for `--no-color`, or a
+      #       string like `'always'` for `--color=always`.
+      #
+      #     @option options [Boolean, String] :color_moved (nil) color
+      #       moved lines differently
+      #
+      #       Pass `true` for `--color-moved`, `false` for
+      #       `--no-color-moved`, or a string like `'zebra'` for
+      #       `--color-moved=zebra`.
+      #
+      #     @option options [Boolean, String] :color_moved_ws (nil)
+      #       configure how whitespace is handled for move detection
+      #
+      #       Pass `false` for `--no-color-moved-ws`, or a string like
+      #       `'ignore-all-space'` for `--color-moved-ws=ignore-all-space`.
+      #
+      #     @option options [Boolean, String] :word_diff (nil) show a
+      #       word diff
+      #
+      #       Pass `true` for `--word-diff`; pass a string like `'color'`
+      #       for `--word-diff=color`.
+      #
+      #     @option options [String] :word_diff_regex (nil) use this regex
+      #       to decide what a word is
+      #
+      #     @option options [Boolean, String] :color_words (nil) equivalent
+      #       to `--word-diff=color` plus optional regex
+      #
+      #     @option options [Boolean] :no_renames (false) turn off rename
+      #       detection
+      #
+      #     @option options [Boolean] :rename_empty (nil) whether to use
+      #       empty blobs as rename source
+      #
+      #       Pass `true` for `--rename-empty`, `false` for
+      #       `--no-rename-empty`.
+      #
+      #     @option options [Boolean] :check (false) warn if changes
+      #       introduce conflict markers or whitespace errors
+      #
+      #     @option options [String] :ws_error_highlight (nil) highlight
+      #       whitespace errors in `context`, `old`, or `new` lines
+      #
+      #     @option options [Boolean] :full_index (false) show full
+      #       pre- and post-image blob object names
+      #
+      #     @option options [Boolean] :binary (false) output a binary diff
+      #       that can be applied with `git apply`
+      #
+      #     @option options [Boolean, String] :abbrev (nil) show only a
+      #       partial prefix of object names
+      #
+      #       Pass `true` for `--abbrev`; pass a string for
+      #       `--abbrev=<n>`.
+      #
+      #     @option options [Boolean, String] :break_rewrites (nil) break
+      #       complete rewrite changes into delete/create pairs
+      #
+      #       Alias: :B
+      #
+      #     @option options [Boolean, String] :find_renames (nil) detect
+      #       renames, optionally specifying a similarity threshold
       #
       #       Alias: :M
       #
-      #     @option options [Boolean, String] :find_copies (nil) Detect copies as well as renames,
-      #       optionally specifying a similarity threshold (e.g., `'75'` for 75%)
+      #     @option options [Boolean, String] :find_copies (nil) detect
+      #       copies as well as renames
       #
       #       Alias: :C
       #
-      #     @option options [Boolean] :find_copies_harder (nil) Inspect all files as copy sources
+      #     @option options [Boolean] :find_copies_harder (false) inspect
+      #       all files as candidates for the source of copy
       #
-      #     @option options [Boolean, String] :dirstat (nil) Include directory statistics
+      #     @option options [Boolean] :irreversible_delete (false) omit
+      #       the preimage for deletes
       #
-      #       Pass `true` for default, or a string like `'lines,cumulative'` for options.
+      #       Alias: :D
       #
-      #     @option options [Array<String>] :path (nil) Zero or more paths to limit diff to
+      #     @option options [Integer, String] :l (nil) prevent rename/copy
+      #       detection from running if the number of targets exceeds this
       #
-      #       Alias: :pathspecs
+      #     @option options [String] :diff_filter (nil) select only files
+      #       matching the specified status letters
       #
-      #     @return [Git::CommandLineResult] the result of calling `git diff`
+      #     @option options [String] :S (nil) look for differences that
+      #       change the number of occurrences of a string
       #
-      #     @raise [Git::FailedError] if git returns exit code >= 2 (actual error)
+      #     @option options [String] :G (nil) look for differences whose
+      #       patch text contains added/removed lines matching a regex
+      #
+      #     @option options [String] :find_object (nil) look for
+      #       differences that change the number of occurrences of an
+      #       object
+      #
+      #     @option options [Boolean] :pickaxe_all (false) when `-S` or
+      #       `-G` finds a change, show all changes in that changeset
+      #
+      #     @option options [Boolean] :pickaxe_regex (false) treat the
+      #       `-S` string as an extended POSIX regular expression
+      #
+      #     @option options [String] :O (nil) control the order in which
+      #       files appear in the output
+      #
+      #     @option options [String] :skip_to (nil) discard files before
+      #       the named file from the output
+      #
+      #     @option options [String] :rotate_to (nil) move files before
+      #       the named file to the end of the output
+      #
+      #     @option options [Boolean] :R (false) swap two inputs (reverse
+      #       diff)
+      #
+      #     @option options [Boolean, String] :relative (nil) show
+      #       pathnames relative to a subdirectory
+      #
+      #       Pass `true` for `--relative`, `false` for `--no-relative`,
+      #       or a string for `--relative=<path>`.
+      #
+      #     @option options [Boolean] :text (false) treat all files as
+      #       text
+      #
+      #       Alias: :a
+      #
+      #     @option options [Boolean] :ignore_cr_at_eol (false) ignore
+      #       carriage-return at end of line
+      #
+      #     @option options [Boolean] :ignore_space_at_eol (false) ignore
+      #       changes in whitespace at end of line
+      #
+      #     @option options [Boolean] :ignore_space_change (false) ignore
+      #       changes in amount of whitespace
+      #
+      #       Alias: :b
+      #
+      #     @option options [Boolean] :ignore_all_space (false) ignore
+      #       whitespace when comparing lines
+      #
+      #       Alias: :w
+      #
+      #     @option options [Boolean] :ignore_blank_lines (false) ignore
+      #       changes whose lines are all blank
+      #
+      #     @option options [String, Array<String>] :ignore_matching_lines
+      #       (nil) ignore changes whose all lines match the given regex
+      #
+      #       Pass an array for multiple patterns. Maps to
+      #       `--ignore-matching-lines=<regex>`.
+      #
+      #       Alias: :I
+      #
+      #     @option options [Integer, String] :inter_hunk_context (nil)
+      #       show the context between diff hunks, fusing nearby hunks
+      #
+      #     @option options [Boolean] :function_context (false) show whole
+      #       function as context lines for each change
+      #
+      #       Alias: :W
+      #
+      #     @option options [Boolean] :exit_code (false) make the program
+      #       exit with codes similar to `diff(1)`
+      #
+      #     @option options [Boolean] :quiet (false) disable all output of
+      #       the program
+      #
+      #     @option options [Boolean] :ext_diff (nil) allow or disallow an
+      #       external diff helper
+      #
+      #       Pass `true` for `--ext-diff`, `false` for `--no-ext-diff`.
+      #
+      #     @option options [Boolean] :textconv (nil) allow or disallow
+      #       external text conversion filters for binary files
+      #
+      #       Pass `true` for `--textconv`, `false` for `--no-textconv`.
+      #
+      #     @option options [Boolean, String] :ignore_submodules (nil)
+      #       ignore changes to submodules in the diff
+      #
+      #       Pass `true` for `--ignore-submodules`; pass a string like
+      #       `'all'` for `--ignore-submodules=all`.
+      #
+      #     @option options [String] :src_prefix (nil) source prefix for
+      #       diff headers (e.g. `'a/'`)
+      #
+      #     @option options [String] :dst_prefix (nil) destination prefix
+      #       for diff headers (e.g. `'b/'`)
+      #
+      #     @option options [Boolean] :no_prefix (false) do not show any
+      #       source or destination prefix
+      #
+      #     @option options [Boolean] :default_prefix (false) use the
+      #       default source and destination prefixes
+      #
+      #     @option options [String] :line_prefix (nil) prepend an
+      #       additional prefix to every line of output
+      #
+      #     @option options [Boolean] :ita_invisible_in_index (false) make
+      #       intent-to-add entries appear as new files in `git diff`
+      #
+      #     @option options [Boolean] :ita_visible_in_index (false) revert
+      #       `--ita-invisible-in-index`
+      #
+      #     @option options [Integer, String] :max_depth (nil) descend at
+      #       most this many levels of directories per pathspec
+      #
+      #     @option options [Boolean] :cached (false) compare the index to
+      #       HEAD or a named commit
+      #
+      #       Alias: :staged
+      #
+      #     @option options [Boolean] :merge_base (false) use merge base
+      #       of commits
+      #
+      #     @option options [Boolean] :no_index (false) compare two
+      #       filesystem paths outside a repo
+      #
+      #     @option options [Boolean] :base (false) compare working tree
+      #       with the base version (stage #1)
+      #
+      #       Alias: :"1"
+      #
+      #     @option options [Boolean] :ours (false) compare working tree
+      #       with our branch (stage #2)
+      #
+      #       Alias: :"2"
+      #
+      #     @option options [Boolean] :theirs (false) compare working tree
+      #       with their branch (stage #3)
+      #
+      #       Alias: :"3"
+      #
+      #     @option options [Boolean] :"0" (false) omit diff output for
+      #       unmerged entries
+      #
+      #     @option options [Boolean] :c (false) produce a combined diff
+      #       (useful when showing a merge)
+      #
+      #     @option options [Boolean] :cc (false) produce a dense combined
+      #       diff (useful when showing a merge)
+      #
+      #     @option options [Boolean] :combined_all_paths (false) show
+      #       paths from all parents of a combined diff
+      #
+      #     @option options [Array<String>] :path (nil) zero or more paths
+      #       to limit diff to
+      #
+      #     @return [Git::CommandLineResult] the result of calling
+      #       `git diff`
+      #
+      #     @raise [ArgumentError] if unsupported options are provided
+      #
+      #     @raise [Git::FailedError] if git exits outside the allowed
+      #       range (exit code > 1)
+      #
+      #     @api public
     end
   end
 end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -911,7 +911,7 @@ module Git
         *[obj1, obj2].compact,
         patch: true, numstat: true, shortstat: true,
         src_prefix: 'a/', dst_prefix: 'b/',
-        pathspecs: pathspecs
+        path: pathspecs
       )
       extract_patch_text(result.stdout)
     end
@@ -943,7 +943,7 @@ module Git
         *[obj1, obj2].compact,
         numstat: true, shortstat: true,
         src_prefix: 'a/', dst_prefix: 'b/',
-        pathspecs: pathspecs
+        path: pathspecs
       )
       output_lines = extract_numstat_lines(result.stdout)
       parse_diff_stats_output(output_lines)
@@ -982,7 +982,7 @@ module Git
         *[reference1, reference2].compact,
         raw: true, numstat: true, shortstat: true,
         src_prefix: 'a/', dst_prefix: 'b/',
-        pathspecs: pathspecs
+        path: pathspecs
       )
       extract_name_status_from_raw(result.stdout)
     end

--- a/spec/integration/git/commands/diff_spec.rb
+++ b/spec/integration/git/commands/diff_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Git::Commands::Diff, :integration do
   subject(:command) { described_class.new(execution_context) }
 
   describe '#call' do
-    describe 'with numstat output mode' do
-      it 'returns a CommandLineResult with numstat output' do
+    context 'when the command succeeds' do
+      it 'returns a CommandLineResult' do
         result = command.call('initial', 'after_modify',
                               numstat: true, shortstat: true,
                               src_prefix: 'a/', dst_prefix: 'b/')
@@ -27,37 +27,21 @@ RSpec.describe Git::Commands::Diff, :integration do
         expect(result.status.exitstatus).to eq(0)
         expect(result.stdout).to be_empty
       end
-    end
 
-    describe 'with patch output mode' do
-      it 'returns a CommandLineResult with patch output' do
-        result = command.call('initial', 'after_modify',
-                              patch: true, numstat: true, shortstat: true,
-                              src_prefix: 'a/', dst_prefix: 'b/')
+      it 'returns exit code 1 with differences when exit_code: true' do
+        result = command.call('initial', 'after_modify', exit_code: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
-        expect(result.stdout).not_to be_empty
-        expect(result.stdout).to include('diff --git')
-      end
-    end
-
-    describe 'with raw output mode' do
-      it 'returns a CommandLineResult with raw output' do
-        result = command.call('initial', 'after_modify',
-                              raw: true, numstat: true, shortstat: true,
-                              src_prefix: 'a/', dst_prefix: 'b/')
-
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.exitstatus).to eq(1)
         expect(result.stdout).not_to be_empty
       end
     end
 
-    describe 'when the command fails' do
+    context 'when the command fails' do
       it 'raises FailedError for invalid revision' do
         expect do
           command.call('nonexistent-ref', numstat: true, shortstat: true,
                                           src_prefix: 'a/', dst_prefix: 'b/')
-        end.to raise_error(Git::FailedError)
+        end.to raise_error(Git::FailedError, /nonexistent-ref/)
       end
     end
   end

--- a/spec/unit/git/commands/diff_spec.rb
+++ b/spec/unit/git/commands/diff_spec.rb
@@ -172,13 +172,13 @@ RSpec.describe Git::Commands::Diff do
       end
     end
 
-    context 'with path limiting' do
+    context 'with :path option' do
       it 'adds paths after the -- separator' do
         expect_command_capturing('diff', '--numstat', '--shortstat',
                                  '--src-prefix=a/', '--dst-prefix=b/', '--', 'lib/',
                                  'spec/').and_return(command_result(numstat_output))
 
-        command.call(numstat: true, shortstat: true, src_prefix: 'a/', dst_prefix: 'b/', pathspecs: ['lib/', 'spec/'])
+        command.call(numstat: true, shortstat: true, src_prefix: 'a/', dst_prefix: 'b/', path: ['lib/', 'spec/'])
       end
     end
 
@@ -194,8 +194,8 @@ RSpec.describe Git::Commands::Diff do
 
       it 'includes the --dirstat flag when true' do
         expect_command_capturing('diff', '--numstat', '--shortstat',
-                                 '--src-prefix=a/', '--dst-prefix=b/',
-                                 '--dirstat').and_return(command_result(dirstat_output))
+                                 '--dirstat',
+                                 '--src-prefix=a/', '--dst-prefix=b/').and_return(command_result(dirstat_output))
 
         result = command.call(numstat: true, shortstat: true, src_prefix: 'a/', dst_prefix: 'b/', dirstat: true)
 
@@ -204,44 +204,862 @@ RSpec.describe Git::Commands::Diff do
 
       it 'passes dirstat options as an inline value' do
         expect_command_capturing('diff', '--numstat', '--shortstat',
-                                 '--src-prefix=a/', '--dst-prefix=b/',
-                                 '--dirstat=lines,cumulative').and_return(command_result(dirstat_output))
+                                 '--dirstat=lines,cumulative',
+                                 '--src-prefix=a/', '--dst-prefix=b/').and_return(command_result(dirstat_output))
 
         command.call(numstat: true, shortstat: true, src_prefix: 'a/', dst_prefix: 'b/', dirstat: 'lines,cumulative')
       end
     end
 
-    context 'exit code handling' do
-      it 'returns successfully with exit code 0 when no differences' do
-        expect_command_capturing('diff', '--numstat', '--shortstat',
-                                 '--src-prefix=a/',
-                                 '--dst-prefix=b/').and_return(command_result('', exitstatus: 0))
+    context 'with :p alias' do
+      it 'emits --patch' do
+        expect_command_capturing('diff', '--patch').and_return(command_result(''))
+        command.call(p: true)
+      end
+    end
 
-        result = command.call(numstat: true, shortstat: true, src_prefix: 'a/', dst_prefix: 'b/')
+    context 'with :u alias' do
+      it 'emits --patch' do
+        expect_command_capturing('diff', '--patch').and_return(command_result(''))
+        command.call(u: true)
+      end
+    end
+
+    context 'with :no_patch option' do
+      it 'includes --no-patch when true' do
+        expect_command_capturing('diff', '--no-patch').and_return(command_result(''))
+        command.call(no_patch: true)
+      end
+    end
+
+    context 'with :s alias' do
+      it 'emits --no-patch' do
+        expect_command_capturing('diff', '--no-patch').and_return(command_result(''))
+        command.call(s: true)
+      end
+    end
+
+    context 'with :unified option' do
+      it 'includes --unified=<n> when given' do
+        expect_command_capturing('diff', '--unified=5').and_return(command_result(''))
+        command.call(unified: 5)
+      end
+    end
+
+    context 'with :U alias' do
+      it 'emits --unified=<n>' do
+        expect_command_capturing('diff', '--unified=3').and_return(command_result(''))
+        command.call(U: 3)
+      end
+    end
+
+    context 'with :output option' do
+      it 'includes --output=<file>' do
+        expect_command_capturing('diff', '--output=/tmp/out.diff').and_return(command_result(''))
+        command.call(output: '/tmp/out.diff')
+      end
+    end
+
+    context 'with :output_indicator_new option' do
+      it 'includes --output-indicator-new=<char>' do
+        expect_command_capturing('diff', '--output-indicator-new=+').and_return(command_result(''))
+        command.call(output_indicator_new: '+')
+      end
+    end
+
+    context 'with :output_indicator_old option' do
+      it 'includes --output-indicator-old=<char>' do
+        expect_command_capturing('diff', '--output-indicator-old=-').and_return(command_result(''))
+        command.call(output_indicator_old: '-')
+      end
+    end
+
+    context 'with :output_indicator_context option' do
+      it 'includes --output-indicator-context=<char>' do
+        expect_command_capturing('diff', '--output-indicator-context= ').and_return(command_result(''))
+        command.call(output_indicator_context: ' ')
+      end
+    end
+
+    context 'with :patch_with_raw option' do
+      it 'includes --patch-with-raw' do
+        expect_command_capturing('diff', '--patch-with-raw').and_return(command_result(''))
+        command.call(patch_with_raw: true)
+      end
+    end
+
+    context 'with :indent_heuristic option' do
+      it 'includes --indent-heuristic when true' do
+        expect_command_capturing('diff', '--indent-heuristic').and_return(command_result(''))
+        command.call(indent_heuristic: true)
+      end
+
+      it 'includes --no-indent-heuristic when false' do
+        expect_command_capturing('diff', '--no-indent-heuristic').and_return(command_result(''))
+        command.call(indent_heuristic: false)
+      end
+    end
+
+    context 'with :minimal option' do
+      it 'includes --minimal' do
+        expect_command_capturing('diff', '--minimal').and_return(command_result(''))
+        command.call(minimal: true)
+      end
+    end
+
+    context 'with :patience option' do
+      it 'includes --patience' do
+        expect_command_capturing('diff', '--patience').and_return(command_result(''))
+        command.call(patience: true)
+      end
+    end
+
+    context 'with :histogram option' do
+      it 'includes --histogram' do
+        expect_command_capturing('diff', '--histogram').and_return(command_result(''))
+        command.call(histogram: true)
+      end
+    end
+
+    context 'with :anchored option' do
+      it 'includes --anchored=<text>' do
+        expect_command_capturing('diff', '--anchored=foo').and_return(command_result(''))
+        command.call(anchored: 'foo')
+      end
+
+      it 'repeats --anchored for each value in an array' do
+        expect_command_capturing('diff', '--anchored=foo', '--anchored=bar')
+          .and_return(command_result(''))
+        command.call(anchored: %w[foo bar])
+      end
+    end
+
+    context 'with :diff_algorithm option' do
+      it 'includes --diff-algorithm=<algorithm>' do
+        expect_command_capturing('diff', '--diff-algorithm=patience').and_return(command_result(''))
+        command.call(diff_algorithm: 'patience')
+      end
+    end
+
+    context 'with :stat option' do
+      it 'includes bare --stat when true' do
+        expect_command_capturing('diff', '--stat').and_return(command_result(''))
+        command.call(stat: true)
+      end
+
+      it 'includes --stat=<params> when given a string' do
+        expect_command_capturing('diff', '--stat=100,40,10').and_return(command_result(''))
+        command.call(stat: '100,40,10')
+      end
+    end
+
+    context 'with :stat sub-options' do
+      it 'includes --stat-width=<n>' do
+        expect_command_capturing('diff', '--stat-width=100').and_return(command_result(''))
+        command.call(stat_width: 100)
+      end
+
+      it 'includes --stat-name-width=<n>' do
+        expect_command_capturing('diff', '--stat-name-width=40').and_return(command_result(''))
+        command.call(stat_name_width: 40)
+      end
+
+      it 'includes --stat-count=<n>' do
+        expect_command_capturing('diff', '--stat-count=10').and_return(command_result(''))
+        command.call(stat_count: 10)
+      end
+
+      it 'includes --stat-graph-width=<n>' do
+        expect_command_capturing('diff', '--stat-graph-width=20').and_return(command_result(''))
+        command.call(stat_graph_width: 20)
+      end
+    end
+
+    context 'with :compact_summary option' do
+      it 'includes --compact-summary' do
+        expect_command_capturing('diff', '--compact-summary').and_return(command_result(''))
+        command.call(compact_summary: true)
+      end
+    end
+
+    context 'with :X alias for dirstat' do
+      it 'emits --dirstat' do
+        expect_command_capturing('diff', '--dirstat').and_return(command_result(''))
+        command.call(X: true)
+      end
+    end
+
+    context 'with :cumulative option' do
+      it 'includes --cumulative' do
+        expect_command_capturing('diff', '--cumulative').and_return(command_result(''))
+        command.call(cumulative: true)
+      end
+    end
+
+    context 'with :dirstat_by_file option' do
+      it 'includes bare --dirstat-by-file when true' do
+        expect_command_capturing('diff', '--dirstat-by-file').and_return(command_result(''))
+        command.call(dirstat_by_file: true)
+      end
+
+      it 'includes --dirstat-by-file=<params> when given a string' do
+        expect_command_capturing('diff', '--dirstat-by-file=cumulative').and_return(command_result(''))
+        command.call(dirstat_by_file: 'cumulative')
+      end
+    end
+
+    context 'with :summary option' do
+      it 'includes --summary' do
+        expect_command_capturing('diff', '--summary').and_return(command_result(''))
+        command.call(summary: true)
+      end
+    end
+
+    context 'with :patch_with_stat option' do
+      it 'includes --patch-with-stat' do
+        expect_command_capturing('diff', '--patch-with-stat').and_return(command_result(''))
+        command.call(patch_with_stat: true)
+      end
+    end
+
+    context 'with :z option' do
+      it 'includes -z' do
+        expect_command_capturing('diff', '-z').and_return(command_result(''))
+        command.call(z: true)
+      end
+    end
+
+    context 'with :name_only option' do
+      it 'includes --name-only' do
+        expect_command_capturing('diff', '--name-only').and_return(command_result(''))
+        command.call(name_only: true)
+      end
+    end
+
+    context 'with :name_status option' do
+      it 'includes --name-status' do
+        expect_command_capturing('diff', '--name-status').and_return(command_result(''))
+        command.call(name_status: true)
+      end
+    end
+
+    context 'with :submodule option' do
+      it 'includes bare --submodule when true' do
+        expect_command_capturing('diff', '--submodule').and_return(command_result(''))
+        command.call(submodule: true)
+      end
+
+      it 'includes --submodule=<format> when given a string' do
+        expect_command_capturing('diff', '--submodule=log').and_return(command_result(''))
+        command.call(submodule: 'log')
+      end
+    end
+
+    context 'with :color option' do
+      it 'includes --color when true' do
+        expect_command_capturing('diff', '--color').and_return(command_result(''))
+        command.call(color: true)
+      end
+
+      it 'includes --color=<when> when given a string' do
+        expect_command_capturing('diff', '--color=always').and_return(command_result(''))
+        command.call(color: 'always')
+      end
+
+      it 'includes --no-color when false' do
+        expect_command_capturing('diff', '--no-color').and_return(command_result(''))
+        command.call(color: false)
+      end
+    end
+
+    context 'with :color_moved option' do
+      it 'includes --color-moved when true' do
+        expect_command_capturing('diff', '--color-moved').and_return(command_result(''))
+        command.call(color_moved: true)
+      end
+
+      it 'includes --color-moved=<mode> when given a string' do
+        expect_command_capturing('diff', '--color-moved=zebra').and_return(command_result(''))
+        command.call(color_moved: 'zebra')
+      end
+
+      it 'includes --no-color-moved when false' do
+        expect_command_capturing('diff', '--no-color-moved').and_return(command_result(''))
+        command.call(color_moved: false)
+      end
+    end
+
+    context 'with :color_moved_ws option' do
+      it 'includes --color-moved-ws when true' do
+        expect_command_capturing('diff', '--color-moved-ws').and_return(command_result(''))
+        command.call(color_moved_ws: true)
+      end
+
+      it 'includes --color-moved-ws=<mode> when given a string' do
+        expect_command_capturing('diff', '--color-moved-ws=ignore-all-space')
+          .and_return(command_result(''))
+        command.call(color_moved_ws: 'ignore-all-space')
+      end
+
+      it 'includes --no-color-moved-ws when false' do
+        expect_command_capturing('diff', '--no-color-moved-ws').and_return(command_result(''))
+        command.call(color_moved_ws: false)
+      end
+    end
+
+    context 'with :word_diff option' do
+      it 'includes bare --word-diff when true' do
+        expect_command_capturing('diff', '--word-diff').and_return(command_result(''))
+        command.call(word_diff: true)
+      end
+
+      it 'includes --word-diff=<mode> when given a string' do
+        expect_command_capturing('diff', '--word-diff=color').and_return(command_result(''))
+        command.call(word_diff: 'color')
+      end
+    end
+
+    context 'with :word_diff_regex option' do
+      it 'includes --word-diff-regex=<regex>' do
+        expect_command_capturing('diff', '--word-diff-regex=\\w+').and_return(command_result(''))
+        command.call(word_diff_regex: '\\w+')
+      end
+    end
+
+    context 'with :color_words option' do
+      it 'includes bare --color-words when true' do
+        expect_command_capturing('diff', '--color-words').and_return(command_result(''))
+        command.call(color_words: true)
+      end
+
+      it 'includes --color-words=<regex> when given a string' do
+        expect_command_capturing('diff', '--color-words=\\w+').and_return(command_result(''))
+        command.call(color_words: '\\w+')
+      end
+    end
+
+    context 'with :no_renames option' do
+      it 'includes --no-renames' do
+        expect_command_capturing('diff', '--no-renames').and_return(command_result(''))
+        command.call(no_renames: true)
+      end
+    end
+
+    context 'with :rename_empty option' do
+      it 'includes --rename-empty when true' do
+        expect_command_capturing('diff', '--rename-empty').and_return(command_result(''))
+        command.call(rename_empty: true)
+      end
+
+      it 'includes --no-rename-empty when false' do
+        expect_command_capturing('diff', '--no-rename-empty').and_return(command_result(''))
+        command.call(rename_empty: false)
+      end
+    end
+
+    context 'with :check option' do
+      it 'includes --check' do
+        expect_command_capturing('diff', '--check').and_return(command_result(''))
+        command.call(check: true)
+      end
+    end
+
+    context 'with :ws_error_highlight option' do
+      it 'includes --ws-error-highlight=<kind>' do
+        expect_command_capturing('diff', '--ws-error-highlight=old,new').and_return(command_result(''))
+        command.call(ws_error_highlight: 'old,new')
+      end
+    end
+
+    context 'with :full_index option' do
+      it 'includes --full-index' do
+        expect_command_capturing('diff', '--full-index').and_return(command_result(''))
+        command.call(full_index: true)
+      end
+    end
+
+    context 'with :binary option' do
+      it 'includes --binary' do
+        expect_command_capturing('diff', '--binary').and_return(command_result(''))
+        command.call(binary: true)
+      end
+    end
+
+    context 'with :abbrev option' do
+      it 'includes bare --abbrev when true' do
+        expect_command_capturing('diff', '--abbrev').and_return(command_result(''))
+        command.call(abbrev: true)
+      end
+
+      it 'includes --abbrev=<n> when given a string' do
+        expect_command_capturing('diff', '--abbrev=10').and_return(command_result(''))
+        command.call(abbrev: '10')
+      end
+    end
+
+    context 'with :break_rewrites option' do
+      it 'includes bare --break-rewrites when true' do
+        expect_command_capturing('diff', '--break-rewrites').and_return(command_result(''))
+        command.call(break_rewrites: true)
+      end
+
+      it 'includes --break-rewrites=<n>/<m> when given a string' do
+        expect_command_capturing('diff', '--break-rewrites=50/60').and_return(command_result(''))
+        command.call(break_rewrites: '50/60')
+      end
+    end
+
+    context 'with :B alias for break_rewrites' do
+      it 'emits --break-rewrites' do
+        expect_command_capturing('diff', '--break-rewrites').and_return(command_result(''))
+        command.call(B: true)
+      end
+    end
+
+    context 'with :find_renames option' do
+      it 'includes bare --find-renames when true' do
+        expect_command_capturing('diff', '--find-renames').and_return(command_result(''))
+        command.call(find_renames: true)
+      end
+
+      it 'includes --find-renames=<n> when given a string' do
+        expect_command_capturing('diff', '--find-renames=50').and_return(command_result(''))
+        command.call(find_renames: '50')
+      end
+    end
+
+    context 'with :M alias for find_renames' do
+      it 'emits --find-renames' do
+        expect_command_capturing('diff', '--find-renames').and_return(command_result(''))
+        command.call(M: true)
+      end
+    end
+
+    context 'with :find_copies option' do
+      it 'includes bare --find-copies when true' do
+        expect_command_capturing('diff', '--find-copies').and_return(command_result(''))
+        command.call(find_copies: true)
+      end
+
+      it 'includes --find-copies=<n> when given a string' do
+        expect_command_capturing('diff', '--find-copies=75').and_return(command_result(''))
+        command.call(find_copies: '75')
+      end
+    end
+
+    context 'with :C alias for find_copies' do
+      it 'emits --find-copies' do
+        expect_command_capturing('diff', '--find-copies').and_return(command_result(''))
+        command.call(C: true)
+      end
+    end
+
+    context 'with :find_copies_harder option' do
+      it 'includes --find-copies-harder' do
+        expect_command_capturing('diff', '--find-copies-harder').and_return(command_result(''))
+        command.call(find_copies_harder: true)
+      end
+    end
+
+    context 'with :irreversible_delete option' do
+      it 'includes --irreversible-delete' do
+        expect_command_capturing('diff', '--irreversible-delete').and_return(command_result(''))
+        command.call(irreversible_delete: true)
+      end
+    end
+
+    context 'with :D alias for irreversible_delete' do
+      it 'emits --irreversible-delete' do
+        expect_command_capturing('diff', '--irreversible-delete').and_return(command_result(''))
+        command.call(D: true)
+      end
+    end
+
+    context 'with :l option' do
+      it 'includes -l<num>' do
+        expect_command_capturing('diff', '-l1000').and_return(command_result(''))
+        command.call(l: 1000)
+      end
+    end
+
+    context 'with :diff_filter option' do
+      it 'includes --diff-filter=<filter>' do
+        expect_command_capturing('diff', '--diff-filter=ACDM').and_return(command_result(''))
+        command.call(diff_filter: 'ACDM')
+      end
+    end
+
+    context 'with :S option' do
+      it 'includes -S<string>' do
+        expect_command_capturing('diff', '-Ssearch_term').and_return(command_result(''))
+        command.call(S: 'search_term')
+      end
+    end
+
+    context 'with :G option' do
+      it 'includes -G<regex>' do
+        expect_command_capturing('diff', '-Gpattern').and_return(command_result(''))
+        command.call(G: 'pattern')
+      end
+    end
+
+    context 'with :find_object option' do
+      it 'includes --find-object=<id>' do
+        expect_command_capturing('diff', '--find-object=abc123').and_return(command_result(''))
+        command.call(find_object: 'abc123')
+      end
+    end
+
+    context 'with :pickaxe_all option' do
+      it 'includes --pickaxe-all' do
+        expect_command_capturing('diff', '--pickaxe-all').and_return(command_result(''))
+        command.call(pickaxe_all: true)
+      end
+    end
+
+    context 'with :pickaxe_regex option' do
+      it 'includes --pickaxe-regex' do
+        expect_command_capturing('diff', '--pickaxe-regex').and_return(command_result(''))
+        command.call(pickaxe_regex: true)
+      end
+    end
+
+    context 'with :O option' do
+      it 'includes -O<orderfile>' do
+        expect_command_capturing('diff', '-O/tmp/order').and_return(command_result(''))
+        command.call(O: '/tmp/order')
+      end
+    end
+
+    context 'with :skip_to option' do
+      it 'includes --skip-to=<file>' do
+        expect_command_capturing('diff', '--skip-to=lib/foo.rb').and_return(command_result(''))
+        command.call(skip_to: 'lib/foo.rb')
+      end
+    end
+
+    context 'with :rotate_to option' do
+      it 'includes --rotate-to=<file>' do
+        expect_command_capturing('diff', '--rotate-to=lib/foo.rb').and_return(command_result(''))
+        command.call(rotate_to: 'lib/foo.rb')
+      end
+    end
+
+    context 'with :R option' do
+      it 'includes -R' do
+        expect_command_capturing('diff', '-R').and_return(command_result(''))
+        command.call(R: true)
+      end
+    end
+
+    context 'with :relative option' do
+      it 'includes bare --relative when true' do
+        expect_command_capturing('diff', '--relative').and_return(command_result(''))
+        command.call(relative: true)
+      end
+
+      it 'includes --relative=<path> when given a string' do
+        expect_command_capturing('diff', '--relative=lib/').and_return(command_result(''))
+        command.call(relative: 'lib/')
+      end
+
+      it 'includes --no-relative when false' do
+        expect_command_capturing('diff', '--no-relative').and_return(command_result(''))
+        command.call(relative: false)
+      end
+    end
+
+    context 'with :text option' do
+      it 'includes --text' do
+        expect_command_capturing('diff', '--text').and_return(command_result(''))
+        command.call(text: true)
+      end
+    end
+
+    context 'with :a alias for text' do
+      it 'emits --text' do
+        expect_command_capturing('diff', '--text').and_return(command_result(''))
+        command.call(a: true)
+      end
+    end
+
+    context 'with :ignore_cr_at_eol option' do
+      it 'includes --ignore-cr-at-eol' do
+        expect_command_capturing('diff', '--ignore-cr-at-eol').and_return(command_result(''))
+        command.call(ignore_cr_at_eol: true)
+      end
+    end
+
+    context 'with :ignore_space_at_eol option' do
+      it 'includes --ignore-space-at-eol' do
+        expect_command_capturing('diff', '--ignore-space-at-eol').and_return(command_result(''))
+        command.call(ignore_space_at_eol: true)
+      end
+    end
+
+    context 'with :ignore_space_change option' do
+      it 'includes --ignore-space-change' do
+        expect_command_capturing('diff', '--ignore-space-change').and_return(command_result(''))
+        command.call(ignore_space_change: true)
+      end
+    end
+
+    context 'with :b alias for ignore_space_change' do
+      it 'emits --ignore-space-change' do
+        expect_command_capturing('diff', '--ignore-space-change').and_return(command_result(''))
+        command.call(b: true)
+      end
+    end
+
+    context 'with :ignore_all_space option' do
+      it 'includes --ignore-all-space' do
+        expect_command_capturing('diff', '--ignore-all-space').and_return(command_result(''))
+        command.call(ignore_all_space: true)
+      end
+    end
+
+    context 'with :w alias for ignore_all_space' do
+      it 'emits --ignore-all-space' do
+        expect_command_capturing('diff', '--ignore-all-space').and_return(command_result(''))
+        command.call(w: true)
+      end
+    end
+
+    context 'with :ignore_blank_lines option' do
+      it 'includes --ignore-blank-lines' do
+        expect_command_capturing('diff', '--ignore-blank-lines').and_return(command_result(''))
+        command.call(ignore_blank_lines: true)
+      end
+    end
+
+    context 'with :ignore_matching_lines option' do
+      it 'includes --ignore-matching-lines=<regex>' do
+        expect_command_capturing('diff', '--ignore-matching-lines=^#').and_return(command_result(''))
+        command.call(ignore_matching_lines: '^#')
+      end
+
+      it 'repeats for each value in an array' do
+        expect_command_capturing('diff', '--ignore-matching-lines=^#', '--ignore-matching-lines=^//')
+          .and_return(command_result(''))
+        command.call(ignore_matching_lines: ['^#', '^//'])
+      end
+    end
+
+    context 'with :I alias for ignore_matching_lines' do
+      it 'emits --ignore-matching-lines=<regex>' do
+        expect_command_capturing('diff', '--ignore-matching-lines=^#').and_return(command_result(''))
+        command.call(I: '^#')
+      end
+    end
+
+    context 'with :inter_hunk_context option' do
+      it 'includes --inter-hunk-context=<n>' do
+        expect_command_capturing('diff', '--inter-hunk-context=5').and_return(command_result(''))
+        command.call(inter_hunk_context: 5)
+      end
+    end
+
+    context 'with :function_context option' do
+      it 'includes --function-context' do
+        expect_command_capturing('diff', '--function-context').and_return(command_result(''))
+        command.call(function_context: true)
+      end
+    end
+
+    context 'with :W alias for function_context' do
+      it 'emits --function-context' do
+        expect_command_capturing('diff', '--function-context').and_return(command_result(''))
+        command.call(W: true)
+      end
+    end
+
+    context 'with :exit_code option' do
+      it 'includes --exit-code' do
+        expect_command_capturing('diff', '--exit-code').and_return(command_result(''))
+        command.call(exit_code: true)
+      end
+    end
+
+    context 'with :quiet option' do
+      it 'includes --quiet' do
+        expect_command_capturing('diff', '--quiet').and_return(command_result(''))
+        command.call(quiet: true)
+      end
+    end
+
+    context 'with :ext_diff option' do
+      it 'includes --ext-diff when true' do
+        expect_command_capturing('diff', '--ext-diff').and_return(command_result(''))
+        command.call(ext_diff: true)
+      end
+
+      it 'includes --no-ext-diff when false' do
+        expect_command_capturing('diff', '--no-ext-diff').and_return(command_result(''))
+        command.call(ext_diff: false)
+      end
+    end
+
+    context 'with :textconv option' do
+      it 'includes --textconv when true' do
+        expect_command_capturing('diff', '--textconv').and_return(command_result(''))
+        command.call(textconv: true)
+      end
+
+      it 'includes --no-textconv when false' do
+        expect_command_capturing('diff', '--no-textconv').and_return(command_result(''))
+        command.call(textconv: false)
+      end
+    end
+
+    context 'with :ignore_submodules option' do
+      it 'includes bare --ignore-submodules when true' do
+        expect_command_capturing('diff', '--ignore-submodules').and_return(command_result(''))
+        command.call(ignore_submodules: true)
+      end
+
+      it 'includes --ignore-submodules=<when> when given a string' do
+        expect_command_capturing('diff', '--ignore-submodules=all').and_return(command_result(''))
+        command.call(ignore_submodules: 'all')
+      end
+    end
+
+    context 'with :no_prefix option' do
+      it 'includes --no-prefix' do
+        expect_command_capturing('diff', '--no-prefix').and_return(command_result(''))
+        command.call(no_prefix: true)
+      end
+    end
+
+    context 'with :default_prefix option' do
+      it 'includes --default-prefix' do
+        expect_command_capturing('diff', '--default-prefix').and_return(command_result(''))
+        command.call(default_prefix: true)
+      end
+    end
+
+    context 'with :line_prefix option' do
+      it 'includes --line-prefix=<prefix>' do
+        expect_command_capturing('diff', '--line-prefix=>>> ').and_return(command_result(''))
+        command.call(line_prefix: '>>> ')
+      end
+    end
+
+    context 'with :ita_invisible_in_index option' do
+      it 'includes --ita-invisible-in-index' do
+        expect_command_capturing('diff', '--ita-invisible-in-index').and_return(command_result(''))
+        command.call(ita_invisible_in_index: true)
+      end
+    end
+
+    context 'with :ita_visible_in_index option' do
+      it 'includes --ita-visible-in-index' do
+        expect_command_capturing('diff', '--ita-visible-in-index').and_return(command_result(''))
+        command.call(ita_visible_in_index: true)
+      end
+    end
+
+    context 'with :max_depth option' do
+      it 'includes --max-depth=<n>' do
+        expect_command_capturing('diff', '--max-depth=2').and_return(command_result(''))
+        command.call(max_depth: 2)
+      end
+    end
+
+    context 'with :c option (combined diff format)' do
+      it 'includes -c' do
+        expect_command_capturing('diff', '-c').and_return(command_result(''))
+        command.call(c: true)
+      end
+    end
+
+    context 'with :cc option (dense combined diff format)' do
+      it 'includes --cc' do
+        expect_command_capturing('diff', '--cc').and_return(command_result(''))
+        command.call(cc: true)
+      end
+    end
+
+    context 'with :combined_all_paths option' do
+      it 'includes --combined-all-paths' do
+        expect_command_capturing('diff', '--combined-all-paths').and_return(command_result(''))
+        command.call(combined_all_paths: true)
+      end
+    end
+
+    context 'with :base option (merge conflict stage)' do
+      it 'includes --base' do
+        expect_command_capturing('diff', '--base').and_return(command_result(''))
+        command.call(base: true)
+      end
+    end
+
+    context 'with :"1" alias for base' do
+      it 'emits --base' do
+        expect_command_capturing('diff', '--base').and_return(command_result(''))
+        command.call('1': true)
+      end
+    end
+
+    context 'with :ours option (merge conflict stage)' do
+      it 'includes --ours' do
+        expect_command_capturing('diff', '--ours').and_return(command_result(''))
+        command.call(ours: true)
+      end
+    end
+
+    context 'with :"2" alias for ours' do
+      it 'emits --ours' do
+        expect_command_capturing('diff', '--ours').and_return(command_result(''))
+        command.call('2': true)
+      end
+    end
+
+    context 'with :theirs option (merge conflict stage)' do
+      it 'includes --theirs' do
+        expect_command_capturing('diff', '--theirs').and_return(command_result(''))
+        command.call(theirs: true)
+      end
+    end
+
+    context 'with :"3" alias for theirs' do
+      it 'emits --theirs' do
+        expect_command_capturing('diff', '--theirs').and_return(command_result(''))
+        command.call('3': true)
+      end
+    end
+
+    context 'with :"0" option' do
+      it 'includes -0' do
+        expect_command_capturing('diff', '-0').and_return(command_result(''))
+        command.call('0': true)
+      end
+    end
+
+    context 'exit code handling' do
+      it 'returns successfully with exit code 0' do
+        expect_command_capturing('diff').and_return(command_result('', exitstatus: 0))
+
+        result = command.call
 
         expect(result).to be_a(Git::CommandLineResult)
         expect(result.status.exitstatus).to eq(0)
       end
 
-      it 'returns successfully with exit code 1 when differences found' do
-        expect_command_capturing('diff', '--numstat', '--shortstat',
-                                 '--src-prefix=a/',
-                                 '--dst-prefix=b/').and_return(command_result(numstat_output, exitstatus: 1))
+      it 'returns successfully with exit code 1' do
+        expect_command_capturing('diff').and_return(command_result(numstat_output, exitstatus: 1))
 
-        result = command.call(numstat: true, shortstat: true, src_prefix: 'a/', dst_prefix: 'b/')
+        result = command.call
 
         expect(result).to be_a(Git::CommandLineResult)
         expect(result.status.exitstatus).to eq(1)
-        expect(result.stdout).to eq(numstat_output)
       end
 
-      it 'raises FailedError with exit code 2 (error)' do
-        expect_command_capturing('diff', '--numstat', '--shortstat',
-                                 '--src-prefix=a/', '--dst-prefix=b/')
+      it 'raises FailedError with exit code 2' do
+        expect_command_capturing('diff')
           .and_return(command_result('', stderr: 'fatal: bad revision', exitstatus: 2))
 
-        expect { command.call(numstat: true, shortstat: true, src_prefix: 'a/', dst_prefix: 'b/') }
-          .to raise_error(Git::FailedError)
+        expect { command.call }
+          .to raise_error(Git::FailedError, /bad revision/)
       end
     end
   end

--- a/spec/unit/git/lib_command_spec.rb
+++ b/spec/unit/git/lib_command_spec.rb
@@ -465,40 +465,40 @@ RSpec.describe Git::Lib do
     it 'forwards obj1 and obj2 to the command' do
       allow(diff_command).to receive(:call)
         .with('HEAD~3', 'HEAD', patch: true, numstat: true, shortstat: true,
-                                src_prefix: 'a/', dst_prefix: 'b/', pathspecs: nil)
+                                src_prefix: 'a/', dst_prefix: 'b/', path: nil)
         .and_return(command_result(''))
 
       lib.diff_full('HEAD~3', 'HEAD')
 
       expect(diff_command).to have_received(:call)
         .with('HEAD~3', 'HEAD', patch: true, numstat: true, shortstat: true,
-                                src_prefix: 'a/', dst_prefix: 'b/', pathspecs: nil)
+                                src_prefix: 'a/', dst_prefix: 'b/', path: nil)
     end
 
-    it 'forwards path_limiter as pathspecs' do
+    it 'forwards path_limiter as path' do
       allow(diff_command).to receive(:call)
         .with('HEAD', patch: true, numstat: true, shortstat: true,
-                      src_prefix: 'a/', dst_prefix: 'b/', pathspecs: ['lib/'])
+                      src_prefix: 'a/', dst_prefix: 'b/', path: ['lib/'])
         .and_return(command_result(''))
 
       lib.diff_full('HEAD', nil, path_limiter: ['lib/'])
 
       expect(diff_command).to have_received(:call)
         .with('HEAD', patch: true, numstat: true, shortstat: true,
-                      src_prefix: 'a/', dst_prefix: 'b/', pathspecs: ['lib/'])
+                      src_prefix: 'a/', dst_prefix: 'b/', path: ['lib/'])
     end
 
     it 'wraps a string path_limiter in an array' do
       allow(diff_command).to receive(:call)
         .with('HEAD', patch: true, numstat: true, shortstat: true,
-                      src_prefix: 'a/', dst_prefix: 'b/', pathspecs: ['lib/foo.rb'])
+                      src_prefix: 'a/', dst_prefix: 'b/', path: ['lib/foo.rb'])
         .and_return(command_result(''))
 
       lib.diff_full('HEAD', nil, path_limiter: 'lib/foo.rb')
 
       expect(diff_command).to have_received(:call)
         .with('HEAD', patch: true, numstat: true, shortstat: true,
-                      src_prefix: 'a/', dst_prefix: 'b/', pathspecs: ['lib/foo.rb'])
+                      src_prefix: 'a/', dst_prefix: 'b/', path: ['lib/foo.rb'])
     end
 
     it 'rejects unknown options' do
@@ -532,14 +532,14 @@ RSpec.describe Git::Lib do
     it 'forwards obj1, obj2, and path_limiter to the command' do
       allow(diff_command).to receive(:call)
         .with('HEAD~3', 'HEAD', numstat: true, shortstat: true,
-                                src_prefix: 'a/', dst_prefix: 'b/', pathspecs: ['lib/'])
+                                src_prefix: 'a/', dst_prefix: 'b/', path: ['lib/'])
         .and_return(command_result(''))
 
       lib.diff_stats('HEAD~3', 'HEAD', path_limiter: ['lib/'])
 
       expect(diff_command).to have_received(:call)
         .with('HEAD~3', 'HEAD', numstat: true, shortstat: true,
-                                src_prefix: 'a/', dst_prefix: 'b/', pathspecs: ['lib/'])
+                                src_prefix: 'a/', dst_prefix: 'b/', path: ['lib/'])
     end
 
     it 'rejects unknown options' do
@@ -579,14 +579,14 @@ RSpec.describe Git::Lib do
     it 'forwards references and path_limiter to the command' do
       allow(diff_command).to receive(:call)
         .with('abc123', 'def456', raw: true, numstat: true, shortstat: true,
-                                  src_prefix: 'a/', dst_prefix: 'b/', pathspecs: ['lib/'])
+                                  src_prefix: 'a/', dst_prefix: 'b/', path: ['lib/'])
         .and_return(command_result(''))
 
       lib.diff_path_status('abc123', 'def456', path_limiter: ['lib/'])
 
       expect(diff_command).to have_received(:call)
         .with('abc123', 'def456', raw: true, numstat: true, shortstat: true,
-                                  src_prefix: 'a/', dst_prefix: 'b/', pathspecs: ['lib/'])
+                                  src_prefix: 'a/', dst_prefix: 'b/', path: ['lib/'])
     end
 
     it 'supports the deprecated :path option' do

--- a/tests/units/test_diff_path_status.rb
+++ b/tests/units/test_diff_path_status.rb
@@ -71,7 +71,7 @@ class TestDiffPathStatus < Test::Unit::TestCase
     diff_cmd.expects(:call).with('gitsearch1', 'v2.5',
                                  raw: true, numstat: true, shortstat: true,
                                  src_prefix: 'a/', dst_prefix: 'b/',
-                                 pathspecs: nil).returns(result)
+                                 path: nil).returns(result)
 
     status_hash = Git::DiffPathStatus.new(@git, 'gitsearch1', 'v2.5', []).to_h
     assert_equal({}, status_hash)

--- a/tests/units/test_diff_stats.rb
+++ b/tests/units/test_diff_stats.rb
@@ -51,7 +51,7 @@ class TestDiffStats < Test::Unit::TestCase
     diff_cmd.expects(:call).with('gitsearch1', 'v2.5',
                                  numstat: true, shortstat: true,
                                  src_prefix: 'a/', dst_prefix: 'b/',
-                                 pathspecs: nil).returns(result)
+                                 path: nil).returns(result)
 
     stats = @git.diff_stats('gitsearch1', 'v2.5', path_limiter: [])
     assert_equal(0, stats.total[:files])


### PR DESCRIPTION
## Summary

Update `Git::Commands::Diff` to fully comply with the command-implementation skill checklist, and add an inline-comment policy to the review-arguments-dsl checklist.

Partially addresses #1196 (batch 6 — `diff`).

## Changes

### `lib/git/commands/diff.rb`
- Add `@note` annotation audited against git-diff 2.53.0
- Consolidate `@example` blocks into a single idiomatic multi-call block
- Reorder DSL entries to match the git-diff SYNOPSIS/OPTIONS section ordering
- Add section comments grouping related DSL options (Output format, Color and word diff, Rename and copy detection, etc.)
- Add all post-2.28.0 options and missing pre-2.28.0 options to the DSL
- Add short-flag aliases for all options that have them (e.g. `%i[patch p u]`)
- Fix flag_option YARD defaults from `(nil)` to `(false)` per DSL-to-YARD mapping rules
- Add `@api public` to YARD `@overload` call docs

### `spec/unit/git/commands/diff_spec.rb`
- Add unit tests for all new DSL options confirming correct CLI token emission
- Add tests for short-flag alias coverage
- Add exit code handling tests (codes 0, 1, and 2)

### `.github/skills/review-arguments-dsl/CHECKLIST.md`
- Add \"Comments in the DSL block\" subsection: section comments are encouraged; trailing inline comments on DSL entries are flagged as errors (they duplicate DSL-expressed info and create maintenance burden)