### PR TITLE
feat(execution-context): add binary_path: keyword and retire Open3 stopgap

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'open3'
-
 require 'active_support'
 require 'active_support/deprecation'
 
@@ -490,8 +488,11 @@ module Git
   #
   # @return [Git::Version] the parsed git version
   #
-  # @raise [Git::Error] if the binary exits with a non-zero status, is not found,
-  #   or the version output cannot be parsed
+  # @raise [Git::UnexpectedResultError] if the version output cannot be parsed
+  #
+  # @raise [Git::FailedError] if the git binary exits with a non-zero status
+  #
+  # @raise [Git::Error] if the binary is not found or fails to launch
   #
   # @example Default binary
   #   Git.git_version #=> #<Git::Version 2.42.0>
@@ -505,28 +506,9 @@ module Git
   end
 
   # @api private
-  # STOPGAP: uses Open3 directly because Git::Lib hardcodes Git::Base.config.binary_path
-  # in its command-line factory, so Git::Commands::Version cannot be used to query an
-  # arbitrary binary path today.
-  #
-  # A future enhancement will add binary_path: to Git::ExecutionContext (see
-  # redesign/3_architecture_implementation.md Phase 3). Once that lands, replace the
-  # Open3 call with:
-  #
-  #   Git::Commands::Version.new(Git::ExecutionContext::Global.new(binary_path: path)).call.stdout
-  #
-  # and remove the Open3 dependency from this method.
   def self.run_git_version(path)
-    output, status = Open3.capture2e(path, 'version')
-    raise Git::Error, "Failed to run `#{path} version`: #{output.chomp}" unless status.success?
-
+    output = Git::Commands::Version.new(Git::ExecutionContext::Global.new(binary_path: path)).call.stdout
     Git::Version.parse(output)
-  rescue Errno::ENOENT
-    raise Git::Error, "Git binary not found: #{path}"
-  rescue SystemCallError => e
-    raise Git::Error, "Failed to execute git binary at `#{path}`: #{e.message}"
-  rescue ArgumentError => e
-    raise Git::Error, "Unable to parse git version from: #{output.inspect} (#{e.message})"
   end
   private_class_method :run_git_version
 

--- a/lib/git/command_line/base.rb
+++ b/lib/git/command_line/base.rb
@@ -151,6 +151,9 @@ module Git
       #
       # @raise [ArgumentError] in place of ProcessExecuter::ArgumentError
       #
+      # @raise [Git::Error] in place of ProcessExecuter::SpawnError (binary not found or
+      #   failed to launch)
+      #
       # @raise [Git::ProcessIOError] in place of ProcessExecuter::ProcessIOError
       #
       # @return [Object] the return value of the block
@@ -161,6 +164,8 @@ module Git
         yield
       rescue ProcessExecuter::ArgumentError => e
         raise ::ArgumentError, e.message
+      rescue ProcessExecuter::SpawnError => e
+        raise Git::Error, e.message, cause: e.cause
       rescue ProcessExecuter::ProcessIOError => e
         raise Git::ProcessIOError, e.message, cause: e.cause
       end

--- a/lib/git/execution_context.rb
+++ b/lib/git/execution_context.rb
@@ -33,6 +33,10 @@ module Git
   # - {Git::ExecutionContext::Global} — for commands that do not require an existing repository
   #   (`init`, `clone`, `version`)
   #
+  # @example Using a concrete subclass
+  #   context = Git::ExecutionContext::Global.new(binary_path: '/usr/local/bin/git2')
+  #   context.binary_path  #=> "/usr/local/bin/git2"
+  #
   # @api private
   #
   class ExecutionContext
@@ -81,15 +85,32 @@ module Git
 
     # Creates a new execution context
     #
-    # @param git_ssh [String, nil, :use_global_config] SSH wrapper path, `nil` to
-    #   unset `GIT_SSH`, or `:use_global_config` (default) to inherit from
-    #   {Git::Base.config}
+    # @param binary_path [String, :use_global_config] path to the git binary
     #
-    # @param logger [Logger, nil] logger forwarded to the CommandLine layer;
-    #   `nil` defaults to a null logger (`Logger.new(nil)`) so that contexts
-    #   created without an explicit logger can always execute commands safely.
+    #   Give `:use_global_config` (the default) to use `Git::Base.config.binary_path`.
     #
-    def initialize(git_ssh: :use_global_config, logger: nil)
+    #   Passing `nil` raises `ArgumentError` — there is no "unset the
+    #   binary" semantic.
+    #
+    # @param git_ssh [String, nil, :use_global_config] the SSH wrapper path
+    #
+    #   Give `nil` to unset `GIT_SSH`, or `:use_global_config` (default) to use `Git::Base.config.git_ssh`.
+    #
+    # @param logger [Logger, nil] the logger to use in the CommandLine layer
+    #
+    #   Give `nil` to use a null logger (`Logger.new(nil)`).
+    #
+    # @raise [NotImplementedError] if called directly on {Git::ExecutionContext} rather than a subclass
+    #
+    # @raise [ArgumentError] if `binary_path` is `nil`
+    #
+    def initialize(binary_path: :use_global_config, git_ssh: :use_global_config, logger: nil)
+      if instance_of?(Git::ExecutionContext)
+        raise NotImplementedError, 'Git::ExecutionContext is an abstract base class'
+      end
+      raise ArgumentError, 'binary_path must not be nil' if binary_path.nil?
+
+      @binary_path = binary_path
       @git_ssh = git_ssh
       @logger = logger || Logger.new(nil)
     end
