### PR TITLE
feat: add global and repository execution contexts

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -509,11 +509,11 @@ module Git
   # in its command-line factory, so Git::Commands::Version cannot be used to query an
   # arbitrary binary path today.
   #
-  # Phase 3 of the redesign (redesign/2_architecture_redesign.md) introduces
-  # Git::GlobalContext, which will accept a binary_path: constructor argument. Once that
-  # lands, replace the Open3 call with:
+  # A future enhancement will add binary_path: to Git::ExecutionContext (see
+  # redesign/3_architecture_implementation.md Phase 3). Once that lands, replace the
+  # Open3 call with:
   #
-  #   Git::Commands::Version.new(Git::GlobalContext.new(binary_path: path)).call.stdout
+  #   Git::Commands::Version.new(Git::ExecutionContext::Global.new(binary_path: path)).call.stdout
   #
   # and remove the Open3 dependency from this method.
   def self.run_git_version(path)

--- a/lib/git/execution_context.rb
+++ b/lib/git/execution_context.rb
@@ -1,35 +1,418 @@
 # frozen_string_literal: true
 
+require 'logger'
+
 module Git
-  # The execution context for running git commands
+  # Base class for execution contexts that run git commands
   #
-  # This class is responsible for executing raw git commands and managing the
-  # repository's environment (working directory, .git path, logger). It uses
-  # the existing `Git::CommandLine` class to interact with the system's git binary.
+  # An execution context bundles three concerns that together describe *how* and
+  # *where* a git command runs:
+  #
+  # 1. **Repository scope** — the public accessors `git_dir`, `git_work_dir`,
+  #    `git_index_file`, and `git_ssh` identify which repository git targets and
+  #    which SSH wrapper to use. Their values are translated into `GIT_*` environment
+  #    variable overrides by the private `env_overrides` method. A `nil` value
+  #    unsets the variable (see `Process.spawn` semantics).
+  #
+  # 2. **CLI global options** — the private `global_opts` method returns the array
+  #    of git flags prepended to every invocation: `--git-dir` / `--work-tree` when
+  #    those attributes are set, plus the static options in {STATIC_GLOBAL_OPTS} that
+  #    ensure deterministic, script-friendly output.
+  #
+  # 3. **Execution defaults** — {COMMAND_CAPTURING_ARG_DEFAULTS} and
+  #    {COMMAND_STREAMING_ARG_DEFAULTS} define the default values for I/O, encoding,
+  #    and behavioral options (`in:`, `out:`, `normalize:`, `timeout:`, etc.) accepted
+  #    by {#command_capturing} and {#command_streaming}.
+  #
+  # Subclasses override the repository-scope accessors to supply context-specific
+  # values. The `env_overrides` and `global_opts` methods are implemented here and
+  # call those accessors, so subclasses do not need to override them directly.
+  #
+  # Concrete subclasses:
+  # - {Git::ExecutionContext::Repository} — for repository-bound commands (`add`, `commit`, …)
+  # - {Git::ExecutionContext::Global} — for commands that do not require an existing repository
+  #   (`init`, `clone`, `version`)
   #
   # @api private
   #
-  # This class is part of the internal implementation and should not be used
-  # directly by users of the gem. For now, it's a thin wrapper around Git::Lib
-  # to maintain compatibility during the architectural transition.
-  #
   class ExecutionContext
-    # Delegate to Git::Lib for now during the transition
+    # Default keyword arguments accepted by {#command_capturing}.
     #
-    # @param base [Git::Base] the base git object
+    # Derived from {Git::CommandLine::Capturing::RUN_OPTION_DEFAULTS} with two
+    # overrides: `normalize: true` and `chomp: true` so callers receive clean
+    # UTF-8 strings by default. New options added to the CommandLine layer are
+    # automatically accepted here without requiring a coordinated edit.
     #
-    def initialize(base)
-      @lib = Git::Lib.new(base)
+    # `timeout: nil` is intentional — the global timeout from {Git.config} is
+    # applied at call-time so that changes to the config are respected.
+    #
+    COMMAND_CAPTURING_ARG_DEFAULTS =
+      Git::CommandLine::Capturing::RUN_OPTION_DEFAULTS
+      .merge(normalize: true, chomp: true)
+      .freeze
+
+    # Default keyword arguments accepted by {#command_streaming}.
+    #
+    # Identical to {Git::CommandLine::Streaming::RUN_OPTION_DEFAULTS}. Defined
+    # here so callers interact with a stable constant on this class, and so that
+    # new options added to the CommandLine layer are automatically accepted.
+    #
+    COMMAND_STREAMING_ARG_DEFAULTS =
+      Git::CommandLine::Streaming::RUN_OPTION_DEFAULTS.dup.freeze
+
+    # Static git global options applied to every invocation.
+    #
+    # These ensure deterministic, script-friendly output regardless of the
+    # user's local git configuration.
+    #
+    STATIC_GLOBAL_OPTS = %w[
+      -c core.quotePath=true
+      -c core.editor=false
+      -c color.ui=false
+      -c color.advice=false
+      -c color.diff=false
+      -c color.grep=false
+      -c color.push=false
+      -c color.remote=false
+      -c color.showBranch=false
+      -c color.status=false
+      -c color.transport=false
+    ].freeze
+
+    # Creates a new execution context
+    #
+    # @param git_ssh [String, nil, :use_global_config] SSH wrapper path, `nil` to
+    #   unset `GIT_SSH`, or `:use_global_config` (default) to inherit from
+    #   {Git::Base.config}
+    #
+    # @param logger [Logger, nil] logger forwarded to the CommandLine layer;
+    #   `nil` defaults to a null logger (`Logger.new(nil)`) so that contexts
+    #   created without an explicit logger can always execute commands safely.
+    #
+    def initialize(git_ssh: :use_global_config, logger: nil)
+      @git_ssh = git_ssh
+      @logger = logger || Logger.new(nil)
     end
 
-    # Forward all method calls to the underlying Git::Lib instance
-    def method_missing(method, ...)
-      @lib.send(method, ...)
+    # Returns the `GIT_DIR` path for this context
+    #
+    # `nil` means `GIT_DIR` will be explicitly **unset** in the child process
+    # (per `Process.spawn` semantics — unset is not the same as inherited).
+    # Subclasses override this to supply a repository-specific path.
+    #
+    # @return [String, nil]
+    #
+    def git_dir = nil
+
+    # Returns the `GIT_WORK_TREE` path for this context
+    #
+    # `nil` means `GIT_WORK_TREE` will be explicitly **unset** in the child process.
+    #
+    # @return [String, nil]
+    #
+    def git_work_dir = nil
+
+    # Returns the `GIT_INDEX_FILE` path for this context
+    #
+    # `nil` means `GIT_INDEX_FILE` will be explicitly **unset** in the child process.
+    #
+    # @return [String, nil]
+    #
+    def git_index_file = nil
+
+    # Returns the resolved `GIT_SSH` wrapper path for this context
+    #
+    # `:use_global_config` is resolved to {Git::Base.config.git_ssh} each time
+    # {#command_line_capturing} or {#command_line_streaming} is called, so
+    # runtime changes to {Git::Base.config.git_ssh} are reflected per command
+    # invocation. `nil` means the variable will be explicitly unset.
+    #
+    # @return [String, nil]
+    #
+    def git_ssh
+      return Git::Base.config.git_ssh if @git_ssh == :use_global_config
+
+      @git_ssh
     end
 
