### PR TITLE
chore(skills): add facade skills and update related skills with facade links

### DIFF
--- a/.github/skills/command-implementation/SKILL.md
+++ b/.github/skills/command-implementation/SKILL.md
@@ -34,6 +34,9 @@ Additional related skills:
   writing and reviewing unit and integration tests for command classes
 - [Review Cross-Command Consistency](../review-cross-command-consistency/SKILL.md) —
   sibling consistency within a command family
+- [Facade Implementation](../facade-implementation/SKILL.md) — the v5.0.0 facade
+  layer (`Git::Repository::*`) that calls these command classes; new facade
+  wiring goes there rather than into `Git::Lib`
 
 ## Input
 

--- a/.github/skills/development-workflow/SKILL.md
+++ b/.github/skills/development-workflow/SKILL.md
@@ -61,6 +61,15 @@ needed.
   failures and environment-specific issues
 - [PR Readiness Review](../pr-readiness-review/SKILL.md) — final quality gate
   before opening a pull request
+- [Command Implementation](../command-implementation/SKILL.md) — scaffolding and
+  reviewing `Git::Commands::*` classes during implementation
+- [Facade Implementation](../facade-implementation/SKILL.md) — scaffolding and
+  reviewing `Git::Repository::*` facade methods during implementation
+- [Extract Command from Lib](../extract-command-from-lib/SKILL.md) — migrating a
+  `#command` call in `Git::Lib` into a `Git::Commands::*` class
+- [Extract Facade from Base/Lib](../extract-facade-from-base-lib/SKILL.md) —
+  migrating a public method from `Git::Base` / `Git::Lib` into a
+  `Git::Repository::*` facade method
 
 ## Core TDD Principles
 

--- a/.github/skills/extract-command-from-lib/SKILL.md
+++ b/.github/skills/extract-command-from-lib/SKILL.md
@@ -71,6 +71,10 @@ Run or reference these skills during the workflow:
 - [Command YARD Documentation](../command-yard-documentation/SKILL.md) — documentation completeness for command classes
 - [Review Cross-Command Consistency](../review-cross-command-consistency/SKILL.md) — sibling consistency within a command family
 - [Review Backward Compatibility](../review-backward-compatibility/SKILL.md) — preserving `Git::Lib` return-value contracts
+- [Extract Facade from Base/Lib](../extract-facade-from-base-lib/SKILL.md) — the
+  follow-on extraction that moves the public method from `Git::Base` /
+  `Git::Lib` into a `Git::Repository::*` facade method (Phase 4 deletes both
+  `Git::Base` and `Git::Lib`)
 
 ## Input
 

