### PR TITLE
feat(repository): add Git::Repository::Committing facade module

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -513,15 +513,14 @@ module Git
     #   :author
     #
     def commit(message, opts = {})
-      lib.commit(message, opts)
+      facade_repository.commit(message, **opts)
     end
 
     # commits all pending changes in the index file to the git repository,
     # but automatically adds all modified files without having to explicitly
     # calling @git.add() on them.
     def commit_all(message, opts = {})
-      opts = { all: true }.merge(opts)
-      lib.commit(message, opts)
+      facade_repository.commit_all(message, **opts)
     end
 
     # checks out a branch as the new git working directory
@@ -828,12 +827,11 @@ module Git
     end
 
     def write_tree
-      lib.write_tree
+      facade_repository.write_tree
     end
 
     def write_and_commit_tree(opts = {})
-      tree = write_tree
-      commit_tree(tree, opts)
+      Git::Object::Commit.new(self, facade_repository.write_and_commit_tree(**opts))
     end
 
     def update_ref(branch, commit)
@@ -930,7 +928,7 @@ module Git
 
     # @return [Git::Object::Commit] a commit object
     def commit_tree(tree = nil, opts = {})
-      Git::Object::Commit.new(self, lib.commit_tree(tree, opts))
+      Git::Object::Commit.new(self, facade_repository.commit_tree(tree, **opts))
     end
 
     # @return [Git::Diff] a Git::Diff object

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'git/execution_context/repository'
+require 'git/repository/committing'
 require 'git/repository/staging'
 
 module Git
@@ -29,7 +30,13 @@ module Git
   # @api public
   #
   class Repository
+    include Git::Repository::Committing
     include Git::Repository::Staging
+
+    # @return [Git::ExecutionContext::Repository] the execution context used to run
+    #   git commands for this repository
+    # @api private
+    attr_reader :execution_context
 
     # @param execution_context [Git::ExecutionContext::Repository] the context used
     #   to run git commands for this repository; must not be nil

