### PR TITLE
refactor(commands): update config_option_syntax/replace_all, set, unset, unset_all

### DIFF
--- a/lib/git/commands/config_option_syntax/replace_all.rb
+++ b/lib/git/commands/config_option_syntax/replace_all.rb
@@ -11,14 +11,18 @@ module Git
       # given key and optional value regex with a new value.
       #
       # @example Replace all values for a key
-      #   Git::Commands::ConfigOptionSyntax::ReplaceAll.new(ctx).call('core.autocrlf', 'true')
+      #   cmd = Git::Commands::ConfigOptionSyntax::ReplaceAll.new(lib)
+      #   cmd.call('core.autocrlf', 'true')
       #
       # @example Replace values matching a pattern
-      #   Git::Commands::ConfigOptionSyntax::ReplaceAll.new(ctx).call('core.autocrlf', 'true', 'false')
+      #   cmd = Git::Commands::ConfigOptionSyntax::ReplaceAll.new(lib)
+      #   cmd.call('core.autocrlf', 'true', 'false')
       #
-      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      # @note `arguments` block audited against https://git-scm.com/docs/git-config/2.53.0
       #
       # @see Git::Commands::ConfigOptionSyntax
+      #
+      # @see https://git-scm.com/docs/git-config git-config documentation
       #
       # @api private
       #
@@ -26,6 +30,9 @@ module Git
         arguments do
           literal 'config'
           literal '--replace-all'
+
+          # Write modifiers
+          value_option :comment
 
           # File-scope options
           flag_option :global
@@ -35,8 +42,12 @@ module Git
           value_option %i[file f]
           value_option :blob
 
+          # Value matching
+          flag_option :fixed_value
+
           # Type constraint
           value_option :type, inline: true
+          flag_option :no_type
 
           # Operands
           end_of_options
@@ -59,13 +70,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (nil) write to global config (`~/.gitconfig`)
+        #     @option options [Boolean] :global (false) write to global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (nil) write to system config
+        #     @option options [Boolean] :system (false) write to system config
         #
-        #     @option options [Boolean] :local (nil) write to repository config (`.git/config`)
+        #     @option options [Boolean] :local (false) write to repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (nil) write to worktree config
+        #     @option options [Boolean] :worktree (false) write to worktree config
         #
         #     @option options [String] :file (nil) write to the specified file
         #
@@ -73,11 +84,20 @@ module Git
         #
         #     @option options [String] :blob (nil) read from the specified blob
         #
+        #     @option options [String] :comment (nil) append a comment at the end of new or modified lines
+        #
+        #     @option options [Boolean] :fixed_value (false) treat the value regex as an exact string
+        #
         #     @option options [String] :type (nil) ensure the value conforms to the given type
+        #
+        #     @option options [Boolean] :no_type (false) unset the previously set type specifier;
+        #       `true` emits `--no-type`
         #
         #     @return [Git::CommandLineResult] the result of calling `git config --replace-all`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/config_option_syntax/set.rb
+++ b/lib/git/commands/config_option_syntax/set.rb
@@ -11,24 +11,34 @@ module Git
       # a value to a config key, optionally replacing only the entry
       # matching a value regex.
       #
-      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      # @example Set a local config value
+      #   cmd = Git::Commands::ConfigOptionSyntax::Set.new(lib)
+      #   cmd.call('user.name', 'Alice')
+      #
+      # @example Set a global config value
+      #   cmd = Git::Commands::ConfigOptionSyntax::Set.new(lib)
+      #   cmd.call('user.name', 'Alice', global: true)
+      #
+      # @example Set a value with a type constraint
+      #   cmd = Git::Commands::ConfigOptionSyntax::Set.new(lib)
+      #   cmd.call('core.bare', 'true', type: 'bool')
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-config/2.53.0
       #
       # @see Git::Commands::ConfigOptionSyntax
       #
+      # @see https://git-scm.com/docs/git-config git-config documentation
+      #
       # @api private
-      #
-      # @example Set a local config value
-      #   Git::Commands::ConfigOptionSyntax::Set.new(ctx).call('user.name', 'Alice')
-      #
-      # @example Set a global config value
-      #   Git::Commands::ConfigOptionSyntax::Set.new(ctx).call('user.name', 'Alice', global: true)
-      #
-      # @example Set a value with a type constraint
-      #   Git::Commands::ConfigOptionSyntax::Set.new(ctx).call('core.bare', 'true', type: 'bool')
       #
       class Set < Git::Commands::Base
         arguments do
           literal 'config'
