### PR TITLE
feat(repository): add Git::Repository::Branching facade module

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -525,12 +525,12 @@ module Git
 
     # checks out a branch as the new git working directory
     def checkout(*, **)
-      lib.checkout(*, **)
+      facade_repository.checkout(*, **)
     end
 
     # checks out an old version of a file
     def checkout_file(version, file)
-      lib.checkout_file(version, file)
+      facade_repository.checkout_file(version, file)
     end
 
     # fetches changes from a remote branch - this does not modify the working directory,
@@ -819,7 +819,7 @@ module Git
     end
 
     def checkout_index(opts = {})
-      lib.checkout_index(opts)
+      facade_repository.checkout_index(opts)
     end
 
     def read_tree(treeish, opts = {})
@@ -893,7 +893,7 @@ module Git
     # @return [String] the name of the branch HEAD refers to or 'HEAD' if detached
     #
     def current_branch
-      lib.branch_current
+      facade_repository.current_branch
     end
 
     # @return [Git::Branch] an object for branch_name

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'git/execution_context/repository'
+require 'git/repository/branching'
 require 'git/repository/committing'
 require 'git/repository/staging'
 
@@ -30,6 +31,7 @@ module Git
   # @api public
   #
   class Repository
+    include Git::Repository::Branching
     include Git::Repository::Committing
     include Git::Repository::Staging
 

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -1,0 +1,221 @@
+# frozen_string_literal: true
+
+require 'pathname'
+require 'git/commands/branch/show_current'
+require 'git/commands/checkout/branch'
+require 'git/commands/checkout/files'
+require 'git/commands/checkout_index'
+require 'git/repository/internal'
+
+module Git
+  class Repository
+    # Facade methods for branching operations: checking out, switching branches,
+    # and querying the current branch
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module Branching
+      # Option keys accepted by {#checkout}
+      #
+      # Derived from the 4.x `CHECKOUT_OPTION_MAP` in `Git::Lib`.
+      CHECKOUT_ALLOWED_OPTS = %i[force f new_branch b start_point].freeze
+      private_constant :CHECKOUT_ALLOWED_OPTS
+
+      # Option keys accepted by {#checkout_index}
+      #
+      # Derived from the 4.x `CHECKOUT_INDEX_OPTION_MAP` in `Git::Lib`.
+      CHECKOUT_INDEX_ALLOWED_OPTS = %i[prefix force all path_limiter].freeze
+      private_constant :CHECKOUT_INDEX_ALLOWED_OPTS
+
+      # Returns the name of the current branch
+      #
+      # @overload current_branch()
+      #
+      #   @example Get the current branch name
+      #     repo.current_branch  # => "main"
+      #
+      #   @example In detached HEAD state
+      #     repo.current_branch  # => "HEAD"
+      #
+      #   @return [String] the current branch name, or `'HEAD'` when in detached
+      #     HEAD state
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def current_branch
+        result = Git::Commands::Branch::ShowCurrent.new(@execution_context).call
+        name = result.stdout.strip
+        name.empty? ? 'HEAD' : name
+      end
+
+      # Restore working tree files from a tree-ish
+      #
+      # @overload checkout_file(version, file)
+      #
+      #   @example Restore README.md to its HEAD state
+      #     repo.checkout_file('HEAD', 'README.md')
+      #
+      #   @param version [String] the tree-ish (branch, tag, commit SHA, etc.) to
+      #     restore the file from
+      #
+      #   @param file [String] the path to the file to restore
+      #
+      #   @return [String] git's stdout from the checkout
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def checkout_file(version, file)
+        Git::Commands::Checkout::Files.new(@execution_context).call(version, pathspec: [file]).stdout
+      end
+
+      # Switch branches or restore working tree files
+      #
+      # @overload checkout(branch = nil, options = {})
+      #
+      #   @example Check out an existing branch
+      #     repo.checkout('main')
+      #
+      #   @example Create and check out a new branch from main
+      #     repo.checkout('new-feature', new_branch: true, start_point: 'main')
+      #
+      #   @example Create a new branch with a name different from the start point
+      #     repo.checkout('main', new_branch: 'new-feature')
+      #
+      #   @example Force checkout discarding local changes
+      #     repo.checkout('main', force: true)
+      #
+      #   @param branch [String, nil] the branch to check out; defaults to nil
+      #     (i.e. restore HEAD state)
+      #
+      #   @param options [Hash] options for the checkout command
+      #
+      #   @option options [Boolean] :force (false) discard local changes when
+      #     switching branches
+      #
+      #   @option options [Boolean, String] :new_branch (false) when `true`,
+      #     creates a new branch named `branch` from `:start_point`; when a
+      #     `String`, creates a new branch with that name from `branch`
+      #
+      #   @option options [Boolean] :b (false) alias for `:new_branch`
+      #
+      #   @option options [Boolean] :f (false) alias for `:force`
+      #
+      #   @option options [String] :start_point the commit or branch to start the
+      #     new branch from; used together with `new_branch: true`
+      #
+      #   @return [String] git's stdout from the checkout
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def checkout(branch = nil, options = {})
+        if branch.is_a?(Hash) && options.empty?
+          options = branch
+          branch = nil
+        end
+
+        Git::Repository::Internal.assert_valid_opts!(CHECKOUT_ALLOWED_OPTS, **options)
+
+        target, translated_opts = translate_checkout_opts(branch, options)
+        Git::Commands::Checkout::Branch.new(@execution_context).call(target, **translated_opts).stdout
+      end
+
+      # Populate the working tree from the index
+      #
+      # @overload checkout_index(options = {})
+      #
+      #   @example Check out all files from the index
+      #     repo.checkout_index(all: true)
+      #
+      #   @example Force check out a specific file
+      #     repo.checkout_index(force: true, path_limiter: 'README.md')
+      #
+      #   @example Check out files to a staging prefix
+      #     repo.checkout_index(prefix: 'tmp/stage/', all: true)
+      #
+      #   @param options [Hash] options for the checkout-index command
+      #
+      #   @option options [Boolean] :all (false) check out all files in the index
+      #
+      #   @option options [Boolean] :force (false) overwrite existing files
+      #
+      #   @option options [String] :prefix write files under this path prefix
+      #     rather than the working directory root
+      #
+      #   @option options [String, Pathname, Array<String, Pathname>] :path_limiter limit the check
+      #     out to the given path(s)
+      #
+      #   @return [String] git's stdout from the checkout-index command
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def checkout_index(options = {})
+        Git::Repository::Internal.assert_valid_opts!(CHECKOUT_INDEX_ALLOWED_OPTS, **options)
+
+        paths = normalize_pathspecs(options[:path_limiter], 'path_limiter')
+        keyword_opts = options.except(:path_limiter)
+        Git::Commands::CheckoutIndex.new(@execution_context).call(*paths.to_a, **keyword_opts).stdout
+      end
+
+      private
+
+      # Translates legacy checkout options to the new command interface.
+      #
+      # Legacy callers passed combinations like:
+      #   checkout('branch', new_branch: true, start_point: 'main')
+      # which should map to:
+      #   checkout('main', b: 'branch')
+      #
+      # @param branch [String, nil] the branch argument passed to {#checkout}
+      # @param options [Hash] the raw options passed to {#checkout}
+      # @return [Array] a two-element tuple +[target, options]+ where +target+ is
+      #   the branch or commit to check out (+String+ or +nil+) and +options+ is
+      #   a +Hash+ of translated keyword arguments for
+      #   +Git::Commands::Checkout::Branch#call+
+      #
+      def translate_checkout_opts(branch, options)
+        if options[:new_branch] == true || options[:b] == true
+          [options[:start_point], options.except(:new_branch, :b, :start_point).merge(b: branch)]
+        elsif options[:new_branch].is_a?(String)
+          [branch, options.except(:new_branch).merge(b: options[:new_branch])]
+        else
+          [branch, options]
+        end
+      end
+
+      # Normalizes path specifications for Git commands.
+      #
+      # @param pathspecs [String, Pathname, Array<String, Pathname>, nil]
+      # @param arg_name [String] used in error messages
+      # @return [Array<String>, nil]
+      # @raise [ArgumentError] if any path is not a String or Pathname
+      #
+      def normalize_pathspecs(pathspecs, arg_name)
+        return nil unless pathspecs
+
+        normalized = Array(pathspecs)
+        validate_pathspec_types(normalized, arg_name)
+
+        normalized = normalized.map(&:to_s).reject(&:empty?)
+        return nil if normalized.empty?
+
+        normalized
+      end
+
+      # @param pathspecs [Array]
+      # @param arg_name [String]
+      # @raise [ArgumentError] if any element is not a String or Pathname
+      #
+      def validate_pathspec_types(pathspecs, arg_name)
+        return if pathspecs.all? { |path| path.is_a?(String) || path.is_a?(Pathname) }
+
+        raise ArgumentError, "Invalid #{arg_name}: must be a String, Pathname, or Array of Strings/Pathnames"
+      end
+    end
+  end
+end

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -23,7 +23,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | ----- | ------ | ----------- |
 | Phase 1 | ✅ Complete | Foundation and scaffolding |
 | Phase 2 | ✅ Complete | Migrating commands (all checklist items done) |