--- a/lib/git/repository/committing.rb
+++ b/lib/git/repository/committing.rb
@@ -1,0 +1,191 @@
+# frozen_string_literal: true
+
+require 'git/commands/commit'
+require 'git/commands/commit_tree'
+require 'git/commands/write_tree'
+require 'git/repository/internal'
+
+module Git
+  class Repository
+    # Facade methods for committing operations: recording commits, manipulating
+    # tree objects, and building commit objects outside the working tree
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module Committing
+      # Option keys accepted by {#commit}
+      COMMIT_ALLOWED_OPTS = %i[
+        all amend allow_empty allow_empty_message author date
+        gpg_sign no_gpg_sign no_verify
+      ].freeze
+      private_constant :COMMIT_ALLOWED_OPTS
+
+      # Option keys accepted by {#commit_tree}
+      COMMIT_TREE_ALLOWED_OPTS = %i[parent p parents message m].freeze
+      private_constant :COMMIT_TREE_ALLOWED_OPTS
+
+      # Record staged changes as a new commit
+      #
+      # @overload commit(message = nil, **options)
+      #
+      #   @example Commit with a message
+      #     repo.commit('Add README')
+      #
+      #   @example Amend the previous commit, reusing its message
+      #     repo.commit(nil, amend: true)
+      #
+      #   @example Stage all modified files and commit
+      #     repo.commit('Cleanup', all: true)
+      #
+      #   @param message [String, nil] the commit message; pass `nil` to omit
+      #     (e.g. when using `:amend` to reuse the previous message)
+      #
+      #   @param options [Hash] options for the commit command
+      #
+      #   @option options [Boolean] :all (false) automatically stage modified and
+      #     deleted files before committing
+      #
+      #   @option options [Boolean] :amend (false) replace the tip of the current
+      #     branch with a new commit
+      #
+      #   @option options [Boolean] :allow_empty (false) allow committing with no
+      #     changes
+      #
+      #   @option options [Boolean] :allow_empty_message (false) allow committing
+      #     with an empty message
+      #
+      #   @option options [String] :author (nil) override the commit author in
+      #     `A U Thor <author@example.com>` format
+      #
+      #   @option options [String] :date (nil) override the author date
+      #
+      #   @option options [Boolean] :gpg_sign (false) GPG-sign the commit
+      #
+      #   @option options [Boolean] :no_gpg_sign (false) disable GPG signing
+      #
+      #   @option options [Boolean] :no_verify (false) bypass the pre-commit and
+      #     commit-msg hooks
+      #
+      #   @return [String] git's stdout from the commit
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def commit(message = nil, **opts)
+        if opts.key?(:add_all)
+          Git::Deprecation.warn('The :add_all option for #commit is deprecated, use :all instead')
+          opts[:all] = opts.delete(:add_all)
+        end
+
+        Git::Repository::Internal.assert_valid_opts!(COMMIT_ALLOWED_OPTS, **opts)
+
+        call_opts = { no_edit: true }
+        call_opts[:message] = message if message
+
+        Git::Commands::Commit.new(@execution_context).call(**call_opts, **opts).stdout
+      end
+
+      # Commit all modified tracked files without explicitly staging them first
+      #
+      # Equivalent to `commit(message, all: true, **options)`.
+      #
+      # @overload commit_all(message, **options)
+      #
+      #   @example
+      #     repo.commit_all('Update everything')
+      #
+      #   @param message [String] the commit message
+      #
+      #   @param options [Hash] additional options forwarded to {#commit}
+      #
+      #   @return [String] git's stdout from the commit
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def commit_all(*, **)
+        commit(*, all: true, **)
+      end
+
+      # Create a commit object from a tree SHA without moving HEAD
+      #
+      # Unlike {#commit}, this does not read the index; it directly wraps
+      # `git commit-tree`.
+      #
+      # @overload commit_tree(tree, **options)
+      #
+      #   @example Commit a tree with a parent
+      #     repo.commit_tree('deadbeef', message: 'snapshot', parent: 'HEAD')
+      #
+      #   @param tree [String] the tree SHA to commit
+      #
+      #   @param options [Hash] options for the commit-tree command
+      #
+      #   @option options [String] :m (nil) the commit message (short form)
+      #
+      #   @option options [String] :message (nil) the commit message (normalized
+      #     to `:m` before passing to the command)
+      #
+      #   @option options [String, Array<String>] :p (nil) parent commit SHA(s)
+      #
+      #   @option options [String] :parent (nil) a single parent commit SHA
+      #     (normalized to `:p`)
+      #
+      #   @option options [Array<String>] :parents (nil) multiple parent commit
+      #     SHAs (normalized to `:p`)
+      #
+      #   @return [String] the SHA of the newly created commit object
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def commit_tree(tree, **opts)
+        Git::Repository::Internal.assert_valid_opts!(COMMIT_TREE_ALLOWED_OPTS, **opts)
+
+        opts[:p] = opts.delete(:parents) if opts.key?(:parents)
+        opts[:p] = opts.delete(:parent) if opts.key?(:parent)
+        opts[:m] = opts.delete(:message) if opts.key?(:message)
+        opts[:m] = "commit tree #{tree}" unless opts[:m]
+
+        Git::Commands::CommitTree.new(@execution_context).call(tree, **opts).stdout
+      end
+
+      # Write the current index to a tree object in the object store
+      #
+      # @example
+      #   tree_sha = repo.write_tree
+      #
+      # @return [String] the SHA of the tree object written
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def write_tree
+        Git::Commands::WriteTree.new(@execution_context).call.stdout
+      end
+
+      # Write the current index to a tree object and immediately commit it
+      #
+      # Combines {#write_tree} and {#commit_tree} in a single call.
+      #
+      # @overload write_and_commit_tree(**options)
+      #
+      #   @example
+      #     commit_sha = repo.write_and_commit_tree(message: 'snapshot')
+      #
+      #   @param options [Hash] options forwarded to {#commit_tree}
+      #
+      #   @return [String] the SHA of the newly created commit object
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def write_and_commit_tree(**)
+        commit_tree(write_tree, **)
+      end
+    end
+  end
+end

