### PR TITLE
feat(execution-context): thread binary_path through execution-context builder chain

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -97,32 +97,62 @@ module Git
     # @param [Hash] options The options for this command (see list of valid
     #   options below)
     #
-    # @option options [Pathname] :working_dir the path to the root of the working
-    #   directory.  Should be `nil` if executing commands on a bare repository.
+    # @option options [Pathname] :working_directory the path to the root of the working
+    #   directory or `nil` if executing commands on a bare repository
     #
     # @option options [Pathname] :repository used to specify a non-standard path to
-    #   the repository directory.  The default is `"#{working_dir}/.git"`.
+    #   the repository directory
+    #
+    #   The default is `"<working_directory>/.git"`.
     #
     # @option options [Pathname] :index used to specify a non-standard path to an
-    #   index file.  The default is `"#{working_dir}/.git/index"`
+    #   index file
     #
-    # @option options [Logger] :log A logger to use for Git operations.  Git
-    #   commands are logged at the `:info` level.  Additional logging is done
+    #   The default is `"<working_directory>/.git/index"`
+    #
+    # @option options [Logger] :log A logger to use for Git operations
+    #
+    #   Git commands are logged at the `:info` level.  Additional logging is done
     #   at the `:debug` level.
     #
-    # @option options [String, nil] :git_ssh Path to a custom SSH executable or script.
+    # @option options [String, nil] :git_ssh Path to a custom SSH executable or script
+    #
     #   Controls how SSH is configured for this {Git::Base} instance:
     #   - If this option is not provided, the global Git::Base.config.git_ssh setting is used.
     #   - If this option is explicitly set to nil, SSH is disabled for this instance.
     #   - If this option is a non-empty String, that value is used as the SSH command for
     #     this instance, overriding the global Git::Base.config.git_ssh setting.
     #
-    # @return [Git::Base] an object that can execute git commands in the context
-    #   of the opened working copy or bare repository
+    # @option options [String, :use_global_config] :binary_path Path to the git binary
+    #
+    #   Controls which git binary is used for commands routed through
+    #   {Git::ExecutionContext} (i.e., commands already migrated to
+    #   +Git::Commands::*+ classes). Commands still delegating through +Git::Lib+
+    #   continue to use the global {Git::Base.config.binary_path} setting.
+    #
+    #   This limitation will be resolved when the architectural migration to
+    #   +Git::Repository+ is complete.
+    #
+    #   - If this option is not provided, the global Git::Base.config.binary_path setting is used.
+    #   - If this option is a String, that value is used as the git binary path for
+    #     migrated commands, overriding the global Git::Base.config.binary_path setting.
+    #   - Passing `nil` raises ArgumentError — there is no "unset the binary" semantic.
+    #
+    # @return [Git::Base] an object that can execute git commands on a working copy or
+    #   bare repository
+    #
+    # @raise [ArgumentError] if `binary_path` is `nil`
     #
     def initialize(options = {})
       setup_logger(options[:log])
       @git_ssh = options.key?(:git_ssh) ? options[:git_ssh] : :use_global_config
+      if options.key?(:binary_path)
+        raise ArgumentError, 'binary_path must not be nil' if options[:binary_path].nil?
+
+        @binary_path = options[:binary_path]
+      else
+        @binary_path = :use_global_config
+      end
       initialize_components(options)
     end
 
@@ -133,10 +163,13 @@ module Git
     #   lib.add(['path/to/file1','path/to/file2'])
     #   lib.add(all: true)
     #
-    # @param [String, Array<String>] paths a file or files to be added to the repository (relative to the worktree root)
+    # @param [String, Array<String>] paths a file or files to be added to the repository
+    #   relative to the worktree root
+    #
     # @param [Hash] options
     #
     # @option options [Boolean] :all Add, modify, and remove index entries to match the worktree
+    #
     # @option options [Boolean] :force Allow adding otherwise ignored files
     #
     def add(paths = '.', **options)
@@ -313,7 +346,7 @@ module Git
       @lib ||= Git::Lib.new(self, @logger)
     end
 
-    # Returns the per-instance git_ssh configuration value.
+    # Returns the per-instance git_ssh configuration value
     #
     # This may be:
     # * a [String] path when an explicit git_ssh command has been configured
@@ -323,6 +356,16 @@ module Git
     # @return [String, Symbol, nil] the git_ssh configuration value for this instance
     # @api private
     attr_reader :git_ssh
+
+    # Returns the per-instance git binary path configuration value
+    #
+    # This may be:
+    # * a [String] path when an explicit binary path has been configured
+    # * the Symbol `:use_global_config` when this instance is using the global config
+    #
+    # @return [String, Symbol] the binary_path configuration value for this instance
+    # @api private
+    attr_reader :binary_path
 
     # Run a grep for 'string' on the HEAD of the git repository
     #

--- a/lib/git/execution_context/repository.rb
+++ b/lib/git/execution_context/repository.rb
@@ -50,6 +50,7 @@ module Git
           git_index_file: base_object.index&.to_s,
           git_work_dir: base_object.dir&.to_s,
           git_ssh: base_object.git_ssh,