@@ -100,7 +121,11 @@ module Git
     # (per `Process.spawn` semantics — unset is not the same as inherited).
     # Subclasses override this to supply a repository-specific path.
     #
-    # @return [String, nil]
+    # @example Base class returns nil; subclasses return the actual path
+    #   context = Git::ExecutionContext::Global.new
+    #   context.git_dir  #=> nil
+    #
+    # @return [String, nil] the `GIT_DIR` path, or `nil` to unset the variable
     #
     def git_dir = nil
 
@@ -108,7 +133,11 @@ module Git
     #
     # `nil` means `GIT_WORK_TREE` will be explicitly **unset** in the child process.
     #
-    # @return [String, nil]
+    # @example Base class returns nil; subclasses return the actual path
+    #   context = Git::ExecutionContext::Global.new
+    #   context.git_work_dir  #=> nil
+    #
+    # @return [String, nil] the `GIT_WORK_TREE` path, or `nil` to unset the variable
     #
     def git_work_dir = nil
 
@@ -116,18 +145,52 @@ module Git
     #
     # `nil` means `GIT_INDEX_FILE` will be explicitly **unset** in the child process.
     #
-    # @return [String, nil]
+    # @example Base class returns nil; subclasses return the actual path
+    #   context = Git::ExecutionContext::Global.new
+    #   context.git_index_file  #=> nil
+    #
+    # @return [String, nil] the `GIT_INDEX_FILE` path, or `nil` to unset the variable
     #
     def git_index_file = nil
 
+    # Returns the resolved git binary path for this context
+    #
+    # `:use_global_config` is resolved to `Git::Base.config.binary_path` each time a
+    # command method is called, so runtime changes to `Git::Base.config.binary_path`
+    # are reflected per command invocation.
+    #
+    # @example With the default sentinel (resolves from Git::Base.config at call-time)
+    #   context = Git::ExecutionContext::Global.new
+    #   context.binary_path  #=> "git"
+    #
+    # @example With an explicit path
+    #   context = Git::ExecutionContext::Global.new(binary_path: '/usr/local/bin/git2')
+    #   context.binary_path  #=> "/usr/local/bin/git2"
+    #
+    # @return [String] the resolved git binary path
+    #
+    def binary_path
+      return Git::Base.config.binary_path if @binary_path == :use_global_config
+
+      @binary_path
+    end
+
     # Returns the resolved `GIT_SSH` wrapper path for this context
     #
-    # `:use_global_config` is resolved to {Git::Base.config.git_ssh} each time
-    # {#command_line_capturing} or {#command_line_streaming} is called, so
-    # runtime changes to {Git::Base.config.git_ssh} are reflected per command
-    # invocation. `nil` means the variable will be explicitly unset.
+    # `:use_global_config` is resolved to `Git::Base.config.git_ssh` each time a
+    # command method is called, so runtime changes to `Git::Base.config.git_ssh`
+    # are reflected per command invocation. `nil` means the variable will be
+    # explicitly unset.
     #
-    # @return [String, nil]
+    # @example With the default sentinel (resolves from Git::Base.config at call-time)
+    #   context = Git::ExecutionContext::Global.new
+    #   context.git_ssh  #=> nil
+    #
+    # @example With an explicit path
+    #   context = Git::ExecutionContext::Global.new(git_ssh: '/usr/bin/ssh-wrapper')
+    #   context.git_ssh  #=> "/usr/bin/ssh-wrapper"
+    #
+    # @return [String, nil] the resolved `GIT_SSH` wrapper path, or `nil` to unset
     #
     def git_ssh
       return Git::Base.config.git_ssh if @git_ssh == :use_global_config
@@ -228,8 +291,6 @@ module Git
     #
     # @see Git::CommandLine::Capturing#run
     #
-    # @see #command_line_capturing
-    #
     def command_capturing(*, **options_hash)
       options_hash = COMMAND_CAPTURING_ARG_DEFAULTS.merge(options_hash)
       options_hash[:timeout] ||= Git.config.timeout
@@ -317,8 +378,6 @@ module Git
     #
     # @see Git::CommandLine::Streaming#run
     #
-    # @see #command_line_streaming
-    #
     def command_streaming(*, **options_hash)
       options_hash = COMMAND_STREAMING_ARG_DEFAULTS.merge(options_hash)
       options_hash[:timeout] ||= Git.config.timeout
@@ -335,16 +394,18 @@ module Git
     #
     # The result is memoized per instance.
     #
+    # @example Get the installed git version
+    #   context = Git::ExecutionContext::Global.new
+    #   context.git_version  #=> #<Git::Version 2.42.0>
+    #
     # @return [Git::Version] the installed git version
     #
-    # @raise [Git::Error] if the version string cannot be parsed
+    # @raise [Git::UnexpectedResultError] if the version string cannot be parsed
     #
     def git_version
       @git_version ||= begin
         output = Git::Commands::Version.new(self).call.stdout
         Git::Version.parse(output)
-      rescue ArgumentError => e
-        raise Git::Error, "Unable to parse git version from: #{output.inspect} (#{e.message})"
       end
     end
 
