### PR TITLE
Update copilot instructions and add anonymous-splat @overload rule to yard-documentation skill

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,6 +14,15 @@ For architecture details, coding standards, design philosophy, key technical det
 and compatibility requirements see the
 [Project Context](skills/project-context/SKILL.md) skill.
 
+## Terminology & Writing Style
+
+- Use American English always. Avoid British English spellings and idioms.
+- **RuboCop** — correct capitalization when referring to the tool by name in prose,
+  documentation, or comments.
+- **`rubocop`** — correct form when referring to the command-line executable or gem
+  name (e.g., `gem 'rubocop'`, `bundle exec rubocop`).
+- **Rubocop** — incorrect; never use this form.
+
 ## Skill Loading
 
 When a skill applies to a request, read the entire `SKILL.md` file before taking
@@ -38,7 +47,7 @@ or explanation does not require a skill.
 **Test suites:** `spec/` (RSpec) is the current suite — all new tests go here.
 `tests/` (Test::Unit) is legacy; only touch it when modifying existing tests there
 or adding pre-migration coverage to verify that a `Git::Lib` → `Git::Commands`
-migration doesn't break existing behaviour.
+migration doesn't break existing behavior.
 
 ## Commit Conventions
 
@@ -68,7 +77,7 @@ footer.
 > Always check `git branch --show-current` before committing. If on a release branch,
 > run `git switch -c <type>/<short-description>` first.
 
-All changes go via PR from a topic branch.
+All changes go through a PR from a topic branch.
 
 **Creating a PR:** Use `gh pr create`. Read `.github/pull_request_template.md` for
 the body structure. Complete the [PR Readiness Review](skills/pr-readiness-review/SKILL.md)

--- a/.github/skills/yard-documentation/SKILL.md
+++ b/.github/skills/yard-documentation/SKILL.md
@@ -9,6 +9,7 @@ General YARD documentation rules and workflow for all Ruby source code.
 
 ## Contents
 
+- [Contents](#contents)
 - [How to use this skill](#how-to-use-this-skill)
 - [Related skills](#related-skills)
 - [Documentation Standards](#documentation-standards)
@@ -16,6 +17,9 @@ General YARD documentation rules and workflow for all Ruby source code.
   - [Element-Specific Rules](#element-specific-rules)
 - [Step 1: Identify What Needs Documentation](#step-1-identify-what-needs-documentation)
 - [Step 2: Write Documentation](#step-2-write-documentation)
+  - [Standard template (no `@overload`)](#standard-template-no-overload)
+  - [Overload template](#overload-template)
+  - [Documenting anonymous splats with `@overload`](#documenting-anonymous-splats-with-overload)
 - [Step 3: Verify Documentation](#step-3-verify-documentation)
 - [Command Reference](#command-reference)
 
@@ -415,6 +419,15 @@ BranchDeleteFailure = Data.define(:name, :result)
   parameters or return types — each overload gets its own full set of tags.
   Methods that yield only when an optional block is given should use `@overload`
   to document the with-block and without-block signatures separately
+- Methods whose signature uses an **anonymous keyword splat** (`**`),
+  **anonymous positional splat** (`*`), or the **argument forwarding
+  parameter** (`...`) must document their call shapes with `@overload` blocks
+  that name the parameters. `@param`, `@option`, `@yield`, and `@yieldparam`
+  cannot bind to an anonymous splat or to `...` — the named overload signature
+  is what gives YARD a parameter to attach the docs to. Do **not** introduce a
+  named splat (or expand `...` into `*args, **kwargs, &block`) solely so the
+  tags will bind; that conflicts with RuboCop's `Style/ArgumentsForwarding`
+  cop, and the `@overload` form satisfies both
 - Use `@note` for callouts that need visual emphasis: thread-safety warnings,
   significant side effects, or platform-specific behaviour
 - Deprecated methods must include `@deprecated` explaining the migration path,
@@ -552,6 +565,86 @@ at the top level:
 def method_name(name, options = {})
 end
 ```
+
+### Documenting anonymous splats with `@overload`
+
+When the method signature uses an anonymous splat — `def foo(*)`, `def foo(**)`,
+`def foo(*, **)` — or the argument forwarding parameter `def foo(...)` —
+`@param`, `@option`, `@yield`, and `@yieldparam` tags have no parameter name
+to bind to. RuboCop's `Style/ArgumentsForwarding` cop prefers these forms when
+arguments are forwarded unchanged, so naming the splat (or expanding `...`
+into `*args, **kwargs, &block`) is **not** an acceptable workaround. Use
+`@overload` blocks that introduce named parameters for documentation purposes
+only:
+
+```ruby
+# Update the index with the current content found in the working tree
+#
+# @overload add(paths = '.', **options)
+#
+#   @example Stage a specific file
+#     git.add('README.md')
+#
+#   @param paths [String, Array<String>] file(s) to add (relative to the
+#     worktree root); defaults to `'.'` (all files)
+#
+#   @param options [Hash] command options
+#
+#   @option options [Boolean] :all add, modify, and remove index entries to
+#     match the worktree
+#
+#   @option options [Boolean] :force allow adding otherwise ignored files
+#
+#   @return [String] the command output
+#
+#   @raise [Git::FailedError] if `git add` exits with a non-zero status
+#
+def add(paths = '.', **)
+  Git::Commands::Add.new(@execution_context).call(*Array(paths), **).stdout
+end
+```
+
+The same approach applies to `...`. The overload signature names the
+parameters; the actual `def` keeps `...` so RuboCop is satisfied:
+
+```ruby
+# Run a command against the underlying execution context
+#
+# @overload run(command, *args, **options, &block)
+#
+#   @example Run git status
+#     result = git.run('status')
+#
+#   @param command [String] the git subcommand to run
+#
+#   @param args [Array<String>] positional arguments forwarded to the command
+#
+#   @param options [Hash] keyword options forwarded to the command
+#
+#   @return [Git::CommandLineResult] the command result
+#
+#   @yield [result] yields the command result, when a block is given
+#
+#   @yieldparam result [Git::CommandLineResult] the command result
+#
+#   @yieldreturn [void]
+#
+def run(command, ...)
+  Git::Commands::Run.new(@execution_context).call(command, ...)
+end
+```
+
+When a method has multiple genuinely distinct call shapes, write one
+`@overload` block per shape as in the [Overload template](#overload-template)
+above.
+
+**Anonymous block parameter (`&`)** is **not** covered by this rule.
+`@yield`, `@yieldparam`, and `@yieldreturn` describe what is yielded to the
+block, not the block parameter itself, so they bind correctly even with an
+anonymous `&`. Use a named block parameter (`&block`) and a `@param block
+[Proc]` tag only in the rare case where the block is documented as a
+first-class `Proc` value (stored, returned, or passed elsewhere) rather than
+yielded to.
 
 ## Step 3: Verify Documentation
 


### PR DESCRIPTION
## Summary

Two small additions to the Copilot agent configuration:

### `.github/copilot-instructions.md`
Adds a `## Terminology & Writing Style` section with an American English rule and RuboCop capitalization conventions (`RuboCop` in prose, `` `rubocop` `` for the executable/gem name).

### `.github/skills/yard-documentation/SKILL.md`
Adds a new rule and workflow step covering how to document methods that use anonymous keyword/positional splats (`**`, `*`, `...`) — the `@overload` form that satisfies `Style/ArgumentsForwarding` without suppressing the cop. This rule is referenced by the sibling `facade-yard-documentation` skill and the `command-yard-documentation` skill.