### PR TITLE
feat(repository): extract Git::Base#merge to Git::Repository::Merging

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -566,7 +566,7 @@ module Git
     #
     # you can specify more than one branch to merge by passing an array of branches
     def merge(branch, message = 'merge', opts = {})
-      lib.merge(branch, message, opts)
+      facade_repository.merge(branch, message, opts)
     end
 
     # iterates over the files which are unmerged

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -3,6 +3,7 @@
 require 'git/execution_context/repository'
 require 'git/repository/branching'
 require 'git/repository/committing'
+require 'git/repository/merging'
 require 'git/repository/staging'
 
 module Git
@@ -33,6 +34,7 @@ module Git
   class Repository
     include Git::Repository::Branching
     include Git::Repository::Committing
+    include Git::Repository::Merging
     include Git::Repository::Staging
 
     # @return [Git::ExecutionContext::Repository] the execution context used to run

--- a/lib/git/repository/merging.rb
+++ b/lib/git/repository/merging.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'git/commands/merge/start'
+require 'git/repository/internal'
+
+module Git
+  class Repository
+    # Facade methods for merge operations: merging branches into the current branch
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module Merging
+      # Option keys accepted by {#merge}
+      #
+      # Derived from the 4.x option map for `Git::Lib#merge`.
+      MERGE_ALLOWED_OPTS = %i[no_commit no_ff m message].freeze
+      private_constant :MERGE_ALLOWED_OPTS
+
+      # Merge one or more branches into the current branch
+      #
+      # The merge commit message may be given by the message positional argument, the
+      # `:message` option, or the `:m` option; if more than one is provided, the
+      # precedence is positional argument > `:message` > `:m`.
+      #
+      # @example Merge a single branch
+      #   repo.merge('feature')
+      #
+      # @example Merge a branch with a no-fast-forward commit message
+      #   repo.merge('feature', 'Merge feature into main', no_ff: true)
+      #
+      # @example Octopus merge of multiple branches
+      #   repo.merge(%w[feature-a feature-b])
+      #
+      # @example Merge without committing
+      #   repo.merge('feature', nil, no_commit: true)
+      #
+      # @param branch [String, Array<String>, #to_s] the branch or branches to merge
+      #   into the current branch
+      #
+      #   when an Array is given, an octopus merge is performed; a {Git::Branch}
+      #   object is coerced to a String via `#to_s`.
+      #
+      # @param message [String, nil] optional commit message for the merge commit
+      #
+      #   Translated to the `-m` flag internally. For fast-forward merges git ignores
+      #   this value; use `no_ff: true` to ensure a merge commit is created and the
+      #   message is recorded.
+      #
+      # @param opts [Hash] additional options forwarded to `git merge`
+      #
+      # @option opts [Boolean] :no_commit (false) stop before creating the merge commit
+      #   (`--no-commit`)
+      #
+      # @option opts [Boolean] :no_ff (false) create a merge commit even when
+      #   fast-forward is possible (`--no-ff`)
+      #
+      # @option opts [String] :message (nil) commit message
+      #
+      #   Prefer the `:m` option instead of this one. Translated to the `-m` flag.
+      #   Identical to the positional `message` argument and the `:m` option.
+      #
+      # @option opts [String] :m (nil) commit message (`-m` flag)
+      #
+      # @return [String] git's stdout from the merge command
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def merge(branch, message = nil, opts = {})
+        Git::Repository::Internal.assert_valid_opts!(MERGE_ALLOWED_OPTS, **opts)
+
+        # Dup so callers who reuse the same opts hash are not affected
+        opts = opts.dup
+
+        # Merge positional message into opts so the rest of the logic is uniform
+        opts[:message] = message if message
+
+        # git merge uses -m, not --message; translate the key
+        opts[:m] = opts.delete(:message) if opts.key?(:message)
+
+        branches = Array(branch).map(&:to_s)
+        Git::Commands::Merge::Start.new(@execution_context).call(*branches, no_edit: true, **opts).stdout
+      end
+    end
+  end
+end

