### PR TITLE
refactor(commands): apply command-implementation skill to grep; backfill log options

### DIFF
--- a/lib/git/commands/grep.rb
+++ b/lib/git/commands/grep.rb
@@ -9,59 +9,38 @@ module Git
     # Searches for a pattern in the contents of tracked files within a repository
     # tree.
     #
+    # @example Typical usage
+    #   grep = Git::Commands::Grep.new(execution_context)
+    #   grep.call('HEAD', pattern: 'search')
+    #   grep.call('HEAD', pattern: 'SEARCH', ignore_case: true)
+    #   grep.call('HEAD', pattern: 'search', invert_match: true)
+    #   grep.call('HEAD', pattern: 'foo|bar', extended_regexp: true)
+    #   grep.call('HEAD', pattern: 'search', pathspec: 'lib/**')
+    #
+    # @note `arguments` block audited against
+    #   https://git-scm.com/docs/git-grep/2.53.0
+    #
     # @see https://git-scm.com/docs/git-grep git-grep
     #
     # @see Git::Commands
     #
     # @api private
     #
-    # @example Search for a pattern in HEAD
-    #   grep = Git::Commands::Grep.new(execution_context)
-    #   result = grep.call('HEAD', pattern: 'search')
-    #
-    # @example Case-insensitive search
-    #   grep = Git::Commands::Grep.new(execution_context)
-    #   result = grep.call('HEAD', pattern: 'SEARCH', ignore_case: true)
-    #
-    # @example Invert match (lines that do NOT match)
-    #   grep = Git::Commands::Grep.new(execution_context)
-    #   result = grep.call('HEAD', pattern: 'search', invert_match: true)
-    #
-    # @example Extended regexp
-    #   grep = Git::Commands::Grep.new(execution_context)
-    #   result = grep.call('HEAD', pattern: 'foo|bar', extended_regexp: true)
-    #
-    # @example Limit search to specific paths
-    #   grep = Git::Commands::Grep.new(execution_context)
-    #   result = grep.call('HEAD', pattern: 'search', pathspec: 'lib/**')
-    #
-    # @example Multiple pathspecs
-    #   grep = Git::Commands::Grep.new(execution_context)
-    #   result = grep.call('HEAD', pattern: 'search', pathspec: ['lib/**', 'spec/**'])
-    #
-    # @example Compound boolean expression (raw args passthrough)
-    #   grep = Git::Commands::Grep.new(execution_context)
-    #   result = grep.call('HEAD', pattern: ['-e', 'foo', '--and', '-e', 'bar'])
-    #
-    # @example Search across multiple trees
-    #   grep = Git::Commands::Grep.new(execution_context)
-    #   result = grep.call('main', 'feature', pattern: 'search')
-    #
     class Grep < Git::Commands::Base
       arguments do
         literal 'grep'
-
-        flag_option :no_color
 
         # Encoding and binary handling
         flag_option %i[text a]
         flag_option :I
         flag_option :textconv, negatable: true
 
-        # Pattern matching behaviour
+        # Pattern matching
         flag_option %i[ignore_case i]
         flag_option %i[word_regexp w]
         flag_option %i[invert_match v]
+        flag_option :h
+        flag_option :H
         flag_option :full_name
 
         # Regexp flavour
@@ -72,13 +51,10 @@ module Git
 
         # Output format
         flag_option %i[line_number n]
-        flag_option :H
-        flag_option :h
         flag_option :column
-        flag_option :break
-        flag_option :heading
         flag_option %i[files_with_matches name_only l]
         flag_option %i[files_without_match L]
+        flag_option %i[null z]
         flag_option %i[only_matching o]
         flag_option %i[count c]
         flag_option :all_match
@@ -88,7 +64,13 @@ module Git
         value_option :max_depth
         flag_option %i[recursive r], negatable: true
 
+        # Color
+        flag_or_value_option :color, inline: true
+        flag_option :no_color
+
         # Display
+        flag_option :break
+        flag_option :heading
         flag_option %i[show_function p]
 
         # Context lines
@@ -100,13 +82,6 @@ module Git
         # Limits and performance
         value_option %i[max_count m]
         value_option :threads
-
-        # Source selection
-        flag_option :recurse_submodules
-        flag_option :exclude_standard, negatable: true
-        flag_option :cached
-        flag_option :untracked
-        flag_option :no_index
 
         # Pattern input
         value_option :f, repeatable: true
@@ -120,6 +95,14 @@ module Git
           else raise ArgumentError, ":pattern must be a String or Array, got #{value.class}"
           end
         end
+
+        # Source selection
+        flag_option :recurse_submodules
+        value_option :parent_basename
+        flag_option :exclude_standard, negatable: true
+        flag_option :cached
+        flag_option :untracked
+        flag_option :no_index
 
         operand :tree, repeatable: true
         end_of_options
@@ -135,185 +118,199 @@ module Git
       #
       #     Execute the `git grep` command
       #
-      #     @param tree [String] one or more tree-ish references to search
+      #     @param tree [Array<String>] zero or more tree-ish references to search
       #       (e.g. commit SHAs, tags, or branch names); when omitted, git
       #       searches the working tree
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :no_color (nil) Suppress color output
-      #
-      #     @option options [Boolean] :text (nil) Process binary files as if they
+      #     @option options [Boolean] :text (false) process binary files as if they
       #       were text
       #
       #       Alias: :a
       #
-      #     @option options [Boolean] :I (nil) Do not match the pattern in binary
+      #     @option options [Boolean] :I (false) do not match the pattern in binary
       #       files
       #
-      #     @option options [Boolean] :textconv (nil) Honor textconv filter settings
+      #     @option options [Boolean] :textconv (nil) honor textconv filter settings
       #
-      #       Pass `false` to emit `--no-textconv`.
+      #       Pass `true` to emit `--textconv`; pass `false` to emit
+      #       `--no-textconv`.
       #
-      #     @option options [Boolean] :ignore_case (nil) Ignore case
-      #       distinctions in both the pattern and the file contents
+      #     @option options [Boolean] :ignore_case (false) ignore case distinctions
+      #       in both the pattern and the file contents
       #
       #       Alias: :i
       #
-      #     @option options [Boolean] :word_regexp (nil) Match the pattern only at
+      #     @option options [Boolean] :word_regexp (false) match the pattern only at
       #       word boundary
       #
       #       Alias: :w
       #
-      #     @option options [Boolean] :invert_match (nil) Select non-matching
-      #       lines
+      #     @option options [Boolean] :invert_match (false) select non-matching lines
       #
       #       Alias: :v
       #
-      #     @option options [Boolean] :full_name (nil) Output paths relative to the
-      #       project top directory rather than the current directory
+      #     @option options [Boolean] :h (false) suppress the filename prefix for
+      #       each match
       #
-      #     @option options [Boolean] :extended_regexp (nil) Use POSIX extended
+      #     @option options [Boolean] :H (false) print the filename for each match;
+      #       overrides `:h` given earlier
+      #
+      #     @option options [Boolean] :full_name (false) output paths relative to
+      #       the project top directory rather than the current directory
+      #
+      #     @option options [Boolean] :extended_regexp (false) use POSIX extended
       #       regular expressions for the pattern
       #
       #       Alias: :E
       #
-      #     @option options [Boolean] :basic_regexp (nil) Use POSIX basic regular
+      #     @option options [Boolean] :basic_regexp (false) use POSIX basic regular
       #       expressions for the pattern (the default regexp flavour)
       #
       #       Alias: :G
       #
-      #     @option options [Boolean] :perl_regexp (nil) Use Perl-compatible regular
-      #       expressions for the pattern
+      #     @option options [Boolean] :perl_regexp (false) use Perl-compatible
+      #       regular expressions for the pattern
       #
       #       Alias: :P
       #
-      #     @option options [Boolean] :fixed_strings (nil) Treat the pattern as a
+      #     @option options [Boolean] :fixed_strings (false) treat the pattern as a
       #       fixed string rather than a regular expression
       #
       #       Alias: :F
       #
-      #     @option options [Boolean] :line_number (nil) Prefix each matching line
+      #     @option options [Boolean] :line_number (false) prefix each matching line
       #       with its line number within the file
       #
       #       Alias: :n
       #
-      #     @option options [Boolean] :H (nil) Print the filename for each match
+      #     @option options [Boolean] :column (false) prefix the 1-indexed
+      #       byte-offset of the first match from the start of the matching line
       #
-      #     @option options [Boolean] :h (nil) Suppress the filename prefix for each
-      #       match
-      #
-      #     @option options [Boolean] :column (nil) Prefix the 1-indexed byte-offset
-      #       of the first match from the start of the matching line
-      #
-      #     @option options [Boolean] :break (nil) Print an empty line between matches
-      #       from different files
-      #
-      #     @option options [Boolean] :heading (nil) Show the filename above the
-      #       matches in that file instead of at the start of each shown line
-      #
-      #     @option options [Boolean] :files_with_matches (nil) Show only the names
-      #       of files that contain matches, not the matching lines
+      #     @option options [Boolean] :files_with_matches (false) show only the
+      #       names of files that contain matches, not the matching lines
       #
       #       Aliases: :name_only, :l
       #
-      #     @option options [Boolean] :files_without_match (nil) Show only the names
-      #       of files that do not contain matches
+      #     @option options [Boolean] :files_without_match (false) show only the
+      #       names of files that do not contain matches
       #
       #       Alias: :L
       #
-      #     @option options [Boolean] :only_matching (nil) Print only the matched
+      #     @option options [Boolean] :null (false) use NUL as the delimiter for
+      #       pathnames in the output, printing them verbatim
+      #
+      #       Alias: :z
+      #
+      #     @option options [Boolean] :only_matching (false) print only the matched
       #       (non-empty) parts of a matching line, each on a separate output line
       #
       #       Alias: :o
       #
-      #     @option options [Boolean] :count (nil) Show the number of matching lines
-      #       per file instead of the matching lines themselves
+      #     @option options [Boolean] :count (false) show the number of matching
+      #       lines per file instead of the matching lines themselves
       #
       #       Alias: :c
       #
-      #     @option options [Boolean] :all_match (nil) When using multiple `--or`
+      #     @option options [Boolean] :all_match (false) when using multiple `--or`
       #       patterns, limit matches to files that have lines matching all of them
       #
-      #     @option options [Boolean] :quiet (nil) Do not output matching lines;
+      #     @option options [Boolean] :quiet (false) do not output matching lines;
       #       exit 0 when there is a match and non-zero when there is not
       #
       #       Alias: :q
       #
-      #     @option options [Integer] :max_depth (nil) Descend at most the given
-      #       number of directory levels for each pathspec argument
+      #     @option options [Integer, String] :max_depth (nil) descend at most this
+      #       many directory levels for each pathspec argument
       #
-      #     @option options [Boolean] :recursive (nil) Recurse into subdirectories
+      #     @option options [Boolean] :recursive (nil) recurse into subdirectories
       #       (same as `--max-depth=-1`; this is the default)
       #
       #       Pass `false` to emit `--no-recursive` (`--max-depth=0`).
       #
       #       Alias: :r
       #
-      #     @option options [Boolean] :show_function (nil) Show the nearest function
-      #       name preceding each match
+      #     @option options [Boolean, String] :color (nil) show colored matches
+      #
+      #       When `true`, emits bare `--color`. Pass a string to emit
+      #       `--color=<when>` (values: `'always'`, `'never'`, `'auto'`).
+      #
+      #     @option options [Boolean] :no_color (false) turn off match highlighting,
+      #       even when the configuration file gives the default to color output
+      #
+      #     @option options [Boolean] :break (false) print an empty line between
+      #       matches from different files
+      #
+      #     @option options [Boolean] :heading (false) show the filename above the
+      #       matches in that file instead of at the start of each shown line
+      #
+      #     @option options [Boolean] :show_function (false) show the nearest
+      #       function name preceding each match
       #
       #       Alias: :p
       #
-      #     @option options [Integer] :after_context (nil) Show the given number of
+      #     @option options [Integer, String] :after_context (nil) show this many
       #       trailing lines after each match
       #
       #       Alias: :A
       #
-      #     @option options [Integer] :before_context (nil) Show the given number of
+      #     @option options [Integer, String] :before_context (nil) show this many
       #       leading lines before each match
       #
       #       Alias: :B
       #
-      #     @option options [Integer] :context (nil) Show the given number of leading
+      #     @option options [Integer, String] :context (nil) show this many leading
       #       and trailing lines around each match
       #
       #       Alias: :C
       #