@@ -390,26 +451,28 @@ module Git
 
     # Creates a {Git::CommandLine::Capturing} instance for the current invocation.
     #
-    # A new instance is created per call so that {#env_overrides} — including
-    # {#git_ssh} resolution for `:use_global_config` — reflects the state of
-    # {Git::Base.config} at the time of each command invocation.
+    # A new instance is created per call so that {#binary_path} — resolved from
+    # `Git::Base.config` when set to `:use_global_config` — and {#env_overrides}
+    # — including {#git_ssh} resolution for `:use_global_config` — reflect the
+    # state of `Git::Base.config` at the time of each command invocation.
     #
     # @return [Git::CommandLine::Capturing] the capturing command line instance
     #
     def command_line_capturing
-      Git::CommandLine::Capturing.new(env_overrides, Git::Base.config.binary_path, global_opts, @logger)
+      Git::CommandLine::Capturing.new(env_overrides, binary_path, global_opts, @logger)
     end
 
     # Creates a {Git::CommandLine::Streaming} instance for the current invocation.
     #
-    # A new instance is created per call so that {#env_overrides} — including
-    # {#git_ssh} resolution for `:use_global_config` — reflects the state of
-    # {Git::Base.config} at the time of each command invocation.
+    # A new instance is created per call so that {#binary_path} — resolved from
+    # `Git::Base.config` when set to `:use_global_config` — and {#env_overrides}
+    # — including {#git_ssh} resolution for `:use_global_config` — reflect the
+    # state of `Git::Base.config` at the time of each command invocation.
     #
     # @return [Git::CommandLine::Streaming] the streaming command line instance
     #
     def command_line_streaming
-      Git::CommandLine::Streaming.new(env_overrides, Git::Base.config.binary_path, global_opts, @logger)
+      Git::CommandLine::Streaming.new(env_overrides, binary_path, global_opts, @logger)
     end
   end
 end

--- a/lib/git/execution_context/global.rb
+++ b/lib/git/execution_context/global.rb
@@ -14,19 +14,41 @@ module Git
     # `GIT_SSH` is still supported to allow SSH-based remote operations
     # (e.g. `git clone git@github.com:...`).
     #
+    # @example Create a context using the default git binary
+    #   context = Git::ExecutionContext::Global.new
+    #
+    # @example Create a context targeting a specific binary
+    #   context = Git::ExecutionContext::Global.new(binary_path: '/usr/local/bin/git2')
+    #
     # @api private
     #
     class Global < ExecutionContext
       # Creates a new global execution context
       #
-      # @param git_ssh [String, nil, :use_global_config] SSH wrapper path, `nil` to
-      #   unset `GIT_SSH`, or `:use_global_config` (default) to inherit from
-      #   {Git::Base.config}
+      # @example Create with default settings
+      #   Git::ExecutionContext::Global.new
       #
-      # @param logger [Logger, nil] logger forwarded to the CommandLine layer;
-      #   `nil` uses a null logger (see {Git::ExecutionContext#initialize})
+      # @example Create with an explicit binary path
+      #   Git::ExecutionContext::Global.new(binary_path: '/usr/local/bin/git2')
       #
-      def initialize(git_ssh: :use_global_config, logger: nil)
+      # @param binary_path [String, :use_global_config] path to the git binary
+      #
+      #   Give `:use_global_config` (the default) to use `Git::Base.config.binary_path`.
+      #
+      #   Passing `nil` raises `ArgumentError` — there is no "unset the
+      #   binary" semantic.
+      #
+      # @param git_ssh [String, nil, :use_global_config] the SSH wrapper path
+      #
+      #   Give `nil` to unset `GIT_SSH`, or `:use_global_config` (default) to use `Git::Base.config.git_ssh`.
+      #
+      # @param logger [Logger, nil] the logger to use in the CommandLine layer
+      #
+      #   Give `nil` to use a null logger (`Logger.new(nil)`).
+      #
+      # @raise [ArgumentError] if `binary_path` is `nil`
+      #
+      def initialize(binary_path: :use_global_config, git_ssh: :use_global_config, logger: nil)
         super
       end
     end

--- a/lib/git/execution_context/repository.rb
+++ b/lib/git/execution_context/repository.rb
@@ -19,10 +19,23 @@ module Git
     #   context = Git::ExecutionContext::Repository.from_base(base)
     #   context = Git::ExecutionContext::Repository.from_hash(repository: '/repo/.git', ...)
     #
+    # @example Build from a Git::Base object
+    #   context = Git::ExecutionContext::Repository.from_base(git)
+    #
+    # @example Build from a configuration hash
+    #   context = Git::ExecutionContext::Repository.from_hash(
+    #     repository: '/path/to/.git',
+    #     working_directory: '/path/to'
+    #   )
+    #
     # @api private
     #
     class Repository < ExecutionContext
       # Creates a Repository context from a {Git::Base} instance
+      #
+      # @example Build from a base object
+      #   git = Git.open('/path/to/repo')
+      #   context = Git::ExecutionContext::Repository.from_base(git)
       #
       # @param base_object [Git::Base] the base Git object to derive context from
       #
@@ -41,9 +54,16 @@ module Git
         )
       end
 
-      # Creates a Repository context from the hash format used by {Git::Base.new}
+      # Creates a Repository context from a Hash
       #