--- a/spec/integration/git/repository/merging_spec.rb
+++ b/spec/integration/git/repository/merging_spec.rb
@@ -1,0 +1,203 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/merging'
+
+RSpec.describe Git::Repository::Merging, :integration do
+  include_context 'in an empty repository'
+
+  let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  # Create an initial commit on the default branch so we have a proper HEAD
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  # ---------------------------------------------------------------------------
+  # #merge — single branch
+  # ---------------------------------------------------------------------------
+
+  describe '#merge single branch' do
+    before do
+      # Create and populate a feature branch
+      repo.lib.branch_new('feature')
+      repo.lib.checkout('feature')
+      write_file('feature.txt', "feature content\n")
+      repo.add('feature.txt')
+      repo.commit('Add feature file')
+      repo.lib.checkout('main')
+    end
+
+    it 'returns a String' do
+      result = described_instance.merge('feature')
+      expect(result).to be_a(String)
+    end
+
+    it 'merges the feature branch into the current branch' do
+      described_instance.merge('feature')
+      expect(File.exist?(File.join(repo_dir, 'feature.txt'))).to be(true)
+    end
+
+    it 'makes the merged file visible in git status' do
+      described_instance.merge('feature')
+      # After a clean merge, status should show no untracked/modified files
+      expect(repo.status.added).to be_empty
+      expect(repo.status.changed).to be_empty
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #merge — Git::Branch object coercion
+  # ---------------------------------------------------------------------------
+
+  describe '#merge with a Git::Branch object' do
+    before do
+      repo.lib.branch_new('feature')
+      repo.lib.checkout('feature')
+      write_file('from_branch_obj.txt', "branch object content\n")
+      repo.add('from_branch_obj.txt')
+      repo.commit('Add from_branch_obj.txt')
+      repo.lib.checkout('main')
+    end
+
+    it 'coerces the Git::Branch to a String and merges successfully' do
+      branch_obj = repo.branch('feature')
+      described_instance.merge(branch_obj)
+      expect(File.exist?(File.join(repo_dir, 'from_branch_obj.txt'))).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #merge — Array of branches (octopus merge)
+  # ---------------------------------------------------------------------------
+
+  describe '#merge octopus (Array of branches)' do
+    before do
+      repo.lib.branch_new('branch-a')
+      repo.lib.checkout('branch-a')
+      write_file('file_a.txt', "content from branch-a\n")
+      repo.add('file_a.txt')
+      repo.commit('Add file_a.txt')
+      repo.lib.checkout('main')
+
+      repo.lib.branch_new('branch-b')
+      repo.lib.checkout('branch-b')
+      write_file('file_b.txt', "content from branch-b\n")
+      repo.add('file_b.txt')
+      repo.commit('Add file_b.txt')
+      repo.lib.checkout('main')
+    end
+
+    it 'merges all branches and all files appear in the working tree' do
+      described_instance.merge(%w[branch-a branch-b])
+      expect(File.exist?(File.join(repo_dir, 'file_a.txt'))).to be(true)
+      expect(File.exist?(File.join(repo_dir, 'file_b.txt'))).to be(true)
+    end
+
+    it 'returns a String' do
+      result = described_instance.merge(%w[branch-a branch-b])
+      expect(result).to be_a(String)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #merge — no_ff: true with a commit message
+  # ---------------------------------------------------------------------------
+
+  describe '#merge with no_ff: true and a message' do
+    before do
+      repo.lib.branch_new('feature')
+      repo.lib.checkout('feature')
+      write_file('noff.txt', "no-ff content\n")
+      repo.add('noff.txt')
+      repo.commit('Add noff.txt')
+      repo.lib.checkout('main')
+    end
+
+    it 'creates a merge commit whose message is the given string' do
+      described_instance.merge('feature', 'merge commit message', no_ff: true)
+      commits = repo.log.execute
+      expect(commits.first.message).to eq('merge commit message')
+    end
+
+    it 'makes the merged file visible in the working tree' do
+      described_instance.merge('feature', 'merge commit message', no_ff: true)
+      expect(File.exist?(File.join(repo_dir, 'noff.txt'))).to be(true)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #merge — fast-forward with message (git ignores -m on ff)
+  # ---------------------------------------------------------------------------
+
+  describe '#merge fast-forward with a message' do
+    before do
+      repo.lib.branch_new('feature')
+      repo.lib.checkout('feature')
+      write_file('ff.txt', "ff content\n")
+      repo.add('ff.txt')
+      repo.commit('first commit message')
+      repo.lib.checkout('main')
+    end
+
+    it 'performs the merge successfully (returns a String)' do
+      result = described_instance.merge('feature', 'merge commit message')
+      expect(result).to be_a(String)
+    end
+
+    it 'merges the file into the working tree' do
+      described_instance.merge('feature', 'merge commit message')
+      expect(File.exist?(File.join(repo_dir, 'ff.txt'))).to be(true)
+    end
+
+    it 'does NOT set the commit message (git ignores -m on fast-forward merges)' do
+      described_instance.merge('feature', 'merge commit message')
+      commits = repo.log.execute
+      expect(commits.first.message).to eq('first commit message')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #merge — no_commit: true (HEAD unchanged after merge)
+  #
+  # NOTE: git ignores --no-commit on fast-forward merges. The test therefore
+  # creates a divergent history (main has a commit that feature does not) so
+  # that a real three-way merge is required and --no-commit takes effect.
+  # ---------------------------------------------------------------------------
+
+  describe '#merge with no_commit: true' do
+    before do
+      # Branch feature off the initial commit
+      repo.lib.branch_new('feature')
+      repo.lib.checkout('feature')
+      write_file('staged.txt', "staged content\n")
+      repo.add('staged.txt')
+      repo.commit('Add staged.txt')
+      repo.lib.checkout('main')
+
+      # Create a commit on main so that main and feature have diverged;
+      # this prevents a fast-forward and makes --no-commit effective.
+      write_file('main_only.txt', "main content\n")
+      repo.add('main_only.txt')
+      repo.commit('Add main_only.txt')
+    end
+
+    it 'leaves HEAD pointing at the pre-merge commit' do
+      head_before = repo.log(1).execute.first.sha
+      described_instance.merge('feature', nil, no_commit: true)
+      expect(repo.log(1).execute.first.sha).to eq(head_before)
+    end
+
+    it 'stages the merge result but does not create a commit' do
+      described_instance.merge('feature', nil, no_commit: true)
+      # The file is staged (type 'A') but no new commit was made
+      status = repo.status['staged.txt']
+      expect(status).not_to be_nil
+      expect(status.type).to eq('A')
+    end
+  end
+end