-    # Respond to methods that Git::Lib responds to
-    def respond_to_missing?(method, include_private = false)
-      @lib.respond_to?(method, include_private) || super
+    # Runs a git command and returns the result
+    #
+    # By default, raises {Git::FailedError} if the command exits with a non-zero
+    # status. Pass `raise_on_failure: false` to suppress this behavior.
+    #
+    # @overload command_capturing(*args, **options_hash)
+    #
+    #   Runs a git command and returns the result
+    #
+    #   Args should exclude the 'git' command itself and global options. Remember to
+    #   splat the arguments if given as an array.
+    #
+    #   @example Run git log
+    #     result = command_capturing('log', '--pretty=oneline')
+    #     result.stdout #=> "abc123 First commit\ndef456 Second commit\n"
+    #
+    #   @example Using an array of arguments
+    #     args = ['log', '--pretty=oneline']
+    #     result = command_capturing(*args)
+    #
+    #   @example Suppress raising on failure
+    #     result = command_capturing('show', 'nonexistent', raise_on_failure: false)
+    #     result.status.success? #=> false
+    #
+    #   @param args [Array<String>] the command and its arguments
+    #
+    #   @param options_hash [Hash] the options to pass to the command
+    #
+    #   @option options_hash [IO, nil] :in the IO object to use as stdin, or nil to
+    #     inherit the parent process stdin
+    #
+    #     Must be a real IO object with a file descriptor.
+    #
+    #   @option options_hash [IO, String, #write, nil] :out the destination for
+    #     captured stdout
+    #
+    #   @option options_hash [IO, String, #write, nil] :err the destination for
+    #     captured stderr
+    #
+    #   @option options_hash [Boolean] :normalize true to normalize the output
+    #     encoding to UTF-8
+    #
+    #   @option options_hash [Boolean] :chomp true to remove trailing newlines from
+    #     the output
+    #
+    #   @option options_hash [Boolean] :merge true to merge stdout and stderr into a
+    #     single output
+    #
+    #   @option options_hash [String, nil] :chdir the directory to run the command in
+    #
+    #   @option options_hash [Hash] :env additional environment variable overrides
+    #     for this command
+    #
+    #   @option options_hash [Boolean] :raise_on_failure (true) whether to raise on
+    #     non-zero exit
+    #
+    #   @option options_hash [Numeric, nil] :timeout the maximum seconds to wait for
+    #     the command to complete
+    #
+    #     If timeout is nil, the global timeout from {Git::Config} is used.
+    #
+    #     If timeout is zero, the timeout will not be enforced.
+    #
+    #     If the command times out, it is killed via a `SIGKILL` signal and
+    #     `Git::TimeoutError` is raised.
+    #
+    #     If the command does not respond to SIGKILL, it will hang this method.
+    #
+    #   @return [Git::CommandLineResult] the result of the command
+    #
+    #   @raise [ArgumentError] if an unknown option is passed
+    #
+    #   @raise [Git::FailedError] if the command failed (when raise_on_failure is
+    #     true)
+    #
+    #   @raise [Git::SignaledError] if the command was signaled
+    #
+    #   @raise [Git::TimeoutError] if the command times out
+    #
+    #   @raise [Git::ProcessIOError] if an exception was raised while collecting
+    #     subprocess output
+    #
+    #     The exception's `result` attribute is a {Git::CommandLineResult} which will
+    #     contain the result of the command including the exit status, stdout, and stderr.
+    #
+    # @note Individual command classes (under {Git::Commands}) can selectively expose
+    #   `:timeout` and `:env` and other options to their callers by declaring them as
+    #   execution options in their Arguments DSL definition and forwarding them to
+    #   this method. See {Git::Commands::Clone#call} for an example of a command that
+    #   exposes `:timeout`.
+    #
+    # @see Git::CommandLine::Capturing#run
+    #
+    # @see #command_line_capturing
+    #
+    def command_capturing(*, **options_hash)
+      options_hash = COMMAND_CAPTURING_ARG_DEFAULTS.merge(options_hash)
+      options_hash[:timeout] ||= Git.config.timeout
+
+      extra_options = options_hash.keys - COMMAND_CAPTURING_ARG_DEFAULTS.keys
+      raise ArgumentError, "Unknown options: #{extra_options.join(', ')}" if extra_options.any?
+
+      env = options_hash.delete(:env)
+      raise_on_failure = options_hash.delete(:raise_on_failure)
+      command_line_capturing.run(*, raise_on_failure: raise_on_failure, env: env, **options_hash)
+    end
+
+    # Runs a git command using the streaming (non-capturing) execution path
+    #
+    # Unlike {#command_capturing}, stdout is NOT buffered in memory. It is
+    # written only to the IO object provided via the `out:` option. Stderr is
+    # captured internally via a StringIO for error diagnostics.
+    #
+    # Use this entry point when you want to stream large output (e.g. blob
+    # content from cat-file) without creating memory pressure.
+    #
+    # @overload command_streaming(*args, **options_hash)
+    #
+    #   Streams a git command's output to the provided IO object
+    #
+    #   @example Stream blob content to a file
+    #     File.open('blob.bin', 'wb') do |f|
+    #       command_streaming('cat-file', 'blob', 'HEAD:large_file.bin', out: f)
+    #     end
+    #
+    #   @param args [Array<String>] the git command and its arguments
+    #
+    #   @param options_hash [Hash] the options to pass to the command
+    #
+    #   @option options_hash [IO, nil] :in the IO object to use as stdin, or nil to
+    #     inherit the parent process stdin
+    #
+    #     Must be a real IO object with a file descriptor.
+    #
+    #   @option options_hash [#write, nil] :out destination for streamed stdout
+    #
+    #   @option options_hash [#write, nil] :err an optional additional destination
+    #     to receive stderr output in real time
+    #
+    #     Stderr is always captured internally; when `err:` is supplied, writes are
+    #     teed to both the internal buffer and this destination. `result.stderr`
+    #     always reflects the internal capture.
+    #
+    #   @option options_hash [String, nil] :chdir the directory to run the command in
+    #
+    #   @option options_hash [Hash] :env additional environment variable overrides
+    #     for this command
+    #
+    #   @option options_hash [Boolean] :raise_on_failure (true) whether to raise on
+    #     non-zero exit
+    #
+    #   @option options_hash [Numeric, nil] :timeout
+    #     the maximum seconds to wait for the command to complete
+    #
+    #     If timeout is nil, the global timeout from {Git::Config} is used.
+    #
+    #     If timeout is zero, the timeout will not be enforced.
+    #
+    #     If the command times out, it is killed via a `SIGKILL` signal and
+    #     `Git::TimeoutError` is raised.
+    #
+    #     If the command does not respond to SIGKILL, it will hang this method.
+    #
+    #   @return [Git::CommandLineResult] the result of the command
+    #
+    #     `result.stdout` will always be `''` — stdout was streamed to `out:`.
+    #
+    #     `result.stderr` contains any stderr output captured for diagnostics.
+    #
+    #   @raise [ArgumentError] if an unknown option is passed
+    #
+    #   @raise [Git::FailedError] if the command failed (when raise_on_failure is true)
+    #
+    #   @raise [Git::SignaledError] if the command was signaled
+    #
+    #   @raise [Git::TimeoutError] if the command times out
+    #
+    #   @raise [Git::ProcessIOError] if an exception was raised while collecting
+    #     subprocess output
+    #
+    # @see Git::CommandLine::Streaming#run
+    #
+    # @see #command_line_streaming
+    #
+    def command_streaming(*, **options_hash)
+      options_hash = COMMAND_STREAMING_ARG_DEFAULTS.merge(options_hash)
+      options_hash[:timeout] ||= Git.config.timeout
+
+      extra_options = options_hash.keys - COMMAND_STREAMING_ARG_DEFAULTS.keys
+      raise ArgumentError, "Unknown options: #{extra_options.join(', ')}" if extra_options.any?
+
+      env = options_hash.delete(:env)
+      raise_on_failure = options_hash.delete(:raise_on_failure)
+      command_line_streaming.run(*, raise_on_failure: raise_on_failure, env: env, **options_hash)
+    end
+
+    # Returns the installed git version
+    #
+    # The result is memoized per instance.
+    #
+    # @return [Git::Version] the installed git version
+    #
+    # @raise [Git::Error] if the version string cannot be parsed
+    #
+    def git_version
+      @git_version ||= begin
+        output = Git::Commands::Version.new(self).call.stdout
+        Git::Version.parse(output)
+      rescue ArgumentError => e
+        raise Git::Error, "Unable to parse git version from: #{output.inspect} (#{e.message})"
+      end
+    end
+
+    private
+
+    # Returns a Hash of environment variable overrides for this context
+    #
+    # Builds the standard git environment from the public accessor methods
+    # ({#git_dir}, {#git_work_dir}, {#git_index_file}, {#git_ssh}), then
+    # merges any per-call `additional_overrides` on top.
+    #
+    # Per `Process.spawn` semantics, a value of `nil` unsets the variable.
+    #
+    # @param additional_overrides [Hash<String, String|nil>] per-call overrides
+    #
+    # @return [Hash<String, String|nil>] the merged environment variable overrides
+    #
+    def env_overrides(**additional_overrides)
+      {
+        'GIT_DIR' => git_dir,
+        'GIT_WORK_TREE' => git_work_dir,
+        'GIT_INDEX_FILE' => git_index_file,
+        'GIT_SSH' => git_ssh,
+        'GIT_EDITOR' => 'true',
+        'LC_ALL' => 'en_US.UTF-8'
+      }.merge(additional_overrides)
+    end
+
+    # Returns the Array of git global option strings for this context
+    #
+    # Prepends `--git-dir` and `--work-tree` when the corresponding attributes
+    # are set, then appends {STATIC_GLOBAL_OPTS}.
+    #
+    # @return [Array<String>] the global options to prepend to every git invocation
+    #
+    def global_opts
+      [].tap do |opts|
+        opts << "--git-dir=#{git_dir}" unless git_dir.nil?
+        opts << "--work-tree=#{git_work_dir}" unless git_work_dir.nil?
+        opts.concat(STATIC_GLOBAL_OPTS)
+      end
+    end
+
+    # Creates a {Git::CommandLine::Capturing} instance for the current invocation.
+    #
+    # A new instance is created per call so that {#env_overrides} — including
+    # {#git_ssh} resolution for `:use_global_config` — reflects the state of
+    # {Git::Base.config} at the time of each command invocation.
+    #
+    # @return [Git::CommandLine::Capturing] the capturing command line instance
+    #
+    def command_line_capturing
+      Git::CommandLine::Capturing.new(env_overrides, Git::Base.config.binary_path, global_opts, @logger)
+    end
+
+    # Creates a {Git::CommandLine::Streaming} instance for the current invocation.
+    #
+    # A new instance is created per call so that {#env_overrides} — including
+    # {#git_ssh} resolution for `:use_global_config` — reflects the state of
+    # {Git::Base.config} at the time of each command invocation.
+    #
+    # @return [Git::CommandLine::Streaming] the streaming command line instance
+    #
+    def command_line_streaming
+      Git::CommandLine::Streaming.new(env_overrides, Git::Base.config.binary_path, global_opts, @logger)
     end
   end
 end
+
+require 'git/execution_context/global'
+require 'git/execution_context/repository'

