### PR TITLE
refactor(commands): update worktree/move, prune, remove, repair, unlock (issue #1196 batch 8)

### DIFF
--- a/lib/git/commands/worktree/move.rb
+++ b/lib/git/commands/worktree/move.rb
@@ -13,6 +13,8 @@ module Git
       # @example Force-move a locked worktree
       #   Git::Commands::Worktree::Move.new(execution_context).call('/tmp/feat', '/tmp/feat2', force: true)
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
@@ -41,7 +43,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, Integer] :force (nil) allow moving a locked worktree
+        #     @option options [Boolean, Integer] :force (false) allow moving a locked worktree
         #
         #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit
         #       `--force --force`, which also handles locked or missing destinations.
@@ -49,6 +51,8 @@ module Git
         #       Alias: :f
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree move`
+        #
+        #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end

--- a/lib/git/commands/worktree/prune.rb
+++ b/lib/git/commands/worktree/prune.rb
@@ -16,6 +16,8 @@ module Git
       # @example Prune entries older than 2 weeks
       #   Git::Commands::Worktree::Prune.new(execution_context).call(expire: '2.weeks.ago')
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
@@ -39,12 +41,12 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :dry_run (nil) report what would be removed
+        #     @option options [Boolean] :dry_run (false) report what would be removed
         #       without removing anything
         #
         #       Alias: :n
         #
-        #     @option options [Boolean] :verbose (nil) report all removals
+        #     @option options [Boolean] :verbose (false) report all removals
         #
         #       Alias: :v
         #
@@ -52,6 +54,8 @@ module Git
         #       this time expression
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree prune`
+        #
+        #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end

--- a/lib/git/commands/worktree/remove.rb
+++ b/lib/git/commands/worktree/remove.rb
@@ -13,6 +13,8 @@ module Git
       # @example Force-remove an unclean worktree
       #   Git::Commands::Worktree::Remove.new(execution_context).call('/tmp/feature', force: true)
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
@@ -38,7 +40,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, Integer] :force (nil) remove even if the worktree has
+        #     @option options [Boolean, Integer] :force (false) remove even if the worktree has
         #       uncommitted changes
         #
         #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit `--force --force`,

--- a/lib/git/commands/worktree/repair.rb
+++ b/lib/git/commands/worktree/repair.rb
@@ -16,6 +16,8 @@ module Git
       # @example Repair specific moved worktrees
       #   Git::Commands::Worktree::Repair.new(execution_context).call('/tmp/moved1', '/tmp/moved2')
       #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
@@ -30,6 +32,9 @@ module Git
           end_of_options
           operand :path, repeatable: true
         end
+
+        # git worktree repair was introduced in git 2.29.0
+        requires_git_version '2.29.0'
 
         # @!method call(*, **)
         #

--- a/lib/git/commands/worktree/unlock.rb
+++ b/lib/git/commands/worktree/unlock.rb
@@ -5,10 +5,12 @@ require 'git/commands/worktree/management_base'
 module Git
   module Commands
     module Worktree
-      # Unlocks a worktree so it can be pruned
+      # Unlocks a worktree, allowing it to be pruned, moved, or deleted
       #
       # @example Unlock a worktree
       #   Git::Commands::Worktree::Unlock.new(execution_context).call('/tmp/feature')
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
@@ -28,7 +30,7 @@ module Git
         #
         #   @overload call(worktree)
         #
-        #     Unlock a worktree so it can be pruned
+        #     Unlock a worktree, allowing it to be pruned, moved, or deleted
         #
         #     @param worktree [String] path or unique suffix identifying the worktree
         #       to unlock

--- a/spec/unit/git/commands/worktree/move_spec.rb
+++ b/spec/unit/git/commands/worktree/move_spec.rb
@@ -46,5 +46,12 @@ RSpec.describe Git::Commands::Worktree::Move do
         command.call('/tmp/old', '/tmp/new', force: 2)
       end
     end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call('/tmp/old', '/tmp/new', invalid: true) }
+          .to raise_error(ArgumentError, /Unsupported options/)
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/worktree/prune_spec.rb
+++ b/spec/unit/git/commands/worktree/prune_spec.rb
@@ -72,5 +72,12 @@ RSpec.describe Git::Commands::Worktree::Prune do
         command.call(dry_run: true, verbose: true)
       end
     end
+
+    context 'input validation' do
+      it 'raises ArgumentError for unsupported options' do
+        expect { command.call(invalid: true) }
+          .to raise_error(ArgumentError, /unsupported/i)
+      end
+    end
   end
 end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository.

# Description

Part of #1196 (Batch 8, second item): backfill post-2.28.0 documentation and versioning annotations into `worktree/move`, `worktree/prune`, `worktree/remove`, `worktree/repair`, and `worktree/unlock` command classes.

## Changes

- **`worktree/move`**: Add `@note` audit annotation (audited against git 2.53.0 docs); add `@raise [ArgumentError]` YARD tag to the `call` method; fix `:force` option default from `nil` to `false` in YARD docs
- **`worktree/prune`**: Add `@note` audit annotation; add `@raise [ArgumentError]` YARD tag to the `call` method; fix `:dry_run` and `:verbose` option defaults from `nil` to `false` in YARD docs
- **`worktree/remove`**: Add `@note` audit annotation; fix `:force` option default from `nil` to `false` in YARD docs
- **`worktree/repair`**: Add `@note` audit annotation; add `requires_git_version '2.29.0'` (worktree repair was introduced in git 2.29.0)
- **`worktree/unlock`**: Add `@note` audit annotation; improve class/method description
- **`move_spec`**: Add `ArgumentError` unit test for unsupported options
- **`prune_spec`**: Add `ArgumentError` unit test for unsupported options

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).