### PR TITLE
docs(commands): audit YARD docs for archive/list_formats, version, worktree/add/list/lock

### DIFF
--- a/lib/git/commands/archive/list_formats.rb
+++ b/lib/git/commands/archive/list_formats.rb
@@ -17,7 +17,9 @@ module Git
       #   result = cmd.call
       #   result.stdout  # => "tar\ntgz\ntar.gz\nzip\n"
       #
-      # @see Git::Commands::Archive
+      # @note `arguments` block audited against https://git-scm.com/docs/git-archive/2.53.0
+      #
+      # @see Git::Commands::Archive Git::Commands::Archive for the full archive command interface
       #
       # @see https://git-scm.com/docs/git-archive git-archive documentation
       #
@@ -33,13 +35,11 @@ module Git
         #
         #   @overload call
         #
-        #     Execute `git archive --list` to show available formats
+        #     Execute `git archive --list` to show available formats.
         #
-        #     @return [Git::CommandLineResult] the result of calling
-        #       `git archive --list`
+        #     @return [Git::CommandLineResult] the result of calling `git archive --list`
         #
-        #     @raise [Git::FailedError] if the command returns a non-zero
-        #       exit status
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/version.rb
+++ b/lib/git/commands/version.rb
@@ -13,9 +13,11 @@ module Git
     #   result = version.call
     #   result.stdout #=> "git version 2.42.0"
     #
-    # @see https://git-scm.com/docs/git-version git-version documentation
+    # @note `arguments` block audited against https://git-scm.com/docs/git-version/2.53.0
     #
     # @see Git::Commands
+    #
+    # @see https://git-scm.com/docs/git-version git-version documentation
     #
     # @api private
     #
@@ -29,15 +31,17 @@ module Git
       #
       #   @overload call(**options)
       #
-      #     Execute the `git version` command
+      #     Execute the `git version` command.
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :build_options (nil) include build options in the output
+      #     @option options [Boolean] :build_options (false) include build options in the output
       #
       #     @return [Git::CommandLineResult] the result of calling `git version`
       #
-      #     @raise [Git::FailedError] if git exits with a non-zero status
+      #     @raise [ArgumentError] if unsupported options are provided
+      #
+      #     @raise [Git::FailedError] if git exits with a non-zero exit status
     end
   end
 end

--- a/lib/git/commands/worktree/add.rb
+++ b/lib/git/commands/worktree/add.rb
@@ -7,11 +7,6 @@ module Git
     module Worktree
       # Creates a new linked worktree
       #
-      # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
-      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
-      #
-      # @api private
-      #
       # @example Add a worktree at a path (auto-creates a branch)
       #   Git::Commands::Worktree::Add.new(execution_context).call('/tmp/feature')
       #
@@ -23,6 +18,14 @@ module Git
       #
       # @example Add a detached-HEAD worktree locked at creation
       #   Git::Commands::Worktree::Add.new(execution_context).call('/tmp/exp', detach: true, lock: true)
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      #
+      # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      # @api private
       #
       class Add < ManagementBase
         arguments do
@@ -60,7 +63,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, Integer] :force (nil) override safety guards
+        #     @option options [Boolean, Integer] :force (false) override safety guards
         #
         #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit
         #       `--force --force`, which also allows adding worktrees for locked branches.
@@ -71,7 +74,7 @@ module Git
         #
         #     @option options [String] :B (nil) create or reset a branch with this name and check it out
         #
-        #     @option options [Boolean] :detach (nil) check out in detached-HEAD state
+        #     @option options [Boolean] :detach (false) check out in detached-HEAD state
         #
         #       Alias: :d
         #
@@ -94,11 +97,11 @@ module Git
         #
         #       When `false`, passes `--no-track`.
         #
-        #     @option options [Boolean] :lock (nil) lock the worktree immediately after creation
+        #     @option options [Boolean] :lock (false) lock the worktree immediately after creation
         #
-        #     @option options [Boolean] :orphan (nil) create an empty worktree associated with a new unborn branch
+        #     @option options [Boolean] :orphan (false) create an empty worktree associated with a new unborn branch
         #
-        #     @option options [Boolean] :quiet (nil) suppress informational messages
+        #     @option options [Boolean] :quiet (false) suppress informational messages
         #
         #       Alias: :q
         #
@@ -107,6 +110,8 @@ module Git
         #       Only meaningful when used with `:lock`.
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree add`
+        #
+        #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end

--- a/lib/git/commands/worktree/list.rb
+++ b/lib/git/commands/worktree/list.rb
@@ -10,7 +10,10 @@ module Git
       # @example List all worktrees in porcelain format
       #   Git::Commands::Worktree::List.new(execution_context).call(porcelain: true)
       #
-      # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      #
+      # @see Git::Commands::Worktree
+      #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
       #
       # @api private
@@ -33,11 +36,11 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :porcelain (nil) produce machine-readable output
+        #     @option options [Boolean] :porcelain (false) produce machine-readable output
         #
-        #     @option options [Boolean] :z (nil) NUL-terminate lines (use with `:porcelain`)
+        #     @option options [Boolean] :z (false) NUL-terminate lines (use with `:porcelain`)
         #
-        #     @option options [Boolean] :verbose (nil) output additional information about worktrees
+        #     @option options [Boolean] :verbose (false) output additional information about worktrees
         #
         #       Alias: :v
         #
@@ -45,6 +48,8 @@ module Git
         #       this time expression
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree list`
+        #
+        #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end

--- a/lib/git/commands/worktree/lock.rb
+++ b/lib/git/commands/worktree/lock.rb
@@ -13,6 +13,8 @@ module Git
       # @example Lock with a reason message
       #   Git::Commands::Worktree::Lock.new(execution_context).call('/tmp/feature', reason: 'on NFS share')
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
@@ -41,6 +43,8 @@ module Git
         #     @option options [String] :reason (nil) human-readable explanation stored alongside the lock
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree lock`
+        #
+        #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end


### PR DESCRIPTION
## Summary

Audits and improves YARD documentation for five command classes as part of the #1196 backfill effort:

- `Git::Commands::Archive::ListFormats`
- `Git::Commands::Version`
- `Git::Commands::Worktree::Add`
- `Git::Commands::Worktree::List`
- `Git::Commands::Worktree::Lock`

## Changes

- Add `@note` marking each `arguments` block as audited against the git 2.53.0 reference docs
- Fix `@option` default values from `(nil)` to `(false)` for boolean flags
- Add `@raise [ArgumentError]` for unsupported options where missing
- Minor wording and ordering improvements for consistency with other command classes

## Related

Contributes to #1196