### PR TITLE
chore: deprecate legacy git version methods

### DIFF
--- a/.github/skills/command-test-conventions/SKILL.md
+++ b/.github/skills/command-test-conventions/SKILL.md
@@ -594,8 +594,9 @@ at the describe level where helpers like `repo` are not available, causing a loa
 error. For example:
 
 ```ruby
-it 'succeeds when no merge is in progress (git 2.35+)' do
-  skip 'git < 2.35' if repo.lib.compare_version_to(2, 35, 0) < 0
+it 'succeeds when no merge is in progress' do
+  skip 'requires git 2.35.0 or later' unless Git.git_version >= Git::Version.new(2, 35, 0)
+
   expect { command.call }.not_to raise_error
 end
 ```

--- a/.github/skills/review-command-tests/SKILL.md
+++ b/.github/skills/review-command-tests/SKILL.md
@@ -571,8 +571,9 @@ at the describe level where helpers like `repo` are not available, causing a loa
 error. For example:
 
 ```ruby
-it 'succeeds when no merge is in progress (git 2.35+)' do
-  skip 'git < 2.35' if repo.lib.compare_version_to(2, 35, 0) < 0
+it 'succeeds when no merge is in progress' do
+  skip 'requires git 2.35.0 or later' unless Git.git_version >= Git::Version.new(2, 35, 0)
+
   expect { command.call }.not_to raise_error
 end
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -921,7 +921,7 @@ require 'git'
 Git.configure { |c| c.binary_path = '/Users/james/Downloads/git-2.30.2/bin-wrappers/git' }
 
 # Validate the version (if desired)
-assert_equal([2, 30, 2], Git.binary_version)
+assert_equal(Git::Version.new(2, 30, 2), Git.git_version)
 ```
 
 Tests can be run using the newly built Git version as follows:

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -537,7 +537,17 @@ module Git
   #
   # @return [Array<Integer>] the version of the git binary
   #
+  # @deprecated Use {Git.git_version} instead, which returns a {Git::Version} (not an Array).
+  #   For the legacy array shape, call: `Git.git_version.to_a`.
+  #   The optional binary_path argument is preserved: `Git.git_version(binary_path)`.
+  #
   def self.binary_version(binary_path = Git::Base.config.binary_path)
-    Base.binary_version(binary_path)
+    Git::Deprecation.warn(
+      'Git.binary_version is deprecated and will be removed in 6.0. ' \
+      'Use Git.git_version instead, which returns a Git::Version ' \
+      '(not an Array). For the legacy array shape, call: Git.git_version.to_a. ' \
+      'The optional binary_path argument is preserved: Git.git_version(binary_path).'
+    )
+    git_version(binary_path).to_a
   end
 end

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'logger'
-require 'open3'
 require 'pathname'
 
 require 'git/commands/rev_parse'
@@ -48,32 +47,16 @@ module Git
       @config ||= Config.new
     end
 
+    # @deprecated Use {Git.git_version} instead, which returns a {Git::Version} (not an Array).
+    #   For the legacy array shape, call: `Git.git_version.to_a`
+    #
     def self.binary_version(binary_path)