-      #     @option options [Boolean] :function_context (nil) Show the surrounding
-      #       text from the previous function name up to the next, effectively
-      #       showing the whole function in which the match was found
+      #     @option options [Boolean] :function_context (false) show the surrounding
+      #       text from the previous function name up to the next
       #
       #       Alias: :W
       #
-      #     @option options [Integer] :max_count (nil) Limit the number of matches
-      #       per file
+      #     @option options [Integer, String] :max_count (nil) limit the number of
+      #       matches per file
       #
       #       Alias: :m
       #
-      #     @option options [Integer] :threads (nil) Number of grep worker threads
-      #       to use
+      #     @option options [Integer, String] :threads (nil) number of grep worker
+      #       threads to use
       #
-      #     @option options [Boolean] :recurse_submodules (nil) Recursively search
-      #       in each active, checked-out submodule
-      #
-      #     @option options [Boolean] :exclude_standard (nil) Honor the `.gitignore`
-      #       mechanism when searching untracked files
-      #
-      #       Pass `false` to emit `--no-exclude-standard` and also search ignored
-      #       files. Only useful with `:untracked` or `:no_index`.
-      #
-      #     @option options [Boolean] :cached (nil) Search blobs registered in the
-      #       index instead of tracked files in the working tree
-      #
-      #     @option options [Boolean] :untracked (nil) Search untracked files in
-      #       addition to tracked files in the working tree
-      #
-      #     @option options [Boolean] :no_index (nil) Search files in the current
-      #       directory without regard to whether it is managed by Git
-      #
-      #     @option options [String, Array<String>] :f (nil) Read patterns from a
+      #     @option options [String, Array<String>] :f (nil) read patterns from a
       #       file, one per line; may be passed as an Array to supply multiple
       #       pattern files
       #
-      #     @option options [String, Array<String>] :pattern The search pattern
-      #       (required; must not be nil)
+      #     @option options [String, Array<String>] :pattern (nil) the search
+      #       pattern (required; must not be nil)
       #
       #       Pass a String for a simple pattern (emitted as `-e <pattern>`).
       #       Pass an Array of raw CLI arguments for compound boolean
       #       expressions (e.g. `['-e', 'foo', '--and', '-e', 'bar']`).
       #
-      #     @option options [String, Array<String>] :pathspec (nil) Limit the
+      #     @option options [Boolean] :recurse_submodules (false) recursively search
+      #       in each active, checked-out submodule
+      #
+      #     @option options [String] :parent_basename (nil) override the name used
+      #       as a prefix for submodule output when used with `:recurse_submodules`
+      #
+      #     @option options [Boolean] :exclude_standard (nil) honor the `.gitignore`
+      #       mechanism when searching untracked files
+      #
+      #       Pass `false` to emit `--no-exclude-standard` and also search ignored
+      #       files. Only useful with `:untracked` or `:no_index`.
+      #
+      #     @option options [Boolean] :cached (false) search blobs registered in the
+      #       index instead of tracked files in the working tree
+      #
+      #     @option options [Boolean] :untracked (false) search untracked files in
+      #       addition to tracked files in the working tree
+      #
+      #     @option options [Boolean] :no_index (false) search files in the current
+      #       directory without regard to whether it is managed by Git
+      #
+      #     @option options [String, Array<String>] :pathspec (nil) limit the
       #       search to files matching the given pathspec(s)
       #
       #       Multiple pathspecs may be passed as an Array. Appended to the
@@ -328,8 +325,8 @@ module Git
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #
-      #     @raise [Git::FailedError] if the command returns exit status greater
-      #       than 1
+      #     @raise [Git::FailedError] if git exits outside the allowed range
+      #       (exit code > 1)
       #
       #   @api public
       #

--- a/lib/git/commands/log.rb
+++ b/lib/git/commands/log.rb
@@ -4,88 +4,157 @@ require 'git/commands/base'
 
 module Git
   module Commands
-    # Implements the `git log` command
+    # Implements the `git log` command.
     #
     # Returns commit history.
     #
+    # @example Typical usage
+    #   log = Git::Commands::Log.new(execution_context)
+    #   log.call
+    #   log.call(max_count: 20, since: '2 weeks ago')
+    #   log.call('v1.0..v2.0', pretty: 'format:%H %s', path: ['lib/', 'spec/'])
+    #   log.call(name_only: true, patch: true)
+    #
+    # @note `arguments` block audited against https://git-scm.com/docs/git-log/2.53.0
+    #
     # @see https://git-scm.com/docs/git-log git-log documentation
+    #
     # @see Git::Commands
     #
     # @api private
     #
-    # @example List all commits on current branch
-    #   log = Git::Commands::Log.new(execution_context)
-    #   result = log.call
-    #
-    # @example Limit to 20 commits since a given date
-    #   log = Git::Commands::Log.new(execution_context)
-    #   result = log.call(max_count: 20, since: '1 week ago')
-    #
-    # @example Show commits between two refs
-    #   log = Git::Commands::Log.new(execution_context)
-    #   result = log.call('v2.5..v2.6', max_count: 10)
-    #
-    # @example Show commits touching specific paths
-    #   log = Git::Commands::Log.new(execution_context)
-    #   result = log.call(path: ['lib/', 'spec/'])
-    #
-    class Log < Git::Commands::Base
+    class Log < Git::Commands::Base # rubocop:disable Metrics/ClassLength
       arguments do
         literal 'log'
 
-        flag_option :no_color
-        value_option :pretty, inline: true
-
-        # Ref inclusion
-        flag_option :all
-        flag_or_value_option :branches, inline: true
-        flag_or_value_option :tags, inline: true
-        flag_or_value_option :remotes, inline: true
-
-        # Symmetric difference / cherry-pick filtering
-        flag_option :cherry
-        flag_option :cherry_mark
-        flag_option :cherry_pick
-        flag_option :left_right
-
-        # Parent count filtering
-        flag_option :merges, negatable: true
-        flag_option :first_parent
-        value_option :min_parents, inline: true
-        value_option :max_parents, inline: true
-
-        # Date filtering
+        # Commit Limiting
+        value_option %i[max_count n], inline: true
+        value_option :skip, inline: true
         value_option :since, inline: true
         value_option :after, inline: true
+        value_option :since_as_filter, inline: true
         value_option :until, inline: true
         value_option :before, inline: true
-
-        # Message / grep filtering
+        value_option :author, inline: true
+        value_option :committer, inline: true
+        value_option :grep_reflog, inline: true
         value_option :grep, inline: true
         flag_option :all_match
         flag_option :invert_grep
         flag_option %i[regexp_ignore_case i]
+        flag_option :basic_regexp
         flag_option %i[extended_regexp E]
         flag_option %i[fixed_strings F]
         flag_option %i[perl_regexp P]
+        flag_option :remove_empty
+        flag_option :merges, negatable: true
+        value_option :min_parents, inline: true
+        value_option :max_parents, inline: true
+        flag_option :first_parent
+        flag_option :exclude_first_parent_only
+        flag_option :all
+        flag_or_value_option :branches, inline: true
+        flag_or_value_option :tags, inline: true
+        flag_or_value_option :remotes, inline: true
+        value_option :glob, inline: true
+        value_option :exclude, inline: true
+        value_option :exclude_hidden, inline: true
+        flag_option :reflog
+        flag_option :alternate_refs
+        flag_option :single_worktree
+        flag_option :ignore_missing
+        flag_option :bisect
+        # --stdin excluded: requires stdin interaction (execution-model conflict)
+        flag_option :cherry_mark
+        flag_option :cherry_pick
+        flag_option :left_only
+        flag_option :right_only
+        flag_option :cherry
+        flag_option %i[walk_reflogs g]
+        flag_option :merge
+        flag_option :boundary
 
-        # Author / committer filtering
-        value_option :author, inline: true
-        value_option :committer, inline: true
-
-        # Output volume
-        value_option :max_count, inline: true
-        value_option :skip, inline: true
-
-        # History traversal / simplification
-        flag_option :follow
+        # History Simplification
+        flag_option :simplify_by_decoration
+        flag_option :show_pulls
         flag_option :full_history
+        flag_option :dense
+        flag_option :sparse
+        flag_option :simplify_merges
+        flag_or_value_option :ancestry_path, inline: true
 
-        # Commit ordering
+        # Commit Ordering
         flag_option :date_order
         flag_option :author_date_order
         flag_option :topo_order
         flag_option :reverse
+
+        # Object Traversal
+        flag_or_value_option :no_walk, inline: true
+        flag_option :do_walk
+
+        # Commit Formatting
+        flag_or_value_option %i[pretty format], inline: true
+        flag_option :abbrev_commit, negatable: true
+        flag_option :oneline
+        value_option :encoding, inline: true
+        flag_or_value_option :expand_tabs, inline: true, negatable: true
+        flag_or_value_option :notes, inline: true, negatable: true
+        flag_option :show_notes_by_default
+        flag_option :show_signature
+        flag_option :relative_date
+        value_option :date, inline: true
+        flag_option :parents
+        flag_option :children
+        flag_option :left_right
+        flag_option :graph
+        flag_or_value_option :show_linear_break, inline: true
+        flag_option :follow
+        flag_or_value_option :decorate, inline: true, negatable: true
+        value_option :decorate_refs, inline: true
+        value_option :decorate_refs_exclude, inline: true
+        flag_option :clear_decorations
+        flag_option :source
+        flag_option :use_mailmap, negatable: true
+        flag_option :full_diff
+        flag_option :log_size
+
+        # Diff Formatting
+        flag_option %i[patch p]
+        flag_option %i[no_patch s]
+        value_option :diff_merges, inline: true
+        flag_option :no_diff_merges
+        flag_option :combined_all_paths
+        flag_option :raw
+        flag_or_value_option :stat, inline: true
+        flag_option :compact_summary
+        flag_option :numstat
+        flag_option :shortstat
+        flag_or_value_option :dirstat, inline: true
+        flag_option :summary
+        flag_option :name_only
+        flag_option :name_status
+        flag_or_value_option :submodule, inline: true
+        flag_or_value_option :color, inline: true, negatable: true
+        flag_option :full_index
+        flag_option :binary
+        flag_or_value_option :abbrev, inline: true
+        value_option :diff_filter, inline: true
+        flag_or_value_option :find_renames, inline: true
+        flag_or_value_option :find_copies, inline: true
+        flag_option :find_copies_harder
+        flag_or_value_option :relative, inline: true, negatable: true
+        flag_option :text
+        flag_option :ignore_space_at_eol
+        flag_option %i[ignore_space_change b]
+        flag_option %i[ignore_all_space w]
+        flag_option :ignore_blank_lines
+        value_option :ignore_matching_lines, inline: true
+        flag_option :ext_diff, negatable: true
+        flag_option :textconv, negatable: true
+        flag_option :no_prefix
+        value_option :src_prefix, inline: true
+        value_option :dst_prefix, inline: true
 
         operand :revision_range, repeatable: true
         end_of_options
@@ -97,7 +166,7 @@ module Git
       #
       #   @overload call(*revision_range, **options)
       #
-      #     Execute the `git log` command
+      #     Execute the `git log` command.
       #
       #     @param revision_range [Array<String>] zero or more revision specifiers
       #
@@ -108,164 +177,443 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :no_color (nil) Suppress color output
+      #     ### Commit Limiting
       #
-      #     @option options [String] :pretty (nil) Format the commit log output
+      #     @option options [Integer, String] :max_count (nil) maximum number of commits to output
       #
-      #     @option options [Boolean] :all (nil) Pretend all refs in refs/, along
-      #       with HEAD, are listed on the command line
+      #       Alias: `:n`
       #
-      #     @option options [Boolean, String] :branches (nil) Pretend all refs in
-      #       refs/heads are listed on the command line
+      #     @option options [Integer, String] :skip (nil) skip this many commits before starting output
       #
-      #       Pass a shell glob pattern (e.g. `'feature*'`) to restrict to
-      #       matching branch names
+      #     @option options [String] :since (nil) show commits more recent than the given date
       #
