### PR TITLE
Update Fetch command class per implementation skill

### DIFF
--- a/lib/git/commands/fetch.rb
+++ b/lib/git/commands/fetch.rb
@@ -10,62 +10,70 @@ module Git
     # and/or tags from one or more other repositories, along with the objects
     # necessary to complete their histories.
     #
-    # @see https://git-scm.com/docs/git-fetch git-fetch documentation
-    #
-    # @api private
-    #
-    # @example Fetch from the default remote
+    # @example Typical usage
     #   fetch = Git::Commands::Fetch.new(execution_context)
     #   fetch.call
-    #
-    # @example Fetch from a named remote
-    #   fetch = Git::Commands::Fetch.new(execution_context)
     #   fetch.call('origin')
-    #
-    # @example Fetch a specific refspec from a remote
-    #   fetch = Git::Commands::Fetch.new(execution_context)
     #   fetch.call('origin', 'refs/heads/main')
-    #
-    # @example Fetch all remotes with pruning
-    #   fetch = Git::Commands::Fetch.new(execution_context)
     #   fetch.call(all: true, prune: true)
-    #
-    # @example Fetch with stderr merged into stdout (for capturing fetch output)
-    #   fetch = Git::Commands::Fetch.new(execution_context)
     #   fetch.call('origin', merge: true)
+    #
+    # @note `arguments` block audited against
+    #   https://git-scm.com/docs/git-fetch/2.53.0
+    #
+    # @see https://git-scm.com/docs/git-fetch git-fetch
+    #
+    # @see Git::Commands
+    #
+    # @api private
     #
     class Fetch < Git::Commands::Base
       arguments do
         literal 'fetch'
 
-        # Remotes and fetching scope
+        # Remote scope
         flag_option :all, negatable: true
         flag_option %i[append a]
         flag_option :atomic
 
         # Shallow clone controls
-        value_option :depth
-        value_option :deepen
+        value_option :depth, inline: true
+        value_option :deepen, inline: true
         value_option :shallow_since, inline: true
         value_option :shallow_exclude,
                      inline: true, repeatable: true
         flag_option :unshallow
         flag_option :update_shallow
 
-        # Output and behavior
+        # Negotiation
+        value_option :negotiation_tip, inline: true, repeatable: true
+        flag_option :negotiate_only
+
+        # Output and dry-run
         flag_option :dry_run
+        flag_option :porcelain
         flag_option :write_fetch_head, negatable: true
-        flag_option :refetch
-        flag_option :prefetch
 
         # Safety and update control
         flag_option %i[force f]
         flag_option %i[keep k]
         flag_option :multiple
 
+        # Maintenance
+        flag_option :auto_maintenance, negatable: true
+        flag_option :auto_gc, negatable: true
+        flag_option :write_commit_graph, negatable: true
+
+        # Prefetching
+        flag_option :prefetch
+
         # Pruning
         flag_option %i[prune p]
         flag_option %i[prune_tags P]
+
+        # Refetching and refmapping
+        flag_option :refetch
+        value_option :refmap, inline: true, repeatable: true
 
         # Tag handling
         flag_option %i[tags t], negatable: true
@@ -75,11 +83,14 @@ module Git
                              inline: true, negatable: true
 
         # Parallelism
-        value_option %i[jobs j]
+        value_option %i[jobs j], inline: true
 
-        # Tracking
+        # Tracking and internal plumbing
         flag_option :set_upstream
+        value_option :submodule_prefix, inline: true
+        value_option :recurse_submodules_default, inline: true
         flag_option %i[update_head_ok u]
+        value_option :upload_pack
 
         # Output verbosity
         flag_option %i[quiet q]
@@ -90,8 +101,11 @@ module Git
         value_option %i[server_option o],
                      inline: true, repeatable: true
         flag_option :show_forced_updates, negatable: true
-        flag_option :ipv4
-        flag_option :ipv6
+        flag_option %i[ipv4 4]
+        flag_option %i[ipv6 6]
+
+        # Stdin
+        flag_option :stdin
 
         # Execution-only options (not emitted as CLI flags)
         execution_option :timeout
@@ -99,163 +113,235 @@ module Git
 
         end_of_options
         operand :repository
-        operand :refspecs, repeatable: true
+        operand :refspec, repeatable: true
       end
 
       # @!method call(*, **)
       #
-      #   Execute the git fetch command
+      #   @overload call(repository = nil, *refspec, **options)
       #
-      #   @overload call(repository = nil, *refspecs, **options)
+      #     Execute the `git fetch` command
       #