-      # Expected keys: `:repository`, `:working_directory`, `:index`, `:git_ssh`
+      # Expected keys: `:repository`, `:working_directory`, `:index`, `:git_ssh`,
+      # `:binary_path`
+      #
+      # @example Build from a configuration hash
+      #   context = Git::ExecutionContext::Repository.from_hash(
+      #     repository: '/path/to/.git',
+      #     working_directory: '/path/to'
+      #   )
       #
       # @param base_hash [Hash] the hash of repository configuration values
       #
@@ -58,11 +78,15 @@ module Git
           git_index_file: base_hash[:index],
           git_work_dir: base_hash[:working_directory],
           git_ssh: base_hash.key?(:git_ssh) ? base_hash[:git_ssh] : :use_global_config,
+          binary_path: base_hash.key?(:binary_path) ? base_hash[:binary_path] : :use_global_config,
           logger: logger
         )
       end
 
       # Creates a new repository execution context
+      #
+      # @example Create with required git_dir
+      #   Git::ExecutionContext::Repository.new(git_dir: '/path/to/.git')
       #
       # @param git_dir [String, nil] path to the `.git` directory
       #
@@ -70,14 +94,32 @@ module Git
       #
       # @param git_index_file [String, nil] path to the index file
       #
-      # @param git_ssh [String, nil, :use_global_config] SSH wrapper path, `nil` to
-      #   unset, or `:use_global_config` (default) to inherit from {Git::Base.config}
+      # @param binary_path [String, :use_global_config] path to the git binary
       #
-      # @param logger [Logger, nil] logger forwarded to the CommandLine layer;
-      #   `nil` uses a null logger (see {Git::ExecutionContext#initialize})
+      #   Give `:use_global_config` (the default) to use `Git::Base.config.binary_path`.
       #
-      def initialize(git_dir:, git_work_dir: nil, git_index_file: nil, git_ssh: :use_global_config, logger: nil)
-        super(git_ssh: git_ssh, logger: logger)
+      #   Passing `nil` raises `ArgumentError` — there is no "unset the
+      #   binary" semantic.
+      #
+      # @param git_ssh [String, nil, :use_global_config] the SSH wrapper path
+      #
+      #   Give `nil` to unset `GIT_SSH`, or `:use_global_config` (default) to use `Git::Base.config.git_ssh`.
+      #
+      # @param logger [Logger, nil] the logger to use in the CommandLine layer
+      #
+      #   Give `nil` to use a null logger (`Logger.new(nil)`).
+      #
+      # @raise [ArgumentError] if `binary_path` is `nil`
+      #
+      def initialize( # rubocop:disable Metrics/ParameterLists
+        git_dir:,
+        git_work_dir: nil,
+        git_index_file: nil,
+        binary_path: :use_global_config,
+        git_ssh: :use_global_config,
+        logger: nil
+      )
+        super(binary_path: binary_path, git_ssh: git_ssh, logger: logger)
         @git_dir = git_dir
         @git_work_dir = git_work_dir
         @git_index_file = git_index_file

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -17,7 +17,6 @@ require 'process_executer'
 require 'stringio'
 require 'tempfile'
 require 'zlib'
-require 'open3'
 
 module Git
   # Internal git operations
@@ -1869,7 +1868,7 @@ module Git
     #
     # @return [Git::Version] the parsed git version
     #
-    # @raise [Git::Error] if the version cannot be parsed
+    # @raise [Git::UnexpectedResultError] if the version string cannot be parsed
     #
     # @example
     #   lib.git_version #=> Git::Version.new(2, 42, 1)
@@ -1878,8 +1877,6 @@ module Git
       self.class.cached_git_version(Git::Base.config.binary_path) do
         output = Git::Commands::Version.new(self).call.stdout
         Git::Version.parse(output)
-      rescue ArgumentError => e
-        raise Git::Error, "Unable to parse git version from: #{output.inspect} (#{e.message})"
       end
     end
 

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -2,7 +2,8 @@
 
 module Git
   # The current gem version
-  # @return [String] the current gem version.
+  #
+  # @return [String] the current gem version
   VERSION = '4.1.2'
 
   # Represents a git version with major, minor, and patch components
@@ -48,20 +49,20 @@ module Git
     # (like `.windows.1` or `.vfs.0`) and padding two-segment versions
     # to three segments.
     #
-    # @param string [String] version string to parse
-    #
-    # @return [Git::Version] the parsed version
-    #
-    # @raise [ArgumentError] if the string cannot be parsed as a version
-    #
-    # @example
+    # @example Parse various version string formats
     #   Git::Version.parse('2.42.1')  #=> Git::Version.new(2, 42, 1)
     #   Git::Version.parse('git version 2.42.1')  #=> Git::Version.new(2, 42, 1)
     #   Git::Version.parse('2.42.0.windows.1')  #=> Git::Version.new(2, 42, 0)
     #
+    # @param string [String] version string to parse
+    #
+    # @return [Git::Version] the parsed version
+    #
+    # @raise [Git::UnexpectedResultError] if the string cannot be parsed as a version
+    #
     def self.parse(string)
       version_match = string&.match(/(\d+)\.(\d+)(?:\.(\d+))?/)