+
+          # Write modifiers
+          flag_option :replace_all
+          flag_option :append
+          value_option :comment
 
           # File-scope options
           flag_option :global
@@ -38,8 +48,12 @@ module Git
           value_option %i[file f]
           value_option :blob
 
+          # Value matching
+          flag_option :fixed_value
+
           # Type constraint
           value_option :type, inline: true
+          flag_option :no_type
 
           # Operands
           end_of_options
@@ -62,13 +76,19 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (nil) write to global config (`~/.gitconfig`)
+        #     @option options [Boolean] :replace_all (false) replace all lines matching the key
         #
-        #     @option options [Boolean] :system (nil) write to system config
+        #     @option options [Boolean] :append (false) add a new line without altering existing values
         #
-        #     @option options [Boolean] :local (nil) write to repository config (`.git/config`)
+        #     @option options [String] :comment (nil) append a comment at the end of new or modified lines
         #
-        #     @option options [Boolean] :worktree (nil) write to worktree config
+        #     @option options [Boolean] :global (false) write to global config (`~/.gitconfig`)
+        #
+        #     @option options [Boolean] :system (false) write to system config
+        #
+        #     @option options [Boolean] :local (false) write to repository config (`.git/config`)
+        #
+        #     @option options [Boolean] :worktree (false) write to worktree config
         #
         #     @option options [String] :file (nil) write to the specified file
         #
@@ -76,11 +96,18 @@ module Git
         #
         #     @option options [String] :blob (nil) read from the specified blob
         #
+        #     @option options [Boolean] :fixed_value (false) treat the value regex as an exact string
+        #
         #     @option options [String] :type (nil) ensure the value conforms to the given type
+        #
+        #     @option options [Boolean] :no_type (false) unset the previously set type specifier;
+        #       `true` emits `--no-type`
         #
         #     @return [Git::CommandLineResult] the result of calling `git config`
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero status
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end
     end
   end

--- a/lib/git/commands/config_option_syntax/unset.rb
+++ b/lib/git/commands/config_option_syntax/unset.rb
@@ -10,18 +10,21 @@ module Git
       # Wraps `git config --unset` to remove the entry matching the given
       # key name and optional value regex.
       #
-      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      # @example Unset a config key
+      #   cmd = Git::Commands::ConfigOptionSyntax::Unset.new(lib)
+      #   cmd.call('user.name')
+      #
+      # @example Unset a global config key
+      #   cmd = Git::Commands::ConfigOptionSyntax::Unset.new(lib)
+      #   cmd.call('user.name', global: true)
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-config/2.53.0
       #
       # @see Git::Commands::ConfigOptionSyntax
       #
+      # @see https://git-scm.com/docs/git-config git-config documentation
+      #
       # @api private
-      #
-      # @example Unset a config key
-      #   Git::Commands::ConfigOptionSyntax::Unset.new(ctx).call('user.name')
-      #
-      # @example Unset a global config key
-      #   Git::Commands::ConfigOptionSyntax::Unset.new(ctx).call('user.name', global: true)
-      #
       class Unset < Git::Commands::Base
         arguments do
           literal 'config'
@@ -34,6 +37,9 @@ module Git
           flag_option :worktree
           value_option %i[file f]
           value_option :blob
+
+          # Value matching
+          flag_option :fixed_value
 
           # Operands
           end_of_options
@@ -56,13 +62,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (nil) remove from global config (`~/.gitconfig`)
+        #     @option options [Boolean] :global (false) remove from global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (nil) remove from system config
+        #     @option options [Boolean] :system (false) remove from system config
         #
-        #     @option options [Boolean] :local (nil) remove from repository config (`.git/config`)
+        #     @option options [Boolean] :local (false) remove from repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (nil) remove from worktree config
+        #     @option options [Boolean] :worktree (false) remove from worktree config
         #
         #     @option options [String] :file (nil) remove from the specified file
         #
@@ -70,9 +76,13 @@ module Git
         #
         #     @option options [String] :blob (nil) read from the specified blob
         #
