### PR TITLE
refactor(commands): update symbolic-ref, tag/verify, write-tree (batch 7)

### DIFF
--- a/lib/git/commands/symbolic_ref/delete.rb
+++ b/lib/git/commands/symbolic_ref/delete.rb
@@ -14,6 +14,8 @@ module Git
       #   cmd = Git::Commands::SymbolicRef::Delete.new(execution_context)
       #   cmd.call('HEAD')
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-symbolic-ref/2.53.0
+      #
       # @see Git::Commands::SymbolicRef
       #
       # @see https://git-scm.com/docs/git-symbolic-ref git-symbolic-ref documentation
@@ -47,7 +49,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :quiet (nil) suppress error message
+        #     @option options [Boolean] :quiet (false) suppress error message
         #       when the name is not a symbolic ref
         #
         #       Alias: :q
@@ -59,8 +61,7 @@ module Git
         #
         #     @raise [ArgumentError] if the name operand is missing
         #
-        #     @raise [Git::FailedError] if the command returns a non-zero
-        #       exit status
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/symbolic_ref/read.rb
+++ b/lib/git/commands/symbolic_ref/read.rb
@@ -25,6 +25,8 @@ module Git
       #   result = cmd.call('HEAD', short: true)
       #   result.stdout  # => "main"
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-symbolic-ref/2.53.0
+      #
       # @see Git::Commands::SymbolicRef
       #
       # @see https://git-scm.com/docs/git-symbolic-ref git-symbolic-ref documentation
@@ -40,6 +42,9 @@ module Git
 
           # Shorten the ref output (e.g. `refs/heads/main` → `main`)
           flag_option :short
+
+          # Follow (or stop after one level of) symbolic ref chain
+          flag_option :recurse, negatable: true
 
           end_of_options
 
@@ -62,13 +67,17 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :quiet (nil) suppress error message
+        #     @option options [Boolean] :quiet (false) suppress error message
         #       when the name is not a symbolic ref
         #
         #       Alias: :q
         #
-        #     @option options [Boolean] :short (nil) shorten the ref output
+        #     @option options [Boolean] :short (false) shorten the ref output
         #       (e.g. `refs/heads/main` → `main`)
+        #
+        #     @option options [Boolean] :recurse (nil) follow chain of symbolic refs
+        #       until result no longer points at a symbolic ref; pass +false+ to emit
+        #       `--no-recurse` and stop after a single level of dereferencing
         #
         #     @return [Git::CommandLineResult] the result of calling
         #       `git symbolic-ref`
@@ -77,7 +86,7 @@ module Git
         #
         #     @raise [ArgumentError] if the name operand is missing
         #
-        #     @raise [Git::FailedError] if git exits with status >= 2
+        #     @raise [Git::FailedError] if git exits outside the allowed range (exit code > 1)
       end
     end
   end

--- a/lib/git/commands/symbolic_ref/update.rb
+++ b/lib/git/commands/symbolic_ref/update.rb
@@ -18,6 +18,8 @@ module Git
       #   cmd = Git::Commands::SymbolicRef::Update.new(execution_context)
       #   cmd.call('HEAD', 'refs/heads/main', m: 'switching to main')
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-symbolic-ref/2.53.0
+      #
       # @see Git::Commands::SymbolicRef
       #
       # @see https://git-scm.com/docs/git-symbolic-ref git-symbolic-ref documentation
@@ -63,10 +65,11 @@ module Git
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #
-        #     @raise [ArgumentError] if the name or ref operand is missing
+        #     @raise [ArgumentError] if the name operand is missing
         #
-        #     @raise [Git::FailedError] if the command returns a non-zero
-        #       exit status
+        #     @raise [ArgumentError] if the ref operand is missing
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/tag/verify.rb
+++ b/lib/git/commands/tag/verify.rb
@@ -11,12 +11,6 @@ module Git
       # It requires that the tags were signed with GPG or another supported
       # signing backend.
       #