+          binary_path: base_object.binary_path,
           logger: logger
         )
       end

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -23,42 +23,52 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
 | Phase 2 | ✅ Complete | Migrating commands (all checklist items done) |
-| Phase 3 | ⏳ In Progress | Refactoring public interface (Tasks 1 ✅, 2 ✅) |
+| Phase 3 | ⏳ In Progress | Refactoring public interface (Tasks 1 ✅, 2 ✅, 3 ✅) |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Phase 3, Task 3: Refactor Factory Methods**
+**Phase 3, Task 4: Implement the `Git::Repository` Facade**
 
-Phase 3, Tasks 1 and 2 are complete — `Git::ExecutionContext` is a real base class with
-a `binary_path:` constructor argument, all subclasses forward it, and the `Open3`
-stopgap in `Git.run_git_version` has been retired in favour of
-`Git::Commands::Version.new(Git::ExecutionContext::Global.new(binary_path: path)).call.stdout`.
+Phase 3, Tasks 1–3 are complete:
+- Tasks 1 and 2: `Git::ExecutionContext` has a `binary_path:` constructor argument;
+  all subclasses accept and store it; `command_line_capturing` /
+  `command_line_streaming` use `@binary_path` instead of reading
+  `Git::Base.config.binary_path` at definition time; `Git.run_git_version` uses
+  `Git::Commands::Version` via `Git::ExecutionContext::Global` — the `Open3` stopgap
+  is gone.
+- Task 3: `Git::Base` has a per-instance `binary_path` attribute (mirrors `git_ssh`);
+  `Git::ExecutionContext::Repository.from_base` forwards it, completing the builder
+  chain so every context can carry an instance-specific binary path end-to-end.
 
-Task 3 refactors the factory methods (`Git::ExecutionContext::Repository.from_base`,
-`.from_hash`) to clean up any remaining coupling and ensure the full builder chain
-is consistent with the new architecture.
+Task 4 populates `Git::Repository` with facade methods — thin, one-line delegators
+that forward each public git operation to the appropriate `Git::Commands::*` class,
+using the `Git::ExecutionContext::Repository` injected at construction time. Facade
+methods are organized into focused modules under `lib/git/repository/` and included
+into the `Git::Repository` class.
 
 #### Workflow
 
-1. **Analyze**: Review `lib/git/execution_context.rb` — specifically
-   `command_line_capturing` and `command_line_streaming`, which currently hardcode
-   `Git::Base.config.binary_path`. Also review `Git.run_git_version` in `lib/git.rb`
-   and the `Git.git_version` public method.
+1. **Analyze**: Review `lib/git/repository.rb` (currently an empty shell) and the
+   existing `Git::Base` public methods to identify the first set of facade methods to
+   implement. Start with one module (e.g., `lib/git/repository/staging.rb` for `add`
+   / `reset`) to establish the pattern before expanding.
 
-2. **Implement**:
-   - Add `binary_path: Git::Base.config.binary_path` to `Git::ExecutionContext#initialize`
-   - Store as `@binary_path`; use it in `command_line_capturing` and `command_line_streaming`
-     instead of `Git::Base.config.binary_path`
-   - Forward `binary_path:` in `Git::ExecutionContext::Repository.from_base` and `.from_hash`
-   - Replace the `Open3` call in `Git.run_git_version` with
-     `Git::Commands::Version.new(Git::ExecutionContext::Global.new(binary_path: path)).call.stdout`
-   - Remove the `Open3` require from `lib/git.rb` if it is no longer needed
+2. **Implement** (one module at a time, TDD):
+   - Create `lib/git/repository/<topic>.rb` with a module
+     `Git::Repository::<Topic>` containing one-line facade methods, e.g.:
+     ```ruby
+     def add(paths = '.', **opts)
+       Git::Commands::Add.new(@execution_context).call(paths, **opts)
+     end
+     ```
+   - `include` the module in `lib/git/repository.rb`
+   - Each method should delegate entirely to the corresponding `Git::Commands::*`
+     class; no logic beyond argument forwarding belongs in the facade
 
-3. **TDD**: Add / update specs in:
-   - `spec/unit/git/execution_context_spec.rb` — `binary_path:` default and override
-   - `spec/unit/git/execution_context/repository_spec.rb` — forwarded via factory methods
-   - `spec/unit/git/execution_context/global_spec.rb` — forwarded via constructor
+3. **TDD**: For each facade module:
+   - `spec/unit/git/repository/<topic>_spec.rb` — stub the command class and assert
+     the facade delegates correctly; do NOT exercise real git commands in unit specs
 
 4. **Verify**:
    - `bundle exec rspec` — all RSpec tests pass
@@ -67,14 +77,15 @@ is consistent with the new architecture.
    - `bundle exec yard` — no yardoc errors
 
 5. **Update Checklist**: Update the Phase 3 progress tracker in this document when
-   Task 2 is complete. Update the "Next Task" heading to describe Task 3 (refactor
-   factory methods).
+   Task 4 (or each module) is complete. Update the "Next Task" heading to describe
+   Task 5 (update `Git.open` / `Git.bare` etc. to return `Git::Repository` instead of
+   `Git::Base`).
 
 #### Reference Files
 
