### PR TITLE
fix(test): use crontab scheduler in maintenance start integration spec

### DIFF
--- a/spec/integration/git/commands/maintenance/start_spec.rb
+++ b/spec/integration/git/commands/maintenance/start_spec.rb
@@ -38,14 +38,24 @@ RSpec.describe Git::Commands::Maintenance::Start, :integration,
 
   describe '#call' do
     context 'when the command succeeds' do
+      # Specify the scheduler explicitly rather than relying on `auto` to avoid
+      # environment-specific failures:
+      #
+      # - Linux `auto` picks `systemd-timer`, which requires git-maintained unit
+      #   files (git-maintenance@*.timer) that may not be present in all CI images.
+      # - Windows `crontab` is not available; its native scheduler is `schtasks`.
+      #
+      # Using the platform-appropriate scheduler keeps the test portable.
+      let(:scheduler) { Gem.win_platform? ? 'schtasks' : 'crontab' }
+
       it 'returns a CommandLineResult' do
-        result = command.call(env: isolated_env)
+        result = command.call(scheduler: scheduler, env: isolated_env)
 
         expect(result).to be_a(Git::CommandLineResult)
       end
 
       it 'returns exit code 0' do
-        result = command.call(env: isolated_env)
+        result = command.call(scheduler: scheduler, env: isolated_env)
 
         expect(result.status.exitstatus).to eq(0)
       end


### PR DESCRIPTION
## Problem

`git maintenance start` defaults to the `systemd-timer` scheduler on Linux. This scheduler requires `git-maintenance@{schedule}.timer` unit files that are installed by the git package itself. On newer GitHub Actions ubuntu runners (observed on Ruby 3.4 CI), these unit files are absent, so the command exits with status 128:

```
Failed to enable unit: Unit file git-maintenance@hourly.timer does not exist.
error: failed to run systemctl
fatal: failed to set up maintenance schedule
```

This caused the integration spec to fail on Ruby 3.4 CI even though the gem code and the `Git::Commands::Maintenance::Start` implementation are both correct.

## Fix

Pass `scheduler: 'crontab'` explicitly in the two "when the command succeeds" examples. `crontab` is reliably available on all Linux and macOS CI runners and requires no git-provided system unit files, making the test deterministic across environments.

The `'when the command fails'` example is unchanged — it already exercises a code path (no `.git` directory) that is independent of the scheduler.

## Checklist

- [x] `bundle exec rake default` passes
