### PR TITLE
fix(docs): pad all markdown table separator cells to fix markdownlint MD055

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,7 +32,7 @@ or explanation does not require a skill.
 ## Project Commands
 
 | Purpose | Command |
-|---|---|
+| --- | --- |
 | First-time setup | `bin/setup` |
 | Run all tests and linters(CI-equivalent) | `bundle exec rake default:parallel` |
 | Run all tests (both suites) | `bundle exec rake test-all:parallel` |
@@ -69,7 +69,7 @@ footer.
 ## Branch & PR Strategy
 
 | Target | When |
-|---|---|
+| --- | --- |
 | `main` | New features, breaking changes, all active development |
 | `4.x` | Security fixes and backward-compatible bug fixes for the v4.x series |
 
@@ -86,7 +86,7 @@ skill first.
 ## Key Documents
 
 | Document | Purpose |
-|---|---|
+| --- | --- |
 | `CONTRIBUTING.md` | Design philosophy, contribution guidelines |
 | `CHANGELOG.md` | Version history (auto-updated by release-please) |
 | `MAINTAINERS.md` | Maintainer list and responsibilities |

--- a/.github/skills/command-implementation/REFERENCE.md
+++ b/.github/skills/command-implementation/REFERENCE.md
@@ -384,7 +384,7 @@ where no pre-call logic is needed.
 > (e.g. "if the branch doesn't exist"). Use:
 >
 > | `allow_exit_status` | Canonical `@raise` wording |
-> |---|---|
+> | --- | --- |
 > | none declared (default `0..0`) | `if git exits with a non-zero exit status` |
 > | `allow_exit_status 0..1` | `if git exits outside the allowed range (exit code > 1)` |
 > | `allow_exit_status 0..N` | `if git exits outside the allowed range (exit code > N)` |
@@ -598,7 +598,7 @@ string (e.g., `'2.29.0'`), not a `Git::Version` or `Range` — pre-release versi
 are not supported.
 
 | Scenario | Action |
-|---|---|
+| --- | --- |
 | Command exists in `Git::MINIMUM_GIT_VERSION` | Do **not** add `requires_git_version` |
 | Command was introduced after `Git::MINIMUM_GIT_VERSION` | Add `requires_git_version '<version>'` at the version the command was introduced |
 
@@ -611,7 +611,7 @@ options by version.
 For each option, make one of three decisions:
 
 | Decision | Reason | Action |