--- a/lib/git/execution_context/global.rb
+++ b/lib/git/execution_context/global.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'git/execution_context'
+
+module Git
+  class ExecutionContext
+    # Execution context for global git commands (no repository required)
+    #
+    # Used for commands that do not require an existing repository — such as
+    # `git init`, `git clone`, and `git version`. Unlike
+    # {Git::ExecutionContext::Repository}, this class leaves `GIT_DIR`,
+    # `GIT_WORK_TREE`, and `GIT_INDEX_FILE` as `nil` (which unsets them), so
+    # that the parent environment cannot leak an unintended repository context.
+    # `GIT_SSH` is still supported to allow SSH-based remote operations
+    # (e.g. `git clone git@github.com:...`).
+    #
+    # @api private
+    #
+    class Global < ExecutionContext
+      # Creates a new global execution context
+      #
+      # @param git_ssh [String, nil, :use_global_config] SSH wrapper path, `nil` to
+      #   unset `GIT_SSH`, or `:use_global_config` (default) to inherit from
+      #   {Git::Base.config}
+      #
+      # @param logger [Logger, nil] logger forwarded to the CommandLine layer;
+      #   `nil` uses a null logger (see {Git::ExecutionContext#initialize})
+      #
+      def initialize(git_ssh: :use_global_config, logger: nil)
+        super
+      end
+    end
+  end
+end

--- a/lib/git/execution_context/repository.rb
+++ b/lib/git/execution_context/repository.rb
@@ -1,0 +1,96 @@
+# frozen_string_literal: true
+
+require 'git/execution_context'
+
+module Git
+  class ExecutionContext
+    # Execution context for repository-bound git commands
+    #
+    # Manages the git environment for commands that operate within an existing
+    # repository — setting `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, and
+    # `GIT_SSH` — and prepending `--git-dir` / `--work-tree` to every git
+    # invocation via {#global_opts}.
+    #
+    # ### Construction
+    #
+    # Prefer the factory class methods over `new` when building from a
+    # {Git::Base} object or a hash:
+    #
+    #   context = Git::ExecutionContext::Repository.from_base(base)
+    #   context = Git::ExecutionContext::Repository.from_hash(repository: '/repo/.git', ...)
+    #
+    # @api private
+    #
+    class Repository < ExecutionContext
+      # Creates a Repository context from a {Git::Base} instance
+      #
+      # @param base_object [Git::Base] the base Git object to derive context from
+      #
+      # @param logger [Logger, nil] logger forwarded to the CommandLine layer;
+      #   `nil` uses a null logger (see {Git::ExecutionContext#initialize})
+      #
+      # @return [Git::ExecutionContext::Repository] the new repository context
+      #
+      def self.from_base(base_object, logger: nil)
+        new(
+          git_dir: base_object.repo.to_s,
+          git_index_file: base_object.index&.to_s,
+          git_work_dir: base_object.dir&.to_s,
+          git_ssh: base_object.git_ssh,
+          logger: logger
+        )
+      end
+
+      # Creates a Repository context from the hash format used by {Git::Base.new}
+      #
+      # Expected keys: `:repository`, `:working_directory`, `:index`, `:git_ssh`
+      #
+      # @param base_hash [Hash] the hash of repository configuration values
+      #
+      # @param logger [Logger, nil] logger forwarded to the CommandLine layer;
+      #   `nil` uses a null logger (see {Git::ExecutionContext#initialize})
+      #
+      # @return [Git::ExecutionContext::Repository] the new repository context
+      #
+      def self.from_hash(base_hash, logger: nil)
+        new(
+          git_dir: base_hash[:repository],
+          git_index_file: base_hash[:index],
+          git_work_dir: base_hash[:working_directory],
+          git_ssh: base_hash.key?(:git_ssh) ? base_hash[:git_ssh] : :use_global_config,
+          logger: logger
+        )
+      end
+
+      # Creates a new repository execution context
+      #
+      # @param git_dir [String, nil] path to the `.git` directory
+      #
+      # @param git_work_dir [String, nil] path to the working tree
+      #
+      # @param git_index_file [String, nil] path to the index file
+      #
+      # @param git_ssh [String, nil, :use_global_config] SSH wrapper path, `nil` to
+      #   unset, or `:use_global_config` (default) to inherit from {Git::Base.config}
+      #
+      # @param logger [Logger, nil] logger forwarded to the CommandLine layer;
+      #   `nil` uses a null logger (see {Git::ExecutionContext#initialize})
+      #
+      def initialize(git_dir:, git_work_dir: nil, git_index_file: nil, git_ssh: :use_global_config, logger: nil)
+        super(git_ssh: git_ssh, logger: logger)
+        @git_dir = git_dir
+        @git_work_dir = git_work_dir
+        @git_index_file = git_index_file
+      end
+
+      # @return [String, nil] path to the `.git` directory
+      attr_reader :git_dir
+
+      # @return [String, nil] path to the working tree
+      attr_reader :git_work_dir
+
+      # @return [String, nil] path to the index file
+      attr_reader :git_index_file
+    end
+  end
+end

--- a/redesign/2_architecture_redesign.md
+++ b/redesign/2_architecture_redesign.md
@@ -106,14 +106,14 @@ into three distinct layers: a Facade, an Execution Context, and Command Objects.
     **Two Context Types**: The execution layer will consist of an abstract base class
     with two concrete implementations:
 
-    - **Git::GlobalContext**: For commands that do not require an existing repository
+    - **Git::ExecutionContext::Global**: For commands that do not require an existing repository
       (`init`, `clone`, `config --global`, `version`). These commands execute in a
       clean environment with no repository paths set. In the specific case of
-      `init`/`clone`, the command itself runs in `GlobalContext`, but on success it
+      `init`/`clone`, the command itself runs in `ExecutionContext::Global`, but on success it
       yields a newly created `Git::Repository` instance backed by a
-      `Git::RepositoryContext`.
+      `Git::ExecutionContext::Repository`.
 
