### PR TITLE
refactor(commands): audit config_option_syntax YARD docs (issue #1196)

### DIFF
--- a/lib/git/commands/config_option_syntax/add.rb
+++ b/lib/git/commands/config_option_syntax/add.rb
@@ -11,13 +11,14 @@ module Git
       # altering existing values.
       #
       # @example Add a value to a multi-valued key
-      #   Git::Commands::ConfigOptionSyntax::Add.new(ctx).call(
-      #     'remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*'
-      #   )
+      #   cmd = Git::Commands::ConfigOptionSyntax::Add.new(lib)
+      #   cmd.call('remote.origin.fetch', '+refs/heads/*:refs/remotes/origin/*')
       #
-      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      # @note `arguments` block audited against https://git-scm.com/docs/git-config/2.53.0
       #
       # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @see https://git-scm.com/docs/git-config git-config documentation
       #
       # @api private
       #
@@ -55,13 +56,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (nil) write to global config (`~/.gitconfig`)
+        #     @option options [Boolean] :global (false) write to global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (nil) write to system config
+        #     @option options [Boolean] :system (false) write to system config
         #
-        #     @option options [Boolean] :local (nil) write to repository config (`.git/config`)
+        #     @option options [Boolean] :local (false) write to repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (nil) write to worktree config
+        #     @option options [Boolean] :worktree (false) write to worktree config
         #
         #     @option options [String] :file (nil) write to the specified file
         #
@@ -73,7 +74,9 @@ module Git
         #
         #     @return [Git::CommandLineResult] the result of calling `git config --add`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/config_option_syntax/get.rb
+++ b/lib/git/commands/config_option_syntax/get.rb
@@ -11,20 +11,24 @@ module Git
       # config entry for the given key name.
       #
       # @example Get a local config value
-      #   Git::Commands::ConfigOptionSyntax::Get.new(ctx).call('user.name')
+      #   cmd = Git::Commands::ConfigOptionSyntax::Get.new(lib)
+      #   cmd.call('user.name')
       #
       # @example Get a global config value
-      #   Git::Commands::ConfigOptionSyntax::Get.new(ctx).call('user.name', global: true)
+      #   cmd = Git::Commands::ConfigOptionSyntax::Get.new(lib)
+      #   cmd.call('user.name', global: true)
       #
       # @example Get a value with a type constraint
-      #   Git::Commands::ConfigOptionSyntax::Get.new(ctx).call('core.bare', type: 'bool')
+      #   cmd = Git::Commands::ConfigOptionSyntax::Get.new(lib)
+      #   cmd.call('core.bare', type: 'bool')
       #
-      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      # @note `arguments` block audited against https://git-scm.com/docs/git-config/2.53.0
       #
       # @see Git::Commands::ConfigOptionSyntax
       #
-      # @api private
+      # @see https://git-scm.com/docs/git-config git-config documentation
       #
+      # @api private
       class Get < Git::Commands::Base
         arguments do
           literal 'config'
@@ -100,6 +104,8 @@ module Git
         #     @option options [String] :default (nil) default value when the key is not found
         #
         #     @return [Git::CommandLineResult] the result of calling `git config --get`
+        #
+        #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits outside the allowed status range (0..1)
       end

--- a/lib/git/commands/config_option_syntax/get_all.rb
+++ b/lib/git/commands/config_option_syntax/get_all.rb
@@ -11,17 +11,20 @@ module Git
       # key name, one per line.
       #
       # @example Get all values for a key
-      #   Git::Commands::ConfigOptionSyntax::GetAll.new(ctx).call('remote.origin.fetch')
+      #   cmd = Git::Commands::ConfigOptionSyntax::GetAll.new(lib)
+      #   cmd.call('remote.origin.fetch')
       #
       # @example Get all values with a value pattern
-      #   Git::Commands::ConfigOptionSyntax::GetAll.new(ctx).call('remote.origin.fetch', '\\+refs/heads/.*')
+      #   cmd = Git::Commands::ConfigOptionSyntax::GetAll.new(lib)
+      #   cmd.call('remote.origin.fetch', '\\+refs/heads/.*')
       #
-      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      # @note `arguments` block audited against https://git-scm.com/docs/git-config/2.53.0
       #
       # @see Git::Commands::ConfigOptionSyntax
       #
-      # @api private
+      # @see https://git-scm.com/docs/git-config git-config documentation
       #
+      # @api private
       class GetAll < Git::Commands::Base
         arguments do
           literal 'config'
@@ -40,6 +43,7 @@ module Git
 
           # Type constraint
           value_option :type, inline: true
+          flag_option :no_type
 
           # Output modifiers
           flag_option :show_origin
@@ -63,17 +67,17 @@ module Git
         #
         #     @param name [String] the config key name to look up
         #
-        #     @param value_regex [String, nil] optional regex to filter values
+        #     @param value_regex [String, nil] (nil) optional regex to filter values
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (nil) read from global config (`~/.gitconfig`)
+        #     @option options [Boolean] :global (false) read from global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (nil) read from system config
+        #     @option options [Boolean] :system (false) read from system config
         #
-        #     @option options [Boolean] :local (nil) read from repository config (`.git/config`)
+        #     @option options [Boolean] :local (false) read from repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (nil) read from worktree config
+        #     @option options [Boolean] :worktree (false) read from worktree config
         #
         #     @option options [String] :file (nil) read from the specified file
         #
@@ -85,17 +89,22 @@ module Git
         #
         #     @option options [String] :type (nil) ensure values conform to the given type
         #
-        #     @option options [Boolean] :show_origin (nil) show the origin of each config value
+        #     @option options [Boolean] :no_type (false) unset the previously set type specifier;
+        #       `true` emits `--no-type`
         #
-        #     @option options [Boolean] :show_scope (nil) show the scope of each config value
+        #     @option options [Boolean] :show_origin (false) show the origin of each config value
         #
-        #     @option options [Boolean] :null (nil) terminate values with NUL byte instead of newline
+        #     @option options [Boolean] :show_scope (false) show the scope of each config value
+        #
+        #     @option options [Boolean] :null (false) terminate values with NUL byte instead of newline
         #
         #       Alias: :z
         #
         #     @return [Git::CommandLineResult] the result of calling `git config --get-all`
         #
-        #     @raise [Git::FailedError] if git exits outside the allowed status range (0..1)
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits outside the allowed range (exit code > 1)
       end
     end
   end

--- a/lib/git/commands/config_option_syntax/get_color.rb
+++ b/lib/git/commands/config_option_syntax/get_color.rb
@@ -11,14 +11,18 @@ module Git
       # and output the ANSI escape sequence for that color.
       #
       # @example Get a color config value
-      #   Git::Commands::ConfigOptionSyntax::GetColor.new(ctx).call('color.diff.new')
+      #   cmd = Git::Commands::ConfigOptionSyntax::GetColor.new(lib)
+      #   cmd.call('color.diff.new')
       #
       # @example Get a color config value with a default
-      #   Git::Commands::ConfigOptionSyntax::GetColor.new(ctx).call('color.diff.new', 'green')
+      #   cmd = Git::Commands::ConfigOptionSyntax::GetColor.new(lib)
+      #   cmd.call('color.diff.new', 'green')
       #
-      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      # @note `arguments` block audited against https://git-scm.com/docs/git-config/2.53.0
       #
       # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @see https://git-scm.com/docs/git-config git-config documentation
       #
       # @api private
       #
@@ -56,13 +60,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (nil) read from global config (`~/.gitconfig`)
+        #     @option options [Boolean] :global (false) read from global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (nil) read from system config
+        #     @option options [Boolean] :system (false) read from system config
         #
-        #     @option options [Boolean] :local (nil) read from repository config (`.git/config`)
+        #     @option options [Boolean] :local (false) read from repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (nil) read from worktree config
+        #     @option options [Boolean] :worktree (false) read from worktree config
         #
         #     @option options [String] :file (nil) read from the specified file
         #
@@ -72,9 +76,13 @@ module Git
         #
         #     @option options [Boolean] :includes (nil) respect include directives in config files
         #
+        #       Pass `true` for `--includes`, `false` for `--no-includes`.
+        #
         #     @return [Git::CommandLineResult] the result of calling `git config --get-color`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/config_option_syntax/get_color_bool.rb
+++ b/lib/git/commands/config_option_syntax/get_color_bool.rb
@@ -12,14 +12,18 @@ module Git
       # git 2.46.0 — it exists only in the option-syntax interface.
       #
       # @example Query whether color is enabled for diff
-      #   Git::Commands::ConfigOptionSyntax::GetColorBool.new(ctx).call('color.diff')
+      #   cmd = Git::Commands::ConfigOptionSyntax::GetColorBool.new(lib)
+      #   cmd.call('color.diff')
       #
       # @example Query with explicit stdout-is-tty hint
-      #   Git::Commands::ConfigOptionSyntax::GetColorBool.new(ctx).call('color.diff', 'true')
+      #   cmd = Git::Commands::ConfigOptionSyntax::GetColorBool.new(lib)
+      #   cmd.call('color.diff', 'true')
       #
-      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      # @note `arguments` block audited against https://git-scm.com/docs/git-config/2.53.0
       #
       # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @see https://git-scm.com/docs/git-config git-config documentation
       #
       # @api private
       #
@@ -60,13 +64,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (nil) read from global config (`~/.gitconfig`)
+        #     @option options [Boolean] :global (false) read from global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (nil) read from system config
+        #     @option options [Boolean] :system (false) read from system config
         #
-        #     @option options [Boolean] :local (nil) read from repository config (`.git/config`)
+        #     @option options [Boolean] :local (false) read from repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (nil) read from worktree config
+        #     @option options [Boolean] :worktree (false) read from worktree config
         #
         #     @option options [String] :file (nil) read from the specified file
         #
@@ -76,9 +80,13 @@ module Git
         #
         #     @option options [Boolean] :includes (nil) respect include directives in config files
         #
+        #       Pass `true` for `--includes`, `false` for `--no-includes`.
+        #
         #     @return [Git::CommandLineResult] the result of calling `git config --get-colorbool`
         #
-        #     @raise [Git::FailedError] if git exits outside the allowed status range (0..1)
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits outside the allowed range (exit code > 1)
       end
     end
   end

--- a/spec/unit/git/commands/config_option_syntax/get_all_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/get_all_spec.rb
@@ -106,6 +106,14 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::GetAll do
       end
     end
 
+    context 'with the :no_type option' do
+      it 'adds --no-type to the command line' do
+        expect_command_capturing('config', '--get-all', '--no-type', '--', 'core.bare').and_return(command_result)
+
+        command.call('core.bare', no_type: true)
+      end
+    end
+
     context 'with the :show_origin option' do
       it 'adds --show-origin to the command line' do
         expect_command_capturing('config', '--get-all', '--show-origin', '--', 'user.name').and_return(command_result)


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository.

# Description

Part of #1196: backfill post-2.28.0 documentation and versioning annotations into the `config_option_syntax` command classes (`add`, `get`, `get_all`, `get_color`, `get_color_bool`).

## Changes

- **All five classes**: Add `@note` audit annotation (audited against git 2.53.0 docs); reformat `@example` blocks to use an intermediate variable for clarity
- **`add`**: Fix `flag_option` `@option` defaults from `(nil)` to `(false)` for `:global`, `:system`, `:local`, `:worktree`; add `@raise [ArgumentError]`; fix `@raise [Git::FailedError]` wording
- **`get`**: Add `@see` link to current git-config docs; fix blank line before `class`
- **`get_all`**: Add missing `flag_option :no_type` to arguments DSL; add `@option :no_type` YARD tag; add `@see` link; add `@raise [ArgumentError]`; fix `@raise [Git::FailedError]` wording; fix `@param value_regex` default annotation
- **`get_color`**: Fix `flag_option` `@option` defaults `(nil)` → `(false)` for `:global`, `:system`, `:local`, `:worktree`; add `@see` link; clarify `:includes` usage note; add `@raise [ArgumentError]`; fix `@raise [Git::FailedError]` wording
- **`get_color_bool`**: Same as `get_color`
- **`get_all_spec`**: Add unit test covering `:no_type` option

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).