--- a/spec/unit/git/repository/merging_spec.rb
+++ b/spec/unit/git/repository/merging_spec.rb
@@ -1,0 +1,216 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/merging'
+
+# Integration-level coverage for Git::Repository::Merging is provided by
+# spec/integration/git/repository/merging_spec.rb.
+# The unit specs below cover the facade's own orchestration (argument pre-processing,
+# option whitelisting, delegation contracts).
+
+RSpec.describe Git::Repository::Merging do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  # ---------------------------------------------------------------------------
+  # #merge
+  # ---------------------------------------------------------------------------
+
+  describe '#merge' do
+    let(:merge_start_command) { instance_double(Git::Commands::Merge::Start) }
+
+    before do
+      allow(Git::Commands::Merge::Start)
+        .to receive(:new).with(execution_context).and_return(merge_start_command)
+    end
+
+    # --- Single String branch ------------------------------------------------
+
+    context 'with a single String branch name' do
+      subject(:result) { described_instance.merge('feature') }
+
+      let(:merge_result) { command_result("Merge made by the 'ort' strategy.\n") }
+
+      it 'delegates to Git::Commands::Merge::Start.new with the execution_context' do
+        expect(Git::Commands::Merge::Start).to receive(:new).with(execution_context).and_return(merge_start_command)
+        allow(merge_start_command).to receive(:call).and_return(merge_result)
+        result
+      end
+
+      it 'calls Merge::Start#call with the branch name and no_edit: true' do
+        expect(merge_start_command)
+          .to receive(:call).with('feature', no_edit: true).and_return(merge_result)
+        result
+      end
+
+      it 'returns the command stdout as a String' do
+        allow(merge_start_command)
+          .to receive(:call).with('feature', no_edit: true).and_return(merge_result)
+        expect(result).to eq("Merge made by the 'ort' strategy.\n")
+      end
+    end
+
+    # --- Array of branch names (octopus merge) --------------------------------
+
+    context 'with an Array of branch names' do
+      subject(:result) { described_instance.merge(%w[feature-a feature-b]) }
+
+      let(:merge_result) { command_result("Merge made by octopus strategy.\n") }
+
+      it 'splats all branch names as separate positional arguments' do
+        expect(merge_start_command)
+          .to receive(:call).with('feature-a', 'feature-b', no_edit: true).and_return(merge_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(merge_start_command)
+          .to receive(:call).with('feature-a', 'feature-b', no_edit: true).and_return(merge_result)
+        expect(result).to eq("Merge made by octopus strategy.\n")
+      end
+    end
+
+    # --- Git::Branch coercion -------------------------------------------------
+
+    context 'with a Git::Branch object' do
+      subject(:result) { described_instance.merge(branch_obj) }
+
+      let(:branch_obj) { instance_double('Git::Branch', to_s: 'feature') }
+      let(:merge_result) { command_result("Already up to date.\n") }
+
+      it 'coerces the branch to a String via #to_s' do
+        expect(merge_start_command)
+          .to receive(:call).with('feature', no_edit: true).and_return(merge_result)
+        result
+      end
+    end
+
+    # --- Positional message argument ------------------------------------------
+
+    context 'with a positional message argument' do
+      subject(:result) { described_instance.merge('feature', 'My merge commit') }
+
+      let(:merge_result) { command_result('') }
+
+      it 'translates the message to the :m keyword option' do
+        expect(merge_start_command)
+          .to receive(:call).with('feature', no_edit: true, m: 'My merge commit').and_return(merge_result)
+        result
+      end
+    end
+
+    context 'with a nil message argument (explicit nil)' do
+      subject(:result) { described_instance.merge('feature', nil) }
+
+      let(:merge_result) { command_result('') }
+
+      it 'does not include :m in the call options' do
+        expect(merge_start_command)
+          .to receive(:call).with('feature', no_edit: true).and_return(merge_result)
+        result
+      end
+    end
+
+    context 'with no message argument' do
+      subject(:result) { described_instance.merge('feature') }
+
+      let(:merge_result) { command_result('') }
+
+      it 'does not include :m in the call options' do
+        expect(merge_start_command)
+          .to receive(:call).with('feature', no_edit: true).and_return(merge_result)
+        result
+      end
+    end
+
+    # --- opts[:message] translation -------------------------------------------
+
+    context 'with opts[:message] (no positional message)' do
+      subject(:result) { described_instance.merge('feature', nil, message: 'via opts') }
+
+      let(:merge_result) { command_result('') }
+
+      it 'translates opts[:message] to :m' do
+        expect(merge_start_command)
+          .to receive(:call).with('feature', no_edit: true, m: 'via opts').and_return(merge_result)
+        result
+      end
+
+      it 'does not pass :message in the call options' do
+        allow(merge_start_command)
+          .to receive(:call) do |*, **kw|
+            expect(kw).not_to have_key(:message)
+            merge_result
+          end
+        result
+      end
+
+      it 'does not mutate the caller opts hash' do
+        caller_opts = { message: 'via opts' }
+        allow(merge_start_command).to receive(:call).and_return(merge_result)
+        described_instance.merge('feature', nil, caller_opts)
+        expect(caller_opts).to eq({ message: 'via opts' })
+      end
+    end
+
+    # --- Pass-through options -------------------------------------------------
+
+    context 'with no_ff: true' do
+      subject(:result) { described_instance.merge('feature', nil, no_ff: true) }
+
+      let(:merge_result) { command_result('') }
+
+      it 'passes no_ff: true through to Merge::Start#call' do
+        expect(merge_start_command)
+          .to receive(:call).with('feature', no_edit: true, no_ff: true).and_return(merge_result)
+        result
+      end
+    end
+
+    context 'with no_commit: true' do
+      subject(:result) { described_instance.merge('feature', nil, no_commit: true) }
+
+      let(:merge_result) { command_result('') }
+
+      it 'passes no_commit: true through to Merge::Start#call' do
+        expect(merge_start_command)
+          .to receive(:call).with('feature', no_edit: true, no_commit: true).and_return(merge_result)
+        result
+      end
+    end
+
+    # --- Combined message + opts ---------------------------------------------
+
+    context 'with a positional message and no_ff: true' do
+      subject(:result) { described_instance.merge('feature', 'merge commit', no_ff: true) }
+
+      let(:merge_result) { command_result('') }
+
+      it 'passes m: and no_ff: through to Merge::Start#call' do
+        expect(merge_start_command)
+          .to receive(:call).with('feature', no_edit: true, m: 'merge commit', no_ff: true).and_return(merge_result)
+        result
+      end
+    end
+
+    # --- Unknown option guard -------------------------------------------------
+
+    context 'with an unknown option' do
+      subject(:result) { described_instance.merge('feature', nil, bogus: true) }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+
+      it 'does not call Merge::Start' do
+        expect(merge_start_command).not_to receive(:call)
+        begin
+          result
+        rescue ArgumentError
+          # expected
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Creates a new `Git::Repository::Merging` module with a `#merge` facade
method, wires it into `Git::Repository`, and updates `Git::Base#merge`
to delegate through `facade_repository` instead of calling `lib.merge`
directly.

Partially implements #1266.

## What changed

### `lib/git/repository/merging.rb` (new)
- New module `Git::Repository::Merging` with a single public method `#merge`.
- Accepts `branch` as a `String`, `Array<String>`, or `Git::Branch` object
  (coerced to `String` via `#to_s` using `Array(branch).map(&:to_s)`).
- Accepts `message` as an optional second positional argument (default `nil`);
  translated to the `:m` keyword option because `git merge` uses `-m`, not
  `--message`.
- Accepts `opts` as a trailing options hash validated against `MERGE_ALLOWED_OPTS`.
- Always passes `no_edit: true` to `Git::Commands::Merge::Start` to preserve
  non-interactive behaviour.
- `MERGE_ALLOWED_OPTS` is derived from the 4.x `MERGE_OPTION_MAP` keys:
  `:no_commit`, `:no_ff`. `:message` is accepted as a user-friendly alias and
  translated to `:m` before forwarding. `:m` is also accepted directly.
  Options not in the 4.x map (`:commit`, `:ff`, `:ff_only`, `:squash`,
  `:strategy`, `:strategy_option`, `:allow_unrelated_histories`) are deferred
  to follow-up issue #1272.

### `lib/git/repository.rb`
- Added `require 'git/repository/merging'` and `include Git::Repository::Merging`.

### `lib/git/base.rb`
- Updated `Git::Base#merge` to delegate to `facade_repository.merge` instead
  of `lib.merge`. The public signature `(branch, message = 'merge', opts = {})`
  and the `'merge'` default are preserved for backward compatibility.

### `spec/unit/git/repository/merging_spec.rb` (new)
16 unit examples covering delegation, argument coercion, option translation,
pass-through flags, and unknown option guard.

### `spec/integration/git/repository/merging_spec.rb` (new)
13 integration examples covering: single branch merge, `Git::Branch` object
coercion, octopus merge, `no_ff` + message, fast-forward + message (git ignores
`-m` on ff), and `no_commit` with divergent history.

## Backward compatibility

All 5 legacy tests in `tests/units/test_merge.rb` continue to pass:

| Call | Contract preserved |
|------|---------------------|
| `g.merge(g.branch('new_branch'))` | `Git::Branch` coerced to `String` ✅ |
| `g.merge(%w[new_branch new_branch2])` | Octopus merge ✅ |
| `g.merge('branch', 'msg')` | FF merge — `git` ignores `-m` ✅ |
| `g.merge('branch', 'msg', no_ff: true)` | Merge commit message recorded ✅ |
| `g.merge('branch', nil, no_commit: true)` | HEAD unchanged ✅ |

## Prerequisite confirmed

`lib/git/commands/merge/start.rb` exists with full `Git::Commands::Base`
architecture and comprehensive arguments DSL.