--- a/.github/skills/extract-facade-from-base-lib/SKILL.md
+++ b/.github/skills/extract-facade-from-base-lib/SKILL.md
@@ -1,0 +1,416 @@
+---
+name: extract-facade-from-base-lib
+description: "Migrates a public method from Git::Base or Git::Lib to a Git::Repository facade method (under lib/git/repository/) as part of the v5.0.0 architectural redesign. Use when extracting a specific public method during the Strangler Fig migration of Git::Base / Git::Lib into Git::Repository."
+---
+
+# Extract Facade from Base/Lib
+
+Migrate an existing public method from `Git::Base` and/or `Git::Lib` to a
+`Git::Repository::*` facade method. This is the second extraction step of the
+v5.0.0 redesign — it follows
+[Extract Command from Lib](../extract-command-from-lib/SKILL.md), which moves
+the underlying CLI invocation into a `Git::Commands::*` class.
+
+In Phase 4 of the redesign, **both `Git::Base` and `Git::Lib` will be deleted**.
+This migration moves their public surface to `Git::Repository`. Until Phase 4,
+the original methods remain in place and delegate to the new facade method to
+preserve backward compatibility within the migration window.
+
+## Contents
+
+- [How to use this skill](#how-to-use-this-skill)
+- [Prerequisites](#prerequisites)
+- [Related skills](#related-skills)
+- [Input](#input)
+- [Source patterns](#source-patterns)
+- [Workflow](#workflow)
+  - [Branch setup](#branch-setup)
+  - [Step 1 — Identify the source pattern](#step-1--identify-the-source-pattern)
+  - [Step 2 — Plan the migration and get approval](#step-2--plan-the-migration-and-get-approval)
+  - [Step 3 — Ensure adequate legacy tests](#step-3--ensure-adequate-legacy-tests)
+  - [Step 4 — Ensure the underlying `Git::Commands::*` class exists](#step-4--ensure-the-underlying-gitcommands-class-exists)
+  - [Step 5 — Implement the facade method](#step-5--implement-the-facade-method)
+  - [Step 6 — Update `Git::Base` and/or `Git::Lib` to delegate](#step-6--update-gitbase-andor-gitlib-to-delegate)
+- [Commit discipline](#commit-discipline)
+- [Quality gates](#quality-gates)
+- [What stays vs. what moves](#what-stays-vs-what-moves)
+
+## How to use this skill
+
+Attach this file to your Copilot Chat context, then invoke with the public method
+to migrate. Examples:
+
+```text
+Using the Extract Facade from Base/Lib skill, migrate Git::Base#commit to
+Git::Repository#commit.
+```
+
+```text
+Extract Facade: Git::Lib#branches_all (called publicly via g.lib.branches_all)
+```
+
+## Prerequisites
+
+Before starting, you **MUST** load the following skill(s):
+
+- [Facade Implementation](../facade-implementation/SKILL.md) — drives the actual
+  scaffolding of the new facade method
+- [YARD Documentation](../yard-documentation/SKILL.md) — baseline YARD rules
+
+## Related skills
+
+- [Facade Implementation](../facade-implementation/SKILL.md) — used in Step 5 to
+  scaffold the new facade method
+- [Facade Test Conventions](../facade-test-conventions/SKILL.md) — unit and
+  integration test conventions for the new facade method
+- [Facade YARD Documentation](../facade-yard-documentation/SKILL.md) — YARD docs
+  for the new facade module/method
+- [Extract Command from Lib](../extract-command-from-lib/SKILL.md) — sibling
+  extraction skill that moves the underlying CLI call into a
+  `Git::Commands::*` class. **Run first** when no command class exists yet.
+- [Command Implementation](../command-implementation/SKILL.md) — used in Step 4
+  if a new `Git::Commands::*` class needs to be scaffolded
+- [Project Context](../project-context/SKILL.md) — three-layer architecture and
+  Phase 4 deletion plan
+
+## Input
+
+Required:
+
+1. The `Git::Base` and/or `Git::Lib` public method to migrate.
+2. The git operation it performs (subcommand + flags).
+
+## Source patterns
+
+Public methods being migrated fall into one of three patterns. Identify which
+pattern applies before planning the migration.
+
+### Pattern A — `Git::Base` wrapper + `Git::Lib` implementation
+
+The most common pattern. `Git::Base#foo` is a thin wrapper that forwards to
+`Git::Lib#foo`, which contains the orchestration logic.
+
+Examples: `commit`, `diff_full`, `branches`, `worktree_add`.
+
+```ruby
+# lib/git/base.rb
+def commit(message, opts = {})
+  self.lib.commit(message, opts)
+end
+
+# lib/git/lib.rb
+def commit(message, opts = {})
+  opts = opts.merge(message: message) if message
+  deprecate_commit_no_gpg_sign_option!(opts)
+  Git::Commands::Commit.new(self).call(edit: false, **opts).stdout
+end
+```
+
+**Public contract source:** `Git::Base#commit` signature; `Git::Lib#commit`
+implementation.
+
+> When migrating, the facade method **must** preserve this signature exactly
+> (e.g. `commit(message, opts = {})`) — even though greenfield facade methods
+> would prefer `**options` per
+> [facade-implementation REFERENCE.md — Choosing the method signature](../facade-implementation/REFERENCE.md#choosing-the-method-signature).
+> The legacy public contract wins during migration.
+
+### Pattern B — `Git::Lib`-only (public-by-exposure)
+
+The public API is `g.lib.foo` — `Git::Base` exposes `Git::Lib` as `#lib` (or
+through a similar accessor), so `Git::Lib` methods are reachable as public API
+even when no `Git::Base` wrapper exists.
+
+Examples: `branches_all`, `worktrees_all`, `current_branch_state`.
+
+```ruby
+# lib/git/lib.rb (no Git::Base wrapper exists)
+def branches_all
+  result = Git::Commands::Branch::List.new(self).call(all: true, format: ...)
+  Git::Parsers::Branch.parse_list(result.stdout)
+end
+```
+
+**Public contract source:** `Git::Lib#foo` signature and implementation.
+
+**Migration consequence:** After Phase 4, callers using `g.lib.foo` must migrate
+to `g.foo` (or `g.repository.foo`). Document this in the migration plan.
+
+### Pattern C — `Git::Base`-only (no `Git::Lib` method)
+
+The implementation lives entirely in `Git::Base` with no `Git::Lib` counterpart.
+The method may call `command(...)` directly via `lib.send(...)` or implement
+filesystem operations.
+
+Examples: `add_remote`, `with_index`, `repo_size`, `archive`.
+
+```ruby
+# lib/git/base.rb
+def repo_size
+  all_files_size = 0
+  Find.find(repo.path) { |f| all_files_size += File.size(f) if File.file?(f) }
+  all_files_size
+end
+```
+
+**Public contract source:** `Git::Base#foo` signature and implementation.
+
+## Workflow
+
+### Branch setup
+
+All work must be done on a feature branch. **Never commit or push directly to
+`main`.**
+
+```bash
+git checkout -b <feature-branch-name>
+```
+
+### Step 1 — Identify the source pattern
+
+1. Locate the public method in `Git::Base` and/or `Git::Lib`.
+2. Determine which [Source pattern](#source-patterns) applies (A, B, or C).
+3. Note:
+   - the public signature (positional args, options hash, keyword args)
+   - the **exact return value** of the legacy method — read the source code to
+     see whether it ends in `.stdout`, `.stdout.chomp`, a parser call, a domain
+     object, `nil`, etc. **Do not assume** from the YARD `@return` tag, which
+     may be stale or missing. The facade must reproduce this exact value (e.g.
+     if `Git::Lib#add` ends in `.stdout`, the facade returns `String`, not
+     `Git::CommandLineResult`).
+   - any pre-processing (path expansion, option whitelisting, deprecation
+     handling)
+   - any post-processing (parsing, result-class assembly)
+   - any execution-context arguments (`timeout:`, `chdir:`, `env:`)
+4. Document the method's current **public contract** in writing — it must be
+   preserved exactly by the facade method.
+5. Run linters and rubocop to confirm a clean baseline:
+
+   ```bash
+   bundle exec rubocop
+   ```
+
+### Step 2 — Plan the migration and get approval
+
+Before writing or changing any code, present a migration plan and **wait for
+explicit confirmation** from the user.
+
+The plan must include:
+
+| Public method | Source pattern | Underlying command class | Class exists? | Target facade module | Notes |
+| --- | --- | --- | --- | --- | --- |
+| `Git::Base#foo` | A / B / C | `Git::Commands::Foo` | ✅ / 🆕 | `Git::Repository::Topic` (existing or new) | mapping decisions |
+
+Also state:
+
+- The exact **public contract** to preserve (signature + return type + raised
+  errors).
+- Whether a new topic module is required (justify per
+  [facade-implementation REFERENCE.md](../facade-implementation/REFERENCE.md#decision-rules-for-adding-a-new-module)).
+  When extracting one method at a time, scan `Git::Base` / `Git::Lib` for
+  siblings on the same git topic and check
+  `redesign/3_architecture_implementation.md` before deciding — see
+  [One-at-a-time extraction](../facade-implementation/REFERENCE.md#one-at-a-time-extraction-from-gitbase--gitlib).
+- The delegation strategy for `Git::Base` and/or `Git::Lib` (Step 6) — both
+  remain in place during the migration window and delegate to the new facade.
+- For Pattern B: explicit note that `g.lib.foo` callers will need to migrate
+  before Phase 4; capture this as a follow-up issue or CHANGELOG entry.
+
+Then ask:
+
+> Does this mapping look correct? Any changes before I start implementing?
+
+**Do not move to Step 3 until the user confirms the plan.**
+
+### Step 3 — Ensure adequate legacy tests
+
+Verify that legacy tests in `tests/units/` and existing specs in `spec/`
+adequately cover the public method. The legacy tests guarantee the migration
+preserves backward compatibility.
+
+1. Search for coverage:
+
+   ```bash
+   grep -rn '<method_name>' tests/units/ spec/
+   ```
+
+2. If coverage is insufficient, add **minimal new tests** that exercise the
+   current public contract. Use existing legacy test conventions for `Test::Unit`
+   tests in `tests/units/`. Do **not** change existing tests.
+
+3. Run the new tests and rubocop:
+
+   ```bash
+   bundle exec bin/test <test-file-basename>
+   bundle exec rubocop tests/units/<test-file>
+   ```
+
+4. Commit:
+
+   ```bash
+   git commit -m "refactor(test): add legacy tests for <method_name>"
+   ```
+
+### Step 4 — Ensure the underlying `Git::Commands::*` class exists
+
+The facade method calls one or more `Git::Commands::*` classes. If any required
+command class does not exist yet, scaffold it first using
+[Extract Command from Lib](../extract-command-from-lib/SKILL.md) (which in turn
+uses [Command Implementation](../command-implementation/SKILL.md)).
+
+For Pattern C migrations, the source `Git::Base` method may not currently call
+through a `Git::Commands::*` class at all (it uses `command(...)` directly or
+filesystem operations). In that case, you must scaffold the `Git::Commands::*`
+class before this step.
+
+Skip this step when every required command class already exists.
+
+### Step 5 — Implement the facade method
+
+Delegate to the [Facade Implementation](../facade-implementation/SKILL.md) skill
+in **Scaffold** or **Update** mode. That skill handles:
+
+- topic module selection
+- generating or extending `lib/git/repository/<topic>.rb`
+- generating or extending `spec/unit/git/repository/<topic>_spec.rb`
+- generating or extending `spec/integration/git/repository/<topic>_spec.rb`
+- YARD documentation
+- running facade-side quality gates
+
+The new facade method **must preserve the source method's public contract
+exactly** — same signature, same return type, same raised errors. Use the
+exact return type the source method documented (String, Array, Hash, domain
+object, `CommandLineResult`).
+
+For Pattern A and B migrations, copy any pre-processing logic
+(option whitelisting, deprecation rewrites, key normalization) from `Git::Lib`
+to the facade method. Do **not** leave it behind in `Git::Lib` — the facade is
+now the source of truth.
+
+For Pattern C migrations, port any pre-processing or filesystem logic from
+`Git::Base` to the facade method.
+
+After the facade method is in place and tests pass, commit:
+
+```bash
+git commit -m "feat(repository): add Git::Repository#<method_name> facade method"
+```
+
+### Step 6 — Update `Git::Base` and/or `Git::Lib` to delegate
+
+The original methods stay in place during the migration window and delegate to
+the new facade method. Both `Git::Base` and `Git::Lib` will be deleted in
+Phase 4; until then, delegation preserves backward compatibility.
+
+For each source pattern, the delegation looks like:
+
+**Pattern A** — both files delegate:
+
+```ruby
+# lib/git/base.rb — already a wrapper; redirect to repository
+def commit(message, opts = {})
+  repository.commit(message, opts)
+end
+
+# lib/git/lib.rb — keep public-by-exposure callers working
+def commit(message, opts = {})
+  @repository.commit(message, opts)
+end
+```
+
+**Pattern B** — `Git::Lib` delegates:
+
+```ruby
+# lib/git/lib.rb
+def branches_all
+  @repository.branches_all
+end
+```
+
+**Pattern C** — `Git::Base` delegates:
+
+```ruby
+# lib/git/base.rb
+def add_remote(name, url, opts = {})
+  repository.add_remote(name, url, opts)
+end
+```
+
+(The exact accessor — `repository`, `@repository`, `self.repository` — depends
+on how `Git::Base` and `Git::Lib` hold their reference to the new
+`Git::Repository` instance during the migration window. Match the existing
+pattern used by other migrated methods.)
+
+After delegation is in place, verify:
+
+```bash
+bundle exec bin/test <legacy-test-file-basename>
+bundle exec rspec
+bundle exec rubocop
+bundle exec rake yard
+```
+
+Commit:
+
+```bash
+git commit -m "refactor(base): delegate <method_name> to Git::Repository"
+```
+
+(Use `refactor(lib):` if only `Git::Lib` was updated. When both files change,
+use two separate commits — one per scope — to keep each commit single-scoped.)
+
+## Commit discipline
+
+Keep work organized into **three logical commit categories** (each optional if
+no changes were needed for that step):
+
+1. `refactor(test): add legacy tests for <method_name>` — new tests in
+   `tests/units/` (Step 3)
+2. `feat(repository): add Git::Repository#<method_name> facade method` — new
+   facade module/method, unit specs, integration specs (Step 5)
+3. `refactor(base): delegate <method_name> to Git::Repository` — `Git::Base`
+   updated to delegate (Step 6); use `refactor(lib):` if only `Git::Lib`
+   changed. When both files change, prefer **two separate commits** — one
+   per scope — so each commit has a single conventional-commits scope.
+
+If a new `Git::Commands::*` class was scaffolded in Step 4, it gets its own
+commit (`refactor(command): add Git::Commands::<Command> class`) per
+[Extract Command from Lib](../extract-command-from-lib/SKILL.md).
+
+**Issue and PR references in commit bodies:** Do not use `#<number>` in the
+commit body — write `issue 1000` not `issue #1000`. To close an issue/PR, use
+`Closes`/`Fixes`/`Resolves #<number>` in the footer.
+
+If further changes are needed after task commits are created, amend into the
+appropriate commit and rebase. Always verify quality gates pass after rebasing.
+
+## Quality gates
+
+Run the gates discovered from the project's parallel default task at every step:
+
+```bash
+bundle exec ruby -e "require 'rake'; load 'Rakefile'; puts Rake::Task['default:parallel'].prerequisites"
+```
+
+Run each listed task individually via `bundle exec rake <task>` and fix
+failures before advancing. All listed tasks must pass before committing.
+
+## What stays vs. what moves
+
+**Stays in `Git::Base` / `Git::Lib` until Phase 4:**
+
+- Delegating methods — one-line forwards to the new `Git::Repository` facade
+  method, preserving backward compatibility during the migration window.
+- Methods not yet migrated — original implementation remains until extracted.
+
+**Moves to `Git::Repository::*`:**
+
+- The full public contract (signature, return type, raised errors).
+- All pre-processing logic (option whitelisting, deprecation handling, key
+  normalization, defaults).
+- All post-processing logic (parsing, result-class assembly).
+- The YARD docs that document the public API.
+
+> **Branch workflow:** Implement migrations on a feature branch. Never commit
+> or push directly to `main` — open a pull request when changes are ready to
+> merge.

--- a/.github/skills/facade-implementation/REFERENCE.md
+++ b/.github/skills/facade-implementation/REFERENCE.md
@@ -1,0 +1,697 @@
+# Facade Implementation — Reference
+
+Detailed reference for `Git::Repository::*` facade modules and methods. This file
+is loaded by subagents during the [Facade Implementation](SKILL.md) workflow.
+
+## Contents
+
+- [Files to generate](#files-to-generate)
+- [Topic module selection](#topic-module-selection)
+  - [Existing modules](#existing-modules)
+  - [Decision rules for adding a new module](#decision-rules-for-adding-a-new-module)
+    - [One-at-a-time extraction from `Git::Base` / `Git::Lib`](#one-at-a-time-extraction-from-gitbase--gitlib)
+  - [Naming a new topic module](#naming-a-new-topic-module)
+- [Designing a facade method](#designing-a-facade-method)
+  - [Choosing the return type](#choosing-the-return-type)
+  - [Choosing the method signature](#choosing-the-method-signature)
+  - [One-line delegator](#one-line-delegator)
+  - [Orchestration sequence](#orchestration-sequence)
+  - [Sequencing multiple commands](#sequencing-multiple-commands)
+- [Topic module skeleton](#topic-module-skeleton)
+- [The five facade responsibilities checklist](#the-five-facade-responsibilities-checklist)
+- [Argument pre-processing patterns](#argument-pre-processing-patterns)
+  - [Path normalization](#path-normalization)
+  - [Option whitelisting (preventing API expansion)](#option-whitelisting-preventing-api-expansion)
+  - [Deprecation handling](#deprecation-handling)
+  - [Defaults and policy options](#defaults-and-policy-options)
+- [Internal helpers and encapsulation](#internal-helpers-and-encapsulation)
+  - [The rule](#the-rule)
+  - [The pattern](#the-pattern)
+  - [Why this works](#why-this-works)
+  - [Naming rules](#naming-rules)
+  - [Growth path](#growth-path)
+  - [When a helper needs `@execution_context`](#when-a-helper-needs-execution_context)
+  - [Why not `ActiveSupport::Concern`?](#why-not-activesupportconcern)
+- [Parser vs. raw stdout](#parser-vs-raw-stdout)
+- [Result-class factory methods](#result-class-factory-methods)
+- [Common failures](#common-failures)
+  - [One-line delegation when orchestration is needed](#one-line-delegation-when-orchestration-is-needed)
+  - [Leaking command-class types into the public API](#leaking-command-class-types-into-the-public-api)
+  - [Exposing command-DSL-shaped argv in the facade signature](#exposing-command-dsl-shaped-argv-in-the-facade-signature)
+  - [Changing the legacy return type or signature on extraction](#changing-the-legacy-return-type-or-signature-on-extraction)
+  - [Bypassing `@execution_context`](#bypassing-execution_context)
+  - [Hardcoding policy options the caller cannot override](#hardcoding-policy-options-the-caller-cannot-override)
+  - [Skipping option whitelisting on opaque opts hashes](#skipping-option-whitelisting-on-opaque-opts-hashes)
+  - [Mixing facade and command responsibilities](#mixing-facade-and-command-responsibilities)
+  - [Adding a new topic module for a single method](#adding-a-new-topic-module-for-a-single-method)
+
+## Files to generate
+
+For a facade method on `Git::Repository::<Topic>`:
+
+- `lib/git/repository/<topic>.rb` — the topic module (created on first method,
+  extended for subsequent methods)
+- `spec/unit/git/repository/<topic>_spec.rb` — unit tests
+- `spec/integration/git/repository/<topic>_spec.rb` — integration tests
+  (omit for true one-line delegators that add no orchestration)
+
+When the topic module is new, also update:
+
+- `lib/git/repository.rb` — add `require 'git/repository/<topic>'` and `include
+  Git::Repository::<Topic>` in alphabetical order with the existing entries.
+
+## Topic module selection
+
+### Existing modules
+
+List `lib/git/repository/` to see all current topic modules. Add to one of those
+modules whenever the new method fits the topic. Do not create a new module when
+an existing one would do.
+
+### Decision rules for adding a new module
+
+Create a new topic module only when **all** of the following are true:
+
+1. At least three related facade methods share the topic and do not fit any
+   existing module. "Related methods" may be **already implemented**, **planned
+   in the migration tracker** (`redesign/3_architecture_implementation.md`), or
+   **identified by grepping `Git::Base` / `Git::Lib`** for siblings that will be
+   extracted to the same topic.
+2. The topic is recognizable to a reader familiar with git — preferably matching
+   one of the categories at <https://git-scm.com/docs> (Working tree, Branching,
+   History, Sharing, Patching, Inspection, Configuration, Plumbing).
+3. The methods would be awkward to place in any existing module without diluting
+   that module's topic.
+
+#### One-at-a-time extraction from `Git::Base` / `Git::Lib`
+
+When migrating a single method without a planned batch:
+
+1. Before deciding placement, scan `Git::Base` and `Git::Lib` for sibling methods
+   on the same git topic (e.g. when extracting `branches_all`, also look for
+   `branch`, `branch_current`, `branch_delete`, `current_branch_state`).
+2. If ≥3 siblings (including the current one) will plausibly land in the same
+   topic, create the new module on this first extraction so subsequent
+   extractions have a home.
+3. Otherwise place the method in the closest existing module. Revisit module
+   organization when a third sibling joins; promote the cluster to its own
+   module in a single `refactor(repository):` commit at that point.
+
+For a one-off method that does not fit any existing module and does not justify a
+new module yet, place it in the closest existing module and revisit the
+organization when more methods join it.
+
+### Naming a new topic module
+
+- Use a single PascalCase word matching the file name (`Branching` →
+  `branching.rb`).
+- Prefer the gerund/noun form used by the git documentation categories
+  (`Branching`, not `Branches`; `Inspection`, not `Inspect`).
+- Avoid names that overlap with existing classes (`Branch`, `Diff`, `Log`) — those
+  belong to result classes, not topic modules.
+- Do not use the `*Info` or `*Result` suffix — reserved for parsed result structs.
+
+## Designing a facade method
+
+Decide the return type and the signature first (together they are the public
+contract), then choose the body shape — one-line delegator for the simplest
+cases, orchestration sequence otherwise.
+
+### Choosing the return type
+
+Apply these rules in order:
+
+1. **Extracting from `Git::Base` or `Git::Lib`?** The facade method **must**
+   return exactly what the legacy method returned (same type, same shape, same
+   nil/empty semantics). Backward compatibility for users who called
+   `g.foo` / `g.lib.foo` is the public contract being preserved during
+   migration; capture the legacy return in the Step 2 plan.
+2. **No legacy method (greenfield facade method)?** Choose the return type from
+   the public-API perspective, in this order of preference:
+   1. A **domain object** (`Git::BranchInfo`, `Git::DiffResult`, …) when the
+      output has structure callers will inspect.
+   2. A **primitive** (`String` of chomped stdout, `Boolean`, `Integer`) when
+      the output is a single value.
+   3. `nil` or `self` when the method is called for its side effects.
+   4. **`Git::CommandLineResult`** only when the topic module explicitly
+      documents that as its contract (rare — reserved for low-level escape
+      hatches). Do not return `CommandLineResult` by default just because the
+      command returns it.
+3. **Never return** a type from `Git::Commands::*` (e.g.
+   `Git::Commands::Foo::Bar::SomeResult`). Command-internal types are not part
+   of the facade's public API.
+
+### Choosing the method signature
+
+The Ruby signature is part of the public contract — just as binding as the
+return type. Apply these rules in order:
+
+1. **Extracting from `Git::Base` or `Git::Lib`?** The facade method **must**
+   preserve the legacy signature exactly: same positional arguments in the same
+   order, same defaults, same `opts = {}` vs. `**options` shape, same
+   nil/sentinel semantics. Capture the legacy signature in the Step 2 plan and
+   diff against it after implementation.
+2. **No legacy method (greenfield facade method)?** Design the signature from
+   the public-API perspective:
+   1. **Positional arguments** for the natural domain identifiers the method
+      operates on (paths, refs, names, messages). At most two or three.
+   2. **Keyword arguments with `**options`** for option hashes. Prefer
+      `**options` over `opts = {}` in greenfield code — it surfaces unknown
+      keys at the call site and reads better with the [whitelist
+      pattern](#option-whitelisting-preventing-api-expansion). When the body
+      forwards the options unchanged (the common case), use the **anonymous**
+      keyword splat (`**`) so RuboCop's `Style/ArgumentsForwarding` cop is
+      satisfied; name the splat (`**options`) only when the body must inspect
+      or mutate the hash before forwarding (e.g. merging a positional
+      argument into it, or applying a deprecation rewrite).
+   3. **Named keyword arguments** (`force: false`, `all: true`) for a small,
+      fixed set of flags that are part of the documented API and unlikely to
+      grow. Switch to `**options` once the set exceeds ~3 keys.
+3. **Validate cross-argument constraints in the facade**, before calling the
+   command. Raise `ArgumentError` with a message that names the offending
+   arguments — for example, `pull` raises when `branch` is given without
+   `remote`. The command class stays neutral about Ruby-level argument
+   relationships.
+4. **Never expose** command-DSL-shaped arguments (`*argv`, raw `Hash` of CLI
+   flags) on the facade. The facade's job is to translate Ruby idioms into
+   command calls; passing through opaque argv defeats the layer.
+
+Mechanical patterns for shaping the inputs (path coercion, option whitelisting,
+deprecation handling) live in [Argument pre-processing
+patterns](#argument-pre-processing-patterns).
+
+### One-line delegator
+
+When the facade method takes no options hash, does no pre-processing, and only
+a trivial post-processing step (such as `.stdout.chomp`), it is a single-line
+delegation. For example, a hypothetical `Git::Repository::Inspection#current_branch`
+preserving `Git::Lib#current_branch`'s `String` contract:
+
+```ruby
+# Return the name of the currently checked-out branch
+#
+# @example Get the current branch name
+#   repo.current_branch #=> "main"
+#
+# @return [String] the current branch name
+#
+# @raise [Git::FailedError] if `git rev-parse` exits with a non-zero status
+#
+def current_branch
+  Git::Commands::RevParse.new(@execution_context).call('--abbrev-ref', 'HEAD').stdout.chomp
+end
+```
+
+Use the one-line form only when **all** of the following hold:
+
+- The Ruby signature exactly matches the command's `#call` signature (with at most
+  trivial coercion like `Array(paths)` or `*[remote, branch].compact`).
+- The method takes no options hash. Any facade method that accepts options must
+  whitelist them — see [Option whitelisting](#option-whitelisting-preventing-api-expansion) —
+  which makes it at minimum a two-line orchestration.
+- The post-processing is at most a single chained call (`.stdout`,
+  `.stdout.chomp`, etc.) that produces the documented return type (see
+  [Choosing the return type](#choosing-the-return-type) above).
+
+If the documented return type requires parsing, multiple commands, validation,
+deprecation, option whitelisting, or any conditional logic, the facade needs an
+orchestration sequence — not a one-line delegator.
+
+### Orchestration sequence
+
+When the facade method needs pre-processing, multiple commands, parsing, or result
+assembly, expand the body into explicit phases:
+
+```ruby
+def branches_all
+  result = Git::Commands::Branch::List.new(@execution_context).call(
+    all: true,
+    format: Git::Parsers::Branch::FORMAT_STRING
+  )
+  Git::Parsers::Branch.parse_list(result.stdout)
+end
+
+def commit(message, opts = {})
+  Git::Repository::Internal.assert_valid_opts!(COMMIT_ALLOWED_OPTS, **opts)
+  opts = opts.merge(message: message) if message
+  opts = deprecate_commit_no_gpg_sign_option(opts)
+  Git::Commands::Commit.new(@execution_context).call(edit: false, **opts).stdout
+end
+```
+
+Three phases — keep them in this order:
+
+1. **Pre-process** — validate, whitelist, normalize, deprecate, default.
+2. **Call** — invoke one or more `Git::Commands::*` instances, each via
+   `@execution_context`.
+3. **Assemble** — pass stdout/stderr/status through a parser or result-class
+   factory method, or return the raw `CommandLineResult` value the topic module
+   documents.
+
+### Sequencing multiple commands
+
+When a facade method orchestrates more than one command, sequence the calls
+explicitly with intermediate results in local variables:
+
+```ruby
+def branch_status(name)
+  upstream_result = Git::Commands::RevParse.new(@execution_context).call("#{name}@{upstream}")
+  ahead_behind = Git::Commands::RevList.new(@execution_context).call(
+    "#{name}...#{upstream_result.stdout.chomp}",
+    left_right: true,
+    count: true
+  )
+  Git::BranchStatus.from_rev_list_output(name, ahead_behind.stdout)
+end
+```
+
+Do not build a generic dispatcher or a "run everything in parallel" abstraction.
+Explicit sequential calls are the documented pattern.
+
+## Topic module skeleton
+
+The full file layout for a topic module under `lib/git/repository/`:
+
+```ruby
+# frozen_string_literal: true
+
+require 'git/commands/<command_a>'
+require 'git/commands/<command_b>'
+# require 'git/parsers/<parser>' — when the module uses a parser
+
+module Git
+  class Repository
+    # Short summary of the topic and the facade methods it provides
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module Topic
+      # YARD docs per facade-yard-documentation skill
+      def method_a(...)
+        # body
+      end
+
+      # YARD docs per facade-yard-documentation skill
+      def method_b(...)
+        # body
+      end
+    end
+  end
+end
+```
+
+Then wire into `lib/git/repository.rb`:
+
+```ruby
+require 'git/repository/topic'
+# ...
+
+class Repository
+  include Git::Repository::Topic
+  # ...
+end
+```
+
+## The five facade responsibilities checklist
+
+From [redesign/2_architecture_redesign.md §2.1](../../../redesign/2_architecture_redesign.md).
+For each facade method, confirm whether each responsibility applies and is handled:
+
+- [ ] **Manage execution context** — calls `Git::Commands::*.new(@execution_context)`,
+  never builds CLI argv directly and never bypasses the execution context.
+- [ ] **Pre-process arguments** — applies path expansion, Ruby-idiomatic defaults,
+  option whitelisting, deprecations.
+- [ ] **Collect data** — gathers any additional information needed before or after
+  command execution to build the response (e.g., reading config, listing refs).
+  Most facade methods do not need this; flag explicitly when present.
+- [ ] **Call commands** — invokes one or more `Git::Commands::*` classes; multiple
+  calls are sequenced explicitly with intermediate results held in local variables.
+- [ ] **Build rich response objects** — passes stdout through a `Git::Parsers::*`
+  class or a result-class factory method to produce the documented return type.
+  Returning the raw `CommandLineResult` is acceptable only when that is the
+  documented public contract for the topic module.
+
+## Argument pre-processing patterns
+
+### Path normalization
+
+Accept `String` or `Array<String>` for path arguments and splat into the command:
+
+```ruby
+def add(paths = '.', **)
+  Git::Repository::Internal.assert_valid_opts!(ADD_ALLOWED_OPTS, **)
+  Git::Commands::Add.new(@execution_context).call(*Array(paths), **).stdout
+end
+```
+
+For path arguments that must be absolute or relative to the worktree root, expand
+with `File.expand_path` against `@execution_context.git_work_dir`.
+
+### Option whitelisting (preventing API expansion)
+
+When the facade method accepts an options hash (positional `opts = {}` *or*
+keyword `**options`) and forwards it to a command, the underlying command class
+typically exposes many more options than the public facade contract. Without
+filtering, callers could pass options that happen to match command DSL names but
+were never part of the facade's public API — silently expanding the contract.
+
+Use a per-method whitelist constant + `Git::Repository::Internal.assert_valid_opts!`:
+
+```ruby
+PULL_ALLOWED_OPTS = %i[allow_unrelated_histories].freeze
+private_constant :PULL_ALLOWED_OPTS
+
+def pull(remote = nil, branch = nil, **)
+  raise ArgumentError, 'You must specify a remote if a branch is specified' if remote.nil? && !branch.nil?
+
+  Git::Repository::Internal.assert_valid_opts!(PULL_ALLOWED_OPTS, **)
+  positional_args = [remote, branch].compact
+  Git::Commands::Pull.new(@execution_context)
+                     .call(*positional_args, edit: false, **)
+                     .stdout
+end
+```
+
+The helper's signature is `assert_valid_opts!(allowed, **opts)` — the allowed
+set comes first as a positional argument so callers can re-forward the
+anonymous splat (`**`) into both the assertion and the command call. Name the
+splat (`**options`) only when the body must inspect or mutate the options
+hash before forwarding it (see the [`commit` example](#orchestration-sequence)
+above for that case).
+
+Rules:
+
+- Name the constant `<METHOD>_ALLOWED_OPTS` and mark it `private_constant`. It
+  is implementation detail, not part of the public API.
+- Place the constant immediately before the method definition.
+- The whitelist must match the `@option` tags in the YARD doc exactly. Reviewers
+  should verify the two lists are equal in both directions.
+- `Git::Repository::Internal.assert_valid_opts!` raises
+  `ArgumentError: Unknown options: <key>` for any unrecognized key. Document this
+  with `@raise [ArgumentError]` on the facade method.
+- Every facade method that accepts an options hash **must** have a unit test
+  that passes an unknown key and expects `ArgumentError`. That test — not a
+  defensive `slice` at the call site — is what guarantees the whitelist stays
+  load-bearing under future refactors. Forward `**options` directly after the
+  assertion; do not also `slice` it (the assertion already proves every key is
+  allowed, and a second mechanism invites cargo-culting and confusion about
+  which one enforces the contract).
+
+Even when the facade uses `**options` keyword forwarding, whitelist explicitly.
+Relying on the command's own `ArgumentError` couples the facade contract to the
+command's argument DSL, which is exactly what this layer exists to prevent.
+
+### Deprecation handling
+
+Handle deprecated option keys explicitly in the facade — never let deprecation
+shims leak into the command class. Pattern:
+
+```ruby
+def commit(message, opts = {})
+  opts = opts.merge(message: message) if message
+  opts = deprecate_commit_no_gpg_sign_option(opts)
+  opts = deprecate_commit_add_all_option(opts)
+  Git::Commands::Commit.new(@execution_context).call(edit: false, **opts).stdout
+end
+
+private
+
+def deprecate_commit_no_gpg_sign_option(opts)
+  return opts unless opts.key?(:no_gpg_sign)
+
+  Git::Deprecation.warn(
+    "Git::Repository#commit's :no_gpg_sign option is deprecated. " \
+    'Use gpg_sign: false instead.'
+  )
+  opts.dup.tap do |o|
+    o[:gpg_sign] = false unless o.key?(:gpg_sign)
+    o.delete(:no_gpg_sign)
+  end
+end
+```
+
+### Defaults and policy options
+
+The facade is where **policy defaults** are applied — options that support
+non-interactive execution, control output format for parsing, or set safe
+command-level defaults. The command class stays neutral; the facade makes the
+defaults explicit; callers may override when needed.
+
+| Policy option | Why facade sets it |
+| --- | --- |
+| `edit: false` | Subprocesses cannot launch `$EDITOR` |
+| `progress: false` | Progress output goes to stderr and pollutes parsing |
+| `no_color: true` | ANSI escapes interfere with parsers |
+| `format: Git::Parsers::Foo::FORMAT_STRING` | Facade wants a parseable format |
+
+Always allow callers to override by placing policy defaults **before** the
+caller's options in the keyword splat:
+
+```ruby
+Git::Commands::Pull.new(@execution_context).call(*args, edit: false, **opts)
+# When opts contains :edit, the caller's value wins.
+```
+
+## Internal helpers and encapsulation
+
+Topic modules under `lib/git/repository/` often share helper logic — option
+validation, path normalization, deprecation warnings, error wrapping. These
+helpers must be reachable from any topic module without leaking onto the public
+`Git::Repository` API surface.
+
+### The rule
+
+**Do not put shared helpers as private methods on `Git::Repository`** (directly
+or via `include`). `include` copies private instance methods onto the host class,
+so any caller with a `Git::Repository` instance can `repo.send(:helper, ...)`.
+This:
+
+1. Re-creates the `Git::Lib` god-class problem the redesign is escaping.
+2. Couples every topic module silently to ambient mixin state.
+3. Is not actually private and not `@api`-marked, so YARD/tooling cannot enforce it.
+
+### The pattern
+
+Put shared helpers in a sibling **internal module** under `lib/git/repository/`
+that is **not** `include`d into `Git::Repository`. Use `module_function` so
+methods are called as fully-qualified singleton methods:
+
+```ruby
+# lib/git/repository/internal.rb
+module Git
+  class Repository
+    # Namespace for internal helpers shared across facade topic modules
+    #
+    # @api private
+    #
+    module Internal
+      module_function
+
+      def assert_valid_opts!(allowed, **options)
+        unknown = options.keys - allowed
+        return if unknown.empty?
+
+        raise ArgumentError, "Unknown options: #{unknown.join(', ')}"
+      end
+    end
+  end
+end
+```
+
+Call sites use the fully-qualified name:
+
+```ruby
+# lib/git/repository/staging.rb
+def add(paths = '.', **)
+  Git::Repository::Internal.assert_valid_opts!(ADD_ALLOWED_OPTS, **)
+  Git::Commands::Add.new(@execution_context)
+                    .call(*Array(paths), **)
+                    .stdout
+end
+```
+
+### Why this works
+
+- **No mixin pollution.** `Git::Repository` instances do not gain
+  `assert_valid_opts!` as a method. The helper is namespaced and private-by-API.
+- **Explicit dependency.** A reader of `staging.rb` sees exactly where the helper
+  comes from. No magic mixin chain.
+- **Stateless by contract.** Without `include`, helpers cannot access
+  `@execution_context` or other instance state — they must take everything as
+  arguments. This keeps them pure and trivially unit-testable.
+- **`@api private` is enforceable.** YARD respects the tag; downstream tooling
+  can flag external use.
+
+### Naming rules
+
+Modules under `lib/git/repository/` use **bare nouns**, never role-suffixes like
+`*Helpers` or `*Utils`:
+
+| Module                              | Distinguished by               |
+|-------------------------------------|--------------------------------|
+| `Git::Repository::Staging`          | `include`d, `@api public`      |
+| `Git::Repository::Branching`        | `include`d, `@api public`      |
+| `Git::Repository::Internal`         | not `include`d, `@api private` |
+| `Git::Repository::OptionValidation` | not `include`d, `@api private` |
+
+Reasons:
+
+- The location (`lib/git/repository/`) plus the `@api` tag and absence of an
+  `include` line in `lib/git/repository.rb` already convey API status. A
+  `*Helpers` suffix is redundant signage.
+- Symmetry with topic modules keeps the directory listing readable.
+- "Helpers" invites junk-drawer dumping; responsibility-named modules invite
+  cohesion. Ruby stdlib follows the same convention (`URI::DEFAULT_PARSER`,
+  `ActiveSupport::Inflector`, not `*Helpers`).
+
+### Growth path
+
+Start with a single `Git::Repository::Internal` catch-all. Split when **either**
+trigger fires:
+
+1. `Internal` accumulates more than ~5 methods.
+2. Clear sub-themes emerge (validation vs. normalization vs. error wrapping).
+
+Then extract responsibility-named sibling modules:
+
+```text
+Git::Repository::Internal              # catch-all (initial)
+        ↓ grows / develops sub-themes
+Git::Repository::OptionValidation      # extracted by responsibility
+Git::Repository::PathNormalization
+Git::Repository::Internal              # remaining miscellany (or deleted)
+```
+
+The extraction is mechanical — call sites change from
+`Git::Repository::Internal.foo(...)` to `Git::Repository::OptionValidation.foo(...)`.
+
+### When a helper needs `@execution_context`
+
+`module_function` helpers cannot access instance state. If a helper needs the
+execution context, prefer in this order:
+
+1. **Pass it explicitly** as a method argument — keeps the helper stateless.
+2. **Extract a small PORO** under `lib/git/repository/` (e.g.
+   `Git::Repository::CommitOperation.new(execution_context).call(...)`),
+   marked `@api private` and not `include`d.
+3. **Inline private instance method on the topic module** — last resort, only
+   when the helper is truly local to one topic. Mark `@api private`.
+
+Avoid: re-introducing instance-method mixins on `Git::Repository` for "shared"
+behavior. That is the exact pattern this rule prohibits.
+
+### Why not `ActiveSupport::Concern`?
+
+`Concern` does not solve the include-time leak: a `Concern` `include`d into a
+class still copies its private instance methods onto that class. Rails tolerates
+the leak via underscore prefixes and `:nodoc:`, or extracts service objects.
+This project takes the stricter approach (sibling module + `module_function`)
+without depending on `activesupport`.
+
+## Parser vs. raw stdout
+
+| Situation | Use |
+| --- | --- |
+| The facade returns a `String` of git's stdout (chomped or as-is) | `.stdout` |
+| The facade returns a structured object built from line-by-line parsing | A `Git::Parsers::*` class |
+| The facade returns a single bool/int derived from output | Inline transformation in the facade |
+| The facade returns a `Git::CommandLineResult` | Return the raw result |
+
+If the parsing logic exceeds ~5 lines, extract it into a `Git::Parsers::*` class
+and call it from the facade. The facade method remains an orchestration sequence,
+not a parser.
+
+## Result-class factory methods
+
+When the facade returns a domain object (e.g. `BranchInfo`, `BranchDeleteResult`,
+`DiffResult`), use a factory method on the result class rather than constructing
+it inline:
+
+```ruby
+def branch_delete(name, force: false)
+  result = Git::Commands::Branch::Delete.new(@execution_context).call(name, force: force)
+  Git::BranchDeleteResult.from(name: name, command_result: result)
+end
+```
+
+This keeps result-object construction in one place per type and makes parsers
+reusable across facade methods.
+
+## Common failures
+
+### One-line delegation when orchestration is needed
+
+If the facade method discards information the caller documented as part of the
+return type (e.g. returns `result.stdout` when the caller expects a parsed Hash),
+the one-line form is wrong. Expand to the orchestration sequence and call the
+appropriate parser.
+
+### Leaking command-class types into the public API
+
+The public return type should never be `Git::Commands::Foo::Bar::SomeResult` or
+any other type from `Git::Commands::*`. Returning `Git::CommandLineResult` is
+acceptable when the topic module documents that as its contract, but is not the
+default — see [Choosing the return type](#choosing-the-return-type). Returning
+domain objects (`Git::BranchInfo`, `Git::DiffResult`, etc.) is preferred for
+methods that produce structured data.
+
+### Exposing command-DSL-shaped argv in the facade signature
+
+The facade signature is a Ruby API, not a transcription of the git CLI. Accepting
+a free-form `*args` that is forwarded straight to the command, or naming keyword
+arguments after CLI flags (e.g. `no_ff:`, `set_upstream_to:`) instead of
+Ruby-idiomatic names, leaks the command DSL into the public contract. Define the
+signature from the caller's perspective; translate to command DSL inside the
+body.
+
+### Changing the legacy return type or signature on extraction
+
+When a facade method is extracted from `Git::Base` / `Git::Lib`, returning a
+different type, accepting a different positional/keyword shape, or changing
+nil-handling silently breaks every caller. Capture the legacy contract in the
+Step 2 plan and diff before/after — see
+[Choosing the return type](#choosing-the-return-type) rule 1 and
+[Choosing the method signature](#choosing-the-method-signature) rule 1.
+
+### Bypassing `@execution_context`
+
+Constructing a command with anything other than `@execution_context` (e.g.
+`Git::Commands::Add.new(self)` from inside a facade method) is wrong. The facade
+holds a `Git::ExecutionContext::Repository`; commands must always be constructed
+with it.
+
+### Hardcoding policy options the caller cannot override
+
+```ruby
+# ❌ Wrong — caller cannot override
+Git::Commands::Pull.new(@execution_context).call(*args, **opts, edit: false)
+
+# ✅ Correct — caller's :edit wins because opts is splatted last
+Git::Commands::Pull.new(@execution_context).call(*args, edit: false, **opts)
+```
+
+Place policy defaults before the caller's `**opts` so the caller's value wins on
+key collision.
+
+### Skipping option whitelisting on opaque opts hashes
+
+If the facade accepts an options hash (positional `opts = {}` *or* keyword
+`**options`), it must call `Git::Repository::Internal.assert_valid_opts!` against
+a `private_constant`-marked `<METHOD>_ALLOWED_OPTS` constant. Without it,
+callers can silently pass any key the command DSL happens to accept, which is
+API expansion that the facade did not commit to.
+
+### Mixing facade and command responsibilities
+
+The facade does not build CLI argv. The command does not pre-process Ruby
+arguments or parse output. If a facade method calls `command(...)` directly
+(rather than `Git::Commands::*.new(...).call(...)`) it is bypassing the command
+layer; refactor by introducing or extending the appropriate command class first.
+
+### Adding a new topic module for a single method
+
+A topic module is justified by ≥3 related methods. Single-method modules
+fragment the API surface; place the method in the closest existing module and
+revisit when more methods join.

--- a/.github/skills/facade-implementation/SKILL.md
+++ b/.github/skills/facade-implementation/SKILL.md
@@ -1,0 +1,246 @@
+---
+name: facade-implementation
+description: "Scaffolds new and reviews existing Git::Repository facade methods (organized into Git::Repository::* topic modules) with unit tests, integration tests, and YARD docs. Use when adding a new facade method to Git::Repository, updating an existing facade method, choosing or creating a topic module under lib/git/repository/, or reviewing a facade method for correctness."
+---
+
+# Facade Implementation
+
+Scaffold new and review existing facade methods on `Git::Repository`. Facade methods
+live in topic modules under `lib/git/repository/<topic>.rb` (e.g.
+{Git::Repository::Staging}) and are included into the `Git::Repository` class.
+
+A facade method is the public-API entry point that orchestrates one or more
+`Git::Commands::*` calls, optional argument pre-processing, and optional output
+parsing into rich Ruby return values. See
+[redesign/2_architecture_redesign.md §2.1](../../../redesign/2_architecture_redesign.md)
+for the five facade responsibilities this layer is designed around.
+
+## Contents
+
+- [Related skills](#related-skills)
+- [Input](#input)
+  - [Existing facade source](#existing-facade-source)
+  - [Existing facade tests](#existing-facade-tests)
+  - [Underlying command class(es)](#underlying-command-classes)
+  - [Underlying parsers (if any)](#underlying-parsers-if-any)
+- [Reference](#reference)
+- [Workflow](#workflow)
+- [Output](#output)
+
+## Related skills
+
+- [Facade Test Conventions](../facade-test-conventions/SKILL.md) — unit and
+  integration test conventions for facade methods (load when scaffolding or
+  reviewing tests)
+- [Facade YARD Documentation](../facade-yard-documentation/SKILL.md) — facade-specific
+  YARD rules for module-level and method-level docs
+- [Extract Facade from Base/Lib](../extract-facade-from-base-lib/SKILL.md) — when a
+  new facade method is migrated from `Git::Base` or `Git::Lib`, the extraction
+  workflow drives this skill in scaffold/update mode
+- [Command Implementation](../command-implementation/SKILL.md) — the underlying
+  `Git::Commands::*` classes a facade method calls. Scaffold any missing command
+  class first.
+- [YARD Documentation](../yard-documentation/SKILL.md) — baseline YARD formatting
+  rules
+- [RSpec Unit Testing Standards](../rspec-unit-testing-standards/SKILL.md) — baseline
+  RSpec rules
+- [Project Context](../project-context/SKILL.md) — three-layer architecture overview
+
+## Input
+
+The user provides:
+
+1. **Method name** — the public Ruby method name (e.g. `add`, `branches_all`,
+   `commit`).
+2. **Git operation(s)** — which `Git::Commands::*` class(es) the method orchestrates.
+   If the relevant command class does not exist yet, scaffold it first via
+   [Command Implementation](../command-implementation/SKILL.md).
+3. **Optional context** — the source `Git::Lib` / `Git::Base` method when migrating
+   (handled by [Extract Facade from Base/Lib](../extract-facade-from-base-lib/SKILL.md)).
+
+> **Note:** `Git::Repository` is intentionally empty during early phases of the
+> redesign. Its `initialize(execution_context:)` constructor is introduced
+> alongside the first facade method extraction; subsequent extractions only
+> add new topic modules and `include` lines.
+
+The agent then gathers:
+
+### Existing facade source
+
+Read `lib/git/repository.rb` to see the `include Git::Repository::<Topic>` lines and
+which topic modules exist. List `lib/git/repository/` to see all current topic
+modules and the facade methods they already define.
+
+Skip when scaffolding into a brand-new topic module.
+
+### Existing facade tests
+
+Read `spec/unit/git/repository/<topic>_spec.rb` and
+`spec/integration/git/repository/<topic>_spec.rb` (if present). Use as supplemental
+evidence of the existing test style before extending or reviewing.
+
+### Underlying command class(es)
+
+Read `lib/git/commands/<command>.rb` for each command the facade method calls.
+The command's `arguments do` block defines the option keys the facade may forward,
+and the YARD `@!method call` block documents what each option does. The facade must
+not pass option keys the command does not declare.
+
+### Underlying parsers (if any)
+
+Read `lib/git/parsers/<parser>.rb` for any parser the facade uses to transform
+command stdout into structured data.
+
+## Reference
+
+See [REFERENCE.md](REFERENCE.md) for the full reference covering:
+
+- Files to generate
+- Topic module selection (existing modules + decision rules for creating a new module)
+- Designing a facade method (return type, signature, body shape)
+- Topic module skeleton (file layout)
+- The five facade responsibilities as a checklist
+- Argument pre-processing patterns (path normalization, option whitelisting via
+  `Git::Repository::Internal.assert_valid_opts!` + `private_constant`,
+  deprecation handling, defaults)
+- Internal helpers and encapsulation (sibling `module_function` modules under
+  `lib/git/repository/` instead of private methods on `Git::Repository`;
+  bare-noun naming; growth path from `Internal` to responsibility-named
+  modules)
+- When to call multiple commands (orchestration sequences)
+- When to use a parser vs. raw stdout
+- When to use a result-class factory method
+- Common failures (one-line delegation when orchestration is needed; leaking
+  command-class types into the public API; bypassing the execution context;
+  hardcoding policy options the caller cannot override)
+
+Subagents load REFERENCE.md directly during the workflow steps that need it.
+
+## Workflow
+
+This skill supports three modes. Determine which mode applies before starting:
+
+- **Scaffold** — adding a new facade method (and possibly a new topic module).
+  Follow all steps.
+- **Update** — modifying an existing facade method (e.g. adding a new option to
+  forward). Skip step 2 (module selection); steps 3a–3c are extending existing files
+  rather than creating them.
+- **Review** — auditing an existing facade method (no changes). Follow all steps but
+  produce findings instead of code.
+
+1. **Gather input** — collect the method name, target git operation(s), and any
+   migration source per [Input](#input). Read the underlying command class(es) and
+   parser(s) the method will call.
+
+2. **Choose the topic module** — load
+   [REFERENCE.md](REFERENCE.md) and apply [Topic module
+   selection](REFERENCE.md#topic-module-selection):
+
+   - Prefer extending an existing module under `lib/git/repository/`.
+   - Create a new module only when there are at least 3 related facade methods that
+     do not fit any existing module.
+   - New module names are inspired by (not slavishly following) the categories at
+     <https://git-scm.com/docs> (Working tree, Branching, History, Sharing,
+     Patching, Inspection, Configuration, etc.).
+
+3. **For the facade method**, repeat steps 3a–3e:
+
+   a. **Scaffold the facade method (subagent)** *(scaffold/update modes only)* —
+      delegate to a subagent: load [REFERENCE.md](REFERENCE.md) and the
+      [Facade YARD Documentation](../facade-yard-documentation/SKILL.md) skill,
+      then create or extend `lib/git/repository/<topic>.rb` using the [Designing
+      a facade method](REFERENCE.md#designing-a-facade-method) section and
+      [Topic module skeleton](REFERENCE.md#topic-module-skeleton). For new topic
+      modules, also add the `require` and `include` lines to
+      `lib/git/repository.rb`.
+
+   Steps 3b and 3c may run **in parallel** (they produce independent files).
+
+   b. **Scaffold unit tests (subagent)** *(scaffold/update modes only)* — delegate
+      to a subagent: load **[Facade Test
+      Conventions](../facade-test-conventions/SKILL.md)** (which loads [RSpec Unit
+      Testing Standards](../rspec-unit-testing-standards/SKILL.md)), then create or
+      extend `spec/unit/git/repository/<topic>_spec.rb` following the unit
+      conventions (stub `Git::Commands::*` and `Git::Parsers::*` via
+      `instance_double`; assert delegation contracts; cover each pre-processing
+      branch).
+
+   c. **Scaffold integration tests (subagent)** *(scaffold/update modes only)* —
+      delegate to a subagent: load **[Facade Test
+      Conventions](../facade-test-conventions/SKILL.md)**, then create or extend
+      `spec/integration/git/repository/<topic>_spec.rb` following the integration
+      conventions (real git in a temp repository; assert end-to-end Ruby return
+      value, not intermediate command results). Skip integration tests for true
+      one-line delegators that add no orchestration on top of the underlying
+      command — the command's own integration tests already cover that path.
+
+   Steps 3d and 3e may run **in parallel** (they review independent file sets).
+
+   d. **Review Facade Tests (subagent)** — delegate to a subagent: load and apply
+      **[Facade Test Conventions](../facade-test-conventions/SKILL.md)** against the
+      unit and integration spec files. Fix all findings, then repeat the review
+      until clean.
+
+   e. **Review YARD Documentation (subagent)** — delegate to a subagent: load and
+      apply **[Facade YARD Documentation](../facade-yard-documentation/SKILL.md)**
+      against the topic module file. Fix all findings, then repeat the review
+      until clean.
+
+4. **Review facade shape and orchestration** — load
+   [REFERENCE.md](REFERENCE.md) and verify against the [Five facade
+   responsibilities checklist](REFERENCE.md#the-five-facade-responsibilities-checklist),
+   the [Designing a facade method](REFERENCE.md#designing-a-facade-method) section, and
+   [Common failures](REFERENCE.md#common-failures). Confirm the method:
+
+   - delegates to a `Git::Commands::*` class via `@execution_context` (never
+     constructs commands with `self` or builds CLI argv directly)
+   - does not return a `Git::CommandLineResult` from the public contract unless
+     that is the documented return type for the entire topic module
+   - whitelists forwarded options when the caller's hash is opaque
+     (per-method `<METHOD>_ALLOWED_OPTS` constant +
+     `Git::Repository::Internal.assert_valid_opts!(allowed, **)` — do **not**
+     also `slice`; see [Option
+     whitelisting](REFERENCE.md#option-whitelisting-preventing-api-expansion))
+   - handles defaults and deprecations explicitly, not by relying on command
+     internals
+
+5. **Run quality gates** — discover the prerequisite tasks for `default:parallel`
+   and run them sequentially, fixing failures before advancing:
+
+   ```bash
+   bundle exec ruby -e "require 'rake'; load 'Rakefile'; puts Rake::Task['default:parallel'].prerequisites"
+   ```
+
+   Run each listed task **individually** in order via `bundle exec rake <task>`
+   (one task per invocation). On failure, fix the issue and re-run that same task.
+   Continue until every task passes on its first attempt with no fixes needed.
+
+## Output
+
+For **scaffold** and **update** modes, produce:
+
+1. **Topic module** — `lib/git/repository/<topic>.rb` (created or extended)
+2. **Facade wiring** — `lib/git/repository.rb` updated with `require` and `include`
+   when a new topic module was created
+3. **Unit tests** — `spec/unit/git/repository/<topic>_spec.rb`
+4. **Integration tests** — `spec/integration/git/repository/<topic>_spec.rb`
+   (omit only for true one-line delegators)
+5. **All quality gates pass** — rspec, minitest, rubocop, and yard all green
+
+For **review** mode, produce:
+
+| Check | Status | Issue |
+| --- | --- | --- |
+| Topic module placement | Pass/Fail | ... |
+| Orchestration via `@execution_context` | Pass/Fail | ... |
+| Argument pre-processing complete | Pass/Fail | ... |
+| Option whitelisting (where required) | Pass/Fail | ... |
+| Return value matches documented contract | Pass/Fail | ... |
+| Parser/result-class wiring correct | Pass/Fail | ... |
+| YARD docs complete | Pass/Fail | ... |
+| Unit + integration coverage | Pass/Fail | ... |
+
+Then list required fixes.
+> **Branch workflow:** Implement scaffolding or updates on a feature branch.
+> Never commit or push directly to `main` — open a pull request when changes
+> are ready to merge.

--- a/.github/skills/facade-test-conventions/SKILL.md
+++ b/.github/skills/facade-test-conventions/SKILL.md
@@ -1,0 +1,365 @@
+---
+name: facade-test-conventions
+description: "Conventions for writing and reviewing unit and integration tests for Git::Repository facade methods (modules under lib/git/repository/). Use when scaffolding new facade tests or auditing existing ones in spec/unit/git/repository/ and spec/integration/git/repository/."
+---
+
+# Facade Test Conventions
+
+Conventions for writing and reviewing unit and integration tests for facade
+methods on `Git::Repository::*` modules.
+
+## Contents
+
+- [Related skills](#related-skills)
+- [Input](#input)
+- [Reference](#reference)
+  - [Unit tests](#unit-tests)
+    - [Setup pattern](#setup-pattern)
+    - [Cover these cases](#cover-these-cases)
+    - [Expectations for command invocation](#expectations-for-command-invocation)
+    - [What not to test](#what-not-to-test)
+    - [Unit test grouping](#unit-test-grouping)
+  - [Integration tests](#integration-tests)
+    - [When to write integration tests](#when-to-write-integration-tests)
+    - [When to skip integration tests](#when-to-skip-integration-tests)
+    - [Integration test grouping](#integration-test-grouping)
+    - [What integration tests assert](#what-integration-tests-assert)
+    - [What integration tests do not assert](#what-integration-tests-do-not-assert)
+- [Workflow](#workflow)
+- [Output](#output)
+  - [When writing new facade tests](#when-writing-new-facade-tests)
+  - [When reviewing existing facade tests](#when-reviewing-existing-facade-tests)
+
+## Related skills
+
+- [RSpec Unit Testing Standards](../rspec-unit-testing-standards/SKILL.md) — baseline
+  RSpec rules that govern all unit test structure, naming, setup, stubbing, and
+  coverage; this skill adds facade-specific conventions on top
+- [Facade Implementation](../facade-implementation/SKILL.md) — facade module
+  structure and orchestration patterns
+- [Facade YARD Documentation](../facade-yard-documentation/SKILL.md) — YARD docs
+  for facade modules and methods
+- [Command Test Conventions](../command-test-conventions/SKILL.md) — sibling skill
+  that tests the underlying `Git::Commands::*` classes the facade calls
+
+## Input
+
+The invocation needs the unit and/or integration spec file(s) to review. Including
+the corresponding facade module file (`lib/git/repository/<topic>.rb`) provides
+useful context for verifying delegation contracts and option forwarding.
+
+**Prerequisite:** Read the **entire** [RSpec Unit Testing
+Standards](../rspec-unit-testing-standards/SKILL.md) skill (line 1 through EOF)
+before beginning. It defines the baseline Rules 1–28 that this skill extends.
+
+## Reference
+
+### Unit tests
+
+Facade unit tests verify the **orchestration contract** between the facade method
+and the components it calls (`Git::Commands::*`, `Git::Parsers::*`,
+`Git::ExecutionContext::Repository`). They do not run real git.
+
+The collaborators (commands, parsers) are stubbed via `instance_double`. The unit
+test asserts:
+
+1. The facade constructs each command class with the injected
+   `@execution_context`.
+2. Each command's `#call` is invoked with the expected positional and keyword
+   arguments (verifying argument pre-processing).
+3. For multi-command sequences, the calls happen in the documented order.
+4. The parser/result-class is invoked with the command's stdout (when applicable).
+5. The facade returns the value its public contract documents.
+
+#### Setup pattern
+
+```ruby
+RSpec.describe Git::Repository::Staging do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+  let(:command_result) { instance_double(Git::CommandLineResult, stdout: '') }
+  let(:add_command) { instance_double(Git::Commands::Add) }
+  let(:add_result) { command_result }
+
+  before do
+    allow(Git::Commands::Add).to receive(:new).with(execution_context).and_return(add_command)
+  end
+
+  describe '#add' do
+    # ...
+  end
+end
+```
+
+The shared `command_result` `let` provides a default empty-stdout result; each
+per-command alias (`add_result`, `branch_list_result`, ...) lets individual
+tests override stdout in isolation — e.g.
+`let(:add_result) { instance_double(Git::CommandLineResult, stdout: 'fixture output') }`
+in a nested `context` — without affecting other tests in the file.
+
+Three rules:
+
+- The subject is an instance of `Git::Repository`, **not** the module itself.
+  Modules are mixed into the class; tests must exercise the class to reflect
+  real call sites.
+- `execution_context` is an `instance_double(Git::ExecutionContext::Repository)`
+  — never a `double('ExecutionContext')` and never a real context.
+- Each command class is stubbed with `allow(Klass).to receive(:new).with(execution_context).and_return(...)`
+  so the facade's command construction (with the right execution context) is
+  verified by the stub.
+
+#### Cover these cases
+
+- **Default invocation** — facade called with no arguments (or only required
+  positional args) delegates with the documented defaults. Assert the return
+  value once per facade method to verify pass-through.
+- **Each positional argument variation** — single value, array, nil where
+  applicable.
+- **Each option the facade exposes** — including aliases, deprecated keys, and
+  policy defaults the facade applies (`edit: false`, etc.).
+- **Multi-command sequences** — when the facade calls more than one command,
+  use `expect ... receive(:call).with(...).ordered` to assert ordering and
+  intermediate-result wiring.
+- **Parser invocation** — when the facade uses a `Git::Parsers::*` class,
+  stub the parser and assert it is called with the command's stdout. Assert the
+  facade returns what the parser returned.
+- **Raw `CommandLineResult` return** — when the facade's contract is to
+  return the command's `Git::CommandLineResult` directly (not `.stdout` and
+  not a parser output), assert `eq(<command>_result)` to verify pass-through.
+- **Option whitelisting** — when the facade defines a `<METHOD>_ALLOWED_OPTS`
+  constant and calls `Git::Repository::Internal.assert_valid_opts!`, test that
+  an unknown key raises `ArgumentError` and a known key is forwarded.
+- **Deprecation handling** — when the facade rewrites or warns on deprecated
+  keys, test that the deprecation warning is emitted and the new key is
+  forwarded.
+
+#### Expectations for command invocation
+
+Use the standard rspec-mocks form (no command-specific helper exists for the
+facade layer):
+
+```ruby
+it 'delegates to Git::Commands::Add#call with the given path' do
+  expect(add_command).to receive(:call).with('path/to/file.rb').and_return(add_result)
+  described_instance.add('path/to/file.rb')
+end
+```
+
+For command + parser orchestration (single command whose stdout is fed to a
+parser), use `.ordered` to assert the call sequence:
+
+```ruby
+it 'lists branches then parses the output' do
+  expect(branch_list_command).to(
+    receive(:call)
+        .with(all: true, format: Git::Parsers::Branch::FORMAT_STRING)
+        .and_return(branch_list_result)
+        .ordered
+  )
+
+  expect(Git::Parsers::Branch).to(
+    receive(:parse_list)
+        .with(branch_list_result.stdout)
+        .and_return(parsed_branches)
+        .ordered
+  )
+
+  expect(described_instance.branches_all).to eq(parsed_branches)
+end
+```
+
+For genuinely multi-command orchestration (the facade calls more than one
+command), chain `.ordered` across each command's `#call`, wiring intermediate
+results through as needed:
+
+```ruby
+it 'saves the stash then lists stashes' do
+  expect(stash_save_command).to(
+    receive(:call).with(message: 'wip').and_return(stash_save_result).ordered
+  )
+
+  expect(stash_list_command).to(
+    receive(:call).and_return(stash_list_result).ordered
+  )
+
+  expect(described_instance.stash_save_and_list(message: 'wip')).to eq(parsed_stashes)
+end
+```
+
+#### What not to test
+
+- **Command argv building.** That is the command class's contract and is covered
+  by `spec/unit/git/commands/<command>_spec.rb`. The facade unit test should
+  stub `#call` and assert the keyword arguments the facade passes — not assert
+  on the CLI tokens that reach git.
+- **Parser internals.** Stub the parser class method and assert the facade calls
+  it with the right input. Parser parsing is covered by `spec/unit/git/parsers/`.
+- **Real command execution.** Facade unit tests must not exercise
+  `Git::ExecutionContext::Repository` for real. Use `instance_double`.
+- **Multiple input strings exercising the same code path** — one test per
+  argument type is sufficient (string vs. array vs. nil), not one per value.
+- **`#initialize` of the facade module.** The module is mixed into
+  `Git::Repository`; constructor coverage belongs to `repository_spec.rb`.
+
+#### Unit test grouping
+
+One `describe '#<method_name>'` block per facade method. Inside, use flat
+`context` blocks per argument variation. Optional sections at the end (in order)
+when present:
+
+- `context 'option whitelisting'` —
+  `Git::Repository::Internal.assert_valid_opts!` raises on unknown keys and
+  forwards known keys unchanged (no `slice` — the assertion is the only
+  enforcement mechanism)
+- `context 'deprecation handling'` — `Git::Deprecation.warn` assertions and
+  key-rewrite tests
+- `context 'input validation'` — `ArgumentError` raised by the facade itself
+  (not by the command)
+
+The exit code section that command specs use does **not** apply to facade specs
+— exit-status handling is the command's concern; the facade's tests assume the
+command either returns a result or raises.
+
+### Integration tests
+
+Facade integration tests run real git in a temp repository and verify the
+**end-to-end Ruby return value** of the facade method.
+
+Each integration spec file tests **one facade module** (one
+`spec/integration/git/repository/<topic>_spec.rb`). Inside, group by facade
+method.
+
+#### When to write integration tests
+
+Facade integration tests are the **exception, not the default**. Most facade
+behavior is already covered end-to-end by the underlying command's own
+integration tests; re-running real git through the facade re-exercises the
+same code path without adding signal.
+
+Write a facade integration test only when the facade adds behavior that is
+**not** exercised by any single command's integration tests:
+
+- **Multi-command orchestration** — the facade calls more than one command
+  and the integration test confirms the documented end-to-end value emerges
+  from the sequence against real git.
+- **Facade-owned post-processing of real git output** — the facade itself
+  (not the command) parses, aggregates, or transforms raw command output
+  before returning. A real git invocation proves the post-processing handles
+  actual output rather than a mocked string.
+
+#### When to skip integration tests
+
+Skip for everything else, including:
+
+- **One-line delegators** that pass arguments through to a single command
+  with no pre/post-processing (e.g. `Git::Repository::Staging#add`,
+  `#reset`).
+- **Single-command facade methods that delegate parsing to a parser or
+  result-class factory** — the command's own integration test already
+  exercises that command + parser against real git.
+- **Argument pre-processing** (path normalization, deprecation key rewrites,
+  option whitelisting) — these are pure-Ruby transforms with no git
+  involvement; unit tests prove them and real git adds no signal.
+- **Error-path assertions** (`raise_error(Git::FailedError)`) — these test
+  the command's error wrapping, not the facade.
+
+When skipping, document why with a code comment in the spec file or a `#`
+header in `spec/integration/git/repository/<topic>_spec.rb` explaining which
+methods are covered exclusively by command integration tests.
+
+#### Integration test grouping
+
+Mirror the [Command Test Conventions](../command-test-conventions/SKILL.md)
+integration grouping. Use a multi-command or post-processing facade method —
+single-command delegators do not warrant integration tests (see [When to skip
+integration tests](#when-to-skip-integration-tests)):
+
+The shared context (e.g. `'in an empty repository'`) provides `repo` and
+`repo_dir` helpers. Facade integration specs must override `execution_context`
+to a `Git::ExecutionContext::Repository` (the shared context's default is
+`repo.lib`, a `Git::Lib`). Stage any required repository state in a `before`
+block inside the spec itself.
+
+```ruby
+RSpec.describe Git::Repository::Stashing, :integration do
+  include_context 'in an empty repository' # provides repo and repo_dir helpers
+
+  let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  before do
+    write_file('README.md', 'initial')
+    repo.add('README.md')
+    repo.commit('Initial commit')
+    write_file('README.md', 'work in progress')
+    repo.add('README.md')
+  end
+
+  describe '#stash_save_and_list' do
+    it 'returns the new stash entry after saving' do
+      result = described_instance.stash_save_and_list(message: 'wip')
+      expect(result).to all(be_a(Git::Stash))
+      expect(result.first.message).to include('wip')
+    end
+  end
+end
+```
+
+One `context 'when the command succeeds'` block (or just `it` blocks directly
+under `describe`) per facade method, with one or more variations that exercise
+the orchestration sequence or post-processing. Do **not** add a `context 'when
+the command fails'` block — error wrapping is the command's concern and is
+covered by command integration tests.
+
+#### What integration tests assert
+
+- The Ruby return value's **structure and key fields** (e.g., classes,
+  required attributes, presence of expected entries).
+- Multi-command orchestration produces the documented end-to-end value, not
+  intermediate command results.
+
+#### What integration tests do not assert
+
+- Specific CLI tokens reaching git (covered by command unit tests).
+- Specific git output formatting (testing git, not the facade).
+- Edge cases that vary between git versions in immaterial ways. Anchor
+  assertions on stable inputs (paths, ref names) the test controls — not on git
+  message phrasing.
+
+## Workflow
+
+1. Load the [RSpec Unit Testing
+   Standards](../rspec-unit-testing-standards/SKILL.md) skill (line 1 through
+   EOF).
+2. Read the spec file(s) under review and the corresponding facade module
+   (`lib/git/repository/<topic>.rb`) plus the underlying `Git::Commands::*` and
+   `Git::Parsers::*` files the facade calls.
+3. Audit each spec against the rules in [Reference](#reference), checking unit
+   and integration tests separately.
+4. Produce the [Output](#output).
+
+## Output
+
+### When writing new facade tests
+
+Produce the unit and (when applicable) integration spec files following the
+patterns above. Then self-verify by running every checklist item in the
+[Reference](#reference) section against your output.
+
+### When reviewing existing facade tests
+
+Provide:
+
+1. issue table
+
+   | Check | Status | Issue |
+   | --- | --- | --- |
+
+2. corrected snippets for failing checks
+
+3. **Self-verify before concluding** — re-run the reference against your proposed
+   snippets until all checks pass.
+
+> **Branch workflow:** Implement any new or updated tests on a feature branch.
+> Never commit or push directly to `main` — open a pull request when changes are
+> ready to merge.

--- a/.github/skills/facade-yard-documentation/SKILL.md
+++ b/.github/skills/facade-yard-documentation/SKILL.md
@@ -1,0 +1,406 @@
+---
+name: facade-yard-documentation
+description: "Facade-specific YARD documentation rules for Git::Repository::* topic modules and their facade methods, overriding and extending the general yard-documentation skill. Use when writing or reviewing YARD docs for facade modules under lib/git/repository/."
+---
+
+# Facade YARD Documentation
+
+Write and verify YARD documentation for facade modules and methods on
+`Git::Repository::*`. This skill overrides and extends the general
+[YARD Documentation](../yard-documentation/SKILL.md) skill with facade-specific
+rules.
+
+The facade is the **public API surface** of the gem. Facade docs describe what
+the caller passes and what they get back — never the internal command class,
+parser, or execution context that implements the behavior.
+
+## Contents
+
+- [Related skills](#related-skills)
+- [Input](#input)
+- [Reference](#reference)
+  - [Module-level docs](#module-level-docs)
+  - [Method-level docs](#method-level-docs)
+  - [Documenting forwarded options with `@overload`](#documenting-forwarded-options-with-overload)
+  - [Return type rules](#return-type-rules)
+  - [`@raise` rules](#raise-rules)
+  - [Cross-referencing the implementation](#cross-referencing-the-implementation)
+  - [Common issues](#common-issues)
+- [Workflow](#workflow)
+- [Output](#output)
+
+## Related skills
+
+- [YARD Documentation](../yard-documentation/SKILL.md) — authoritative source for
+  general YARD formatting rules; **must be loaded** as a prerequisite
+- [Facade Implementation](../facade-implementation/SKILL.md) — facade module
+  structure and orchestration patterns
+- [Facade Test Conventions](../facade-test-conventions/SKILL.md) — unit and
+  integration test conventions for facade methods
+- [Command YARD Documentation](../command-yard-documentation/SKILL.md) — sibling
+  skill for the underlying command classes (different rules — facade docs do
+  **not** mirror command DSL)
+
+## Input
+
+Before starting, you **MUST** load the following skill(s) in their entirety:
+
+- [YARD Documentation](../yard-documentation/SKILL.md) — authoritative source for
+  YARD formatting rules and writing standards
+
+Then gather:
+
+1. **Facade module source** — `lib/git/repository/<topic>.rb`
+2. **Underlying command class(es)** — `lib/git/commands/<command>.rb` for each
+   command the facade method calls. Use these to confirm option semantics, but
+   do **not** copy the command's `@option` docs verbatim — the facade only
+   exposes the options it documents in its public contract.
+3. **Underlying parser/result class** — when the facade returns a structured
+   value, read the parser or result class to confirm the documented return type.
+
+## Reference
+
+### Module-level docs
+
+Every facade module under `lib/git/repository/` requires a module-level YARD
+block:
+
+```ruby
+module Git
+  class Repository
+    # Short summary of the topic and the facade methods it provides
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module Topic
+      # ...
+    end
+  end
+end
+```
+
+Module-level tags appear in the order required by
+[YARD Documentation — Modules](../yard-documentation/SKILL.md#element-specific-rules):
+`@note`, `@deprecated`, `@see`, `@api`. (Facade modules do not use module-level
+`@example` — see the override note below.)
+
+Required tags:
+
+- [ ] short summary describing the topic (e.g. "Facade methods for staging-area
+  operations: adding and resetting files") — follows the short-description
+  rules in [YARD Documentation](../yard-documentation/SKILL.md)
+- [ ] sentence noting "Included by {Git::Repository}." with the YARD link
+- [ ] `@api public` — every facade module is part of the public API
+
+Do **not** add:
+
+- `@see Git::Commands::*` at the module level — implementation detail
+- `@see https://git-scm.com/docs/...` at the module level — git man-page
+  links belong on the individual facade methods, where the link maps directly
+  to the command being invoked. A module typically groups several facade
+  methods (sometimes spanning multiple git commands), so a single module-level
+  link is misleading; for single-command modules it is redundant with the
+  method-level link.
+- `@example` blocks at the module level — **facade-specific override of
+  [YARD Documentation — Modules](../yard-documentation/SKILL.md#element-specific-rules)**,
+  which permits module-level `@example` when a module provides standalone
+  methods. Facade modules do provide standalone methods, but every facade
+  method already carries its own `@example`, so a module-level example would
+  be redundant. Examples belong on the methods.
+
+### Method-level docs
+
+Every facade method requires full YARD docs. Two acceptable forms:
+
+**Form A — `@overload` with anonymous splat in the `def`** (the **default**
+for any method that forwards positional args and/or keyword options unchanged
+to the underlying command). The `def` uses an anonymous splat — `**`, `*`, or
+`...` — to satisfy RuboCop's `Style/ArgumentsForwarding` cop, and the
+`@overload` block introduces named parameters that `@param` and `@option` bind
+to:
+
+```ruby
+# Update the index with the current content found in the working tree
+#
+# @overload add(paths = '.', **options)
+#
+#   @example Stage all changed files
+#     repo.add
+#
+#   @example Stage a specific file
+#     repo.add('README.md')
+#
+#   @param paths [String, Array<String>] a file or files to add (relative to
+#     the worktree root); defaults to `'.'` (all files)
+#
+#   @param options [Hash] options for the add command
+#
+#   @option options [Boolean] :all (false) add, modify, and remove index
+#     entries to match the worktree
+#
+#   @option options [Boolean] :force (false) allow adding otherwise ignored
+#     files
+#
+#   @return [String] git's stdout from the add
+#
+# @raise [ArgumentError] if unsupported options are provided
+#
+# @raise [Git::FailedError] if `git add` exits with a non-zero status
+#
+def add(paths = '.', **)
+  Git::Repository::Internal.assert_valid_opts!(ADD_ALLOWED_OPTS, **)
+  Git::Commands::Add.new(@execution_context).call(*Array(paths), **).stdout
+end
+```
+
+See [Documenting forwarded options with
+`@overload`](#documenting-forwarded-options-with-overload) for the rationale
+and variations (`*`, `...`, multiple call shapes).
+
+**Form B — direct doc comment on a fully named signature** (the **narrow
+exception**: use only when the method body must inspect or mutate the options
+hash before forwarding it, or when the signature has no splat at all). When
+the `def` has a named parameter for every documented argument, `@param` and
+`@option` bind directly:
+
+```ruby
+# Commit staged changes
+#
+# @example Commit with a message
+#   repo.commit('Initial commit')
+#
+# @example Amend the previous commit
+#   repo.commit('Updated message', amend: true)
+#
+# @param message [String] the commit message
+#
+# @param opts [Hash] commit options
+#
+# @option opts [Boolean] :amend (false) amend the previous commit
+#
+# @return [String] git's stdout from the commit
+#
+# @raise [ArgumentError] if unsupported options are provided
+#
+# @raise [Git::FailedError] if `git commit` exits with a non-zero status
+#
+def commit(message, opts = {})
+  Git::Repository::Internal.assert_valid_opts!(COMMIT_ALLOWED_OPTS, **opts)
+  opts = opts.merge(message: message) if message
+  Git::Commands::Commit.new(@execution_context).call(edit: false, **opts).stdout
+end
+```
+
+Form B is required here because the method body needs a named variable (`opts`)
+to build and transform before forwarding — e.g. `opts.merge(message: message)`
+returns a new hash that is assigned back, and `opts = deprecate_commit_no_gpg_sign_option(opts)`
+reassigns it; an anonymous `**` in the `def` provides no named variable to
+operate on.
+
+When a method has multiple genuinely distinct call shapes (e.g.
+`commit(message)` vs. `commit(message, opts)` with materially different
+return types), use one `@overload` block per shape — see
+[YARD Documentation — Overload
+template](../yard-documentation/SKILL.md#overload-template).
+
+Required elements (apply to both forms):
+
+- [ ] one-line summary describing what the method does from the caller's
+  perspective (not "calls `Git::Commands::Foo`")
+- [ ] at least one `@example` block with a descriptive title (required on every
+  public facade method; use representative input and show the return value)
+- [ ] `@param` for every positional parameter, with type and short description
+- [ ] `@param <name> [Hash]` preceding any `@option` tags — the name comes
+  from the `@overload` signature (e.g. `options` or `opts`) when the actual
+  `def` uses anonymous `**` for `Style/ArgumentsForwarding`; otherwise it
+  matches the named parameter on the `def` itself
+- [ ] `@option` for every option the facade exposes (the caller-facing contract,
+  not every option the underlying command accepts)
+- [ ] `@return` with the **documented public return type** (see [Return type
+  rules](#return-type-rules))
+- [ ] `@raise` for every error the caller can hit (see [`@raise`
+  rules](#raise-rules))
+
+### Documenting forwarded options with `@overload`
+
+When a facade method forwards positional args and/or keyword options unchanged
+to the underlying command, keep the anonymous splat (`**`, `*`, or `...`) in
+the `def` (so `Style/ArgumentsForwarding` stays satisfied) and document the
+call shape with an `@overload` block that names the parameters — Form A in
+[Method-level docs](#method-level-docs) above shows the canonical `add`
+example.
+
+Key constraints:
+
+- **Do not** name the splat — or expand `...` into `*args, **kwargs, &block` —
+  solely to make `@param`/`@option` bind. **Do not** suppress
+  `Style/ArgumentsForwarding` with `# rubocop:disable`. The `@overload` form is
+  the project-standard resolution.
+- The `@overload` signature owns the parameter names; `@param`, `@option`,
+  `@yield`, and `@yieldparam` tags inside the overload bind to those names.
+- When a facade method has multiple distinct call shapes (e.g.
+  `commit(message)` vs. `commit(message, **opts)`), write one `@overload`
+  block per shape.
+- Form B (named splat, direct doc comment) is the narrow exception — use only
+  when the body inspects or mutates the options hash before forwarding it.
+- The **anonymous block parameter (`&`)** is not covered by this rule.
+  `@yield`/`@yieldparam`/`@yieldreturn` describe what is yielded rather than
+  the block parameter itself, so anonymous `&` is fine. Name the block
+  (`&block`) only when documenting it as a first-class `Proc` value.
+
+See the general
+[YARD Documentation — Documenting anonymous splats with `@overload`](../yard-documentation/SKILL.md#documenting-anonymous-splats-with-overload)
+for the underlying rule.
+
+### Return type rules
+
+The `@return` annotation must reflect the **public contract** of the facade
+method, not the type of the underlying call expression.
+
+| Facade does | `@return` type |
+|---|---|
+| Returns the raw `CommandLineResult` | `[Git::CommandLineResult]` |
+| Returns `result.stdout` (chomped or raw) | `[String]` |
+| Returns parsed structured data via a parser | The parser's return type (e.g. `[Array<Git::BranchInfo>]`, `[Hash]`) |
+| Returns a result-class instance via a factory | The result class (e.g. `[Git::BranchDeleteResult]`) |
+| Returns a single Boolean derived from the result | `[Boolean]` |
+
+Never write `@return [Git::Commands::Foo::Result]` — command-class result types
+are internal. Surface `Git::CommandLineResult` only when the topic module's
+documented contract is to expose raw results.
+
+### `@raise` rules
+
+- Always include `@raise [Git::FailedError]` for any facade method that can
+  cause git to exit non-zero. Use the canonical generic wording matching the
+  command's exit-status range:
+
+  | Command's `allow_exit_status` | Facade `@raise` wording |
+  |---|---|
+  | none / `0..0` | `if git exits with a non-zero exit status` |
+  | `0..1` | `if git exits outside the allowed range (exit code > 1)` |
+
+- When the facade calls `assert_valid_opts!`, include
+  `@raise [ArgumentError] if unsupported options are provided`.
+- When the facade itself validates arguments and raises (e.g. "you must specify
+  a remote if a branch is specified"), document with a specific `@raise
+  [ArgumentError]` line that names the constraint.
+- Do **not** enumerate specific git failure causes (no "if the branch doesn't
+  exist", no "if the working tree is dirty"). Use the generic form.
+
+### Cross-referencing the implementation
+
+When useful, cross-link to the underlying components with `@see` tags **at the
+end** of the method's doc block:
+
+```ruby
+# @see Git::Commands::Branch::List
+# @see Git::Parsers::Branch
+# @see https://git-scm.com/docs/git-branch git-branch
+```
+
+Use sparingly — only when the cross-link helps a reader navigate to non-obvious
+internals. Do not add `@see` for every command and parser by default; trivial
+delegators do not need them.
+
+### Common issues
+
+- **`@return [Git::CommandLineResult]` on a method that actually returns a
+  parsed value.** Match the actual return value, not the inner call expression.
+- **Copying `@option` blocks from the command class.** The facade exposes only
+  the options listed in its public contract (and the `<METHOD>_ALLOWED_OPTS`
+  whitelist when present). Do not copy every option the command DSL declares.
+- **Documenting policy defaults as caller options.** When the facade hardcodes
+  `edit: false`, do not list `:edit` as a caller option. The facade's contract
+  is "non-interactive commit"; mention the policy in prose if relevant, not as
+  an `@option`.
+- **Documenting the underlying command in the summary.** Wrong: "Calls
+  `Git::Commands::Add.#call`". Right: "Update the index with the current
+  content found in the working tree."
+- **Leaking `Git::ExecutionContext::Repository` into docs.** The execution
+  context is injected once at construction; facade method docs do not mention
+  it.
+- **Missing `@example` on a public method.** Every public facade method requires
+  at least one `@example` block with a descriptive title. Examples belong on the
+  method, not at the module level.
+- **Missing `@param <name> [Hash]` before `@option` tags.** Every `@option` tag
+  requires a preceding `@param` for the options hash. Use the parameter name from
+  the `@overload` signature when the `def` uses anonymous `**`.
+- **Missing `@api public` on the module.** Every facade module is part of the
+  public API and must declare it.
+- **Uppercase first letter or trailing period on tag short descriptions.** Same
+  rule as command YARD: lowercase start, no trailing punctuation on the short
+  description.
+- **Raw blank line inside a doc comment block.** A line with no leading `#`
+  silently terminates the YARD block. Use blank comment lines (`#`) inside
+  multi-paragraph descriptions.
+
+## Workflow
+
+For each facade module file, run through these checks in order:
+
+### 1. Module-level docs
+
+- [ ] short topic summary (per
+  [YARD Documentation](../yard-documentation/SKILL.md) short-description rules)
+- [ ] "Included by {Git::Repository}." sentence with the YARD link
+- [ ] `@api public`
+- [ ] no `@example` at the module level
+- [ ] no `@see Git::Commands::*` at the module level
+- [ ] no `@see https://git-scm.com/docs/...` at the module level (those belong
+  on the individual facade methods)
+
+### 2. Method-level docs (per method)
+
+- [ ] one-line summary describing caller-facing behavior
+- [ ] at least one `@example` block with a descriptive title
+- [ ] every positional parameter has `@param` with type and short description
+- [ ] every facade-exposed option has `@option` (matching the
+  `<METHOD>_ALLOWED_OPTS` whitelist when present)
+- [ ] when `@option` is used, `@param <name> [Hash]` precedes the `@option`
+  tags; for methods using `@overload`, the parameter name comes from the
+  overload signature (e.g. `@overload add(paths, **options)`) — the `def`
+  may still use anonymous `**`
+- [ ] options that exist on the underlying command but are not exposed by the
+  facade are **not** listed
+- [ ] policy defaults the facade hardcodes are not listed as `@option`
+- [ ] `@return` matches the actual return value type per [Return type
+  rules](#return-type-rules)
+- [ ] `@raise` tags follow [`@raise` rules](#raise-rules)
+- [ ] `@see` tags appear at the end and are limited to non-obvious cross-links
+
+### 3. Formatting consistency
+
+- [ ] every YARD tag is preceded by a blank comment line (`#`)
+- [ ] no raw blank lines inside any doc block
+- [ ] tag short descriptions start lowercase and have no trailing punctuation
+- [ ] multi-paragraph tag descriptions have a blank `#` line between paragraphs
+- [ ] all general formatting rules from
+  [YARD Documentation](../yard-documentation/SKILL.md) are satisfied
+
+## Output
+
+### When writing new facade YARD docs
+
+Produce the complete YARD doc block(s) for the module and each method, then
+self-verify by running every checklist item from [Workflow](#workflow) against
+your output. Fix and re-verify until all checks pass.
+
+### When reviewing existing facade YARD docs
+
+For each file, provide:
+
+1. issue table
+
+   | Check | Status | Issue |
+   | --- | --- | --- |
+
+2. corrected doc block snippets (only where needed)
+
+3. **Self-verify before concluding** — re-run every checklist item against
+   your proposed snippets until all checks pass.
+
+> **Branch workflow:** Implement any fixes on a feature branch. Never commit or
+> push directly to `main` — open a pull request when changes are ready to merge.

--- a/.github/skills/pr-readiness-review/SKILL.md
+++ b/.github/skills/pr-readiness-review/SKILL.md
@@ -46,6 +46,10 @@ Before starting, you **MUST** load the following skill(s) in their entirety:
   test conventions for command classes
 - [Command YARD Documentation](../command-yard-documentation/SKILL.md)
   — verify command documentation completeness and consistency
+- [Facade Test Conventions](../facade-test-conventions/SKILL.md) —
+  unit/integration test conventions for `Git::Repository::*` facade methods
+- [Facade YARD Documentation](../facade-yard-documentation/SKILL.md) — verify
+  facade module/method documentation completeness and consistency
 
 ## 1. Run Final Validation
 

--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -33,6 +33,13 @@ coding standard details, or implementation constraints.
   conventions for day-to-day work
 - [Command Implementation](../command-implementation/SKILL.md) — generating and
   reviewing command classes in the layered architecture
+- [Facade Implementation](../facade-implementation/SKILL.md) — generating and
+  reviewing `Git::Repository::*` facade methods (the planned v5.0.0 facade
+  layer is being introduced incrementally during the architectural redesign;
+  `Git::Base` / `Git::Lib` remain the current public API until the migration
+  completes)
+- [Extract Facade from Base/Lib](../extract-facade-from-base-lib/SKILL.md) —
+  migrating public methods from `Git::Base` / `Git::Lib` into facade methods
 - [YARD Documentation](../yard-documentation/SKILL.md) — documentation
   standards
 


### PR DESCRIPTION
## Summary

Adds new Agent Skills supporting the Git::Repository facade layer and updates existing skills with cross-references to the new facade skills.

### New skills added
- `extract-facade-from-base-lib` — guides migration of public methods from `Git::Base`/`Git::Lib` to `Git::Repository::*` facade modules
- `facade-implementation` — scaffolds and reviews `Git::Repository` facade methods with unit tests, integration tests, and YARD docs
- `facade-test-conventions` — conventions for writing and reviewing unit/integration tests for `Git::Repository` facade methods
- `facade-yard-documentation` — facade-specific YARD documentation rules for `Git::Repository::*` topic modules

### Existing skills updated
- `command-implementation` — added link to facade skills
- `development-workflow` — added facade skill references
- `extract-command-from-lib` — added link to facade skills
- `pr-readiness-review` — added facade skill references
- `project-context` — updated with facade layer context