-      # @see Git::Commands::Tag
-      #
-      # @see https://git-scm.com/docs/git-tag git-tag
-      #
-      # @api private
-      #
       # @example Verify a single tag
       #   verify = Git::Commands::Tag::Verify.new(execution_context)
       #   verify.call('v1.0.0')
@@ -29,11 +23,22 @@ module Git
       #   verify = Git::Commands::Tag::Verify.new(execution_context)
       #   verify.call('v1.0.0', format: '%(refname:short) %(contents:subject)')
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-tag/2.53.0
+      #
+      # @see Git::Commands::Tag
+      #
+      # @see https://git-scm.com/docs/git-tag git-tag
+      #
+      # @api private
+      #
       class Verify < Git::Commands::Base
         arguments do
           literal 'tag'
           literal '--verify'
           value_option :format, inline: true
+
+          end_of_options
+
           operand :tagname, repeatable: true, required: true
         end
 
@@ -43,20 +48,22 @@ module Git
         #
         #   @overload call(*tagname, **options)
         #
-        #     @param tagname [Array<String>] One or more tag names to verify.
-        #       At least one tag name is required.
+        #     @param tagname [Array<String>] one or more tag names to verify
         #
         #     @param options [Hash] command options
         #
-        #     @option options [String] :format (nil) A format string that interpolates
-        #       `%(fieldname)` from the tag ref being shown and the object it points at.
-        #       The format is the same as that of git-for-each-ref.
+        #     @option options [String] :format (nil) a format string interpolating
+        #       `%(fieldname)` from the tag ref being shown and the object it points at
+        #
+        #       The format is the same as that of git-for-each-ref(1).
         #
         #     @return [Git::CommandLineResult] the result of calling `git tag --verify`
         #
-        #     @raise [Git::FailedError] if the tag does not exist or signature verification fails
+        #     @raise [ArgumentError] if unsupported options are provided
         #
-        #     @raise [ArgumentError] if no tag names are provided
+        #     @raise [ArgumentError] if no tagname operands are provided
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
         #
       end
     end

--- a/lib/git/commands/write_tree.rb
+++ b/lib/git/commands/write_tree.rb
@@ -23,7 +23,9 @@ module Git
     #   write_tree = Git::Commands::WriteTree.new(execution_context)
     #   result = write_tree.call(missing_ok: true)
     #
-    # @see https://git-scm.com/docs/git-write-tree git-write-tree documentation
+    # @note `arguments` block audited against https://git-scm.com/docs/git-write-tree/2.53.0
+    #
+    # @see https://git-scm.com/docs/git-write-tree git-write-tree
     #
     # @see Git::Commands
     #
@@ -32,11 +34,7 @@ module Git
     class WriteTree < Git::Commands::Base
       arguments do
         literal 'write-tree'
-
-        # Disable check that all referenced objects exist in the object database
         flag_option :missing_ok
-
-        # Write a tree for a subdirectory instead of the full index
         value_option :prefix, inline: true
       end
 
@@ -48,25 +46,23 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :missing_ok (nil) disable the check that
+      #     @option options [Boolean] :missing_ok (false) disable the check that
       #       all objects referenced by the directory exist in the object
       #       database
-      #
-      #       Maps to `--missing-ok`.
       #
       #     @option options [String] :prefix (nil) write a tree object that
       #       represents a subdirectory
       #
-      #       The prefix path should end with `/` (e.g. `'lib/'`). Maps to
-      #       `--prefix=<prefix>/`.
+      #       The prefix path should end with `/` (e.g., `'lib/'`).
       #
-      #     @return [Git::CommandLineResult] the result of calling
-      #       `git write-tree`
+      #     @return [Git::CommandLineResult] the result of calling `git write-tree`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #
-      #     @raise [Git::FailedError] if the command returns a non-zero exit
-      #       status
+      #     @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      #   @api public
+      #
     end
   end
 end

--- a/spec/unit/git/commands/symbolic_ref/read_spec.rb
+++ b/spec/unit/git/commands/symbolic_ref/read_spec.rb
@@ -47,6 +47,22 @@ RSpec.describe Git::Commands::SymbolicRef::Read do
       end
     end
 