-      #     @param repository [String, nil] (nil) The remote name or URL to fetch from
+      #     @param repository [String, nil] (nil) the remote name or URL to fetch from
       #
       #       When nil, git uses the default remote configured for the current branch.
       #
-      #     @param refspecs [Array<String>] One or more refspecs to fetch
+      #     @param refspec [Array<String>] one or more refspecs to fetch
       #
-      #       Each may be a branch name, a refspec pattern such as `+refs/heads/*:refs/remotes/origin/*`,
-      #       or a commit SHA.
+      #       Each may be a branch name, a refspec pattern such as
+      #       `+refs/heads/*:refs/remotes/origin/*`, or a commit SHA.
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean, nil] :all (nil) Fetch all remotes
+      #     @option options [Boolean] :all (nil) fetch all remotes
       #
-      #       Pass `false` to emit `--no-all`.
+      #       Pass `true` to emit `--all`; pass `false` to emit `--no-all`.
       #
-      #     @option options [Boolean] :append (nil) Append ref names and object names of fetched
-      #       refs to the existing contents of `.git/FETCH_HEAD`
+      #     @option options [Boolean] :append (false) append ref names and object
+      #       names of fetched refs to the existing contents of `.git/FETCH_HEAD`
       #
       #       Alias: :a
       #
-      #     @option options [Boolean] :atomic (nil) Use an atomic transaction to update local refs
+      #     @option options [Boolean] :atomic (false) use an atomic transaction
+      #       to update local refs
       #
-      #     @option options [String] :depth (nil) Limit fetching to the specified number of commits
-      #       from the tip of each remote branch history
+      #     @option options [String] :depth (nil) limit fetching to the specified
+      #       number of commits from the tip of each remote branch history
       #
-      #     @option options [String] :deepen (nil) Deepen or shorten history by the specified number
-      #       of commits from the current shallow boundary
+      #     @option options [String] :deepen (nil) deepen or shorten history by
+      #       the specified number of commits from the current shallow boundary
       #
-      #     @option options [String] :shallow_since (nil) Deepen or shorten the history to include
-      #       all reachable commits after the given date
+      #     @option options [String] :shallow_since (nil) deepen or shorten the
+      #       history to include all reachable commits after the given date
       #
-      #     @option options [String, Array<String>] :shallow_exclude (nil) Exclude commits reachable
-      #       from the specified remote branch or tag
+      #     @option options [String, Array<String>] :shallow_exclude (nil) exclude
+      #       commits reachable from the specified remote branch or tag
       #
       #       Repeatable.
       #
-      #     @option options [Boolean] :unshallow (nil) Convert a shallow repository to a complete one,
-      #       or fetch as much as possible from a shallow source
+      #     @option options [Boolean] :unshallow (false) convert a shallow
+      #       repository to a complete one, or fetch as much as possible from
+      #       a shallow source
       #
-      #     @option options [Boolean] :update_shallow (nil) Accept refs that would normally require
-      #       updating `.git/shallow`
+      #     @option options [Boolean] :update_shallow (false) accept refs that
+      #       would normally require updating `.git/shallow`
       #
-      #     @option options [Boolean] :dry_run (nil) Show what would be done without making changes
+      #     @option options [String, Array<String>] :negotiation_tip (nil) only
+      #       report commits reachable from the given tips when negotiating
       #
-      #     @option options [Boolean, nil] :write_fetch_head (nil) Control whether to write the
-      #       fetched remote refs to `.git/FETCH_HEAD`
+      #       Repeatable. The argument may be a ref, a glob on ref names, or an
+      #       abbreviated SHA-1.
       #
-      #       Pass `false` to emit `--no-write-fetch-head`.
+      #     @option options [Boolean] :negotiate_only (false) do not fetch
+      #       anything from the server; print ancestors of `--negotiation-tip`
+      #       arguments that we have in common
       #
-      #     @option options [Boolean] :refetch (nil) Fetch all objects as a fresh clone would,
-      #       bypassing negotiation
+      #     @option options [Boolean] :dry_run (false) show what would be done
+      #       without making changes
       #
-      #     @option options [Boolean] :prefetch (nil) Modify the configured refspec to place all
-      #       refs into the `refs/prefetch/` namespace
+      #     @option options [Boolean] :porcelain (false) print the output to
+      #       standard output in an easy-to-parse format for scripts
       #