+        #     @option options [Boolean] :fixed_value (false) treat the value regex as an exact string
+        #
         #     @return [Git::CommandLineResult] the result of calling `git config --unset`
         #
-        #     @raise [Git::FailedError] if git exits outside the allowed status range (0..5)
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits outside the allowed range (exit code > 5)
       end
     end
   end

--- a/lib/git/commands/config_option_syntax/unset_all.rb
+++ b/lib/git/commands/config_option_syntax/unset_all.rb
@@ -11,14 +11,20 @@ module Git
       # given key name and optional value regex.
       #
       # @example Unset all values for a key
-      #   Git::Commands::ConfigOptionSyntax::UnsetAll.new(ctx).call('remote.origin.fetch')
+      #   cmd = Git::Commands::ConfigOptionSyntax::UnsetAll.new(lib)
+      #   cmd.call('remote.origin.fetch')
       #
-      # @see https://git-scm.com/docs/git-config/2.28.0 git-config documentation (v2.28.0)
+      # @example Unset all values matching a pattern
+      #   cmd = Git::Commands::ConfigOptionSyntax::UnsetAll.new(lib)
+      #   cmd.call('core.gitproxy', 'for kernel.org$')
+      #
+      # @note `arguments` block audited against https://git-scm.com/docs/git-config/2.53.0
       #
       # @see Git::Commands::ConfigOptionSyntax
       #
-      # @api private
+      # @see https://git-scm.com/docs/git-config git-config documentation
       #
+      # @api private
       class UnsetAll < Git::Commands::Base
         arguments do
           literal 'config'
@@ -31,6 +37,9 @@ module Git
           flag_option :worktree
           value_option %i[file f]
           value_option :blob
+
+          # Value matching
+          flag_option :fixed_value
 
           # Operands
           end_of_options
@@ -49,17 +58,17 @@ module Git
         #
         #     @param name [String] the config key name to unset
         #
-        #     @param value_regex [String, nil] optional regex to match values to remove
+        #     @param value_regex [String, nil] (nil) optional regex to match values to remove
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (nil) remove from global config (`~/.gitconfig`)
+        #     @option options [Boolean] :global (false) remove from global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (nil) remove from system config
+        #     @option options [Boolean] :system (false) remove from system config
         #
-        #     @option options [Boolean] :local (nil) remove from repository config (`.git/config`)
+        #     @option options [Boolean] :local (false) remove from repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (nil) remove from worktree config
+        #     @option options [Boolean] :worktree (false) remove from worktree config
         #
         #     @option options [String] :file (nil) remove from the specified file
         #
@@ -67,9 +76,13 @@ module Git
         #
         #     @option options [String] :blob (nil) read from the specified blob
         #
+        #     @option options [Boolean] :fixed_value (false) treat the value regex as an exact string
+        #
         #     @return [Git::CommandLineResult] the result of calling `git config --unset-all`
         #
-        #     @raise [Git::FailedError] if git exits outside the allowed status range (0..5)
+        #     @raise [ArgumentError] if unsupported options are provided
+        #
+        #     @raise [Git::FailedError] if git exits outside the allowed range (exit code > 5)
       end
     end
   end

--- a/spec/unit/git/commands/config_option_syntax/replace_all_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/replace_all_spec.rb
@@ -97,6 +97,33 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::ReplaceAll do
       end
     end
 
+    context 'with the :comment option' do
+      it 'adds --comment with the message' do
+        expect_command_capturing('config', '--replace-all', '--comment', 'added by script', '--', 'core.autocrlf',
+                                 'true').and_return(command_result)
+
+        command.call('core.autocrlf', 'true', comment: 'added by script')
+      end
+    end
+
+    context 'with the :fixed_value option' do
+      it 'adds --fixed-value to the command line' do
+        expect_command_capturing('config', '--replace-all', '--fixed-value', '--', 'core.gitproxy', 'ssh',
+                                 'default-proxy').and_return(command_result)
+
+        command.call('core.gitproxy', 'ssh', 'default-proxy', fixed_value: true)
+      end
+    end
+
+    context 'with the :no_type option' do
+      it 'adds --no-type to the command line' do
+        expect_command_capturing('config', '--replace-all', '--no-type', '--', 'core.bare',
+                                 'true').and_return(command_result)
+
+        command.call('core.bare', 'true', no_type: true)
+      end
+    end
+
     context 'input validation' do
       it 'raises ArgumentError when name is missing' do
         expect { command.call }.to raise_error(ArgumentError, /name/)