-- Execution context: `lib/git/execution_context.rb`,
-  `lib/git/execution_context/repository.rb`, `lib/git/execution_context/global.rb`
-- Stopgap method: `lib/git.rb` (`Git.run_git_version`)
+- Facade shell: `lib/git/repository.rb`
+- Existing public API to replicate: `lib/git/base.rb` public methods
+- Command classes: `lib/git/commands/`
 - Phase 3 plan: see "Phase 3: Refactoring the Public Interface" section below
 
 ## Phase 1: Foundation and Scaffolding

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::Base do
+  describe '#binary_path' do
+    context 'when not specified' do
+      subject(:base) { described_class.new }
+
+      it 'defaults to :use_global_config' do
+        expect(base.binary_path).to eq(:use_global_config)
+      end
+    end
+
+    context 'when an explicit path is provided' do
+      subject(:base) { described_class.new(binary_path: '/custom/git') }
+
+      it 'returns the provided path' do
+        expect(base.binary_path).to eq('/custom/git')
+      end
+    end
+
+    context 'when binary_path is explicitly nil' do
+      it 'raises ArgumentError' do
+        expect { described_class.new(binary_path: nil) }.to raise_error(ArgumentError, /binary_path/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/execution_context/repository_spec.rb
+++ b/spec/unit/git/execution_context/repository_spec.rb
@@ -187,7 +187,9 @@ RSpec.describe Git::ExecutionContext::Repository do
     let(:index_double) { double('index', to_s: git_index_file) }
     let(:dir_double) { double('dir', to_s: git_work_dir) }
     let(:base) do
-      double('Git::Base', repo: repo_double, index: index_double, dir: dir_double, git_ssh: nil)
+      double('Git::Base',
+             repo: repo_double, index: index_double, dir: dir_double,
+             git_ssh: nil, binary_path: :use_global_config)
     end
 
     subject(:context) { described_class.from_base(base) }
@@ -206,6 +208,25 @@ RSpec.describe Git::ExecutionContext::Repository do
 
     it 'extracts git_index_file from base.index.to_s' do
       expect(context.git_index_file).to eq(git_index_file)
+    end
+
+    context 'when base.binary_path is an explicit path' do
+      let(:base) do
+        double('Git::Base',
+               repo: repo_double, index: index_double, dir: dir_double,
+               git_ssh: nil, binary_path: '/custom/git')
+      end
+
+      it 'forwards binary_path to the context' do
+        expect(context.binary_path).to eq('/custom/git')
+      end
+    end
+
+    context 'when base.binary_path is :use_global_config (default)' do
+      it 'delegates binary_path resolution to Git::Base.config' do
+        allow(Git::Base).to receive_message_chain(:config, :binary_path).and_return('/global/git')
+        expect(context.binary_path).to eq('/global/git')
+      end
     end
 
     context 'when base.dir is nil' do


### PR DESCRIPTION
## Summary

Completes Phase 3 Tasks 2 and 3 of the architectural redesign — threading a
per-instance `binary_path` through the full execution-context builder chain so that
every git command can target a custom binary without touching the global
`Git::Base.config.binary_path`.

## Changes

### Task 2 — Add `binary_path:` to `Git::ExecutionContext` and retire `Open3` stopgap

- `Git::ExecutionContext#initialize` now accepts `binary_path: :use_global_config`.
  Stores `@binary_path`; `command_line_capturing` and `command_line_streaming` resolve
  it at call time (`:use_global_config` → `Git::Base.config.binary_path`).
- `Git::ExecutionContext::Repository.from_hash` forwards `:binary_path` from the hash.
- `Git::ExecutionContext::Global.new(binary_path: path)` works as expected.
- `Git.run_git_version` now uses
  `Git::Commands::Version.new(Git::ExecutionContext::Global.new(binary_path: path)).call.stdout`
  — the `Open3` stopgap is removed.

### Task 3 — Add `binary_path` to `Git::Base` and forward via `from_base`

- `Git::Base#initialize` now accepts `binary_path:` (mirrors the existing `git_ssh`
  pattern). Defaults to `:use_global_config` when not provided.
- `attr_reader :binary_path` exposed on `Git::Base`.
- `Git::ExecutionContext::Repository.from_base` forwards `base_object.binary_path`,
  completing the chain: instance-specific binary path flows from `Git::Base` all the
  way through to every `Git::Commands::*` call.

## Tests

- `spec/unit/git/base_spec.rb` (new) — covers default and explicit `binary_path`
  on `Git::Base`.
- `spec/unit/git/execution_context/repository_spec.rb` — `from_base` double updated
  to include `binary_path:`; new contexts for explicit-path forwarding and
  `:use_global_config` delegation.
- `spec/unit/git/execution_context/global_spec.rb` and
  `spec/unit/git/execution_context_spec.rb` — existing coverage retained.

4743 RSpec examples, 0 failures. 559 TestUnit tests pass. Rubocop clean.

## Related

Part of the Phase 3 architectural redesign tracked in
`redesign/3_architecture_implementation.md`.