### PR TITLE
fix(staging): remove false-stripping workaround from add

### DIFF
--- a/lib/git/repository/staging.rb
+++ b/lib/git/repository/staging.rb
@@ -47,10 +47,9 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
-      def add(paths = '.', **options)
-        Git::Repository::Internal.assert_valid_opts!(ADD_ALLOWED_OPTS, **options)
-        normalized = options.reject { |_k, v| v == false }
-        Git::Commands::Add.new(@execution_context).call(*Array(paths), **normalized).stdout
+      def add(paths = '.', **)
+        Git::Repository::Internal.assert_valid_opts!(ADD_ALLOWED_OPTS, **)
+        Git::Commands::Add.new(@execution_context).call(*Array(paths), **).stdout
       end
 
       # Option keys accepted by {#reset}

--- a/spec/unit/git/repository/staging_spec.rb
+++ b/spec/unit/git/repository/staging_spec.rb
@@ -10,8 +10,8 @@ require 'git/repository/staging'
 #   spec/integration/git/commands/reset_spec.rb
 # Both #add and #reset delegate to a single Git::Commands::* class with no
 # multi-command orchestration or facade-owned post-processing of git output.
-# The unit specs below cover the facade's own behavior (option whitelisting and
-# negatable-flag normalization); the command integration specs cover end-to-end
+# The unit specs below cover the facade's own behavior (option whitelisting);
+# the command integration specs cover end-to-end
 # git execution. No facade integration spec is needed.
 
 RSpec.describe Git::Repository::Staging do
@@ -84,8 +84,8 @@ RSpec.describe Git::Repository::Staging do
     context 'with all: false' do
       subject(:result) { described_instance.add('file.rb', all: false) }
 
-      it 'normalizes all: false away so --no-all is never emitted' do
-        expect(add_command).to receive(:call).with('file.rb').and_return(add_result)
+      it 'forwards all: false to Git::Commands::Add#call' do
+        expect(add_command).to receive(:call).with('file.rb', all: false).and_return(add_result)
         result
       end
     end


### PR DESCRIPTION
## Summary

PR 4 of issue 1260.

Removes the `false`-stripping workaround in `Git::Repository::Staging#add` that was introduced to work around the old tri-state negatable DSL semantics.

## Background

Under the old `boolean_negatable` tri-state model, passing `all: false` to `Git::Commands::Add` would have emitted `--no-all`. The facade worked around this by stripping all `false` values before forwarding options:

```ruby
# Before
normalized = options.reject { |_k, v| v == false }
Git::Commands::Add.new(@execution_context).call(*Array(paths), **normalized).stdout
```

With the two-entry negatable DSL introduced in PR 2, `false` values are simply omitted by the arguments layer — the workaround is no longer needed.

## Changes

- `lib/git/repository/staging.rb`: Remove the `normalized` intermediate variable; forward options directly with anonymous keyword forwarding (`**`), consistent with the existing `#reset` method.
- `spec/unit/git/repository/staging_spec.rb`: Update the `all: false` test to assert that the value is forwarded as-is (not stripped), and remove the mention of negatable-flag normalization from the module comment.

## Acceptance criteria

From issue 1260:

- [x] `false`-stripping workaround removed from `lib/git/repository/staging.rb#add`

Closes part of issue 1260 (PR 4).
Depends on PR 2 (issue 1260) being merged first.