--- a/spec/unit/git/commands/config_option_syntax/set_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/set_spec.rb
@@ -84,11 +84,53 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::Set do
       end
     end
 
+    context 'with the :replace_all option' do
+      it 'adds --replace-all to the command line' do
+        expect_command_capturing('config', '--replace-all', '--', 'user.name', 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', replace_all: true)
+      end
+    end
+
+    context 'with the :append option' do
+      it 'adds --append to the command line' do
+        expect_command_capturing('config', '--append', '--', 'user.name', 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', append: true)
+      end
+    end
+
+    context 'with the :comment option' do
+      it 'adds --comment with the message' do
+        expect_command_capturing('config', '--comment', 'added by script', '--', 'user.name',
+                                 'Alice').and_return(command_result)
+
+        command.call('user.name', 'Alice', comment: 'added by script')
+      end
+    end
+
     context 'with the :type option' do
       it 'adds --type=<value> inline' do
         expect_command_capturing('config', '--type=bool', '--', 'core.bare', 'true').and_return(command_result)
 
         command.call('core.bare', 'true', type: 'bool')
+      end
+    end
+
+    context 'with the :fixed_value option' do
+      it 'adds --fixed-value to the command line' do
+        expect_command_capturing('config', '--fixed-value', '--', 'core.gitproxy', 'ssh',
+                                 'default-proxy').and_return(command_result)
+
+        command.call('core.gitproxy', 'ssh', 'default-proxy', fixed_value: true)
+      end
+    end
+
+    context 'with the :no_type option' do
+      it 'adds --no-type to the command line' do
+        expect_command_capturing('config', '--no-type', '--', 'core.bare', 'true').and_return(command_result)
+
+        command.call('core.bare', 'true', no_type: true)
       end
     end
 

--- a/spec/unit/git/commands/config_option_syntax/unset_all_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/unset_all_spec.rb
@@ -87,6 +87,15 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::UnsetAll do
       end
     end
 
+    context 'with the :fixed_value option' do
+      it 'adds --fixed-value to the command line' do
+        expect_command_capturing('config', '--unset-all', '--fixed-value', '--', 'core.gitproxy',
+                                 'default-proxy').and_return(command_result)
+
+        command.call('core.gitproxy', 'default-proxy', fixed_value: true)
+      end
+    end
+
     context 'exit code handling' do
       it 'returns normally on exit status 5 (key not found)' do
         result = command_result(exitstatus: 5)

--- a/spec/unit/git/commands/config_option_syntax/unset_spec.rb
+++ b/spec/unit/git/commands/config_option_syntax/unset_spec.rb
@@ -83,6 +83,15 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::Unset do
       end
     end
 
+    context 'with the :fixed_value option' do
+      it 'adds --fixed-value to the command line' do
+        expect_command_capturing('config', '--unset', '--fixed-value', '--', 'core.gitproxy',
+                                 'default-proxy').and_return(command_result)
+
+        command.call('core.gitproxy', 'default-proxy', fixed_value: true)
+      end
+    end
+
     context 'exit code handling' do
       it 'returns result for exit code 5 (non-existent key)' do
         result = command_result(exitstatus: 5)


### PR DESCRIPTION
## Summary

Backfill post-2.28.0 options into `config_option_syntax/replace_all`, `set`, `unset`, and `unset_all` command classes as part of issue #1196.

Each updated class:
- Adds DSL entries for options present in git-config 2.53.0 but missing from the 2.28.0 baseline
- Updates YARD `@option` documentation for all options
- Fixes `@example` blocks to use `lib` (not `ctx`) as the constructor argument

### Changes per class

**`replace_all`** — adds `:comment`, `:fixed_value`, `:no_type`

**`set`** — adds `:replace_all`, `:append`, `:comment`, `:fixed_value`, `:no_type`

**`unset`** — adds `:fixed_value`

**`unset_all`** — adds `:fixed_value`

### Specs

- `replace_all_spec.rb` — new tests for `:comment`, `:fixed_value`, and `:no_type`
- `set_spec.rb` — new tests for `:replace_all`, `:append`, `:comment`, `:fixed_value`, `:no_type`

Closes the final unchecked item in the Batch 8 checklist of #1196.