-      #     @option options [Boolean] :force (nil) Override the fast-forward check when using
-      #       explicit refspecs
+      #     @option options [Boolean] :write_fetch_head (nil) control whether to
+      #       write the fetched remote refs to `.git/FETCH_HEAD`
+      #
+      #       Pass `true` to emit `--write-fetch-head`; pass `false` to emit
+      #       `--no-write-fetch-head`.
+      #
+      #     @option options [Boolean] :force (false) override the fast-forward
+      #       check when using explicit refspecs
       #
       #       Alias: :f
       #
-      #     @option options [Boolean] :keep (nil) Keep the downloaded pack
+      #     @option options [Boolean] :keep (false) keep the downloaded pack
       #
       #       Alias: :k
       #
-      #     @option options [Boolean] :multiple (nil) Allow several repository and group arguments
-      #       to be specified
+      #     @option options [Boolean] :multiple (false) allow several repository
+      #       and group arguments to be specified
       #
-      #       When using this option, pass additional repository or group names as extra positional
-      #       arguments; they are bound to the `:refspecs` slot in the DSL but are passed through
-      #       to git correctly.
+      #       When using this option, pass additional repository or group names
+      #       as extra positional arguments; they are bound to the `:refspec`
+      #       slot in the DSL but are passed through to git correctly.
       #
-      #     @option options [Boolean] :prune (nil) Before fetching, remove any remote-tracking
-      #       references that no longer exist on the remote
+      #     @option options [Boolean] :auto_maintenance (nil) run automatic
+      #       repository maintenance after fetching
+      #
+      #       Pass `true` to emit `--auto-maintenance`; pass `false` to emit
+      #       `--no-auto-maintenance`.
+      #
+      #     @option options [Boolean] :auto_gc (nil) run automatic garbage
+      #       collection after fetching (deprecated alias for
+      #       `:auto_maintenance`)
+      #
+      #       Pass `true` to emit `--auto-gc`; pass `false` to emit
+      #       `--no-auto-gc`.
+      #
+      #     @option options [Boolean] :write_commit_graph (nil) write a
+      #       commit-graph after fetching
+      #
+      #       Pass `true` to emit `--write-commit-graph`; pass `false` to emit
+      #       `--no-write-commit-graph`.
+      #
+      #     @option options [Boolean] :prefetch (false) modify the configured
+      #       refspec to place all refs into the `refs/prefetch/` namespace
+      #
+      #     @option options [Boolean] :prune (false) before fetching, remove any
+      #       remote-tracking references that no longer exist on the remote
       #
       #       Alias: :p
       #
-      #     @option options [Boolean] :prune_tags (nil) Before fetching, remove any local tags that
-      #       no longer exist on the remote (requires `--prune`)
+      #     @option options [Boolean] :prune_tags (false) before fetching, remove
+      #       any local tags that no longer exist on the remote (requires
+      #       `--prune`)
       #
       #       Alias: :P
       #
-      #     @option options [Boolean, nil] :tags (nil) Fetch all tags from the remote
+      #     @option options [Boolean] :refetch (false) fetch all objects as a
+      #       fresh clone would, bypassing negotiation
       #
-      #       Pass `false` to emit `--no-tags` and disable automatic tag following.
+      #     @option options [String, Array<String>] :refmap (nil) use the
+      #       specified refspec to map refs to remote-tracking branches instead
+      #       of the configured `remote.*.fetch` values
+      #
+      #       Repeatable.
+      #
+      #     @option options [Boolean] :tags (nil) fetch all tags from the remote
+      #
+      #       Pass `true` to emit `--tags`; pass `false` to emit `--no-tags`
+      #       and disable automatic tag following.
       #
       #       Alias: :t
       #
-      #     @option options [Boolean, String, nil] :recurse_submodules (nil) Control whether new
-      #       commits of submodules should be fetched
+      #     @option options [Boolean, String] :recurse_submodules (nil) control
+      #       whether new commits of submodules should be fetched
       #
-      #       When `true`, uses `--recurse-submodules`. When a string (e.g. `'yes'`, `'on-demand'`,
-      #       `'no'`), passes that value. When `false`, emits `--no-recurse-submodules`.
+      #       When `true`, uses `--recurse-submodules`. When a string (e.g.
+      #       `'yes'`, `'on-demand'`, `'no'`), passes that value. When `false`,
+      #       emits `--no-recurse-submodules`.
       #
-      #     @option options [String] :jobs (nil) Number of submodules or parallel fetches
+      #     @option options [String] :jobs (nil) number of submodules or parallel
+      #       fetches
       #
       #       Alias: :j
       #