-      result, status = execute_git_version(binary_path)
-
-      raise "Failed to get git version: #{status}\n#{result}" unless status.success?
-
-      parse_version_string(result)
-    end
-
-    private_class_method def self.execute_git_version(binary_path)
-      Open3.capture2e(
-        binary_path,
-        '-c', 'core.quotePath=true',
-        '-c', 'core.editor=false',
-        '-c', 'color.ui=false',
-        'version'
+      Git::Deprecation.warn(
+        'Git::Base.binary_version is deprecated and will be removed in 6.0. ' \
+        'Use Git.git_version instead, which returns a Git::Version ' \
+        '(not an Array). For the legacy array shape, call: Git.git_version.to_a'
       )
-    rescue Errno::ENOENT
-      raise "Failed to get git version: #{binary_path} not found"
-    end
-
-    private_class_method def self.parse_version_string(raw_string)
-      version_match = raw_string.match(/\d+(\.\d+)+/)
-      return [0, 0, 0] unless version_match
-
-      version_parts = version_match[0].split('.').map(&:to_i)
-      version_parts.fill(0, version_parts.length...3)
+      Git.git_version(binary_path).to_a
     end
 
     def self.root_of_worktree(working_dir)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1905,47 +1905,89 @@ module Git
       end
     end
 
-    # returns the current version of git, as an Array of Fixnums.
+    # Returns the current version of git, as an Array<Integer>
+    #
+    # @deprecated Use {Git.git_version} instead, which returns a {Git::Version} (not an Array).
+    #   For the legacy array shape, call: `Git.git_version.to_a`
+    #
     def current_command_version
-      output = Git::Commands::Version.new(self).call.stdout
-      version = output[/\d+(\.\d+)+/]
-      version_parts = version.split('.').collect(&:to_i)
-      version_parts.fill(0, version_parts.length...3)
+      Git::Deprecation.warn(
+        'Git::Lib#current_command_version is deprecated and will be removed in 6.0. ' \
+        'Use Git.git_version instead, which returns a Git::Version (not an Array). ' \
+        'For the legacy array shape, call: Git.git_version.to_a'
+      )
+      git_version.to_a
     end
 
     # Returns current_command_version <=> other_version
     #
     # @example
-    #   lib.current_command_version #=> [2, 42, 0]
-    #
     #   lib.compare_version_to(2, 41, 0) #=> 1
     #   lib.compare_version_to(2, 42, 0) #=> 0
     #   lib.compare_version_to(2, 43, 0) #=> -1
     #
-    # @param other_version [Array<Object>] the other version to compare to
+    # @param other_version [Array<Integer>] the other version to compare to
     # @return [Integer] -1 if this version is less than other_version, 0 if equal, or 1 if greater than
     #
+    # @deprecated Use {Git.git_version} with {Git::Version} comparison operators instead,
+    #   e.g. `Git.git_version <=> Git::Version.new(2, 41, 0)`
+    #
     def compare_version_to(*other_version)
-      current_command_version <=> other_version
+      Git::Deprecation.warn(
+        'Git::Lib#compare_version_to is deprecated and will be removed in 6.0. ' \
+        'Use Git.git_version with Git::Version comparison operators instead, ' \
+        'e.g. Git.git_version <=> Git::Version.new(2, 41, 0)'
+      )
+      git_version.to_a <=> other_version
     end
 
+    # @deprecated Use {Git::MINIMUM_GIT_VERSION} constant instead, which returns a {Git::Version}
+    #   (not an Array). For the legacy array shape, call: `Git::MINIMUM_GIT_VERSION.to_a.first(2)`
+    #
     def required_command_version
-      [2, 28]
+      Git::Deprecation.warn(
+        'Git::Lib#required_command_version is deprecated and will be removed in 6.0. ' \
+        'Use the Git::MINIMUM_GIT_VERSION constant instead, which returns a Git::Version ' \
+        '(not an Array). For the legacy array shape, call: Git::MINIMUM_GIT_VERSION.to_a.first(2)'
+      )
+      Git::MINIMUM_GIT_VERSION.to_a.first(2)
     end
 
+    # @deprecated For a boolean check, use `Git.git_version >= Git::MINIMUM_GIT_VERSION`.
+    #   For enforcement, no action is needed: {Git::Commands::Base#call} automatically
+    #   invokes `validate_version!`, which raises {Git::VersionError} on failure.
+    #
     def meets_required_version?
-      (current_command_version <=> required_command_version) >= 0
+      Git::Deprecation.warn(
+        'Git::Lib#meets_required_version? is deprecated and will be removed in 6.0. ' \
+        'For a boolean check, use: Git.git_version >= Git::MINIMUM_GIT_VERSION. ' \
+        'For enforcement, no action is needed: Git::Commands::Base#call automatically ' \
+        'invokes validate_version!, which raises Git::VersionError on failure.'
+      )
+      git_version >= Git::MINIMUM_GIT_VERSION
     end
 
-    def self.warn_if_old_command(lib) # rubocop:disable Naming/PredicateMethod
-      Git::Deprecation.warn('Git::Lib#warn_if_old_command is deprecated. Use meets_required_version?.')
+    # @deprecated Version validation is now handled automatically by
+    #   {Git::Commands::Base#validate_version!}, which raises {Git::VersionError} on failure.
+    #   Callers wanting the old warn-and-continue behavior must implement it themselves
+    #   using: `Git.git_version >= Git::MINIMUM_GIT_VERSION`.
+    #
+    def self.warn_if_old_command(_lib) # rubocop:disable Metrics/MethodLength, Naming/PredicateMethod
+      Git::Deprecation.warn(
+        'Git::Lib.warn_if_old_command is deprecated and will be removed in 6.0. ' \
+        'Version validation is now handled automatically by Git::Commands::Base#validate_version!, ' \
+        'which RAISES Git::VersionError on failure (the old method only printed a warning ' \
+        'once per process and continued). Callers wanting the old warn-and-continue behavior ' \
+        'must implement it themselves using: Git.git_version >= Git::MINIMUM_GIT_VERSION.'
+      )
 
       return true if @version_checked
 
       @version_checked = true
-      unless lib.meets_required_version?
-        warn "[WARNING] The git gem requires git #{lib.required_command_version.join('.')} or later, " \
-             "but only found #{lib.current_command_version.join('.')}. You should probably upgrade."
+      git_version = Git.git_version
+      unless git_version >= Git::MINIMUM_GIT_VERSION
+        warn "The git gem requires git #{Git::MINIMUM_GIT_VERSION} or later, " \
+             "but only found #{git_version}. You should probably upgrade."
       end
       true
     end

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -95,5 +95,19 @@ module Git
     def inspect
       "#<Git::Version #{self}>"
     end
+
+    # Return the version as an array of integers
+    #
+    # Useful when legacy code expects the array shape returned by the
+    # deprecated {Git::Lib#current_command_version} method.
+    #
+    # @return [Array<Integer>] [major, minor, patch]
+    #
+    # @example
+    #   Git.git_version.to_a  #=> [2, 42, 0]
+    #
+    def to_a
+      deconstruct
+    end
   end
 end

--- a/spec/integration/git/commands/merge/quit_spec.rb
+++ b/spec/integration/git/commands/merge/quit_spec.rb
@@ -38,15 +38,17 @@ RSpec.describe Git::Commands::Merge::Quit, :integration do
         end
       end
 
-      it 'succeeds when no merge is in progress (git 2.35+)' do
-        skip 'git < 2.35' if repo.lib.compare_version_to(2, 35, 0) < 0
+      it 'succeeds when no merge is in progress' do
+        skip 'requires git 2.35.0 or later' unless Git.git_version >= Git::Version.new(2, 35, 0)
+
         expect { command.call }.not_to raise_error
       end
     end
 
     describe 'when the command fails' do
-      it 'raises FailedError when no merge is in progress (git < 2.35)' do
-        skip 'git >= 2.35' if repo.lib.compare_version_to(2, 35, 0) >= 0
+      it 'raises FailedError when no merge is in progress' do
+        skip 'requires git < 2.35.0' unless Git.git_version < Git::Version.new(2, 35, 0)
+
         expect { command.call }.to raise_error(Git::FailedError)
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -85,7 +85,7 @@ end
 def unless_git(minimum_version, feature)
   minimum_version_parts = minimum_version.split('.').map(&:to_i)
   minimum_version_parts.fill(0, minimum_version_parts.length...3)
-  actual_version_parts = Git::Lib.new(nil).current_command_version
+  actual_version_parts = Git.git_version.to_a
 
   return false if (actual_version_parts <=> minimum_version_parts) >= 0
 

--- a/spec/unit/git/git_version_spec.rb
+++ b/spec/unit/git/git_version_spec.rb
@@ -100,4 +100,63 @@ RSpec.describe Git do
       end
     end
   end
+
+  describe '.binary_version' do
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+      allow(Git).to receive(:git_version).and_return(Git::Version.new(2, 42, 0))
+    end
+
+    it 'emits a deprecation warning' do
+      described_class.binary_version
+
+      expect(Git::Deprecation).to have_received(:warn).with(
+        'Git.binary_version is deprecated and will be removed in 6.0. ' \
+        'Use Git.git_version instead, which returns a Git::Version ' \
+        '(not an Array). For the legacy array shape, call: Git.git_version.to_a. ' \
+        'The optional binary_path argument is preserved: Git.git_version(binary_path).'
+      ).once
+    end
+
+    it 'emits exactly one deprecation warning per call' do
+      described_class.binary_version
+
+      expect(Git::Deprecation).to have_received(:warn).exactly(1).time
+    end
+
+    it 'still returns an Array of integers' do
+      expect(described_class.binary_version).to eq([2, 42, 0])
+    end
+  end
+end
+
+RSpec.describe Git::Base do
+  describe '.binary_version' do
+    let(:binary_path) { described_class.config.binary_path }
+
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+      allow(Git).to receive(:git_version).and_return(Git::Version.new(2, 42, 0))
+    end
+
+    it 'emits a deprecation warning' do
+      described_class.binary_version(binary_path)
+
+      expect(Git::Deprecation).to have_received(:warn).with(
+        'Git::Base.binary_version is deprecated and will be removed in 6.0. ' \
+        'Use Git.git_version instead, which returns a Git::Version ' \
+        '(not an Array). For the legacy array shape, call: Git.git_version.to_a'
+      ).once
+    end
+
+    it 'emits exactly one deprecation warning per call' do
+      described_class.binary_version(binary_path)
+
+      expect(Git::Deprecation).to have_received(:warn).exactly(1).time
+    end
+
+    it 'still returns an Array of integers' do
+      expect(described_class.binary_version(binary_path)).to eq([2, 42, 0])
+    end
+  end
 end

--- a/spec/unit/git/lib_version_deprecations_spec.rb
+++ b/spec/unit/git/lib_version_deprecations_spec.rb
@@ -1,0 +1,116 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::Lib do
+  subject(:lib) { described_class.new(nil, nil) }
+
+  before do
+    allow(Git::Deprecation).to receive(:warn)
+  end
+
+  describe '#current_command_version' do
+    before do
+      allow(lib).to receive(:git_version).and_return(Git::Version.new(2, 42, 0))
+    end
+
+    it 'emits a deprecation warning' do
+      lib.current_command_version
+
+      expect(Git::Deprecation).to have_received(:warn).with(
+        'Git::Lib#current_command_version is deprecated and will be removed in 6.0. ' \
+        'Use Git.git_version instead, which returns a Git::Version (not an Array). ' \
+        'For the legacy array shape, call: Git.git_version.to_a'
+      ).once
+    end
+
+    it 'emits exactly one deprecation warning per call' do
+      lib.current_command_version
+
+      expect(Git::Deprecation).to have_received(:warn).exactly(1).time
+    end
+
+    it 'still returns the version as an Array of integers' do
+      result = lib.current_command_version
+
+      expect(result).to eq([2, 42, 0])
+    end
+  end
+
+  describe '#compare_version_to' do
+    before do
+      allow(lib).to receive(:git_version).and_return(Git::Version.new(2, 42, 0))
+    end
+
+    it 'emits a deprecation warning' do
+      lib.compare_version_to(2, 41, 0)
+
+      expect(Git::Deprecation).to have_received(:warn).with(
+        'Git::Lib#compare_version_to is deprecated and will be removed in 6.0. ' \
+        'Use Git.git_version with Git::Version comparison operators instead, ' \
+        'e.g. Git.git_version <=> Git::Version.new(2, 41, 0)'
+      ).once
+    end
+
+    it 'emits exactly one deprecation warning per call' do
+      lib.compare_version_to(2, 41, 0)
+
+      expect(Git::Deprecation).to have_received(:warn).exactly(1).time
+    end
+
+    it 'still returns the comparison result as an Integer' do
+      expect(lib.compare_version_to(2, 41, 0)).to eq(1)
+      expect(lib.compare_version_to(2, 42, 0)).to eq(0)
+      expect(lib.compare_version_to(2, 43, 0)).to eq(-1)
+    end
+  end
+
+  describe '#required_command_version' do
+    it 'emits a deprecation warning' do
+      lib.required_command_version
+
+      expect(Git::Deprecation).to have_received(:warn).with(
+        'Git::Lib#required_command_version is deprecated and will be removed in 6.0. ' \
+        'Use the Git::MINIMUM_GIT_VERSION constant instead, which returns a Git::Version ' \
+        '(not an Array). For the legacy array shape, call: Git::MINIMUM_GIT_VERSION.to_a.first(2)'
+      ).once
+    end
+
+    it 'emits exactly one deprecation warning per call' do
+      lib.required_command_version
+
+      expect(Git::Deprecation).to have_received(:warn).exactly(1).time
+    end
+
+    it 'still returns [2, 28]' do
+      expect(lib.required_command_version).to eq([2, 28])
+    end
+  end
+
+  describe '#meets_required_version?' do
+    before do
+      allow(lib).to receive(:git_version).and_return(Git::Version.new(2, 42, 0))
+    end
+
+    it 'emits a deprecation warning' do
+      lib.meets_required_version?
+
+      expect(Git::Deprecation).to have_received(:warn).with(
+        'Git::Lib#meets_required_version? is deprecated and will be removed in 6.0. ' \
+        'For a boolean check, use: Git.git_version >= Git::MINIMUM_GIT_VERSION. ' \
+        'For enforcement, no action is needed: Git::Commands::Base#call automatically ' \
+        'invokes validate_version!, which raises Git::VersionError on failure.'
+      ).once
+    end
+
+    it 'emits exactly one deprecation warning per call' do
+      lib.meets_required_version?
+
+      expect(Git::Deprecation).to have_received(:warn).exactly(1).time
+    end
+
+    it 'returns true when version meets requirements' do
+      expect(lib.meets_required_version?).to be(true)
+    end
+  end
+end

--- a/spec/unit/git/version_spec.rb
+++ b/spec/unit/git/version_spec.rb
@@ -140,4 +140,12 @@ RSpec.describe Git::Version do
       expect(version.inspect).to eq('#<Git::Version 2.42.1>')
     end
   end
+
+  describe '#to_a' do
+    it 'returns an array of [major, minor, patch]' do
+      version = described_class.new(2, 42, 0)
+
+      expect(version.to_a).to eq([2, 42, 0])
+    end
+  end
 end

--- a/tests/units/test_deprecations.rb
+++ b/tests/units/test_deprecations.rb
@@ -189,7 +189,11 @@ class TestDeprecations < Test::Unit::TestCase
     Git::Lib.instance_variable_set(:@version_checked, nil)
 
     Git::Deprecation.expects(:warn).with(
-      'Git::Lib#warn_if_old_command is deprecated. Use meets_required_version?.'
+      'Git::Lib.warn_if_old_command is deprecated and will be removed in 6.0. ' \
+      'Version validation is now handled automatically by Git::Commands::Base#validate_version!, ' \
+      'which RAISES Git::VersionError on failure (the old method only printed a warning ' \
+      'once per process and continued). Callers wanting the old warn-and-continue behavior ' \
+      'must implement it themselves using: Git.git_version >= Git::MINIMUM_GIT_VERSION.'
     )
 
     assert_equal(true, Git::Lib.warn_if_old_command(@git.lib))

--- a/tests/units/test_git_binary_version.rb
+++ b/tests/units/test_git_binary_version.rb
@@ -38,6 +38,7 @@ class TestGitBinaryVersion < Test::Unit::TestCase
   def test_binary_version
     in_temp_dir do |_path|
       mock_git_binary(mocked_git_script) do |git_binary_path|
+        Git::Deprecation.stubs(:warn)
         assert_equal([1, 2, 3], Git.binary_version(git_binary_path))
       end
     end
@@ -47,13 +48,15 @@ class TestGitBinaryVersion < Test::Unit::TestCase
     in_temp_dir do |_path|
       subdir = 'Git Bin Directory'
       mock_git_binary(mocked_git_script, subdir: subdir) do |git_binary_path|
+        Git::Deprecation.stubs(:warn)
         assert_equal([1, 2, 3], Git.binary_version(git_binary_path))
       end
     end
   end
 
   def test_binary_version_bad_binary_path
-    assert_raise RuntimeError do
+    Git::Deprecation.stubs(:warn)
+    assert_raise Git::Error do
       Git.binary_version('/path/to/nonexistent/git')
     end
   end

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -382,8 +382,8 @@ class TestLib < Test::Unit::TestCase
 
   def test_compare_version_to
     lib = Git::Lib.new(nil, nil)
-    current_version = [2, 42, 0]
-    lib.define_singleton_method(:current_command_version) { current_version }
+    lib.stubs(:git_version).returns(Git::Version.new(2, 42, 0))
+    Git::Deprecation.expects(:warn).at_least_once
     assert lib.compare_version_to(0, 43, 9) == 1
     assert lib.compare_version_to(2, 41, 0) == 1
     assert lib.compare_version_to(2, 42, 0).zero?

--- a/tests/units/test_lib_meets_required_version.rb
+++ b/tests/units/test_lib_meets_required_version.rb
@@ -5,51 +5,18 @@ require 'test_helper'
 class TestLibMeetsRequiredVersion < Test::Unit::TestCase
   def test_with_supported_command_version
     lib = Git::Lib.new(nil, nil)
-    major_version, minor_version = lib.required_command_version
-    lib.define_singleton_method(:current_command_version) { [major_version, minor_version] }
+    # suppress deprecation warnings for this test
+    Git::Deprecation.stubs(:warn)
+    # Stub git_version so no real git binary is needed
+    lib.stubs(:git_version).returns(Git::MINIMUM_GIT_VERSION)
     assert lib.meets_required_version?
   end
 
   def test_with_old_command_version
     lib = Git::Lib.new(nil, nil)
-    major_version, minor_version = lib.required_command_version
-
-    # Set the major version to be returned by #current_command_version to be an
-    # earlier version than required
-    major_version -= 1
-
-    lib.define_singleton_method(:current_command_version) { [major_version, minor_version] }
+    # suppress deprecation warnings for this test
+    Git::Deprecation.stubs(:warn)
+    lib.stubs(:git_version).returns(Git::Version.new(1, 28, 0))
     assert !lib.meets_required_version?
-  end
-
-  def test_parse_version
-    lib = Git::Lib.new(nil, nil)
-
-    versions_to_test = [
-      { version_string: 'git version 2.1', expected_result: [2, 1, 0] },
-      { version_string: 'git version 2.28.4', expected_result: [2, 28, 4] },
-      { version_string: 'git version 2.32.GIT', expected_result: [2, 32, 0] }
-    ]
-
-    lib.instance_variable_set(:@next_version_index, 0)
-
-    lib.define_singleton_method(:command_capturing) do |cmd, *_opts, **_kwargs|
-      raise ArgumentError unless cmd == 'version'
-
-      version_string = versions_to_test[@next_version_index][:version_string]
-      @next_version_index += 1
-      status = Struct.new(:success?, :exitstatus).new(true, 0)
-      Git::CommandLineResult.new(['git', cmd], status, version_string, '')
-    end
-
-    lib.define_singleton_method(:next_version_index) { @next_version_index }
-
-    expected_version = versions_to_test[lib.next_version_index][:expected_result]
-    actual_version = lib.current_command_version
-    assert_equal(expected_version, actual_version)
-
-    expected_version = versions_to_test[lib.next_version_index][:expected_result]
-    actual_version = lib.current_command_version
-    assert_equal(expected_version, actual_version)
   end
 end

--- a/tests/units/test_worktree.rb
+++ b/tests/units/test_worktree.rb
@@ -31,7 +31,7 @@ class TestWorktree < Test::Unit::TestCase
   end
 
   test 'adding a worktree when there are no commits should fail' do
-    omit('Omitted since git version is >= 2.42.0') if Git::Lib.new(nil, nil).compare_version_to(2, 42, 0) >= 0
+    omit('Omitted since git version is >= 2.42.0') if Git.git_version >= Git::Version.new(2, 42, 0)
 
     in_temp_dir do |_path|
       Dir.mkdir('main_worktree')
@@ -50,7 +50,7 @@ class TestWorktree < Test::Unit::TestCase
   end
 
   test 'adding a worktree when there are no commits should succeed' do
-    omit('Omitted since git version is < 2.42.0') if Git::Lib.new(nil, nil).compare_version_to(2, 42, 0).negative?
+    omit('Omitted since git version is < 2.42.0') if (Git.git_version <=> Git::Version.new(2, 42, 0)).negative?
 
     in_temp_dir do |path|
       Dir.mkdir('main_worktree')


### PR DESCRIPTION
Closes #1193

## Summary

Deprecates the legacy git version methods in `Git::Lib`, `Git::Base`, and the `Git` module, replacing them with the modern `Git.git_version` API (introduced in #1249) that returns a `Git::Version` value object.

## Changes

### New: `Git::Version#to_a`
- Adds `#to_a` to `Git::Version` so callers migrating from array-returning methods can do `Git.git_version.to_a` for the legacy array shape.

### Deprecated: `Git::Lib` instance methods
All emit `Git::Deprecation.warn` pointing to their replacements:

| Deprecated | Replacement |
|---|---|
| `Git::Lib#current_command_version` | `Git.git_version.to_a` |
| `Git::Lib#compare_version_to` | `Git.git_version <=> Git::Version.new(...)` |
| `Git::Lib#required_command_version` | `Git::MINIMUM_GIT_VERSION` |
| `Git::Lib#meets_required_version?` | `Git.git_version >= Git::MINIMUM_GIT_VERSION` |

### Deprecated: `Git::Lib.warn_if_old_command`
Version validation is now handled automatically by `Git::Commands::Base#validate_version!`, which **raises** `Git::VersionError` on failure (rather than only printing a warning once and continuing).

### Deprecated: `Git.binary_version` and `Git::Base.binary_version`
Both now emit `Git::Deprecation.warn` pointing to `Git.git_version`.

## Implementation notes

- **No cascading warnings**: Deprecated public methods should not call other methods that also give deprecation warnings so that one deprecated method calling another does not emit multiple warnings.
- **`private :method_name` syntax**: Used instead of placing `private` as a keyword before helpers (which would have made all following methods in the file private).
- All tests updated: `Git::Deprecation.stubs(:warn)` / `expect` added where callers invoke deprecated methods in test suite.