-      raise ArgumentError, "Invalid version: #{string.inspect}" unless version_match
+      raise Git::UnexpectedResultError, "Invalid version: #{string.inspect}" unless version_match
 
       major = version_match[1].to_i
       minor = version_match[2].to_i

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -23,19 +23,21 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
 | Phase 2 | ✅ Complete | Migrating commands (all checklist items done) |
-| Phase 3 | ⏳ In Progress | Refactoring public interface (Task 1 ✅) |
+| Phase 3 | ⏳ In Progress | Refactoring public interface (Tasks 1 ✅, 2 ✅) |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Phase 3, Task 2: Add `binary_path:` to `Git::ExecutionContext`**
+**Phase 3, Task 3: Refactor Factory Methods**
 
-Phase 3, Task 1 is complete — `Git::ExecutionContext` is now a real base class, and
-`Git::ExecutionContext::Repository` and `Git::ExecutionContext::Global` are implemented and fully tested.
+Phase 3, Tasks 1 and 2 are complete — `Git::ExecutionContext` is a real base class with
+a `binary_path:` constructor argument, all subclasses forward it, and the `Open3`
+stopgap in `Git.run_git_version` has been retired in favour of
+`Git::Commands::Version.new(Git::ExecutionContext::Global.new(binary_path: path)).call.stdout`.
 
-Task 2 adds a `binary_path:` constructor argument to `Git::ExecutionContext` so that
-context objects can target an arbitrary git binary, and retires the `Open3` stopgap
-in `Git.run_git_version`.
+Task 3 refactors the factory methods (`Git::ExecutionContext::Repository.from_base`,
+`.from_hash`) to clean up any remaining coupling and ensure the full builder chain
+is consistent with the new architecture.
 
 #### Workflow
 

--- a/spec/unit/git/execution_context/global_spec.rb
+++ b/spec/unit/git/execution_context/global_spec.rb
@@ -23,6 +23,25 @@ RSpec.describe Git::ExecutionContext::Global do
     it 'accepts an optional git_ssh path' do
       expect { described_class.new(git_ssh: '/usr/bin/ssh') }.not_to raise_error
     end
+
+    it 'accepts an optional binary_path' do
+      expect { described_class.new(binary_path: '/usr/local/bin/git') }.not_to raise_error
+    end
+  end
+
+  describe 'binary_path resolution' do
+    it 'delegates to Git::Base.config by default' do
+      allow(Git::Base).to receive_message_chain(:config, :binary_path).and_return('/global/git')
+      expect(described_class.new.binary_path).to eq('/global/git')
+    end
+
+    it 'returns an explicit path when provided' do
+      expect(described_class.new(binary_path: '/usr/local/bin/git').binary_path).to eq('/usr/local/bin/git')
+    end
+
+    it 'raises ArgumentError when explicitly passed nil' do
+      expect { described_class.new(binary_path: nil) }.to raise_error(ArgumentError, /binary_path/)
+    end
   end
 
   describe 'accessor methods' do

--- a/spec/unit/git/execution_context/repository_spec.rb
+++ b/spec/unit/git/execution_context/repository_spec.rb
@@ -27,9 +27,29 @@ RSpec.describe Git::ExecutionContext::Repository do
           git_work_dir: git_work_dir,
           git_index_file: git_index_file,
           git_ssh: '/usr/bin/ssh',
+          binary_path: '/usr/local/bin/git',
           logger: nil
         )
       end.not_to raise_error
+    end
+  end
+
+  describe 'binary_path resolution' do
+    context 'with :use_global_config (default)' do
+      let(:context) { described_class.new(git_dir: git_dir) }
+
+      it 'delegates to Git::Base.config.binary_path' do
+        allow(Git::Base).to receive_message_chain(:config, :binary_path).and_return('/global/git')
+        expect(context.binary_path).to eq('/global/git')
+      end
+    end
+
+    context 'with a literal binary_path' do
+      let(:context) { described_class.new(git_dir: git_dir, binary_path: '/usr/local/bin/git') }
+
+      it 'returns the provided path' do
+        expect(context.binary_path).to eq('/usr/local/bin/git')
+      end
     end
   end
 
@@ -240,6 +260,16 @@ RSpec.describe Git::ExecutionContext::Repository do
     it 'uses the provided git_ssh when :git_ssh is present in hash' do
       hash[:git_ssh] = '/custom/ssh'
       expect(context.git_ssh).to eq('/custom/ssh')
+    end
+
+    it 'defaults binary_path to :use_global_config when :binary_path is absent' do
+      allow(Git::Base).to receive_message_chain(:config, :binary_path).and_return('/global/git')
+      expect(context.binary_path).to eq('/global/git')
+    end
+
+    it 'uses the provided binary_path when :binary_path is present in hash' do
+      hash[:binary_path] = '/custom/git'
+      expect(context.binary_path).to eq('/custom/git')
     end
   end
 

--- a/spec/unit/git/execution_context_spec.rb
+++ b/spec/unit/git/execution_context_spec.rb
@@ -3,6 +3,13 @@
 require 'spec_helper'
 
 RSpec.describe Git::ExecutionContext do
+  describe '.new' do
+    it 'raises NotImplementedError when instantiated directly' do
+      expect { described_class.new }
+        .to raise_error(NotImplementedError, /abstract base class/)
+    end
+  end
+
   describe 'constants' do
     it 'defines COMMAND_CAPTURING_ARG_DEFAULTS' do
       expect(described_class::COMMAND_CAPTURING_ARG_DEFAULTS).to be_a(Hash)