-      #     @option options [Boolean, String] :tags (nil) Pretend all refs in
-      #       refs/tags are listed on the command line
+      #       Examples: `'2 weeks ago'`, `'2024-01-01'`
+      #
+      #     @option options [String] :after (nil) show commits more recent than the given date
+      #       (synonym for `:since`)
+      #
+      #     @option options [String] :since_as_filter (nil) like `:since` but visits all commits
+      #       in the range rather than stopping at the first older commit
+      #
+      #     @option options [String] :until (nil) show commits older than the given date
+      #
+      #       Examples: `'1 month ago'`, `'2024-01-01'`
+      #
+      #     @option options [String] :before (nil) show commits older than the given date
+      #       (synonym for `:until`)
+      #
+      #     @option options [String] :author (nil) limit commits to those whose author line
+      #       matches the given pattern (regular expression)
+      #
+      #     @option options [String] :committer (nil) limit commits to those whose committer
+      #       line matches the given pattern (regular expression)
+      #
+      #     @option options [String] :grep_reflog (nil) limit commits to those with reflog entries
+      #       matching the given pattern; requires `:walk_reflogs`
+      #
+      #     @option options [String] :grep (nil) limit commits to those whose log message matches
+      #       the given pattern (regular expression)
+      #
+      #     @option options [Boolean] :all_match (false) limit output to commits matching all
+      #       `--grep` patterns (default: any)
+      #
+      #     @option options [Boolean] :invert_grep (false) limit output to commits whose log
+      #       message does **not** match the `:grep` pattern
+      #
+      #     @option options [Boolean] :regexp_ignore_case (false) match `--grep`, `--author`,
+      #       and `--committer` patterns case-insensitively
+      #
+      #       Alias: `:i`
+      #
+      #     @option options [Boolean] :basic_regexp (false) treat limiting patterns as basic POSIX
+      #       regular expressions (this is the default behavior)
+      #
+      #     @option options [Boolean] :extended_regexp (false) treat limiting patterns as extended
+      #       POSIX regular expressions
+      #
+      #       Mutually exclusive with `:fixed_strings` and `:perl_regexp`. Alias: `:E`
+      #
+      #     @option options [Boolean] :fixed_strings (false) treat limiting patterns as fixed
+      #       strings instead of regular expressions
+      #
+      #       Mutually exclusive with `:extended_regexp` and `:perl_regexp`. Alias: `:F`
+      #
+      #     @option options [Boolean] :perl_regexp (false) treat limiting patterns as
+      #       Perl-compatible regular expressions
+      #
+      #       Mutually exclusive with `:extended_regexp` and `:fixed_strings`. Alias: `:P`
+      #
+      #     @option options [Boolean] :remove_empty (false) stop when a given path disappears
+      #       from the tree
+      #
+      #     @option options [Boolean] :merges (nil) filter by merge status
+      #
+      #       `true` → `--merges` (only merge commits); `false` → `--no-merges`
+      #       (exclude merge commits); `nil` → no filter (neither flag is emitted).
+      #
+      #       Note: `--merges` is equivalent to `--min-parents=2` and `--no-merges` is
+      #       equivalent to `--max-parents=1`.
+      #
+      #     @option options [Integer, String] :min_parents (nil) show only commits with at least this
+      #       many parents
+      #
+      #     @option options [Integer, String] :max_parents (nil) show only commits with at most this
+      #       many parents
+      #
+      #     @option options [Boolean] :first_parent (false) follow only the first parent commit
+      #       upon seeing a merge commit
+      #
+      #     @option options [Boolean] :exclude_first_parent_only (false) when excluding commits
+      #       with `^`, follow only the first parent of merge commits
+      #
+      #     @option options [Boolean] :all (false) pretend as if all refs in `refs/`, along
+      #       with `HEAD`, are listed on the command line
+      #
+      #     @option options [Boolean, String] :branches (false) pretend as if all refs in
+      #       `refs/heads` are listed on the command line
+      #
+      #       Pass a shell glob pattern (e.g. `'feature*'`) to restrict to matching branch names
+      #
+      #     @option options [Boolean, String] :tags (false) pretend as if all refs in
+      #       `refs/tags` are listed on the command line
       #
       #       Pass a shell glob pattern to restrict to matching tag names
       #
-      #     @option options [Boolean, String] :remotes (nil) Pretend all refs in
-      #       refs/remotes are listed on the command line
+      #     @option options [Boolean, String] :remotes (false) pretend as if all refs in
+      #       `refs/remotes` are listed on the command line
       #
       #       Pass a shell glob pattern to restrict to matching remote-tracking branches
       #
-      #     @option options [Boolean] :cherry (nil) Synonym for
+      #     @option options [String] :glob (nil) pretend as if all refs matching the given shell
+      #       glob pattern are listed on the command line
+      #
+      #     @option options [String] :exclude (nil) do not include refs matching the given glob
+      #       that `--all`, `--branches`, `--tags`, `--remotes`, or `--glob` would otherwise use
+      #
+      #     @option options [String] :exclude_hidden (nil) do not include refs hidden by the given
+      #       configuration; value is one of `fetch`, `receive`, or `uploadpack`
+      #
+      #     @option options [Boolean] :reflog (false) pretend as if all objects mentioned by
+      #       reflogs are listed on the command line
+      #
+      #     @option options [Boolean] :alternate_refs (false) pretend as if all objects mentioned
+      #       as ref tips of alternate repositories are listed on the command line
+      #
+      #     @option options [Boolean] :single_worktree (false) examine only the current working
+      #       tree when `--all`, `--reflog`, or similar options are in use
+      #
+      #     @option options [Boolean] :ignore_missing (false) ignore invalid object names in input
+      #
+      #     @option options [Boolean] :bisect (false) pretend as if the bad bisect ref was listed
+      #       and the good bisect refs were excluded
+      #
+      #     @option options [Boolean] :cherry_mark (false) like `:cherry_pick` but marks
+      #       equivalent commits with `=` instead of omitting them; inequivalent ones with +++
+      #
+      #     @option options [Boolean] :cherry_pick (false) omit commits that introduce the same
+      #       change as a commit on the other side of a symmetric difference
+      #
+      #     @option options [Boolean] :left_only (false) list only commits reachable from the
+      #       left side of a symmetric difference
+      #
+      #     @option options [Boolean] :right_only (false) list only commits reachable from the
+      #       right side of a symmetric difference
+      #
+      #     @option options [Boolean] :cherry (false) synonym for
       #       `--right-only --cherry-mark --no-merges`
       #
-      #       Marks commits equivalent on both sides of a symmetric range
+      #     @option options [Boolean] :walk_reflogs (false) walk reflog entries from most recent
+      #       to oldest instead of the commit ancestry chain
       #
-      #     @option options [Boolean] :cherry_mark (nil) Like `--cherry-pick`,
-      #       but marks equivalent commits with `=` instead of omitting them
+      #       Alias: `:g`
       #
-      #       Inequivalent commits are marked with `+`
+      #     @option options [Boolean] :merge (false) show commits touching conflicted paths in
+      #       the range `HEAD...MERGE_HEAD`; only useful with unmerged index entries
       #
-      #     @option options [Boolean] :cherry_pick (nil) Omit commits that
-      #       introduce the same change as a commit on the other side of a
-      #       symmetric difference
+      #     @option options [Boolean] :boundary (false) output excluded boundary commits,
+      #       prefixed with `-`
       #
-      #       Only meaningful in combination with a symmetric difference range
+      #     ### History Simplification
       #
-      #     @option options [Boolean] :left_right (nil) Mark which side of a
-      #       symmetric difference a commit is reachable from
+      #     @option options [Boolean] :simplify_by_decoration (false) show only commits referenced
+      #       by some branch or tag
       #
-      #       Commits reachable from the left side are marked `<`, right side `>`
+      #     @option options [Boolean] :show_pulls (false) include merge commits that are not
+      #       TREESAME to their first parent but are TREESAME to a later parent
       #
-      #     @option options [Boolean] :merges (nil) Filter by merge status
+      #     @option options [Boolean] :full_history (false) do not prune history; show all commits
+      #       that touched the given path(s)
       #
-      #       `true` → `--merges` (only merge commits); `false` → `--no-merges`
-      #       (exclude merge commits); `nil` → no filter.
+      #     @option options [Boolean] :dense (false) show only commits not TREESAME to any parent
       #
-      #       Note: `--merges` is equivalent to `--min-parents=2` and
-      #       `--no-merges` is equivalent to `--max-parents=1`. Specifying
-      #       both `:merges` and a contradictory `:min_parents`/`:max_parents`
-      #       value will produce inconsistent results.
+      #     @option options [Boolean] :sparse (false) show all commits in the simplified history
       #
-      #     @option options [Boolean] :first_parent (nil) Follow only the first
-      #       parent commit upon seeing a merge commit
+      #     @option options [Boolean] :simplify_merges (false) remove needless merges from the
+      #       result of `:full_history` with parent rewriting
       #
-      #     @option options [Integer] :min_parents (nil) Show only commits with at
-      #       least this many parents
+      #     @option options [Boolean, String] :ancestry_path (false) limit to commits on the
+      #       ancestry chain between the range endpoints
       #
-      #     @option options [Integer] :max_parents (nil) Show only commits with at
-      #       most this many parents
+      #       Pass `true` for `--ancestry-path`; pass a commit SHA for `--ancestry-path=<commit>`
       #
-      #     @option options [String] :since (nil) Show commits more recent than
-      #       the given date
+      #     ### Commit Ordering
       #
-      #       Examples: `'2 weeks ago'`, `'2024-01-01'`
+      #     @option options [Boolean] :date_order (false) show commits in commit timestamp order,
+      #       no parents before all children
       #
-      #     @option options [String] :after (nil) Show commits more recent than
-      #       the given date (synonym for `:since`)
+      #     @option options [Boolean] :author_date_order (false) like `:date_order` but ordered
+      #       by author timestamp
       #
-      #       Examples: `'2 weeks ago'`, `'2024-01-01'`
+      #     @option options [Boolean] :topo_order (false) avoid showing commits on multiple lines
+      #       of history intermixed
       #
-      #     @option options [String] :until (nil) Show commits older than the
-      #       given date
+      #     @option options [Boolean] :reverse (false) output selected commits in reverse order;
+      #       cannot be combined with `:walk_reflogs`
       #
-      #       Examples: `'1 month ago'`, `'2024-01-01'`
+      #     ### Object Traversal
       #
-      #     @option options [String] :before (nil) Show commits older than the
-      #       given date (synonym for `:until`)
+      #     @option options [Boolean, String] :no_walk (false) show only the given commits without
+      #       traversing ancestors
       #
-      #       Examples: `'1 month ago'`, `'2024-01-01'`
+      #       Pass `true` for `--no-walk` (sorted); pass `"unsorted"` for `--no-walk=unsorted`
       #
-      #     @option options [String] :grep (nil) Limit commits to those whose log
-      #       message matches the given pattern
+      #     @option options [Boolean] :do_walk (false) override a previous `--no-walk`
       #
-      #     @option options [Boolean] :all_match (nil) Limit output to commits
-      #       that match all `--grep` patterns (default: any)
+      #     ### Commit Formatting
       #
-      #       Requires `:grep` to be set
+      #     @option options [Boolean, String] :pretty (false) pretty-print commit log in a format
       #
-      #     @option options [Boolean] :invert_grep (nil) Limit output to commits
-      #       whose log message does **not** match the `--grep` pattern
+      #       Pass `true` for `--pretty` (`medium` format); pass a format name such as `"oneline"`,
+      #       `"short"`, `"full"`, `"fuller"`, `"email"`, `"raw"`, or a `format:<string>`
+      #       expression for `--pretty=<format>`.
       #
-      #       Requires `:grep` to be set
+      #       Alias: `:format`
       #
-      #     @option options [Boolean] :regexp_ignore_case (nil) Match `--grep`,
-      #       `--author`, and `--committer` patterns case-insensitively
+      #     @option options [Boolean] :abbrev_commit (nil) abbreviate commit hash
       #
-      #       Short alias: `:i`
+      #       `true` → `--abbrev-commit`; `false` → `--no-abbrev-commit`; `nil` → neither
       #
-      #     @option options [Boolean] :extended_regexp (nil) Treat limiting
-      #       patterns as extended POSIX regular expressions
+      #     @option options [Boolean] :oneline (false) shorthand for
+      #       `--pretty=oneline --abbrev-commit`
       #
-      #       Mutually exclusive with `:fixed_strings` and `:perl_regexp`.
-      #       Short alias: `:E`
+      #     @option options [String] :encoding (nil) re-encode the commit log message in the
+      #       given character encoding before output
       #
-      #     @option options [Boolean] :fixed_strings (nil) Treat limiting
-      #       patterns as fixed strings instead of regular expressions
+      #     @option options [Boolean, String] :expand_tabs (nil) expand tabs in log messages
       #