--- a/spec/integration/git/repository/committing_spec.rb
+++ b/spec/integration/git/repository/committing_spec.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/committing'
+
+# Integration-level coverage notes:
+#
+# Single-command delegator methods (#commit, #commit_all, #commit_tree,
+# #write_tree) are covered end-to-end by the underlying command integration
+# tests:
+#   spec/integration/git/commands/commit_spec.rb
+#   spec/integration/git/commands/commit_tree_spec.rb
+#   spec/integration/git/commands/write_tree_spec.rb
+#
+# The integration test below covers only #write_and_commit_tree, which
+# performs multi-command orchestration (write_tree followed by commit_tree)
+# and warrants an end-to-end test to confirm the sequence produces the
+# correct result against real git.
+
+RSpec.describe Git::Repository::Committing, :integration do
+  include_context 'in an empty repository'
+
+  let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  # Create an initial commit so the index has a tree to write
+  before do
+    write_file('file.txt', "initial content\n")
+    repo.add('file.txt')
+    repo.commit('Initial commit')
+  end
+
+  describe '#write_and_commit_tree' do
+    context 'with a message option' do
+      it 'returns a 40-character commit SHA string' do
+        result = described_instance.write_and_commit_tree(message: 'snapshot')
+
+        expect(result).to match(/\A[0-9a-f]{40}\z/)
+      end
+
+      it 'creates a commit whose tree matches the current index' do
+        index_tree = described_instance.write_tree.strip
+        commit_sha = described_instance.write_and_commit_tree(message: 'snapshot')
+        commit_tree = execution_context.command_capturing('cat-file', '-p', commit_sha.strip)
+                                       .stdout
+                                       .then { |s| s[/^tree ([0-9a-f]{40})/, 1] }
+
+        expect(commit_tree).to eq(index_tree)
+      end
+    end
+
+    context 'with no options (default message)' do
+      it 'returns a 40-character commit SHA string' do
+        result = described_instance.write_and_commit_tree
+
+        expect(result).to match(/\A[0-9a-f]{40}\z/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository/committing_spec.rb
+++ b/spec/unit/git/repository/committing_spec.rb
@@ -1,0 +1,416 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/committing'
+
+# Integration-level coverage for Git::Repository::Committing:
+#
+# Single-command delegators (#commit, #commit_all, #commit_tree, #write_tree)
+# are covered end-to-end by:
+#   spec/integration/git/commands/commit_spec.rb
+#   spec/integration/git/commands/commit_tree_spec.rb
+#   spec/integration/git/commands/write_tree_spec.rb
+#
+# The multi-command #write_and_commit_tree method is covered by:
+#   spec/integration/git/repository/committing_spec.rb
+#
+# The unit specs below cover the facade's own behavior: option whitelisting,
+# argument pre-processing, deprecation handling, and delegation contracts.
+
+RSpec.describe Git::Repository::Committing do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # #commit
+  # ─────────────────────────────────────────────────────────────────────────
+  describe '#commit' do
+    let(:commit_command) { instance_double(Git::Commands::Commit) }
+    let(:commit_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Commit).to receive(:new).with(execution_context).and_return(commit_command)
+    end
+
+    context 'with a message only' do
+      subject(:result) { described_instance.commit('Initial commit') }
+
+      it 'delegates to Git::Commands::Commit#call with no_edit: true and the message' do
+        expect(commit_command).to receive(:call).with(no_edit: true,
+                                                      message: 'Initial commit').and_return(commit_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(commit_command).to receive(:call).and_return(command_result('main 1234abc] Initial commit'))
+        expect(result).to eq('main 1234abc] Initial commit')
+      end
+    end
+
+    context 'with message nil' do
+      subject(:result) { described_instance.commit(nil) }
+
+      it 'does not include :message in the call' do
+        expect(commit_command).to receive(:call).with(no_edit: true).and_return(commit_result)
+        result
+      end
+    end
+
+    context 'with no message argument' do
+      subject(:result) { described_instance.commit(amend: true) }
+
+      it 'does not include :message in the call' do
+        expect(commit_command).to receive(:call).with(no_edit: true, amend: true).and_return(commit_result)
+        result
+      end
+    end
+
+    context 'with all: true' do
+      subject(:result) { described_instance.commit('msg', all: true) }
+
+      it 'forwards all: true to the command' do
+        expect(commit_command).to receive(:call).with(no_edit: true, message: 'msg',
+                                                      all: true).and_return(commit_result)
+        result
+      end
+    end
+
+    context 'with amend: true' do
+      subject(:result) { described_instance.commit('msg', amend: true) }
+
+      it 'forwards amend: true to the command' do
+        expect(commit_command).to receive(:call).with(no_edit: true, message: 'msg',
+                                                      amend: true).and_return(commit_result)
+        result
+      end
+    end
+
+    context 'with allow_empty: true' do
+      subject(:result) { described_instance.commit('msg', allow_empty: true) }
+
+      it 'forwards allow_empty: true to the command' do
+        expect(commit_command).to receive(:call).with(no_edit: true, message: 'msg',
+                                                      allow_empty: true).and_return(commit_result)
+        result
+      end
+    end
+
+    context 'with allow_empty_message: true' do
+      subject(:result) { described_instance.commit('msg', allow_empty_message: true) }
+
+      it 'forwards allow_empty_message: true to the command' do
+        expect(commit_command).to receive(:call).with(no_edit: true, message: 'msg',
+                                                      allow_empty_message: true).and_return(commit_result)
+        result
+      end
+    end
+
+    context 'with author: option' do
+      subject(:result) { described_instance.commit('msg', author: 'Jane <jane@example.com>') }
+
+      it 'forwards author to the command' do
+        expect(commit_command).to receive(:call).with(no_edit: true, message: 'msg',
+                                                      author: 'Jane <jane@example.com>').and_return(commit_result)
+        result
+      end
+    end
+
+    context 'with date: option' do
+      subject(:result) { described_instance.commit('msg', date: '2024-01-01T00:00:00') }
+
+      it 'forwards date to the command' do
+        expect(commit_command).to receive(:call).with(no_edit: true, message: 'msg',
+                                                      date: '2024-01-01T00:00:00').and_return(commit_result)
+        result
+      end
+    end
+
+    context 'with gpg_sign: true' do
+      subject(:result) { described_instance.commit('msg', gpg_sign: true) }
+
+      it 'forwards gpg_sign: true to the command' do
+        expect(commit_command).to receive(:call).with(no_edit: true, message: 'msg',
+                                                      gpg_sign: true).and_return(commit_result)
+        result
+      end
+    end
+
+    context 'with no_gpg_sign: true' do
+      subject(:result) { described_instance.commit('msg', no_gpg_sign: true) }
+
+      it 'forwards no_gpg_sign: true to the command' do
+        expect(commit_command).to receive(:call).with(no_edit: true, message: 'msg',
+                                                      no_gpg_sign: true).and_return(commit_result)
+        result
+      end
+    end
+
+    context 'with no_verify: true' do
+      subject(:result) { described_instance.commit('msg', no_verify: true) }
+
+      it 'forwards no_verify: true to the command' do
+        expect(commit_command).to receive(:call).with(no_edit: true, message: 'msg',
+                                                      no_verify: true).and_return(commit_result)
+        result
+      end
+    end
+
+    context 'with deprecated :add_all option' do
+      subject(:result) { described_instance.commit('msg', add_all: true) }
+
+      it 'emits a deprecation warning' do
+        allow(commit_command).to receive(:call).and_return(commit_result)
+        expect(Git::Deprecation).to receive(:warn).with(a_string_including(':add_all'))
+        result
+      end
+
+      it 'converts :add_all to :all and forwards to the command' do
+        allow(Git::Deprecation).to receive(:warn)
+        expect(commit_command).to receive(:call).with(no_edit: true, message: 'msg',
+                                                      all: true).and_return(commit_result)
+        result
+      end
+    end
+
+    context 'with an unknown option' do
+      subject(:result) { described_instance.commit('msg', bogus: true) }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+
+      it 'does not call Git::Commands::Commit' do
+        expect(commit_command).not_to receive(:call)
+        begin
+          result
+        rescue ArgumentError
+          # expected
+        end
+      end
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # #commit_all
+  # ─────────────────────────────────────────────────────────────────────────
+  describe '#commit_all' do
+    let(:commit_command) { instance_double(Git::Commands::Commit) }
+    let(:commit_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Commit).to receive(:new).with(execution_context).and_return(commit_command)
+    end
+
+    context 'with a message only' do
+      subject(:result) { described_instance.commit_all('msg') }
+
+      it 'delegates to the commit command with all: true' do
+        expect(commit_command).to receive(:call).with(no_edit: true, message: 'msg',
+                                                      all: true).and_return(commit_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(commit_command).to receive(:call).and_return(command_result('commit output'))
+        expect(result).to eq('commit output')
+      end
+    end
+
+    context 'with additional options' do
+      subject(:result) { described_instance.commit_all('msg', no_verify: true) }
+
+      it 'forwards extra options alongside all: true' do
+        expect(commit_command).to receive(:call).with(no_edit: true, message: 'msg', all: true,
+                                                      no_verify: true).and_return(commit_result)
+        result
+      end
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # #commit_tree
+  # ─────────────────────────────────────────────────────────────────────────
+  describe '#commit_tree' do
+    let(:commit_tree_command) { instance_double(Git::Commands::CommitTree) }
+    let(:commit_tree_result) { command_result('abc1234') }
+
+    before do
+      allow(Git::Commands::CommitTree).to receive(:new).with(execution_context).and_return(commit_tree_command)
+    end
+
+    context 'with a tree and no options' do
+      subject(:result) { described_instance.commit_tree('tree-sha') }
+
+      it 'delegates with a default message derived from the tree' do
+        expect(commit_tree_command).to(
+          receive(:call)
+            .with('tree-sha', m: 'commit tree tree-sha')
+            .and_return(commit_tree_result)
+        )
+        result
+      end
+
+      it 'returns the SHA string from stdout' do
+        allow(commit_tree_command).to receive(:call).and_return(commit_tree_result)
+        expect(result).to eq('abc1234')
+      end
+    end
+
+    context 'with a message option' do
+      subject(:result) { described_instance.commit_tree('tree-sha', message: 'my message') }
+
+      it 'normalizes :message to :m before calling the command' do
+        expect(commit_tree_command).to receive(:call).with('tree-sha',
+                                                           m: 'my message').and_return(commit_tree_result)
+        result
+      end
+    end
+
+    context 'with :m option directly' do
+      subject(:result) { described_instance.commit_tree('tree-sha', m: 'my message') }
+
+      it 'passes :m directly to the command' do
+        expect(commit_tree_command).to receive(:call).with('tree-sha', m: 'my message').and_return(commit_tree_result)
+        result
+      end
+    end
+
+    context 'with message: nil explicitly' do
+      subject(:result) { described_instance.commit_tree('tree-sha', message: nil) }
+
+      it 'falls back to the default message' do
+        expect(commit_tree_command).to(
+          receive(:call)
+            .with('tree-sha', m: 'commit tree tree-sha')
+            .and_return(commit_tree_result)
+        )
+        result
+      end
+    end
+
+    context 'with m: nil explicitly' do
+      subject(:result) { described_instance.commit_tree('tree-sha', m: nil) }
+
+      it 'falls back to the default message' do
+        expect(commit_tree_command).to(
+          receive(:call)
+            .with('tree-sha', m: 'commit tree tree-sha')
+            .and_return(commit_tree_result)
+        )
+        result
+      end
+    end
+
+    context 'with :parent option' do
+      subject(:result) { described_instance.commit_tree('tree-sha', parent: 'parent-sha', message: 'msg') }
+
+      it 'normalizes :parent to :p and :message to :m before calling the command' do
+        expect(commit_tree_command).to receive(:call).with('tree-sha', p: 'parent-sha',
+                                                                       m: 'msg').and_return(commit_tree_result)
+        result
+      end
+    end
+
+    context 'with :parents option (array)' do
+      subject(:result) { described_instance.commit_tree('tree-sha', parents: %w[sha1 sha2], message: 'msg') }
+
+      it 'normalizes :parents to :p and :message to :m before calling the command' do
+        expect(commit_tree_command).to receive(:call).with('tree-sha', p: %w[sha1 sha2],
+                                                                       m: 'msg').and_return(commit_tree_result)
+        result
+      end
+    end
+
+    context 'with :p option directly' do
+      subject(:result) { described_instance.commit_tree('tree-sha', p: 'parent-sha', message: 'msg') }
+
+      it 'normalizes :message to :m and passes :p directly to the command' do
+        expect(commit_tree_command).to receive(:call).with('tree-sha', p: 'parent-sha',
+                                                                       m: 'msg').and_return(commit_tree_result)
+        result
+      end
+    end
+
+    context 'with an unknown option' do
+      subject(:result) { described_instance.commit_tree('tree-sha', bogus: true) }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # #write_tree
+  # ─────────────────────────────────────────────────────────────────────────
+  describe '#write_tree' do
+    let(:write_tree_command) { instance_double(Git::Commands::WriteTree) }
+    let(:write_tree_result) { command_result('deadbeef') }
+
+    before do
+      allow(Git::Commands::WriteTree).to receive(:new).with(execution_context).and_return(write_tree_command)
+    end
+
+    it 'delegates to Git::Commands::WriteTree#call' do
+      expect(write_tree_command).to receive(:call).and_return(write_tree_result)
+      described_instance.write_tree
+    end
+
+    it 'returns the tree SHA from stdout' do
+      allow(write_tree_command).to receive(:call).and_return(write_tree_result)
+      expect(described_instance.write_tree).to eq('deadbeef')
+    end
+  end
+
+  # ─────────────────────────────────────────────────────────────────────────
+  # #write_and_commit_tree
+  # ─────────────────────────────────────────────────────────────────────────
+  describe '#write_and_commit_tree' do
+    let(:write_tree_command) { instance_double(Git::Commands::WriteTree) }
+    let(:commit_tree_command) { instance_double(Git::Commands::CommitTree) }
+    let(:tree_sha) { 'deadbeef' }
+    let(:commit_sha) { 'cafebabe' }
+
+    before do
+      allow(Git::Commands::WriteTree).to receive(:new).with(execution_context).and_return(write_tree_command)
+      allow(Git::Commands::CommitTree).to receive(:new).with(execution_context).and_return(commit_tree_command)
+    end
+
+    context 'with no options' do
+      subject(:result) { described_instance.write_and_commit_tree }
+
+      it 'calls write_tree then commit_tree in order' do
+        expect(write_tree_command).to(
+          receive(:call)
+            .and_return(command_result(tree_sha))
+            .ordered
+        )
+        expect(commit_tree_command).to(
+          receive(:call)
+          .with(tree_sha, m: "commit tree #{tree_sha}")
+          .and_return(command_result(commit_sha))
+          .ordered
+        )
+        result
+      end
+
+      it 'returns the commit SHA from stdout' do
+        allow(write_tree_command).to receive(:call).and_return(command_result(tree_sha))
+        allow(commit_tree_command).to receive(:call).and_return(command_result(commit_sha))
+        expect(result).to eq(commit_sha)
+      end
+    end
+
+    context 'with message option' do
+      subject(:result) { described_instance.write_and_commit_tree(message: 'my commit') }
+
+      it 'forwards options to commit_tree' do
+        allow(write_tree_command).to receive(:call).and_return(command_result(tree_sha))
+        expect(commit_tree_command).to receive(:call).with(tree_sha,
+                                                           m: 'my commit').and_return(command_result(commit_sha))
+        result
+      end
+    end
+  end
+end

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -150,10 +150,13 @@ module Test
       #   assert_command_line_eq(expected_command_line) { |git| git.fetch('origin', { ref: 'master', depth: '2' }) }
       #
       # @param expected_command_line [Array<String>] The expected arguments to be sent to Git::Lib#command_capturing
+      #
       # @param mocked_output [String] The mocked output to be returned by the Git::Lib#command_capturing method
       #
       # @yield [git] a block to call the method to be tested
+      #
       # @yieldparam git [Git::Base] The Git::Base object resulting from initializing the test project
+      #
       # @yieldreturn [void] the return value of the block is ignored
       #
       # @return [void]
@@ -187,6 +190,12 @@ module Test
           end
 
           git.lib.define_singleton_method(method, &mock_command)
+
+          # Also stub the facade repository's execution context for methods
+          # that have been migrated from Git::Lib to Git::Repository facade modules.
+          facade_ec = git.send(:facade_repository).execution_context
+          facade_ec.define_singleton_method(method, &mock_command)
+          facade_ec.define_singleton_method(:git_version) { git.lib.git_version }
 
           Dir.chdir 'test_project' do
             yield(git) if block_given?


### PR DESCRIPTION
Partially implements #1266

## Summary

Extracts `commit`, `commit_all`, `commit_tree`, `write_tree`, and `write_and_commit_tree` from `Git::Base` / `Git::Lib` into a new `Git::Repository::Committing` facade module, following the Phase 3 strangler-fig migration pattern established by the Staging module.

## Changes

### New files

- **`lib/git/repository/committing.rb`** — `Git::Repository::Committing` module with all five facade methods, full YARD documentation, `COMMIT_ALLOWED_OPTS` / `COMMIT_TREE_ALLOWED_OPTS` allowlists, deprecation handling for `:add_all`, and option normalization (`:message` → `:m`, `:parent`/`:parents` → `:p`).
- **`spec/unit/git/repository/committing_spec.rb`** — unit specs covering option whitelisting, argument normalization, deprecation handling, and delegation contracts for all five methods.
- **`spec/integration/git/repository/committing_spec.rb`** — integration spec for `#write_and_commit_tree` (the only multi-command method) verifying the write-tree → commit-tree sequence against real git.

### Modified files

- **`lib/git/repository.rb`** — requires and includes `Git::Repository::Committing`.
- **`lib/git/base.rb`** — all five `Git::Base` methods now delegate to `facade_repository` instead of `lib`.
- **`lib/git/commands/commit_tree.rb`** — adds long-form `:message` and `:parent` option aliases (with `as:` preserving the short CLI flags `-m` / `-p`), making the command DSL consistent with the facade's option normalization.
- **`tests/test_helper.rb`** — `assert_command_line_eq` now also stubs the facade's `ExecutionContext` so legacy unit tests work correctly with methods migrated from `Git::Lib` to `Git::Repository`.

## Test results

All tests pass:

```
bundle exec rake  # 556 tests, 1838 assertions, 0 failures, 0 errors
bundle exec rspec spec/unit/git/repository/committing_spec.rb \
                  spec/integration/git/repository/committing_spec.rb
# 35 examples, 0 failures
bundle exec rubocop  # no offenses
```