### PR TITLE
feat(repository): implement Git::Repository with Staging facade module

### DIFF
--- a/.github/skills/extract-facade-from-base-lib/SKILL.md
+++ b/.github/skills/extract-facade-from-base-lib/SKILL.md
@@ -18,11 +18,17 @@ preserve backward compatibility within the migration window.
 
 ## Contents
 
+- [Contents](#contents)
 - [How to use this skill](#how-to-use-this-skill)
 - [Prerequisites](#prerequisites)
 - [Related skills](#related-skills)
 - [Input](#input)
 - [Source patterns](#source-patterns)
+  - [Pattern A — `Git::Base` wrapper + `Git::Lib` implementation](#pattern-a--gitbase-wrapper--gitlib-implementation)
+  - [Pattern B — `Git::Lib`-only (public-by-exposure)](#pattern-b--gitlib-only-public-by-exposure)
+  - [Pattern C — `Git::Base`-only (no `Git::Lib` method)](#pattern-c--gitbase-only-no-gitlib-method)
+- [Determining the option allowlist](#determining-the-option-allowlist)
+- [Negatable flag normalization](#negatable-flag-normalization)
 - [Workflow](#workflow)
   - [Branch setup](#branch-setup)
   - [Step 1 — Identify the source pattern](#step-1--identify-the-source-pattern)
@@ -34,6 +40,14 @@ preserve backward compatibility within the migration window.
 - [Commit discipline](#commit-discipline)
 - [Quality gates](#quality-gates)
 - [What stays vs. what moves](#what-stays-vs-what-moves)
+- [Review mode](#review-mode)
+  - [Invoke](#invoke)
+  - [R1 — Source analysis](#r1--source-analysis)
+  - [R2 — Legacy test coverage](#r2--legacy-test-coverage)
+  - [R3 — Command class](#r3--command-class)
+  - [R4 — Facade implementation](#r4--facade-implementation)
+  - [R5 — Delegation](#r5--delegation)
+  - [R6 — Quality gates](#r6--quality-gates)
 
 ## How to use this skill
 
@@ -155,6 +169,72 @@ end
 
 **Public contract source:** `Git::Base#foo` signature and implementation.
 
+## Determining the option allowlist
+
+When the facade method uses `assert_valid_opts!`, the allowlist (`*_ALLOWED_OPTS`) must
+contain **only the options that were accepted in the 4.x branch** of this gem. Do not
+expand the allowlist to match everything the underlying `Git::Commands::*` class
+supports — new options are deferred to a follow-up PR so they can be properly
+documented and tested.
+
+**How to find the 4.x allowlist for a method:**
+
+1. Open `https://github.com/ruby-git/ruby-git/blob/4.x/lib/git/lib.rb` and search
+   for the method's `*_OPTION_MAP` constant (e.g. `ADD_OPTION_MAP`,
+   `RESET_OPTION_MAP`).
+2. The option keys declared in that map are the only keys that were valid in 4.x.
+   Any key not present in the map would have raised `ArgumentError` via
+   `ArgsBuilder.validate!` — confirmed by
+   `https://github.com/ruby-git/ruby-git/blob/4.x/lib/git/args_builder.rb`.
+3. Use those keys — and only those keys — in the facade's `*_ALLOWED_OPTS`
+   constant, `@option` YARD tags, and integration/unit tests.
+4. If the underlying `Git::Commands::*` class supports additional options beyond the
+   4.x map, note them in a follow-up issue rather than silently including them.
+
+## Negatable flag normalization
+
+Some options in `Git::Commands::*` classes are declared with `negatable: true`:
+
+```ruby
+flag_option %i[all A], negatable: true
+```
+
+A negatable flag maps its value to a different CLI flag depending on truthiness:
+
+| Ruby value | CLI flag emitted |
+| --- | --- |
+| `true` | `--all` |
+| `false` | `--no-all` |
+| `nil` / omitted | *(flag absent)* |
+
+In 4.x, boolean options were always simple flags — `false` or `nil` meant
+_omission_, never `--no-<flag>`. If a facade method passes a caller's `false`
+value straight through to a negatable command option, it silently emits
+`--no-<flag>`, breaking the 4.x contract.
+
+**Fix:** After `assert_valid_opts!`, strip any `false` values from the options
+hash before forwarding to the command:
+
+```ruby
+def add(paths = '.', **options)
+  Git::Repository::Internal.assert_valid_opts!(ADD_ALLOWED_OPTS, **options)
+  normalized = options.reject { |_k, v| v == false }
+  Git::Commands::Add.new(@execution_context).call(*Array(paths), **normalized).stdout
+end
+```
+
+**How to detect negatable flags:** Open the command class
+(`lib/git/commands/<command>.rb`) and look for `flag_option` declarations with
+`negatable: true`. Cross-check every key in `*_ALLOWED_OPTS` against those
+declarations — any match requires the normalization step above.
+
+**Unit spec coverage:** For each allowlisted option that maps to a negatable
+flag, add two spec contexts:
+
+- `option: true` — verifies the key is forwarded as-is to the command
+- `option: false` — verifies the key is **omitted** (command receives no
+  keyword for that key, so `--no-<flag>` is never emitted)
+
 ## Workflow
 
 ### Branch setup
@@ -182,6 +262,10 @@ git checkout -b <feature-branch-name>
      handling)
    - any post-processing (parsing, result-class assembly)
    - any execution-context arguments (`timeout:`, `chdir:`, `env:`)
+   - the **4.x-supported options**: locate the corresponding `*_OPTION_MAP`
+     constant in `4.x/lib/git/lib.rb` and record which option keys it declared.
+     These become the facade's `*_ALLOWED_OPTS` allowlist — see
+     [Determining the option allowlist](#determining-the-option-allowlist).
 4. Document the method's current **public contract** in writing — it must be
    preserved exactly by the facade method.
 5. Run linters and rubocop to confirm a clean baseline:
@@ -286,6 +370,16 @@ For Pattern A and B migrations, copy any pre-processing logic
 (option whitelisting, deprecation rewrites, key normalization) from `Git::Lib`
 to the facade method. Do **not** leave it behind in `Git::Lib` — the facade is
 now the source of truth.
+
+When copying option whitelisting logic, use only the keys from the 4.x
+`*_OPTION_MAP` for the `*_ALLOWED_OPTS` constant — do not expand to match the
+full `Git::Commands::*` argument DSL. See
+[Determining the option allowlist](#determining-the-option-allowlist).
+
+After building the allowlist, check each key against the command class's
+`arguments` block for `negatable: true` declarations. Any match requires the
+normalization step described in
+[Negatable flag normalization](#negatable-flag-normalization).
 
 For Pattern C migrations, port any pre-processing or filesystem logic from
 `Git::Base` to the facade method.
@@ -414,3 +508,92 @@ failures before advancing. All listed tasks must pass before committing.
 > **Branch workflow:** Implement migrations on a feature branch. Never commit
 > or push directly to `main` — open a pull request when changes are ready to
 > merge.
+
+## Review mode
+
+Use this checklist to audit a completed extraction PR. For each item, read the
+relevant source files, check the box, and note any finding.
+
+### Invoke
+
+```text
+Using the Extract Facade from Base/Lib skill (review mode), audit the extraction
+of Git::Base#<method_name>.
+```
+
+### R1 — Source analysis
+
+- [ ] **Pattern identified.** Confirm which source pattern (A, B, or C) applies
+  by reading `Git::Base` and `Git::Lib`.
+- [ ] **Signature preserved.** The facade method's signature (positional args,
+  optional args, keyword splat) matches the 4.x `Git::Base#<method>` signature
+  exactly.
+- [ ] **Return type correct.** The facade returns the same type as the legacy
+  implementation (e.g. `String` from `.stdout`, not `CommandLineResult`). Read
+  the source — do not rely on YARD tags alone.
+- [ ] **4.x options only in allowlist.** The `*_ALLOWED_OPTS` constant contains
+  only keys declared in the corresponding `*_OPTION_MAP` in
+  `4.x/lib/git/lib.rb`. Look up the map at
+  `https://github.com/ruby-git/ruby-git/blob/4.x/lib/git/lib.rb`. Any extra
+  keys are a finding.
+- [ ] **Pre-processing ported.** All option whitelisting, deprecation handling,
+  and key normalization from `Git::Lib` is reproduced in the facade. Nothing
+  was left behind in `Git::Lib`.
+- [ ] **Post-processing ported.** Any parsing or result-class assembly that
+  lived in `Git::Lib` is reproduced in the facade.
+
+### R2 — Legacy test coverage
+
+- [ ] **Legacy tests exist and pass.** `tests/units/` has tests exercising the
+  public method. Verify with `bundle exec bin/test <test-file-basename>`.
+- [ ] **All 4.x options exercised.** Every option in `*_ALLOWED_OPTS` has at
+  least one legacy or integration test that passes an actual value and asserts
+  the outcome.
+
+### R3 — Command class
+
+- [ ] **Command class exists.** The `Git::Commands::*` class used by the facade
+  exists in `lib/git/commands/`.
+- [ ] **Arguments DSL covers the allowlisted options.** Every key in
+  `*_ALLOWED_OPTS` maps to a declared entry in the command's `arguments` block.
+
+### R4 — Facade implementation
+
+- [ ] **Topic module correct.** The facade method is placed in the right
+  `Git::Repository::*` module per the redesign topic groupings.
+- [ ] **`assert_valid_opts!` used.** The facade calls
+  `Git::Repository::Internal.assert_valid_opts!(ALLOWED_OPTS, **)` before
+  forwarding to the command.
+- [ ] **Negatable flags normalized.** For every key in `*_ALLOWED_OPTS` that
+  maps to a `negatable: true` entry in the command's `arguments` block, the
+  facade strips `false` values before forwarding (so `--no-<flag>` is never
+  emitted from the facade API).
+- [ ] **YARD docs complete.** Each allowed option has an `@option` tag with
+  type, name, default, and description. `@param`, `@return`, `@raise` are
+  present and accurate.
+- [ ] **Unit specs present.** `spec/unit/git/repository/<topic>_spec.rb`
+  covers: default call, explicit path(s), each documented option, unknown
+  option raises `ArgumentError`, return value is `.stdout`.
+- [ ] **Integration specs present (or explicitly skipped).** Write
+  `spec/integration/git/repository/<topic>_spec.rb` **only** when the facade
+  adds behavior not exercised by any single command's integration tests —
+  specifically multi-command orchestration or facade-owned post-processing of
+  real git output. For one-line delegators (e.g. `#add`, `#reset`) the
+  command's own integration tests already provide end-to-end coverage; omit
+  the facade integration spec and add a comment in the unit spec explaining
+  which command integration specs provide coverage.
+
+### R5 — Delegation
+
+- [ ] **`Git::Base` delegates.** The original `Git::Base` method is a one-line
+  forward to `facade_repository.<method>(...)`.
+- [ ] **`Git::Lib` delegates (Pattern A/B only).** The original `Git::Lib`
+  method is a one-line forward to the facade.
+- [ ] **Legacy tests still pass after delegation.** Run
+  `bundle exec bin/test <test-file-basename>` against the delegating methods.
+
+### R6 — Quality gates
+
+- [ ] `bundle exec rspec` passes
+- [ ] `bundle exec rubocop` passes
+- [ ] `bundle exec rake yard` passes (no undocumented public methods)

--- a/.github/skills/yard-documentation/SKILL.md
+++ b/.github/skills/yard-documentation/SKILL.md
@@ -457,6 +457,16 @@ distinct call signatures with different parameters or return types.
 silently ignores top-level tags when overloads are present. In both templates
 below, include only the tags that apply to the method.
 
+**Trigger: always use `@overload` when the signature contains `*`, `**`, or `...`**
+
+Anonymous splats and the forwarding parameter give `@param`, `@option`, `@yield`,
+and `@yieldparam` no named parameter to bind to. YARD silently drops or
+mis-renders these tags when the signature is, for example, `def foo(**)` or
+`def foo(paths = '.', **)` — even though `paths` is named, the keyword options
+have no name so every `@option` is unbound. As soon as any parameter in the
+signature is anonymous (`*`, `**`, or `...`), switch to `@overload` for the entire
+signature (see [Documenting anonymous splats with `@overload`](#documenting-anonymous-splats-with-overload)).
+
 ### Standard template (no `@overload`)
 
 When present, tags must appear in the order shown. `@param` tags appear in

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -21,7 +21,6 @@ module Git
 end
 
 require 'git/author'
-require 'git/base'
 require 'git/branch'
 require 'git/branch_info'
 require 'git/branches'
@@ -50,6 +49,7 @@ require 'git/log'
 require 'git/object'
 require 'git/remote'
 require 'git/repository'
+require 'git/base'
 require 'git/status'
 require 'git/stash'
 require 'git/stash_info'

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -128,7 +128,7 @@ module Git
     #   Controls which git binary is used for commands routed through
     #   {Git::ExecutionContext} (i.e., commands already migrated to
     #   +Git::Commands::*+ classes). Commands still delegating through +Git::Lib+
-    #   continue to use the global {Git::Base.config.binary_path} setting.
+    #   continue to use the global `Git::Base.config.binary_path` setting.
     #
     #   This limitation will be resolved when the architectural migration to
     #   +Git::Repository+ is complete.
@@ -156,24 +156,41 @@ module Git
       initialize_components(options)
     end
 
-    # Update the index from the current worktree to prepare the for the next commit
+    # Update the index from the current worktree to prepare for the next commit
     #
-    # @example
-    #   lib.add('path/to/file')
-    #   lib.add(['path/to/file1','path/to/file2'])
-    #   lib.add(all: true)
+    # @overload add(paths = '.', **options)
     #
-    # @param [String, Array<String>] paths a file or files to be added to the repository
-    #   relative to the worktree root
+    #   @example Stage all changed files
+    #     git.add
     #
-    # @param [Hash] options
+    #   @example Stage a specific file
+    #     git.add('path/to/file.rb')
     #
-    # @option options [Boolean] :all Add, modify, and remove index entries to match the worktree
+    #   @example Stage multiple files
+    #     git.add(['path/to/file1.rb', 'path/to/file2.rb'])
     #
-    # @option options [Boolean] :force Allow adding otherwise ignored files
+    #   @example Stage all changes including deletions
+    #     git.add(all: true)
     #
-    def add(paths = '.', **options)
-      lib.add(paths, options)
+    #   @param paths [String, Array<String>] a file or files to add (relative to
+    #     the worktree root); defaults to `'.'` (all files)
+    #
+    #   @param options [Hash] options for the add command
+    #
+    #   @option options [Boolean] :all (false) add, modify, and remove index
+    #     entries to match the worktree
+    #
+    #   @option options [Boolean] :force (false) allow adding otherwise ignored
+    #     files
+    #
+    #   @return [String] git's stdout from the add
+    #
+    #   @raise [ArgumentError] if unsupported options are provided
+    #
+    #   @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    def add(paths = '.', **)
+      facade_repository.add(paths, **)
     end
 
     # adds a new remote to this repository
@@ -288,12 +305,14 @@ module Git
     def set_index(index_file, check = nil, must_exist: nil)
       must_exist = deprecate_check_argument(check, must_exist)
       @lib = nil
+      @facade_repository = nil
       @index = validate_path(index_file, must_exist)
     end
 
     def set_working(work_dir, check = nil, must_exist: nil)
       must_exist = deprecate_check_argument(check, must_exist)
       @lib = nil
+      @facade_repository = nil
       @working_directory = validate_path(work_dir, must_exist)
     end
 
@@ -344,6 +363,16 @@ module Git
     # class with one that uses native methods or libgit C bindings
     def lib
       @lib ||= Git::Lib.new(self, @logger)
+    end
+
+    # Returns the {Git::Repository} facade for this repository
+    #
+    # @return [Git::Repository]
+    # @api private
+    def facade_repository
+      @facade_repository ||= Git::Repository.new(
+        execution_context: Git::ExecutionContext::Repository.from_base(self, logger: @logger)
+      )
     end
 
     # Returns the per-instance git_ssh configuration value
@@ -419,7 +448,7 @@ module Git
 
     # resets the working directory to the provided commitish
     def reset(commitish = nil, opts = {})
-      lib.reset(commitish, opts)
+      facade_repository.reset(commitish, **opts)
     end
 
     # resets the working directory to the commitish with '--hard'

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -1,21 +1,45 @@
 # frozen_string_literal: true
 
+require 'git/execution_context/repository'
+require 'git/repository/staging'
+
 module Git
   # The main public interface for interacting with a Git repository
   #
-  # This class will serve as a clean, high-level facade for all common git
-  # operations. Its methods will be simple, one-line calls that delegate the
-  # actual work to appropriate command objects.
+  # `Git::Repository` is the **orchestration layer** for all git operations. It acts
+  # as the glue between the user-facing API and the underlying components, but
+  # contains minimal domain logic itself. For each operation it:
   #
-  # During the architectural transition (Phase 1-2), this class remains empty.
-  # In Phase 3, it will be populated with facade methods that delegate to
-  # Git::Commands::* objects, and eventually replace Git::Base as the primary
-  # public interface.
+  # 1. **Pre-processes arguments** — transforms user-provided values into forms
+  #    suitable for the command layer (e.g. path expansion, option normalization,
+  #    Ruby-idiomatic defaults, deprecation handling, input validation).
+  # 2. **Calls commands** — invokes one or more `Git::Commands::*` classes via the
+  #    injected `Git::ExecutionContext::Repository`.
+  # 3. **Builds rich return values** — passes raw command output through
+  #    `Git::Parsers::*` classes and result-class factory methods to assemble the
+  #    meaningful Ruby objects the caller expects.
+  #
+  # Some operations are genuinely one-line delegators when no pre/post-processing is
+  # needed (e.g. `add`, `reset`), but many are short orchestration sequences that
+  # coordinate argument preparation, one or more command calls, and result assembly.
+  #
+  # Facade methods are organized into focused modules under `lib/git/repository/`
+  # (e.g. {Git::Repository::Staging}) and included into this class.
   #
   # @api public
   #
-  class Repository # rubocop:disable Lint/EmptyClass
-    # This class is intentionally empty during Phase 1 of the redesign.
-    # It will be populated with methods in Phase 3.
+  class Repository
+    include Git::Repository::Staging
+
+    # @param execution_context [Git::ExecutionContext::Repository] the context used
+    #   to run git commands for this repository; must not be nil
+    #
+    # @raise [ArgumentError] if `execution_context` is nil
+    #
+    def initialize(execution_context:)
+      raise ArgumentError, 'execution_context must not be nil' if execution_context.nil?
+
+      @execution_context = execution_context
+    end
   end
 end

--- a/lib/git/repository/internal.rb
+++ b/lib/git/repository/internal.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Git
+  class Repository
+    # Internal helpers shared by `Git::Repository::*` topic modules
+    #
+    # Methods defined here use `module_function` so they are callable as
+    # `Git::Repository::Internal.foo(...)` from any topic module without being
+    # added to `Git::Repository`'s instance namespace via `include`.
+    #
+    # @api private
+    #
+    module Internal
+      module_function
+
+      # Validate that `options` contains only keys listed in `allowed`
+      #
+      # Used by facade methods to enforce that only documented options (those
+      # named in `@option` tags) are accepted, even when the underlying command
+      # class would accept more keys. This prevents silent expansion of the
+      # facade's public contract.
+      #
+      # @example Reject an undocumented option
+      #   ADD_ALLOWED_OPTS = %i[all force].freeze
+      #
+      #   Git::Repository::Internal.assert_valid_opts!(ADD_ALLOWED_OPTS, bogus: true)
+      #   #=> raises ArgumentError: Unknown options: bogus
+      #
+      # @param allowed [Array<Symbol>] the keys permitted by the facade method
+      #
+      # @param options [Hash] the options hash provided by the caller
+      #
+      # @return [void]
+      #
+      # @raise [ArgumentError] when `options` contains any key not in `allowed`
+      #
+      def assert_valid_opts!(allowed, **options)
+        unknown = options.keys - allowed
+        return if unknown.empty?
+
+        raise ArgumentError, "Unknown options: #{unknown.join(', ')}"
+      end
+    end
+  end
+end

--- a/lib/git/repository/staging.rb
+++ b/lib/git/repository/staging.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'git/commands/add'
+require 'git/commands/reset'
+require 'git/repository/internal'
+
+module Git
+  class Repository
+    # Facade methods for staging-area operations: adding and resetting files
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module Staging
+      # Option keys accepted by {#add}
+      ADD_ALLOWED_OPTS = %i[all force].freeze
+      private_constant :ADD_ALLOWED_OPTS
+
+      # Update the index with the current content found in the working tree
+      #
+      # @overload add(paths = '.', **options)
+      #
+      #   @example Stage all changed files
+      #     repo.add
+      #
+      #   @example Stage a specific file
+      #     repo.add('README.md')
+      #
+      #   @example Stage all changes including deletions
+      #     repo.add(all: true)
+      #
+      #   @param paths [String, Array<String>] a file or files to add (relative to
+      #     the worktree root); defaults to `'.'` (all files)
+      #
+      #   @param options [Hash] options for the add command
+      #
+      #   @option options [Boolean] :all (false) add, modify, and remove index
+      #     entries to match the worktree
+      #
+      #   @option options [Boolean] :force (false) allow adding otherwise ignored
+      #     files
+      #
+      #   @return [String] git's stdout from the add
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def add(paths = '.', **options)
+        Git::Repository::Internal.assert_valid_opts!(ADD_ALLOWED_OPTS, **options)
+        normalized = options.reject { |_k, v| v == false }
+        Git::Commands::Add.new(@execution_context).call(*Array(paths), **normalized).stdout
+      end
+
+      # Option keys accepted by {#reset}
+      RESET_ALLOWED_OPTS = %i[hard].freeze
+      private_constant :RESET_ALLOWED_OPTS
+
+      # Reset the current HEAD to a specified state
+      #
+      # @overload reset(commitish = nil, **options)
+      #
+      #   @example Reset the index and working tree to HEAD
+      #     repo.reset
+      #
+      #   @example Hard reset to a specific commit
+      #     repo.reset('HEAD~1', hard: true)
+      #
+      #   @param commitish [String, nil] the commit or tree-ish to reset to;
+      #     defaults to HEAD when `nil`
+      #
+      #   @param options [Hash] options for the reset command
+      #
+      #   @option options [Boolean] :hard (false) reset the index and working
+      #     tree; discards all tracked changes
+      #
+      #   @return [String] git's stdout from the reset
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def reset(commitish = nil, **)
+        Git::Repository::Internal.assert_valid_opts!(RESET_ALLOWED_OPTS, **)
+        Git::Commands::Reset.new(@execution_context).call(commitish, **).stdout
+      end
+    end
+  end
+end

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -23,14 +23,14 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
 | Phase 2 | ✅ Complete | Migrating commands (all checklist items done) |
-| Phase 3 | ⏳ In Progress | Refactoring public interface (Tasks 1 ✅, 2 ✅, 3 ✅) |
+| Phase 3 | ⏳ In Progress | Refactoring public interface (Tasks 1 ✅, 2 ✅, 3 ✅, 4 ✅ staging module) |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
 
-**Phase 3, Task 4: Implement the `Git::Repository` Facade**
+**Phase 3, Task 4 (continued): Add more `Git::Repository` facade modules**
 
-Phase 3, Tasks 1–3 are complete:
+Phase 3, Tasks 1–4 (staging module) are complete:
 - Tasks 1 and 2: `Git::ExecutionContext` has a `binary_path:` constructor argument;
   all subclasses accept and store it; `command_line_capturing` /
   `command_line_streaming` use `@binary_path` instead of reading
@@ -40,26 +40,24 @@ Phase 3, Tasks 1–3 are complete:
 - Task 3: `Git::Base` has a per-instance `binary_path` attribute (mirrors `git_ssh`);
   `Git::ExecutionContext::Repository.from_base` forwards it, completing the builder
   chain so every context can carry an instance-specific binary path end-to-end.
+- Task 4 (staging): `Git::Repository` has a proper `initialize(execution_context:)`
+  constructor and includes `Git::Repository::Staging` (first facade module):
+  - `lib/git/repository/staging.rb` — `add` and `reset` facade methods
+  - `lib/git/repository.rb` — includes `Git::Repository::Staging`
+  - `spec/unit/git/repository/staging_spec.rb` — delegation unit tests
 
-Task 4 populates `Git::Repository` with facade methods — thin, one-line delegators
-that forward each public git operation to the appropriate `Git::Commands::*` class,
-using the `Git::ExecutionContext::Repository` injected at construction time. Facade
-methods are organized into focused modules under `lib/git/repository/` and included
-into the `Git::Repository` class.
+The next step is to expand the facade by adding more modules. Continue with one
+module at a time following the same TDD pattern established by the staging module:
 
-#### Workflow
-
-1. **Analyze**: Review `lib/git/repository.rb` (currently an empty shell) and the
-   existing `Git::Base` public methods to identify the first set of facade methods to
-   implement. Start with one module (e.g., `lib/git/repository/staging.rb` for `add`
-   / `reset`) to establish the pattern before expanding.
+1. **Choose the next topic group** from `Git::Base` public methods (e.g., `commit`,
+   `push`, `pull`, `fetch`, `branch`, `tag`, `status`, etc.).
 
 2. **Implement** (one module at a time, TDD):
    - Create `lib/git/repository/<topic>.rb` with a module
      `Git::Repository::<Topic>` containing one-line facade methods, e.g.:
      ```ruby
-     def add(paths = '.', **opts)
-       Git::Commands::Add.new(@execution_context).call(paths, **opts)
+     def commit(message, **)
+       Git::Commands::Commit.new(@execution_context).call(message: message, **).stdout
      end
      ```
    - `include` the module in `lib/git/repository.rb`
@@ -76,14 +74,16 @@ into the `Git::Repository` class.
    - `bundle exec rubocop` — no lint errors
    - `bundle exec yard` — no yardoc errors
 
-5. **Update Checklist**: Update the Phase 3 progress tracker in this document when
-   Task 4 (or each module) is complete. Update the "Next Task" heading to describe
-   Task 5 (update `Git.open` / `Git.bare` etc. to return `Git::Repository` instead of
-   `Git::Base`).
+5. **Update Checklist**: Update the Phase 3 progress tracker in this document after
+   each module. When all `Git::Base` public methods are covered, update the "Next
+   Task" heading to describe Task 5 (update `Git.open` / `Git.bare` etc. to return
+   `Git::Repository` instead of `Git::Base`).
 
 #### Reference Files
 
 - Facade shell: `lib/git/repository.rb`
+- Staging module (pattern reference): `lib/git/repository/staging.rb`
+- Staging spec (pattern reference): `spec/unit/git/repository/staging_spec.rb`
 - Existing public API to replicate: `lib/git/base.rb` public methods
 - Command classes: `lib/git/commands/`
 - Phase 3 plan: see "Phase 3: Refactoring the Public Interface" section below

--- a/spec/unit/git/repository/staging_spec.rb
+++ b/spec/unit/git/repository/staging_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/staging'
+
+# Integration-level coverage for Git::Repository::Staging is provided by the
+# underlying command integration tests:
+#   spec/integration/git/commands/add_spec.rb
+#   spec/integration/git/commands/reset_spec.rb
+# Both #add and #reset delegate to a single Git::Commands::* class with no
+# multi-command orchestration or facade-owned post-processing of git output.
+# The unit specs below cover the facade's own behavior (option whitelisting and
+# negatable-flag normalization); the command integration specs cover end-to-end
+# git execution. No facade integration spec is needed.
+
+RSpec.describe Git::Repository::Staging do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  describe '#add' do
+    subject(:result) { described_instance.add }
+
+    let(:add_command) { instance_double(Git::Commands::Add) }
+    let(:add_result) { command_result('add output') }
+
+    before do
+      allow(Git::Commands::Add).to receive(:new).with(execution_context).and_return(add_command)
+    end
+
+    context 'with default arguments' do
+      it 'delegates to Git::Commands::Add#call with the default path' do
+        expect(add_command).to receive(:call).with('.').and_return(add_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(add_command).to receive(:call).with('.').and_return(add_result)
+        expect(result).to eq('add output')
+      end
+    end
+
+    context 'with a single file path' do
+      subject(:result) { described_instance.add('path/to/file.rb') }
+
+      it 'delegates to Git::Commands::Add#call with the given path' do
+        expect(add_command).to receive(:call).with('path/to/file.rb').and_return(add_result)
+        result
+      end
+    end
+
+    context 'with an array of paths' do
+      subject(:result) { described_instance.add(['a.rb', 'b.rb']) }
+
+      it 'splatted paths are forwarded as separate arguments' do
+        expect(add_command).to receive(:call).with('a.rb', 'b.rb').and_return(add_result)
+        result
+      end
+    end
+
+    context 'with force: true' do
+      subject(:result) { described_instance.add('file.rb', force: true) }
+
+      it 'forwards force: true to Git::Commands::Add#call' do
+        expect(add_command).to receive(:call).with('file.rb', force: true).and_return(add_result)
+        result
+      end
+    end
+
+    context 'with all: true' do
+      subject(:result) { described_instance.add('file.rb', all: true) }
+
+      it 'forwards all: true to Git::Commands::Add#call' do
+        expect(add_command).to receive(:call).with('file.rb', all: true).and_return(add_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(add_command).to receive(:call).with('file.rb', all: true).and_return(add_result)
+        expect(result).to eq('add output')
+      end
+    end
+
+    context 'with all: false' do
+      subject(:result) { described_instance.add('file.rb', all: false) }
+
+      it 'normalizes all: false away so --no-all is never emitted' do
+        expect(add_command).to receive(:call).with('file.rb').and_return(add_result)
+        result
+      end
+    end
+
+    context 'with an unknown option' do
+      subject(:result) { described_instance.add('file.rb', bogus: true) }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+
+      it 'does not call Git::Commands::Add' do
+        expect(add_command).not_to receive(:call)
+        begin
+          result
+        rescue ArgumentError
+          # expected
+        end
+      end
+    end
+  end
+
+  describe '#reset' do
+    subject(:result) { described_instance.reset }
+
+    let(:reset_command) { instance_double(Git::Commands::Reset) }
+    let(:reset_result) { command_result('reset output') }
+
+    before do
+      allow(Git::Commands::Reset).to receive(:new).with(execution_context).and_return(reset_command)
+    end
+
+    context 'with no arguments' do
+      it 'delegates to Git::Commands::Reset#call with nil commit' do
+        expect(reset_command).to receive(:call).with(nil).and_return(reset_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(reset_command).to receive(:call).with(nil).and_return(reset_result)
+        expect(result).to eq('reset output')
+      end
+    end
+
+    context 'with a commitish' do
+      subject(:result) { described_instance.reset('HEAD~1') }
+
+      it 'delegates to Git::Commands::Reset#call with the given commitish' do
+        expect(reset_command).to receive(:call).with('HEAD~1').and_return(reset_result)
+        result
+      end
+    end
+
+    context 'with options' do
+      subject(:result) { described_instance.reset('HEAD~1', hard: true) }
+
+      it 'forwards options to Git::Commands::Reset#call' do
+        expect(reset_command).to receive(:call).with('HEAD~1', hard: true).and_return(reset_result)
+        result
+      end
+    end
+
+    context 'with an unknown option' do
+      subject(:result) { described_instance.reset('HEAD~1', bogus: true) }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository_spec.rb
+++ b/spec/unit/git/repository_spec.rb
@@ -1,15 +1,27 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'git/repository'
 
 RSpec.describe Git::Repository do
-  it 'is defined' do
-    expect(described_class).to be_a(Class)
-  end
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { described_class.new(execution_context: execution_context) }
 
-  it 'is intentionally empty during Phase 1' do
-    # This class will be populated with facade methods in Phase 3
-    # For now, we just verify it exists and can be instantiated
-    expect { described_class.new }.not_to raise_error
+  describe '#initialize' do
+    subject { described_instance }
+
+    it 'can be constructed with an execution_context:' do
+      expect { described_class.new(execution_context: execution_context) }.not_to raise_error
+    end
+
+    it 'raises ArgumentError when execution_context: is missing' do
+      expect { described_class.new }.to raise_error(ArgumentError)
+    end
+
+    it 'raises ArgumentError when execution_context: is nil' do
+      expect do
+        described_class.new(execution_context: nil)
+      end.to raise_error(ArgumentError, /execution_context must not be nil/)
+    end
   end
 end

--- a/tests/units/test_index_ops.rb
+++ b/tests/units/test_index_ops.rb
@@ -134,6 +134,23 @@ class TestIndexOps < Test::Unit::TestCase
     end
   end
 
+  def test_add_force
+    in_bare_repo_clone do
+      g = Git.open('.')
+
+      new_file('.gitignore', 'ignored_file')
+      g.add('.gitignore')
+      g.commit('add .gitignore')
+
+      new_file('ignored_file', 'ignored file contents')
+      assert(File.exist?('ignored_file'))
+      assert(!g.status.added.assoc('ignored_file'))
+
+      g.add('ignored_file', force: true)
+      assert(g.status.added.assoc('ignored_file'))
+    end
+  end
+
   def test_reset
     in_bare_repo_clone do
       g = Git.open('.')


### PR DESCRIPTION
## Summary

Implements the first `Git::Repository` facade module as part of Phase 3 (Task 4) of the v5.0.0 architectural redesign (Strangler Fig migration away from `Git::Base` / `Git::Lib`).

This PR introduces:

- **`Git::Repository`** — the new orchestration layer with a proper `initialize(execution_context:)` constructor (raises `ArgumentError` when `execution_context` is `nil`), into which facade topic modules are `include`d
- **`Git::Repository::Staging`** — the first facade topic module, providing `#add` and `#reset`
- **`Git::Repository::Internal`** — a `module_function` helper module (not included into `Git::Repository`) providing `assert_valid_opts!` for option whitelisting across facade methods
- **Delegation in `Git::Base`** — `Git::Base#add` and `Git::Base#reset` now delegate to `facade_repository` (a lazy `Git::Repository` built via `Git::ExecutionContext::Repository.from_base(self)`), completing the backward-compatible migration step for these two methods
- **Skill update** — `extract-facade-from-base-lib` skill extended with an option-allowlist policy section and a six-section review checklist (R1–R6)

## Changed files

| File | Change |
| --- | --- |
| `lib/git/repository.rb` | New: `Git::Repository` class with `initialize(execution_context:)` (nil guard + `ArgumentError`), `include Git::Repository::Staging` |
| `lib/git/repository/staging.rb` | New: `Git::Repository::Staging` facade module with `#add` and `#reset` |
| `lib/git/repository/internal.rb` | New: `Git::Repository::Internal` with `assert_valid_opts!(allowed, **options)` |
| `lib/git/base.rb` | Step 6 delegation: `#add` and `#reset` delegate to `facade_repository`; adds `facade_repository` lazy accessor |
| `lib/git.rb` | Load order fix: `git/repository` loaded before `git/base` |
| `spec/unit/git/repository/staging_spec.rb` | New: unit tests for `Git::Repository::Staging#add` and `#reset` |
| `spec/unit/git/repository_spec.rb` | New: unit tests for `Git::Repository` constructor, including nil `execution_context` guard |
| `tests/units/test_index_ops.rb` | New: `test_add_force` integration test for `Git::Base#add` with `force: true` |
| `redesign/3_architecture_implementation.md` | Progress tracker updated: Phase 3 Task 4 (staging) marked complete |
| `.github/skills/extract-facade-from-base-lib/SKILL.md` | Added "Determining the option allowlist" policy section and "Review mode" (R1–R6) review checklist |

## Design notes

- `Git::Repository::Staging` methods are one-line delegators — no orchestration logic beyond option whitelisting via `Git::Repository::Internal.assert_valid_opts!`
- Option allowlists (`ADD_ALLOWED_OPTS`, `RESET_ALLOWED_OPTS`) contain only the options accepted in the 4.x branch (`ADD_OPTION_MAP`, `RESET_OPTION_MAP` in `4.x/lib/git/lib.rb`); options supported by the underlying command classes but absent from the 4.x map are intentionally excluded and deferred to a follow-up PR
- YARD docs use Form A (`@overload` block with `@example`, `@param`, `@option`, `@return`); `@raise` tags sit outside the `@overload` block
- `Git::Lib#add` and `Git::Lib#reset` are unchanged — they already delegated directly to `Git::Commands::Add` / `Git::Commands::Reset`, so no intermediate delegation step is needed there
- Integration tests for `#add` and `#reset` are intentionally omitted at the facade layer; coverage comes from the existing `Git::Commands::Add` and `Git::Commands::Reset` integration specs

## Quality gates

All passing: `rake test:parallel`, `rspec`, `rubocop`, `yard`