-      #       Mutually exclusive with `:extended_regexp` and `:perl_regexp`.
-      #       Short alias: `:F`
+      #       `true` → `--expand-tabs` (width 8); integer string like `"4"` →
+      #       `--expand-tabs=<n>`; `false` → `--no-expand-tabs`; `nil` → neither
       #
-      #     @option options [Boolean] :perl_regexp (nil) Treat limiting patterns
-      #       as Perl-compatible regular expressions
+      #     @option options [Boolean, String] :notes (nil) show notes annotating the commit
       #
-      #       Mutually exclusive with `:extended_regexp` and `:fixed_strings`.
-      #       Short alias: `:P`
+      #       `true` → `--notes`; a ref string → `--notes=<ref>`;
+      #       `false` → `--no-notes`; `nil` → neither
       #
-      #     @option options [String] :author (nil) Limit commits to those whose
-      #       author line matches the given pattern (name or email)
+      #     @option options [Boolean] :show_notes_by_default (false) show the default notes unless
+      #       options for displaying specific notes are given
       #
-      #     @option options [String] :committer (nil) Limit commits to those
-      #       whose committer line matches the given pattern (name or email)
+      #     @option options [Boolean] :show_signature (false) verify a signed commit with
+      #       `gpg --verify`
       #
-      #     @option options [Integer] :max_count (nil) Maximum number of commits
-      #       to output
+      #     @option options [Boolean] :relative_date (false) show dates relative to the current
+      #       time (synonym for `--date=relative`)
       #
-      #     @option options [Integer] :skip (nil) Skip the given number of
-      #       commits before starting to output
+      #     @option options [String] :date (nil) format for dates in human-readable output
       #
-      #     @option options [Boolean] :follow (nil) Continue listing the history
-      #       of a file beyond renames
+      #       Examples: `'relative'`, `'iso'`, `'short'`, `'format:%Y-%m-%d'`
       #
-      #       Requires `:path` to be set to exactly one path element
+      #     @option options [Boolean] :parents (false) print the parents of each commit and
+      #       enable parent rewriting
       #
-      #     @option options [Boolean] :full_history (nil) Do not prune history;
-      #       show all commits that touched the given path(s)
+      #     @option options [Boolean] :children (false) print the children of each commit and
+      #       enable parent rewriting
       #
-      #     @option options [Boolean] :date_order (nil) Show no parents before
-      #       all of their children are shown, ordered by commit timestamp
+      #     @option options [Boolean] :left_right (false) mark which side of a symmetric
+      #       difference a commit is reachable from (`<` for left, `>` for right)
       #
-      #     @option options [Boolean] :author_date_order (nil) Like `:date_order`
-      #       but ordered by author timestamp
+      #     @option options [Boolean] :graph (false) draw a text-based graphical representation
+      #       of the commit history on the left side of output; implies `--topo-order`
       #
-      #     @option options [Boolean] :topo_order (nil) Avoid showing commits on
-      #       multiple lines of history intermixed
+      #     @option options [Boolean, String] :show_linear_break (false) put a barrier between
+      #       non-linear consecutive commits when `--graph` is not used
       #
-      #     @option options [Boolean] :reverse (nil) Output selected commits in
-      #       reverse order
+      #       Pass `true` for `--show-linear-break`; pass a string for a custom barrier text
       #
-      #     @option options [Array<String>] :path (nil) Limit commits to those
-      #       that affected the given paths
+      #     @option options [Boolean] :follow (false) continue listing the history of a file
+      #       beyond renames; requires `:path` to be set to exactly one path element
       #
-      #     @option options [Integer, Float] :timeout (nil) Number of seconds to
-      #       wait before the command is aborted with a timeout error
+      #     @option options [Boolean, String] :decorate (nil) print ref names of commits shown
+      #
+      #       `true` → `--decorate` (short format); string `"full"` → `--decorate=full`;
+      #       `false` → `--no-decorate`; `nil` → neither
+      #
+      #     @option options [String] :decorate_refs (nil) use only refs matching this pattern
+      #       for decorations
+      #
+      #     @option options [String] :decorate_refs_exclude (nil) do not use refs matching this
+      #       pattern for decorations
+      #
+      #     @option options [Boolean] :clear_decorations (false) clear all previous
+      #       `--decorate-refs` / `--decorate-refs-exclude` options
+      #
+      #     @option options [Boolean] :source (false) print the ref name by which each commit
+      #       was reached
+      #
+      #     @option options [Boolean] :use_mailmap (nil) use the mailmap file to map author/
+      #       committer names and addresses to canonical real names
+      #
+      #       `true` → `--use-mailmap`; `false` → `--no-use-mailmap`; `nil` → neither
+      #
+      #     @option options [Boolean] :full_diff (false) show full diff for commits touching the
+      #       specified paths, not just the diff for those paths
+      #
+      #     @option options [Boolean] :log_size (false) include a `log size <n>` line for each
+      #       commit indicating the length of the commit message in bytes
+      #
+      #     ### Diff Formatting
+      #
+      #     @option options [Boolean] :patch (false) generate patch output
+      #
+      #       Alias: `:p`
+      #
+      #     @option options [Boolean] :no_patch (false) suppress all diff output
+      #
+      #       Alias: `:s`
+      #
+      #     @option options [String] :diff_merges (nil) diff format for merge commits
+      #
+      #       Values: `"off"`, `"on"`, `"first-parent"`, `"separate"`, `"combined"`,
+      #       `"dense-combined"`, `"remerge"`
+      #
+      #     @option options [Boolean] :no_diff_merges (false) disable diff output for merge
+      #       commits (synonym for `--diff-merges=off`)
+      #
+      #     @option options [Boolean] :combined_all_paths (false) in combined diffs, list the
+      #       file name from all parents; only meaningful with `-c` or `--cc`
+      #
+      #     @option options [Boolean] :raw (false) show a summary of changes using the raw diff
+      #       format for each commit
+      #
+      #     @option options [Boolean, String] :stat (false) generate a diffstat
+      #
+      #       Pass `true` for `--stat`; pass a string such as `"80,40"` for
+      #       `--stat=<width>[,<name-width>[,<count>]]`
+      #
+      #     @option options [Boolean] :compact_summary (false) output a condensed summary of
+      #       extended header information in diffstat; implies `--stat`
+      #
+      #     @option options [Boolean] :numstat (false) like `--stat` but shows numbers of added
+      #       and deleted lines in decimal notation without abbreviation
+      #
+      #     @option options [Boolean] :shortstat (false) output only the last line of the
+      #       `--stat` format
+      #
+      #     @option options [Boolean, String] :dirstat (false) output distribution of relative
+      #       amount of changes per sub-directory
+      #
+      #       Pass `true` for `--dirstat`; pass a parameter string such as `"files,10"` for
+      #       `--dirstat=<params>`
+      #
+      #     @option options [Boolean] :summary (false) output a condensed summary of extended
+      #       header information such as creations, renames, and mode changes
+      #
+      #     @option options [Boolean] :name_only (false) show only the names of changed files
+      #
+      #     @option options [Boolean] :name_status (false) show only the names and status of
+      #       changed files
+      #
+      #     @option options [Boolean, String] :submodule (false) specify how differences in
+      #       submodules are shown
+      #
+      #       Pass `true` for `--submodule` (log format); pass `"short"`, `"log"`, or `"diff"`
+      #       for `--submodule=<format>`
+      #
+      #     @option options [Boolean, String] :color (nil) show colored diff output
+      #
+      #       `true` → `--color`; string `"always"` → `--color=always`;
+      #       `false` → `--no-color`; `nil` → neither
+      #
+      #     @option options [Boolean] :full_index (false) show the full pre- and post-image blob
+      #       object names on the index line of patch output
+      #
+      #     @option options [Boolean] :binary (false) output a binary diff that can be applied
+      #       with `git apply`; implies `--patch`
+      #
+      #     @option options [Boolean, String] :abbrev (false) show the shortest unique object
+      #       name prefix in diff-raw output
+      #
+      #       Pass `true` for `--abbrev`; pass an integer string for `--abbrev=<n>`
+      #
+      #     @option options [String] :diff_filter (nil) select files by status letter
+      #       (e.g. `"AD"` for Added and Deleted)
+      #
+      #     @option options [Boolean, String] :find_renames (false) detect renames
+      #
+      #       Pass `true` for `--find-renames`; pass a percentage threshold string such as
+      #       `"90"` for `--find-renames=<n>`
+      #
+      #     @option options [Boolean, String] :find_copies (false) detect copies as well as
+      #       renames
+      #
+      #       Pass `true` for `--find-copies`; pass a threshold string for `--find-copies=<n>`
+      #
+      #     @option options [Boolean] :find_copies_harder (false) inspect unmodified files as
+      #       candidates for copy source; expensive for large projects
+      #
+      #     @option options [Boolean, String] :relative (nil) show pathnames relative to the
+      #       given subdirectory, or the current directory when run from a subdirectory
+      #
+      #       `true` → `--relative`; path string → `--relative=<path>`;
+      #       `false` → `--no-relative`; `nil` → neither
+      #
+      #     @option options [Boolean] :text (false) treat all files as text; alias `-a`
+      #
+      #     @option options [Boolean] :ignore_space_at_eol (false) ignore changes in whitespace
+      #       at end of line
+      #
+      #     @option options [Boolean] :ignore_space_change (false) ignore changes in amount of
+      #       whitespace; alias `-b`
+      #
+      #     @option options [Boolean] :ignore_all_space (false) ignore whitespace when comparing
+      #       lines; alias `-w`
+      #
+      #     @option options [Boolean] :ignore_blank_lines (false) ignore changes whose lines are
+      #       all blank
+      #
+      #     @option options [String] :ignore_matching_lines (nil) ignore changes whose all lines
+      #       match the given regular expression
+      #
+      #     @option options [Boolean] :ext_diff (nil) allow (or disallow) external diff helpers
+      #
+      #       `true` → `--ext-diff`; `false` → `--no-ext-diff`; `nil` → neither
+      #
+      #     @option options [Boolean] :textconv (nil) allow (or disallow) external text conversion
+      #       filters when comparing binary files
+      #
+      #       `true` → `--textconv`; `false` → `--no-textconv`; `nil` → neither
+      #
+      #     @option options [Boolean] :no_prefix (false) do not show any source or destination
+      #       prefix
+      #
+      #     @option options [String] :src_prefix (nil) show the given source prefix instead of
+      #       `a/`
+      #
+      #     @option options [String] :dst_prefix (nil) show the given destination prefix instead
+      #       of `b/`
+      #
+      #     ### Paths
+      #
+      #     @option options [Array<String>] :path (nil) limit commits to those that affected the
+      #       given paths
+      #
+      #     ### Execution
+      #
+      #     @option options [Integer, Float] :timeout (nil) number of seconds to wait before the
+      #       command is aborted with a timeout error
       #
       #     @return [Git::CommandLineResult] the result of calling `git log`
+      #
+      #     @raise [ArgumentError] if unsupported options are provided
       #
       #     @raise [Git::FailedError] if git exits with a non-zero exit status
       #

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -2732,7 +2732,7 @@ module Git
       log_or_empty_on_unborn do
         result = Git::Commands::Log.new(self).call(
           *revision_range_args,
-          no_color: true, pretty: 'raw',
+          color: false, pretty: 'raw',
           **call_opts
         )
         process_commit_log_data(result.stdout.split("\n"))

--- a/spec/integration/git/commands/log_spec.rb
+++ b/spec/integration/git/commands/log_spec.rb
@@ -20,25 +20,28 @@ RSpec.describe Git::Commands::Log, :integration do
 
   describe '#call' do
     context 'when the command succeeds' do
-      it 'returns a CommandLineResult' do
+      it 'returns a CommandLineResult with non-empty output' do
         result = command.call
 
         expect(result).to be_a(Git::CommandLineResult)
+        expect(result.stdout).not_to be_empty
       end
 
       context 'with a revision range operand' do
-        it 'returns a CommandLineResult' do
+        it 'returns a CommandLineResult for the given range' do
           first_sha = repo.lib.rev_parse('HEAD~1')
           result = command.call("#{first_sha}..")
 
           expect(result).to be_a(Git::CommandLineResult)
+          expect(result.stdout).not_to be_empty
         end
       end
     end
 
     context 'when the command fails' do
       it 'raises FailedError for an invalid revision' do
-        expect { command.call('nonexistent-branch') }.to raise_error(Git::FailedError)
+        expect { command.call('nonexistent-branch') }
+          .to raise_error(Git::FailedError, /nonexistent-branch/)
       end
     end
   end

