### PR TITLE
feat(api): add Git.git_version method

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'open3'
+
 require 'active_support'
 require 'active_support/deprecation'
 
@@ -480,6 +482,53 @@ module Git
   def self.open(working_dir, options = {})
     Base.open(working_dir, options)
   end
+
+  # Return the version of a git binary as a {Git::Version}
+  #
+  # @param binary_path [String, nil] path to the git binary; defaults to
+  #   `Git::Base.config.binary_path`
+  #
+  # @return [Git::Version] the parsed git version
+  #
+  # @raise [Git::Error] if the binary exits with a non-zero status, is not found,
+  #   or the version output cannot be parsed
+  #
+  # @example Default binary
+  #   Git.git_version #=> #<Git::Version 2.42.0>
+  #
+  # @example Explicit binary path
+  #   Git.git_version('/opt/homebrew/bin/git') #=> #<Git::Version 2.42.0>
+  #
+  def self.git_version(binary_path = nil)
+    path = binary_path || Git::Base.config.binary_path
+    Git::Lib.cached_git_version(path) { run_git_version(path) }
+  end
+
+  # @api private
+  # STOPGAP: uses Open3 directly because Git::Lib hardcodes Git::Base.config.binary_path
+  # in its command-line factory, so Git::Commands::Version cannot be used to query an
+  # arbitrary binary path today.
+  #
+  # Phase 3 of the redesign (redesign/2_architecture_redesign.md) introduces
+  # Git::GlobalContext, which will accept a binary_path: constructor argument. Once that
+  # lands, replace the Open3 call with:
+  #
+  #   Git::Commands::Version.new(Git::GlobalContext.new(binary_path: path)).call.stdout
+  #
+  # and remove the Open3 dependency from this method.
+  def self.run_git_version(path)
+    output, status = Open3.capture2e(path, 'version')
+    raise Git::Error, "Failed to run `#{path} version`: #{output.chomp}" unless status.success?
+
+    Git::Version.parse(output)
+  rescue Errno::ENOENT
+    raise Git::Error, "Git binary not found: #{path}"
+  rescue SystemCallError => e
+    raise Git::Error, "Failed to execute git binary at `#{path}`: #{e.message}"
+  rescue ArgumentError => e
+    raise Git::Error, "Unable to parse git version from: #{output.inspect} (#{e.message})"
+  end
+  private_class_method :run_git_version
 
   # Return the version of the git binary
   #

--- a/spec/unit/git/git_version_spec.rb
+++ b/spec/unit/git/git_version_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git do
+  describe '.git_version' do
+    let(:binary_path) { Git::Base.config.binary_path }
+    let(:success_status) { instance_double(Process::Status, success?: true) }
+    let(:failure_status) { instance_double(Process::Status, success?: false) }
+
+    before { Git::Lib.clear_git_version_cache }
+
+    context 'when called with no argument (default binary)' do
+      before do
+        allow(Open3).to receive(:capture2e).with(binary_path, 'version')
+                                           .and_return(['git version 2.42.0', success_status])
+      end
+
+      it 'returns a Git::Version' do
+        version = described_class.git_version
+
+        expect(version).to be_a(Git::Version)
+      end
+    end
+
+    context 'when called with an explicit binary_path' do
+      let(:explicit_path) { '/usr/local/bin/git2' }
+
+      it 'returns a Git::Version for the specified binary' do
+        allow(Open3).to receive(:capture2e).with(explicit_path, 'version')
+                                           .and_return(['git version 2.42.0', success_status])
+
+        version = described_class.git_version(explicit_path)
+
+        expect(version).to be_a(Git::Version)
+        expect(Open3).to have_received(:capture2e).with(explicit_path, 'version').once
+      end
+
+      it 'caches the result per binary path (second call does not re-shell)' do
+        allow(Open3).to receive(:capture2e).with(explicit_path, 'version')
+                                           .and_return(['git version 2.40.0', success_status])
+
+        described_class.git_version(explicit_path)
+        described_class.git_version(explicit_path)
+
+        expect(Open3).to have_received(:capture2e).once
+      end
+
+      it 'caches independently from the default binary path' do
+        allow(Open3).to receive(:capture2e).with(binary_path, 'version')
+                                           .and_return(['git version 2.42.0', success_status])
+        allow(Open3).to receive(:capture2e).with(explicit_path, 'version')
+                                           .and_return(['git version 2.40.0', success_status])
+
+        described_class.git_version
+        described_class.git_version(explicit_path)
+
+        expect(Open3).to have_received(:capture2e).with(binary_path, 'version').once
+        expect(Open3).to have_received(:capture2e).with(explicit_path, 'version').once
+      end
+    end
+
+    context 'when the binary is not found' do
+      before do
+        allow(Open3).to receive(:capture2e).and_raise(Errno::ENOENT)
+      end
+
+      it 'raises Git::Error' do
+        expect { described_class.git_version }.to raise_error(Git::Error, /Git binary not found/)
+      end
+    end
+
+    context 'when the binary exists but is not executable' do
+      before do
+        allow(Open3).to receive(:capture2e).and_raise(Errno::EACCES)
+      end
+
+      it 'raises Git::Error' do
+        expect { described_class.git_version }.to raise_error(Git::Error, /Failed to execute git binary/)
+      end
+    end
+
+    context 'when the binary exits with a non-zero status' do
+      before do
+        allow(Open3).to receive(:capture2e).and_return(['git: command not found', failure_status])
+      end
+
+      it 'raises Git::Error' do
+        expect { described_class.git_version }.to raise_error(Git::Error, /Failed to run/)
+      end
+    end
+
+    context 'when the version cannot be parsed' do
+      before do
+        allow(Open3).to receive(:capture2e).and_return(['not a version string', success_status])
+      end
+
+      it 'raises Git::Error' do
+        expect { described_class.git_version }.to raise_error(Git::Error, /Unable to parse git version/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `Git.git_version(binary_path = nil)` to the top-level `Git` module as the
stable public API for querying a git binary's version. This is the migration target
for the `Git.binary_version` / `Git::Base.binary_version` deprecations tracked in
#1193.

## Changes

### `lib/git.rb`

- Added `Git.git_version(binary_path = nil)` class method
  - Returns `Git::Version` for the configured default binary or any explicit path
  - Results are cached per binary path via the existing `Git::Lib.cached_git_version`
    mechanism — no new cache is introduced
  - Raises `Git::Error` if the version output cannot be parsed
  - Full YARD docs with `@param`, `@return`, `@raise`, and two `@example` tags

### `spec/unit/git/git_version_spec.rb` (new file)

Unit specs covering all acceptance criteria:

| Behaviour | Test |
|---|---|
| Default binary returns `Git::Version` | ✓ |
| Explicit `binary_path` returns `Git::Version` | ✓ |
| Cache: second call with same path does not re-shell | ✓ |
| Parse failure raises `Git::Error` | ✓ |

## Implementation notes

- Executes `git version` via `Open3.capture2e(path, 'version')` so that an
  arbitrary binary path is honoured correctly (unlike `Git::Lib`, which hardcodes
  `Git::Base.config.binary_path`).
- Parsing reuses `Git::Version.parse` with the same `ArgumentError → Git::Error`
  rescue pattern used by `Git::Lib#git_version`.
- Internally delegates to `Git::Lib.cached_git_version` — when Phase 3 of the
  redesign arrives, the internals can be re-pointed at `Git::GlobalContext` without
  changing any call sites.

## Checklist

- [x] All new code has unit tests
- [x] `bundle exec rake default` passes
- [x] YARD docs include `@param`, `@return`, `@raise`, and at least one `@example`

Closes #1249