@@ -21,7 +28,7 @@ RSpec.describe Git::ExecutionContext do
   end
 
   describe 'accessor defaults' do
-    let(:context) { described_class.new }
+    let(:context) { Git::ExecutionContext::Global.new }
 
     it 'returns nil for git_dir' do
       expect(context.git_dir).to be_nil
@@ -41,16 +48,31 @@ RSpec.describe Git::ExecutionContext do
     end
 
     it 'returns nil for git_ssh when explicitly passed nil' do
-      expect(described_class.new(git_ssh: nil).git_ssh).to be_nil
+      expect(Git::ExecutionContext::Global.new(git_ssh: nil).git_ssh).to be_nil
     end
 
     it 'returns a literal git_ssh path when provided' do
-      expect(described_class.new(git_ssh: '/usr/bin/ssh').git_ssh).to eq('/usr/bin/ssh')
+      expect(Git::ExecutionContext::Global.new(git_ssh: '/usr/bin/ssh').git_ssh).to eq('/usr/bin/ssh')
+    end
+
+    it 'delegates binary_path to Git::Base.config by default' do
+      allow(Git::Base).to receive_message_chain(:config, :binary_path).and_return('/configured/git')
+      expect(context.binary_path).to eq('/configured/git')
+    end
+
+    it 'returns an explicit binary_path when provided' do
+      expect(Git::ExecutionContext::Global.new(binary_path: '/usr/local/bin/git').binary_path).to(
+        eq('/usr/local/bin/git')
+      )
+    end
+
+    it 'raises ArgumentError when explicitly passed nil' do
+      expect { Git::ExecutionContext::Global.new(binary_path: nil) }.to raise_error(ArgumentError, /binary_path/)
     end
   end
 
   describe 'env_overrides (via #send)' do
-    let(:context) { described_class.new(git_ssh: nil) }
+    let(:context) { Git::ExecutionContext::Global.new(git_ssh: nil) }
 
     it 'returns GIT_DIR as nil by default' do
       expect(context.send(:env_overrides)['GIT_DIR']).to be_nil
@@ -84,13 +106,13 @@ RSpec.describe Git::ExecutionContext do
 
   describe 'global_opts (via #send)' do
     it 'includes only static opts when git_dir and git_work_dir are nil' do
-      context = described_class.new
+      context = Git::ExecutionContext::Global.new
       expect(context.send(:global_opts)).to eq(described_class::STATIC_GLOBAL_OPTS)
     end
   end
 
   describe '#command_capturing' do
-    let(:context) { described_class.new }
+    let(:context) { Git::ExecutionContext::Global.new }
     let(:command_line_double) { instance_double(Git::CommandLine::Capturing) }
     let(:result) { command_result('output') }
 
@@ -113,7 +135,7 @@ RSpec.describe Git::ExecutionContext do
   end
 
   describe '#command_streaming' do
-    let(:context) { described_class.new }
+    let(:context) { Git::ExecutionContext::Global.new }
     let(:command_line_double) { instance_double(Git::CommandLine::Streaming) }
     let(:result) { command_result('') }
 
@@ -136,7 +158,7 @@ RSpec.describe Git::ExecutionContext do
   end
 
   describe '#git_version' do
-    let(:context) { described_class.new }
+    let(:context) { Git::ExecutionContext::Global.new }
     let(:version_command_double) { instance_double(Git::Commands::Version) }
 
     before do
@@ -155,10 +177,10 @@ RSpec.describe Git::ExecutionContext do
       context.git_version
     end
 
-    it 'raises Git::Error with a helpful message when the output cannot be parsed' do
+    it 'raises Git::UnexpectedResultError when the output cannot be parsed' do
       allow(version_command_double).to receive(:call).and_return(command_result('not a version string'))
       expect { context.git_version }
-        .to raise_error(Git::Error, /Unable to parse git version/)
+        .to raise_error(Git::UnexpectedResultError)
     end
   end
 end

--- a/spec/unit/git/git_version_spec.rb
+++ b/spec/unit/git/git_version_spec.rb
@@ -5,15 +5,18 @@ require 'spec_helper'
 RSpec.describe Git do
   describe '.git_version' do
     let(:binary_path) { Git::Base.config.binary_path }
-    let(:success_status) { instance_double(Process::Status, success?: true) }
-    let(:failure_status) { instance_double(Process::Status, success?: false) }
+    let(:context) { instance_double(Git::ExecutionContext::Global) }
+    let(:version_cmd) { instance_double(Git::Commands::Version) }
 
-    before { Git::Lib.clear_git_version_cache }
+    before do
+      Git::Lib.clear_git_version_cache
+      allow(Git::ExecutionContext::Global).to receive(:new).and_return(context)
+      allow(Git::Commands::Version).to receive(:new).with(context).and_return(version_cmd)
+    end
 
     context 'when called with no argument (default binary)' do
       before do
-        allow(Open3).to receive(:capture2e).with(binary_path, 'version')
-                                           .and_return(['git version 2.42.0', success_status])
+        allow(version_cmd).to receive(:call).and_return(command_result('git version 2.42.0'))
       end
 
       it 'returns a Git::Version' do