-      #     @option options [Boolean] :set_upstream (nil) Add upstream tracking reference if the
-      #       remote is fetched successfully
+      #     @option options [Boolean] :set_upstream (false) add upstream tracking
+      #       reference if the remote is fetched successfully
       #
-      #     @option options [Boolean] :update_head_ok (nil) Allow updating the HEAD that corresponds
-      #       to the current branch
+      #     @option options [String] :submodule_prefix (nil) prepend the given
+      #       path to informative messages such as "Fetching submodule foo"
+      #
+      #       Used internally when recursing over submodules.
+      #
+      #     @option options [String] :recurse_submodules_default (nil) provide a
+      #       non-negative default value for `--recurse-submodules`
+      #
+      #       Used internally.
+      #
+      #     @option options [Boolean] :update_head_ok (false) allow updating the
+      #       HEAD that corresponds to the current branch
       #
       #       Used internally by `git pull`.
       #
       #       Alias: :u
       #
-      #     @option options [Boolean] :quiet (nil) Suppress all output
+      #     @option options [String] :upload_pack (nil) specify a non-default
+      #       path for `git-upload-pack` on the remote side
+      #
+      #     @option options [Boolean] :quiet (false) suppress all output
       #
       #       Alias: :q
       #
-      #     @option options [Boolean] :verbose (nil) Be verbose
+      #     @option options [Boolean] :verbose (false) be verbose
       #
       #       Alias: :v
       #
-      #     @option options [Boolean] :progress (nil) Force progress status on standard error even
-      #       when the stream is not attached to a terminal
+      #     @option options [Boolean] :progress (false) force progress status on
+      #       standard error even when the stream is not attached to a terminal
       #
-      #     @option options [String, Array<String>] :server_option (nil) Transmit the given string
-      #       to the server when communicating using protocol version 2
+      #     @option options [String, Array<String>] :server_option (nil) transmit
+      #       the given string to the server when communicating using protocol
+      #       version 2
       #
       #       Repeatable.
       #
       #       Alias: :o
       #
-      #     @option options [Boolean, nil] :show_forced_updates (nil) Check for force-updated branches
-      #       during fetch
+      #     @option options [Boolean] :show_forced_updates (nil) check for
+      #       force-updated branches during fetch
       #
-      #       Pass `false` to emit `--no-show-forced-updates`.
+      #       Pass `true` to emit `--show-forced-updates`; pass `false` to emit
+      #       `--no-show-forced-updates`.
       #
-      #     @option options [Boolean] :ipv4 (nil) Use IPv4 addresses only
+      #     @option options [Boolean] :ipv4 (false) use IPv4 addresses only
       #
-      #     @option options [Boolean] :ipv6 (nil) Use IPv6 addresses only
+      #       Alias: :"4"
       #
-      #     @option options [Numeric, nil] :timeout (nil) Maximum seconds to wait for the command
-      #       to complete
+      #     @option options [Boolean] :ipv6 (false) use IPv6 addresses only
+      #
+      #       Alias: :"6"
+      #
+      #     @option options [Boolean] :stdin (false) read refspecs from stdin in
+      #       addition to those provided as arguments
+      #
+      #     @option options [Numeric, nil] :timeout (nil) maximum seconds to wait
+      #       for the command to complete
       #
       #       If nil, uses the global timeout from {Git::Config}.
       #
-      #     @option options [Boolean] :merge (nil) Merge stderr into stdout in the returned result
+      #     @option options [Boolean] :merge (nil) merge stderr into stdout in
+      #       the returned result
       #
-      #       Pass `true` to capture git fetch output (which is written to stderr by default).
+      #       Pass `true` to capture git fetch output (which is written to stderr
+      #       by default).
       #
       #     @return [Git::CommandLineResult] the result of calling `git fetch`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #
-      #     @raise [Git::FailedError] if the command returns a non-zero exit status
+      #     @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      #     @api public
     end
   end
 end

--- a/spec/unit/git/commands/fetch_spec.rb
+++ b/spec/unit/git/commands/fetch_spec.rb
@@ -93,16 +93,16 @@ RSpec.describe Git::Commands::Fetch do
     end
 
     context 'with the :depth option' do
-      it 'adds --depth <n> to the command line' do
-        expect_command_capturing('fetch', '--depth', '5').and_return(command_result)
+      it 'adds --depth=<n> to the command line' do
+        expect_command_capturing('fetch', '--depth=5').and_return(command_result)
 
         command.call(depth: '5')
       end
     end
 
     context 'with the :deepen option' do