+    context 'with the :recurse option' do
+      it 'adds --recurse to the command line when true' do
+        expect_command_capturing('symbolic-ref', '--recurse', '--', 'HEAD')
+          .and_return(command_result('refs/heads/main'))
+
+        command.call('HEAD', recurse: true)
+      end
+
+      it 'adds --no-recurse to the command line when false' do
+        expect_command_capturing('symbolic-ref', '--no-recurse', '--', 'HEAD')
+          .and_return(command_result('refs/heads/main'))
+
+        command.call('HEAD', recurse: false)
+      end
+    end
+
     context 'with multiple options combined' do
       it 'includes all specified options in definition order' do
         expect_command_capturing('symbolic-ref', '--quiet', '--short', '--', 'HEAD')

--- a/spec/unit/git/commands/tag/verify_spec.rb
+++ b/spec/unit/git/commands/tag/verify_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Git::Commands::Tag::Verify do
     context 'with a single tag name' do
       it 'calls git tag --verify with the tag name' do
         expected_result = command_result
-        expect_command_capturing('tag', '--verify', 'v1.0.0').and_return(expected_result)
+        expect_command_capturing('tag', '--verify', '--', 'v1.0.0').and_return(expected_result)
 
         result = command.call('v1.0.0')
 
@@ -25,19 +25,19 @@ RSpec.describe Git::Commands::Tag::Verify do
 
     context 'with multiple tag names' do
       it 'passes all tag names to the command' do
-        expect_command_capturing('tag', '--verify', 'v1.0.0', 'v2.0.0', 'v3.0.0')
+        expect_command_capturing('tag', '--verify', '--', 'v1.0.0', 'v2.0.0', 'v3.0.0')
         command.call('v1.0.0', 'v2.0.0', 'v3.0.0')
       end
     end
 
     context 'with :format option' do
       it 'adds --format flag with the specified format string' do
-        expect_command_capturing('tag', '--verify', '--format=%(refname:short)', 'v1.0.0')
+        expect_command_capturing('tag', '--verify', '--format=%(refname:short)', '--', 'v1.0.0')
         command.call('v1.0.0', format: '%(refname:short)')
       end
 
       it 'works with multiple tags and format' do
-        expect_command_capturing('tag', '--verify', '--format=%(objectname)', 'v1.0.0', 'v2.0.0')
+        expect_command_capturing('tag', '--verify', '--format=%(objectname)', '--', 'v1.0.0', 'v2.0.0')
         command.call('v1.0.0', 'v2.0.0', format: '%(objectname)')
       end
     end


### PR DESCRIPTION
## Summary

Apply the command-implementation skill to five command classes as part of batch 7 of #1196.

### Commands updated

| Command class | File |
|---|---|
| `Git::Commands::SymbolicRef::Delete` | `lib/git/commands/symbolic_ref/delete.rb` |
| `Git::Commands::SymbolicRef::Read` | `lib/git/commands/symbolic_ref/read.rb` |
| `Git::Commands::SymbolicRef::Update` | `lib/git/commands/symbolic_ref/update.rb` |
| `Git::Commands::Tag::Verify` | `lib/git/commands/tag/verify.rb` |
| `Git::Commands::WriteTree` | `lib/git/commands/write_tree.rb` |

### Changes applied

- Add `@note` with audited YARD note referencing the specific git-scm docs version (`2.53.0`)
- Move `@see` and `@api private` tags after `@example` blocks per project convention
- Add missing `--recurse` / `--no-recurse` option to `SymbolicRef::Read` (negatable flag)
- Add `end_of_options` to `Tag::Verify` argument block
- Backfill unit test examples for `SymbolicRef::Read` and `Tag::Verify`
- Fix `@raise` wording in `SymbolicRef::Read` to match standard convention ("exits outside the allowed range")

### Related

Partially addresses #1196 (batch 7). See also the other batch 7 PRs for read-tree/repack/reset/rev-parse/rm, merge-base/mv/name-rev/pull/push, and show/status/tag.