@@ -25,78 +28,98 @@ RSpec.describe Git do
 
     context 'when called with an explicit binary_path' do
       let(:explicit_path) { '/usr/local/bin/git2' }
+      let(:explicit_context) { instance_double(Git::ExecutionContext::Global) }
+      let(:explicit_cmd) { instance_double(Git::Commands::Version) }
+
+      before do
+        allow(Git::ExecutionContext::Global).to receive(:new)
+          .with(binary_path: explicit_path).and_return(explicit_context)
+        allow(Git::Commands::Version).to receive(:new).with(explicit_context).and_return(explicit_cmd)
+        allow(explicit_cmd).to receive(:call).and_return(command_result('git version 2.42.0'))
+      end
 
       it 'returns a Git::Version for the specified binary' do
-        allow(Open3).to receive(:capture2e).with(explicit_path, 'version')
-                                           .and_return(['git version 2.42.0', success_status])
-
         version = described_class.git_version(explicit_path)
 
         expect(version).to be_a(Git::Version)
-        expect(Open3).to have_received(:capture2e).with(explicit_path, 'version').once
+        expect(explicit_cmd).to have_received(:call).once
       end
 
       it 'caches the result per binary path (second call does not re-shell)' do
-        allow(Open3).to receive(:capture2e).with(explicit_path, 'version')
-                                           .and_return(['git version 2.40.0', success_status])
+        allow(explicit_cmd).to receive(:call).and_return(command_result('git version 2.40.0'))
 
         described_class.git_version(explicit_path)
         described_class.git_version(explicit_path)
 
-        expect(Open3).to have_received(:capture2e).once
+        expect(explicit_cmd).to have_received(:call).once
       end
 
       it 'caches independently from the default binary path' do
-        allow(Open3).to receive(:capture2e).with(binary_path, 'version')
-                                           .and_return(['git version 2.42.0', success_status])
-        allow(Open3).to receive(:capture2e).with(explicit_path, 'version')
-                                           .and_return(['git version 2.40.0', success_status])
+        allow(version_cmd).to receive(:call).and_return(command_result('git version 2.42.0'))
 
         described_class.git_version
         described_class.git_version(explicit_path)
 
-        expect(Open3).to have_received(:capture2e).with(binary_path, 'version').once
-        expect(Open3).to have_received(:capture2e).with(explicit_path, 'version').once
+        expect(version_cmd).to have_received(:call).once
+        expect(explicit_cmd).to have_received(:call).once
       end
     end
 
     context 'when the binary is not found' do
       before do
-        allow(Open3).to receive(:capture2e).and_raise(Errno::ENOENT)
+        allow(Git::ExecutionContext::Global).to receive(:new).and_call_original
+        allow(Git::Commands::Version).to receive(:new).and_call_original
+        allow(ProcessExecuter).to receive(:run_with_capture) do
+          raise Errno::ENOENT, 'git'
+        rescue Errno::ENOENT
+          raise ProcessExecuter::SpawnError, 'Failed to spawn process: No such file or directory - git'
+        end
       end
 
-      it 'raises Git::Error' do
-        expect { described_class.git_version }.to raise_error(Git::Error, /Git binary not found/)
+      it 'raises Git::Error with Errno::ENOENT as cause' do
+        expect { described_class.git_version }.to raise_error(Git::Error) do |error|
+          expect(error.cause).to be_a(Errno::ENOENT)
+        end
       end
     end
 
     context 'when the binary exists but is not executable' do
       before do
-        allow(Open3).to receive(:capture2e).and_raise(Errno::EACCES)
+        allow(Git::ExecutionContext::Global).to receive(:new).and_call_original
+        allow(Git::Commands::Version).to receive(:new).and_call_original
+        allow(ProcessExecuter).to receive(:run_with_capture) do
+          raise Errno::EACCES, 'git'
+        rescue Errno::EACCES
+          raise ProcessExecuter::SpawnError, 'Failed to spawn process: Permission denied - git'
+        end
       end
 
-      it 'raises Git::Error' do
-        expect { described_class.git_version }.to raise_error(Git::Error, /Failed to execute git binary/)
+      it 'raises Git::Error with Errno::EACCES as cause' do
+        expect { described_class.git_version }.to raise_error(Git::Error) do |error|
+          expect(error.cause).to be_a(Errno::EACCES)
+        end
       end
     end
 
     context 'when the binary exits with a non-zero status' do
       before do
-        allow(Open3).to receive(:capture2e).and_return(['git: command not found', failure_status])
+        allow(version_cmd).to receive(:call).and_raise(
+          Git::FailedError.new(command_result('', stderr: 'git: command not found', exitstatus: 1))
+        )
       end
 
-      it 'raises Git::Error' do
-        expect { described_class.git_version }.to raise_error(Git::Error, /Failed to run/)
+      it 'raises Git::FailedError' do
+        expect { described_class.git_version }.to raise_error(Git::FailedError)
       end
     end
 
     context 'when the version cannot be parsed' do
       before do
-        allow(Open3).to receive(:capture2e).and_return(['not a version string', success_status])
+        allow(version_cmd).to receive(:call).and_return(command_result('not a version string'))
       end
 