-      it 'adds --deepen <n> to the command line' do
-        expect_command_capturing('fetch', '--deepen', '3').and_return(command_result)
+      it 'adds --deepen=<n> to the command line' do
+        expect_command_capturing('fetch', '--deepen=3').and_return(command_result)
 
         command.call(deepen: '3')
       end
@@ -291,14 +291,14 @@ RSpec.describe Git::Commands::Fetch do
     end
 
     context 'with the :jobs option' do
-      it 'adds --jobs <n> to the command line' do
-        expect_command_capturing('fetch', '--jobs', '4').and_return(command_result)
+      it 'adds --jobs=<n> to the command line' do
+        expect_command_capturing('fetch', '--jobs=4').and_return(command_result)
 
         command.call(jobs: '4')
       end
 
       it 'supports the :j alias' do
-        expect_command_capturing('fetch', '--jobs', '2').and_return(command_result)
+        expect_command_capturing('fetch', '--jobs=2').and_return(command_result)
 
         command.call(j: '2')
       end
@@ -404,6 +404,12 @@ RSpec.describe Git::Commands::Fetch do
 
         command.call(ipv4: true)
       end
+
+      it 'supports the :"4" alias' do
+        expect_command_capturing('fetch', '--ipv4').and_return(command_result)
+
+        command.call('4': true)
+      end
     end
 
     context 'with the :ipv6 option' do
@@ -411,6 +417,134 @@ RSpec.describe Git::Commands::Fetch do
         expect_command_capturing('fetch', '--ipv6').and_return(command_result)
 
         command.call(ipv6: true)
+      end
+
+      it 'supports the :"6" alias' do
+        expect_command_capturing('fetch', '--ipv6').and_return(command_result)
+
+        command.call('6': true)
+      end
+    end
+
+    context 'with the :negotiation_tip option' do
+      it 'adds --negotiation-tip=<ref> to the command line' do
+        expect_command_capturing('fetch', '--negotiation-tip=refs/heads/main').and_return(command_result)
+
+        command.call(negotiation_tip: 'refs/heads/main')
+      end
+
+      it 'repeats the option for multiple values' do
+        expect_command_capturing(
+          'fetch', '--negotiation-tip=refs/heads/main', '--negotiation-tip=refs/heads/dev'
+        ).and_return(command_result)
+
+        command.call(negotiation_tip: %w[refs/heads/main refs/heads/dev])
+      end
+    end
+
+    context 'with the :negotiate_only option' do
+      it 'adds --negotiate-only to the command line' do
+        expect_command_capturing('fetch', '--negotiate-only').and_return(command_result)
+
+        command.call(negotiate_only: true)
+      end
+    end
+
+    context 'with the :porcelain option' do
+      it 'adds --porcelain to the command line' do
+        expect_command_capturing('fetch', '--porcelain').and_return(command_result)
+
+        command.call(porcelain: true)
+      end
+    end
+
+    context 'with the :auto_maintenance option' do
+      it 'adds --auto-maintenance when true' do
+        expect_command_capturing('fetch', '--auto-maintenance').and_return(command_result)
+
+        command.call(auto_maintenance: true)
+      end
+
+      it 'adds --no-auto-maintenance when false' do
+        expect_command_capturing('fetch', '--no-auto-maintenance').and_return(command_result)
+
+        command.call(auto_maintenance: false)
+      end
+    end
+
+    context 'with the :auto_gc option' do
+      it 'adds --auto-gc when true' do
+        expect_command_capturing('fetch', '--auto-gc').and_return(command_result)
+
+        command.call(auto_gc: true)
+      end
+
+      it 'adds --no-auto-gc when false' do
+        expect_command_capturing('fetch', '--no-auto-gc').and_return(command_result)
+
+        command.call(auto_gc: false)
+      end
+    end
+
+    context 'with the :write_commit_graph option' do
+      it 'adds --write-commit-graph when true' do
+        expect_command_capturing('fetch', '--write-commit-graph').and_return(command_result)
+
+        command.call(write_commit_graph: true)
+      end
+
+      it 'adds --no-write-commit-graph when false' do
+        expect_command_capturing('fetch', '--no-write-commit-graph').and_return(command_result)
+
+        command.call(write_commit_graph: false)
+      end
+    end
+
+    context 'with the :refmap option' do
+      it 'adds --refmap=<refspec> to the command line' do
+        expect_command_capturing('fetch', '--refmap=+refs/heads/*:refs/remotes/origin/*').and_return(command_result)
+
+        command.call(refmap: '+refs/heads/*:refs/remotes/origin/*')
+      end
+
+      it 'repeats the option for multiple values' do
+        expect_command_capturing(
+          'fetch', '--refmap=rs1', '--refmap=rs2'
+        ).and_return(command_result)
+
+        command.call(refmap: %w[rs1 rs2])
+      end
+    end
+
+    context 'with the :submodule_prefix option' do
+      it 'adds --submodule-prefix=<path> to the command line' do
+        expect_command_capturing('fetch', '--submodule-prefix=libs/foo').and_return(command_result)
+
+        command.call(submodule_prefix: 'libs/foo')
+      end
+    end
+
+    context 'with the :recurse_submodules_default option' do
+      it 'adds --recurse-submodules-default=<value> to the command line' do
+        expect_command_capturing('fetch', '--recurse-submodules-default=on-demand').and_return(command_result)
+
+        command.call(recurse_submodules_default: 'on-demand')
+      end
+    end
+
+    context 'with the :upload_pack option' do
+      it 'adds --upload-pack <path> to the command line' do
+        expect_command_capturing('fetch', '--upload-pack', '/usr/lib/git/git-upload-pack').and_return(command_result)
+
+        command.call(upload_pack: '/usr/lib/git/git-upload-pack')
+      end
+    end
+
+    context 'with the :stdin option' do
+      it 'adds --stdin to the command line' do
+        expect_command_capturing('fetch', '--stdin').and_return(command_result)
+
+        command.call(stdin: true)
       end
     end
 