--- a/spec/unit/git/commands/grep_spec.rb
+++ b/spec/unit/git/commands/grep_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::Grep do
       end
     end
 
-    context 'with parser-contract options (no_color:)' do
+    context 'with :no_color option' do
       it 'includes --no-color when no_color: true' do
         expect_command_capturing('grep', '--no-color', '-e', 'search', 'HEAD')
           .and_return(command_result('HEAD:file.txt:5:to search'))
@@ -571,7 +571,7 @@ RSpec.describe Git::Commands::Grep do
 
     context 'with :recurse_submodules option' do
       it 'includes --recurse-submodules flag' do
-        expect_command_capturing('grep', '--recurse-submodules', '-e', 'search', 'HEAD')
+        expect_command_capturing('grep', '-e', 'search', '--recurse-submodules', 'HEAD')
           .and_return(command_result(''))
 
         command.call('HEAD', pattern: 'search', recurse_submodules: true)
@@ -580,7 +580,7 @@ RSpec.describe Git::Commands::Grep do
 
     context 'with :exclude_standard option' do
       it 'includes --exclude-standard flag' do
-        expect_command_capturing('grep', '--exclude-standard', '--untracked', '-e', 'search')
+        expect_command_capturing('grep', '-e', 'search', '--exclude-standard', '--untracked')
           .and_return(command_result(''))
 
         command.call(pattern: 'search', exclude_standard: true, untracked: true)
@@ -589,7 +589,7 @@ RSpec.describe Git::Commands::Grep do
 
     context 'with :exclude_standard false' do
       it 'includes --no-exclude-standard flag' do
-        expect_command_capturing('grep', '--no-exclude-standard', '--no-index', '-e', 'search')
+        expect_command_capturing('grep', '-e', 'search', '--no-exclude-standard', '--no-index')
           .and_return(command_result(''))
 
         command.call(pattern: 'search', exclude_standard: false, no_index: true)
@@ -598,7 +598,7 @@ RSpec.describe Git::Commands::Grep do
 
     context 'with :cached option' do
       it 'includes --cached flag' do
-        expect_command_capturing('grep', '--cached', '-e', 'search')
+        expect_command_capturing('grep', '-e', 'search', '--cached')
           .and_return(command_result(''))
 
         command.call(pattern: 'search', cached: true)
@@ -607,7 +607,7 @@ RSpec.describe Git::Commands::Grep do
 
     context 'with :untracked option' do
       it 'includes --untracked flag' do
-        expect_command_capturing('grep', '--untracked', '-e', 'search')
+        expect_command_capturing('grep', '-e', 'search', '--untracked')
           .and_return(command_result(''))
 
         command.call(pattern: 'search', untracked: true)
@@ -616,10 +616,60 @@ RSpec.describe Git::Commands::Grep do
 
     context 'with :no_index option' do
       it 'includes --no-index flag' do
-        expect_command_capturing('grep', '--no-index', '-e', 'search')
+        expect_command_capturing('grep', '-e', 'search', '--no-index')
           .and_return(command_result(''))
 
         command.call(pattern: 'search', no_index: true)