-|---|---|---|
+| --- | --- | --- |
 | **Include** | All behavioral options — including output-format flags (`--pretty=`, `--patch`, `--numstat`, `--name-only`, etc.) and filtering/selection flags | Add to `arguments do` |
 | **Exclude (wrong sub-action)** | Option belongs to a different sub-action than the one this class implements | Omit — see [Scoping options to sub-command classes](#scoping-options-to-sub-command-classes) below |
 | **Exclude (execution-model conflict)** | Requires TTY input or otherwise makes the command incompatible with non-interactive subprocess execution | Omit — see [Execution-model conflicts](#execution-model-conflicts) below |
@@ -713,7 +713,7 @@ will reject or misinterpret.
 **Example — `git branch`:**
 
 | Option | Create | List | Delete | Move/Copy |
-|---|---|---|---|---|
+| --- | --- | --- | --- | --- |
 | `--track` | Yes | — | — | — |
 | `--force` | Yes | — | Yes | Yes |
 | `--sort` | — | Yes | — | — |

--- a/.github/skills/command-yard-documentation/SKILL.md
+++ b/.github/skills/command-yard-documentation/SKILL.md
@@ -362,7 +362,7 @@ For each command file, run through these checks in order:
       declared exit-status range:
 
   | `allow_exit_status` | Canonical `@raise` wording |
-  |---|---|
+  | --- | --- |
   | none declared (default `0..0`) | `if git exits with a non-zero exit status` |
   | `allow_exit_status 0..1` | `if git exits outside the allowed range (exit code > 1)` |
   | `allow_exit_status 0..N` | `if git exits outside the allowed range (exit code > N)` |

--- a/.github/skills/facade-implementation/REFERENCE.md
+++ b/.github/skills/facade-implementation/REFERENCE.md
@@ -5,6 +5,7 @@ is loaded by subagents during the [Facade Implementation](SKILL.md) workflow.
 
 ## Contents
 
+- [Contents](#contents)
 - [Files to generate](#files-to-generate)
 - [Topic module selection](#topic-module-selection)
   - [Existing modules](#existing-modules)
@@ -541,7 +542,7 @@ Modules under `lib/git/repository/` use **bare nouns**, never role-suffixes like
 `*Helpers` or `*Utils`:
 
 | Module                              | Distinguished by               |
-|-------------------------------------|--------------------------------|
+| ----------------------------------- | ------------------------------ |
 | `Git::Repository::Staging`          | `include`d, `@api public`      |
 | `Git::Repository::Branching`        | `include`d, `@api public`      |
 | `Git::Repository::Internal`         | not `include`d, `@api private` |

--- a/.github/skills/facade-yard-documentation/SKILL.md
+++ b/.github/skills/facade-yard-documentation/SKILL.md
@@ -260,7 +260,7 @@ The `@return` annotation must reflect the **public contract** of the facade
 method, not the type of the underlying call expression.
 
 | Facade does | `@return` type |
-|---|---|
+| --- | --- |
 | Returns the raw `CommandLineResult` | `[Git::CommandLineResult]` |
 | Returns `result.stdout` (chomped or raw) | `[String]` |
 | Returns parsed structured data via a parser | The parser's return type (e.g. `[Array<Git::BranchInfo>]`, `[Hash]`) |
@@ -278,7 +278,7 @@ documented contract is to expose raw results.
   command's exit-status range:
 
   | Command's `allow_exit_status` | Facade `@raise` wording |
-  |---|---|
+  | --- | --- |
   | none / `0..0` | `if git exits with a non-zero exit status` |
   | `0..1` | `if git exits outside the allowed range (exit code > 1)` |
 

--- a/.github/skills/make-skill-template/SKILL.md
+++ b/.github/skills/make-skill-template/SKILL.md
@@ -73,7 +73,7 @@ description: '<What it does>. Use when <specific triggers, scenarios, keywords u
 #### Frontmatter Field Requirements
 
 | Field | Required | Constraints |
-|-------|----------|-------------|
+| ----- | -------- | ----------- |
 | `name` | **Yes** | 1-64 chars, lowercase letters/numbers/hyphens only, must match folder name |
 | `description` | **Yes** | 10-1024 chars, must describe WHAT it does AND WHEN to use it |
 | `license` | No | License name or reference to bundled LICENSE.txt |
@@ -106,7 +106,7 @@ description: 'Web testing helpers'
 After the frontmatter, add markdown instructions. Recommended sections:
 
 | Section | Purpose |
-|---------|---------|
+| ------- | ------- |
 | `# Title` | Brief overview |
 | `## When to Use This Skill` | Reinforces description triggers |
 | `## Prerequisites` | Required tools, dependencies |
@@ -117,7 +117,7 @@ After the frontmatter, add markdown instructions. Recommended sections:
 ### Step 4: Add Optional Directories (If Needed)
 
 | Folder | Purpose | When to Use |
-|--------|---------|-------------|
+| ------ | ------- | ----------- |
 | `scripts/` | Executable code (Python, Bash, JS) | Automation that performs operations |
 | `references/` | Documentation agent reads | API references, schemas, guides |
 | `assets/` | Static files used AS-IS | Images, fonts, templates |
@@ -164,7 +164,7 @@ my-awesome-skill/
 ## Troubleshooting
 
 | Issue | Solution |
-|-------|----------|
+| ----- | -------- |
 | Skill not discovered | Improve description with more keywords and triggers |
 | Validation fails on name | Ensure lowercase, no consecutive hyphens, matches folder |
 | Description too short | Add capabilities, triggers, and keywords |

--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -48,7 +48,7 @@ coding standard details, or implementation constraints.
 **Key modules and their roles:**
 
 | Class | Role |
-|---|---|
+| --- | --- |
 | `Git::Base` | Main facade — entry point for all user-facing operations |
 | `Git::Lib` | Low-level adapter/facade; calls `Git::Commands::*`, builds rich objects via parsers |
 | `Git::Commands::*` | Command classes: define CLI API, bind args, execute → return `CommandLineResult` |
@@ -139,14 +139,14 @@ incompatibilities — `conflicts` and/or `requires_one_of` are appropriate. Exam
 `cat-file --batch` uses both because `:objects` is `skip_cli: true`:
 
 | Validated by Commands | Mechanism |
-|---|---|
+| --- | --- |
 | Unknown options | `validate_unsupported_options!` in Arguments DSL |
 | Required options | `required: true` in Arguments DSL |
 | Type checking | `type:` in Arguments DSL |
 | Option-like operand rejection | Automatic for operands before `--` |
 
 | Delegated to git (semantic) | Surfaced as |
-|---|---|
+| --- | --- |
 | Option conflicts (`--soft` vs `--hard`) | `Git::FailedError` |
 | Option dependencies (`--all-match` requires `--grep`) | `Git::FailedError` |
 | At-least-one-of groups | `Git::FailedError` |
@@ -171,7 +171,7 @@ See `redesign/3_architecture_implementation.md` Insight 6 for the full policy an
 ### Naming
 
 | Kind | Convention | Example |
-|---|---|---|
+| --- | --- | --- |
 | Class/Module | PascalCase | `Git::CommandLine` |
 | Method/variable | snake_case | `current_branch` |
 | Constant | UPPER_SNAKE_CASE | `VERSION` |

--- a/.github/skills/release-management/SKILL.md
+++ b/.github/skills/release-management/SKILL.md
@@ -47,7 +47,7 @@ Releases are **fully automated** via
 Key config files:
 
 | File | Purpose |
-|------|---------|
+| ---- | ------- |
 | `.release-please-config.json` | Release-please settings (release type, changelog sections, versioning strategy) |
 | `.release-please-manifest.json` | Tracks the current released version |
 | `lib/git/version.rb` | Version constant (updated automatically by release-please) |

--- a/.github/skills/reviewing-skills/SKILL.md
+++ b/.github/skills/reviewing-skills/SKILL.md
@@ -157,8 +157,8 @@ For each reviewed skill, produce:
 
 1. A per-check result table:
 
-   | # | Check | Status | Issue |
-   |---|-------|--------|-------|
+   |  #  | Check | Status | Issue |
+   | --- | ----- | ------ | ----- |
 
 2. A summary of required fixes (if any)
 
@@ -173,7 +173,7 @@ practices at
 Key principles distilled:
 
 | Principle | One-liner |
-|-----------|-----------|
+| --------- | --------- |
 | Concise is key | Only add context the model does not already have |
 | Degrees of freedom | Match specificity to task fragility |
 | Progressive disclosure | SKILL.md is an overview; details in separate files |

--- a/.github/skills/rspec-unit-testing-standards/SKILL.md
+++ b/.github/skills/rspec-unit-testing-standards/SKILL.md
@@ -630,7 +630,7 @@ checklist above. No additional structured output is required.
 1. A per-rule compliance table:
 
    | Rule | Status | Issue |
-   |------|--------|-------|
+   | ---- | ------ | ----- |
 
    Use **Pass**, **Fail**, or **N/A** for each rule.
 

--- a/.github/skills/tdd-refactor-step/SKILL.md
+++ b/.github/skills/tdd-refactor-step/SKILL.md
@@ -61,8 +61,8 @@ If any condition is false, proceed with the relevant technique below.
 
 Check the code written or modified in this task for these smells, in priority order:
 
-| # | Smell | Threshold | Action |
-|---|-------|-----------|--------|
+|  #  | Smell | Threshold | Action |
+| --- | ----- | --------- | ------ |
 | 1 | **Hardcoded values** from GREEN step | Any | Generalize to actual logic |
 | 2 | **Duplication** between new code and existing code | ≥ 3 similar lines | Extract shared method or constant |
 | 3 | **Long method** | > 10 lines (body) | Extract private helper |
@@ -163,7 +163,7 @@ If the duplication is in tests, see Test Code Refactoring below.
 Test code deserves the same refactoring attention as production code:
 
 | Smell | Technique |
-|-------|-----------|
+| ----- | --------- |
 | Duplicated `let`/`before` across contexts | Move to nearest shared `describe` or `context` |
 | Long example bodies (> 5 lines of setup) | Extract to `let` declarations or `before` block |
 | Repeated literal values | Extract to `let` or constant at top of file |

--- a/.github/skills/test-debugging/SKILL.md
+++ b/.github/skills/test-debugging/SKILL.md
@@ -115,7 +115,7 @@ Present diagnostic findings to the user:
 ## Step 4: Determine Fix Strategy
 
 | Scenario | Strategy | Commit Type |
-|---|---|---|
+| --- | --- | --- |
 | **Production code bug** (test caught a real bug) | Fix production code using the development-workflow TDD process. The failing test is the RED step. | `fix(component): <description>` |
 | **Test needs updating** (intentional API change) | Get user confirmation first. Update test assertions. | `test(component): update test for <change>` |
 | **Flaky test** (non-determinism) | Make test deterministic. Run 20+ times to verify. | `test(component): fix flaky test in <test_name>` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -173,7 +173,7 @@ what the caller passes.
 The three architectural layers each play a distinct role:
 
 | Layer | Responsibility | Mechanism |
-|---|---|---|
+| --- | --- | --- |
 | **Command** (`Git::Commands::*`) | Neutral git CLI interface | Declares options via DSL (e.g. `flag_option :edit, negatable: true`) — no policy |
 | **Facade** (`Git::Lib`) | Safe defaults | Sets policy options at each call site (e.g. `edit: false`); callers may override |
 | **Execution** (`Git::CommandLine`) | Unconditional safety net | `GIT_EDITOR='true'` in every subprocess environment |

--- a/lib/git/commands/arguments.rb
+++ b/lib/git/commands/arguments.rb
@@ -49,7 +49,7 @@ module Git
     # argument types:
     #
     # | CLI (POSIX)            | Ruby Interface         | Description                                         |
-    # |------------------------|------------------------|-----------------------------------------------------|
+    # | ---------------------- | ---------------------- | --------------------------------------------------- |
     # | argument specification | DSL definition         | Declared command inputs and constraints             |
     # | arguments              | arguments              | Values passed when calling a command/method         |
     # | operands               | positional arguments   | Arguments identified by position                    |

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -359,7 +359,7 @@ future work:
    **What command classes validate:**
 
    | Validation | Mechanism | Rationale |
-   |---|---|---|
+   | --- | --- | --- |
    | Unknown options | `validate_unsupported_options!` in Arguments DSL | Catches typos/misspellings before spawning a process. Git would also reject these, but the error message would be less clear about the Ruby-side fix needed. |
    | Required options | `required: true` in Arguments DSL | Enforces the minimum contract for a command to be meaningful. Avoids spawning a process that will certainly fail. |
    | Type checking | `type:` in Arguments DSL | Catches programming errors (e.g., passing an Integer where a String is expected) that would produce confusing git errors or silent coercion. |
@@ -368,7 +368,7 @@ future work:
    **What command classes do NOT validate (semantic concerns — delegated to git):**
 
    | Validation | Delegated to | Rationale |
-   |---|---|---|
+   | --- | --- | --- |
    | Option conflicts (`--soft` vs `--hard`) | Git (stderr → `Git::FailedError`) | Git is the authority on which options conflict. Constraints drift as git evolves. |
    | Option dependencies (`--all-match` requires `--grep`) | Git (stderr or silent behavior) | Same drift risk. Some dependencies are version-specific. |
    | At-least-one-of groups | Git (stderr → `Git::FailedError`) | Git enforces its own required-argument semantics. |


### PR DESCRIPTION
## Problem

Table separator rows throughout the codebase used unpadded cells — e.g. `|---|` or `|--------|` — which violate the [markdownlint MD055](https://github.com/DavidAnson/markdownlint/blob/main/doc/md055.md) (table-pipe-style) rule. The rule requires consistent spacing around pipe characters in all separator cells, regardless of cell width.

## Change

Replace all unpadded separator cells with padded equivalents (e.g. `|---|` → `| --- |`, `|--------|` → `| -------- |`) across 14 markdown files and 1 YARD comment table:

**Markdown files:**
- `.github/copilot-instructions.md`
- `.github/skills/command-implementation/REFERENCE.md`
- `.github/skills/command-yard-documentation/SKILL.md`
- `.github/skills/facade-implementation/REFERENCE.md`
- `.github/skills/facade-yard-documentation/SKILL.md`
- `.github/skills/make-skill-template/SKILL.md`
- `.github/skills/project-context/SKILL.md`
- `.github/skills/release-management/SKILL.md`
- `.github/skills/reviewing-skills/SKILL.md`
- `.github/skills/rspec-unit-testing-standards/SKILL.md`
- `.github/skills/tdd-refactor-step/SKILL.md`
- `.github/skills/test-debugging/SKILL.md`
- `CONTRIBUTING.md`
- `redesign/3_architecture_implementation.md`

**YARD comment table:**
- `lib/git/commands/arguments.rb`

The change is purely cosmetic — no content, logic, or formatting of table data rows is altered.