@@ -432,7 +566,7 @@ RSpec.describe Git::Commands::Fetch do
 
     context 'with options and repository combined' do
       it 'places flags before -- and repository (in DSL definition order)' do
-        expect_command_capturing('fetch', '--depth', '2', '--force', '--', 'origin').and_return(command_result)
+        expect_command_capturing('fetch', '--depth=2', '--force', '--', 'origin').and_return(command_result)
 
         command.call('origin', force: true, depth: '2')
       end

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -227,7 +227,7 @@ class TestRemotes < Test::Unit::TestCase
   end
 
   def test_fetch_cmd_with_origin_and_branch
-    expected_command_line = ['fetch', '--depth', '2', '--', 'origin', 'master', { merge: true }]
+    expected_command_line = ['fetch', '--depth=2', '--', 'origin', 'master', { merge: true }]
     assert_command_line_eq(expected_command_line) { |git| git.fetch('origin', { ref: 'master', depth: '2' }) }
   end
 
@@ -238,7 +238,7 @@ class TestRemotes < Test::Unit::TestCase
 
   def test_fetch_cmd_with_all_with_other_args
     # Args are rendered in DSL definition order: --depth is defined before --force
-    expected_command_line = ['fetch', '--all', '--depth', '2', '--force', { merge: true }]
+    expected_command_line = ['fetch', '--all', '--depth=2', '--force', { merge: true }]
     assert_command_line_eq(expected_command_line) { |git| git.fetch({ all: true, force: true, depth: '2' }) }
   end
 


### PR DESCRIPTION
Update the `Fetch` command class to align with the implementation skill conventions.

Partially implements batch 6 of #1196.

## Changes

**Arguments DSL**
- Add `inline: true` to `depth`, `deepen`, and `jobs` value_options
- Rename operand `:refspecs` to `:refspec` (singular, matching git docs)
- Add `ipv4`/`4` and `ipv6`/`6` short-flag aliases
- Add 11 new options: `negotiation_tip`, `negotiate_only`, `porcelain`, `auto_maintenance`, `auto_gc`, `write_commit_graph`, `refmap`, `submodule_prefix`, `recurse_submodules_default`, `upload_pack`, `stdin`
- Reorder DSL entries to match git-fetch OPTIONS section ordering

**YARD documentation**
- Consolidate `@example` into a single idiomatic multi-call block
- Add `@note` annotation audited against git-fetch 2.53.0
- Add `@see Git::Commands` cross-reference
- Fix `flag_option` YARD defaults from `(nil)` to `(false)` per DSL-to-YARD mapping
- Add `@raise [ArgumentError]` and `@api public` to YARD call docs

**Unit tests**
- Update expectations for inline depth/deepen/jobs format (`--depth=5` not `--depth`, `5`)
- Add tests for all 11 new options
- Add alias tests for `:"4"` and `:"6"`

**Minitest**
- Fix `test_remotes.rb` expectations for inline `--depth=` format