-| Phase 3 | ⏳ In Progress | Refactoring public interface (Tasks 1 ✅, 2 ✅, 3 ✅, 4 ✅ staging module) |
+| Phase 3 | ⏳ In Progress | Refactoring public interface (Tasks 1 ✅, 2 ✅, 3 ✅, 4 ✅ staging module, 4 ✅ committing module, 4 ✅ branching module) |
 | Phase 4 | ⏳ Not Started | Final cleanup and release |
 
 ### Next Task
@@ -45,6 +45,14 @@ Phase 3, Tasks 1–4 (staging module) are complete:
   - `lib/git/repository/staging.rb` — `add` and `reset` facade methods
   - `lib/git/repository.rb` — includes `Git::Repository::Staging`
   - `spec/unit/git/repository/staging_spec.rb` — delegation unit tests
+- Task 4 (committing): `Git::Repository::Committing` facade module added.
+- Task 4 (branching): `Git::Repository::Branching` facade module added:
+  - `lib/git/repository/branching.rb` — `checkout`, `checkout_file`,
+    `checkout_index`, and `current_branch` facade methods
+  - `lib/git/repository.rb` — includes `Git::Repository::Branching`
+  - `spec/unit/git/repository/branching_spec.rb` — delegation unit tests
+  - `spec/integration/git/repository/branching_spec.rb` — integration tests
+  - `Git::Base` delegates all four methods to `facade_repository`
 
 The next step is to expand the facade by adding more modules. Continue with one
 module at a time following the same TDD pattern established by the staging module:

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/branching'
+
+RSpec.describe Git::Repository::Branching, :integration do
+  include_context 'in an empty repository'
+
+  let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  # Create an initial commit so we have a proper HEAD
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#current_branch' do
+    context 'when on the default branch' do
+      it 'returns the current branch name (a non-empty string)' do
+        branch_name = described_instance.current_branch
+        expect(branch_name).to be_a(String)
+        expect(branch_name).not_to be_empty
+      end
+    end
+
+    context 'in detached HEAD state' do
+      before do
+        sha = repo.log(1).first.sha
+        repo.lib.checkout(sha)
+      end
+
+      it "returns 'HEAD'" do
+        expect(described_instance.current_branch).to eq('HEAD')
+      end
+    end
+  end
+
+  describe '#checkout_file' do
+    before do
+      write_file('README.md', "# Modified\n")
+    end
+
+    it 'restores the file to the HEAD version' do
+      described_instance.checkout_file('HEAD', 'README.md')
+      content = File.read(File.join(repo.dir.to_s, 'README.md'))
+      expect(content).to eq("# Hello\n")
+    end
+
+    it 'returns a String' do
+      result = described_instance.checkout_file('HEAD', 'README.md')
+      expect(result).to be_a(String)
+    end
+  end
+
+  describe '#checkout' do
+    context 'checking out an existing branch' do
+      before do
+        repo.branch('new-branch').create
+      end
+
+      it 'switches to that branch' do
+        described_instance.checkout('new-branch')
+        expect(described_instance.current_branch).to eq('new-branch')
+      end
+    end
+
+    context 'creating and checking out a new branch' do
+      it 'creates and switches to the new branch' do
+        described_instance.checkout('feature', new_branch: true, start_point: 'HEAD')
+        expect(described_instance.current_branch).to eq('feature')
+      end
+    end
+  end
+
+  describe '#checkout_index' do
+    before do
+      write_file('indexed.txt', "indexed content\n")
+      repo.add('indexed.txt')
+    end
+
+    context 'with all: true' do
+      it 'returns a String' do
+        result = described_instance.checkout_index(all: true, force: true)
+        expect(result).to be_a(String)
+      end
+    end
+
+    context 'with path_limiter' do
+      it 'returns a String' do
+        result = described_instance.checkout_index(path_limiter: 'indexed.txt', force: true)
+        expect(result).to be_a(String)
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -1,0 +1,269 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/branching'
+
+# Integration-level coverage for Git::Repository::Branching is provided by
+# spec/integration/git/repository/branching_spec.rb.
+# The unit specs below cover the facade's own orchestration (argument pre-processing,
+# option whitelisting, delegation contracts).
+
+RSpec.describe Git::Repository::Branching do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  # ---------------------------------------------------------------------------
+  # #current_branch
+  # ---------------------------------------------------------------------------
+
+  describe '#current_branch' do
+    subject(:result) { described_instance.current_branch }
+
+    let(:show_current_command) { instance_double(Git::Commands::Branch::ShowCurrent) }
+
+    before do
+      allow(Git::Commands::Branch::ShowCurrent)
+        .to receive(:new).with(execution_context).and_return(show_current_command)
+    end
+
+    context 'when on a normal branch' do
+      let(:show_current_result) { command_result("main\n") }
+
+      it 'delegates to Git::Commands::Branch::ShowCurrent#call' do
+        expect(show_current_command).to receive(:call).and_return(show_current_result)
+        result
+      end
+
+      it 'returns the stripped branch name' do
+        allow(show_current_command).to receive(:call).and_return(show_current_result)
+        expect(result).to eq('main')
+      end
+    end
+
+    context 'when in detached HEAD state (empty stdout)' do
+      let(:show_current_result) { command_result('') }
+
+      it "returns 'HEAD'" do
+        allow(show_current_command).to receive(:call).and_return(show_current_result)
+        expect(result).to eq('HEAD')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #checkout_file
+  # ---------------------------------------------------------------------------
+
+  describe '#checkout_file' do
+    subject(:result) { described_instance.checkout_file('HEAD', 'README.md') }
+
+    let(:checkout_files_command) { instance_double(Git::Commands::Checkout::Files) }
+    let(:checkout_files_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Checkout::Files)
+        .to receive(:new).with(execution_context).and_return(checkout_files_command)
+    end
+
+    it 'delegates to Git::Commands::Checkout::Files#call with the tree-ish and pathspec' do
+      expect(checkout_files_command)
+        .to receive(:call).with('HEAD', pathspec: ['README.md']).and_return(checkout_files_result)
+      result
+    end
+
+    it 'returns the command stdout' do
+      allow(checkout_files_command)
+        .to receive(:call).with('HEAD', pathspec: ['README.md']).and_return(checkout_files_result)
+      expect(result).to eq('')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #checkout
+  # ---------------------------------------------------------------------------
+
+  describe '#checkout' do
+    let(:checkout_branch_command) { instance_double(Git::Commands::Checkout::Branch) }
+    let(:checkout_branch_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Checkout::Branch)
+        .to receive(:new).with(execution_context).and_return(checkout_branch_command)
+    end
+
+    context 'with no arguments' do
+      subject(:result) { described_instance.checkout }
+
+      it 'delegates to Git::Commands::Checkout::Branch#call with nil branch and no options' do
+        expect(checkout_branch_command).to receive(:call).with(nil).and_return(checkout_branch_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(checkout_branch_command).to receive(:call).with(nil).and_return(checkout_branch_result)
+        expect(result).to eq('')
+      end
+    end
+
+    context 'with a branch name' do
+      subject(:result) { described_instance.checkout('main') }
+
+      it 'delegates with the branch name' do
+        expect(checkout_branch_command).to receive(:call).with('main').and_return(checkout_branch_result)
+        result
+      end
+    end
+
+    context 'with force: true' do
+      subject(:result) { described_instance.checkout('main', force: true) }
+
+      it 'forwards force: true to the command' do
+        expect(checkout_branch_command)
+          .to receive(:call).with('main', force: true).and_return(checkout_branch_result)
+        result
+      end
+    end
+
+    context 'with legacy new_branch: true and start_point option' do
+      subject(:result) { described_instance.checkout('new-branch', new_branch: true, start_point: 'main') }
+
+      it 'translates to call(start_point, b: branch)' do
+        expect(checkout_branch_command)
+          .to receive(:call).with('main', b: 'new-branch').and_return(checkout_branch_result)
+        result
+      end
+    end
+
+    context 'with legacy b: true and start_point option' do
+      subject(:result) { described_instance.checkout('new-branch', b: true, start_point: 'main') }
+
+      it 'translates to call(start_point, b: branch)' do
+        expect(checkout_branch_command)
+          .to receive(:call).with('main', b: 'new-branch').and_return(checkout_branch_result)
+        result
+      end
+    end
+
+    context 'with legacy new_branch: String option' do
+      subject(:result) { described_instance.checkout('main', new_branch: 'new-feature') }
+
+      it 'translates to call(branch, b: new_branch_name)' do
+        expect(checkout_branch_command)
+          .to receive(:call).with('main', b: 'new-feature').and_return(checkout_branch_result)
+        result
+      end
+    end
+
+    context 'with an unknown option' do
+      subject(:result) { described_instance.checkout('main', bogus: true) }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+
+      it 'does not call the command' do
+        expect(checkout_branch_command).not_to receive(:call)
+        begin
+          result
+        rescue ArgumentError
+          # expected
+        end
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #checkout_index
+  # ---------------------------------------------------------------------------
+
+  describe '#checkout_index' do
+    let(:checkout_index_command) { instance_double(Git::Commands::CheckoutIndex) }
+    let(:checkout_index_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::CheckoutIndex)
+        .to receive(:new).with(execution_context).and_return(checkout_index_command)
+    end
+
+    context 'with no arguments' do
+      subject(:result) { described_instance.checkout_index }
+
+      it 'delegates to Git::Commands::CheckoutIndex#call with no args' do
+        expect(checkout_index_command).to receive(:call).with(no_args).and_return(checkout_index_result)
+        result
+      end
+
+      it 'returns stdout as a String' do
+        allow(checkout_index_command).to receive(:call).with(no_args).and_return(checkout_index_result)
+        expect(result).to eq('')
+      end
+    end
+
+    context 'with all: true' do
+      subject(:result) { described_instance.checkout_index(all: true) }
+
+      it 'forwards the option to the command' do
+        expect(checkout_index_command).to receive(:call).with(all: true).and_return(checkout_index_result)
+        result
+      end
+    end
+
+    context 'with force: true' do
+      subject(:result) { described_instance.checkout_index(force: true) }
+
+      it 'forwards the option to the command' do
+        expect(checkout_index_command).to receive(:call).with(force: true).and_return(checkout_index_result)
+        result
+      end
+    end
+
+    context 'with prefix: value' do
+      subject(:result) { described_instance.checkout_index(prefix: 'tmp/') }
+
+      it 'forwards the option to the command' do
+        expect(checkout_index_command)
+          .to receive(:call).with(prefix: 'tmp/').and_return(checkout_index_result)
+        result
+      end
+    end
+
+    context 'with path_limiter as a String' do
+      subject(:result) { described_instance.checkout_index(path_limiter: 'README.md') }
+
+      it 'converts path_limiter to a positional operand' do
+        expect(checkout_index_command)
+          .to receive(:call).with('README.md').and_return(checkout_index_result)
+        result
+      end
+    end
+
+    context 'with path_limiter as an Array' do
+      subject(:result) { described_instance.checkout_index(path_limiter: ['a.rb', 'b.rb']) }
+
+      it 'splatts each path as a separate operand' do
+        expect(checkout_index_command)
+          .to receive(:call).with('a.rb', 'b.rb').and_return(checkout_index_result)
+        result
+      end
+    end
+
+    context 'with path_limiter and force: true' do
+      subject(:result) { described_instance.checkout_index(path_limiter: 'foo.rb', force: true) }
+
+      it 'passes the path as operand and force as keyword option' do
+        expect(checkout_index_command)
+          .to receive(:call).with('foo.rb', force: true).and_return(checkout_index_result)
+        result
+      end
+    end
+
+    context 'with an unknown option' do
+      subject(:result) { described_instance.checkout_index(bogus: true) }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `Git::Repository::Branching`, a new facade topic module that migrates the
`checkout`, `checkout_file`, `checkout_index`, and `current_branch` public methods
from `Git::Base` / `Git::Lib` into the new `Git::Repository::*` architecture.

Partially implements issue 1266.

## Changes

### New files

- **`lib/git/repository/branching.rb`** — `Git::Repository::Branching` topic module
  with four facade methods:
  - `#current_branch` — delegates to `Git::Commands::Branch::ShowCurrent`; returns
    `'HEAD'` in detached HEAD state
  - `#checkout_file(version, file)` — delegates to `Git::Commands::Checkout::Files`
  - `#checkout(branch = nil, opts = {})` — delegates to
    `Git::Commands::Checkout::Branch`; includes a private `translate_checkout_opts`
    helper that normalises the legacy `new_branch` / `b` / `start_point` option
    surface that callers depend on
  - `#checkout_index(opts = {})` — delegates to `Git::Commands::CheckoutIndex`;
    normalises the `path_limiter` option into positional file operands; returns the
    raw `Git::CommandLineResult` (consistent with existing behaviour)

- **`spec/unit/git/repository/branching_spec.rb`** — 23 unit examples covering
  delegation contracts, option translation, option whitelisting, and return-value
  pass-through for all four facade methods

- **`spec/integration/git/repository/branching_spec.rb`** — 9 integration examples
  exercising each facade method against a real git repository

### Modified files

- **`lib/git/repository.rb`** — `require`s and `include`s `Git::Repository::Branching`
- **`lib/git/base.rb`** — `#checkout`, `#checkout_file`, `#checkout_index`, and
  `#current_branch` now delegate to `facade_repository` instead of `lib`
- **`redesign/3_architecture_implementation.md`** — progress tracker updated

## Test coverage

```
spec/unit/git/repository/branching_spec.rb        23 examples, 0 failures
spec/integration/git/repository/branching_spec.rb  9 examples, 0 failures
```