-      it 'raises Git::Error' do
-        expect { described_class.git_version }.to raise_error(Git::Error, /Unable to parse git version/)
+      it 'raises Git::UnexpectedResultError' do
+        expect { described_class.git_version }.to raise_error(Git::UnexpectedResultError)
       end
     end
   end

--- a/spec/unit/git/lib/git_version_spec.rb
+++ b/spec/unit/git/lib/git_version_spec.rb
@@ -24,11 +24,11 @@ RSpec.describe Git::Lib do
     end
 
     context 'with unparseable output' do
-      it 'raises Git::Error' do
+      it 'raises Git::UnexpectedResultError' do
         allow(version_command).to receive(:call).and_return(command_result('not a version'))
-        allow(Git::Version).to receive(:parse).and_raise(ArgumentError, 'Invalid version')
+        allow(Git::Version).to receive(:parse).and_raise(Git::UnexpectedResultError, 'Invalid version')
 
-        expect { lib.git_version }.to raise_error(Git::Error, /Unable to parse git version/)
+        expect { lib.git_version }.to raise_error(Git::UnexpectedResultError, 'Invalid version')
       end
     end
 

--- a/spec/unit/git/version_spec.rb
+++ b/spec/unit/git/version_spec.rb
@@ -72,20 +72,20 @@ RSpec.describe Git::Version do
     end
 
     context 'with invalid input' do
-      it 'raises ArgumentError for nil' do
-        expect { described_class.parse(nil) }.to raise_error(ArgumentError, /Invalid version/)
+      it 'raises Git::UnexpectedResultError for nil' do
+        expect { described_class.parse(nil) }.to raise_error(Git::UnexpectedResultError, /Invalid version/)
       end
 
-      it 'raises ArgumentError for empty string' do
-        expect { described_class.parse('') }.to raise_error(ArgumentError, /Invalid version/)
+      it 'raises Git::UnexpectedResultError for empty string' do
+        expect { described_class.parse('') }.to raise_error(Git::UnexpectedResultError, /Invalid version/)
       end
 
-      it 'raises ArgumentError for non-version string' do
-        expect { described_class.parse('not a version') }.to raise_error(ArgumentError, /Invalid version/)
+      it 'raises Git::UnexpectedResultError for non-version string' do
+        expect { described_class.parse('not a version') }.to raise_error(Git::UnexpectedResultError, /Invalid version/)
       end
 
-      it 'raises ArgumentError for single segment' do
-        expect { described_class.parse('2') }.to raise_error(ArgumentError, /Invalid version/)
+      it 'raises Git::UnexpectedResultError for single segment' do
+        expect { described_class.parse('2') }.to raise_error(Git::UnexpectedResultError, /Invalid version/)
       end
     end
   end


### PR DESCRIPTION
## Summary

Adds a `binary_path:` keyword argument to `Git::ExecutionContext` and all subclasses so that execution context objects can target an arbitrary git binary, rather than always reading `Git::Base.config.binary_path` at call-time. This completes Phase 3, Task 2 of the architectural redesign.

Also retires the `Open3` stopgap in `Git.run_git_version` and removes the stale `require 'open3'` from both `lib/git.rb` and `lib/git/lib.rb`.

## Changes

### Production code

- **`lib/git/execution_context.rb`** — `#initialize` gains `binary_path: :use_global_config`; new `#binary_path` reader resolves the sentinel to `Git::Base.config.binary_path` at call-time; both `command_line_capturing` and `command_line_streaming` now use `#binary_path` instead of the global config directly; `#initialize` now raises `NotImplementedError` when called directly on the base class.
- **`lib/git/execution_context/global.rb`** — forwards `binary_path:` through its constructor.
- **`lib/git/execution_context/repository.rb`** — forwards `binary_path:` through its constructor and `from_hash` factory.
- **`lib/git/command_line/base.rb`** — wraps `ProcessExecuter::SpawnError` into `Git::Error` (with preserved `cause`) so callers see a stable error type when the binary cannot be spawned.
- **`lib/git.rb`** — removes `require 'open3'`; rewrites `run_git_version` to use `Git::Commands::Version.new(Git::ExecutionContext::Global.new(binary_path: path)).call.stdout`. Spawn errors (binary not found, permission denied, etc.) are now surfaced as `Git::Error` via the `command_line/base.rb` rescue with the original `Errno::*` preserved as `cause`.
- **`lib/git/lib.rb`** — removes the unused `require 'open3'`.

### Tests

- **`spec/unit/git/git_version_spec.rb`** — all `Open3` stubs replaced with `ExecutionContext::Global` / `Git::Commands::Version` doubles; error expectations updated for the new error types.
- **`spec/unit/git/execution_context_spec.rb`** — new tests for `binary_path:` default and override; `described_class.new` usages updated to `Git::ExecutionContext::Global.new` after the abstract-class guard was added.
- **`spec/unit/git/execution_context/global_spec.rb`** — 4 new tests for `binary_path:` forwarding and resolution.
- **`spec/unit/git/execution_context/repository_spec.rb`** — 4 new/updated tests for `binary_path:` forwarding via constructor and `from_hash`.

## Testing

- 4741 RSpec examples, 0 failures
- 559 TestUnit tests, 0 failures
- rubocop: no offenses

## Redesign progress

Phase 3, Tasks 1 ✅ and 2 ✅ are complete. Next: Task 3 — refactor factory methods.