+      end
+    end
+
+    # Output format
+
+    context 'with :null option' do
+      it 'includes --null flag' do
+        expect_command_capturing('grep', '--null', '-e', 'search', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', pattern: 'search', null: true)
+      end
+    end
+
+    context 'with :z alias' do
+      it 'accepts :z as alias for :null' do
+        expect_command_capturing('grep', '--null', '-e', 'search', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', pattern: 'search', z: true)
+      end
+    end
+
+    # Color
+
+    context 'with :color option' do
+      it 'includes --color when color: true' do
+        expect_command_capturing('grep', '--color', '-e', 'search', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', pattern: 'search', color: true)
+      end
+
+      it 'includes --color=<value> when color: string' do
+        expect_command_capturing('grep', '--color=always', '-e', 'search', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', pattern: 'search', color: 'always')
+      end
+    end
+
+    # Source selection
+
+    context 'with :parent_basename option' do
+      it 'includes --parent-basename with the given value' do
+        expect_command_capturing('grep', '-e', 'search', '--parent-basename', 'superproject',
+                                 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', pattern: 'search', parent_basename: 'superproject')
       end
     end
 

--- a/spec/unit/git/commands/log_spec.rb
+++ b/spec/unit/git/commands/log_spec.rb
@@ -4,6 +4,8 @@ require 'spec_helper'
 require 'git/commands/log'
 
 RSpec.describe Git::Commands::Log do
+  # Duck-type collaborator: command specs depend on the #command_capturing interface,
+  # not a single concrete ExecutionContext class.
   let(:execution_context) { double('ExecutionContext') }
   let(:command) { described_class.new(execution_context) }
 
@@ -19,23 +21,233 @@ RSpec.describe Git::Commands::Log do
       end
     end
 
-    context 'with parser-contract options (no_color:, pretty:)' do
-      it 'includes --no-color when no_color: true' do
-        expect_command_capturing('log', '--no-color').and_return(command_result)
+    # Commit Limiting
 
-        command.call(no_color: true)
+    context 'with the :max_count option' do
+      it 'includes --max-count=<n>' do
+        expect_command_capturing('log', '--max-count=10').and_return(command_result)
+
+        command.call(max_count: 10)
       end
 
-      it 'includes --pretty=raw when pretty: "raw"' do
-        expect_command_capturing('log', '--pretty=raw').and_return(command_result)
+      it 'accepts :n as an alias for :max_count' do
+        expect_command_capturing('log', '--max-count=5').and_return(command_result)
 
-        command.call(pretty: 'raw')
+        command.call(n: 5)
+      end
+    end
+
+    context 'with the :skip option' do
+      it 'includes --skip=<n>' do
+        expect_command_capturing('log', '--skip=5').and_return(command_result)
+
+        command.call(skip: 5)
+      end
+    end
+
+    context 'with the :since option' do
+      it 'includes --since=<value>' do
+        expect_command_capturing('log', '--since=1 week ago').and_return(command_result)
+
+        command.call(since: '1 week ago')
+      end
+    end
+
+    context 'with the :after option' do
+      it 'includes --after=<value>' do
+        expect_command_capturing('log', '--after=2024-01-01').and_return(command_result)
+
+        command.call(after: '2024-01-01')
+      end
+    end
+
+    context 'with the :since_as_filter option' do
+      it 'includes --since-as-filter=<value>' do
+        expect_command_capturing('log', '--since-as-filter=2024-01-01').and_return(command_result)
+
+        command.call(since_as_filter: '2024-01-01')
+      end
+    end
+
+    context 'with the :until option' do
+      it 'includes --until=<value>' do
+        expect_command_capturing('log', '--until=2024-01-01').and_return(command_result)
+
+        command.call(until: '2024-01-01')
+      end
+    end
+
+    context 'with the :before option' do
+      it 'includes --before=<value>' do
+        expect_command_capturing('log', '--before=2024-06-01').and_return(command_result)
+
+        command.call(before: '2024-06-01')
+      end
+    end
+
+    context 'with the :author option' do
+      it 'includes --author=<value>' do
+        expect_command_capturing('log', '--author=Jane Doe').and_return(command_result)
+
+        command.call(author: 'Jane Doe')
+      end
+    end
+
+    context 'with the :committer option' do
+      it 'includes --committer=<value>' do
+        expect_command_capturing('log', '--committer=Jane Doe').and_return(command_result)
+
+        command.call(committer: 'Jane Doe')
+      end
+    end
+
+    context 'with the :grep_reflog option' do
+      it 'includes --grep-reflog=<value>' do
+        expect_command_capturing('log', '--grep-reflog=HEAD@{1}').and_return(command_result)
+
+        command.call(grep_reflog: 'HEAD@{1}')
+      end
+    end
+
+    context 'with the :grep option' do
+      it 'includes --grep=<value>' do
+        expect_command_capturing('log', '--grep=fix bug').and_return(command_result)
+
+        command.call(grep: 'fix bug')
+      end
+    end
+
+    context 'with the :all_match option' do
+      it 'includes the --all-match flag' do
+        expect_command_capturing('log', '--all-match').and_return(command_result)
+
+        command.call(all_match: true)
+      end
+    end
+
+    context 'with the :invert_grep option' do
+      it 'includes the --invert-grep flag' do
+        expect_command_capturing('log', '--invert-grep').and_return(command_result)
+
+        command.call(invert_grep: true)
+      end
+    end
+
+    context 'with the :regexp_ignore_case option' do
+      it 'includes the --regexp-ignore-case flag' do
+        expect_command_capturing('log', '--regexp-ignore-case').and_return(command_result)
+
+        command.call(regexp_ignore_case: true)
       end
 
-      it 'combines --no-color and --pretty=raw as the facade would' do
-        expect_command_capturing('log', '--no-color', '--pretty=raw').and_return(command_result)
+      it 'accepts :i as an alias for :regexp_ignore_case' do
+        expect_command_capturing('log', '--regexp-ignore-case').and_return(command_result)
 
-        command.call(no_color: true, pretty: 'raw')
+        command.call(i: true)
+      end
+    end
+
+    context 'with the :basic_regexp option' do
+      it 'includes the --basic-regexp flag' do
+        expect_command_capturing('log', '--basic-regexp').and_return(command_result)
+
+        command.call(basic_regexp: true)
+      end
+    end
+
+    context 'with the :extended_regexp option' do
+      it 'includes the --extended-regexp flag' do
+        expect_command_capturing('log', '--extended-regexp').and_return(command_result)
+
+        command.call(extended_regexp: true)
+      end
+
+      it 'accepts :E as an alias for :extended_regexp' do
+        expect_command_capturing('log', '--extended-regexp').and_return(command_result)
+
+        command.call(E: true)
+      end
+    end
+
+    context 'with the :fixed_strings option' do
+      it 'includes the --fixed-strings flag' do
+        expect_command_capturing('log', '--fixed-strings').and_return(command_result)
+
+        command.call(fixed_strings: true)
+      end
+
+      it 'accepts :F as an alias for :fixed_strings' do
+        expect_command_capturing('log', '--fixed-strings').and_return(command_result)
+
+        command.call(F: true)
+      end
+    end
+
+    context 'with the :perl_regexp option' do
+      it 'includes the --perl-regexp flag' do
+        expect_command_capturing('log', '--perl-regexp').and_return(command_result)
+
+        command.call(perl_regexp: true)
+      end
+
+      it 'accepts :P as an alias for :perl_regexp' do
+        expect_command_capturing('log', '--perl-regexp').and_return(command_result)
+
+        command.call(P: true)
+      end
+    end
+
+    context 'with the :remove_empty option' do
+      it 'includes the --remove-empty flag' do
+        expect_command_capturing('log', '--remove-empty').and_return(command_result)
+
+        command.call(remove_empty: true)
+      end
+    end
+
+    context 'with the :merges option' do
+      it 'includes the --merges flag' do
+        expect_command_capturing('log', '--merges').and_return(command_result)
+
+        command.call(merges: true)
+      end
+
+      it 'includes the --no-merges flag when false' do
+        expect_command_capturing('log', '--no-merges').and_return(command_result)
+
+        command.call(merges: false)
+      end
+    end
+
+    context 'with the :min_parents option' do
+      it 'includes --min-parents=<n>' do
+        expect_command_capturing('log', '--min-parents=2').and_return(command_result)
+
+        command.call(min_parents: 2)
+      end
+    end
+
+    context 'with the :max_parents option' do
+      it 'includes --max-parents=<n>' do
+        expect_command_capturing('log', '--max-parents=1').and_return(command_result)
+
+        command.call(max_parents: 1)
+      end
+    end
+
+    context 'with the :first_parent option' do
+      it 'includes the --first-parent flag' do
+        expect_command_capturing('log', '--first-parent').and_return(command_result)
+
+        command.call(first_parent: true)
+      end
+    end
+
+    context 'with the :exclude_first_parent_only option' do
+      it 'includes the --exclude-first-parent-only flag' do
+        expect_command_capturing('log', '--exclude-first-parent-only').and_return(command_result)
+
+        command.call(exclude_first_parent_only: true)
       end
     end
 
@@ -89,11 +301,67 @@ RSpec.describe Git::Commands::Log do
       end
     end
 
-    context 'with the :cherry option' do
-      it 'includes the --cherry flag' do
-        expect_command_capturing('log', '--cherry').and_return(command_result)
+    context 'with the :glob option' do
+      it 'includes --glob=<value>' do
+        expect_command_capturing('log', '--glob=refs/heads/feature*').and_return(command_result)
 
-        command.call(cherry: true)
+        command.call(glob: 'refs/heads/feature*')
+      end
+    end
+
+    context 'with the :exclude option' do
+      it 'includes --exclude=<value>' do
+        expect_command_capturing('log', '--exclude=refs/heads/tmp/*').and_return(command_result)
+
+        command.call(exclude: 'refs/heads/tmp/*')
+      end
+    end
+
+    context 'with the :exclude_hidden option' do
+      it 'includes --exclude-hidden=<value>' do
+        expect_command_capturing('log', '--exclude-hidden=fetch').and_return(command_result)
+
+        command.call(exclude_hidden: 'fetch')
+      end
+    end
+
+    context 'with the :reflog option' do
+      it 'includes the --reflog flag' do
+        expect_command_capturing('log', '--reflog').and_return(command_result)
+
+        command.call(reflog: true)
+      end
+    end
+
+    context 'with the :alternate_refs option' do
+      it 'includes the --alternate-refs flag' do
+        expect_command_capturing('log', '--alternate-refs').and_return(command_result)
+
+        command.call(alternate_refs: true)
+      end
+    end
+
+    context 'with the :single_worktree option' do
+      it 'includes the --single-worktree flag' do
+        expect_command_capturing('log', '--single-worktree').and_return(command_result)
+
+        command.call(single_worktree: true)
+      end
+    end
+
+    context 'with the :ignore_missing option' do
+      it 'includes the --ignore-missing flag' do
+        expect_command_capturing('log', '--ignore-missing').and_return(command_result)
+
+        command.call(ignore_missing: true)
+      end
+    end
+
+    context 'with the :bisect option' do
+      it 'includes the --bisect flag' do
+        expect_command_capturing('log', '--bisect').and_return(command_result)
+
+        command.call(bisect: true)
       end
     end
 
@@ -113,125 +381,75 @@ RSpec.describe Git::Commands::Log do
       end
     end
 
-    context 'with the :left_right option' do
-      it 'includes the --left-right flag' do
-        expect_command_capturing('log', '--left-right').and_return(command_result)
+    context 'with the :left_only option' do
+      it 'includes the --left-only flag' do
+        expect_command_capturing('log', '--left-only').and_return(command_result)
 
-        command.call(left_right: true)
+        command.call(left_only: true)
       end
     end
 
-    context 'with the :merges option' do
-      it 'includes the --merges flag' do
-        expect_command_capturing('log', '--merges').and_return(command_result)
+    context 'with the :right_only option' do
+      it 'includes the --right-only flag' do
+        expect_command_capturing('log', '--right-only').and_return(command_result)
 
-        command.call(merges: true)
-      end
-
-      it 'includes the --no-merges flag when false' do
-        expect_command_capturing('log', '--no-merges').and_return(command_result)
-
-        command.call(merges: false)
+        command.call(right_only: true)
       end
     end
 
-    context 'with the :first_parent option' do
-      it 'includes the --first-parent flag' do
-        expect_command_capturing('log', '--first-parent').and_return(command_result)
+    context 'with the :cherry option' do
+      it 'includes the --cherry flag' do
+        expect_command_capturing('log', '--cherry').and_return(command_result)
 
-        command.call(first_parent: true)
+        command.call(cherry: true)
       end
     end
 
-    context 'with the :min_parents option' do
-      it 'includes --min-parents=<n>' do
-        expect_command_capturing('log', '--min-parents=2').and_return(command_result)
+    context 'with the :walk_reflogs option' do
+      it 'includes the --walk-reflogs flag' do
+        expect_command_capturing('log', '--walk-reflogs').and_return(command_result)
 
-        command.call(min_parents: 2)
+        command.call(walk_reflogs: true)
+      end
+
+      it 'accepts :g as an alias for :walk_reflogs' do
+        expect_command_capturing('log', '--walk-reflogs').and_return(command_result)
+
+        command.call(g: true)
       end
     end
 
-    context 'with the :max_parents option' do
-      it 'includes --max-parents=<n>' do
-        expect_command_capturing('log', '--max-parents=1').and_return(command_result)
+    context 'with the :merge option' do
+      it 'includes the --merge flag' do
+        expect_command_capturing('log', '--merge').and_return(command_result)
 
-        command.call(max_parents: 1)
+        command.call(merge: true)
       end
     end
 
-    context 'with the :since option' do
-      it 'includes --since=<value>' do
-        expect_command_capturing('log', '--since=1 week ago').and_return(command_result)
+    context 'with the :boundary option' do
+      it 'includes the --boundary flag' do
+        expect_command_capturing('log', '--boundary').and_return(command_result)
 
-        command.call(since: '1 week ago')
+        command.call(boundary: true)
       end
     end
 
-    context 'with the :after option' do
-      it 'includes --after=<value>' do
-        expect_command_capturing('log', '--after=2024-01-01').and_return(command_result)
+    # History Simplification
 
-        command.call(after: '2024-01-01')
+    context 'with the :simplify_by_decoration option' do
+      it 'includes the --simplify-by-decoration flag' do
+        expect_command_capturing('log', '--simplify-by-decoration').and_return(command_result)
+
+        command.call(simplify_by_decoration: true)
       end
     end
 
-    context 'with the :until option' do
-      it 'includes --until=<value>' do
-        expect_command_capturing('log', '--until=2024-01-01').and_return(command_result)
+    context 'with the :show_pulls option' do
+      it 'includes the --show-pulls flag' do
+        expect_command_capturing('log', '--show-pulls').and_return(command_result)
 
-        command.call(until: '2024-01-01')
-      end
-    end
-
-    context 'with the :before option' do
-      it 'includes --before=<value>' do
-        expect_command_capturing('log', '--before=2024-06-01').and_return(command_result)
-
-        command.call(before: '2024-06-01')
-      end
-    end
-
-    context 'with the :grep option' do
-      it 'includes --grep=<value>' do
-        expect_command_capturing('log', '--grep=fix bug').and_return(command_result)
-
-        command.call(grep: 'fix bug')
-      end
-    end
-
-    context 'with the :author option' do
-      it 'includes --author=<value>' do
-        expect_command_capturing(
-          'log', '--author=Jane Doe'
-        ).and_return(command_result)
-
-        command.call(author: 'Jane Doe')
-      end
-    end
-
-    context 'with the :committer option' do
-      it 'includes --committer=<value>' do
-        expect_command_capturing(
-          'log', '--committer=Jane Doe'
-        ).and_return(command_result)
-
-        command.call(committer: 'Jane Doe')
-      end
-    end
-
-    context 'with the :max_count option' do
-      it 'includes --max-count=<n>' do
-        expect_command_capturing('log', '--max-count=10').and_return(command_result)
-
-        command.call(max_count: 10)
-      end
-    end
-
-    context 'with the :skip option' do
-      it 'includes --skip=<n>' do
-        expect_command_capturing('log', '--skip=5').and_return(command_result)
-
-        command.call(skip: 5)
+        command.call(show_pulls: true)
       end
     end
 
@@ -242,6 +460,46 @@ RSpec.describe Git::Commands::Log do
         command.call(full_history: true)
       end
     end
+
+    context 'with the :dense option' do
+      it 'includes the --dense flag' do
+        expect_command_capturing('log', '--dense').and_return(command_result)
+
+        command.call(dense: true)
+      end
+    end
+
+    context 'with the :sparse option' do
+      it 'includes the --sparse flag' do
+        expect_command_capturing('log', '--sparse').and_return(command_result)
+
+        command.call(sparse: true)
+      end
+    end
+
+    context 'with the :simplify_merges option' do
+      it 'includes the --simplify-merges flag' do
+        expect_command_capturing('log', '--simplify-merges').and_return(command_result)
+
+        command.call(simplify_merges: true)
+      end
+    end
+
+    context 'with the :ancestry_path option' do
+      it 'includes the bare --ancestry-path flag when true' do
+        expect_command_capturing('log', '--ancestry-path').and_return(command_result)
+
+        command.call(ancestry_path: true)
+      end
+
+      it 'includes --ancestry-path=<commit> when a commit is given' do
+        expect_command_capturing('log', '--ancestry-path=abc123').and_return(command_result)
+
+        command.call(ancestry_path: 'abc123')
+      end
+    end
+
+    # Commit Ordering
 
     context 'with the :date_order option' do
       it 'includes the --date-order flag' do
@@ -275,6 +533,670 @@ RSpec.describe Git::Commands::Log do
       end
     end
 
+    # Object Traversal
+
+    context 'with the :no_walk option' do
+      it 'includes the bare --no-walk flag when true' do
+        expect_command_capturing('log', '--no-walk').and_return(command_result)
+
+        command.call(no_walk: true)
+      end
+
+      it 'includes --no-walk=unsorted when "unsorted"' do
+        expect_command_capturing('log', '--no-walk=unsorted').and_return(command_result)
+
+        command.call(no_walk: 'unsorted')
+      end
+    end
+
+    context 'with the :do_walk option' do
+      it 'includes the --do-walk flag' do
+        expect_command_capturing('log', '--do-walk').and_return(command_result)
+
+        command.call(do_walk: true)
+      end
+    end
+
+    # Commit Formatting
+
+    context 'with the :pretty / :format option' do
+      it 'includes the bare --pretty flag when true' do
+        expect_command_capturing('log', '--pretty').and_return(command_result)
+
+        command.call(pretty: true)
+      end
+
+      it 'includes --pretty=raw when pretty: "raw"' do
+        expect_command_capturing('log', '--pretty=raw').and_return(command_result)
+
+        command.call(pretty: 'raw')
+      end
+
+      it 'accepts :format as an alias for :pretty' do
+        expect_command_capturing('log', '--pretty=oneline').and_return(command_result)
+
+        command.call(format: 'oneline')
+      end
+    end
+
+    context 'with the :abbrev_commit option' do
+      it 'includes the --abbrev-commit flag when true' do
+        expect_command_capturing('log', '--abbrev-commit').and_return(command_result)
+
+        command.call(abbrev_commit: true)
+      end
+
+      it 'includes the --no-abbrev-commit flag when false' do
+        expect_command_capturing('log', '--no-abbrev-commit').and_return(command_result)
+
+        command.call(abbrev_commit: false)
+      end
+    end
+
+    context 'with the :oneline option' do
+      it 'includes the --oneline flag' do
+        expect_command_capturing('log', '--oneline').and_return(command_result)
+
+        command.call(oneline: true)
+      end
+    end
+
+    context 'with the :encoding option' do
+      it 'includes --encoding=<value>' do
+        expect_command_capturing('log', '--encoding=UTF-8').and_return(command_result)
+
+        command.call(encoding: 'UTF-8')
+      end
+    end
+
+    context 'with the :expand_tabs option' do
+      it 'includes the bare --expand-tabs flag when true' do
+        expect_command_capturing('log', '--expand-tabs').and_return(command_result)
+
+        command.call(expand_tabs: true)
+      end
+
+      it 'includes --expand-tabs=<n> when given a value' do
+        expect_command_capturing('log', '--expand-tabs=4').and_return(command_result)
+
+        command.call(expand_tabs: '4')
+      end
+
+      it 'includes the --no-expand-tabs flag when false' do
+        expect_command_capturing('log', '--no-expand-tabs').and_return(command_result)
+
+        command.call(expand_tabs: false)
+      end
+    end
+
+    context 'with the :notes option' do
+      it 'includes the bare --notes flag when true' do
+        expect_command_capturing('log', '--notes').and_return(command_result)
+
+        command.call(notes: true)
+      end
+
+      it 'includes --notes=<ref> when a ref is given' do
+        expect_command_capturing('log', '--notes=refs/notes/review').and_return(command_result)
+
+        command.call(notes: 'refs/notes/review')
+      end
+
+      it 'includes the --no-notes flag when false' do
+        expect_command_capturing('log', '--no-notes').and_return(command_result)
+
+        command.call(notes: false)
+      end
+    end
+
+    context 'with the :show_notes_by_default option' do
+      it 'includes the --show-notes-by-default flag' do
+        expect_command_capturing('log', '--show-notes-by-default').and_return(command_result)
+
+        command.call(show_notes_by_default: true)
+      end
+    end
+
+    context 'with the :show_signature option' do
+      it 'includes the --show-signature flag' do
+        expect_command_capturing('log', '--show-signature').and_return(command_result)
+
+        command.call(show_signature: true)
+      end
+    end
+
+    context 'with the :relative_date option' do
+      it 'includes the --relative-date flag' do
+        expect_command_capturing('log', '--relative-date').and_return(command_result)
+
+        command.call(relative_date: true)
+      end
+    end
+
+    context 'with the :date option' do
+      it 'includes --date=<value>' do
+        expect_command_capturing('log', '--date=iso').and_return(command_result)
+
+        command.call(date: 'iso')
+      end
+    end
+
+    context 'with the :parents option' do
+      it 'includes the --parents flag' do
+        expect_command_capturing('log', '--parents').and_return(command_result)
+
+        command.call(parents: true)
+      end
+    end
+
+    context 'with the :children option' do
+      it 'includes the --children flag' do
+        expect_command_capturing('log', '--children').and_return(command_result)
+
+        command.call(children: true)
+      end
+    end
+
+    context 'with the :left_right option' do
+      it 'includes the --left-right flag' do
+        expect_command_capturing('log', '--left-right').and_return(command_result)
+
+        command.call(left_right: true)
+      end
+    end
+
+    context 'with the :graph option' do
+      it 'includes the --graph flag' do
+        expect_command_capturing('log', '--graph').and_return(command_result)
+
+        command.call(graph: true)
+      end
+    end
+
+    context 'with the :show_linear_break option' do
+      it 'includes the bare --show-linear-break flag when true' do
+        expect_command_capturing('log', '--show-linear-break').and_return(command_result)
+
+        command.call(show_linear_break: true)
+      end
+
+      it 'includes --show-linear-break=<text> when a string is given' do
+        expect_command_capturing('log', '--show-linear-break=---').and_return(command_result)
+
+        command.call(show_linear_break: '---')
+      end
+    end
+
+    context 'with the :follow option' do
+      it 'includes the --follow flag' do
+        expect_command_capturing('log', '--follow').and_return(command_result)
+
+        command.call(follow: true)
+      end
+    end
+
+    context 'with the :decorate option' do
+      it 'includes the bare --decorate flag when true' do
+        expect_command_capturing('log', '--decorate').and_return(command_result)
+
+        command.call(decorate: true)
+      end
+
+      it 'includes --decorate=<format> when a format is given' do
+        expect_command_capturing('log', '--decorate=full').and_return(command_result)
+
+        command.call(decorate: 'full')
+      end
+
+      it 'includes the --no-decorate flag when false' do
+        expect_command_capturing('log', '--no-decorate').and_return(command_result)
+
+        command.call(decorate: false)
+      end
+    end
+
+    context 'with the :decorate_refs option' do
+      it 'includes --decorate-refs=<value>' do
+        expect_command_capturing('log', '--decorate-refs=refs/heads/*').and_return(command_result)
+
+        command.call(decorate_refs: 'refs/heads/*')
+      end
+    end
+
+    context 'with the :decorate_refs_exclude option' do
+      it 'includes --decorate-refs-exclude=<value>' do
+        expect_command_capturing('log', '--decorate-refs-exclude=refs/remotes/*').and_return(command_result)
+
+        command.call(decorate_refs_exclude: 'refs/remotes/*')
+      end
+    end
+
+    context 'with the :clear_decorations option' do
+      it 'includes the --clear-decorations flag' do
+        expect_command_capturing('log', '--clear-decorations').and_return(command_result)
+
+        command.call(clear_decorations: true)
+      end
+    end
+
+    context 'with the :source option' do
+      it 'includes the --source flag' do
+        expect_command_capturing('log', '--source').and_return(command_result)
+
+        command.call(source: true)
+      end
+    end
+
+    context 'with the :use_mailmap option' do
+      it 'includes the --use-mailmap flag when true' do
+        expect_command_capturing('log', '--use-mailmap').and_return(command_result)
+
+        command.call(use_mailmap: true)
+      end
+
+      it 'includes the --no-use-mailmap flag when false' do
+        expect_command_capturing('log', '--no-use-mailmap').and_return(command_result)
+
+        command.call(use_mailmap: false)
+      end
+    end
+
+    context 'with the :full_diff option' do
+      it 'includes the --full-diff flag' do
+        expect_command_capturing('log', '--full-diff').and_return(command_result)
+
+        command.call(full_diff: true)
+      end
+    end
+
+    context 'with the :log_size option' do
+      it 'includes the --log-size flag' do
+        expect_command_capturing('log', '--log-size').and_return(command_result)
+
+        command.call(log_size: true)
+      end
+    end
+
+    # Diff Formatting
+
+    context 'with the :patch option' do
+      it 'includes the --patch flag' do
+        expect_command_capturing('log', '--patch').and_return(command_result)
+
+        command.call(patch: true)
+      end
+
+      it 'accepts :p as an alias for :patch' do
+        expect_command_capturing('log', '--patch').and_return(command_result)
+
+        command.call(p: true)
+      end
+    end
+
+    context 'with the :no_patch option' do
+      it 'includes the --no-patch flag' do
+        expect_command_capturing('log', '--no-patch').and_return(command_result)
+
+        command.call(no_patch: true)
+      end
+
+      it 'accepts :s as an alias for :no_patch' do
+        expect_command_capturing('log', '--no-patch').and_return(command_result)
+
+        command.call(s: true)
+      end
+    end
+
+    context 'with the :diff_merges option' do
+      it 'includes --diff-merges=<value>' do
+        expect_command_capturing('log', '--diff-merges=separate').and_return(command_result)
+
+        command.call(diff_merges: 'separate')
+      end
+    end
+
+    context 'with the :no_diff_merges option' do
+      it 'includes the --no-diff-merges flag' do
+        expect_command_capturing('log', '--no-diff-merges').and_return(command_result)
+
+        command.call(no_diff_merges: true)
+      end
+    end
+
+    context 'with the :combined_all_paths option' do
+      it 'includes the --combined-all-paths flag' do
+        expect_command_capturing('log', '--combined-all-paths').and_return(command_result)
+
+        command.call(combined_all_paths: true)
+      end
+    end
+
+    context 'with the :raw option' do
+      it 'includes the --raw flag' do
+        expect_command_capturing('log', '--raw').and_return(command_result)
+
+        command.call(raw: true)
+      end
+    end
+
+    context 'with the :stat option' do
+      it 'includes the bare --stat flag when true' do
+        expect_command_capturing('log', '--stat').and_return(command_result)
+
+        command.call(stat: true)
+      end
+
+      it 'includes --stat=<width> when given a string' do
+        expect_command_capturing('log', '--stat=80').and_return(command_result)
+
+        command.call(stat: '80')
+      end
+    end
+
+    context 'with the :compact_summary option' do
+      it 'includes the --compact-summary flag' do
+        expect_command_capturing('log', '--compact-summary').and_return(command_result)
+
+        command.call(compact_summary: true)
+      end
+    end
+
+    context 'with the :numstat option' do
+      it 'includes the --numstat flag' do
+        expect_command_capturing('log', '--numstat').and_return(command_result)
+
+        command.call(numstat: true)
+      end
+    end
+
+    context 'with the :shortstat option' do
+      it 'includes the --shortstat flag' do
+        expect_command_capturing('log', '--shortstat').and_return(command_result)
+
+        command.call(shortstat: true)
+      end
+    end
+
+    context 'with the :dirstat option' do
+      it 'includes the bare --dirstat flag when true' do
+        expect_command_capturing('log', '--dirstat').and_return(command_result)
+
+        command.call(dirstat: true)
+      end
+
+      it 'includes --dirstat=<params> when given a string' do
+        expect_command_capturing('log', '--dirstat=files,10').and_return(command_result)
+
+        command.call(dirstat: 'files,10')
+      end
+    end
+
+    context 'with the :summary option' do
+      it 'includes the --summary flag' do
+        expect_command_capturing('log', '--summary').and_return(command_result)
+
+        command.call(summary: true)
+      end
+    end
+
+    context 'with the :name_only option' do
+      it 'includes the --name-only flag' do
+        expect_command_capturing('log', '--name-only').and_return(command_result)
+
+        command.call(name_only: true)
+      end
+    end
+
+    context 'with the :name_status option' do
+      it 'includes the --name-status flag' do
+        expect_command_capturing('log', '--name-status').and_return(command_result)
+
+        command.call(name_status: true)
+      end
+    end
+
+    context 'with the :submodule option' do
+      it 'includes the bare --submodule flag when true' do
+        expect_command_capturing('log', '--submodule').and_return(command_result)
+
+        command.call(submodule: true)
+      end
+
+      it 'includes --submodule=<format> when given a string' do
+        expect_command_capturing('log', '--submodule=diff').and_return(command_result)
+
+        command.call(submodule: 'diff')
+      end
+    end
+
+    context 'with the :color option' do
+      it 'includes the bare --color flag when true' do
+        expect_command_capturing('log', '--color').and_return(command_result)
+
+        command.call(color: true)
+      end
+
+      it 'includes --color=always when color: "always"' do
+        expect_command_capturing('log', '--color=always').and_return(command_result)
+
+        command.call(color: 'always')
+      end
+
+      it 'includes --no-color when color: false' do
+        expect_command_capturing('log', '--no-color').and_return(command_result)
+
+        command.call(color: false)
+      end
+    end
+
+    context 'with the :full_index option' do
+      it 'includes the --full-index flag' do
+        expect_command_capturing('log', '--full-index').and_return(command_result)
+
+        command.call(full_index: true)
+      end
+    end
+
+    context 'with the :binary option' do
+      it 'includes the --binary flag' do
+        expect_command_capturing('log', '--binary').and_return(command_result)
+
+        command.call(binary: true)
+      end
+    end
+
+    context 'with the :abbrev option' do
+      it 'includes the bare --abbrev flag when true' do
+        expect_command_capturing('log', '--abbrev').and_return(command_result)
+
+        command.call(abbrev: true)
+      end
+
+      it 'includes --abbrev=<n> when given a string' do
+        expect_command_capturing('log', '--abbrev=7').and_return(command_result)
+
+        command.call(abbrev: '7')
+      end
+    end
+
+    context 'with the :diff_filter option' do
+      it 'includes --diff-filter=<value>' do
+        expect_command_capturing('log', '--diff-filter=AD').and_return(command_result)
+
+        command.call(diff_filter: 'AD')
+      end
+    end
+
+    context 'with the :find_renames option' do
+      it 'includes the bare --find-renames flag when true' do
+        expect_command_capturing('log', '--find-renames').and_return(command_result)
+
+        command.call(find_renames: true)
+      end
+
+      it 'includes --find-renames=<n> when given a threshold' do
+        expect_command_capturing('log', '--find-renames=90').and_return(command_result)
+
+        command.call(find_renames: '90')
+      end
+    end
+
+    context 'with the :find_copies option' do
+      it 'includes the bare --find-copies flag when true' do
+        expect_command_capturing('log', '--find-copies').and_return(command_result)
+
+        command.call(find_copies: true)
+      end
+
+      it 'includes --find-copies=<n> when given a threshold' do
+        expect_command_capturing('log', '--find-copies=90').and_return(command_result)
+
+        command.call(find_copies: '90')
+      end
+    end
+
+    context 'with the :find_copies_harder option' do
+      it 'includes the --find-copies-harder flag' do
+        expect_command_capturing('log', '--find-copies-harder').and_return(command_result)
+
+        command.call(find_copies_harder: true)
+      end
+    end
+
+    context 'with the :relative option' do
+      it 'includes the bare --relative flag when true' do
+        expect_command_capturing('log', '--relative').and_return(command_result)
+
+        command.call(relative: true)
+      end
+
+      it 'includes --relative=<path> when given a path' do
+        expect_command_capturing('log', '--relative=subdir/').and_return(command_result)
+
+        command.call(relative: 'subdir/')
+      end
+
+      it 'includes the --no-relative flag when false' do
+        expect_command_capturing('log', '--no-relative').and_return(command_result)
+
+        command.call(relative: false)
+      end
+    end
+
+    context 'with the :text option' do
+      it 'includes the --text flag' do
+        expect_command_capturing('log', '--text').and_return(command_result)
+
+        command.call(text: true)
+      end
+    end
+
+    context 'with the :ignore_space_at_eol option' do
+      it 'includes the --ignore-space-at-eol flag' do
+        expect_command_capturing('log', '--ignore-space-at-eol').and_return(command_result)
+
+        command.call(ignore_space_at_eol: true)
+      end
+    end
+
+    context 'with the :ignore_space_change option' do
+      it 'includes the --ignore-space-change flag' do
+        expect_command_capturing('log', '--ignore-space-change').and_return(command_result)
+
+        command.call(ignore_space_change: true)
+      end
+
+      it 'accepts :b as an alias for :ignore_space_change' do
+        expect_command_capturing('log', '--ignore-space-change').and_return(command_result)
+
+        command.call(b: true)
+      end
+    end
+
+    context 'with the :ignore_all_space option' do
+      it 'includes the --ignore-all-space flag' do
+        expect_command_capturing('log', '--ignore-all-space').and_return(command_result)
+
+        command.call(ignore_all_space: true)
+      end
+
+      it 'accepts :w as an alias for :ignore_all_space' do
+        expect_command_capturing('log', '--ignore-all-space').and_return(command_result)
+
+        command.call(w: true)
+      end
+    end
+
+    context 'with the :ignore_blank_lines option' do
+      it 'includes the --ignore-blank-lines flag' do
+        expect_command_capturing('log', '--ignore-blank-lines').and_return(command_result)
+
+        command.call(ignore_blank_lines: true)
+      end
+    end
+
+    context 'with the :ignore_matching_lines option' do
+      it 'includes --ignore-matching-lines=<value>' do
+        expect_command_capturing('log', '--ignore-matching-lines=^#').and_return(command_result)
+
+        command.call(ignore_matching_lines: '^#')
+      end
+    end
+
+    context 'with the :ext_diff option' do
+      it 'includes the --ext-diff flag when true' do
+        expect_command_capturing('log', '--ext-diff').and_return(command_result)
+
+        command.call(ext_diff: true)
+      end
+
+      it 'includes the --no-ext-diff flag when false' do
+        expect_command_capturing('log', '--no-ext-diff').and_return(command_result)
+
+        command.call(ext_diff: false)
+      end
+    end
+
+    context 'with the :textconv option' do
+      it 'includes the --textconv flag when true' do
+        expect_command_capturing('log', '--textconv').and_return(command_result)
+
+        command.call(textconv: true)
+      end
+
+      it 'includes the --no-textconv flag when false' do
+        expect_command_capturing('log', '--no-textconv').and_return(command_result)
+
+        command.call(textconv: false)
+      end
+    end
+
+    context 'with the :no_prefix option' do
+      it 'includes the --no-prefix flag' do
+        expect_command_capturing('log', '--no-prefix').and_return(command_result)
+
+        command.call(no_prefix: true)
+      end
+    end
+
+    context 'with the :src_prefix option' do
+      it 'includes --src-prefix=<value>' do
+        expect_command_capturing('log', '--src-prefix=old/').and_return(command_result)
+
+        command.call(src_prefix: 'old/')
+      end
+    end
+
+    context 'with the :dst_prefix option' do
+      it 'includes --dst-prefix=<value>' do
+        expect_command_capturing('log', '--dst-prefix=new/').and_return(command_result)
+
+        command.call(dst_prefix: 'new/')
+      end
+    end
+
+    # Operands and paths
+
     context 'with a :revision_range operand' do
       it 'appends a single revision range directly' do
         expect_command_capturing('log', 'v1.0..v2.0').and_return(command_result)
@@ -283,8 +1205,7 @@ RSpec.describe Git::Commands::Log do
       end
 
       it 'appends multiple revision specifiers as separate arguments' do
-        expect_command_capturing('log', 'v1.0', 'v2.0',
-                                 '^v0.9').and_return(command_result)
+        expect_command_capturing('log', 'v1.0', 'v2.0', '^v0.9').and_return(command_result)
 
         command.call('v1.0', 'v2.0', '^v0.9')
       end
@@ -292,17 +1213,13 @@ RSpec.describe Git::Commands::Log do
 
     context 'with a :path option' do
       it 'appends -- and the path(s)' do
-        expect_command_capturing(
-          'log', '--', 'lib/'
-        ).and_return(command_result)
+        expect_command_capturing('log', '--', 'lib/').and_return(command_result)
 
         command.call(path: ['lib/'])
       end
 
       it 'supports multiple paths' do
-        expect_command_capturing(
-          'log', '--', 'lib/', 'spec/'
-        ).and_return(command_result)
+        expect_command_capturing('log', '--', 'lib/', 'spec/').and_return(command_result)
 
         command.call(path: %w[lib/ spec/])
       end
@@ -312,61 +1229,11 @@ RSpec.describe Git::Commands::Log do
       it 'includes all specified options in DSL order' do
         expect_command_capturing(
           'log',
-          '--all', '--since=2 weeks ago', '--max-count=20',
+          '--max-count=20', '--since=2 weeks ago', '--all',
           'v1.0', '--', 'lib/'
         ).and_return(command_result)
 
         command.call('v1.0', all: true, max_count: 20, since: '2 weeks ago', path: ['lib/'])
-      end
-    end
-
-    context 'with regexp flag aliases' do
-      it 'accepts :regexp_ignore_case for --regexp-ignore-case' do
-        expect_command_capturing('log', '--regexp-ignore-case').and_return(command_result)
-
-        command.call(regexp_ignore_case: true)
-      end
-
-      it 'accepts :i as an alias for :regexp_ignore_case' do
-        expect_command_capturing('log', '--regexp-ignore-case').and_return(command_result)
-
-        command.call(i: true)
-      end
-
-      it 'accepts :extended_regexp for --extended-regexp' do
-        expect_command_capturing('log', '--extended-regexp').and_return(command_result)
-
-        command.call(extended_regexp: true)
-      end
-
-      it 'accepts :E as an alias for :extended_regexp' do
-        expect_command_capturing('log', '--extended-regexp').and_return(command_result)
-
-        command.call(E: true)
-      end
-
-      it 'accepts :fixed_strings for --fixed-strings' do
-        expect_command_capturing('log', '--fixed-strings').and_return(command_result)
-
-        command.call(fixed_strings: true)
-      end
-
-      it 'accepts :F as an alias for :fixed_strings' do
-        expect_command_capturing('log', '--fixed-strings').and_return(command_result)
-
-        command.call(F: true)
-      end
-
-      it 'accepts :perl_regexp for --perl-regexp' do
-        expect_command_capturing('log', '--perl-regexp').and_return(command_result)
-
-        command.call(perl_regexp: true)
-      end
-
-      it 'accepts :P as an alias for :perl_regexp' do
-        expect_command_capturing('log', '--perl-regexp').and_return(command_result)
-
-        command.call(P: true)
       end
     end
 
@@ -380,7 +1247,7 @@ RSpec.describe Git::Commands::Log do
 
     context 'input validation' do
       it 'raises ArgumentError for unsupported options' do
-        expect { command.call(bogus: true) }.to raise_error(ArgumentError)
+        expect { command.call(bogus: true) }.to raise_error(ArgumentError, /Unsupported options/)
       end
     end
   end

--- a/spec/unit/git/lib_command_spec.rb
+++ b/spec/unit/git/lib_command_spec.rb
@@ -803,29 +803,29 @@ RSpec.describe Git::Lib do
       allow(Git::Commands::Log).to receive(:new).with(lib).and_return(log_command)
     end
 
-    it 'passes no_color: true and pretty: "raw" as hardcoded parser-contract options' do
+    it 'passes color: false and pretty: "raw" as hardcoded parser-contract options' do
       allow(log_command).to receive(:call)
-        .with(no_color: true, pretty: 'raw')
+        .with(color: false, pretty: 'raw')
         .and_return(command_result(''))
 
       lib.full_log_commits
 
-      expect(log_command).to have_received(:call).with(no_color: true, pretty: 'raw')
+      expect(log_command).to have_received(:call).with(color: false, pretty: 'raw')
     end
 
     it 'forwards documented options to the command' do
       allow(log_command).to receive(:call)
-        .with(no_color: true, pretty: 'raw', max_count: 5, all: true)
+        .with(color: false, pretty: 'raw', max_count: 5, all: true)
         .and_return(command_result(''))
 
       lib.full_log_commits(count: 5, all: true)
 
       expect(log_command).to have_received(:call)
-        .with(no_color: true, pretty: 'raw', max_count: 5, all: true)
+        .with(color: false, pretty: 'raw', max_count: 5, all: true)
     end
 
     context 'with parser-contract options the facade owns' do
-      it 'rejects :no_color because the facade always sets it' do
+      it 'rejects :no_color because it is not a recognized option (facade uses color: false)' do
         expect { lib.full_log_commits(no_color: false) }
           .to raise_error(ArgumentError, /Unknown options: no_color/)
       end

--- a/tests/units/test_log.rb
+++ b/tests/units/test_log.rb
@@ -151,7 +151,7 @@ class TestLog < Test::Unit::TestCase
   end
 
   def test_log_merges
-    expected_command_line = ['log', '--no-color', '--pretty=raw', '--merges', '--max-count=30', {}]
+    expected_command_line = ['log', '--max-count=30', '--merges', '--pretty=raw', '--no-color', {}]
     assert_command_line_eq(expected_command_line) do |git|
       git.log.merges.execute
     end

--- a/tests/units/test_log_execute.rb
+++ b/tests/units/test_log_execute.rb
@@ -132,7 +132,7 @@ class TestLogExecute < Test::Unit::TestCase
   end
 
   def test_log_merges
-    expected_command_line = ['log', '--no-color', '--pretty=raw', '--merges', '--max-count=30', {}]
+    expected_command_line = ['log', '--max-count=30', '--merges', '--pretty=raw', '--no-color', {}]
     assert_command_line_eq(expected_command_line) { |git| git.log.merges.execute }
   end
 


### PR DESCRIPTION
## Summary

Partial implementation of #1196 (Batch 6: Top-level A–L).

Applies the command-implementation skill to `Git::Commands::Grep` and backfills
missing post-2.28.0 options for `Git::Commands::Log`.

## Changes

### `git grep` (`lib/git/commands/grep.rb`)

Full command-implementation skill pass:
- Reorder DSL to follow SYNOPSIS option order
- Add missing options:
  - `:h` / `:H` — suppress/force filename prefix in output
  - `:null` / `:z` — use NUL as output delimiter
  - `:color` — show colored matches (`--color[=<when>]`)
  - `:parent_basename` — override the name used as prefix for submodule output
- Add `@note` annotation audited against `git-grep/2.53.0`
- Fix YARD `@option` defaults from `(nil)` to `(false)` for non-negatable flags
- Fix class-level YARD tag order (examples → note → see → api)
- Update unit tests to match new DSL ordering and add coverage for new options

### `git log` (`lib/git/commands/log.rb`)

Backfill post-2.28.0 options (introduced between git 2.28.0 and 2.53.0):
- `:max_count` / `:n` — limit number of commits
- `:skip` — skip the first N commits
- `:since_as_filter` — like `--since` but always shows newer commits
- `:author`, `:committer` — filter by author/committer pattern
- `:grep_reflog` — filter by reflog message
- `:basic_regexp` — use POSIX basic regular expressions
- `:remove_empty` — stop when a given path disappears from the tree
- `:merges` / `:no_merges` — show/hide merge commits
- `:min_parents`, `:max_parents` — filter by parent count
- `:first_parent` — follow only the first parent of merges
- `:exclude_first_parent_only` — exclude first-parent-only merges
- `:all`, `:branches`, `:tags`, `:remotes`, `:glob` — commit range selectors
- `:exclude`, `:exclude_hidden` — exclude refs
- `:reflog`, `:alternate_refs` — walk reflog / alternate refs
- `:single_worktree` — restrict to current worktree
- `:ignore_missing` — ignore missing objects
- `:bisect`, `:cherry_mark`, `:cherry_pick`, `:cherry` — bisect helpers
- `:left_only`, `:right_only` — symmetric difference filtering
- `:walk_reflogs` / `:g` — walk reflogs
- `:merge`, `:boundary` — revision walking options
- `:simplify_by_decoration`, `:show_pulls`, `:dense`, `:sparse`, `:simplify_merges` — history simplification
- `:ancestry_path`, `:no_walk` — ancestry filtering
- `:diff_merges`, `:remerge_diff`, `:invert_grep` — diff and grep controls
- And several more diff format and output options
- Add `@note` annotation audited against `git-log/2.53.0`
- Update unit tests for new and changed options

### Other

- `lib/git/lib.rb`: use `color: false` instead of `no_color: true` (aligns with updated DSL)
- `tests/units/test_log.rb`: fix expected command line to match new DSL ordering

## Remaining in Batch 6

- [ ] `ls_files`, `ls_remote`, `ls_tree`

Closes part of #1196