-    - **Git::RepositoryContext**: For repository-bound commands (`add`, `commit`,
+    - **Git::ExecutionContext::Repository**: For repository-bound commands (`add`, `commit`,
       `status`, `log`, etc.). Manages the repository environment (working directory,
       .git path, index file) and provides the ability to override environment
       variables per-command (e.g., unsetting `GIT_INDEX_FILE` for worktree
@@ -340,8 +340,8 @@ The circular dependency will be resolved by implementing a clear, one-way depend
 flow.
 
 1. The factory methods (`Git.open`, `Git.clone`) will create and configure an
-   instance of the appropriate `Git::ExecutionContext` subclass (`Git::GlobalContext`
-   for `init`/`clone`, `Git::RepositoryContext` for `open`/`bare`).
+   instance of the appropriate `Git::ExecutionContext` subclass (`Git::ExecutionContext::Global`
+   for `init`/`clone`, `Git::ExecutionContext::Repository` for `open`/`bare`).
 
 2. This context instance will then be wired into the system in two ways:
    - For commands that run before a repository exists (e.g., `Git::Commands::Init`,

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -23,64 +23,56 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
 | Phase 2 | ✅ Complete | Migrating commands (all checklist items done) |
-| Phase 3 | ⏳ Not Started | Refactoring public interface |
+| Phase 3 | ⏳ In Progress | Refactoring public interface (Task 1 ✅) |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Phase 3, Task 1: Create `Git::RepositoryContext` and `Git::GlobalContext`**
+**Phase 3, Task 2: Add `binary_path:` to `Git::ExecutionContext`**
 
-Phase 2 is complete — all commands have been migrated to `Git::Commands::*` classes.
-Phase 3 begins with creating proper `Git::ExecutionContext` subclasses. These replace
-the current `method_missing` delegation stub and become the context objects that
-`Git::Commands::*` classes receive once the factory methods are refactored.
+Phase 3, Task 1 is complete — `Git::ExecutionContext` is now a real base class, and
+`Git::ExecutionContext::Repository` and `Git::ExecutionContext::Global` are implemented and fully tested.
+
+Task 2 adds a `binary_path:` constructor argument to `Git::ExecutionContext` so that
+context objects can target an arbitrary git binary, and retires the `Open3` stopgap
+in `Git.run_git_version`.
 
 #### Workflow
 
-1. **Analyze**: Review `lib/git/execution_context.rb`, and the relevant private methods
-   in `lib/git/lib.rb`: `initialize_from_base`, `initialize_from_hash`, `env_overrides`,
-   `global_opts`, `command_capturing`, `command_streaming`, `command_line_capturing`, and
-   `command_line_streaming`. These are the methods to extract into `Git::ExecutionContext`
-   and its subclasses.
+1. **Analyze**: Review `lib/git/execution_context.rb` — specifically
+   `command_line_capturing` and `command_line_streaming`, which currently hardcode
+   `Git::Base.config.binary_path`. Also review `Git.run_git_version` in `lib/git.rb`
+   and the `Git.git_version` public method.
 
-2. **Design**: Plan the interfaces for `Git::RepositoryContext` and `Git::GlobalContext`:
-   - Both must implement `command_capturing` and `command_streaming` (the interface
-     expected by `Git::Commands::Base`)
-   - `Git::RepositoryContext` manages `git_dir`, `git_work_dir`, `git_index_file`,
-     and SSH config
-   - `Git::GlobalContext` has no repository paths (for `init`, `clone`, `version`)
-   - Shared execution logic lives in the `Git::ExecutionContext` base class
+2. **Implement**:
+   - Add `binary_path: Git::Base.config.binary_path` to `Git::ExecutionContext#initialize`
+   - Store as `@binary_path`; use it in `command_line_capturing` and `command_line_streaming`
+     instead of `Git::Base.config.binary_path`
+   - Forward `binary_path:` in `Git::ExecutionContext::Repository.from_base` and `.from_hash`
+   - Replace the `Open3` call in `Git.run_git_version` with
+     `Git::Commands::Version.new(Git::ExecutionContext::Global.new(binary_path: path)).call.stdout`
+   - Remove the `Open3` require from `lib/git.rb` if it is no longer needed
 
-3. **TDD**: Write spec files *before* implementing:
-   - `spec/unit/git/repository_context_spec.rb`
-   - `spec/unit/git/global_context_spec.rb`
-   - Test: initialization with paths, `env_overrides` hash contents, delegation to
-     `command_capturing`/`command_streaming`
+3. **TDD**: Add / update specs in:
+   - `spec/unit/git/execution_context_spec.rb` — `binary_path:` default and override
+   - `spec/unit/git/execution_context/repository_spec.rb` — forwarded via factory methods
+   - `spec/unit/git/execution_context/global_spec.rb` — forwarded via constructor
 
-4. **Implement**:
-   - Extract execution logic from `Git::Lib` into `Git::ExecutionContext` base class
-   - Create `Git::RepositoryContext < Git::ExecutionContext` in
-     `lib/git/repository_context.rb`
-   - Create `Git::GlobalContext < Git::ExecutionContext` in
-     `lib/git/global_context.rb`
-
-5. **Verify**:
-   - `bundle exec rspec spec/unit/git/repository_context_spec.rb` — new tests pass
-   - `bundle exec rspec spec/unit/git/global_context_spec.rb` — new tests pass
+4. **Verify**:
    - `bundle exec rspec` — all RSpec tests pass
    - `bundle exec rake test` — legacy TestUnit tests pass
    - `bundle exec rubocop` — no lint errors
    - `bundle exec yard` — no yardoc errors
 
-6. **Update Checklist**: Update the Phase 3 progress tracker in this document when
-   each sub-task is complete. Update the "Next Task" heading and Workflow steps to
-   describe the next Phase 3 sub-task (e.g. "Task 2: Refactor factory methods").
+5. **Update Checklist**: Update the Phase 3 progress tracker in this document when
+   Task 2 is complete. Update the "Next Task" heading to describe Task 3 (refactor
+   factory methods).
 
 #### Reference Files
 
-- Execution methods to extract: `lib/git/lib.rb` (`env_overrides`, `global_opts`,
-  `command_capturing`, `command_streaming`)
-- Current stub: `lib/git/execution_context.rb`
+- Execution context: `lib/git/execution_context.rb`,
+  `lib/git/execution_context/repository.rb`, `lib/git/execution_context/global.rb`
+- Stopgap method: `lib/git.rb` (`Git.run_git_version`)
 - Phase 3 plan: see "Phase 3: Refactoring the Public Interface" section below
 
 ## Phase 1: Foundation and Scaffolding
@@ -108,8 +100,9 @@ logic. The gem will be fully functional after this phase.*
 3. **Introduce New Core Classes (Empty Shells)**
 
    - `Git::ExecutionContext` in `lib/git/execution_context.rb` ✅
-     - Currently a thin wrapper around `Git::Lib` using `method_missing` delegation
-     - `GlobalContext` and `RepositoryContext` subclasses will be added in Phase 3
+     - Real base class with `command_capturing`, `command_streaming`, `git_version`
+     - `Git::ExecutionContext::Repository` subclass in `lib/git/execution_context/repository.rb` ✅
+     - `Git::ExecutionContext::Global` subclass in `lib/git/execution_context/global.rb` ✅
 
    - `Git::Repository` in `lib/git/repository.rb` ✅
      - Currently an empty shell, to be populated in Phase 3
@@ -131,9 +124,9 @@ a Test-Driven Development workflow.*
 **Important Note**: During this phase, `Git::Lib` acts as a stand-in for the
 `ExecutionContext` hierarchy:
 
-- `Git::Lib.new(nil, logger)` effectively acts like `GlobalContext` (no repository
+- `Git::Lib.new(nil, logger)` effectively acts like `ExecutionContext::Global` (no repository
   paths set)
-- `Git::Lib.new(base, logger)` effectively acts like `RepositoryContext` (repository
+- `Git::Lib.new(base, logger)` effectively acts like `ExecutionContext::Repository` (repository
   paths set)
 
 All new `Git::Commands::*` classes should accept any object that responds to
@@ -989,16 +982,30 @@ order: Basic Snapshotting → Branching & Merging → etc.
 ***Goal**: Switch the public-facing classes to use the new architecture directly,
 breaking the final ties to the old implementation.*
 
-1. **Refactor Factory Methods**:
+1. **Add `binary_path:` to `Git::ExecutionContext`**:
+
+   Add a `binary_path:` constructor argument to `Git::ExecutionContext` (base class)
+   so that all context subclasses can target an arbitrary git binary rather than
+   always reading `Git::Base.config.binary_path` at runtime.
+
+   - `Git::ExecutionContext#initialize` gains `binary_path: Git::Base.config.binary_path`
+   - `command_line_capturing` and `command_line_streaming` use `@binary_path` instead
+     of `Git::Base.config.binary_path`
+   - `Git::ExecutionContext::Repository.from_base` and `.from_hash` forward
+     `binary_path:` when constructing the context
+   - Once in place, remove the `Open3` stopgap in `Git.run_git_version` and replace
+     it with `Git::Commands::Version.new(Git::ExecutionContext::Global.new(binary_path: path)).call.stdout`
+
+2. **Refactor Factory Methods**:
 
    - Modify the factory methods in the top-level `Git` module (`.open`, `.clone`,
      etc.).
 
    - These methods will now be responsible for creating an instance of the
      appropriate `Git::ExecutionContext` subclass and injecting it:
-     - `Git.init` and `Git.clone`: Use `Git::GlobalContext` to run the command, then
+     - `Git.init` and `Git.clone`: Use `Git::ExecutionContext::Global` to run the command, then
        open the repository
-     - `Git.open` and `Git.bare`: Create `Git::RepositoryContext` and inject it into
+     - `Git.open` and `Git.bare`: Create `Git::ExecutionContext::Repository` and inject it into
        `Git::Repository`
 
     The return value of these factories will now be a `Git::Repository` instance, not

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -28,150 +28,60 @@ risk and allows for a gradual, controlled migration to the new architecture.
 
 ### Next Task
 
-**Begin Phase 3: Refactoring the Public Interface**
+**Phase 3, Task 1: Create `Git::RepositoryContext` and `Git::GlobalContext`**
 
 Phase 2 is complete — all commands have been migrated to `Git::Commands::*` classes.
-The next step is Phase 3: introducing `Git::Repository` as the public facade,
-populating it with delegate methods, and deprecating `Git::Base`.
+Phase 3 begins with creating proper `Git::ExecutionContext` subclasses. These replace
+the current `method_missing` delegation stub and become the context objects that
+`Git::Commands::*` classes receive once the factory methods are refactored.
 
 #### Workflow
 
-1. **Analyze**: Review the Phase 3 plan below and the current state of `lib/git/repository.rb` and `lib/git/base.rb`.
+1. **Analyze**: Review `lib/git/execution_context.rb`, and the relevant private methods
+   in `lib/git/lib.rb`: `initialize_from_base`, `initialize_from_hash`, `env_overrides`,
+   `global_opts`, `command_capturing`, `command_streaming`, `command_line_capturing`, and
+   `command_line_streaming`. These are the methods to extract into `Git::ExecutionContext`
+   and its subclasses.
 
-2. **Design**: Create command class following the pattern in
-   `lib/git/commands/branch/delete.rb`. The interface for `#call` should only include
-   options relevant to the command being implemented.
+2. **Design**: Plan the interfaces for `Git::RepositoryContext` and `Git::GlobalContext`:
+   - Both must implement `command_capturing` and `command_streaming` (the interface
+     expected by `Git::Commands::Base`)
+   - `Git::RepositoryContext` manages `git_dir`, `git_work_dir`, `git_index_file`,
+     and SSH config
+   - `Git::GlobalContext` has no repository paths (for `init`, `clone`, `version`)
+   - Shared execution logic lives in the `Git::ExecutionContext` base class
 
-3. **TDD**: Write spec file *before* implementing:
-   - Test every option using separate `context` blocks
-   - Mock the execution context with `double('ExecutionContext')`
-   - Verify argument building matches expected git CLI args
-   - Unit tests go in `spec/unit/git/commands/`
-   - Optionally add integration tests in `spec/integration/` to verify behavior
-     against real git (see CONTRIBUTING.md for integration test guidelines). Only
-     add essential integration tests for edge cases and testing that the assumptions
-     for git output used in unit tests are correct.
+3. **TDD**: Write spec files *before* implementing:
+   - `spec/unit/git/repository_context_spec.rb`
+   - `spec/unit/git/global_context_spec.rb`
+   - Test: initialization with paths, `env_overrides` hash contents, delegation to
+     `command_capturing`/`command_streaming`
 
 4. **Implement**:
-   - Use `Git::Commands::Arguments.define` DSL for argument handling
-   - Include comprehensive YARD documentation (see format below)
-   - Mark class with `@api private`
+   - Extract execution logic from `Git::Lib` into `Git::ExecutionContext` base class
+   - Create `Git::RepositoryContext < Git::ExecutionContext` in
+     `lib/git/repository_context.rb`
+   - Create `Git::GlobalContext < Git::ExecutionContext` in
+     `lib/git/global_context.rb`
 
-   **YARD Documentation Format for `#call` methods:**
-
-   ```ruby
-   # Execute the git example command
-   #
-   # @overload call(operand_arg, *repeatable_args, **options)
-   #
-   #   @param operand_arg [String] Description of the operand (positional argument)
-   #
-   #   @param repeatable_args [Array<String>] Description of repeatable arguments
-   #
-   #   @param options [Hash] command options
-   #
-   #   @option options [Boolean] :force (nil) Description. Alias: :f
-   #
-   #   @option options [String] :message (nil) Description
-   #
-   # @return [String] the command output
-   #
-   # @raise [Git::FailedError] if the command fails
-   #
-   def call(*, **)
-   ```
-
-   **Important**: Keep empty comment lines between each yard tag
-
-   **Note on Return Types**: Commands return `Git::CommandLineResult` by default.
-   If the command output needs to be parsed into structured data, create a Parser
-   class (see step 4a below).
-
-4a. **Create Parser Classes** (when output needs transformation):
-
-   If the command produces output that needs to be parsed into structured data,
-   create a Parser class or module in `lib/git/parsers/` following existing patterns.
-   For example, see `Git::Parsers::Diff` which uses nested classes for different
-   output formats:
-
-   ```ruby
-   # lib/git/parsers/diff.rb (existing pattern)
-   module Git
-     module Parsers
-       module Diff
-         # Nested parser for --numstat format
-         class Numstat
-           def self.parse(output)
-             output.lines.map { |line| parse_line(line) }
-           end
-         end
-
-         # Nested parser for --raw format
-         class Raw
-           def self.parse(output)
-             # Parse into DiffFileRawInfo value objects
-           end
-         end
-       end
-     end
-   end
-   ```
-
-   Parser classes/modules should:
-   - Be stateless (class methods or module methods)
-   - Return value objects (e.g., `DiffFileNumstatInfo`, `BranchInfo`)
-   - Be independently testable
-   - Live outside the Commands namespace (they're reusable utilities)
-
-5. **Delegate**: Update related methods in `Git::Lib` to delegate to the new class(es).
-   Here is an example pattern for facade methods in `Git::Lib`:
-
-   ```ruby
-   # Example pattern (aspirational - specific classes/methods may vary)
-   def branch_new(branch_name, options = {})
-     result = Git::Commands::Branch::Create.new(self).call(branch_name, **options)
-     # Facade builds rich return value from CommandLineResult
-     # Using a Result factory method or Parser class
-     result.stdout  # Or parse into a value object as needed
-   end
-
-   def branch_delete(branch_name, options = {})
-     result = Git::Commands::Branch::Delete.new(self).call(branch_name, **options)
-     # Facade parses output into result object using existing parser
-     Git::BranchDeleteResult.parse(result.stdout)
-   end
-   ```
-
-   Note: `Git::Lib` methods may accept an options hash for backward compatibility,
-   but they must convert it to keyword arguments when calling the command class
-   using `**options`.
-
-   Note: `Git::Lib` methods must remain backward compatible. The facade layer is
-   responsible for building rich response objects from `CommandLineResult` using
-   Parser classes and Result factories.
-
-6. **Verify**:
-   - `bundle exec rspec spec/unit/git/commands/pull_spec.rb` — new tests pass
+5. **Verify**:
+   - `bundle exec rspec spec/unit/git/repository_context_spec.rb` — new tests pass
+   - `bundle exec rspec spec/unit/git/global_context_spec.rb` — new tests pass
    - `bundle exec rspec` — all RSpec tests pass
    - `bundle exec rake test` — legacy TestUnit tests pass
    - `bundle exec rubocop` — no lint errors
    - `bundle exec yard` — no yardoc errors
 
-  To run a single legacy test: `bundle exec bin/test test_<name>` (e.g., `bundle exec bin/test test_branch`)
-
-7. **Update Checklist**: Move the command from "Commands To Migrate" to "Migrated
-   Commands" table in this document, and update the "Next Task" section to point to
-   the next command in the list. When updating "Next Task", also update the Workflow
-   steps below it — they contain method names and search strings specific to the
-   previous task (e.g. the `def <method>` reference in step 1) that must be changed
-   to match the new task.
+6. **Update Checklist**: Update the Phase 3 progress tracker in this document when
+   each sub-task is complete. Update the "Next Task" heading and Workflow steps to
+   describe the next Phase 3 sub-task (e.g. "Task 2: Refactor factory methods").
 
 #### Reference Files
 
-- Pattern to follow: `lib/git/commands/commit.rb` + `spec/unit/git/commands/commit_spec.rb`
-- Namespace example: `lib/git/commands/checkout/branch.rb`
-- Complex options example: `lib/git/commands/clone.rb`
-- Contributing guide: `CONTRIBUTING.md` (see "Wrapping a git command")
+- Execution methods to extract: `lib/git/lib.rb` (`env_overrides`, `global_opts`,
+  `command_capturing`, `command_streaming`)
+- Current stub: `lib/git/execution_context.rb`
+- Phase 3 plan: see "Phase 3: Refactoring the Public Interface" section below
 
 ## Phase 1: Foundation and Scaffolding
 
@@ -903,9 +813,7 @@ The following tracks the migration status of commands from `Git::Lib` to
 | N/A (new) | `Git::Commands::Branch::Copy` | `spec/unit/git/commands/branch/copy_spec.rb` | `git branch --copy <old-name> <new-name>` |
 | N/A (new) | `Git::Commands::Branch::SetUpstream` | `spec/unit/git/commands/branch/set_upstream_spec.rb` | `git branch --set-upstream-to <upstream> [<branch>]` |
 | N/A (new) | `Git::Commands::Branch::UnsetUpstream` | `spec/unit/git/commands/branch/unset_upstream_spec.rb` | `git branch --unset-upstream [<branch>]` |
-| `diff_full` | `Git::Commands::Diff::Patch` | `spec/unit/git/commands/diff/patch_spec.rb` | `git diff` (patch format) |
-| `diff_stats` | `Git::Commands::Diff::Numstat` | `spec/unit/git/commands/diff/numstat_spec.rb` | `git diff --numstat` |
-| `diff_path_status` / `diff_index` | `Git::Commands::Diff::Raw` | `spec/unit/git/commands/diff/raw_spec.rb` | `git diff --raw` |
+| `diff_full` / `diff_stats` / `diff_path_status` / `diff_index` | `Git::Commands::Diff` | `spec/unit/git/commands/diff_spec.rb` | `git diff` |
 | `stashes_list` | `Git::Commands::Stash::List` | `spec/unit/git/commands/stash/list_spec.rb` | `git stash list` |
 | `stash_save` | `Git::Commands::Stash::Push` | `spec/unit/git/commands/stash/push_spec.rb` | `git stash push` |
 | `stash_pop` | `Git::Commands::Stash::Pop` | `spec/unit/git/commands/stash/pop_spec.rb` | `git stash pop` |
@@ -922,9 +830,7 @@ The following tracks the migration status of commands from `Git::Lib` to
 | N/A (new) | `Git::Commands::Stash::Create` | `spec/unit/git/commands/stash/create_spec.rb` | `git stash create` |
 | N/A (new) | `Git::Commands::Stash::Store` | `spec/unit/git/commands/stash/store_spec.rb` | `git stash store` |
 | N/A (new) | `Git::Commands::Stash::Branch` | `spec/unit/git/commands/stash/branch_spec.rb` | `git stash branch` |
-| N/A (new) | `Git::Commands::Stash::ShowNumstat` | `spec/unit/git/commands/stash/show_numstat_spec.rb` | `git stash show --numstat` |
-| N/A (new) | `Git::Commands::Stash::ShowPatch` | `spec/unit/git/commands/stash/show_patch_spec.rb` | `git stash show --patch` |
-| N/A (new) | `Git::Commands::Stash::ShowRaw` | `spec/unit/git/commands/stash/show_raw_spec.rb` | `git stash show --raw` |
+| N/A (new) | `Git::Commands::Stash::Show` | `spec/unit/git/commands/stash/show_spec.rb` | `git stash show` |
 | `cat_file_*` | `Git::Commands::CatFile::*` | `spec/unit/git/commands/cat_file/*_spec.rb` | `git cat-file` |
 | `checkout_index` | `Git::Commands::CheckoutIndex` | `spec/unit/git/commands/checkout_index_spec.rb` | `git checkout-index` |
 | `archive` | `Git::Commands::Archive` | `spec/unit/git/commands/archive_spec.rb` | `git archive` |
@@ -978,6 +884,13 @@ The following tracks the migration status of commands from `Git::Lib` to
 | `worktrees_all` / `worktree_add` / `worktree_remove` / `worktree_prune` | `Git::Commands::Worktree::List` / `Git::Commands::Worktree::Add` / `Git::Commands::Worktree::Remove` / `Git::Commands::Worktree::Prune` (+ `Lock`, `Unlock`, `Move`, `Repair`) | `spec/unit/git/commands/worktree/*_spec.rb` | `git worktree` |
 | `change_head_branch` | `Git::Commands::SymbolicRef::Update` (+ `Read`, `Delete`) | `spec/unit/git/commands/symbolic_ref/*_spec.rb` | `git symbolic-ref` |
 | `current_command_version` | `Git::Commands::Version` | `spec/unit/git/commands/version_spec.rb` | `git version` |
+| `diff_as_hash` (private) | `Git::Commands::DiffFiles` / `Git::Commands::DiffIndex` | `spec/unit/git/commands/diff_files_spec.rb` / `spec/unit/git/commands/diff_index_spec.rb` | `git diff-files` / `git diff-index` |
+| `remote_add` / `remote_remove` / `remote_set_url` / `remote_set_branches` | `Git::Commands::Remote::*` | `spec/unit/git/commands/remote/*_spec.rb` | `git remote` |
+| `revert` | `Git::Commands::Revert::*` | `spec/unit/git/commands/revert/*_spec.rb` | `git revert` |
+| `rev_parse` | `Git::Commands::RevParse` | `spec/unit/git/commands/rev_parse_spec.rb` | `git rev-parse` |
+| `read_tree` | `Git::Commands::ReadTree` | `spec/unit/git/commands/read_tree_spec.rb` | `git read-tree` |
+| `write_tree` | `Git::Commands::WriteTree` | `spec/unit/git/commands/write_tree_spec.rb` | `git write-tree` |
+| N/A (new) | `Git::Commands::Maintenance::*` | `spec/unit/git/commands/maintenance/*_spec.rb` ⚠️ missing — needs specs | `git maintenance` |
 
 #### ⏳ Commands To Migrate
 
@@ -1007,13 +920,13 @@ order: Basic Snapshotting → Branching & Merging → etc.
 - [x] `merge` → `Git::Commands::Merge::Start` — `git merge`
 - [x] N/A (new) → `Git::Commands::Merge::Abort` / `Git::Commands::Merge::Continue` / `Git::Commands::Merge::Quit` — `git merge --abort/--continue/--quit`
 - [x] `tag` → `Git::Commands::Tag::*` — `git tag` (implemented as `List`, `Create`, `Delete`, and `Verify`)
-- [x] `stash_*` → `Git::Commands::Stash::*` — `git stash` (List, Push, Pop, Apply, Drop, Clear, Create, Store, Branch, ShowNumstat, ShowPatch, ShowRaw)
+- [x] `stash_*` → `Git::Commands::Stash::*` — `git stash` (List, Push, Pop, Apply, Drop, Clear, Create, Store, Branch, Show)
 
 **Inspection & Comparison:**
 
 - [x] `log_commits` / `full_log_commits` → `Git::Commands::Log` — `git log`
 - [x] `diff_full` / `diff_stats` / `diff_path_status` / `diff_index` →
-  `Git::Commands::Diff::*` — `git diff` (implemented as `Patch`, `Numstat`, and `Raw`)
+  `Git::Commands::Diff` — `git diff`
 - [x] `unmerged` → (use existing `Git::Commands::Diff` class) — `git diff`
   (one unmigrated call site in `Git::Lib#unmerged`; command class already exists)
 - [x] `diff_as_hash` (private) → `Git::Commands::DiffFiles` / `Git::Commands::DiffIndex`
@@ -1069,6 +982,7 @@ order: Basic Snapshotting → Branching & Merging → etc.
 - [x] `change_head_branch` → `Git::Commands::SymbolicRef` — `git symbolic-ref`
 - [x] `repository_default_branch` → (part of `Git::Commands::LsRemote`)
 - [x] `current_command_version` → `Git::Commands::Version` — `git version`
+- [x] N/A (new) → `Git::Commands::Maintenance::*` — `git maintenance` (Register, Run, Start, Stop, Unregister) ⚠️ missing specs
 
 ## Phase 3: Refactoring the Public Interface
 

--- a/spec/unit/git/execution_context/global_spec.rb
+++ b/spec/unit/git/execution_context/global_spec.rb
@@ -1,0 +1,144 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/execution_context/global'
+
+RSpec.describe Git::ExecutionContext::Global do
+  describe 'inheritance' do
+    it 'is a Git::ExecutionContext' do
+      expect(described_class.new).to be_a(Git::ExecutionContext)
+    end
+  end
+
+  describe '#initialize' do
+    it 'can be created with no arguments' do
+      expect { described_class.new }.not_to raise_error
+    end
+
+    it 'accepts an optional logger' do
+      logger = double('logger')
+      expect { described_class.new(logger: logger) }.not_to raise_error
+    end
+
+    it 'accepts an optional git_ssh path' do
+      expect { described_class.new(git_ssh: '/usr/bin/ssh') }.not_to raise_error
+    end
+  end
+
+  describe 'accessor methods' do
+    let(:context) { described_class.new(git_ssh: nil) }
+
+    it 'returns nil for git_dir' do
+      expect(context.git_dir).to be_nil
+    end
+
+    it 'returns nil for git_work_dir' do
+      expect(context.git_work_dir).to be_nil
+    end
+
+    it 'returns nil for git_index_file' do
+      expect(context.git_index_file).to be_nil
+    end
+  end
+
+  describe 'git_ssh resolution' do
+    it 'delegates to Git::Base.config by default' do
+      allow(Git::Base).to receive_message_chain(:config, :git_ssh).and_return('/global/ssh')
+      expect(described_class.new.git_ssh).to eq('/global/ssh')
+    end
+
+    it 'returns nil when explicitly passed nil' do
+      expect(described_class.new(git_ssh: nil).git_ssh).to be_nil
+    end
+
+    it 'returns a literal path when provided' do
+      expect(described_class.new(git_ssh: '/usr/bin/ssh').git_ssh).to eq('/usr/bin/ssh')
+    end
+  end
+
+  describe 'env_overrides (via #send)' do
+    let(:context) { described_class.new(git_ssh: nil) }
+
+    it 'explicitly unsets GIT_DIR' do
+      expect(context.send(:env_overrides)['GIT_DIR']).to be_nil
+    end
+
+    it 'explicitly unsets GIT_WORK_TREE' do
+      expect(context.send(:env_overrides)['GIT_WORK_TREE']).to be_nil
+    end
+
+    it 'explicitly unsets GIT_INDEX_FILE' do
+      expect(context.send(:env_overrides)['GIT_INDEX_FILE']).to be_nil
+    end
+
+    it 'explicitly unsets GIT_SSH when git_ssh is nil' do
+      expect(context.send(:env_overrides)['GIT_SSH']).to be_nil
+    end
+
+    it 'sets GIT_EDITOR to "true" (no-op editor)' do
+      expect(context.send(:env_overrides)['GIT_EDITOR']).to eq('true')
+    end
+
+    it 'sets LC_ALL to "en_US.UTF-8"' do
+      expect(context.send(:env_overrides)['LC_ALL']).to eq('en_US.UTF-8')
+    end
+
+    it 'merges caller-supplied additional overrides' do
+      env = context.send(:env_overrides, 'MY_VAR' => 'val')
+      expect(env['MY_VAR']).to eq('val')
+    end
+  end
+
+  describe 'global_opts (via #send)' do
+    let(:context) { described_class.new }
+
+    it 'does not include --git-dir' do
+      expect(context.send(:global_opts).grep(/\A--git-dir/)).to be_empty
+    end
+
+    it 'does not include --work-tree' do
+      expect(context.send(:global_opts).grep(/\A--work-tree/)).to be_empty
+    end
+
+    it 'includes the static global opts' do
+      expect(context.send(:global_opts)).to include('-c', 'core.quotePath=true')
+    end
+  end
+
+  describe '#command_capturing' do
+    let(:context) { described_class.new }
+    let(:command_line_double) { instance_double(Git::CommandLine::Capturing) }
+    let(:result) { command_result('git version 2.40.0') }
+
+    before do
+      allow(context).to receive(:command_line_capturing).and_return(command_line_double)
+      allow(Git::Base).to receive_message_chain(:config, :timeout).and_return(nil)
+    end
+
+    it 'delegates to command_line_capturing.run' do
+      expect(command_line_double).to receive(:run)
+        .with('version', hash_including(raise_on_failure: true, normalize: true))
+        .and_return(result)
+      context.command_capturing('version')
+    end
+  end
+
+  describe '#command_streaming' do
+    let(:context) { described_class.new }
+    let(:command_line_double) { instance_double(Git::CommandLine::Streaming) }
+    let(:result) { command_result('') }
+    let(:out_io) { StringIO.new }
+
+    before do
+      allow(context).to receive(:command_line_streaming).and_return(command_line_double)
+      allow(Git::Base).to receive_message_chain(:config, :timeout).and_return(nil)
+    end
+
+    it 'delegates to command_line_streaming.run' do
+      expect(command_line_double).to receive(:run)
+        .with('clone', hash_including(out: out_io, raise_on_failure: true, timeout: nil))
+        .and_return(result)
+      context.command_streaming('clone', out: out_io)
+    end
+  end
+end

--- a/spec/unit/git/execution_context/repository_spec.rb
+++ b/spec/unit/git/execution_context/repository_spec.rb
@@ -1,0 +1,307 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/execution_context/repository'
+
+RSpec.describe Git::ExecutionContext::Repository do
+  let(:git_dir) { '/repo/.git' }
+  let(:git_work_dir) { '/repo' }
+  let(:git_index_file) { '/repo/.git/index' }
+
+  describe 'inheritance' do
+    it 'is a Git::ExecutionContext' do
+      context = described_class.new(git_dir: git_dir)
+      expect(context).to be_a(Git::ExecutionContext)
+    end
+  end
+
+  describe '#initialize' do
+    it 'accepts git_dir as a keyword argument' do
+      expect { described_class.new(git_dir: git_dir) }.not_to raise_error
+    end
+
+    it 'accepts all repository path options' do
+      expect do
+        described_class.new(
+          git_dir: git_dir,
+          git_work_dir: git_work_dir,
+          git_index_file: git_index_file,
+          git_ssh: '/usr/bin/ssh',
+          logger: nil
+        )
+      end.not_to raise_error
+    end
+  end
+
+  describe 'accessor methods' do
+    let(:context) do
+      described_class.new(
+        git_dir: git_dir,
+        git_work_dir: git_work_dir,
+        git_index_file: git_index_file
+      )
+    end
+
+    it 'exposes git_dir' do
+      expect(context.git_dir).to eq(git_dir)
+    end
+
+    it 'exposes git_work_dir' do
+      expect(context.git_work_dir).to eq(git_work_dir)
+    end
+
+    it 'exposes git_index_file' do
+      expect(context.git_index_file).to eq(git_index_file)
+    end
+  end
+
+  describe 'env_overrides (via #send)' do
+    let(:context) do
+      described_class.new(
+        git_dir: git_dir,
+        git_work_dir: git_work_dir,
+        git_index_file: git_index_file
+      )
+    end
+
+    before do
+      allow(Git::Base).to receive_message_chain(:config, :git_ssh).and_return(nil)
+    end
+
+    it 'sets GIT_DIR to git_dir' do
+      expect(context.send(:env_overrides)['GIT_DIR']).to eq(git_dir)
+    end
+
+    it 'sets GIT_WORK_TREE to git_work_dir' do
+      expect(context.send(:env_overrides)['GIT_WORK_TREE']).to eq(git_work_dir)
+    end
+
+    it 'sets GIT_INDEX_FILE to git_index_file' do
+      expect(context.send(:env_overrides)['GIT_INDEX_FILE']).to eq(git_index_file)
+    end
+
+    it 'sets GIT_EDITOR to "true" (no-op editor)' do
+      expect(context.send(:env_overrides)['GIT_EDITOR']).to eq('true')
+    end
+
+    it 'sets LC_ALL to "en_US.UTF-8"' do
+      expect(context.send(:env_overrides)['LC_ALL']).to eq('en_US.UTF-8')
+    end
+
+    it 'merges caller-supplied additional overrides' do
+      env = context.send(:env_overrides, 'GIT_TRACE' => '1')
+      expect(env['GIT_TRACE']).to eq('1')
+    end
+
+    it 'allows unsetting an env var by passing nil' do
+      env = context.send(:env_overrides, 'GIT_INDEX_FILE' => nil)
+      expect(env['GIT_INDEX_FILE']).to be_nil
+    end
+  end
+
+  describe 'global_opts (via #send)' do
+    context 'with git_dir and git_work_dir set' do
+      let(:context) do
+        described_class.new(git_dir: git_dir, git_work_dir: git_work_dir)
+      end
+
+      it 'includes --git-dir=<path>' do
+        expect(context.send(:global_opts)).to include("--git-dir=#{git_dir}")
+      end
+
+      it 'includes --work-tree=<path>' do
+        expect(context.send(:global_opts)).to include("--work-tree=#{git_work_dir}")
+      end
+
+      it 'includes the static global opts' do
+        expect(context.send(:global_opts)).to include('-c', 'core.quotePath=true')
+      end
+    end
+
+    context 'without git_work_dir' do
+      let(:context) { described_class.new(git_dir: git_dir) }
+
+      it 'does not include --work-tree' do
+        expect(context.send(:global_opts).grep(/\A--work-tree/)).to be_empty
+      end
+    end
+
+    context 'without git_dir' do
+      let(:context) { described_class.new(git_dir: nil) }
+
+      it 'does not include --git-dir' do
+        expect(context.send(:global_opts).grep(/\A--git-dir/)).to be_empty
+      end
+    end
+  end
+
+  describe 'git_ssh resolution' do
+    context 'with a literal git_ssh path' do
+      let(:context) { described_class.new(git_dir: git_dir, git_ssh: '/usr/bin/ssh') }
+
+      it 'returns the provided path' do
+        expect(context.git_ssh).to eq('/usr/bin/ssh')
+      end
+    end
+
+    context 'with :use_global_config (default)' do
+      let(:context) { described_class.new(git_dir: git_dir) }
+
+      it 'delegates to Git::Base.config.git_ssh' do
+        allow(Git::Base).to receive_message_chain(:config, :git_ssh).and_return('/configured/ssh')
+        expect(context.git_ssh).to eq('/configured/ssh')
+      end
+    end
+
+    context 'with nil git_ssh explicitly passed' do
+      let(:context) { described_class.new(git_dir: git_dir, git_ssh: nil) }
+
+      it 'returns nil' do
+        expect(context.git_ssh).to be_nil
+      end
+    end
+  end
+
+  describe '.from_base' do
+    let(:repo_double) { double('repo', to_s: git_dir) }
+    let(:index_double) { double('index', to_s: git_index_file) }
+    let(:dir_double) { double('dir', to_s: git_work_dir) }
+    let(:base) do
+      double('Git::Base', repo: repo_double, index: index_double, dir: dir_double, git_ssh: nil)
+    end
+
+    subject(:context) { described_class.from_base(base) }
+
+    it 'returns a Git::ExecutionContext::Repository' do
+      expect(context).to be_a(described_class)
+    end
+
+    it 'extracts git_dir from base.repo.to_s' do
+      expect(context.git_dir).to eq(git_dir)
+    end
+
+    it 'extracts git_work_dir from base.dir.to_s' do
+      expect(context.git_work_dir).to eq(git_work_dir)
+    end
+
+    it 'extracts git_index_file from base.index.to_s' do
+      expect(context.git_index_file).to eq(git_index_file)
+    end
+
+    context 'when base.dir is nil' do
+      let(:dir_double) { nil }
+
+      it 'sets git_work_dir to nil' do
+        expect(context.git_work_dir).to be_nil
+      end
+    end
+
+    context 'when base.index is nil' do
+      let(:index_double) { nil }
+
+      it 'sets git_index_file to nil' do
+        expect(context.git_index_file).to be_nil
+      end
+    end
+  end
+
+  describe '.from_hash' do
+    let(:hash) do
+      {
+        repository: git_dir,
+        working_directory: git_work_dir,
+        index: git_index_file
+      }
+    end
+
+    subject(:context) { described_class.from_hash(hash) }
+
+    it 'returns a Git::ExecutionContext::Repository' do
+      expect(context).to be_a(described_class)
+    end
+
+    it 'extracts git_dir from hash[:repository]' do
+      expect(context.git_dir).to eq(git_dir)
+    end
+
+    it 'extracts git_work_dir from hash[:working_directory]' do
+      expect(context.git_work_dir).to eq(git_work_dir)
+    end
+
+    it 'extracts git_index_file from hash[:index]' do
+      expect(context.git_index_file).to eq(git_index_file)
+    end
+
+    it 'defaults git_ssh to :use_global_config when :git_ssh is absent' do
+      allow(Git::Base).to receive_message_chain(:config, :git_ssh).and_return('/global/ssh')
+      expect(context.git_ssh).to eq('/global/ssh')
+    end
+
+    it 'uses the provided git_ssh when :git_ssh is present in hash' do
+      hash[:git_ssh] = '/custom/ssh'
+      expect(context.git_ssh).to eq('/custom/ssh')
+    end
+  end
+
+  describe '#command_capturing' do
+    let(:context) { described_class.new(git_dir: git_dir, git_work_dir: git_work_dir) }
+    let(:command_line_double) { instance_double(Git::CommandLine::Capturing) }
+    let(:result) { command_result('output') }
+
+    before do
+      allow(context).to receive(:command_line_capturing).and_return(command_line_double)
+      allow(Git::Base).to receive_message_chain(:config, :timeout).and_return(nil)
+    end
+
+    it 'delegates to command_line_capturing.run' do
+      expect(command_line_double).to receive(:run)
+        .with('version', hash_including(raise_on_failure: true, normalize: true))
+        .and_return(result)
+      context.command_capturing('version')
+    end
+
+    it 'passes raise_on_failure: false when specified' do
+      expect(command_line_double).to receive(:run)
+        .with('status', hash_including(raise_on_failure: false))
+        .and_return(result)
+      context.command_capturing('status', raise_on_failure: false)
+    end
+
+    it 'applies the global timeout when no timeout is specified' do
+      allow(Git::Base).to receive_message_chain(:config, :timeout).and_return(30)
+      expect(command_line_double).to receive(:run)
+        .with('status', hash_including(timeout: 30))
+        .and_return(result)
+      context.command_capturing('status')
+    end
+
+    it 'raises ArgumentError for unknown options' do
+      expect { context.command_capturing('version', unknown_opt: true) }
+        .to raise_error(ArgumentError, /Unknown options: unknown_opt/)
+    end
+  end
+
+  describe '#command_streaming' do
+    let(:context) { described_class.new(git_dir: git_dir, git_work_dir: git_work_dir) }
+    let(:command_line_double) { instance_double(Git::CommandLine::Streaming) }
+    let(:result) { command_result('') }
+    let(:out_io) { StringIO.new }
+
+    before do
+      allow(context).to receive(:command_line_streaming).and_return(command_line_double)
+      allow(Git::Base).to receive_message_chain(:config, :timeout).and_return(nil)
+    end
+
+    it 'delegates to command_line_streaming.run' do
+      expect(command_line_double).to receive(:run)
+        .with('cat-file', '--batch', hash_including(out: out_io, raise_on_failure: true, timeout: nil))
+        .and_return(result)
+      context.command_streaming('cat-file', '--batch', out: out_io)
+    end
+
+    it 'raises ArgumentError for unknown options' do
+      expect { context.command_streaming('cat-file', unknown_opt: true) }
+        .to raise_error(ArgumentError, /Unknown options: unknown_opt/)
+    end
+  end
+end

--- a/spec/unit/git/execution_context_spec.rb
+++ b/spec/unit/git/execution_context_spec.rb
@@ -3,23 +3,162 @@
 require 'spec_helper'
 
 RSpec.describe Git::ExecutionContext do
-  describe 'delegation to Git::Lib' do
-    let(:base) { instance_double(Git::Base) }
-    let(:lib) { instance_double(Git::Lib, branches_all: %w[main develop]) }
-    let(:context) { described_class.new(base) }
+  describe 'constants' do
+    it 'defines COMMAND_CAPTURING_ARG_DEFAULTS' do
+      expect(described_class::COMMAND_CAPTURING_ARG_DEFAULTS).to be_a(Hash)
+      expect(described_class::COMMAND_CAPTURING_ARG_DEFAULTS).to include(:normalize, :chomp, :raise_on_failure)
+    end
+
+    it 'defines COMMAND_STREAMING_ARG_DEFAULTS' do
+      expect(described_class::COMMAND_STREAMING_ARG_DEFAULTS).to be_a(Hash)
+      expect(described_class::COMMAND_STREAMING_ARG_DEFAULTS).to include(:raise_on_failure)
+    end
+
+    it 'defines STATIC_GLOBAL_OPTS' do
+      expect(described_class::STATIC_GLOBAL_OPTS).to be_a(Array)
+      expect(described_class::STATIC_GLOBAL_OPTS).to include('-c', 'core.quotePath=true')
+    end
+  end
+
+  describe 'accessor defaults' do
+    let(:context) { described_class.new }
+
+    it 'returns nil for git_dir' do
+      expect(context.git_dir).to be_nil
+    end
+
+    it 'returns nil for git_work_dir' do
+      expect(context.git_work_dir).to be_nil
+    end
+
+    it 'returns nil for git_index_file' do
+      expect(context.git_index_file).to be_nil
+    end
+
+    it 'delegates git_ssh to Git::Base.config by default' do
+      allow(Git::Base).to receive_message_chain(:config, :git_ssh).and_return('/configured/ssh')
+      expect(context.git_ssh).to eq('/configured/ssh')
+    end
+
+    it 'returns nil for git_ssh when explicitly passed nil' do
+      expect(described_class.new(git_ssh: nil).git_ssh).to be_nil
+    end
+
+    it 'returns a literal git_ssh path when provided' do
+      expect(described_class.new(git_ssh: '/usr/bin/ssh').git_ssh).to eq('/usr/bin/ssh')
+    end
+  end
+
+  describe 'env_overrides (via #send)' do
+    let(:context) { described_class.new(git_ssh: nil) }
+
+    it 'returns GIT_DIR as nil by default' do
+      expect(context.send(:env_overrides)['GIT_DIR']).to be_nil
+    end
+
+    it 'returns GIT_WORK_TREE as nil by default' do
+      expect(context.send(:env_overrides)['GIT_WORK_TREE']).to be_nil
+    end
+
+    it 'returns GIT_INDEX_FILE as nil by default' do
+      expect(context.send(:env_overrides)['GIT_INDEX_FILE']).to be_nil
+    end
+
+    it 'returns GIT_SSH as nil when git_ssh is nil' do
+      expect(context.send(:env_overrides)['GIT_SSH']).to be_nil
+    end
+
+    it 'sets GIT_EDITOR to "true"' do
+      expect(context.send(:env_overrides)['GIT_EDITOR']).to eq('true')
+    end
+
+    it 'sets LC_ALL to "en_US.UTF-8"' do
+      expect(context.send(:env_overrides)['LC_ALL']).to eq('en_US.UTF-8')
+    end
+
+    it 'merges caller-supplied additional overrides' do
+      env = context.send(:env_overrides, 'GIT_TRACE' => '1')
+      expect(env['GIT_TRACE']).to eq('1')
+    end
+  end
+
+  describe 'global_opts (via #send)' do
+    it 'includes only static opts when git_dir and git_work_dir are nil' do
+      context = described_class.new
+      expect(context.send(:global_opts)).to eq(described_class::STATIC_GLOBAL_OPTS)
+    end
+  end
+
+  describe '#command_capturing' do
+    let(:context) { described_class.new }
+    let(:command_line_double) { instance_double(Git::CommandLine::Capturing) }
+    let(:result) { command_result('output') }
 
     before do
-      allow(Git::Lib).to receive(:new).with(base).and_return(lib)
+      allow(context).to receive(:command_line_capturing).and_return(command_line_double)
+      allow(Git::Base).to receive_message_chain(:config, :timeout).and_return(nil)
     end
 
-    it 'delegates methods to Git::Lib' do
-      expect(context.branches_all).to eq(%w[main develop])
+    it 'delegates to command_line_capturing.run with defaults' do
+      expect(command_line_double).to receive(:run)
+        .with('version', hash_including(raise_on_failure: true, normalize: true, chomp: true))
+        .and_return(result)
+      context.command_capturing('version')
     end
 
-    it 'responds to methods that Git::Lib responds to' do
-      allow(lib).to receive(:respond_to?).with(:branches_all, false).and_return(true)
+    it 'raises ArgumentError for unknown option keys' do
+      expect { context.command_capturing('version', bogus: true) }
+        .to raise_error(ArgumentError, /Unknown options: bogus/)
+    end
+  end
 
-      expect(context.respond_to?(:branches_all)).to be true
+  describe '#command_streaming' do
+    let(:context) { described_class.new }
+    let(:command_line_double) { instance_double(Git::CommandLine::Streaming) }
+    let(:result) { command_result('') }
+
+    before do
+      allow(context).to receive(:command_line_streaming).and_return(command_line_double)
+      allow(Git::Base).to receive_message_chain(:config, :timeout).and_return(nil)
+    end
+
+    it 'delegates to command_line_streaming.run' do
+      expect(command_line_double).to receive(:run)
+        .with('cat-file', '--batch', hash_including(raise_on_failure: true, timeout: nil))
+        .and_return(result)
+      context.command_streaming('cat-file', '--batch')
+    end
+
+    it 'raises ArgumentError for unknown option keys' do
+      expect { context.command_streaming('cat-file', bogus: true) }
+        .to raise_error(ArgumentError, /Unknown options: bogus/)
+    end
+  end
+
+  describe '#git_version' do
+    let(:context) { described_class.new }
+    let(:version_command_double) { instance_double(Git::Commands::Version) }
+
+    before do
+      allow(Git::Commands::Version).to receive(:new).with(context).and_return(version_command_double)
+    end
+
+    it 'calls Git::Commands::Version and returns a parsed Git::Version' do
+      allow(version_command_double).to receive(:call).and_return(command_result('git version 2.40.0'))
+      expect(context.git_version).to be_a(Git::Version)
+      expect(context.git_version.to_s).to eq('2.40.0')
+    end
+
+    it 'memoizes the result per instance' do
+      allow(version_command_double).to receive(:call).once.and_return(command_result('git version 2.40.0'))
+      context.git_version
+      context.git_version
+    end
+
+    it 'raises Git::Error with a helpful message when the output cannot be parsed' do
+      allow(version_command_double).to receive(:call).and_return(command_result('not a version string'))
+      expect { context.git_version }
+        .to raise_error(Git::Error, /Unable to parse git version/)
     end
   end
 end


### PR DESCRIPTION
## Summary

Phase 3, Task 1 of the architectural redesign (see `redesign/3_architecture_implementation.md`): create proper `Git::ExecutionContext` subclasses that replace the temporary `method_missing` delegation stub.

## What Changed

### `Git::ExecutionContext` (real base class)

Replaces the previous thin `method_missing` stub with a real implementation:
- `command_capturing` / `command_streaming` — the interface expected by `Git::Commands::Base`, extracted from `Git::Lib`
- `git_version` — memoized per-instance
- `STATIC_GLOBAL_OPTS`, `COMMAND_CAPTURING_ARG_DEFAULTS`, `COMMAND_STREAMING_ARG_DEFAULTS` constants
- Public accessor defaults: `git_dir` / `git_work_dir` / `git_index_file` return `nil`; `git_ssh` resolves `:use_global_config` sentinel to `Git::Base.config.git_ssh`
- `env_overrides` / `global_opts` implemented here using the accessor methods (private; subclasses override accessors, not these methods)

### `Git::ExecutionContext::Repository < Git::ExecutionContext` (`lib/git/execution_context/repository.rb`)

For repository-bound commands (`add`, `commit`, `status`, `log`, etc.):
- Overrides `git_dir`, `git_work_dir`, `git_index_file` accessors with stored values
- Inherits `env_overrides` (sets `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_SSH`, `GIT_EDITOR`, `LC_ALL`) and `global_opts` from base
- Factory methods `from_base(base_object)` and `from_hash(hash)` for construction from existing `Git::Base` instances

### `Git::ExecutionContext::Global < Git::ExecutionContext` (`lib/git/execution_context/global.rb`)

For commands that require no existing repository (`init`, `clone`, `version`):
- No accessor overrides; base class nil defaults cause `env_overrides` to unset `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE` (preventing parent environment from leaking an unintended repository context)
- `git_ssh` still supported via constructor for SSH-based remote operations (e.g. `clone`)
- Inherits `global_opts` from base; since `git_dir` is nil, `--git-dir` / `--work-tree` are omitted automatically

### Plan document updates

- Fixed stale entries in `redesign/3_architecture_implementation.md` (Diff/Stash Show anti-pattern subclasses, missing commands table rows)
- Marked Phase 3 Task 1 complete; added Task 2 workflow (refactor factory methods)
- Added Phase 3 task to add `binary_path:` to `Git::ExecutionContext`; updated `Git.run_git_version` stopgap comment accordingly

## Tests

82 unit specs across:
- `spec/unit/git/execution_context_spec.rb` (updated)
- `spec/unit/git/execution_context/repository_spec.rb` (new)
- `spec/unit/git/execution_context/global_spec.rb` (new)

Full suite: `bundle exec rspec` — 4702 examples, 2 pre-existing unrelated failures. Legacy `bundle exec rake test` — 559 tests, 0 failures.

## Next Task

Phase 3, Task 2: Add `binary_path:` to `Git::ExecutionContext` so context objects can target an arbitrary git binary, then retire the `Open3` stopgap in `Git.run_git_version`.
