### PR TITLE
docs: use [Boolean, nil] type with (nil) default for flag options

### DIFF
--- a/.github/skills/command-implementation/REFERENCE.md
+++ b/.github/skills/command-implementation/REFERENCE.md
@@ -341,23 +341,23 @@ module Git
         #
         #     Execute the git ... command.
         #
-        #     @param operand [String, nil] (nil) Short description without trailing period
+        #     @param operand [String, nil] (nil) short description without trailing period
         #
         #       Continuation paragraph separated by a blank comment line. Only needed
         #       when the short description alone is insufficient.
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :simple_flag (false) One-sentence description without period
+        #     @option options [Boolean, nil] :simple_flag (nil) one-sentence description without period
         #
-        #     @option options [Boolean, Integer] :force (false) Short description without period
+        #     @option options [Boolean, Integer, nil] :force (nil) short description without period
         #
         #       When an integer is given, the flag is repeated that many times (up to the
         #       configured `max_times:` limit).
         #
         #       Alias: :f
         #
-        #     @option options [Boolean, String, nil] :complex_flag (nil) Short description without period
+        #     @option options [Boolean, String, nil] :complex_flag (nil) short description without period
         #
         #       Continuation: explain the `true`/`false`/string forms here, each separated by
         #       a blank comment line from the short description above.
@@ -455,7 +455,7 @@ an explicit override.
 #
 #   @param options [Hash] command options
 #
-#   @option options [Boolean] :unordered (false) Unordered output
+#   @option options [Boolean, nil] :unordered (nil) unordered output
 #
 #   @return [Git::CommandLineResult] the result of calling `git cat-file --batch`
 #

--- a/.github/skills/command-yard-documentation/SKILL.md
+++ b/.github/skills/command-yard-documentation/SKILL.md
@@ -109,7 +109,7 @@ without a method definition in the subclass:
 #
 #     @param options [Hash] command options
 #
-#     @option options [Boolean] :force (false) ...
+#     @option options [Boolean, nil] :force (nil) ...
 #
 #     @return [Git::CommandLineResult]
 ```
@@ -140,7 +140,7 @@ method:
 #
 #   @param options [Hash] command options
 #
-#   @option options [Boolean] :all (false) ...
+#   @option options [Boolean, nil] :all (nil) ...
 #
 #   @return [Git::CommandLineResult] the result of calling `git log`
 #
@@ -160,11 +160,11 @@ conflicting documentation for the method.
 
 | DSL method | YARD type |
 | --- | --- |
-| `flag_option` | `[Boolean]` — default `(false)` (flag not emitted by default) |
-| `flag_option ..., max_times: N` | `[Boolean, Integer]` |
-| `flag_option ..., negatable: true` | registers two entries; document **two** `@option` tags: positive key `[Boolean]` (`true` → `--flag`; default `(false)` → nothing), negative key `[Boolean]` (`true` → `--no-flag`; default `(false)` → nothing) |
-| `flag_or_value_option` | `[Boolean, String]` (or the specific value type) |
-| `flag_or_value_option ..., negatable: true` | registers two entries; document **two** `@option` tags: positive key `[Boolean, String]` (`true` → `--flag`; string → `--flag=value` with `inline: true`, or `--flag <value>` without; default `(false)` → nothing), negative key `[Boolean]` (`true` → `--no-flag`; default `(false)` → nothing) |
+| `flag_option` | `[Boolean, nil]` — default `(nil)` (flag not emitted by default; both `false` and `nil` suppress the flag) |
+| `flag_option ..., max_times: N` | `[Boolean, Integer, nil]` |
+| `flag_option ..., negatable: true` | registers two entries; document **two** `@option` tags: positive key `[Boolean, nil]` (`true` → `--flag`; default `(nil)` → nothing), negative key `[Boolean, nil]` (`true` → `--no-flag`; default `(nil)` → nothing) |
+| `flag_or_value_option` | `[Boolean, String, nil]` (or the specific value type with `nil` appended) |
+| `flag_or_value_option ..., negatable: true` | registers two entries; document **two** `@option` tags: positive key `[Boolean, String, nil]` (`true` → `--flag`; string → `--flag=value` with `inline: true`, or `--flag <value>` without; default `(nil)` → nothing), negative key `[Boolean, nil]` (`true` → `--no-flag`; default `(nil)` → nothing) |
 | `value_option` | `[String]` — `value_option` does not enforce types; it accepts any non-nil value and converts it to a string. Use `[String]` unless callers are expected to pass a narrower type, in which case widen the annotation to reflect reality (e.g. `[Integer, String]` for options documented as taking `<n>` lines/bytes). Never use a bare numeric type such as `[Integer]` alone — that misrepresents what the implementation accepts. |
 | `operand` (repeatable) | `[Array<String>]` |
 | `operand` (single) | `[String]` |
@@ -177,22 +177,6 @@ conflicting documentation for the method.
 - Missing `# @!method call(*, **)` directive when there is no `def call` override
   (loses child-specific docs in generated YARD)
 - `@option` docs out of sync with `arguments do`
-- **`(nil)` default for `flag_option` entries** — the DSL-to-YARD type mapping
-  requires `(false)` for plain `flag_option` entries (the flag is not emitted by
-  default). Using `(nil)` implies the caller explicitly passes `nil` to opt out,
-  which is not the intended semantics.
-
-  ```ruby
-  # ❌ Wrong — (nil) implies explicit nil opt-out
-  # @option options [Boolean] :tags (nil) limit output to refs/tags/
-
-  # ✅ Correct — (false) means the flag is not emitted when the caller omits the option
-  # @option options [Boolean] :tags (false) limit output to refs/tags/
-  ```
-
-  This applies to negatable flags as well — both the positive key and the negative
-  `no_` companion key use `(false)`. There is no three-state exception: `false` and
-  `nil` both mean omit for every key.
 - **Missing `@raise [ArgumentError]` when `**options` is in the overload signature** —
   every `@overload` that includes `**options` requires
   `@raise [ArgumentError] if unsupported options are provided`. The base `ArgsBuilder`
@@ -223,12 +207,12 @@ conflicting documentation for the method.
 
   ```ruby
   # ❌ Missing negative companion tag
-  # @option options [Boolean] :create_reflog (false) create the branch's reflog
+  # @option options [Boolean, nil] :create_reflog (nil) create the branch's reflog
 
   # ✅ Both forms documented with separate tags
-  # @option options [Boolean] :create_reflog (false) create the branch's reflog
+  # @option options [Boolean, nil] :create_reflog (nil) create the branch's reflog
   #
-  # @option options [Boolean] :no_create_reflog (false) suppress branch reflog
+  # @option options [Boolean, nil] :no_create_reflog (nil) suppress branch reflog
   #   creation (`--no-create-reflog`)
   ```
 - Missing/incorrect `@raise` guidance for `allow_exit_status`
@@ -259,11 +243,11 @@ conflicting documentation for the method.
 
   ```ruby
   # ❌ Wrong — describes -v as if it is emitted
-  # @option options [Boolean, Integer] :verbose (false) ...
+  # @option options [Boolean, Integer, nil] :verbose (nil) ...
   #   Pass `true` for `-v`; pass `2` for `-v -v`.
 
   # ✅ Correct — describes the actually emitted flag
-  # @option options [Boolean, Integer] :verbose (false) ...
+  # @option options [Boolean, Integer, nil] :verbose (nil) ...
   #   Pass `true` for `--verbose`; pass `2` for `--verbose --verbose`.
   ```
 
@@ -278,10 +262,10 @@ conflicting documentation for the method.
 
   ```ruby
   # ❌ Copied verbatim from the git man page
-  # @option options [Boolean] :force (false) Allow renaming even if target already exists.
+  # @option options [Boolean, nil] :force (nil) Allow renaming even if target already exists.
 
   # ✅ Correct — lowercase start, no trailing period
-  # @option options [Boolean] :force (false) allow renaming even if target already exists
+  # @option options [Boolean, nil] :force (nil) allow renaming even if target already exists
   ```
 - **Raw blank line inside a doc comment block** — a raw blank line (an empty line
   with no leading `#`) silently terminates the YARD block. Any comment lines after
@@ -290,7 +274,7 @@ conflicting documentation for the method.
   continuation paragraphs and alias notes. Correct form:
 
   ```ruby
-  # @option options [Boolean] :ipv4 (false) use IPv4 addresses only
+  # @option options [Boolean, nil] :ipv4 (nil) use IPv4 addresses only
   #
   #   Alias: :"4"
   ```
@@ -302,7 +286,7 @@ conflicting documentation for the method.
   short-description rule. Correct form:
 
   ```ruby
-  # @option options [Boolean] :update_head_ok (false) allow updating HEAD ref
+  # @option options [Boolean, nil] :update_head_ok (nil) allow updating HEAD ref
   #
   #   When true, passes --update-head-ok. By default git fetch refuses to update HEAD.
   ```
@@ -335,12 +319,10 @@ For each command file, run through these checks in order:
 - [ ] `@option` types match the DSL method (see
       [DSL-to-YARD type mapping](#dsl-to-yard-type-mapping))
 - [ ] `@option` defaults match the DSL method — `flag_option` (plain or negatable)
-      always uses `(false)` for both the positive and negative `no_` companion tag;
-      `value_option` uses `(nil)`. Using `(nil)` on any `flag_option` entry is a bug:
-      it implies the caller can pass explicit `nil` to opt out, which is not the
-      intended semantics. Check every `@option` default tag against the DSL entry.
+      always uses `(nil)` for both the positive and negative `no_` companion tag;
+      `value_option` uses `(nil)`. Check every `@option` default tag against the DSL entry.
       For `negatable:` options, verify that **two** `@option` tags are present (one
-      for the positive key, one for the `no_` companion key) and that both use `(false)`.
+      for the positive key, one for the `no_` companion key) and that both use `(nil)`.
 - [ ] option defaults/types are consistent with DSL definitions
 - [ ] `@option` descriptions for options that have an `allowed_values` declaration
       enumerate the accepted values in the description text, e.g.: `@option options

--- a/.github/skills/facade-yard-documentation/SKILL.md
+++ b/.github/skills/facade-yard-documentation/SKILL.md
@@ -137,10 +137,10 @@ to:
 #
 #   @param options [Hash] options for the add command
 #
-#   @option options [Boolean] :all (false) add, modify, and remove index
+#   @option options [Boolean, nil] :all (nil) add, modify, and remove index
 #     entries to match the worktree
 #
-#   @option options [Boolean] :force (false) allow adding otherwise ignored
+#   @option options [Boolean, nil] :force (nil) allow adding otherwise ignored
 #     files
 #
 #   @return [String] git's stdout from the add
@@ -178,7 +178,7 @@ the `def` has a named parameter for every documented argument, `@param` and
 #
 # @param opts [Hash] commit options
 #
-# @option opts [Boolean] :amend (false) amend the previous commit
+# @option opts [Boolean, nil] :amend (nil) amend the previous commit
 #
 # @return [String] git's stdout from the commit
 #

--- a/.github/skills/review-arguments-dsl/CHECKLIST.md
+++ b/.github/skills/review-arguments-dsl/CHECKLIST.md
@@ -631,17 +631,17 @@ documentation.
 two separate `@option` entries are required: one for the positive key (`:foo`) and
 one for the negative companion key (`:no_foo`). Both follow standard boolean
 semantics (`true` emits the flag, `false`/`nil`/omitted emits nothing); both use
-`(false)` as the default value. A single merged tag or "Pass `false` for `--no-foo`" prose
+`(nil)` as the default value. A single merged tag or "Pass `false` for `--no-foo`" prose
 does not satisfy this requirement.
 
 ```ruby
 # ❌ Missing negative companion tag
-# @option options [Boolean] :create_reflog (false) create the branch's reflog
+# @option options [Boolean, nil] :create_reflog (nil) create the branch's reflog
 
 # ✅ Both forms documented with separate tags
-# @option options [Boolean] :create_reflog (false) create the branch's reflog
+# @option options [Boolean, nil] :create_reflog (nil) create the branch's reflog
 #
-# @option options [Boolean] :no_create_reflog (false) suppress branch reflog
+# @option options [Boolean, nil] :no_create_reflog (nil) suppress branch reflog
 #   creation (`--no-create-reflog`)
 ```
 
@@ -652,11 +652,11 @@ is misleading and must be corrected to the long form:
 
 ```ruby
 # ❌ Misleading — describes -v as emitted
-# @option options [Boolean, Integer] :verbose (false) ...
+# @option options [Boolean, Integer, nil] :verbose (nil) ...
 #   Pass `true` for `-v`; pass `2` for `-v -v`.
 
 # ✅ Correct — describes the emitted flag
-# @option options [Boolean, Integer] :verbose (false) ...
+# @option options [Boolean, Integer, nil] :verbose (nil) ...
 #   Pass `true` for `--verbose`; pass `2` for `--verbose --verbose`.
 ```
 

--- a/.github/skills/yard-documentation/SKILL.md
+++ b/.github/skills/yard-documentation/SKILL.md
@@ -78,7 +78,7 @@ continuation text within a YARD block:
 Correct — blank comment line keeps the block intact:
 
 ```ruby
-# @option options [Boolean] :ipv4 (nil) use IPv4 addresses only
+# @option options [Boolean, nil] :ipv4 (nil) use IPv4 addresses only
 #
 #   Alias: :"4"
 ```
@@ -86,7 +86,7 @@ Correct — blank comment line keeps the block intact:
 Incorrect — raw blank line silently drops the alias note:
 
 ```ruby
-# @option options [Boolean] :ipv4 (nil) use IPv4 addresses only
+# @option options [Boolean, nil] :ipv4 (nil) use IPv4 addresses only
 
 #   Alias: :"4"
 ```
@@ -106,14 +106,14 @@ a `@param`, `@return`, `@raise`, etc. tag) must:
   `Represents a Git branch`)
 - **Tag short descriptions** (`@option`, `@param`, `@return`, `@raise`, `@yield`,
   `@yieldparam`, etc.) **all start with a lowercase letter** (e.g. `@option options
-  [Boolean] :force (nil) overwrite existing files`, `@param name [String] the branch
+  [Boolean, nil] :force (nil) overwrite existing files`, `@param name [String] the branch
   name`, `@return [String] the result`, `@raise [ArgumentError] when no name is provided`)
 
 For tags, the **summary text** is the description that follows the tag
 metadata (tag name, `[Type]`, option key, and `(default)`). For example, in:
 
 ```
-@option options [Boolean] :ignore_case (nil) ignore case distinctions
+@option options [Boolean, nil] :ignore_case (nil) ignore case distinctions
 ```
 
 the summary text is `ignore case distinctions`. The entire physical line —
@@ -134,7 +134,7 @@ Separate continuation paragraphs with a blank comment line.
 Correct — tag title without punctuation, blank line before continuation:
 
 ```ruby
-# @option options [Boolean] :ignore_case (nil) ignore case
+# @option options [Boolean, nil] :ignore_case (nil) ignore case
 #   distinctions in both the pattern and the file contents
 #
 #   Alias: :i
@@ -155,7 +155,7 @@ Correct — tag title without punctuation, blank line before continuation:
 Incorrect — trailing period on title, missing blank line before continuation:
 
 ```ruby
-# @option options [Boolean] :ignore_case (nil) ignore case
+# @option options [Boolean, nil] :ignore_case (nil) ignore case
 #   distinctions in both the pattern and the file contents.
 #   Alias: :i
 #
@@ -600,10 +600,10 @@ only:
 #
 #   @param options [Hash] command options
 #
-#   @option options [Boolean] :all add, modify, and remove index entries to
+#   @option options [Boolean, nil] :all (nil) add, modify, and remove index entries to
 #     match the worktree
 #
-#   @option options [Boolean] :force allow adding otherwise ignored files
+#   @option options [Boolean, nil] :force (nil) allow adding otherwise ignored files
 #
 #   @return [String] the command output
 #

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -177,10 +177,10 @@ module Git
     #
     #   @param options [Hash] options for the add command
     #
-    #   @option options [Boolean] :all (false) add, modify, and remove index
+    #   @option options [Boolean, nil] :all (nil) add, modify, and remove index
     #     entries to match the worktree
     #
-    #   @option options [Boolean] :force (false) allow adding otherwise ignored
+    #   @option options [Boolean, nil] :force (nil) allow adding otherwise ignored
     #     files
     #
     #   @return [String] git's stdout from the add
@@ -411,9 +411,9 @@ module Git
     #   of paths to limit the search to or nil for no limit
     # @param opts [Hash] options to pass to the underlying `git grep` command
     #
-    # @option opts [Boolean] :ignore_case (false) ignore case when matching
-    # @option opts [Boolean] :invert_match (false) select non-matching lines
-    # @option opts [Boolean] :extended_regexp (false) use extended regular expressions
+    # @option opts [Boolean, nil] :ignore_case (nil) ignore case when matching
+    # @option opts [Boolean, nil] :invert_match (nil) select non-matching lines
+    # @option opts [Boolean, nil] :extended_regexp (nil) use extended regular expressions
     # @option opts [String] :object (HEAD) the object to search from
     #
     # @return [Hash<String, Array>] a hash of arrays
@@ -543,15 +543,22 @@ module Git
     # Push changes to a remote repository
     #
     # @overload push(remote = nil, branch = nil, options = {})
+    #
     #   @param remote [String] the remote repository to push to
+    #
     #   @param branch [String] the branch to push
+    #
     #   @param options [Hash] options to pass to the push command
     #
-    #   @option opts [Boolean] :mirror (false) Push all refs under refs/heads/, refs/tags/ and refs/remotes/
-    #   @option opts [Boolean] :delete (false) Delete refs that don't exist on the remote
-    #   @option opts [Boolean] :force (false) Force updates
-    #   @option opts [Boolean] :tags (false) Push all refs under refs/tags/
-    #   @option opts [Array, String] :push_options (nil) Push options to transmit
+    #   @option options [Boolean, nil] :mirror (nil) push all refs under refs/heads/, refs/tags/ and refs/remotes/
+    #
+    #   @option options [Boolean, nil] :delete (nil) delete refs that don't exist on the remote
+    #
+    #   @option options [Boolean, nil] :force (nil) force updates
+    #
+    #   @option options [Boolean, nil] :tags (nil) push all refs under refs/tags/
+    #
+    #   @option options [String, Array<String>] :push_option (nil) push options to transmit
     #
     #   @return [Void]
     #
@@ -580,7 +587,7 @@ module Git
     # @param branch [String] the branch to pull from
     # @param opts [Hash] options to pass to the pull command
     #
-    # @option opts [Boolean] :allow_unrelated_histories (false) Merges histories of
+    # @option opts [Boolean, nil] :allow_unrelated_histories (nil) merges histories of
     #   two projects that started their lives independently
     # @example pulls from origin/master
     #   @git.pull
@@ -670,15 +677,15 @@ module Git
     #   repo.add_tag('tag_name', {:options => 'here'})
     #
     # @param [String] name The name of the tag to add
-    # @param [Hash] options Opstions to pass to `git tag`.
+    # @param [Hash] options Options to pass to `git tag`.
     #   See [git-tag](https://git-scm.com/docs/git-tag) for more details.
-    # @option options [boolean] :annotate Make an unsigned, annotated tag object
-    # @option options [boolean] :a An alias for the `:annotate` option
-    # @option options [boolean] :d Delete existing tag with the given names.
-    # @option options [boolean] :f Replace an existing tag with the given name (instead of failing)
+    # @option options [Boolean, nil] :annotate (nil) make an unsigned, annotated tag object
+    # @option options [Boolean, nil] :a (nil) an alias for the `:annotate` option
+    # @option options [Boolean, nil] :d (nil) delete existing tag with the given names
+    # @option options [Boolean, nil] :f (nil) replace an existing tag with the given name (instead of failing)
     # @option options [String] :message Use the given tag message
     # @option options [String] :m An alias for the `:message` option
-    # @option options [boolean] :s Make a GPG-signed tag.
+    # @option options [Boolean, nil] :s (nil) make a GPG-signed tag
     #
     def add_tag(name, *options)
       lib.tag(name, *options)
@@ -731,14 +738,14 @@ module Git
     #     references in the refs namespace, and all reflogs.
     #   @param [Hash] options options to pass to the underlying `git fsck` command
     #
-    #   @option options [Boolean] :unreachable print unreachable objects
-    #   @option options [Boolean] :strict enable strict checking
-    #   @option options [Boolean] :connectivity_only check only connectivity (faster)
-    #   @option options [Boolean] :root report root nodes
-    #   @option options [Boolean] :tags report tags
-    #   @option options [Boolean] :cache consider objects in the index
-    #   @option options [Boolean] :no_reflogs do not consider reflogs
-    #   @option options [Boolean] :lost_found write dangling objects to .git/lost-found
+    #   @option options [Boolean, nil] :unreachable (nil) print unreachable objects
+    #   @option options [Boolean, nil] :strict (nil) enable strict checking
+    #   @option options [Boolean, nil] :connectivity_only (nil) check only connectivity (faster)
+    #   @option options [Boolean, nil] :root (nil) report root nodes
+    #   @option options [Boolean, nil] :tags (nil) report tags
+    #   @option options [Boolean, nil] :cache (nil) consider objects in the index
+    #   @option options [Boolean, nil] :no_reflogs (nil) do not consider reflogs
+    #   @option options [Boolean, nil] :lost_found (nil) write dangling objects to .git/lost-found
     #     (note: this modifies the repository by creating files)
     #   @option options [Boolean, nil] :dangling print dangling objects (true/false/nil for default)
     #   @option options [Boolean, nil] :full check objects in alternate pools (true/false/nil for default)

--- a/lib/git/commands/add.rb
+++ b/lib/git/commands/add.rb
@@ -57,53 +57,56 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :verbose (false) be verbose
+      #     @option options [Boolean, nil] :verbose (nil) be verbose
       #
       #       Alias: :v
       #
-      #     @option options [Boolean] :dry_run (false) don't actually add files; show what would be added
+      #     @option options [Boolean, nil] :dry_run (nil) don't actually add files; show what would be added
       #
       #       Alias: :n
       #
-      #     @option options [Boolean] :force (false) allow adding otherwise ignored files
+      #     @option options [Boolean, nil] :force (nil) allow adding otherwise ignored files
       #
       #       Alias: :f
       #
-      #     @option options [Boolean] :all (false) add, modify, and remove index entries to match the worktree (--all)
+      #     @option options [Boolean, nil] :all (nil) add, modify, and remove index entries to
+      #       match the worktree (--all)
       #
       #       Alias: :A
       #
-      #     @option options [Boolean] :no_all (false) add and modify index entries without staging removals (--no-all)
+      #     @option options [Boolean, nil] :no_all (nil) add and modify index entries without staging
+      #       removals (--no-all)
       #
-      #     @option options [Boolean] :ignore_removal (false) add and modify files; ignore removals (--ignore-removal)
+      #     @option options [Boolean, nil] :ignore_removal (nil) add and modify files; ignore removals
+      #       (--ignore-removal)
       #
-      #     @option options [Boolean] :no_ignore_removal (false) include file removals (--no-ignore-removal)
+      #     @option options [Boolean, nil] :no_ignore_removal (nil) include file removals (--no-ignore-removal)
       #
-      #     @option options [Boolean] :update (false) update tracked files only; does not add new files
+      #     @option options [Boolean, nil] :update (nil) update tracked files only; does not add new files
       #
       #       Alias: :u
       #
-      #     @option options [Boolean] :sparse (false) allow updating index entries outside the
+      #     @option options [Boolean, nil] :sparse (nil) allow updating index entries outside the
       #       sparse-checkout cone
       #
-      #     @option options [Boolean] :intent_to_add (false) record that the path will be added later,
+      #     @option options [Boolean, nil] :intent_to_add (nil) record that the path will be added later,
       #       placing an empty entry in the index
       #
       #       Alias: :N
       #
-      #     @option options [Boolean] :refresh (false) refresh stat() information in the index without
+      #     @option options [Boolean, nil] :refresh (nil) refresh stat() information in the index without
       #       adding files
       #
-      #     @option options [Boolean] :ignore_errors (false) continue adding other files if some files
+      #     @option options [Boolean, nil] :ignore_errors (nil) continue adding other files if some files
       #       cannot be added due to indexing errors
       #
-      #     @option options [Boolean] :ignore_missing (false) check whether any given files would be
+      #     @option options [Boolean, nil] :ignore_missing (nil) check whether any given files would be
       #       ignored
       #
-      #     @option options [Boolean] :renormalize (false) apply the "clean" process freshly to all tracked
+      #     @option options [Boolean, nil] :renormalize (nil) apply the "clean" process freshly to all tracked
       #       files to forcibly re-add them with correct line endings
       #
-      #     @option options [Boolean] :no_warn_embedded_repo (false) suppress warning when adding an
+      #     @option options [Boolean, nil] :no_warn_embedded_repo (nil) suppress warning when adding an
       #       embedded repository without using `git submodule add`
       #
       #     @option options [String] :chmod (nil) override the executable bit of added files in the index
@@ -113,7 +116,7 @@ module Git
       #     @option options [String] :pathspec_from_file (nil) read pathspec from the given file
       #       (use `'-'` for stdin)
       #
-      #     @option options [Boolean] :pathspec_file_nul (false) separate pathspec elements with NUL
+      #     @option options [Boolean, nil] :pathspec_file_nul (nil) separate pathspec elements with NUL
       #       when reading from a file
       #
       #     @return [Git::CommandLineResult] the result of calling `git add`

--- a/lib/git/commands/am/apply.rb
+++ b/lib/git/commands/am/apply.rb
@@ -97,28 +97,28 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :signoff (nil) add Signed-off-by trailer
+        #     @option options [Boolean, nil] :signoff (nil) add Signed-off-by trailer
         #
         #       Alias: `:s`
         #
-        #     @option options [Boolean] :keep (nil) pass -k flag to git-mailinfo,
+        #     @option options [Boolean, nil] :keep (nil) pass -k flag to git-mailinfo,
         #       preserving the Subject line intact
         #
         #       Alias: `:k`
         #
-        #     @option options [Boolean] :keep_non_patch (nil) pass -b flag to
+        #     @option options [Boolean, nil] :keep_non_patch (nil) pass -b flag to
         #       git-mailinfo
         #
-        #     @option options [Boolean] :keep_cr (false) retain CR at end of lines (`--keep-cr`)
+        #     @option options [Boolean, nil] :keep_cr (nil) retain CR at end of lines (`--keep-cr`)
         #
-        #     @option options [Boolean] :no_keep_cr (false) strip CR at end of lines (`--no-keep-cr`)
+        #     @option options [Boolean, nil] :no_keep_cr (nil) strip CR at end of lines (`--no-keep-cr`)
         #
-        #     @option options [Boolean] :scissors (false) remove everything in the
+        #     @option options [Boolean, nil] :scissors (nil) remove everything in the
         #       body before a scissors line (`--scissors`)
         #
         #       Alias: `:c`
         #
-        #     @option options [Boolean] :no_scissors (false) disable scissors mode (`--no-scissors`)
+        #     @option options [Boolean, nil] :no_scissors (nil) disable scissors mode (`--no-scissors`)
         #
         #     @option options [String] :quoted_cr (nil) how to handle CR in quoted
         #       text passed to git-mailinfo
@@ -131,40 +131,40 @@ module Git
         #       Valid values: `'stop'` (fail, default), `'drop'` (skip the message),
         #       `'keep'` (create an empty commit).
         #
-        #     @option options [Boolean] :message_id (false) pass -m flag to
+        #     @option options [Boolean, nil] :message_id (nil) pass -m flag to
         #       git-mailinfo, adding the Message-ID header to the commit message (`--message-id`)
         #
         #       Alias: `:m`
         #
-        #     @option options [Boolean] :no_message_id (false) do not add the Message-ID header (`--no-message-id`)
+        #     @option options [Boolean, nil] :no_message_id (nil) do not add the Message-ID header (`--no-message-id`)
         #
-        #     @option options [Boolean] :quiet (nil) be quiet; only print error
+        #     @option options [Boolean, nil] :quiet (nil) be quiet; only print error
         #       messages
         #
         #       Alias: `:q`
         #
-        #     @option options [Boolean] :utf8 (false) re-code the commit log message
+        #     @option options [Boolean, nil] :utf8 (nil) re-code the commit log message
         #       in UTF-8 (`--utf8`)
         #
         #       Alias: `:u`
         #
-        #     @option options [Boolean] :no_utf8 (false) do not re-code the commit log message (`--no-utf8`)
+        #     @option options [Boolean, nil] :no_utf8 (nil) do not re-code the commit log message (`--no-utf8`)
         #
-        #     @option options [Boolean] :three_way (false) attempt 3-way merge when
+        #     @option options [Boolean, nil] :three_way (nil) attempt 3-way merge when
         #       context does not match (`--3way`)
         #
-        #     @option options [Boolean] :no_three_way (false) disable 3-way merge fallback (`--no-3way`)
+        #     @option options [Boolean, nil] :no_three_way (nil) disable 3-way merge fallback (`--no-3way`)
         #
-        #     @option options [Boolean] :rerere_autoupdate (false) allow rerere to
+        #     @option options [Boolean, nil] :rerere_autoupdate (nil) allow rerere to
         #       update the index with auto-resolved conflicts (`--rerere-autoupdate`)
         #
-        #     @option options [Boolean] :no_rerere_autoupdate (false) prevent rerere from
+        #     @option options [Boolean, nil] :no_rerere_autoupdate (nil) prevent rerere from
         #       auto-updating the index (`--no-rerere-autoupdate`)
         #
-        #     @option options [Boolean] :ignore_space_change (nil) ignore whitespace
+        #     @option options [Boolean, nil] :ignore_space_change (nil) ignore whitespace
         #       changes when applying (passed to git-apply)
         #
-        #     @option options [Boolean] :ignore_whitespace (nil) ignore whitespace
+        #     @option options [Boolean, nil] :ignore_whitespace (nil) ignore whitespace
         #       when applying (passed to git-apply)
         #
         #     @option options [String] :whitespace (nil) whitespace error handling
@@ -197,7 +197,7 @@ module Git
         #
         #       May be repeated. Passed to git-apply.
         #
-        #     @option options [Boolean] :reject (nil) leave rejected hunks in
+        #     @option options [Boolean, nil] :reject (nil) leave rejected hunks in
         #       `*.rej` files instead of aborting
         #
         #       Passed to git-apply.
@@ -208,32 +208,32 @@ module Git
         #       Valid formats: `'mbox'`, `'mboxrd'`, `'stgit'`, `'stgit-series'`,
         #       `'hg'`.
         #
-        #     @option options [Boolean] :interactive (false) run interactively,
+        #     @option options [Boolean, nil] :interactive (nil) run interactively,
         #       prompting before each patch is applied
         #
         #       Alias: `:i`
         #
-        #     @option options [Boolean] :verify (false) run pre-applypatch and
+        #     @option options [Boolean, nil] :verify (nil) run pre-applypatch and
         #       applypatch-msg hooks (`--verify`)
         #
         #       Hooks are run by default when this option is omitted.
         #
-        #     @option options [Boolean] :no_verify (false) bypass pre-applypatch and
+        #     @option options [Boolean, nil] :no_verify (nil) bypass pre-applypatch and
         #       applypatch-msg hooks (`--no-verify`)
         #
-        #     @option options [Boolean] :committer_date_is_author_date (nil) use the
+        #     @option options [Boolean, nil] :committer_date_is_author_date (nil) use the
         #       author date as the committer date
         #
-        #     @option options [Boolean] :ignore_date (nil) use the committer date as
+        #     @option options [Boolean, nil] :ignore_date (nil) use the committer date as
         #       the author date
         #
-        #     @option options [Boolean, String] :gpg_sign (false) sign commits using
+        #     @option options [Boolean, String, nil] :gpg_sign (nil) sign commits using
         #       GPG (`--gpg-sign`)
         #
         #       Pass a key-ID string to select the signing key; pass `true` to use
         #       the committer identity. Alias: `:S`
         #
-        #     @option options [Boolean] :no_gpg_sign (false) countermand commit.gpgSign
+        #     @option options [Boolean, nil] :no_gpg_sign (nil) countermand commit.gpgSign
         #       configuration (`--no-gpg-sign`)
         #
         #     @option options [String] :chdir (nil) change to this directory before

--- a/lib/git/commands/apply.rb
+++ b/lib/git/commands/apply.rb
@@ -101,75 +101,75 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :stat (nil) show diffstat for the input
+      #     @option options [Boolean, nil] :stat (nil) show diffstat for the input
       #       instead of applying
       #
       #       Turns off apply mode.
       #
-      #     @option options [Boolean] :numstat (nil) show numeric diffstat for
+      #     @option options [Boolean, nil] :numstat (nil) show numeric diffstat for
       #       the input instead of applying
       #
       #       Turns off apply mode. Output is in machine-friendly decimal format.
       #
-      #     @option options [Boolean] :summary (nil) show a condensed summary of
+      #     @option options [Boolean, nil] :summary (nil) show a condensed summary of
       #       extended header information instead of applying
       #
       #       Turns off apply mode.
       #
-      #     @option options [Boolean] :check (nil) check whether the patch applies
+      #     @option options [Boolean, nil] :check (nil) check whether the patch applies
       #       cleanly without modifying any files
       #
       #       Turns off apply mode.
       #
-      #     @option options [Boolean] :index (nil) apply the patch to both the
+      #     @option options [Boolean, nil] :index (nil) apply the patch to both the
       #       index and the working tree
       #
-      #     @option options [Boolean] :intent_to_add (nil) mark new files added by
+      #     @option options [Boolean, nil] :intent_to_add (nil) mark new files added by
       #       the patch for later addition to the index
       #
       #       Alias: `:N`
       #
-      #     @option options [Boolean] :three_way (nil) attempt a 3-way merge if
+      #     @option options [Boolean, nil] :three_way (nil) attempt a 3-way merge if
       #       the patch does not apply cleanly (`--3way`)
       #
-      #     @option options [Boolean] :ours (nil) resolve 3-way conflicts by
+      #     @option options [Boolean, nil] :ours (nil) resolve 3-way conflicts by
       #       favouring our side of the conflict
       #
       #       Requires `:three_way`.
       #
-      #     @option options [Boolean] :theirs (nil) resolve 3-way conflicts by
+      #     @option options [Boolean, nil] :theirs (nil) resolve 3-way conflicts by
       #       favouring their side of the conflict
       #
       #       Requires `:three_way`.
       #
-      #     @option options [Boolean] :union (nil) resolve 3-way conflicts by
+      #     @option options [Boolean, nil] :union (nil) resolve 3-way conflicts by
       #       including both sides of the conflict
       #
       #       Requires `:three_way`.
       #
-      #     @option options [Boolean] :apply (nil) re-enable the apply step even
+      #     @option options [Boolean, nil] :apply (nil) re-enable the apply step even
       #       when a "turns off apply" flag such as `:stat` is also given
       #
-      #     @option options [Boolean] :no_add (nil) ignore additions made by the
+      #     @option options [Boolean, nil] :no_add (nil) ignore additions made by the
       #       patch; apply only the deletions
       #
       #     @option options [String] :build_fake_ancestor (nil) path to a
       #       temporary index file for building a fake ancestor from the embedded
       #       blob identities in the patch
       #
-      #     @option options [Boolean] :reverse (nil) apply the patch in reverse
+      #     @option options [Boolean, nil] :reverse (nil) apply the patch in reverse
       #
       #       Alias: `:R`
       #
-      #     @option options [Boolean] :allow_binary_replacement (nil) allow
+      #     @option options [Boolean, nil] :allow_binary_replacement (nil) allow
       #       binary patch application (no-op in Git 2.28+)
       #
       #       Alias: `:binary`
       #
-      #     @option options [Boolean] :reject (nil) leave rejected hunks in
+      #     @option options [Boolean, nil] :reject (nil) leave rejected hunks in
       #       `.rej` files instead of aborting
       #
-      #     @option options [Boolean] :z (nil) use NUL-terminated output for
+      #     @option options [Boolean, nil] :z (nil) use NUL-terminated output for
       #       `--numstat` pathnames (`-z`)
       #
       #     @option options [Integer] :p (nil) strip this many leading path
@@ -178,22 +178,22 @@ module Git
       #     @option options [Integer] :C (nil) require at least this many lines
       #       of surrounding context before and after each change (`-C<n>`)
       #
-      #     @option options [Boolean] :unidiff_zero (nil) bypass context-line
+      #     @option options [Boolean, nil] :unidiff_zero (nil) bypass context-line
       #       safety checks for diffs generated with `--unified=0`
       #
-      #     @option options [Boolean] :inaccurate_eof (nil) work around diffs
+      #     @option options [Boolean, nil] :inaccurate_eof (nil) work around diffs
       #       that do not correctly detect a missing newline at end of file
       #
-      #     @option options [Boolean] :recount (nil) infer hunk sizes from the
+      #     @option options [Boolean, nil] :recount (nil) infer hunk sizes from the
       #       patch content rather than trusting the hunk header counts
       #
-      #     @option options [Boolean] :cached (nil) apply the patch only to the
+      #     @option options [Boolean, nil] :cached (nil) apply the patch only to the
       #       index without touching the working tree
       #
-      #     @option options [Boolean] :ignore_space_change (nil) ignore changes
+      #     @option options [Boolean, nil] :ignore_space_change (nil) ignore changes
       #       in the amount of whitespace in context lines
       #
-      #     @option options [Boolean] :ignore_whitespace (nil) ignore all
+      #     @option options [Boolean, nil] :ignore_whitespace (nil) ignore all
       #       whitespace differences in context lines
       #
       #     @option options [String] :whitespace (nil) whitespace error handling
@@ -208,18 +208,18 @@ module Git
       #     @option options [String] :directory (nil) prepend this root to all
       #       filenames in the patch
       #
-      #     @option options [Boolean] :verbose (nil) report progress to stderr
+      #     @option options [Boolean, nil] :verbose (nil) report progress to stderr
       #
       #       Alias: `:v`
       #
-      #     @option options [Boolean] :quiet (nil) suppress stderr output
+      #     @option options [Boolean, nil] :quiet (nil) suppress stderr output
       #
       #       Alias: `:q`
       #
-      #     @option options [Boolean] :unsafe_paths (nil) override the safety
+      #     @option options [Boolean, nil] :unsafe_paths (nil) override the safety
       #       check that rejects patches affecting paths outside the working area
       #
-      #     @option options [Boolean] :allow_empty (nil) do not return an error
+      #     @option options [Boolean, nil] :allow_empty (nil) do not return an error
       #       for patches containing no diff
       #
       #     @option options [String] :chdir (nil) change to this directory before

--- a/lib/git/commands/archive.rb
+++ b/lib/git/commands/archive.rb
@@ -75,11 +75,11 @@ module Git
       #     @option options [String] :format (nil) archive format — `tar`, `zip`, `tar.gz`,
       #       `tgz`, or any format defined via `tar.<format>.command`
       #
-      #     @option options [Boolean] :list (false) show all available archive formats
+      #     @option options [Boolean, nil] :list (nil) show all available archive formats
       #
       #       Alias: :l
       #
-      #     @option options [Boolean] :verbose (false) report progress to stderr
+      #     @option options [Boolean, nil] :verbose (nil) report progress to stderr
       #
       #       Alias: :v
       #
@@ -97,7 +97,7 @@ module Git
       #     @option options [String, Array<String>] :add_virtual_file (nil) add one or
       #       more virtual files by `<path>:<content>`; may be passed multiple times
       #
-      #     @option options [Boolean] :worktree_attributes (false) look for attributes in
+      #     @option options [Boolean, nil] :worktree_attributes (nil) look for attributes in
       #       `.gitattributes` files in the working tree as well
       #
       #     @option options [String] :mtime (nil) set modification time of archive entries

--- a/lib/git/commands/branch/copy.rb
+++ b/lib/git/commands/branch/copy.rb
@@ -59,7 +59,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :force (nil) Allow copying even if new_branch already exists.
+        #     @option options [Boolean, nil] :force (nil) allow copying even if new_branch already exists
         #
         #       Alias: :f
         #
@@ -79,7 +79,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :force (nil) Allow copying even if new_branch already exists.
+        #     @option options [Boolean, nil] :force (nil) allow copying even if new_branch already exists
         #
         #       Alias: :f
         #

--- a/lib/git/commands/branch/create.rb
+++ b/lib/git/commands/branch/create.rb
@@ -65,7 +65,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, String] :track (false)
+        #     @option options [Boolean, String, nil] :track (nil)
         #       configure upstream tracking for the new branch
         #
         #       - `true`: Set up tracking using the start-point branch itself (`--track`)
@@ -74,34 +74,34 @@ module Git
         #
         #       Alias: :t
         #
-        #     @option options [Boolean] :no_track (false)
+        #     @option options [Boolean, nil] :no_track (nil)
         #       do not set up tracking even if `branch.autoSetupMerge` is set (`--no-track`)
         #
-        #     @option options [Boolean] :force (false)
+        #     @option options [Boolean, nil] :force (nil)
         #       reset the branch to start point even if it already exists
         #
         #       Without this, git branch refuses to change an existing branch.
         #
         #       Alias: :f
         #
-        #     @option options [Boolean] :recurse_submodules (false)
+        #     @option options [Boolean, nil] :recurse_submodules (nil)
         #       create the branch in the superproject and all submodules
         #
         #       This is an experimental feature.
         #
-        #     @option options [Boolean] :quiet (false)
+        #     @option options [Boolean, nil] :quiet (nil)
         #       suppress informational messages
         #
         #       Alias: :q
         #
-        #     @option options [Boolean] :create_reflog (false)
+        #     @option options [Boolean, nil] :create_reflog (nil)
         #       create the branch's reflog (`--create-reflog`)
         #
         #       Enables date-based sha1 expressions such as `branch@{yesterday}`.
         #       In non-bare repositories, reflogs are usually enabled by default
         #       via `core.logAllRefUpdates`.
         #
-        #     @option options [Boolean] :no_create_reflog (false)
+        #     @option options [Boolean, nil] :no_create_reflog (nil)
         #       forcibly disable the branch's reflog (`--no-create-reflog`)
         #
         #     @return [Git::CommandLineResult] the result of calling `git branch`
@@ -123,7 +123,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, String] :track (false)
+        #     @option options [Boolean, String, nil] :track (nil)
         #       configure upstream tracking for the new branch
         #
         #       - `true`: Set up tracking using the start-point branch itself (`--track`)
@@ -132,34 +132,34 @@ module Git
         #
         #       Alias: :t
         #
-        #     @option options [Boolean] :no_track (false)
+        #     @option options [Boolean, nil] :no_track (nil)
         #       do not set up tracking even if `branch.autoSetupMerge` is set (`--no-track`)
         #
-        #     @option options [Boolean] :force (false)
+        #     @option options [Boolean, nil] :force (nil)
         #       reset the branch to start point even if it already exists
         #
         #       Without this, git branch refuses to change an existing branch.
         #
         #       Alias: :f
         #
-        #     @option options [Boolean] :recurse_submodules (false)
+        #     @option options [Boolean, nil] :recurse_submodules (nil)
         #       create the branch in the superproject and all submodules
         #
         #       This is an experimental feature.
         #
-        #     @option options [Boolean] :quiet (false)
+        #     @option options [Boolean, nil] :quiet (nil)
         #       suppress informational messages
         #
         #       Alias: :q
         #
-        #     @option options [Boolean] :create_reflog (false)
+        #     @option options [Boolean, nil] :create_reflog (nil)
         #       create the branch's reflog (`--create-reflog`)
         #
         #       Enables date-based sha1 expressions such as `branch@{yesterday}`.
         #       In non-bare repositories, reflogs are usually enabled by default
         #       via `core.logAllRefUpdates`.
         #
-        #     @option options [Boolean] :no_create_reflog (false)
+        #     @option options [Boolean, nil] :no_create_reflog (nil)
         #       forcibly disable the branch's reflog (`--no-create-reflog`)
         #
         #     @return [Git::CommandLineResult] the result of calling `git branch`

--- a/lib/git/commands/branch/delete.rb
+++ b/lib/git/commands/branch/delete.rb
@@ -56,13 +56,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :force (nil) Allow deleting the branch irrespective of its merged
+        #     @option options [Boolean, nil] :force (nil) allow deleting the branch irrespective of its merged
         #       status, or whether it even points to a valid commit. This is equivalent
         #       to the `-D` shortcut (`--delete --force`).
         #
         #       Alias: :f
         #
-        #     @option options [Boolean] :remotes (nil) Delete remote-tracking branches. Use this together
+        #     @option options [Boolean, nil] :remotes (nil) delete remote-tracking branches. Use this together
         #       with `--delete` to delete remote-tracking branches. Note that this only
         #       makes sense if the remote-tracking branches no longer exist in the remote
         #       repository or if `git fetch` was configured not to fetch them again.

--- a/lib/git/commands/branch/list.rb
+++ b/lib/git/commands/branch/list.rb
@@ -69,13 +69,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, String] :color (false) color branches output
+        #     @option options [Boolean, String, nil] :color (nil) color branches output
         #
         #       Pass `true` for `--color` or a string (`'always'`, `'never'`, `'auto'`) for `--color=<when>`.
         #
-        #     @option options [Boolean] :no_color (false) suppress colored output (`--no-color`)
+        #     @option options [Boolean, nil] :no_color (nil) suppress colored output (`--no-color`)
         #
-        #     @option options [Boolean, Integer] :verbose (nil) show sha1 and commit
+        #     @option options [Boolean, Integer, nil] :verbose (nil) show sha1 and commit
         #       subject for each branch
         #
         #       Pass `true` for `--verbose` (show sha1 and subject); pass `2` for
@@ -84,20 +84,20 @@ module Git
         #
         #       Alias: :v
         #
-        #     @option options [Boolean, Integer] :abbrev (false) minimum sha1 display
+        #     @option options [Boolean, Integer, nil] :abbrev (nil) minimum sha1 display
         #       length when used with verbose mode
         #
         #       Pass an integer for `--abbrev=<n>` or `true` for `--abbrev` (default length).
         #
-        #     @option options [Boolean] :no_abbrev (false) show full sha1s (`--no-abbrev`)
+        #     @option options [Boolean, nil] :no_abbrev (nil) show full sha1s (`--no-abbrev`)
         #
-        #     @option options [Boolean, String] :column (false) display branch listing in
+        #     @option options [Boolean, String, nil] :column (nil) display branch listing in
         #       columns
         #
         #       Pass `true` for `--column` or a string of options for `--column=<options>`.
         #       Only applicable in non-verbose mode.
         #
-        #     @option options [Boolean] :no_column (false) disable column output (`--no-column`)
+        #     @option options [Boolean, nil] :no_column (nil) disable column output (`--no-column`)
         #
         #     @option options [String, Array<String>] :sort (nil) sort branches by the
         #       specified key(s)
@@ -105,25 +105,25 @@ module Git
         #       Give an array to add multiple --sort options. Prefix each key with '-' for
         #       descending order. For example, sort: ['refname', '-committerdate'].
         #
-        #     @option options [Boolean, String] :merged (nil) list only branches merged
+        #     @option options [Boolean, String, nil] :merged (nil) list only branches merged
         #       into the specified commit
         #
         #       Pass `true` to default to HEAD or a commit ref string to filter by
         #       that commit.
         #
-        #     @option options [Boolean, String] :no_merged (nil) list only branches not
+        #     @option options [Boolean, String, nil] :no_merged (nil) list only branches not
         #       merged into the specified commit
         #
         #       Pass `true` to default to HEAD or a commit ref string to filter by
         #       that commit.
         #
-        #     @option options [Boolean, String] :contains (nil) list only branches that
+        #     @option options [Boolean, String, nil] :contains (nil) list only branches that
         #       contain the specified commit
         #
         #       Pass `true` to default to HEAD or a commit ref string to filter by
         #       that commit.
         #
-        #     @option options [Boolean, String] :no_contains (nil) list only branches
+        #     @option options [Boolean, String, nil] :no_contains (nil) list only branches
         #       that don't contain the specified commit
         #
         #       Pass `true` to default to HEAD or a commit ref string to filter by
@@ -134,21 +134,21 @@ module Git
         #
         #     @option options [String] :format (nil) output format string for each branch
         #
-        #     @option options [Boolean] :remotes (nil) list only remote-tracking
+        #     @option options [Boolean, nil] :remotes (nil) list only remote-tracking
         #       branches
         #
         #       Alias: :r
         #
-        #     @option options [Boolean] :all (nil) list both local and remote branches
+        #     @option options [Boolean, nil] :all (nil) list both local and remote branches
         #
         #       Alias: :a
         #
-        #     @option options [Boolean] :ignore_case (nil) sort and filter branches
+        #     @option options [Boolean, nil] :ignore_case (nil) sort and filter branches
         #       case insensitively
         #
         #       Alias: :i
         #
-        #     @option options [Boolean] :omit_empty (nil) do not print a newline after
+        #     @option options [Boolean, nil] :omit_empty (nil) do not print a newline after
         #       formatted refs where the format expands to the empty string
         #
         #     @return [Git::CommandLineResult] the result of calling `git branch --list`

--- a/lib/git/commands/branch/move.rb
+++ b/lib/git/commands/branch/move.rb
@@ -59,7 +59,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :force (nil) allow renaming even if new_branch already exists
+        #     @option options [Boolean, nil] :force (nil) allow renaming even if new_branch already exists
         #
         #       Alias: :f
         #
@@ -79,7 +79,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :force (nil) allow renaming even if new_branch already exists
+        #     @option options [Boolean, nil] :force (nil) allow renaming even if new_branch already exists
         #
         #       Alias: :f
         #

--- a/lib/git/commands/cat_file/batch.rb
+++ b/lib/git/commands/cat_file/batch.rb
@@ -130,25 +130,25 @@ module Git
         #
         #   @param options [Hash] command options
         #
-        #   @option options [Boolean] :buffer (false) Use normal stdio buffering for better throughput
+        #   @option options [Boolean, nil] :buffer (nil) use normal stdio buffering for better throughput
         #
-        #   @option options [Boolean] :follow_symlinks (false) Follow symlinks in trees
+        #   @option options [Boolean, nil] :follow_symlinks (nil) follow symlinks in trees
         #
-        #   @option options [Boolean] :unordered (false) Output in arbitrary order
+        #   @option options [Boolean, nil] :unordered (nil) output in arbitrary order
         #
-        #   @option options [Boolean] :textconv (false) Apply textconv filters
+        #   @option options [Boolean, nil] :textconv (nil) apply textconv filters
         #
-        #   @option options [Boolean] :filters (false) Apply full working-tree filters
+        #   @option options [Boolean, nil] :filters (nil) apply full working-tree filters
         #
-        #   @option options [Boolean] :use_mailmap (false) Remap identities via mailmap (`--use-mailmap`)
+        #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #
-        #   @option options [Boolean] :no_use_mailmap (false) Suppress mailmap remapping (`--no-use-mailmap`)
+        #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
-        #   @option options [String] :filter (nil) Omit objects matching the given filter spec
+        #   @option options [String] :filter (nil) omit objects matching the given filter spec
         #
-        #   @option options [Boolean] :Z (false) Use NUL-delimited I/O
+        #   @option options [Boolean, nil] :Z (nil) use NUL-delimited I/O
         #
-        #   @option options [#write, nil] :out (nil) Stream stdout to this IO object
+        #   @option options [#write, nil] :out (nil) stream stdout to this IO object
         #     instead of buffering in memory; when given, `result.stdout` will be `''`
         #
         #   @return [Git::CommandLineResult] the result of calling `git cat-file`
@@ -171,26 +171,26 @@ module Git
         #
         #   @param options [Hash] command options
         #
-        #   @option options [Boolean] :buffer (false) Use normal stdio buffering for better
+        #   @option options [Boolean, nil] :buffer (nil) use normal stdio buffering for better
         #     throughput when processing large numbers of objects
         #
-        #   @option options [Boolean] :follow_symlinks (false) Follow symlinks in trees
+        #   @option options [Boolean, nil] :follow_symlinks (nil) follow symlinks in trees
         #
-        #   @option options [Boolean] :unordered (false) Output in arbitrary order
+        #   @option options [Boolean, nil] :unordered (nil) output in arbitrary order
         #
-        #   @option options [Boolean] :textconv (false) Apply textconv filters
+        #   @option options [Boolean, nil] :textconv (nil) apply textconv filters
         #
-        #   @option options [Boolean] :filters (false) Apply full working-tree filters
+        #   @option options [Boolean, nil] :filters (nil) apply full working-tree filters
         #
-        #   @option options [Boolean] :use_mailmap (false) Remap identities via mailmap (`--use-mailmap`)
+        #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #
-        #   @option options [Boolean] :no_use_mailmap (false) Suppress mailmap remapping (`--no-use-mailmap`)
+        #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
-        #   @option options [String] :filter (nil) Omit objects matching the given filter spec
+        #   @option options [String] :filter (nil) omit objects matching the given filter spec
         #
-        #   @option options [Boolean] :Z (false) Use NUL-delimited I/O
+        #   @option options [Boolean, nil] :Z (nil) use NUL-delimited I/O
         #
-        #   @option options [#write, nil] :out (nil) Stream stdout to this IO object
+        #   @option options [#write, nil] :out (nil) stream stdout to this IO object
         #     instead of buffering in memory; when given, `result.stdout` will be `''`
         #
         #   @return [Git::CommandLineResult] the result of calling `git cat-file`
@@ -216,21 +216,21 @@ module Git
         #
         #   @param options [Hash] command options
         #
-        #   @option options [Boolean] :buffer (false) Use normal stdio buffering for better throughput
+        #   @option options [Boolean, nil] :buffer (nil) use normal stdio buffering for better throughput
         #
-        #   @option options [Boolean] :textconv (false) Apply textconv filters
+        #   @option options [Boolean, nil] :textconv (nil) apply textconv filters
         #
-        #   @option options [Boolean] :filters (false) Apply full working-tree filters
+        #   @option options [Boolean, nil] :filters (nil) apply full working-tree filters
         #
-        #   @option options [Boolean] :use_mailmap (false) Remap identities via mailmap (`--use-mailmap`)
+        #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #
-        #   @option options [Boolean] :no_use_mailmap (false) Suppress mailmap remapping (`--no-use-mailmap`)
+        #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
-        #   @option options [String] :filter (nil) Omit objects matching the given filter spec
+        #   @option options [String] :filter (nil) omit objects matching the given filter spec
         #
-        #   @option options [Boolean] :Z (false) Use NUL-delimited I/O
+        #   @option options [Boolean, nil] :Z (nil) use NUL-delimited I/O
         #
-        #   @option options [#write, nil] :out (nil) Stream stdout to this IO object
+        #   @option options [#write, nil] :out (nil) stream stdout to this IO object
         #     instead of buffering in memory; when given, `result.stdout` will be `''`
         #
         #   @return [Git::CommandLineResult] the result of calling `git cat-file`
@@ -251,20 +251,20 @@ module Git
         #
         #   @param options [Hash] command options
         #
-        #   @option options [Boolean] :buffer (false) Use normal stdio buffering for better throughput
+        #   @option options [Boolean, nil] :buffer (nil) use normal stdio buffering for better throughput
         #
-        #   @option options [Boolean] :unordered (false) Output in arbitrary order
+        #   @option options [Boolean, nil] :unordered (nil) output in arbitrary order
         #
-        #   @option options [Boolean] :use_mailmap (false) Remap identities via mailmap for
+        #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap for
         #     commit and tag objects (`--use-mailmap`)
         #
-        #   @option options [Boolean] :no_use_mailmap (false) Suppress mailmap remapping (`--no-use-mailmap`)
+        #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
-        #   @option options [String] :filter (nil) Omit objects matching the given filter spec
+        #   @option options [String] :filter (nil) omit objects matching the given filter spec
         #
-        #   @option options [Boolean] :Z (false) Use NUL-delimited I/O
+        #   @option options [Boolean, nil] :Z (nil) use NUL-delimited I/O
         #
-        #   @option options [#write, nil] :out (nil) Stream stdout to this IO object
+        #   @option options [#write, nil] :out (nil) stream stdout to this IO object
         #     instead of buffering in memory; when given, `result.stdout` will be `''`
         #
         #   @return [Git::CommandLineResult] the result of calling `git cat-file`
@@ -285,21 +285,21 @@ module Git
         #
         #   @param options [Hash] command options
         #
-        #   @option options [Boolean] :buffer (false) Use normal stdio buffering for better
+        #   @option options [Boolean, nil] :buffer (nil) use normal stdio buffering for better
         #     throughput when processing large numbers of objects
         #
-        #   @option options [Boolean] :unordered (false) Output in arbitrary order
+        #   @option options [Boolean, nil] :unordered (nil) output in arbitrary order
         #
-        #   @option options [Boolean] :use_mailmap (false) Remap identities via mailmap for
+        #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap for
         #     commit and tag objects (`--use-mailmap`)
         #
-        #   @option options [Boolean] :no_use_mailmap (false) Suppress mailmap remapping (`--no-use-mailmap`)
+        #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
-        #   @option options [String] :filter (nil) Omit objects matching the given filter spec
+        #   @option options [String] :filter (nil) omit objects matching the given filter spec
         #
-        #   @option options [Boolean] :Z (false) Use NUL-delimited I/O
+        #   @option options [Boolean, nil] :Z (nil) use NUL-delimited I/O
         #
-        #   @option options [#write, nil] :out (nil) Stream stdout to this IO object
+        #   @option options [#write, nil] :out (nil) stream stdout to this IO object
         #     instead of buffering in memory; when given, `result.stdout` will be `''`
         #
         #   @return [Git::CommandLineResult] the result of calling `git cat-file`

--- a/lib/git/commands/cat_file/raw.rb
+++ b/lib/git/commands/cat_file/raw.rb
@@ -89,9 +89,9 @@ module Git
         #
         #   @param options [Hash] command options
         #
-        #   @option options [Boolean] :use_mailmap (false) Remap identities via mailmap (`--use-mailmap`)
+        #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #
-        #   @option options [Boolean] :no_use_mailmap (false) Suppress mailmap remapping (`--no-use-mailmap`)
+        #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
         #   @return [Git::CommandLineResult] the result of calling `git cat-file`
         #
@@ -110,12 +110,12 @@ module Git
         #
         #   @param options [Hash] command options
         #
-        #   @option options [Boolean] :allow_unknown_type (false) Allow querying broken or corrupt objects of
+        #   @option options [Boolean, nil] :allow_unknown_type (nil) allow querying broken or corrupt objects of
         #     unknown type
         #
-        #   @option options [Boolean] :use_mailmap (false) Remap identities via mailmap (`--use-mailmap`)
+        #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #
-        #   @option options [Boolean] :no_use_mailmap (false) Suppress mailmap remapping (`--no-use-mailmap`)
+        #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
         #   @return [Git::CommandLineResult] the result of calling `git cat-file`
         #
@@ -134,12 +134,12 @@ module Git
         #
         #   @param options [Hash] command options
         #
-        #   @option options [Boolean] :allow_unknown_type (false) Allow querying broken or corrupt objects of
+        #   @option options [Boolean, nil] :allow_unknown_type (nil) allow querying broken or corrupt objects of
         #     unknown type
         #
-        #   @option options [Boolean] :use_mailmap (false) Remap identities via mailmap (`--use-mailmap`)
+        #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #
-        #   @option options [Boolean] :no_use_mailmap (false) Suppress mailmap remapping (`--no-use-mailmap`)
+        #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
         #   @return [Git::CommandLineResult] the result of calling `git cat-file`
         #
@@ -158,9 +158,9 @@ module Git
         #
         #   @param options [Hash] command options
         #
-        #   @option options [Boolean] :use_mailmap (false) Remap identities via mailmap (`--use-mailmap`)
+        #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #
-        #   @option options [Boolean] :no_use_mailmap (false) Suppress mailmap remapping (`--no-use-mailmap`)
+        #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
         #   @return [Git::CommandLineResult] the result of calling `git cat-file`
         #
@@ -179,9 +179,9 @@ module Git
         #
         #   @param options [Hash] command options
         #
-        #   @option options [Boolean] :use_mailmap (false) Remap identities via mailmap (`--use-mailmap`)
+        #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #
-        #   @option options [Boolean] :no_use_mailmap (false) Suppress mailmap remapping (`--no-use-mailmap`)
+        #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
         #   @return [Git::CommandLineResult] the result of calling `git cat-file`
         #

--- a/lib/git/commands/checkout/branch.rb
+++ b/lib/git/commands/checkout/branch.rb
@@ -65,17 +65,17 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :quiet (false) suppress feedback messages
+        #     @option options [Boolean, nil] :quiet (nil) suppress feedback messages
         #
         #       Alias: `:q`
         #
-        #     @option options [Boolean] :progress (false) force progress reporting even
+        #     @option options [Boolean, nil] :progress (nil) force progress reporting even
         #       when not attached to a terminal (`--progress`)
         #
-        #     @option options [Boolean] :no_progress (false) disable progress reporting
+        #     @option options [Boolean, nil] :no_progress (nil) disable progress reporting
         #       even when attached to a terminal (`--no-progress`)
         #
-        #     @option options [Boolean] :force (false) proceed even if the index or
+        #     @option options [Boolean, nil] :force (nil) proceed even if the index or
         #       working tree differs from HEAD; discards local changes and untracked
         #       files that are in the way
         #
@@ -87,25 +87,25 @@ module Git
         #     @option options [String] :B (nil) like `:b`, but reset the branch to the
         #       start point if it already exists
         #
-        #     @option options [Boolean, String] :track (false) set up upstream tracking
+        #     @option options [Boolean, String, nil] :track (nil) set up upstream tracking
         #       configuration; `true` emits `--track`, `'direct'` emits
         #       `--track=direct`, `'inherit'` emits `--track=inherit` (`--track`)
         #
         #       Alias: `:t`
         #
-        #     @option options [Boolean] :no_track (false) do not set up branch tracking
+        #     @option options [Boolean, nil] :no_track (nil) do not set up branch tracking
         #       even if `branch.autoSetupMerge` is configured (`--no-track`)
         #
-        #     @option options [Boolean] :guess (false) automatically create and check out
+        #     @option options [Boolean, nil] :guess (nil) automatically create and check out
         #       a local branch from a uniquely matching remote-tracking branch
         #       (`--guess`)
         #
-        #     @option options [Boolean] :no_guess (false) disable automatic remote branch
+        #     @option options [Boolean, nil] :no_guess (nil) disable automatic remote branch
         #       matching (`--no-guess`)
         #
-        #     @option options [Boolean] :l (false) create the new branch's reflog
+        #     @option options [Boolean, nil] :l (nil) create the new branch's reflog
         #
-        #     @option options [Boolean] :detach (false) detach HEAD at the specified
+        #     @option options [Boolean, nil] :detach (nil) detach HEAD at the specified
         #       commit rather than pointing a branch at it
         #
         #       Alias: `:d`
@@ -113,25 +113,25 @@ module Git
         #     @option options [String] :orphan (nil) create a new unborn branch with no
         #       history; the positional `branch` argument becomes the start point
         #
-        #     @option options [Boolean] :merge (false) perform a three-way merge when
+        #     @option options [Boolean, nil] :merge (nil) perform a three-way merge when
         #       local modifications conflict with the target branch
         #
         #       Alias: `:m`
         #
-        #     @option options [Boolean] :ignore_other_worktrees (false) check out the
+        #     @option options [Boolean, nil] :ignore_other_worktrees (nil) check out the
         #       branch even if it is already in use by another worktree
         #
-        #     @option options [Boolean] :overwrite_ignore (false) silently overwrite
+        #     @option options [Boolean, nil] :overwrite_ignore (nil) silently overwrite
         #       ignored files when switching branches (`--overwrite-ignore`)
         #
-        #     @option options [Boolean] :no_overwrite_ignore (false) abort the checkout
+        #     @option options [Boolean, nil] :no_overwrite_ignore (nil) abort the checkout
         #       if ignored files would be overwritten (`--no-overwrite-ignore`)
         #
-        #     @option options [Boolean] :recurse_submodules (false) update all active
+        #     @option options [Boolean, nil] :recurse_submodules (nil) update all active
         #       submodule working trees to match the new branch
         #       (`--recurse-submodules`)
         #
-        #     @option options [Boolean] :no_recurse_submodules (false) do not update
+        #     @option options [Boolean, nil] :no_recurse_submodules (nil) do not update
         #       submodule working trees when switching branches
         #       (`--no-recurse-submodules`)
         #

--- a/lib/git/commands/checkout/files.rb
+++ b/lib/git/commands/checkout/files.rb
@@ -60,17 +60,17 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :force (false) ignore unmerged entries
+        #     @option options [Boolean, nil] :force (nil) ignore unmerged entries
         #
         #       Alias: `:f`
         #
-        #     @option options [Boolean] :ours (false) for unmerged paths, check out
+        #     @option options [Boolean, nil] :ours (nil) for unmerged paths, check out
         #       stage #2 (our version)
         #
-        #     @option options [Boolean] :theirs (false) for unmerged paths, check out
+        #     @option options [Boolean, nil] :theirs (nil) for unmerged paths, check out
         #       stage #3 (their version)
         #
-        #     @option options [Boolean] :merge (false) recreate the conflicted merge in
+        #     @option options [Boolean, nil] :merge (nil) recreate the conflicted merge in
         #       the specified paths; cannot be used when checking out from a tree-ish
         #
         #       Alias: `:m`
@@ -78,20 +78,20 @@ module Git
         #     @option options [String] :conflict (nil) conflict marker style; valid
         #       values are `'merge'`, `'diff3'`, and `'zdiff3'`
         #
-        #     @option options [Boolean] :overlay (false) never remove files from the
+        #     @option options [Boolean, nil] :overlay (nil) never remove files from the
         #       index or working tree that are not present in the tree-ish (`--overlay`)
         #
-        #     @option options [Boolean] :no_overlay (false) remove files not present
+        #     @option options [Boolean, nil] :no_overlay (nil) remove files not present
         #       in the tree-ish from the index and working tree (`--no-overlay`)
         #
-        #     @option options [Boolean] :ignore_skip_worktree_bits (false) in sparse
+        #     @option options [Boolean, nil] :ignore_skip_worktree_bits (nil) in sparse
         #       checkout mode, ignore sparse patterns and update all files matched by
         #       pathspec
         #
         #     @option options [String] :pathspec_from_file (nil) read pathspec from
         #       this file; pass `'-'` to read from stdin
         #
-        #     @option options [Boolean] :pathspec_file_nul (false) with
+        #     @option options [Boolean, nil] :pathspec_file_nul (nil) with
         #       `:pathspec_from_file`, separate pathspec elements with NUL instead of
         #       newline
         #

--- a/lib/git/commands/checkout_index.rb
+++ b/lib/git/commands/checkout_index.rb
@@ -55,25 +55,25 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :index (false) update stat information for the
+      #     @option options [Boolean, nil] :index (nil) update stat information for the
       #       checked out entries in the index file
       #
       #       Alias: `:u`
       #
-      #     @option options [Boolean] :quiet (false) suppress messages when files
+      #     @option options [Boolean, nil] :quiet (nil) suppress messages when files
       #       exist or are not in the index
       #
       #       Alias: `:q`
       #
-      #     @option options [Boolean] :all (false) check out all files in the index
+      #     @option options [Boolean, nil] :all (nil) check out all files in the index
       #
       #       Alias: `:a`
       #
-      #     @option options [Boolean] :force (false) force overwrite of existing files
+      #     @option options [Boolean, nil] :force (nil) force overwrite of existing files
       #
       #       Alias: `:f`
       #
-      #     @option options [Boolean] :no_create (false) don't checkout new files,
+      #     @option options [Boolean, nil] :no_create (nil) don't checkout new files,
       #       only refresh files already checked out
       #
       #       Alias: `:n`
@@ -86,10 +86,10 @@ module Git
       #       Pass `'1'`, `'2'`, or `'3'` for a specific stage number, or `'all'` to
       #       check out all stages (automatically implies `--temp`).
       #
-      #     @option options [Boolean] :temp (false) write file content to temporary
+      #     @option options [Boolean, nil] :temp (nil) write file content to temporary
       #       files near the target location instead of checking them out
       #
-      #     @option options [Boolean] :ignore_skip_worktree_bits (false) check out
+      #     @option options [Boolean, nil] :ignore_skip_worktree_bits (nil) check out
       #       all files, including those with the skip-worktree bit set
       #
       #     @return [Git::CommandLineResult] the result of calling `git checkout-index`

--- a/lib/git/commands/clean.rb
+++ b/lib/git/commands/clean.rb
@@ -51,9 +51,9 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :d (false) recurse into untracked directories
+      #     @option options [Boolean, nil] :d (nil) recurse into untracked directories
       #
-      #     @option options [Boolean, Integer] :force (false) force the removal of untracked files
+      #     @option options [Boolean, Integer, nil] :force (nil) force the removal of untracked files
       #
       #       When `clean.requireForce` is not set to `false`, git-clean will refuse to
       #       delete files or directories unless this option is given.
@@ -64,12 +64,12 @@ module Git
       #
       #       Alias: `:f`
       #
-      #     @option options [Boolean] :dry_run (false) don't actually remove anything, just
+      #     @option options [Boolean, nil] :dry_run (nil) don't actually remove anything, just
       #       show what would be done
       #
       #       Alias: `:n`
       #
-      #     @option options [Boolean] :quiet (false) be quiet, only report errors
+      #     @option options [Boolean, nil] :quiet (nil) be quiet, only report errors
       #
       #       Alias: `:q`
       #
@@ -78,9 +78,9 @@ module Git
       #
       #       May be specified multiple times. Alias: `:e`
       #
-      #     @option options [Boolean] :x (false) don't use the standard ignore rules
+      #     @option options [Boolean, nil] :x (nil) don't use the standard ignore rules
       #
-      #     @option options [Boolean] :X (false) remove only files ignored by Git
+      #     @option options [Boolean, nil] :X (nil) remove only files ignored by Git
       #
       #     @option options [String, Array<String>] :pathspec (nil) limit cleaning to files
       #       matching the given pathspec(s)

--- a/lib/git/commands/clone.rb
+++ b/lib/git/commands/clone.rb
@@ -84,41 +84,41 @@ module Git
       #     @option options [String] :template (nil) directory from which templates
       #       will be used
       #
-      #     @option options [Boolean] :local (false) bypass the normal Git-aware transport
+      #     @option options [Boolean, nil] :local (nil) bypass the normal Git-aware transport
       #       for local clones (`--local`)
       #
       #       Alias: `:l`
       #
-      #     @option options [Boolean] :no_local (false) disable the local optimization
+      #     @option options [Boolean, nil] :no_local (nil) disable the local optimization
       #       and use the normal transport (`--no-local`)
       #
-      #     @option options [Boolean] :shared (false) set up a shared clone using
+      #     @option options [Boolean, nil] :shared (nil) set up a shared clone using
       #       alternates instead of hardlinks
       #
       #       Alias: `:s`
       #
-      #     @option options [Boolean] :no_hardlinks (false) force file-copy instead of
+      #     @option options [Boolean, nil] :no_hardlinks (nil) force file-copy instead of
       #       hardlinks when cloning from a local filesystem
       #
-      #     @option options [Boolean] :quiet (false) suppress progress output to stderr
+      #     @option options [Boolean, nil] :quiet (nil) suppress progress output to stderr
       #
       #       Alias: `:q`
       #
-      #     @option options [Boolean] :verbose (false) run verbosely
+      #     @option options [Boolean, nil] :verbose (nil) run verbosely
       #
       #       Alias: `:v`
       #
-      #     @option options [Boolean] :progress (false) force progress status even when
+      #     @option options [Boolean, nil] :progress (nil) force progress status even when
       #       stderr is not a terminal
       #
-      #     @option options [Boolean] :no_checkout (false) skip checking out HEAD after
+      #     @option options [Boolean, nil] :no_checkout (nil) skip checking out HEAD after
       #       the clone
       #
       #       Alias: `:n`
       #
-      #     @option options [Boolean] :bare (false) clone as a bare repository
+      #     @option options [Boolean, nil] :bare (nil) clone as a bare repository
       #
-      #     @option options [Boolean] :mirror (false) set up a mirror clone (implies
+      #     @option options [Boolean, nil] :mirror (nil) set up a mirror clone (implies
       #       --bare)
       #
       #     @option options [String] :origin (nil) name of the remote to use instead of
@@ -144,7 +144,7 @@ module Git
       #     @option options [String, Array<String>] :reference_if_able (nil) like
       #       :reference but skip with a warning when the reference does not exist
       #
-      #     @option options [Boolean] :dissociate (false) stop borrowing from reference
+      #     @option options [Boolean, nil] :dissociate (nil) stop borrowing from reference
       #       repositories after the clone is complete
       #
       #     @option options [String] :separate_git_dir (nil) place the git directory at
@@ -162,31 +162,31 @@ module Git
       #     @option options [String, Array<String>] :shallow_exclude (nil) exclude
       #       commits reachable from the specified remote branch or tag
       #
-      #     @option options [Boolean] :single_branch (false) clone only the history for
+      #     @option options [Boolean, nil] :single_branch (nil) clone only the history for
       #       one branch (`--single-branch`)
       #
-      #     @option options [Boolean] :no_single_branch (false) clone history for all
+      #     @option options [Boolean, nil] :no_single_branch (nil) clone history for all
       #       branches (`--no-single-branch`)
       #
-      #     @option options [Boolean] :tags (false) include tags in the clone (`--tags`)
+      #     @option options [Boolean, nil] :tags (nil) include tags in the clone (`--tags`)
       #
-      #     @option options [Boolean] :no_tags (false) exclude tags from the clone
+      #     @option options [Boolean, nil] :no_tags (nil) exclude tags from the clone
       #       (`--no-tags`)
       #
-      #     @option options [Boolean, String, Array<String>] :recurse_submodules (nil)
+      #     @option options [Boolean, String, Array<String>, nil] :recurse_submodules (nil)
       #       initialize submodules after cloning; pass true for all submodules or a
       #       pathspec string/array for a subset
       #
-      #     @option options [Boolean] :shallow_submodules (false) clone submodules with
+      #     @option options [Boolean, nil] :shallow_submodules (nil) clone submodules with
       #       depth 1 (`--shallow-submodules`)
       #
-      #     @option options [Boolean] :no_shallow_submodules (false) clone submodules
+      #     @option options [Boolean, nil] :no_shallow_submodules (nil) clone submodules
       #       with full history (`--no-shallow-submodules`)
       #
-      #     @option options [Boolean] :remote_submodules (false) use submodule
+      #     @option options [Boolean, nil] :remote_submodules (nil) use submodule
       #       remote-tracking branch status (`--remote-submodules`)
       #
-      #     @option options [Boolean] :no_remote_submodules (false) use the locally
+      #     @option options [Boolean, nil] :no_remote_submodules (nil) use the locally
       #       recorded SHA-1 for submodules (`--no-remote-submodules`)
       #
       #     @option options [Integer, String] :jobs (nil) number of submodules fetched
@@ -194,19 +194,19 @@ module Git
       #
       #       Alias: `:j`
       #
-      #     @option options [Boolean] :sparse (false) enable sparse checkout with
+      #     @option options [Boolean, nil] :sparse (nil) enable sparse checkout with
       #       top-level files only
       #
-      #     @option options [Boolean] :reject_shallow (false) fail if source is shallow
+      #     @option options [Boolean, nil] :reject_shallow (nil) fail if source is shallow
       #       (`--reject-shallow`)
       #
-      #     @option options [Boolean] :no_reject_shallow (false) allow cloning from
+      #     @option options [Boolean, nil] :no_reject_shallow (nil) allow cloning from
       #       shallow sources (`--no-reject-shallow`)
       #
       #     @option options [String] :filter (nil) specify a partial clone filter
       #       (e.g., 'blob:none', 'tree:0')
       #
-      #     @option options [Boolean] :also_filter_submodules (false) apply the partial
+      #     @option options [Boolean, nil] :also_filter_submodules (nil) apply the partial
       #       clone filter to submodules; requires :filter and :recurse_submodules
       #
       #     @option options [String, Array<String>] :config (nil) set configuration

--- a/lib/git/commands/commit.rb
+++ b/lib/git/commands/commit.rb
@@ -106,18 +106,18 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :all (false) automatically stage modified and deleted
+      #     @option options [Boolean, nil] :all (nil) automatically stage modified and deleted
       #       files before committing
       #
       #       Alias: `:a`
       #
-      #     @option options [Boolean] :edit (false) open an editor for the commit message (`--edit`)
+      #     @option options [Boolean, nil] :edit (nil) open an editor for the commit message (`--edit`)
       #
       #       Alias: `:e`
       #
-      #     @option options [Boolean] :no_edit (false) suppress the editor (`--no-edit`)
+      #     @option options [Boolean, nil] :no_edit (nil) suppress the editor (`--no-edit`)
       #
-      #     @option options [Boolean] :amend (false) replace the tip of the current branch
+      #     @option options [Boolean, nil] :amend (nil) replace the tip of the current branch
       #       with a new commit
       #
       #     @option options [String] :reuse_message (nil) reuse the log message and
@@ -148,7 +148,7 @@ module Git
       #
       #       Alias: `:t`
       #
-      #     @option options [Boolean] :reset_author (false) when used with `:reuse_message`
+      #     @option options [Boolean, nil] :reset_author (nil) when used with `:reuse_message`
       #       or `:amend`, declare the committer as the new author
       #
       #     @option options [String] :author (nil) override the commit author
@@ -161,64 +161,64 @@ module Git
       #     @option options [String, Array<String>] :trailer (nil) add one or more
       #       `<token>[=<value>]` trailers to the commit message
       #
-      #     @option options [Boolean] :verify (false) run pre-commit and commit-msg hooks (`--verify`)
+      #     @option options [Boolean, nil] :verify (nil) run pre-commit and commit-msg hooks (`--verify`)
       #
       #       Alias: `:n`
       #
-      #     @option options [Boolean] :no_verify (false) bypass pre-commit and commit-msg hooks (`--no-verify`)
+      #     @option options [Boolean, nil] :no_verify (nil) bypass pre-commit and commit-msg hooks (`--no-verify`)
       #
-      #     @option options [Boolean] :allow_empty (false) allow committing with no changes
+      #     @option options [Boolean, nil] :allow_empty (nil) allow committing with no changes
       #
-      #     @option options [Boolean] :allow_empty_message (false) allow committing with an
+      #     @option options [Boolean, nil] :allow_empty_message (nil) allow committing with an
       #       empty message
       #
-      #     @option options [Boolean] :no_post_rewrite (false) bypass the post-rewrite hook
+      #     @option options [Boolean, nil] :no_post_rewrite (nil) bypass the post-rewrite hook
       #
-      #     @option options [Boolean] :include (false) stage the listed paths before
+      #     @option options [Boolean, nil] :include (nil) stage the listed paths before
       #       committing in addition to already-staged contents
       #
       #       Alias: `:i`
       #
-      #     @option options [Boolean] :only (false) commit only the listed paths from the
+      #     @option options [Boolean, nil] :only (nil) commit only the listed paths from the
       #       working tree, ignoring staged changes for other paths
       #
       #       Alias: `:o`
       #
-      #     @option options [Boolean] :dry_run (false) do not create a commit; show what
+      #     @option options [Boolean, nil] :dry_run (nil) do not create a commit; show what
       #       would be committed
       #
-      #     @option options [Boolean] :short (false) show short-format dry-run output;
+      #     @option options [Boolean, nil] :short (nil) show short-format dry-run output;
       #       implies `:dry_run`
       #
-      #     @option options [Boolean] :branch (false) show branch and tracking info in
+      #     @option options [Boolean, nil] :branch (nil) show branch and tracking info in
       #       short-format dry-run output
       #
-      #     @option options [Boolean] :porcelain (false) show porcelain-format dry-run
+      #     @option options [Boolean, nil] :porcelain (nil) show porcelain-format dry-run
       #       output; implies `:dry_run`
       #
-      #     @option options [Boolean] :long (false) show long-format dry-run output;
+      #     @option options [Boolean, nil] :long (nil) show long-format dry-run output;
       #       implies `:dry_run`
       #
-      #     @option options [Boolean] :null (false) terminate dry-run output entries with
+      #     @option options [Boolean, nil] :null (nil) terminate dry-run output entries with
       #       NUL instead of LF
       #
       #       Alias: `:z`
       #
-      #     @option options [Boolean, Integer] :verbose (false) show unified diff between
+      #     @option options [Boolean, Integer, nil] :verbose (nil) show unified diff between
       #       HEAD and what would be committed at the bottom of the commit message template
       #
       #       Pass `2` to also show the unified diff between staged and working-tree changes.
       #
       #       Alias: `:v`
       #
-      #     @option options [Boolean] :quiet (false) suppress commit summary message
+      #     @option options [Boolean, nil] :quiet (nil) suppress commit summary message
       #
       #       Alias: `:q`
       #
-      #     @option options [Boolean] :status (false) include `git status` output in the
+      #     @option options [Boolean, nil] :status (nil) include `git status` output in the
       #       commit message template (`--status`)
       #
-      #     @option options [Boolean] :no_status (false) omit `git status` output from the
+      #     @option options [Boolean, nil] :no_status (nil) omit `git status` output from the
       #       commit message template (`--no-status`)
       #
       #     @option options [Integer] :unified (nil) generate verbose diff with the given
@@ -229,23 +229,23 @@ module Git
       #     @option options [Integer] :inter_hunk_context (nil) show context between diff
       #       hunks up to the given number of lines (for use with `:verbose`)
       #
-      #     @option options [Boolean] :signoff (false) add a `Signed-off-by` trailer to
+      #     @option options [Boolean, nil] :signoff (nil) add a `Signed-off-by` trailer to
       #       the commit message (`--signoff`)
       #
       #       Alias: `:s`
       #
-      #     @option options [Boolean] :no_signoff (false) suppress the `Signed-off-by` trailer (`--no-signoff`)
+      #     @option options [Boolean, nil] :no_signoff (nil) suppress the `Signed-off-by` trailer (`--no-signoff`)
       #
-      #     @option options [Boolean, String] :gpg_sign (false) GPG-sign the commit (`--gpg-sign`)
+      #     @option options [Boolean, String, nil] :gpg_sign (nil) GPG-sign the commit (`--gpg-sign`)
       #
       #       When `true`, uses the default key. When a `String`, uses the specified key ID.
       #
       #       Alias: `:S`
       #
-      #     @option options [Boolean] :no_gpg_sign (false) disable GPG signing, overriding
+      #     @option options [Boolean, nil] :no_gpg_sign (nil) disable GPG signing, overriding
       #       `commit.gpgSign` config (`--no-gpg-sign`)
       #
-      #     @option options [Boolean, String] :untracked_files (nil) show untracked files
+      #     @option options [Boolean, String, nil] :untracked_files (nil) show untracked files
       #       in the dry-run status output
       #
       #       When `true`, uses git's default mode (`all`). Pass a `String` (`"no"`,
@@ -256,7 +256,7 @@ module Git
       #     @option options [String] :pathspec_from_file (nil) read pathspec from the given
       #       file instead of the command line
       #
-      #     @option options [Boolean] :pathspec_file_nul (false) pathspec elements in
+      #     @option options [Boolean, nil] :pathspec_file_nul (nil) pathspec elements in
       #       `:pathspec_from_file` are NUL-separated instead of newline-separated
       #
       #     @return [Git::CommandLineResult] the result of calling `git commit`

--- a/lib/git/commands/commit_tree.rb
+++ b/lib/git/commands/commit_tree.rb
@@ -64,13 +64,13 @@ module Git
       #       with more than one it is a merge commit. Initial (root) commits
       #       have no parents.
       #
-      #     @option options [Boolean, String] :gpg_sign (false) sign the
+      #     @option options [Boolean, String, nil] :gpg_sign (nil) sign the
       #       commit with GPG (`--gpg-sign`)
       #
       #       Pass a key-ID string to select the signing key; pass `true` to use
       #       the committer identity. Alias: `:S`
       #
-      #     @option options [Boolean] :no_gpg_sign (false) countermand commit.gpgSign
+      #     @option options [Boolean, nil] :no_gpg_sign (nil) countermand commit.gpgSign
       #       configuration (`--no-gpg-sign`)
       #
       #     @option options [String, Array<String>] :m (nil) a paragraph

--- a/lib/git/commands/config_option_syntax/add.rb
+++ b/lib/git/commands/config_option_syntax/add.rb
@@ -56,13 +56,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (false) write to global config (`~/.gitconfig`)
+        #     @option options [Boolean, nil] :global (nil) write to global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (false) write to system config
+        #     @option options [Boolean, nil] :system (nil) write to system config
         #
-        #     @option options [Boolean] :local (false) write to repository config (`.git/config`)
+        #     @option options [Boolean, nil] :local (nil) write to repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (false) write to worktree config
+        #     @option options [Boolean, nil] :worktree (nil) write to worktree config
         #
         #     @option options [String] :file (nil) write to the specified file
         #

--- a/lib/git/commands/config_option_syntax/get.rb
+++ b/lib/git/commands/config_option_syntax/get.rb
@@ -75,13 +75,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (nil) read from global config (`~/.gitconfig`)
+        #     @option options [Boolean, nil] :global (nil) read from global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (nil) read from system config
+        #     @option options [Boolean, nil] :system (nil) read from system config
         #
-        #     @option options [Boolean] :local (nil) read from repository config (`.git/config`)
+        #     @option options [Boolean, nil] :local (nil) read from repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (nil) read from worktree config
+        #     @option options [Boolean, nil] :worktree (nil) read from worktree config
         #
         #     @option options [String] :file (nil) read from the specified file
         #
@@ -89,18 +89,18 @@ module Git
         #
         #     @option options [String] :blob (nil) read from the specified blob
         #
-        #     @option options [Boolean] :includes (false) respect include directives in config files (`--includes`)
+        #     @option options [Boolean, nil] :includes (nil) respect include directives in config files (`--includes`)
         #
-        #     @option options [Boolean] :no_includes (false) do not respect include directives
+        #     @option options [Boolean, nil] :no_includes (nil) do not respect include directives
         #       in config files (`--no-includes`)
         #
         #     @option options [String] :type (nil) ensure the value conforms to the given type
         #
-        #     @option options [Boolean] :show_origin (nil) show the origin of the config value
+        #     @option options [Boolean, nil] :show_origin (nil) show the origin of the config value
         #
-        #     @option options [Boolean] :show_scope (nil) show the scope of the config value
+        #     @option options [Boolean, nil] :show_scope (nil) show the scope of the config value
         #
-        #     @option options [Boolean] :null (nil) terminate values with NUL byte instead of newline
+        #     @option options [Boolean, nil] :null (nil) terminate values with NUL byte instead of newline
         #
         #       Alias: :z
         #

--- a/lib/git/commands/config_option_syntax/get_all.rb
+++ b/lib/git/commands/config_option_syntax/get_all.rb
@@ -71,13 +71,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (false) read from global config (`~/.gitconfig`)
+        #     @option options [Boolean, nil] :global (nil) read from global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (false) read from system config
+        #     @option options [Boolean, nil] :system (nil) read from system config
         #
-        #     @option options [Boolean] :local (false) read from repository config (`.git/config`)
+        #     @option options [Boolean, nil] :local (nil) read from repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (false) read from worktree config
+        #     @option options [Boolean, nil] :worktree (nil) read from worktree config
         #
         #     @option options [String] :file (nil) read from the specified file
         #
@@ -85,22 +85,22 @@ module Git
         #
         #     @option options [String] :blob (nil) read from the specified blob
         #
-        #     @option options [Boolean] :includes (false) follow include directives in config files
+        #     @option options [Boolean, nil] :includes (nil) follow include directives in config files
         #       (`--includes`)
         #
-        #     @option options [Boolean] :no_includes (false) suppress include directive processing
+        #     @option options [Boolean, nil] :no_includes (nil) suppress include directive processing
         #       (`--no-includes`)
         #
         #     @option options [String] :type (nil) ensure values conform to the given type
         #
-        #     @option options [Boolean] :no_type (false) unset the previously set type specifier;
+        #     @option options [Boolean, nil] :no_type (nil) unset the previously set type specifier;
         #       `true` emits `--no-type`
         #
-        #     @option options [Boolean] :show_origin (false) show the origin of each config value
+        #     @option options [Boolean, nil] :show_origin (nil) show the origin of each config value
         #
-        #     @option options [Boolean] :show_scope (false) show the scope of each config value
+        #     @option options [Boolean, nil] :show_scope (nil) show the scope of each config value
         #
-        #     @option options [Boolean] :null (false) terminate values with NUL byte instead of newline
+        #     @option options [Boolean, nil] :null (nil) terminate values with NUL byte instead of newline
         #
         #       Alias: :z
         #

--- a/lib/git/commands/config_option_syntax/get_color.rb
+++ b/lib/git/commands/config_option_syntax/get_color.rb
@@ -60,13 +60,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (false) read from global config (`~/.gitconfig`)
+        #     @option options [Boolean, nil] :global (nil) read from global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (false) read from system config
+        #     @option options [Boolean, nil] :system (nil) read from system config
         #
-        #     @option options [Boolean] :local (false) read from repository config (`.git/config`)
+        #     @option options [Boolean, nil] :local (nil) read from repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (false) read from worktree config
+        #     @option options [Boolean, nil] :worktree (nil) read from worktree config
         #
         #     @option options [String] :file (nil) read from the specified file
         #
@@ -74,10 +74,10 @@ module Git
         #
         #     @option options [String] :blob (nil) read from the specified blob
         #
-        #     @option options [Boolean] :includes (false) respect include directives in config files
+        #     @option options [Boolean, nil] :includes (nil) respect include directives in config files
         #       (`--includes`)
         #
-        #     @option options [Boolean] :no_includes (false) suppress include directive processing
+        #     @option options [Boolean, nil] :no_includes (nil) suppress include directive processing
         #       (`--no-includes`)
         #
         #     @return [Git::CommandLineResult] the result of calling `git config --get-color`

--- a/lib/git/commands/config_option_syntax/get_color_bool.rb
+++ b/lib/git/commands/config_option_syntax/get_color_bool.rb
@@ -64,13 +64,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (false) read from global config (`~/.gitconfig`)
+        #     @option options [Boolean, nil] :global (nil) read from global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (false) read from system config
+        #     @option options [Boolean, nil] :system (nil) read from system config
         #
-        #     @option options [Boolean] :local (false) read from repository config (`.git/config`)
+        #     @option options [Boolean, nil] :local (nil) read from repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (false) read from worktree config
+        #     @option options [Boolean, nil] :worktree (nil) read from worktree config
         #
         #     @option options [String] :file (nil) read from the specified file
         #
@@ -78,9 +78,9 @@ module Git
         #
         #     @option options [String] :blob (nil) read from the specified blob
         #
-        #     @option options [Boolean] :includes (false) respect include directives in config files (`--includes`)
+        #     @option options [Boolean, nil] :includes (nil) respect include directives in config files (`--includes`)
         #
-        #     @option options [Boolean] :no_includes (false) disable include directive processing (`--no-includes`)
+        #     @option options [Boolean, nil] :no_includes (nil) disable include directive processing (`--no-includes`)
         #
         #     @return [Git::CommandLineResult] the result of calling `git config --get-colorbool`
         #

--- a/lib/git/commands/config_option_syntax/get_regexp.rb
+++ b/lib/git/commands/config_option_syntax/get_regexp.rb
@@ -72,13 +72,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (false) read from global config (`~/.gitconfig`)
+        #     @option options [Boolean, nil] :global (nil) read from global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (false) read from system config
+        #     @option options [Boolean, nil] :system (nil) read from system config
         #
-        #     @option options [Boolean] :local (false) read from repository config (`.git/config`)
+        #     @option options [Boolean, nil] :local (nil) read from repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (false) read from worktree config
+        #     @option options [Boolean, nil] :worktree (nil) read from worktree config
         #
         #     @option options [String] :file (nil) read from the specified file
         #
@@ -86,21 +86,23 @@ module Git
         #
         #     @option options [String] :blob (nil) read from the specified blob
         #
-        #     @option options [Boolean] :includes (false) respect include directives in config files (`--includes`)
+        #     @option options [Boolean, nil] :includes (nil) respect include directives in
+        #       config files (`--includes`)
         #
-        #     @option options [Boolean] :no_includes (false) ignore include directives in config files (`--no-includes`)
+        #     @option options [Boolean, nil] :no_includes (nil) ignore include directives in
+        #       config files (`--no-includes`)
         #
         #     @option options [String] :type (nil) ensure values conform to the given type
         #
-        #     @option options [Boolean] :show_origin (false) show the origin of each config entry
+        #     @option options [Boolean, nil] :show_origin (nil) show the origin of each config entry
         #
-        #     @option options [Boolean] :show_scope (false) show the scope of each config entry
+        #     @option options [Boolean, nil] :show_scope (nil) show the scope of each config entry
         #
-        #     @option options [Boolean] :null (false) terminate values with NUL byte instead of newline
+        #     @option options [Boolean, nil] :null (nil) terminate values with NUL byte instead of newline
         #
         #       Alias: :z
         #
-        #     @option options [Boolean] :name_only (false) output only the names of config keys
+        #     @option options [Boolean, nil] :name_only (nil) output only the names of config keys
         #
         #     @return [Git::CommandLineResult] the result of calling `git config --get-regexp`
         #

--- a/lib/git/commands/config_option_syntax/get_urlmatch.rb
+++ b/lib/git/commands/config_option_syntax/get_urlmatch.rb
@@ -66,13 +66,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (false) read from global config (`~/.gitconfig`)
+        #     @option options [Boolean, nil] :global (nil) read from global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (false) read from system config
+        #     @option options [Boolean, nil] :system (nil) read from system config
         #
-        #     @option options [Boolean] :local (false) read from repository config (`.git/config`)
+        #     @option options [Boolean, nil] :local (nil) read from repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (false) read from worktree config
+        #     @option options [Boolean, nil] :worktree (nil) read from worktree config
         #
         #     @option options [String] :file (nil) read from the specified file
         #
@@ -82,13 +82,13 @@ module Git
         #
         #     @option options [String] :type (nil) ensure values conform to the given type
         #
-        #     @option options [Boolean] :null (false) terminate values with NUL byte instead of newline
+        #     @option options [Boolean, nil] :null (nil) terminate values with NUL byte instead of newline
         #
         #       Alias: :z
         #
-        #     @option options [Boolean] :includes (false) respect include directives in config files (`--includes`)
+        #     @option options [Boolean, nil] :includes (nil) respect include directives in config files (`--includes`)
         #
-        #     @option options [Boolean] :no_includes (false) disable include directives
+        #     @option options [Boolean, nil] :no_includes (nil) disable include directives
         #       in config files (`--no-includes`)
         #
         #     @return [Git::CommandLineResult] the result of calling `git config --get-urlmatch`

--- a/lib/git/commands/config_option_syntax/list.rb
+++ b/lib/git/commands/config_option_syntax/list.rb
@@ -64,13 +64,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (false) list only global config entries
+        #     @option options [Boolean, nil] :global (nil) list only global config entries
         #
-        #     @option options [Boolean] :system (false) list only system config entries
+        #     @option options [Boolean, nil] :system (nil) list only system config entries
         #
-        #     @option options [Boolean] :local (false) list only repository config entries
+        #     @option options [Boolean, nil] :local (nil) list only repository config entries
         #
-        #     @option options [Boolean] :worktree (false) list only worktree config entries
+        #     @option options [Boolean, nil] :worktree (nil) list only worktree config entries
         #
         #     @option options [String] :file (nil) list entries from the specified file
         #
@@ -78,21 +78,21 @@ module Git
         #
         #     @option options [String] :blob (nil) list entries from the specified blob
         #
-        #     @option options [Boolean] :includes (false) respect include directives in config files
+        #     @option options [Boolean, nil] :includes (nil) respect include directives in config files
         #       (`--includes`)
         #
-        #     @option options [Boolean] :no_includes (false) suppress include directive processing
+        #     @option options [Boolean, nil] :no_includes (nil) suppress include directive processing
         #       (`--no-includes`)
         #
-        #     @option options [Boolean] :show_origin (false) show the origin of each config entry
+        #     @option options [Boolean, nil] :show_origin (nil) show the origin of each config entry
         #
-        #     @option options [Boolean] :show_scope (false) show the scope of each config entry
+        #     @option options [Boolean, nil] :show_scope (nil) show the scope of each config entry
         #
-        #     @option options [Boolean] :null (false) terminate values with NUL byte instead of newline
+        #     @option options [Boolean, nil] :null (nil) terminate values with NUL byte instead of newline
         #
         #       Alias: :z
         #
-        #     @option options [Boolean] :name_only (false) output only the names of config keys
+        #     @option options [Boolean, nil] :name_only (nil) output only the names of config keys
         #
         #     @option options [String] :type (nil) ensure values conform to the given type
         #

--- a/lib/git/commands/config_option_syntax/remove_section.rb
+++ b/lib/git/commands/config_option_syntax/remove_section.rb
@@ -49,13 +49,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (false) remove from global config (`~/.gitconfig`)
+        #     @option options [Boolean, nil] :global (nil) remove from global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (false) remove from system config
+        #     @option options [Boolean, nil] :system (nil) remove from system config
         #
-        #     @option options [Boolean] :local (false) remove from repository config (`.git/config`)
+        #     @option options [Boolean, nil] :local (nil) remove from repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (false) remove from worktree config
+        #     @option options [Boolean, nil] :worktree (nil) remove from worktree config
         #
         #     @option options [String] :file (nil) remove from the specified file
         #

--- a/lib/git/commands/config_option_syntax/rename_section.rb
+++ b/lib/git/commands/config_option_syntax/rename_section.rb
@@ -53,13 +53,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (nil) operate on global config (`~/.gitconfig`)
+        #     @option options [Boolean, nil] :global (nil) operate on global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (nil) operate on system config
+        #     @option options [Boolean, nil] :system (nil) operate on system config
         #
-        #     @option options [Boolean] :local (nil) operate on repository config (`.git/config`)
+        #     @option options [Boolean, nil] :local (nil) operate on repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (nil) operate on worktree config
+        #     @option options [Boolean, nil] :worktree (nil) operate on worktree config
         #
         #     @option options [String] :file (nil) operate on the specified file
         #

--- a/lib/git/commands/config_option_syntax/replace_all.rb
+++ b/lib/git/commands/config_option_syntax/replace_all.rb
@@ -70,13 +70,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (false) write to global config (`~/.gitconfig`)
+        #     @option options [Boolean, nil] :global (nil) write to global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (false) write to system config
+        #     @option options [Boolean, nil] :system (nil) write to system config
         #
-        #     @option options [Boolean] :local (false) write to repository config (`.git/config`)
+        #     @option options [Boolean, nil] :local (nil) write to repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (false) write to worktree config
+        #     @option options [Boolean, nil] :worktree (nil) write to worktree config
         #
         #     @option options [String] :file (nil) write to the specified file
         #
@@ -86,11 +86,11 @@ module Git
         #
         #     @option options [String] :comment (nil) append a comment at the end of new or modified lines
         #
-        #     @option options [Boolean] :fixed_value (false) treat the value regex as an exact string
+        #     @option options [Boolean, nil] :fixed_value (nil) treat the value regex as an exact string
         #
         #     @option options [String] :type (nil) ensure the value conforms to the given type
         #
-        #     @option options [Boolean] :no_type (false) unset the previously set type specifier;
+        #     @option options [Boolean, nil] :no_type (nil) unset the previously set type specifier;
         #       `true` emits `--no-type`
         #
         #     @return [Git::CommandLineResult] the result of calling `git config --replace-all`

--- a/lib/git/commands/config_option_syntax/set.rb
+++ b/lib/git/commands/config_option_syntax/set.rb
@@ -76,19 +76,19 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :replace_all (false) replace all lines matching the key
+        #     @option options [Boolean, nil] :replace_all (nil) replace all lines matching the key
         #
-        #     @option options [Boolean] :append (false) add a new line without altering existing values
+        #     @option options [Boolean, nil] :append (nil) add a new line without altering existing values
         #
         #     @option options [String] :comment (nil) append a comment at the end of new or modified lines
         #
-        #     @option options [Boolean] :global (false) write to global config (`~/.gitconfig`)
+        #     @option options [Boolean, nil] :global (nil) write to global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (false) write to system config
+        #     @option options [Boolean, nil] :system (nil) write to system config
         #
-        #     @option options [Boolean] :local (false) write to repository config (`.git/config`)
+        #     @option options [Boolean, nil] :local (nil) write to repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (false) write to worktree config
+        #     @option options [Boolean, nil] :worktree (nil) write to worktree config
         #
         #     @option options [String] :file (nil) write to the specified file
         #
@@ -96,11 +96,11 @@ module Git
         #
         #     @option options [String] :blob (nil) read from the specified blob
         #
-        #     @option options [Boolean] :fixed_value (false) treat the value regex as an exact string
+        #     @option options [Boolean, nil] :fixed_value (nil) treat the value regex as an exact string
         #
         #     @option options [String] :type (nil) ensure the value conforms to the given type
         #
-        #     @option options [Boolean] :no_type (false) unset the previously set type specifier;
+        #     @option options [Boolean, nil] :no_type (nil) unset the previously set type specifier;
         #       `true` emits `--no-type`
         #
         #     @return [Git::CommandLineResult] the result of calling `git config`

--- a/lib/git/commands/config_option_syntax/unset.rb
+++ b/lib/git/commands/config_option_syntax/unset.rb
@@ -62,13 +62,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (false) remove from global config (`~/.gitconfig`)
+        #     @option options [Boolean, nil] :global (nil) remove from global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (false) remove from system config
+        #     @option options [Boolean, nil] :system (nil) remove from system config
         #
-        #     @option options [Boolean] :local (false) remove from repository config (`.git/config`)
+        #     @option options [Boolean, nil] :local (nil) remove from repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (false) remove from worktree config
+        #     @option options [Boolean, nil] :worktree (nil) remove from worktree config
         #
         #     @option options [String] :file (nil) remove from the specified file
         #
@@ -76,7 +76,7 @@ module Git
         #
         #     @option options [String] :blob (nil) read from the specified blob
         #
-        #     @option options [Boolean] :fixed_value (false) treat the value regex as an exact string
+        #     @option options [Boolean, nil] :fixed_value (nil) treat the value regex as an exact string
         #
         #     @return [Git::CommandLineResult] the result of calling `git config --unset`
         #

--- a/lib/git/commands/config_option_syntax/unset_all.rb
+++ b/lib/git/commands/config_option_syntax/unset_all.rb
@@ -62,13 +62,13 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :global (false) remove from global config (`~/.gitconfig`)
+        #     @option options [Boolean, nil] :global (nil) remove from global config (`~/.gitconfig`)
         #
-        #     @option options [Boolean] :system (false) remove from system config
+        #     @option options [Boolean, nil] :system (nil) remove from system config
         #
-        #     @option options [Boolean] :local (false) remove from repository config (`.git/config`)
+        #     @option options [Boolean, nil] :local (nil) remove from repository config (`.git/config`)
         #
-        #     @option options [Boolean] :worktree (false) remove from worktree config
+        #     @option options [Boolean, nil] :worktree (nil) remove from worktree config
         #
         #     @option options [String] :file (nil) remove from the specified file
         #
@@ -76,7 +76,7 @@ module Git
         #
         #     @option options [String] :blob (nil) read from the specified blob
         #
-        #     @option options [Boolean] :fixed_value (false) treat the value regex as an exact string
+        #     @option options [Boolean, nil] :fixed_value (nil) treat the value regex as an exact string
         #
         #     @return [Git::CommandLineResult] the result of calling `git config --unset-all`
         #

--- a/lib/git/commands/describe.rb
+++ b/lib/git/commands/describe.rb
@@ -77,29 +77,29 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :all (false) use any ref found in the
+      #     @option options [Boolean, nil] :all (nil) use any ref found in the
       #       `refs/` namespace, not just tags
       #
-      #     @option options [Boolean] :tags (false) use any tag found in the
+      #     @option options [Boolean, nil] :tags (nil) use any tag found in the
       #       `refs/tags` namespace, instead of only annotated tags
       #
-      #     @option options [Boolean] :contains (false) find the tag that
+      #     @option options [Boolean, nil] :contains (nil) find the tag that
       #       comes after the commit and thus contains it, rather than the
       #       most recent tag reachable from it
       #
-      #     @option options [Boolean, String] :abbrev (nil) use this many
+      #     @option options [Boolean, String, nil] :abbrev (nil) use this many
       #       digits for the abbreviated commit object name
       #
       #       When `true`, emits bare `--abbrev` (which uses git's default
       #       length). Pass a string to emit `--abbrev=<n>`.
       #
-      #     @option options [Boolean, String] :dirty (nil) describe the
+      #     @option options [Boolean, String, nil] :dirty (nil) describe the
       #       working tree
       #
       #       When `true`, appends `-dirty`; when a String, appends that
       #       string as the dirty mark. Maps to `--dirty[=<mark>]`.
       #
-      #     @option options [Boolean, String] :broken (nil) describe the
+      #     @option options [Boolean, String, nil] :broken (nil) describe the
       #       working tree, treating broken links as dirty
       #
       #       When `true`, appends `-broken`; when a String, appends that
@@ -112,13 +112,13 @@ module Git
       #       longer time but may produce a more accurate result. Maps to
       #       `--candidates=<n>`.
       #
-      #     @option options [Boolean] :exact_match (false) only output exact
+      #     @option options [Boolean, nil] :exact_match (nil) only output exact
       #       matches (a tag directly references the supplied commit object)
       #
-      #     @option options [Boolean] :debug (false) verbosely display
+      #     @option options [Boolean, nil] :debug (nil) verbosely display
       #       information about the searching strategy being employed
       #
-      #     @option options [Boolean] :long (false) always output the long
+      #     @option options [Boolean, nil] :long (nil) always output the long
       #       format (the tag, the number of commits, and the abbreviated
       #       object name) even when it matches a tag exactly
       #
@@ -134,11 +134,11 @@ module Git
       #       Pass an array to exclude multiple patterns. Maps to
       #       `--exclude <pattern>`.
       #
-      #     @option options [Boolean] :always (false) show uniquely
+      #     @option options [Boolean, nil] :always (nil) show uniquely
       #       abbreviated commit object as fallback when the commit cannot
       #       be described
       #
-      #     @option options [Boolean] :first_parent (false) follow only the
+      #     @option options [Boolean, nil] :first_parent (nil) follow only the
       #       first parent of a merge commit
       #
       #     @return [Git::CommandLineResult] the result of calling

--- a/lib/git/commands/diff.rb
+++ b/lib/git/commands/diff.rb
@@ -259,11 +259,11 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :patch (false) generate patch output
+      #     @option options [Boolean, nil] :patch (nil) generate patch output
       #
       #       Alias: :p, :u
       #
-      #     @option options [Boolean] :no_patch (false) suppress all diff
+      #     @option options [Boolean, nil] :no_patch (nil) suppress all diff
       #       output
       #
       #       Alias: :s
@@ -285,25 +285,25 @@ module Git
       #     @option options [String] :output_indicator_context (nil)
       #       character to indicate context lines in the patch
       #
-      #     @option options [Boolean] :raw (false) generate the diff in raw
+      #     @option options [Boolean, nil] :raw (nil) generate the diff in raw
       #       format
       #
-      #     @option options [Boolean] :patch_with_raw (false) synonym for
+      #     @option options [Boolean, nil] :patch_with_raw (nil) synonym for
       #       `--patch --raw`
       #
-      #     @option options [Boolean] :indent_heuristic (false) enable the
+      #     @option options [Boolean, nil] :indent_heuristic (nil) enable the
       #       indent heuristic for patch readability (`--indent-heuristic`)
       #
-      #     @option options [Boolean] :no_indent_heuristic (false) disable
+      #     @option options [Boolean, nil] :no_indent_heuristic (nil) disable
       #       the indent heuristic (`--no-indent-heuristic`)
       #
-      #     @option options [Boolean] :minimal (false) spend extra time to
+      #     @option options [Boolean, nil] :minimal (nil) spend extra time to
       #       produce the smallest possible diff
       #
-      #     @option options [Boolean] :patience (false) use the patience
+      #     @option options [Boolean, nil] :patience (nil) use the patience
       #       diff algorithm
       #
-      #     @option options [Boolean] :histogram (false) use the histogram
+      #     @option options [Boolean, nil] :histogram (nil) use the histogram
       #       diff algorithm
       #
       #     @option options [String, Array<String>] :anchored (nil)
@@ -315,7 +315,7 @@ module Git
       #     @option options [String] :diff_algorithm (nil) choose a diff
       #       algorithm (`patience`, `minimal`, `histogram`, or `myers`)
       #
-      #     @option options [Boolean, String] :stat (nil) generate a
+      #     @option options [Boolean, String, nil] :stat (nil) generate a
       #       diffstat
       #
       #       Pass `true` for `--stat`; pass a string like
@@ -333,16 +333,16 @@ module Git
       #     @option options [Integer, String] :stat_graph_width (nil) limit
       #       the graph width of `--stat` output
       #
-      #     @option options [Boolean] :compact_summary (false) output a
+      #     @option options [Boolean, nil] :compact_summary (nil) output a
       #       condensed summary of extended header information
       #
-      #     @option options [Boolean] :numstat (false) show per-file
+      #     @option options [Boolean, nil] :numstat (nil) show per-file
       #       insertion/deletion counts in decimal notation
       #
-      #     @option options [Boolean] :shortstat (false) output only the
+      #     @option options [Boolean, nil] :shortstat (nil) output only the
       #       aggregate totals line from `--stat`
       #
-      #     @option options [Boolean, String] :dirstat (nil) output the
+      #     @option options [Boolean, String, nil] :dirstat (nil) output the
       #       distribution of relative amount of changes per sub-directory
       #
       #       Pass `true` for `--dirstat`; pass a string like
@@ -350,63 +350,63 @@ module Git
       #
       #       Alias: :X
       #
-      #     @option options [Boolean] :cumulative (false) synonym for
+      #     @option options [Boolean, nil] :cumulative (nil) synonym for
       #       `--dirstat=cumulative`
       #
-      #     @option options [Boolean, String] :dirstat_by_file (nil)
+      #     @option options [Boolean, String, nil] :dirstat_by_file (nil)
       #       synonym for `--dirstat=files,...`
       #
-      #     @option options [Boolean] :summary (false) output a condensed
+      #     @option options [Boolean, nil] :summary (nil) output a condensed
       #       summary of extended header information
       #
-      #     @option options [Boolean] :patch_with_stat (false) synonym for
+      #     @option options [Boolean, nil] :patch_with_stat (nil) synonym for
       #       `--patch --stat`
       #
-      #     @option options [Boolean] :z (false) use NUL as output field
+      #     @option options [Boolean, nil] :z (nil) use NUL as output field
       #       terminators
       #
-      #     @option options [Boolean] :name_only (false) show only the name
+      #     @option options [Boolean, nil] :name_only (nil) show only the name
       #       of each changed file
       #
-      #     @option options [Boolean] :name_status (false) show only the
+      #     @option options [Boolean, nil] :name_status (nil) show only the
       #       name and status of each changed file
       #
-      #     @option options [Boolean, String] :submodule (nil) specify how
+      #     @option options [Boolean, String, nil] :submodule (nil) specify how
       #       differences in submodules are shown
       #
       #       Pass `true` for `--submodule`; pass a string like `'log'`
       #       or `'diff'` for `--submodule=<format>`.
       #
-      #     @option options [Boolean, String] :color (false) show colored
+      #     @option options [Boolean, String, nil] :color (nil) show colored
       #       diff
       #
       #       Pass `true` for `--color` or a string like `'always'` for
       #       `--color=always`.
       #
-      #     @option options [Boolean] :no_color (false) disable colored
+      #     @option options [Boolean, nil] :no_color (nil) disable colored
       #       diff (`--no-color`)
       #
-      #     @option options [Boolean, String] :color_moved (false) color
+      #     @option options [Boolean, String, nil] :color_moved (nil) color
       #       moved lines differently
       #
       #       Pass `true` for `--color-moved` or a string like `'zebra'`
       #       for `--color-moved=zebra`.
       #
-      #     @option options [Boolean] :no_color_moved (false) disable
+      #     @option options [Boolean, nil] :no_color_moved (nil) disable
       #       coloring moved lines (`--no-color-moved`)
       #
-      #     @option options [Boolean, String] :color_moved_ws (false)
+      #     @option options [Boolean, String, nil] :color_moved_ws (nil)
       #       configure how whitespace is handled for move detection
       #
       #       Pass `true` for `--color-moved-ws` or a string like
       #       `'ignore-all-space'` for
       #       `--color-moved-ws=ignore-all-space`.
       #
-      #     @option options [Boolean] :no_color_moved_ws (false) disable
+      #     @option options [Boolean, nil] :no_color_moved_ws (nil) disable
       #       whitespace handling for move detection
       #       (`--no-color-moved-ws`)
       #
-      #     @option options [Boolean, String] :word_diff (nil) show a
+      #     @option options [Boolean, String, nil] :word_diff (nil) show a
       #       word diff
       #
       #       Pass `true` for `--word-diff`; pass a string like `'color'`
@@ -415,55 +415,55 @@ module Git
       #     @option options [String] :word_diff_regex (nil) use this regex
       #       to decide what a word is
       #
-      #     @option options [Boolean, String] :color_words (nil) equivalent
+      #     @option options [Boolean, String, nil] :color_words (nil) equivalent
       #       to `--word-diff=color` plus optional regex
       #
-      #     @option options [Boolean] :no_renames (false) turn off rename
+      #     @option options [Boolean, nil] :no_renames (nil) turn off rename
       #       detection
       #
-      #     @option options [Boolean] :rename_empty (false) use empty blobs
+      #     @option options [Boolean, nil] :rename_empty (nil) use empty blobs
       #       as rename source (`--rename-empty`)
       #
-      #     @option options [Boolean] :no_rename_empty (false) do not use
+      #     @option options [Boolean, nil] :no_rename_empty (nil) do not use
       #       empty blobs as rename source (`--no-rename-empty`)
       #
-      #     @option options [Boolean] :check (false) warn if changes
+      #     @option options [Boolean, nil] :check (nil) warn if changes
       #       introduce conflict markers or whitespace errors
       #
       #     @option options [String] :ws_error_highlight (nil) highlight
       #       whitespace errors in `context`, `old`, or `new` lines
       #
-      #     @option options [Boolean] :full_index (false) show full
+      #     @option options [Boolean, nil] :full_index (nil) show full
       #       pre- and post-image blob object names
       #
-      #     @option options [Boolean] :binary (false) output a binary diff
+      #     @option options [Boolean, nil] :binary (nil) output a binary diff
       #       that can be applied with `git apply`
       #
-      #     @option options [Boolean, String] :abbrev (nil) show only a
+      #     @option options [Boolean, String, nil] :abbrev (nil) show only a
       #       partial prefix of object names
       #
       #       Pass `true` for `--abbrev`; pass a string for
       #       `--abbrev=<n>`.
       #
-      #     @option options [Boolean, String] :break_rewrites (nil) break
+      #     @option options [Boolean, String, nil] :break_rewrites (nil) break
       #       complete rewrite changes into delete/create pairs
       #
       #       Alias: :B
       #
-      #     @option options [Boolean, String] :find_renames (nil) detect
+      #     @option options [Boolean, String, nil] :find_renames (nil) detect
       #       renames, optionally specifying a similarity threshold
       #
       #       Alias: :M
       #
-      #     @option options [Boolean, String] :find_copies (nil) detect
+      #     @option options [Boolean, String, nil] :find_copies (nil) detect
       #       copies as well as renames
       #
       #       Alias: :C
       #
-      #     @option options [Boolean] :find_copies_harder (false) inspect
+      #     @option options [Boolean, nil] :find_copies_harder (nil) inspect
       #       all files as candidates for the source of copy
       #
-      #     @option options [Boolean] :irreversible_delete (false) omit
+      #     @option options [Boolean, nil] :irreversible_delete (nil) omit
       #       the preimage for deletes
       #
       #       Alias: :D
@@ -484,10 +484,10 @@ module Git
       #       differences that change the number of occurrences of an
       #       object
       #
-      #     @option options [Boolean] :pickaxe_all (false) when `-S` or
+      #     @option options [Boolean, nil] :pickaxe_all (nil) when `-S` or
       #       `-G` finds a change, show all changes in that changeset
       #
-      #     @option options [Boolean] :pickaxe_regex (false) treat the
+      #     @option options [Boolean, nil] :pickaxe_regex (nil) treat the
       #       `-S` string as an extended POSIX regular expression
       #
       #     @option options [String] :O (nil) control the order in which
@@ -499,40 +499,40 @@ module Git
       #     @option options [String] :rotate_to (nil) move files before
       #       the named file to the end of the output
       #
-      #     @option options [Boolean] :R (false) swap two inputs (reverse
+      #     @option options [Boolean, nil] :R (nil) swap two inputs (reverse
       #       diff)
       #
-      #     @option options [Boolean, String] :relative (false) show
+      #     @option options [Boolean, String, nil] :relative (nil) show
       #       pathnames relative to a subdirectory
       #
       #       Pass `true` for `--relative` or a string for
       #       `--relative=<path>`.
       #
-      #     @option options [Boolean] :no_relative (false) show pathnames
+      #     @option options [Boolean, nil] :no_relative (nil) show pathnames
       #       relative to the working directory (`--no-relative`)
       #
-      #     @option options [Boolean] :text (false) treat all files as
+      #     @option options [Boolean, nil] :text (nil) treat all files as
       #       text
       #
       #       Alias: :a
       #
-      #     @option options [Boolean] :ignore_cr_at_eol (false) ignore
+      #     @option options [Boolean, nil] :ignore_cr_at_eol (nil) ignore
       #       carriage-return at end of line
       #
-      #     @option options [Boolean] :ignore_space_at_eol (false) ignore
+      #     @option options [Boolean, nil] :ignore_space_at_eol (nil) ignore
       #       changes in whitespace at end of line
       #
-      #     @option options [Boolean] :ignore_space_change (false) ignore
+      #     @option options [Boolean, nil] :ignore_space_change (nil) ignore
       #       changes in amount of whitespace
       #
       #       Alias: :b
       #
-      #     @option options [Boolean] :ignore_all_space (false) ignore
+      #     @option options [Boolean, nil] :ignore_all_space (nil) ignore
       #       whitespace when comparing lines
       #
       #       Alias: :w
       #
-      #     @option options [Boolean] :ignore_blank_lines (false) ignore
+      #     @option options [Boolean, nil] :ignore_blank_lines (nil) ignore
       #       changes whose lines are all blank
       #
       #     @option options [String, Array<String>] :ignore_matching_lines
@@ -546,31 +546,31 @@ module Git
       #     @option options [Integer, String] :inter_hunk_context (nil)
       #       show the context between diff hunks, fusing nearby hunks
       #
-      #     @option options [Boolean] :function_context (false) show whole
+      #     @option options [Boolean, nil] :function_context (nil) show whole
       #       function as context lines for each change
       #
       #       Alias: :W
       #
-      #     @option options [Boolean] :exit_code (false) make the program
+      #     @option options [Boolean, nil] :exit_code (nil) make the program
       #       exit with codes similar to `diff(1)`
       #
-      #     @option options [Boolean] :quiet (false) disable all output of
+      #     @option options [Boolean, nil] :quiet (nil) disable all output of
       #       the program
       #
-      #     @option options [Boolean] :ext_diff (false) allow an external
+      #     @option options [Boolean, nil] :ext_diff (nil) allow an external
       #       diff helper (`--ext-diff`)
       #
-      #     @option options [Boolean] :no_ext_diff (false) disallow an
+      #     @option options [Boolean, nil] :no_ext_diff (nil) disallow an
       #       external diff helper (`--no-ext-diff`)
       #
-      #     @option options [Boolean] :textconv (false) allow external
+      #     @option options [Boolean, nil] :textconv (nil) allow external
       #       text conversion filters for binary files (`--textconv`)
       #
-      #     @option options [Boolean] :no_textconv (false) disallow
+      #     @option options [Boolean, nil] :no_textconv (nil) disallow
       #       external text conversion filters for binary files
       #       (`--no-textconv`)
       #
-      #     @option options [Boolean, String] :ignore_submodules (nil)
+      #     @option options [Boolean, String, nil] :ignore_submodules (nil)
       #       ignore changes to submodules in the diff
       #
       #       Pass `true` for `--ignore-submodules`; pass a string like
@@ -582,60 +582,60 @@ module Git
       #     @option options [String] :dst_prefix (nil) destination prefix
       #       for diff headers (e.g. `'b/'`)
       #
-      #     @option options [Boolean] :no_prefix (false) do not show any
+      #     @option options [Boolean, nil] :no_prefix (nil) do not show any
       #       source or destination prefix
       #
-      #     @option options [Boolean] :default_prefix (false) use the
+      #     @option options [Boolean, nil] :default_prefix (nil) use the
       #       default source and destination prefixes
       #
       #     @option options [String] :line_prefix (nil) prepend an
       #       additional prefix to every line of output
       #
-      #     @option options [Boolean] :ita_invisible_in_index (false) make
+      #     @option options [Boolean, nil] :ita_invisible_in_index (nil) make
       #       intent-to-add entries appear as new files in `git diff`
       #
-      #     @option options [Boolean] :ita_visible_in_index (false) revert
+      #     @option options [Boolean, nil] :ita_visible_in_index (nil) revert
       #       `--ita-invisible-in-index`
       #
       #     @option options [Integer, String] :max_depth (nil) descend at
       #       most this many levels of directories per pathspec
       #
-      #     @option options [Boolean] :cached (false) compare the index to
+      #     @option options [Boolean, nil] :cached (nil) compare the index to
       #       HEAD or a named commit
       #
       #       Alias: :staged
       #
-      #     @option options [Boolean] :merge_base (false) use merge base
+      #     @option options [Boolean, nil] :merge_base (nil) use merge base
       #       of commits
       #
-      #     @option options [Boolean] :no_index (false) compare two
+      #     @option options [Boolean, nil] :no_index (nil) compare two
       #       filesystem paths outside a repo
       #
-      #     @option options [Boolean] :base (false) compare working tree
+      #     @option options [Boolean, nil] :base (nil) compare working tree
       #       with the base version (stage #1)
       #
       #       Alias: :"1"
       #
-      #     @option options [Boolean] :ours (false) compare working tree
+      #     @option options [Boolean, nil] :ours (nil) compare working tree
       #       with our branch (stage #2)
       #
       #       Alias: :"2"
       #
-      #     @option options [Boolean] :theirs (false) compare working tree
+      #     @option options [Boolean, nil] :theirs (nil) compare working tree
       #       with their branch (stage #3)
       #
       #       Alias: :"3"
       #
-      #     @option options [Boolean] :"0" (false) omit diff output for
+      #     @option options [Boolean, nil] :"0" (nil) omit diff output for
       #       unmerged entries
       #
-      #     @option options [Boolean] :c (false) produce a combined diff
+      #     @option options [Boolean, nil] :c (nil) produce a combined diff
       #       (useful when showing a merge)
       #
-      #     @option options [Boolean] :cc (false) produce a dense combined
+      #     @option options [Boolean, nil] :cc (nil) produce a dense combined
       #       diff (useful when showing a merge)
       #
-      #     @option options [Boolean] :combined_all_paths (false) show
+      #     @option options [Boolean, nil] :combined_all_paths (nil) show
       #       paths from all parents of a combined diff
       #
       #     @option options [Array<String>] :path (nil) zero or more paths

--- a/lib/git/commands/diff_files.rb
+++ b/lib/git/commands/diff_files.rb
@@ -160,43 +160,43 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :q (false) do not complain about nonexistent files; only
+      #     @option options [Boolean, nil] :q (nil) do not complain about nonexistent files; only
       #       report exit status
       #
-      #     @option options [Boolean] :unmerged (false) for unmerged entries, suppress diff output
+      #     @option options [Boolean, nil] :unmerged (nil) for unmerged entries, suppress diff output
       #       and show only "Unmerged"
       #
-      #     @option options [Boolean] :base (false) for unmerged entries, diff against stage 1
+      #     @option options [Boolean, nil] :base (nil) for unmerged entries, diff against stage 1
       #       (common ancestor)
       #
       #       Short form: `-1`
       #
-      #     @option options [Boolean] :ours (false) for unmerged entries, diff against stage 2
+      #     @option options [Boolean, nil] :ours (nil) for unmerged entries, diff against stage 2
       #       (our changes)
       #
       #       Short form: `-2`
       #
-      #     @option options [Boolean] :theirs (false) for unmerged entries, diff against stage 3
+      #     @option options [Boolean, nil] :theirs (nil) for unmerged entries, diff against stage 3
       #       (their changes)
       #
       #       Short form: `-3`
       #
-      #     @option options [Boolean] :c (false) for unmerged entries, show a combined diff of
+      #     @option options [Boolean, nil] :c (nil) for unmerged entries, show a combined diff of
       #       stage 2, stage 3, and the working tree
       #
-      #     @option options [Boolean] :cc (false) synonym for `c: true`
+      #     @option options [Boolean, nil] :cc (nil) synonym for `c: true`
       #
-      #     @option options [Boolean] :patch (false) generate unified diff patch output
+      #     @option options [Boolean, nil] :patch (nil) generate unified diff patch output
       #
       #       Alias: :p, :u
       #
-      #     @option options [Boolean] :no_patch (false) suppress all diff output
+      #     @option options [Boolean, nil] :no_patch (nil) suppress all diff output
       #
       #       Alias: :s
       #
-      #     @option options [Boolean] :raw (false) generate diff in raw format (default output)
+      #     @option options [Boolean, nil] :raw (nil) generate diff in raw format (default output)
       #
-      #     @option options [Boolean] :patch_with_raw (false) synonym for `patch: true, raw: true`
+      #     @option options [Boolean, nil] :patch_with_raw (nil) synonym for `patch: true, raw: true`
       #
       #     @option options [Integer, String] :unified (nil) number of context lines around diff
       #       hunks
@@ -212,17 +212,17 @@ module Git
       #     @option options [String] :output_indicator_context (nil) character for context lines in
       #       patch output
       #
-      #     @option options [Boolean] :indent_heuristic (false) shift hunk boundaries for readability
+      #     @option options [Boolean, nil] :indent_heuristic (nil) shift hunk boundaries for readability
       #       (`--indent-heuristic`)
       #
-      #     @option options [Boolean] :no_indent_heuristic (false) do not shift hunk boundaries
+      #     @option options [Boolean, nil] :no_indent_heuristic (nil) do not shift hunk boundaries
       #       for readability (`--no-indent-heuristic`)
       #
-      #     @option options [Boolean] :minimal (false) spend extra time to minimize diff size
+      #     @option options [Boolean, nil] :minimal (nil) spend extra time to minimize diff size
       #
-      #     @option options [Boolean] :patience (false) use patience diff algorithm
+      #     @option options [Boolean, nil] :patience (nil) use patience diff algorithm
       #
-      #     @option options [Boolean] :histogram (false) use histogram diff algorithm
+      #     @option options [Boolean, nil] :histogram (nil) use histogram diff algorithm
       #
       #     @option options [String, Array<String>] :anchored (nil) anchor lines matching the
       #       given text (repeatable)
@@ -231,7 +231,7 @@ module Git
       #
       #       Accepted values: `'default'`, `'myers'`, `'minimal'`, `'patience'`, `'histogram'`.
       #
-      #     @option options [Boolean, String] :stat (nil) show a diffstat
+      #     @option options [Boolean, String, nil] :stat (nil) show a diffstat
       #
       #       Pass `true` for the default format, or a string like `'80,40,5'` for custom limits.
       #
@@ -245,56 +245,56 @@ module Git
       #
       #     @option options [Integer, String] :stat_count (nil) limit diffstat to this many lines
       #
-      #     @option options [Boolean] :compact_summary (false) include creation/deletion mode
+      #     @option options [Boolean, nil] :compact_summary (nil) include creation/deletion mode
       #       changes in stat
       #
-      #     @option options [Boolean] :numstat (false) show per-file insertion/deletion counts
+      #     @option options [Boolean, nil] :numstat (nil) show per-file insertion/deletion counts
       #       (machine-friendly)
       #
-      #     @option options [Boolean] :shortstat (false) show aggregate totals line only
+      #     @option options [Boolean, nil] :shortstat (nil) show aggregate totals line only
       #
-      #     @option options [Boolean, String] :dirstat (nil) show distribution of changes per
+      #     @option options [Boolean, String, nil] :dirstat (nil) show distribution of changes per
       #       directory
       #
       #       Pass `true` for the default, or a string like `'lines,cumulative,10'` for params.
       #
       #       Alias: :X
       #
-      #     @option options [Boolean] :cumulative (false) synonym for `dirstat: 'cumulative'`
+      #     @option options [Boolean, nil] :cumulative (nil) synonym for `dirstat: 'cumulative'`
       #
-      #     @option options [Boolean, String] :dirstat_by_file (nil) synonym for
+      #     @option options [Boolean, String, nil] :dirstat_by_file (nil) synonym for
       #       `dirstat: 'files,...'`
       #
-      #     @option options [Boolean] :summary (false) show condensed extended header information
+      #     @option options [Boolean, nil] :summary (nil) show condensed extended header information
       #
-      #     @option options [Boolean] :patch_with_stat (false) synonym for
+      #     @option options [Boolean, nil] :patch_with_stat (nil) synonym for
       #       `patch: true, stat: true`
       #
-      #     @option options [Boolean] :z (false) use NUL as output field terminator instead of
+      #     @option options [Boolean, nil] :z (nil) use NUL as output field terminator instead of
       #       newline
       #
-      #     @option options [Boolean] :name_only (false) show only changed file names
+      #     @option options [Boolean, nil] :name_only (nil) show only changed file names
       #
-      #     @option options [Boolean] :name_status (false) show changed file names with status
+      #     @option options [Boolean, nil] :name_status (nil) show changed file names with status
       #       letters
       #
-      #     @option options [Boolean, String] :submodule (nil) how to show submodule differences
+      #     @option options [Boolean, String, nil] :submodule (nil) how to show submodule differences
       #
       #       Pass `true` for the default, or a string like `'log'` or `'diff'` for a format
       #       name.
       #
-      #     @option options [Boolean, String] :color (false) control diff colorization (`--color`)
+      #     @option options [Boolean, String, nil] :color (nil) control diff colorization (`--color`)
       #
       #       Pass `true` for `--color` or a string like `'always'` or `'auto'` for a specific mode.
       #
-      #     @option options [Boolean] :no_color (false) suppress colorized output (`--no-color`)
+      #     @option options [Boolean, nil] :no_color (nil) suppress colorized output (`--no-color`)
       #
-      #     @option options [Boolean, String] :color_moved (false) color moved lines differently
+      #     @option options [Boolean, String, nil] :color_moved (nil) color moved lines differently
       #       (`--color-moved`)
       #
       #       Pass `true` for the default, or a mode string such as `'zebra'` or `'dimmed-zebra'`.
       #
-      #     @option options [Boolean] :no_color_moved (false) disable moved-line coloring (`--no-color-moved`)
+      #     @option options [Boolean, nil] :no_color_moved (nil) disable moved-line coloring (`--no-color-moved`)
       #
       #     @option options [String] :color_moved_ws (nil) whitespace handling for moved-line
       #       color detection
@@ -302,10 +302,10 @@ module Git
       #       Comma-separated list of modes, e.g.
       #       `'ignore-space-at-eol,ignore-space-change'`.
       #
-      #     @option options [Boolean] :no_color_moved_ws (false) synonym for
+      #     @option options [Boolean, nil] :no_color_moved_ws (nil) synonym for
       #       `color_moved_ws: 'no'`
       #
-      #     @option options [Boolean, String] :word_diff (nil) show a word-level diff
+      #     @option options [Boolean, String, nil] :word_diff (nil) show a word-level diff
       #
       #       Pass `true` for the default `plain` mode, or a string like `'color'`,
       #       `'porcelain'`, or `'none'` for a specific mode.
@@ -313,26 +313,26 @@ module Git
       #     @option options [String] :word_diff_regex (nil) regular expression defining word
       #       boundaries for word diff
       #
-      #     @option options [Boolean, String] :color_words (nil) equivalent to
+      #     @option options [Boolean, String, nil] :color_words (nil) equivalent to
       #       `word_diff: 'color'` plus an optional word regex
       #
-      #     @option options [Boolean] :ignore_cr_at_eol (false) ignore carriage-return at end
+      #     @option options [Boolean, nil] :ignore_cr_at_eol (nil) ignore carriage-return at end
       #       of line
       #
-      #     @option options [Boolean] :ignore_space_at_eol (false) ignore whitespace changes
+      #     @option options [Boolean, nil] :ignore_space_at_eol (nil) ignore whitespace changes
       #       at end of line
       #
-      #     @option options [Boolean] :ignore_space_change (false) ignore changes in amount of
+      #     @option options [Boolean, nil] :ignore_space_change (nil) ignore changes in amount of
       #       whitespace
       #
       #       Alias: :b
       #
-      #     @option options [Boolean] :ignore_all_space (false) ignore all whitespace when
+      #     @option options [Boolean, nil] :ignore_all_space (nil) ignore all whitespace when
       #       comparing lines
       #
       #       Alias: :w
       #
-      #     @option options [Boolean] :ignore_blank_lines (false) ignore changes whose lines
+      #     @option options [Boolean, nil] :ignore_blank_lines (nil) ignore changes whose lines
       #       are all blank
       #
       #     @option options [String, Array<String>] :ignore_matching_lines (nil) ignore changes
@@ -340,43 +340,43 @@ module Git
       #
       #       Alias: :I
       #
-      #     @option options [Boolean] :check (false) warn if changes introduce whitespace errors
+      #     @option options [Boolean, nil] :check (nil) warn if changes introduce whitespace errors
       #       or conflict markers
       #
       #     @option options [String] :ws_error_highlight (nil) highlight whitespace errors in
       #       the given diff line types (e.g. `'new'`, `'old,new'`, `'all'`)
       #
-      #     @option options [Boolean] :no_renames (false) disable rename detection
+      #     @option options [Boolean, nil] :no_renames (nil) disable rename detection
       #
-      #     @option options [Boolean] :rename_empty (false) use empty blobs as rename sources
+      #     @option options [Boolean, nil] :rename_empty (nil) use empty blobs as rename sources
       #       (`--rename-empty`)
       #
-      #     @option options [Boolean] :no_rename_empty (false) disallow empty blobs as rename
+      #     @option options [Boolean, nil] :no_rename_empty (nil) disallow empty blobs as rename
       #       sources (`--no-rename-empty`)
       #
-      #     @option options [Boolean] :full_index (false) show full blob SHA in index line
+      #     @option options [Boolean, nil] :full_index (nil) show full blob SHA in index line
       #
-      #     @option options [Boolean] :binary (false) output binary diff suitable for
+      #     @option options [Boolean, nil] :binary (nil) output binary diff suitable for
       #       `git apply`
       #
-      #     @option options [Boolean, String] :abbrev (nil) abbreviate blob names in raw output
+      #     @option options [Boolean, String, nil] :abbrev (nil) abbreviate blob names in raw output
       #
       #       Pass `true` for the default, or an integer string like `'10'` for a specific
       #       length.
       #
-      #     @option options [Boolean, String] :break_rewrites (nil) break total rewrites into
+      #     @option options [Boolean, String, nil] :break_rewrites (nil) break total rewrites into
       #       delete-and-create pairs
       #
       #       Alias: :B
       #
-      #     @option options [Boolean, String] :find_renames (nil) detect renames
+      #     @option options [Boolean, String, nil] :find_renames (nil) detect renames
       #
       #       Pass `true` for the default threshold, or a string like `'90%'` for a custom
       #       similarity threshold.
       #
       #       Alias: :M
       #
-      #     @option options [Boolean, String] :find_copies (nil) detect copies as well as
+      #     @option options [Boolean, String, nil] :find_copies (nil) detect copies as well as
       #       renames
       #
       #       Pass `true` for the default threshold, or a string like `'75%'` for a custom
@@ -384,10 +384,10 @@ module Git
       #
       #       Alias: :C
       #
-      #     @option options [Boolean] :find_copies_harder (false) inspect all unmodified files
+      #     @option options [Boolean, nil] :find_copies_harder (nil) inspect all unmodified files
       #       as copy sources (very expensive for large repos)
       #
-      #     @option options [Boolean] :irreversible_delete (false) omit preimage for deleted
+      #     @option options [Boolean, nil] :irreversible_delete (nil) omit preimage for deleted
       #       files
       #
       #       Alias: :D
@@ -410,10 +410,10 @@ module Git
       #     @option options [String] :find_object (nil) find changes involving the given
       #       object id
       #
-      #     @option options [Boolean] :pickaxe_all (false) show all changes in a changeset
+      #     @option options [Boolean, nil] :pickaxe_all (nil) show all changes in a changeset
       #       when using `-S` or `-G`
       #
-      #     @option options [Boolean] :pickaxe_regex (false) treat the `-S` string as an
+      #     @option options [Boolean, nil] :pickaxe_regex (nil) treat the `-S` string as an
       #       extended POSIX regular expression
       #
       #     @option options [String] :O (nil) path to an orderfile controlling output file
@@ -425,44 +425,46 @@ module Git
       #     @option options [String] :rotate_to (nil) move files before the named file to end
       #       of output
       #
-      #     @option options [Boolean] :R (false) swap the two diff inputs
+      #     @option options [Boolean, nil] :R (nil) swap the two diff inputs
       #
-      #     @option options [Boolean, String] :relative (false) show paths relative to a
+      #     @option options [Boolean, String, nil] :relative (nil) show paths relative to a
       #       directory (`--relative`)
       #
       #       Pass `true` to use the current directory, or a path string to name the directory
       #       explicitly.
       #
-      #     @option options [Boolean] :no_relative (false) use absolute paths in output (`--no-relative`)
+      #     @option options [Boolean, nil] :no_relative (nil) use absolute paths in output (`--no-relative`)
       #
-      #     @option options [Boolean] :text (false) treat all files as text
+      #     @option options [Boolean, nil] :text (nil) treat all files as text
       #
       #       Alias: :a
       #
       #     @option options [Integer, String] :inter_hunk_context (nil) show context between
       #       diff hunks up to this many lines, fusing close hunks
       #
-      #     @option options [Boolean] :function_context (false) show whole function as context
+      #     @option options [Boolean, nil] :function_context (nil) show whole function as context
       #       for each change
       #
       #       Alias: :W
       #
-      #     @option options [Boolean] :exit_code (false) exit with status 1 if differences
+      #     @option options [Boolean, nil] :exit_code (nil) exit with status 1 if differences
       #       are found, 0 if none
       #
-      #     @option options [Boolean] :quiet (false) suppress all output
+      #     @option options [Boolean, nil] :quiet (nil) suppress all output
       #
       #       Implies `--exit-code`.
       #
-      #     @option options [Boolean] :ext_diff (false) allow external diff helpers (`--ext-diff`)
+      #     @option options [Boolean, nil] :ext_diff (nil) allow external diff helpers (`--ext-diff`)
       #
-      #     @option options [Boolean] :no_ext_diff (false) disallow external diff helpers (`--no-ext-diff`)
+      #     @option options [Boolean, nil] :no_ext_diff (nil) disallow external diff helpers (`--no-ext-diff`)
       #
-      #     @option options [Boolean] :textconv (false) allow external text-conversion filters (`--textconv`)
+      #     @option options [Boolean, nil] :textconv (nil) allow external text-conversion
+      #       filters (`--textconv`)
       #
-      #     @option options [Boolean] :no_textconv (false) disallow external text-conversion filters (`--no-textconv`)
+      #     @option options [Boolean, nil] :no_textconv (nil) disallow external text-conversion
+      #       filters (`--no-textconv`)
       #
-      #     @option options [Boolean, String] :ignore_submodules (nil) ignore submodule changes
+      #     @option options [Boolean, String, nil] :ignore_submodules (nil) ignore submodule changes
       #
       #       Pass `true` for `--ignore-submodules` (equivalent to `'all'`), or a string such
       #       as `'untracked'`, `'dirty'`, `'none'`, or `'all'`.
@@ -473,15 +475,15 @@ module Git
       #     @option options [String] :dst_prefix (nil) destination prefix for diff headers
       #       (e.g. `'b/'`)
       #
-      #     @option options [Boolean] :no_prefix (false) omit source and destination prefixes
+      #     @option options [Boolean, nil] :no_prefix (nil) omit source and destination prefixes
       #
-      #     @option options [Boolean] :default_prefix (false) use the default `a/` and `b/`
+      #     @option options [Boolean, nil] :default_prefix (nil) use the default `a/` and `b/`
       #       prefixes
       #
       #     @option options [String] :line_prefix (nil) prepend this prefix to every output
       #       line
       #
-      #     @option options [Boolean] :ita_invisible_in_index (false) make `git add -N` entries
+      #     @option options [Boolean, nil] :ita_invisible_in_index (nil) make `git add -N` entries
       #       appear as new files in `git diff` and non-existent in `git diff --cached`
       #
       #     @option options [Integer, String] :max_depth (nil) maximum directory depth to

--- a/lib/git/commands/diff_index.rb
+++ b/lib/git/commands/diff_index.rb
@@ -180,30 +180,30 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :m (false) treat non-checked-out files as up to date
+      #     @option options [Boolean, nil] :m (nil) treat non-checked-out files as up to date
       #
       #       By default, files recorded in the index but not checked out are reported as
       #       deleted. This flag makes `git diff-index` report all such files as up to date.
       #
-      #     @option options [Boolean] :cached (false) compare the tree to the index only (staged
+      #     @option options [Boolean, nil] :cached (nil) compare the tree to the index only (staged
       #       changes), without considering the working tree
       #
-      #     @option options [Boolean] :merge_base (false) use the merge base between the tree-ish
+      #     @option options [Boolean, nil] :merge_base (nil) use the merge base between the tree-ish
       #       and `HEAD` rather than the tree-ish directly
       #
       #       `tree_ish` must be a commit when this option is used.
       #
-      #     @option options [Boolean] :patch (false) generate unified diff patch output
+      #     @option options [Boolean, nil] :patch (nil) generate unified diff patch output
       #
       #       Alias: :p, :u
       #
-      #     @option options [Boolean] :no_patch (false) suppress all diff output
+      #     @option options [Boolean, nil] :no_patch (nil) suppress all diff output
       #
       #       Alias: :s
       #
-      #     @option options [Boolean] :raw (false) generate diff in raw format (default output)
+      #     @option options [Boolean, nil] :raw (nil) generate diff in raw format (default output)
       #
-      #     @option options [Boolean] :patch_with_raw (false) synonym for `patch: true, raw: true`
+      #     @option options [Boolean, nil] :patch_with_raw (nil) synonym for `patch: true, raw: true`
       #
       #     @option options [Integer, String] :unified (nil) number of context lines around diff
       #       hunks (e.g., `3`)
@@ -218,17 +218,17 @@ module Git
       #
       #     @option options [String] :output_indicator_context (nil) character for context lines in patch output
       #
-      #     @option options [Boolean] :indent_heuristic (false) shift hunk boundaries for readability
+      #     @option options [Boolean, nil] :indent_heuristic (nil) shift hunk boundaries for readability
       #       (`--indent-heuristic`)
       #
-      #     @option options [Boolean] :no_indent_heuristic (false) do not shift hunk boundaries
+      #     @option options [Boolean, nil] :no_indent_heuristic (nil) do not shift hunk boundaries
       #       for readability (`--no-indent-heuristic`)
       #
-      #     @option options [Boolean] :minimal (false) spend extra time to minimize diff size
+      #     @option options [Boolean, nil] :minimal (nil) spend extra time to minimize diff size
       #
-      #     @option options [Boolean] :patience (false) use patience diff algorithm
+      #     @option options [Boolean, nil] :patience (nil) use patience diff algorithm
       #
-      #     @option options [Boolean] :histogram (false) use histogram diff algorithm
+      #     @option options [Boolean, nil] :histogram (nil) use histogram diff algorithm
       #
       #     @option options [String, Array<String>] :anchored (nil) anchor lines matching the given
       #       text to prevent them from appearing as additions or deletions (repeatable)
@@ -237,7 +237,7 @@ module Git
       #
       #       Accepted values: `'default'`, `'myers'`, `'minimal'`, `'patience'`, `'histogram'`.
       #
-      #     @option options [Boolean, String] :stat (nil) show a diffstat
+      #     @option options [Boolean, String, nil] :stat (nil) show a diffstat
       #
       #       Pass `true` for the default format, or a string like `'80,40,5'` for custom
       #       `width,name-width,count` limits.
@@ -250,105 +250,105 @@ module Git
       #
       #     @option options [Integer, String] :stat_count (nil) limit diffstat to this many lines
       #
-      #     @option options [Boolean] :compact_summary (false) include creation/deletion mode changes in stat
+      #     @option options [Boolean, nil] :compact_summary (nil) include creation/deletion mode changes in stat
       #
-      #     @option options [Boolean] :numstat (false) show per-file insertion/deletion counts (machine-friendly)
+      #     @option options [Boolean, nil] :numstat (nil) show per-file insertion/deletion counts (machine-friendly)
       #
-      #     @option options [Boolean] :shortstat (false) show aggregate totals line only
+      #     @option options [Boolean, nil] :shortstat (nil) show aggregate totals line only
       #
-      #     @option options [Boolean, String] :dirstat (nil) show distribution of changes per directory
+      #     @option options [Boolean, String, nil] :dirstat (nil) show distribution of changes per directory
       #
       #       Pass `true` for the default, or a string like `'lines,cumulative,10'` to pass params.
       #
       #       Alias: :X
       #
-      #     @option options [Boolean] :cumulative (false) synonym for `dirstat: 'cumulative'`
+      #     @option options [Boolean, nil] :cumulative (nil) synonym for `dirstat: 'cumulative'`
       #
-      #     @option options [Boolean, String] :dirstat_by_file (nil) synonym for `dirstat: 'files,...'`
+      #     @option options [Boolean, String, nil] :dirstat_by_file (nil) synonym for `dirstat: 'files,...'`
       #
-      #     @option options [Boolean] :summary (false) show condensed extended header information
+      #     @option options [Boolean, nil] :summary (nil) show condensed extended header information
       #
-      #     @option options [Boolean] :patch_with_stat (false) synonym for `patch: true, stat: true`
+      #     @option options [Boolean, nil] :patch_with_stat (nil) synonym for `patch: true, stat: true`
       #
-      #     @option options [Boolean] :z (false) use NUL as output field terminator instead of newline
+      #     @option options [Boolean, nil] :z (nil) use NUL as output field terminator instead of newline
       #
-      #     @option options [Boolean] :name_only (false) show only changed file names
+      #     @option options [Boolean, nil] :name_only (nil) show only changed file names
       #
-      #     @option options [Boolean] :name_status (false) show changed file names with status letters
+      #     @option options [Boolean, nil] :name_status (nil) show changed file names with status letters
       #
-      #     @option options [Boolean, String] :submodule (nil) how to show submodule differences
+      #     @option options [Boolean, String, nil] :submodule (nil) how to show submodule differences
       #
       #       Pass `true` for the default, or a string like `'log'` or `'diff'` for a format name.
       #
-      #     @option options [Boolean, String] :color (false) control diff colorization (`--color`)
+      #     @option options [Boolean, String, nil] :color (nil) control diff colorization (`--color`)
       #
       #       Pass `true` for `--color` or a string like `'always'` or `'auto'` for a specific mode.
       #
-      #     @option options [Boolean] :no_color (false) suppress colorized output (`--no-color`)
+      #     @option options [Boolean, nil] :no_color (nil) suppress colorized output (`--no-color`)
       #
-      #     @option options [Boolean, String] :color_moved (false) color moved lines differently (`--color-moved`)
+      #     @option options [Boolean, String, nil] :color_moved (nil) color moved lines differently (`--color-moved`)
       #
       #       Pass `true` for the default, or a mode string such as `'zebra'` or `'dimmed-zebra'`.
       #
-      #     @option options [Boolean] :no_color_moved (false) disable moved-line coloring (`--no-color-moved`)
+      #     @option options [Boolean, nil] :no_color_moved (nil) disable moved-line coloring (`--no-color-moved`)
       #
       #     @option options [String] :color_moved_ws (nil) whitespace handling for moved-line color detection
       #
       #       Comma-separated list of modes, e.g. `'ignore-space-at-eol,ignore-space-change'`.
       #
-      #     @option options [Boolean] :no_color_moved_ws (false) synonym for `color_moved_ws: 'no'`
+      #     @option options [Boolean, nil] :no_color_moved_ws (nil) synonym for `color_moved_ws: 'no'`
       #
-      #     @option options [Boolean, String] :word_diff (nil) show a word-level diff
+      #     @option options [Boolean, String, nil] :word_diff (nil) show a word-level diff
       #
       #       Pass `true` for the default `plain` mode, or a string like `'color'`, `'porcelain'`,
       #       or `'none'` for a specific mode.
       #
       #     @option options [String] :word_diff_regex (nil) regular expression defining word boundaries for word diff
       #
-      #     @option options [Boolean, String] :color_words (nil) equivalent to `word_diff: 'color'`
+      #     @option options [Boolean, String, nil] :color_words (nil) equivalent to `word_diff: 'color'`
       #       plus an optional word regex
       #
-      #     @option options [Boolean] :ignore_cr_at_eol (false) ignore carriage-return at end of line
+      #     @option options [Boolean, nil] :ignore_cr_at_eol (nil) ignore carriage-return at end of line
       #
-      #     @option options [Boolean] :ignore_space_at_eol (false) ignore whitespace changes at end of line
+      #     @option options [Boolean, nil] :ignore_space_at_eol (nil) ignore whitespace changes at end of line
       #
-      #     @option options [Boolean] :ignore_space_change (false) ignore changes in amount of whitespace
+      #     @option options [Boolean, nil] :ignore_space_change (nil) ignore changes in amount of whitespace
       #
       #       Alias: :b
       #
-      #     @option options [Boolean] :ignore_all_space (false) ignore all whitespace when comparing lines
+      #     @option options [Boolean, nil] :ignore_all_space (nil) ignore all whitespace when comparing lines
       #
       #       Alias: :w
       #
-      #     @option options [Boolean] :ignore_blank_lines (false) ignore changes whose lines are all blank
+      #     @option options [Boolean, nil] :ignore_blank_lines (nil) ignore changes whose lines are all blank
       #
       #     @option options [String, Array<String>] :ignore_matching_lines (nil) ignore changes whose lines all match
       #       the given regex (repeatable)
       #
       #       Alias: :I
       #
-      #     @option options [Boolean] :check (false) warn if changes introduce whitespace errors or
+      #     @option options [Boolean, nil] :check (nil) warn if changes introduce whitespace errors or
       #       conflict markers
       #
       #     @option options [String] :ws_error_highlight (nil) highlight whitespace errors in the
       #       given diff line types (e.g. `'new'`, `'old,new'`, `'all'`)
       #
-      #     @option options [Boolean] :no_renames (false) disable rename detection
+      #     @option options [Boolean, nil] :no_renames (nil) disable rename detection
       #
-      #     @option options [Boolean] :rename_empty (false) use empty blobs as rename sources (`--rename-empty`)
+      #     @option options [Boolean, nil] :rename_empty (nil) use empty blobs as rename sources (`--rename-empty`)
       #
-      #     @option options [Boolean] :no_rename_empty (false) disallow empty blobs as rename
+      #     @option options [Boolean, nil] :no_rename_empty (nil) disallow empty blobs as rename
       #       sources (`--no-rename-empty`)
       #
-      #     @option options [Boolean] :full_index (false) show full blob SHA in index line
+      #     @option options [Boolean, nil] :full_index (nil) show full blob SHA in index line
       #
-      #     @option options [Boolean] :binary (false) output binary diff suitable for `git apply`
+      #     @option options [Boolean, nil] :binary (nil) output binary diff suitable for `git apply`
       #
-      #     @option options [Boolean, String] :abbrev (nil) abbreviate blob names in raw output
+      #     @option options [Boolean, String, nil] :abbrev (nil) abbreviate blob names in raw output
       #
       #       Pass `true` for the default, or an integer string like `'10'` for a specific length.
       #
-      #     @option options [Boolean, String] :break_rewrites (nil) break total rewrites into
+      #     @option options [Boolean, String, nil] :break_rewrites (nil) break total rewrites into
       #       delete-and-create pairs
       #
       #       Pass `true` for defaults, or a threshold string like `'80%'` or `'50%/70%'` for custom
@@ -356,24 +356,24 @@ module Git
       #
       #       Alias: :B
       #
-      #     @option options [Boolean, String] :find_renames (nil) detect renames
+      #     @option options [Boolean, String, nil] :find_renames (nil) detect renames
       #
       #       Pass `true` for the default threshold, or a string like `'90%'` for a custom
       #       similarity threshold.
       #
       #       Alias: :M
       #
-      #     @option options [Boolean, String] :find_copies (nil) detect copies as well as renames
+      #     @option options [Boolean, String, nil] :find_copies (nil) detect copies as well as renames
       #
       #       Pass `true` for the default threshold, or a string like `'75%'` for a custom
       #       similarity threshold.
       #
       #       Alias: :C
       #
-      #     @option options [Boolean] :find_copies_harder (false) inspect all unmodified files as copy
+      #     @option options [Boolean, nil] :find_copies_harder (nil) inspect all unmodified files as copy
       #       sources (very expensive for large repos)
       #
-      #     @option options [Boolean] :irreversible_delete (false) omit preimage for deleted files
+      #     @option options [Boolean, nil] :irreversible_delete (nil) omit preimage for deleted files
       #
       #       Alias: :D
       #
@@ -393,10 +393,10 @@ module Git
       #
       #     @option options [String] :find_object (nil) find changes involving the given object id
       #
-      #     @option options [Boolean] :pickaxe_all (false) show all changes in a changeset when using
+      #     @option options [Boolean, nil] :pickaxe_all (nil) show all changes in a changeset when using
       #       `-S` or `-G`
       #
-      #     @option options [Boolean] :pickaxe_regex (false) treat the `-S` string as an extended POSIX
+      #     @option options [Boolean, nil] :pickaxe_regex (nil) treat the `-S` string as an extended POSIX
       #       regular expression
       #
       #     @option options [String] :O (nil) path to an orderfile controlling output file order
@@ -405,41 +405,42 @@ module Git
       #
       #     @option options [String] :rotate_to (nil) move files before the named file to end of output
       #
-      #     @option options [Boolean] :R (false) swap the two diff inputs
+      #     @option options [Boolean, nil] :R (nil) swap the two diff inputs
       #
-      #     @option options [Boolean, String] :relative (false) show paths relative to a directory (`--relative`)
+      #     @option options [Boolean, String, nil] :relative (nil) show paths relative to a directory (`--relative`)
       #
       #       Pass `true` to use the current directory, or a path string to name the directory explicitly.
       #
-      #     @option options [Boolean] :no_relative (false) use absolute paths in output (`--no-relative`)
+      #     @option options [Boolean, nil] :no_relative (nil) use absolute paths in output (`--no-relative`)
       #
-      #     @option options [Boolean] :text (false) treat all files as text
+      #     @option options [Boolean, nil] :text (nil) treat all files as text
       #
       #       Alias: :a
       #
       #     @option options [Integer, String] :inter_hunk_context (nil) show context between diff hunks
       #       up to this many lines, fusing close hunks
       #
-      #     @option options [Boolean] :function_context (false) show whole function as context for each change
+      #     @option options [Boolean, nil] :function_context (nil) show whole function as context for each change
       #
       #       Alias: :W
       #
-      #     @option options [Boolean] :exit_code (false) exit with status 1 if differences are found,
+      #     @option options [Boolean, nil] :exit_code (nil) exit with status 1 if differences are found,
       #       0 if none
       #
-      #     @option options [Boolean] :quiet (false) suppress all output
+      #     @option options [Boolean, nil] :quiet (nil) suppress all output
       #
       #       Implies `--exit-code`.
       #
-      #     @option options [Boolean] :ext_diff (false) allow external diff helpers (`--ext-diff`)
+      #     @option options [Boolean, nil] :ext_diff (nil) allow external diff helpers (`--ext-diff`)
       #
-      #     @option options [Boolean] :no_ext_diff (false) disallow external diff helpers (`--no-ext-diff`)
+      #     @option options [Boolean, nil] :no_ext_diff (nil) disallow external diff helpers (`--no-ext-diff`)
       #
-      #     @option options [Boolean] :textconv (false) allow external text-conversion filters (`--textconv`)
+      #     @option options [Boolean, nil] :textconv (nil) allow external text-conversion filters (`--textconv`)
       #
-      #     @option options [Boolean] :no_textconv (false) disallow external text-conversion filters (`--no-textconv`)
+      #     @option options [Boolean, nil] :no_textconv (nil) disallow external text-conversion filters
+      #       (`--no-textconv`)
       #
-      #     @option options [Boolean, String] :ignore_submodules (nil) ignore submodule changes
+      #     @option options [Boolean, String, nil] :ignore_submodules (nil) ignore submodule changes
       #
       #       Pass `true` for `--ignore-submodules` (equivalent to `'all'`), or a string such as
       #       `'untracked'`, `'dirty'`, `'none'`, or `'all'`.
@@ -448,13 +449,13 @@ module Git
       #
       #     @option options [String] :dst_prefix (nil) destination prefix for diff headers (e.g. `'b/'`)
       #
-      #     @option options [Boolean] :no_prefix (false) omit source and destination prefixes
+      #     @option options [Boolean, nil] :no_prefix (nil) omit source and destination prefixes
       #
-      #     @option options [Boolean] :default_prefix (false) use the default `a/` and `b/` prefixes
+      #     @option options [Boolean, nil] :default_prefix (nil) use the default `a/` and `b/` prefixes
       #
       #     @option options [String] :line_prefix (nil) prepend this prefix to every output line
       #
-      #     @option options [Boolean] :ita_invisible_in_index (false) make `git add -N` entries appear as
+      #     @option options [Boolean, nil] :ita_invisible_in_index (nil) make `git add -N` entries appear as
       #       new files in `git diff` and non-existent in `git diff --cached`
       #
       #     @option options [Integer, String] :max_depth (nil) maximum directory depth to descend for

--- a/lib/git/commands/fetch.rb
+++ b/lib/git/commands/fetch.rb
@@ -133,16 +133,16 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :all (false) fetch all remotes (`--all`)
+      #     @option options [Boolean, nil] :all (nil) fetch all remotes (`--all`)
       #
-      #     @option options [Boolean] :no_all (false) do not fetch all remotes (`--no-all`)
+      #     @option options [Boolean, nil] :no_all (nil) do not fetch all remotes (`--no-all`)
       #
-      #     @option options [Boolean] :append (false) append ref names and object
+      #     @option options [Boolean, nil] :append (nil) append ref names and object
       #       names of fetched refs to the existing contents of `.git/FETCH_HEAD`
       #
       #       Alias: :a
       #
-      #     @option options [Boolean] :atomic (false) use an atomic transaction
+      #     @option options [Boolean, nil] :atomic (nil) use an atomic transaction
       #       to update local refs
       #
       #     @option options [String] :depth (nil) limit fetching to the specified
@@ -159,11 +159,11 @@ module Git
       #
       #       Repeatable.
       #
-      #     @option options [Boolean] :unshallow (false) convert a shallow
+      #     @option options [Boolean, nil] :unshallow (nil) convert a shallow
       #       repository to a complete one, or fetch as much as possible from
       #       a shallow source
       #
-      #     @option options [Boolean] :update_shallow (false) accept refs that
+      #     @option options [Boolean, nil] :update_shallow (nil) accept refs that
       #       would normally require updating `.git/shallow`
       #
       #     @option options [String, Array<String>] :negotiation_tip (nil) only
@@ -172,73 +172,73 @@ module Git
       #       Repeatable. The argument may be a ref, a glob on ref names, or an
       #       abbreviated SHA-1.
       #
-      #     @option options [Boolean] :negotiate_only (false) do not fetch
+      #     @option options [Boolean, nil] :negotiate_only (nil) do not fetch
       #       anything from the server; print ancestors of `--negotiation-tip`
       #       arguments that we have in common
       #
-      #     @option options [Boolean] :dry_run (false) show what would be done
+      #     @option options [Boolean, nil] :dry_run (nil) show what would be done
       #       without making changes
       #
-      #     @option options [Boolean] :porcelain (false) print the output to
+      #     @option options [Boolean, nil] :porcelain (nil) print the output to
       #       standard output in an easy-to-parse format for scripts
       #
-      #     @option options [Boolean] :write_fetch_head (false) write the fetched
+      #     @option options [Boolean, nil] :write_fetch_head (nil) write the fetched
       #       remote refs to `.git/FETCH_HEAD` (`--write-fetch-head`)
       #
-      #     @option options [Boolean] :no_write_fetch_head (false) do not write
+      #     @option options [Boolean, nil] :no_write_fetch_head (nil) do not write
       #       fetched remote refs to `.git/FETCH_HEAD` (`--no-write-fetch-head`)
       #
-      #     @option options [Boolean] :force (false) override the fast-forward
+      #     @option options [Boolean, nil] :force (nil) override the fast-forward
       #       check when using explicit refspecs
       #
       #       Alias: :f
       #
-      #     @option options [Boolean] :keep (false) keep the downloaded pack
+      #     @option options [Boolean, nil] :keep (nil) keep the downloaded pack
       #
       #       Alias: :k
       #
-      #     @option options [Boolean] :multiple (false) allow several repository
+      #     @option options [Boolean, nil] :multiple (nil) allow several repository
       #       and group arguments to be specified
       #
       #       When using this option, pass additional repository or group names
       #       as extra positional arguments; they are bound to the `:refspec`
       #       slot in the DSL but are passed through to git correctly.
       #
-      #     @option options [Boolean] :auto_maintenance (false) run automatic
+      #     @option options [Boolean, nil] :auto_maintenance (nil) run automatic
       #       repository maintenance after fetching (`--auto-maintenance`)
       #
-      #     @option options [Boolean] :no_auto_maintenance (false) do not run
+      #     @option options [Boolean, nil] :no_auto_maintenance (nil) do not run
       #       automatic repository maintenance after fetching
       #       (`--no-auto-maintenance`)
       #
-      #     @option options [Boolean] :auto_gc (false) run automatic garbage
+      #     @option options [Boolean, nil] :auto_gc (nil) run automatic garbage
       #       collection after fetching — deprecated alias for `:auto_maintenance`
       #       (`--auto-gc`)
       #
-      #     @option options [Boolean] :no_auto_gc (false) do not run automatic
+      #     @option options [Boolean, nil] :no_auto_gc (nil) do not run automatic
       #       garbage collection after fetching (`--no-auto-gc`)
       #
-      #     @option options [Boolean] :write_commit_graph (false) write a
+      #     @option options [Boolean, nil] :write_commit_graph (nil) write a
       #       commit-graph after fetching (`--write-commit-graph`)
       #
-      #     @option options [Boolean] :no_write_commit_graph (false) do not write
+      #     @option options [Boolean, nil] :no_write_commit_graph (nil) do not write
       #       a commit-graph after fetching (`--no-write-commit-graph`)
       #
-      #     @option options [Boolean] :prefetch (false) modify the configured
+      #     @option options [Boolean, nil] :prefetch (nil) modify the configured
       #       refspec to place all refs into the `refs/prefetch/` namespace
       #
-      #     @option options [Boolean] :prune (false) before fetching, remove any
+      #     @option options [Boolean, nil] :prune (nil) before fetching, remove any
       #       remote-tracking references that no longer exist on the remote
       #
       #       Alias: :p
       #
-      #     @option options [Boolean] :prune_tags (false) before fetching, remove
+      #     @option options [Boolean, nil] :prune_tags (nil) before fetching, remove
       #       any local tags that no longer exist on the remote (requires
       #       `--prune`)
       #
       #       Alias: :P
       #
-      #     @option options [Boolean] :refetch (false) fetch all objects as a
+      #     @option options [Boolean, nil] :refetch (nil) fetch all objects as a
       #       fresh clone would, bypassing negotiation
       #
       #     @option options [String, Array<String>] :refmap (nil) use the
@@ -247,21 +247,21 @@ module Git
       #
       #       Repeatable.
       #
-      #     @option options [Boolean] :tags (false) fetch all tags from the
+      #     @option options [Boolean, nil] :tags (nil) fetch all tags from the
       #       remote (`--tags`)
       #
       #       Alias: :t
       #
-      #     @option options [Boolean] :no_tags (false) disable automatic tag
+      #     @option options [Boolean, nil] :no_tags (nil) disable automatic tag
       #       following (`--no-tags`)
       #
-      #     @option options [Boolean, String] :recurse_submodules (false) control
+      #     @option options [Boolean, String, nil] :recurse_submodules (nil) control
       #       whether new commits of submodules should be fetched
       #
       #       When `true`, uses `--recurse-submodules`. When a string (e.g.
       #       `'yes'`, `'on-demand'`, `'no'`), passes that value.
       #
-      #     @option options [Boolean] :no_recurse_submodules (false) do not
+      #     @option options [Boolean, nil] :no_recurse_submodules (nil) do not
       #       recurse into submodules (`--no-recurse-submodules`)
       #
       #     @option options [String] :jobs (nil) number of submodules or parallel
@@ -269,7 +269,7 @@ module Git
       #
       #       Alias: :j
       #
-      #     @option options [Boolean] :set_upstream (false) add upstream tracking
+      #     @option options [Boolean, nil] :set_upstream (nil) add upstream tracking
       #       reference if the remote is fetched successfully
       #
       #     @option options [String] :submodule_prefix (nil) prepend the given
@@ -282,7 +282,7 @@ module Git
       #
       #       Used internally.
       #
-      #     @option options [Boolean] :update_head_ok (false) allow updating the
+      #     @option options [Boolean, nil] :update_head_ok (nil) allow updating the
       #       HEAD that corresponds to the current branch
       #
       #       Used internally by `git pull`.
@@ -292,15 +292,15 @@ module Git
       #     @option options [String] :upload_pack (nil) specify a non-default
       #       path for `git-upload-pack` on the remote side
       #
-      #     @option options [Boolean] :quiet (false) suppress all output
+      #     @option options [Boolean, nil] :quiet (nil) suppress all output
       #
       #       Alias: :q
       #
-      #     @option options [Boolean] :verbose (false) be verbose
+      #     @option options [Boolean, nil] :verbose (nil) be verbose
       #
       #       Alias: :v
       #
-      #     @option options [Boolean] :progress (false) force progress status on
+      #     @option options [Boolean, nil] :progress (nil) force progress status on
       #       standard error even when the stream is not attached to a terminal
       #
       #     @option options [String, Array<String>] :server_option (nil) transmit
@@ -311,22 +311,22 @@ module Git
       #
       #       Alias: :o
       #
-      #     @option options [Boolean] :show_forced_updates (false) check for
+      #     @option options [Boolean, nil] :show_forced_updates (nil) check for
       #       force-updated branches during fetch (`--show-forced-updates`)
       #
-      #     @option options [Boolean] :no_show_forced_updates (false) do not
+      #     @option options [Boolean, nil] :no_show_forced_updates (nil) do not
       #       check for force-updated branches during fetch
       #       (`--no-show-forced-updates`)
       #
-      #     @option options [Boolean] :ipv4 (false) use IPv4 addresses only
+      #     @option options [Boolean, nil] :ipv4 (nil) use IPv4 addresses only
       #
       #       Alias: :"4"
       #
-      #     @option options [Boolean] :ipv6 (false) use IPv6 addresses only
+      #     @option options [Boolean, nil] :ipv6 (nil) use IPv6 addresses only
       #
       #       Alias: :"6"
       #
-      #     @option options [Boolean] :stdin (false) read refspecs from stdin in
+      #     @option options [Boolean, nil] :stdin (nil) read refspecs from stdin in
       #       addition to those provided as arguments
       #
       #     @option options [Numeric, nil] :timeout (nil) maximum seconds to wait
@@ -334,7 +334,7 @@ module Git
       #
       #       If nil, uses the global timeout from {Git::Config}.
       #
-      #     @option options [Boolean] :merge (nil) merge stderr into stdout in
+      #     @option options [Boolean, nil] :merge (nil) merge stderr into stdout in
       #       the returned result
       #
       #       Pass `true` to capture git fetch output (which is written to stderr

--- a/lib/git/commands/fsck.rb
+++ b/lib/git/commands/fsck.rb
@@ -68,59 +68,59 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :tags (false) report tags
+      #     @option options [Boolean, nil] :tags (nil) report tags
       #
-      #     @option options [Boolean] :root (false) report root nodes
+      #     @option options [Boolean, nil] :root (nil) report root nodes
       #
-      #     @option options [Boolean] :unreachable (false) print out objects that
+      #     @option options [Boolean, nil] :unreachable (nil) print out objects that
       #       exist but are not reachable from any of the reference nodes
       #
-      #     @option options [Boolean] :cache (false) consider any object recorded
+      #     @option options [Boolean, nil] :cache (nil) consider any object recorded
       #       in the index also as a head node for reachability
       #
-      #     @option options [Boolean] :no_reflogs (false) do not consider commits
+      #     @option options [Boolean, nil] :no_reflogs (nil) do not consider commits
       #       referenced only by reflogs to be reachable
       #
-      #     @option options [Boolean] :full (false) check not just objects in
+      #     @option options [Boolean, nil] :full (nil) check not just objects in
       #       `GIT_OBJECT_DIRECTORY` but also those in alternate object pools and
       #       packed archives (`--full`)
       #
-      #     @option options [Boolean] :no_full (false) skip checking alternate object
+      #     @option options [Boolean, nil] :no_full (nil) skip checking alternate object
       #       pools and packed archives (`--no-full`)
       #
-      #     @option options [Boolean] :strict (false) enable more strict checking,
+      #     @option options [Boolean, nil] :strict (nil) enable more strict checking,
       #       catching files with `g+w` bits set
       #
-      #     @option options [Boolean] :verbose (false) be chatty
+      #     @option options [Boolean, nil] :verbose (nil) be chatty
       #
-      #     @option options [Boolean] :lost_found (false) write dangling objects
+      #     @option options [Boolean, nil] :lost_found (nil) write dangling objects
       #       into `.git/lost-found/commit/` or `.git/lost-found/other/`
       #
-      #     @option options [Boolean] :dangling (false) print dangling objects (`--dangling`)
+      #     @option options [Boolean, nil] :dangling (nil) print dangling objects (`--dangling`)
       #
-      #     @option options [Boolean] :no_dangling (false) suppress dangling object
+      #     @option options [Boolean, nil] :no_dangling (nil) suppress dangling object
       #       reporting (`--no-dangling`)
       #
-      #     @option options [Boolean] :progress (false) show progress status on
+      #     @option options [Boolean, nil] :progress (nil) show progress status on
       #       standard error (`--progress`)
       #
-      #     @option options [Boolean] :no_progress (false) suppress progress output
+      #     @option options [Boolean, nil] :no_progress (nil) suppress progress output
       #       when attached to a terminal (`--no-progress`)
       #
-      #     @option options [Boolean] :connectivity_only (false) check only the
+      #     @option options [Boolean, nil] :connectivity_only (nil) check only the
       #       connectivity of reachable objects; faster but does not validate
       #       blob content
       #
-      #     @option options [Boolean] :name_objects (false) show the name of each
+      #     @option options [Boolean, nil] :name_objects (nil) show the name of each
       #       reachable object alongside its identifier (`--name-objects`)
       #
-      #     @option options [Boolean] :no_name_objects (false) suppress object name
+      #     @option options [Boolean, nil] :no_name_objects (nil) suppress object name
       #       display (`--no-name-objects`)
       #
-      #     @option options [Boolean] :references (false) check reference database
+      #     @option options [Boolean, nil] :references (nil) check reference database
       #       consistency via `git refs verify` (`--references`)
       #
-      #     @option options [Boolean] :no_references (false) skip reference checking
+      #     @option options [Boolean, nil] :no_references (nil) skip reference checking
       #       (`--no-references`)
       #
       #     @return [Git::CommandLineResult] the result of calling `git fsck`

--- a/lib/git/commands/gc.rb
+++ b/lib/git/commands/gc.rb
@@ -61,32 +61,32 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :aggressive (false) be more thorough at the
+      #     @option options [Boolean, nil] :aggressive (nil) be more thorough at the
       #       expense of increased runtime
       #
       #       When `true`, git gc runs more aggressively to optimize the repository.
       #       The effects are mostly persistent.
       #
-      #     @option options [Boolean] :auto (false) check whether housekeeping is
+      #     @option options [Boolean, nil] :auto (nil) check whether housekeeping is
       #       required before performing any work
       #
       #       When `true`, git gc checks whether housekeeping is needed; if not, it
       #       exits without doing anything.
       #
-      #     @option options [Boolean] :detach (false) run in the background if the
+      #     @option options [Boolean, nil] :detach (nil) run in the background if the
       #       system supports it (`--detach`)
       #
       #       Overrides the `gc.autoDetach` configuration.
       #
-      #     @option options [Boolean] :no_detach (false) run in the foreground
+      #     @option options [Boolean, nil] :no_detach (nil) run in the foreground
       #       (`--no-detach`)
       #
       #       Overrides the `gc.autoDetach` configuration.
       #
-      #     @option options [Boolean] :cruft (false) pack unreachable objects into a
+      #     @option options [Boolean, nil] :cruft (nil) pack unreachable objects into a
       #       cruft pack instead of storing them as loose objects (`--cruft`)
       #
-      #     @option options [Boolean] :no_cruft (false) do not create a cruft pack;
+      #     @option options [Boolean, nil] :no_cruft (nil) do not create a cruft pack;
       #       store unreachable objects as loose objects (`--no-cruft`)
       #
       #     @option options [String] :max_cruft_size (nil) limit the size of new
@@ -101,21 +101,21 @@ module Git
       #       Only has an effect when used together with `:cruft`. Maps to
       #       `--expire-to=<dir>`.
       #
-      #     @option options [Boolean, String] :prune (false) prune loose objects
+      #     @option options [Boolean, String, nil] :prune (nil) prune loose objects
       #       older than the given date (`--prune`, `--prune=<date>`)
       #
       #       When `true`, passes `--prune` (uses git's default expiry of 2 weeks
       #       ago). When a String, passes `--prune=<date>`.
       #
-      #     @option options [Boolean] :no_prune (false) do not prune any loose
+      #     @option options [Boolean, nil] :no_prune (nil) do not prune any loose
       #       objects (`--no-prune`)
       #
-      #     @option options [Boolean] :quiet (false) suppress all progress reports
+      #     @option options [Boolean, nil] :quiet (nil) suppress all progress reports
       #
-      #     @option options [Boolean] :force (false) force running gc even if
+      #     @option options [Boolean, nil] :force (nil) force running gc even if
       #       another gc instance may be running on this repository
       #
-      #     @option options [Boolean] :keep_largest_pack (false) repack all packs
+      #     @option options [Boolean, nil] :keep_largest_pack (nil) repack all packs
       #       except the largest non-cruft pack and those marked with a `.keep` file
       #
       #       When `true`, `gc.bigPackThreshold` is ignored.

--- a/lib/git/commands/grep.rb
+++ b/lib/git/commands/grep.rb
@@ -124,100 +124,100 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :text (false) process binary files as if they
+      #     @option options [Boolean, nil] :text (nil) process binary files as if they
       #       were text
       #
       #       Alias: :a
       #
-      #     @option options [Boolean] :I (false) do not match the pattern in binary
+      #     @option options [Boolean, nil] :I (nil) do not match the pattern in binary
       #       files
       #
-      #     @option options [Boolean] :textconv (false) honor textconv filter
+      #     @option options [Boolean, nil] :textconv (nil) honor textconv filter
       #       settings (`--textconv`)
       #
-      #     @option options [Boolean] :no_textconv (false) suppress textconv filter
+      #     @option options [Boolean, nil] :no_textconv (nil) suppress textconv filter
       #       processing (`--no-textconv`)
       #
-      #     @option options [Boolean] :ignore_case (false) ignore case distinctions
+      #     @option options [Boolean, nil] :ignore_case (nil) ignore case distinctions
       #       in both the pattern and the file contents
       #
       #       Alias: :i
       #
-      #     @option options [Boolean] :word_regexp (false) match the pattern only at
+      #     @option options [Boolean, nil] :word_regexp (nil) match the pattern only at
       #       word boundary
       #
       #       Alias: :w
       #
-      #     @option options [Boolean] :invert_match (false) select non-matching lines
+      #     @option options [Boolean, nil] :invert_match (nil) select non-matching lines
       #
       #       Alias: :v
       #
-      #     @option options [Boolean] :h (false) suppress the filename prefix for
+      #     @option options [Boolean, nil] :h (nil) suppress the filename prefix for
       #       each match
       #
-      #     @option options [Boolean] :H (false) print the filename for each match;
+      #     @option options [Boolean, nil] :H (nil) print the filename for each match;
       #       overrides `:h` given earlier
       #
-      #     @option options [Boolean] :full_name (false) output paths relative to
+      #     @option options [Boolean, nil] :full_name (nil) output paths relative to
       #       the project top directory rather than the current directory
       #
-      #     @option options [Boolean] :extended_regexp (false) use POSIX extended
+      #     @option options [Boolean, nil] :extended_regexp (nil) use POSIX extended
       #       regular expressions for the pattern
       #
       #       Alias: :E
       #
-      #     @option options [Boolean] :basic_regexp (false) use POSIX basic regular
+      #     @option options [Boolean, nil] :basic_regexp (nil) use POSIX basic regular
       #       expressions for the pattern (the default regexp flavour)
       #
       #       Alias: :G
       #
-      #     @option options [Boolean] :perl_regexp (false) use Perl-compatible
+      #     @option options [Boolean, nil] :perl_regexp (nil) use Perl-compatible
       #       regular expressions for the pattern
       #
       #       Alias: :P
       #
-      #     @option options [Boolean] :fixed_strings (false) treat the pattern as a
+      #     @option options [Boolean, nil] :fixed_strings (nil) treat the pattern as a
       #       fixed string rather than a regular expression
       #
       #       Alias: :F
       #
-      #     @option options [Boolean] :line_number (false) prefix each matching line
+      #     @option options [Boolean, nil] :line_number (nil) prefix each matching line
       #       with its line number within the file
       #
       #       Alias: :n
       #
-      #     @option options [Boolean] :column (false) prefix the 1-indexed
+      #     @option options [Boolean, nil] :column (nil) prefix the 1-indexed
       #       byte-offset of the first match from the start of the matching line
       #
-      #     @option options [Boolean] :files_with_matches (false) show only the
+      #     @option options [Boolean, nil] :files_with_matches (nil) show only the
       #       names of files that contain matches, not the matching lines
       #
       #       Aliases: :name_only, :l
       #
-      #     @option options [Boolean] :files_without_match (false) show only the
+      #     @option options [Boolean, nil] :files_without_match (nil) show only the
       #       names of files that do not contain matches
       #
       #       Alias: :L
       #
-      #     @option options [Boolean] :null (false) use NUL as the delimiter for
+      #     @option options [Boolean, nil] :null (nil) use NUL as the delimiter for
       #       pathnames in the output, printing them verbatim
       #
       #       Alias: :z
       #
-      #     @option options [Boolean] :only_matching (false) print only the matched
+      #     @option options [Boolean, nil] :only_matching (nil) print only the matched
       #       (non-empty) parts of a matching line, each on a separate output line
       #
       #       Alias: :o
       #
-      #     @option options [Boolean] :count (false) show the number of matching
+      #     @option options [Boolean, nil] :count (nil) show the number of matching
       #       lines per file instead of the matching lines themselves
       #
       #       Alias: :c
       #
-      #     @option options [Boolean] :all_match (false) when using multiple `--or`
+      #     @option options [Boolean, nil] :all_match (nil) when using multiple `--or`
       #       patterns, limit matches to files that have lines matching all of them
       #
-      #     @option options [Boolean] :quiet (false) do not output matching lines;
+      #     @option options [Boolean, nil] :quiet (nil) do not output matching lines;
       #       exit 0 when there is a match and non-zero when there is not
       #
       #       Alias: :q
@@ -225,29 +225,29 @@ module Git
       #     @option options [Integer, String] :max_depth (nil) descend at most this
       #       many directory levels for each pathspec argument
       #
-      #     @option options [Boolean] :recursive (false) recurse into subdirectories
+      #     @option options [Boolean, nil] :recursive (nil) recurse into subdirectories
       #       (same as `--max-depth=-1`; this is the default)
       #
       #       Alias: :r
       #
-      #     @option options [Boolean] :no_recursive (false) do not recurse into
+      #     @option options [Boolean, nil] :no_recursive (nil) do not recurse into
       #       subdirectories (`--no-recursive`, equivalent to `--max-depth=0`)
       #
-      #     @option options [Boolean, String] :color (nil) show colored matches
+      #     @option options [Boolean, String, nil] :color (nil) show colored matches
       #
       #       When `true`, emits bare `--color`. Pass a string to emit
       #       `--color=<when>` (values: `'always'`, `'never'`, `'auto'`).
       #
-      #     @option options [Boolean] :no_color (false) turn off match highlighting,
+      #     @option options [Boolean, nil] :no_color (nil) turn off match highlighting,
       #       even when the configuration file gives the default to color output
       #
-      #     @option options [Boolean] :break (false) print an empty line between
+      #     @option options [Boolean, nil] :break (nil) print an empty line between
       #       matches from different files
       #
-      #     @option options [Boolean] :heading (false) show the filename above the
+      #     @option options [Boolean, nil] :heading (nil) show the filename above the
       #       matches in that file instead of at the start of each shown line
       #
-      #     @option options [Boolean] :show_function (false) show the nearest
+      #     @option options [Boolean, nil] :show_function (nil) show the nearest
       #       function name preceding each match
       #
       #       Alias: :p
@@ -267,7 +267,7 @@ module Git
       #
       #       Alias: :C
       #
-      #     @option options [Boolean] :function_context (false) show the surrounding
+      #     @option options [Boolean, nil] :function_context (nil) show the surrounding
       #       text from the previous function name up to the next
       #
       #       Alias: :W
@@ -291,26 +291,26 @@ module Git
       #       Pass an Array of raw CLI arguments for compound boolean
       #       expressions (e.g. `['-e', 'foo', '--and', '-e', 'bar']`).
       #
-      #     @option options [Boolean] :recurse_submodules (false) recursively search
+      #     @option options [Boolean, nil] :recurse_submodules (nil) recursively search
       #       in each active, checked-out submodule
       #
       #     @option options [String] :parent_basename (nil) override the name used
       #       as a prefix for submodule output when used with `:recurse_submodules`
       #
-      #     @option options [Boolean] :exclude_standard (false) honor the `.gitignore`
+      #     @option options [Boolean, nil] :exclude_standard (nil) honor the `.gitignore`
       #       mechanism when searching untracked files (`--exclude-standard`)
       #
-      #     @option options [Boolean] :no_exclude_standard (false) do not honor the
+      #     @option options [Boolean, nil] :no_exclude_standard (nil) do not honor the
       #       `.gitignore` mechanism; also search ignored files
       #       (`--no-exclude-standard`); only useful with `:untracked` or `:no_index`
       #
-      #     @option options [Boolean] :cached (false) search blobs registered in the
+      #     @option options [Boolean, nil] :cached (nil) search blobs registered in the
       #       index instead of tracked files in the working tree
       #
-      #     @option options [Boolean] :untracked (false) search untracked files in
+      #     @option options [Boolean, nil] :untracked (nil) search untracked files in
       #       addition to tracked files in the working tree
       #
-      #     @option options [Boolean] :no_index (false) search files in the current
+      #     @option options [Boolean, nil] :no_index (nil) search files in the current
       #       directory without regard to whether it is managed by Git
       #
       #     @option options [String, Array<String>] :pathspec (nil) limit the

--- a/lib/git/commands/init.rb
+++ b/lib/git/commands/init.rb
@@ -56,12 +56,12 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :quiet (false) suppress all output except errors
+      #     @option options [Boolean, nil] :quiet (nil) suppress all output except errors
       #       and warnings
       #
       #       Alias: `:q`
       #
-      #     @option options [Boolean] :bare (false) create a bare repository
+      #     @option options [Boolean, nil] :bare (nil) create a bare repository
       #
       #     @option options [String] :template (nil) path to the directory from which
       #       templates will be used
@@ -80,7 +80,7 @@ module Git
       #
       #       Alias: `:b`
       #
-      #     @option options [Boolean, String] :shared (nil) configure the repository
+      #     @option options [Boolean, String, nil] :shared (nil) configure the repository
       #       to be shared among multiple users
       #
       #       Pass `true` to emit `--shared` (which defaults to `group` permissions).

--- a/lib/git/commands/log.rb
+++ b/lib/git/commands/log.rb
@@ -214,43 +214,43 @@ module Git
       #     @option options [String] :grep (nil) limit commits to those whose log message matches
       #       the given pattern (regular expression)
       #
-      #     @option options [Boolean] :all_match (false) limit output to commits matching all
+      #     @option options [Boolean, nil] :all_match (nil) limit output to commits matching all
       #       `--grep` patterns (default: any)
       #
-      #     @option options [Boolean] :invert_grep (false) limit output to commits whose log
+      #     @option options [Boolean, nil] :invert_grep (nil) limit output to commits whose log
       #       message does **not** match the `:grep` pattern
       #
-      #     @option options [Boolean] :regexp_ignore_case (false) match `--grep`, `--author`,
+      #     @option options [Boolean, nil] :regexp_ignore_case (nil) match `--grep`, `--author`,
       #       and `--committer` patterns case-insensitively
       #
       #       Alias: `:i`
       #
-      #     @option options [Boolean] :basic_regexp (false) treat limiting patterns as basic POSIX
+      #     @option options [Boolean, nil] :basic_regexp (nil) treat limiting patterns as basic POSIX
       #       regular expressions (this is the default behavior)
       #
-      #     @option options [Boolean] :extended_regexp (false) treat limiting patterns as extended
+      #     @option options [Boolean, nil] :extended_regexp (nil) treat limiting patterns as extended
       #       POSIX regular expressions
       #
       #       Mutually exclusive with `:fixed_strings` and `:perl_regexp`. Alias: `:E`
       #
-      #     @option options [Boolean] :fixed_strings (false) treat limiting patterns as fixed
+      #     @option options [Boolean, nil] :fixed_strings (nil) treat limiting patterns as fixed
       #       strings instead of regular expressions
       #
       #       Mutually exclusive with `:extended_regexp` and `:perl_regexp`. Alias: `:F`
       #
-      #     @option options [Boolean] :perl_regexp (false) treat limiting patterns as
+      #     @option options [Boolean, nil] :perl_regexp (nil) treat limiting patterns as
       #       Perl-compatible regular expressions
       #
       #       Mutually exclusive with `:extended_regexp` and `:fixed_strings`. Alias: `:P`
       #
-      #     @option options [Boolean] :remove_empty (false) stop when a given path disappears
+      #     @option options [Boolean, nil] :remove_empty (nil) stop when a given path disappears
       #       from the tree
       #
-      #     @option options [Boolean] :merges (false) include only merge commits (`--merges`)
+      #     @option options [Boolean, nil] :merges (nil) include only merge commits (`--merges`)
       #
       #       Equivalent to `--min-parents=2`.
       #
-      #     @option options [Boolean] :no_merges (false) exclude merge commits (`--no-merges`)
+      #     @option options [Boolean, nil] :no_merges (nil) exclude merge commits (`--no-merges`)
       #
       #       Equivalent to `--max-parents=1`.
       #
@@ -260,26 +260,26 @@ module Git
       #     @option options [Integer, String] :max_parents (nil) show only commits with at most this
       #       many parents
       #
-      #     @option options [Boolean] :first_parent (false) follow only the first parent commit
+      #     @option options [Boolean, nil] :first_parent (nil) follow only the first parent commit
       #       upon seeing a merge commit
       #
-      #     @option options [Boolean] :exclude_first_parent_only (false) when excluding commits
+      #     @option options [Boolean, nil] :exclude_first_parent_only (nil) when excluding commits
       #       with `^`, follow only the first parent of merge commits
       #
-      #     @option options [Boolean] :all (false) pretend as if all refs in `refs/`, along
+      #     @option options [Boolean, nil] :all (nil) pretend as if all refs in `refs/`, along
       #       with `HEAD`, are listed on the command line
       #
-      #     @option options [Boolean, String] :branches (false) pretend as if all refs in
+      #     @option options [Boolean, String, nil] :branches (nil) pretend as if all refs in
       #       `refs/heads` are listed on the command line
       #
       #       Pass a shell glob pattern (e.g. `'feature*'`) to restrict to matching branch names
       #
-      #     @option options [Boolean, String] :tags (false) pretend as if all refs in
+      #     @option options [Boolean, String, nil] :tags (nil) pretend as if all refs in
       #       `refs/tags` are listed on the command line
       #
       #       Pass a shell glob pattern to restrict to matching tag names
       #
-      #     @option options [Boolean, String] :remotes (false) pretend as if all refs in
+      #     @option options [Boolean, String, nil] :remotes (nil) pretend as if all refs in
       #       `refs/remotes` are listed on the command line
       #
       #       Pass a shell glob pattern to restrict to matching remote-tracking branches
@@ -293,95 +293,95 @@ module Git
       #     @option options [String] :exclude_hidden (nil) do not include refs hidden by the given
       #       configuration; value is one of `fetch`, `receive`, or `uploadpack`
       #
-      #     @option options [Boolean] :reflog (false) pretend as if all objects mentioned by
+      #     @option options [Boolean, nil] :reflog (nil) pretend as if all objects mentioned by
       #       reflogs are listed on the command line
       #
-      #     @option options [Boolean] :alternate_refs (false) pretend as if all objects mentioned
+      #     @option options [Boolean, nil] :alternate_refs (nil) pretend as if all objects mentioned
       #       as ref tips of alternate repositories are listed on the command line
       #
-      #     @option options [Boolean] :single_worktree (false) examine only the current working
+      #     @option options [Boolean, nil] :single_worktree (nil) examine only the current working
       #       tree when `--all`, `--reflog`, or similar options are in use
       #
-      #     @option options [Boolean] :ignore_missing (false) ignore invalid object names in input
+      #     @option options [Boolean, nil] :ignore_missing (nil) ignore invalid object names in input
       #
-      #     @option options [Boolean] :bisect (false) pretend as if the bad bisect ref was listed
+      #     @option options [Boolean, nil] :bisect (nil) pretend as if the bad bisect ref was listed
       #       and the good bisect refs were excluded
       #
-      #     @option options [Boolean] :cherry_mark (false) like `:cherry_pick` but marks
+      #     @option options [Boolean, nil] :cherry_mark (nil) like `:cherry_pick` but marks
       #       equivalent commits with `=` instead of omitting them; inequivalent ones with +++
       #
-      #     @option options [Boolean] :cherry_pick (false) omit commits that introduce the same
+      #     @option options [Boolean, nil] :cherry_pick (nil) omit commits that introduce the same
       #       change as a commit on the other side of a symmetric difference
       #
-      #     @option options [Boolean] :left_only (false) list only commits reachable from the
+      #     @option options [Boolean, nil] :left_only (nil) list only commits reachable from the
       #       left side of a symmetric difference
       #
-      #     @option options [Boolean] :right_only (false) list only commits reachable from the
+      #     @option options [Boolean, nil] :right_only (nil) list only commits reachable from the
       #       right side of a symmetric difference
       #
-      #     @option options [Boolean] :cherry (false) synonym for
+      #     @option options [Boolean, nil] :cherry (nil) synonym for
       #       `--right-only --cherry-mark --no-merges`
       #
-      #     @option options [Boolean] :walk_reflogs (false) walk reflog entries from most recent
+      #     @option options [Boolean, nil] :walk_reflogs (nil) walk reflog entries from most recent
       #       to oldest instead of the commit ancestry chain
       #
       #       Alias: `:g`
       #
-      #     @option options [Boolean] :merge (false) show commits touching conflicted paths in
+      #     @option options [Boolean, nil] :merge (nil) show commits touching conflicted paths in
       #       the range `HEAD...MERGE_HEAD`; only useful with unmerged index entries
       #
-      #     @option options [Boolean] :boundary (false) output excluded boundary commits,
+      #     @option options [Boolean, nil] :boundary (nil) output excluded boundary commits,
       #       prefixed with `-`
       #
       #     ### History Simplification
       #
-      #     @option options [Boolean] :simplify_by_decoration (false) show only commits referenced
+      #     @option options [Boolean, nil] :simplify_by_decoration (nil) show only commits referenced
       #       by some branch or tag
       #
-      #     @option options [Boolean] :show_pulls (false) include merge commits that are not
+      #     @option options [Boolean, nil] :show_pulls (nil) include merge commits that are not
       #       TREESAME to their first parent but are TREESAME to a later parent
       #
-      #     @option options [Boolean] :full_history (false) do not prune history; show all commits
+      #     @option options [Boolean, nil] :full_history (nil) do not prune history; show all commits
       #       that touched the given path(s)
       #
-      #     @option options [Boolean] :dense (false) show only commits not TREESAME to any parent
+      #     @option options [Boolean, nil] :dense (nil) show only commits not TREESAME to any parent
       #
-      #     @option options [Boolean] :sparse (false) show all commits in the simplified history
+      #     @option options [Boolean, nil] :sparse (nil) show all commits in the simplified history
       #
-      #     @option options [Boolean] :simplify_merges (false) remove needless merges from the
+      #     @option options [Boolean, nil] :simplify_merges (nil) remove needless merges from the
       #       result of `:full_history` with parent rewriting
       #
-      #     @option options [Boolean, String] :ancestry_path (false) limit to commits on the
+      #     @option options [Boolean, String, nil] :ancestry_path (nil) limit to commits on the
       #       ancestry chain between the range endpoints
       #
       #       Pass `true` for `--ancestry-path`; pass a commit SHA for `--ancestry-path=<commit>`
       #
       #     ### Commit Ordering
       #
-      #     @option options [Boolean] :date_order (false) show commits in commit timestamp order,
+      #     @option options [Boolean, nil] :date_order (nil) show commits in commit timestamp order,
       #       no parents before all children
       #
-      #     @option options [Boolean] :author_date_order (false) like `:date_order` but ordered
+      #     @option options [Boolean, nil] :author_date_order (nil) like `:date_order` but ordered
       #       by author timestamp
       #
-      #     @option options [Boolean] :topo_order (false) avoid showing commits on multiple lines
+      #     @option options [Boolean, nil] :topo_order (nil) avoid showing commits on multiple lines
       #       of history intermixed
       #
-      #     @option options [Boolean] :reverse (false) output selected commits in reverse order;
+      #     @option options [Boolean, nil] :reverse (nil) output selected commits in reverse order;
       #       cannot be combined with `:walk_reflogs`
       #
       #     ### Object Traversal
       #
-      #     @option options [Boolean, String] :no_walk (false) show only the given commits without
+      #     @option options [Boolean, String, nil] :no_walk (nil) show only the given commits without
       #       traversing ancestors
       #
       #       Pass `true` for `--no-walk` (sorted); pass `"unsorted"` for `--no-walk=unsorted`
       #
-      #     @option options [Boolean] :do_walk (false) override a previous `--no-walk`
+      #     @option options [Boolean, nil] :do_walk (nil) override a previous `--no-walk`
       #
       #     ### Commit Formatting
       #
-      #     @option options [Boolean, String] :pretty (false) pretty-print commit log in a format
+      #     @option options [Boolean, String, nil] :pretty (nil) pretty-print commit log in a format
       #
       #       Pass `true` for `--pretty` (`medium` format); pass a format name such as `"oneline"`,
       #       `"short"`, `"full"`, `"fuller"`, `"email"`, `"raw"`, or a `format:<string>`
@@ -389,68 +389,68 @@ module Git
       #
       #       Alias: `:format`
       #
-      #     @option options [Boolean] :abbrev_commit (false) abbreviate commit hash (`--abbrev-commit`)
+      #     @option options [Boolean, nil] :abbrev_commit (nil) abbreviate commit hash (`--abbrev-commit`)
       #
-      #     @option options [Boolean] :no_abbrev_commit (false) do not abbreviate commit hash (`--no-abbrev-commit`)
+      #     @option options [Boolean, nil] :no_abbrev_commit (nil) do not abbreviate commit hash (`--no-abbrev-commit`)
       #
-      #     @option options [Boolean] :oneline (false) shorthand for
+      #     @option options [Boolean, nil] :oneline (nil) shorthand for
       #       `--pretty=oneline --abbrev-commit`
       #
       #     @option options [String] :encoding (nil) re-encode the commit log message in the
       #       given character encoding before output
       #
-      #     @option options [Boolean, String] :expand_tabs (false) expand tabs in log messages (`--expand-tabs`)
+      #     @option options [Boolean, String, nil] :expand_tabs (nil) expand tabs in log messages (`--expand-tabs`)
       #
       #       Pass `true` for `--expand-tabs` (width 8); pass an integer string like `"4"` for
       #       `--expand-tabs=<n>`
       #
-      #     @option options [Boolean] :no_expand_tabs (false) do not expand tabs in log messages (`--no-expand-tabs`)
+      #     @option options [Boolean, nil] :no_expand_tabs (nil) do not expand tabs in log messages (`--no-expand-tabs`)
       #
-      #     @option options [Boolean, String] :notes (false) show notes annotating the commit (`--notes`)
+      #     @option options [Boolean, String, nil] :notes (nil) show notes annotating the commit (`--notes`)
       #
       #       Pass `true` for `--notes`; pass a ref string for `--notes=<ref>`
       #
-      #     @option options [Boolean] :no_notes (false) suppress notes output (`--no-notes`)
+      #     @option options [Boolean, nil] :no_notes (nil) suppress notes output (`--no-notes`)
       #
-      #     @option options [Boolean] :show_notes_by_default (false) show the default notes unless
+      #     @option options [Boolean, nil] :show_notes_by_default (nil) show the default notes unless
       #       options for displaying specific notes are given
       #
-      #     @option options [Boolean] :show_signature (false) verify a signed commit with
+      #     @option options [Boolean, nil] :show_signature (nil) verify a signed commit with
       #       `gpg --verify`
       #
-      #     @option options [Boolean] :relative_date (false) show dates relative to the current
+      #     @option options [Boolean, nil] :relative_date (nil) show dates relative to the current
       #       time (synonym for `--date=relative`)
       #
       #     @option options [String] :date (nil) format for dates in human-readable output
       #
       #       Examples: `'relative'`, `'iso'`, `'short'`, `'format:%Y-%m-%d'`
       #
-      #     @option options [Boolean] :parents (false) print the parents of each commit and
+      #     @option options [Boolean, nil] :parents (nil) print the parents of each commit and
       #       enable parent rewriting
       #
-      #     @option options [Boolean] :children (false) print the children of each commit and
+      #     @option options [Boolean, nil] :children (nil) print the children of each commit and
       #       enable parent rewriting
       #
-      #     @option options [Boolean] :left_right (false) mark which side of a symmetric
+      #     @option options [Boolean, nil] :left_right (nil) mark which side of a symmetric
       #       difference a commit is reachable from (`<` for left, `>` for right)
       #
-      #     @option options [Boolean] :graph (false) draw a text-based graphical representation
+      #     @option options [Boolean, nil] :graph (nil) draw a text-based graphical representation
       #       of the commit history on the left side of output; implies `--topo-order`
       #
-      #     @option options [Boolean, String] :show_linear_break (false) put a barrier between
+      #     @option options [Boolean, String, nil] :show_linear_break (nil) put a barrier between
       #       non-linear consecutive commits when `--graph` is not used
       #
       #       Pass `true` for `--show-linear-break`; pass a string for a custom barrier text
       #
-      #     @option options [Boolean] :follow (false) continue listing the history of a file
+      #     @option options [Boolean, nil] :follow (nil) continue listing the history of a file
       #       beyond renames; requires `:path` to be set to exactly one path element
       #
-      #     @option options [Boolean, String] :decorate (false) print ref names of commits shown (`--decorate`)
+      #     @option options [Boolean, String, nil] :decorate (nil) print ref names of commits shown (`--decorate`)
       #
       #       Pass `true` for `--decorate` (short format); pass a string such as `"full"` for
       #       `--decorate=<format>`
       #
-      #     @option options [Boolean] :no_decorate (false) do not print ref names (`--no-decorate`)
+      #     @option options [Boolean, nil] :no_decorate (nil) do not print ref names (`--no-decorate`)
       #
       #     @option options [String] :decorate_refs (nil) use only refs matching this pattern
       #       for decorations
@@ -458,30 +458,30 @@ module Git
       #     @option options [String] :decorate_refs_exclude (nil) do not use refs matching this
       #       pattern for decorations
       #
-      #     @option options [Boolean] :clear_decorations (false) clear all previous
+      #     @option options [Boolean, nil] :clear_decorations (nil) clear all previous
       #       `--decorate-refs` / `--decorate-refs-exclude` options
       #
-      #     @option options [Boolean] :source (false) print the ref name by which each commit
+      #     @option options [Boolean, nil] :source (nil) print the ref name by which each commit
       #       was reached
       #
-      #     @option options [Boolean] :use_mailmap (false) use the mailmap file to map author/
+      #     @option options [Boolean, nil] :use_mailmap (nil) use the mailmap file to map author/
       #       committer names and addresses to canonical real names (`--use-mailmap`)
       #
-      #     @option options [Boolean] :no_use_mailmap (false) disable mailmap substitution (`--no-use-mailmap`)
+      #     @option options [Boolean, nil] :no_use_mailmap (nil) disable mailmap substitution (`--no-use-mailmap`)
       #
-      #     @option options [Boolean] :full_diff (false) show full diff for commits touching the
+      #     @option options [Boolean, nil] :full_diff (nil) show full diff for commits touching the
       #       specified paths, not just the diff for those paths
       #
-      #     @option options [Boolean] :log_size (false) include a `log size <n>` line for each
+      #     @option options [Boolean, nil] :log_size (nil) include a `log size <n>` line for each
       #       commit indicating the length of the commit message in bytes
       #
       #     ### Diff Formatting
       #
-      #     @option options [Boolean] :patch (false) generate patch output
+      #     @option options [Boolean, nil] :patch (nil) generate patch output
       #
       #       Alias: `:p`
       #
-      #     @option options [Boolean] :no_patch (false) suppress all diff output
+      #     @option options [Boolean, nil] :no_patch (nil) suppress all diff output
       #
       #       Alias: `:s`
       #
@@ -490,62 +490,62 @@ module Git
       #       Values: `"off"`, `"on"`, `"first-parent"`, `"separate"`, `"combined"`,
       #       `"dense-combined"`, `"remerge"`
       #
-      #     @option options [Boolean] :no_diff_merges (false) disable diff output for merge
+      #     @option options [Boolean, nil] :no_diff_merges (nil) disable diff output for merge
       #       commits (synonym for `--diff-merges=off`)
       #
-      #     @option options [Boolean] :combined_all_paths (false) in combined diffs, list the
+      #     @option options [Boolean, nil] :combined_all_paths (nil) in combined diffs, list the
       #       file name from all parents; only meaningful with `-c` or `--cc`
       #
-      #     @option options [Boolean] :raw (false) show a summary of changes using the raw diff
+      #     @option options [Boolean, nil] :raw (nil) show a summary of changes using the raw diff
       #       format for each commit
       #
-      #     @option options [Boolean, String] :stat (false) generate a diffstat
+      #     @option options [Boolean, String, nil] :stat (nil) generate a diffstat
       #
       #       Pass `true` for `--stat`; pass a string such as `"80,40"` for
       #       `--stat=<width>[,<name-width>[,<count>]]`
       #
-      #     @option options [Boolean] :compact_summary (false) output a condensed summary of
+      #     @option options [Boolean, nil] :compact_summary (nil) output a condensed summary of
       #       extended header information in diffstat; implies `--stat`
       #
-      #     @option options [Boolean] :numstat (false) like `--stat` but shows numbers of added
+      #     @option options [Boolean, nil] :numstat (nil) like `--stat` but shows numbers of added
       #       and deleted lines in decimal notation without abbreviation
       #
-      #     @option options [Boolean] :shortstat (false) output only the last line of the
+      #     @option options [Boolean, nil] :shortstat (nil) output only the last line of the
       #       `--stat` format
       #
-      #     @option options [Boolean, String] :dirstat (false) output distribution of relative
+      #     @option options [Boolean, String, nil] :dirstat (nil) output distribution of relative
       #       amount of changes per sub-directory
       #
       #       Pass `true` for `--dirstat`; pass a parameter string such as `"files,10"` for
       #       `--dirstat=<params>`
       #
-      #     @option options [Boolean] :summary (false) output a condensed summary of extended
+      #     @option options [Boolean, nil] :summary (nil) output a condensed summary of extended
       #       header information such as creations, renames, and mode changes
       #
-      #     @option options [Boolean] :name_only (false) show only the names of changed files
+      #     @option options [Boolean, nil] :name_only (nil) show only the names of changed files
       #
-      #     @option options [Boolean] :name_status (false) show only the names and status of
+      #     @option options [Boolean, nil] :name_status (nil) show only the names and status of
       #       changed files
       #
-      #     @option options [Boolean, String] :submodule (false) specify how differences in
+      #     @option options [Boolean, String, nil] :submodule (nil) specify how differences in
       #       submodules are shown
       #
       #       Pass `true` for `--submodule` (log format); pass `"short"`, `"log"`, or `"diff"`
       #       for `--submodule=<format>`
       #
-      #     @option options [Boolean, String] :color (false) show colored diff output (`--color`)
+      #     @option options [Boolean, String, nil] :color (nil) show colored diff output (`--color`)
       #
       #       Pass `true` for `--color`; pass a string such as `"always"` for `--color=<when>`
       #
-      #     @option options [Boolean] :no_color (false) suppress colored diff output (`--no-color`)
+      #     @option options [Boolean, nil] :no_color (nil) suppress colored diff output (`--no-color`)
       #
-      #     @option options [Boolean] :full_index (false) show the full pre- and post-image blob
+      #     @option options [Boolean, nil] :full_index (nil) show the full pre- and post-image blob
       #       object names on the index line of patch output
       #
-      #     @option options [Boolean] :binary (false) output a binary diff that can be applied
+      #     @option options [Boolean, nil] :binary (nil) output a binary diff that can be applied
       #       with `git apply`; implies `--patch`
       #
-      #     @option options [Boolean, String] :abbrev (false) show the shortest unique object
+      #     @option options [Boolean, String, nil] :abbrev (nil) show the shortest unique object
       #       name prefix in diff-raw output
       #
       #       Pass `true` for `--abbrev`; pass an integer string for `--abbrev=<n>`
@@ -553,54 +553,54 @@ module Git
       #     @option options [String] :diff_filter (nil) select files by status letter
       #       (e.g. `"AD"` for Added and Deleted)
       #
-      #     @option options [Boolean, String] :find_renames (false) detect renames
+      #     @option options [Boolean, String, nil] :find_renames (nil) detect renames
       #
       #       Pass `true` for `--find-renames`; pass a percentage threshold string such as
       #       `"90"` for `--find-renames=<n>`
       #
-      #     @option options [Boolean, String] :find_copies (false) detect copies as well as
+      #     @option options [Boolean, String, nil] :find_copies (nil) detect copies as well as
       #       renames
       #
       #       Pass `true` for `--find-copies`; pass a threshold string for `--find-copies=<n>`
       #
-      #     @option options [Boolean] :find_copies_harder (false) inspect unmodified files as
+      #     @option options [Boolean, nil] :find_copies_harder (nil) inspect unmodified files as
       #       candidates for copy source; expensive for large projects
       #
-      #     @option options [Boolean, String] :relative (false) show pathnames relative to the
+      #     @option options [Boolean, String, nil] :relative (nil) show pathnames relative to the
       #       given subdirectory, or the current directory when run from a subdirectory (`--relative`)
       #
       #       Pass `true` for `--relative`; pass a path string for `--relative=<path>`
       #
-      #     @option options [Boolean] :no_relative (false) show absolute pathnames (`--no-relative`)
+      #     @option options [Boolean, nil] :no_relative (nil) show absolute pathnames (`--no-relative`)
       #
-      #     @option options [Boolean] :text (false) treat all files as text; alias `-a`
+      #     @option options [Boolean, nil] :text (nil) treat all files as text; alias `-a`
       #
-      #     @option options [Boolean] :ignore_space_at_eol (false) ignore changes in whitespace
+      #     @option options [Boolean, nil] :ignore_space_at_eol (nil) ignore changes in whitespace
       #       at end of line
       #
-      #     @option options [Boolean] :ignore_space_change (false) ignore changes in amount of
+      #     @option options [Boolean, nil] :ignore_space_change (nil) ignore changes in amount of
       #       whitespace; alias `-b`
       #
-      #     @option options [Boolean] :ignore_all_space (false) ignore whitespace when comparing
+      #     @option options [Boolean, nil] :ignore_all_space (nil) ignore whitespace when comparing
       #       lines; alias `-w`
       #
-      #     @option options [Boolean] :ignore_blank_lines (false) ignore changes whose lines are
+      #     @option options [Boolean, nil] :ignore_blank_lines (nil) ignore changes whose lines are
       #       all blank
       #
       #     @option options [String] :ignore_matching_lines (nil) ignore changes whose all lines
       #       match the given regular expression
       #
-      #     @option options [Boolean] :ext_diff (false) allow external diff helpers (`--ext-diff`)
+      #     @option options [Boolean, nil] :ext_diff (nil) allow external diff helpers (`--ext-diff`)
       #
-      #     @option options [Boolean] :no_ext_diff (false) disallow external diff helpers (`--no-ext-diff`)
+      #     @option options [Boolean, nil] :no_ext_diff (nil) disallow external diff helpers (`--no-ext-diff`)
       #
-      #     @option options [Boolean] :textconv (false) allow external text conversion filters
+      #     @option options [Boolean, nil] :textconv (nil) allow external text conversion filters
       #       when comparing binary files (`--textconv`)
       #
-      #     @option options [Boolean] :no_textconv (false) disallow external text conversion filters
+      #     @option options [Boolean, nil] :no_textconv (nil) disallow external text conversion filters
       #       (`--no-textconv`)
       #
-      #     @option options [Boolean] :no_prefix (false) do not show any source or destination
+      #     @option options [Boolean, nil] :no_prefix (nil) do not show any source or destination
       #       prefix
       #
       #     @option options [String] :src_prefix (nil) show the given source prefix instead of

--- a/lib/git/commands/ls_files.rb
+++ b/lib/git/commands/ls_files.rb
@@ -83,29 +83,29 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :z (false) use NUL line termination and do not quote filenames
+      #     @option options [Boolean, nil] :z (nil) use NUL line termination and do not quote filenames
       #
-      #     @option options [Boolean] :t (false) show status tags together with filenames
+      #     @option options [Boolean, nil] :t (nil) show status tags together with filenames
       #
-      #     @option options [Boolean] :v (false) similar to `-t` but use lowercase letters for files
+      #     @option options [Boolean, nil] :v (nil) similar to `-t` but use lowercase letters for files
       #       that are marked as assume unchanged
       #
-      #     @option options [Boolean] :f (false) similar to `-t` but use lowercase letters for files
+      #     @option options [Boolean, nil] :f (nil) similar to `-t` but use lowercase letters for files
       #       that are marked as fsmonitor valid
       #
-      #     @option options [Boolean] :cached (false) show all files cached in the index
+      #     @option options [Boolean, nil] :cached (nil) show all files cached in the index
       #
       #       Alias: :c
       #
-      #     @option options [Boolean] :deleted (false) show files with an unstaged deletion
+      #     @option options [Boolean, nil] :deleted (nil) show files with an unstaged deletion
       #
       #       Alias: :d
       #
-      #     @option options [Boolean] :others (false) show other (i.e. untracked) files in the output
+      #     @option options [Boolean, nil] :others (nil) show other (i.e. untracked) files in the output
       #
       #       Alias: :o
       #
-      #     @option options [Boolean] :ignored (false) show only ignored files in the output
+      #     @option options [Boolean, nil] :ignored (nil) show only ignored files in the output
       #
       #       Must be used with either `:cached` or `:others`. When used with `:cached`, shows only
       #       cached files matching an exclude pattern. When used with `:others`, shows only
@@ -113,33 +113,33 @@ module Git
       #
       #       Alias: :i
       #
-      #     @option options [Boolean] :stage (false) show object name, mode bits, and stage number
+      #     @option options [Boolean, nil] :stage (nil) show object name, mode bits, and stage number
       #
       #       Alias: :s
       #
-      #     @option options [Boolean] :unmerged (false) show information about unmerged files
+      #     @option options [Boolean, nil] :unmerged (nil) show information about unmerged files
       #
       #       Alias: :u
       #
-      #     @option options [Boolean] :killed (false) show untracked files that need to be removed
+      #     @option options [Boolean, nil] :killed (nil) show untracked files that need to be removed
       #       due to file/directory conflicts for tracked files
       #
       #       Alias: :k
       #
-      #     @option options [Boolean] :modified (false) show files with an unstaged modification
+      #     @option options [Boolean, nil] :modified (nil) show files with an unstaged modification
       #
       #       Alias: :m
       #
-      #     @option options [Boolean] :resolve_undo (false) show files having resolve-undo information
+      #     @option options [Boolean, nil] :resolve_undo (nil) show files having resolve-undo information
       #
-      #     @option options [Boolean] :directory (false) show just the directory name (with trailing
+      #     @option options [Boolean, nil] :directory (nil) show just the directory name (with trailing
       #       slash) when a whole directory is classified as "other"
       #
-      #     @option options [Boolean] :no_empty_directory (false) do not list empty directories
+      #     @option options [Boolean, nil] :no_empty_directory (nil) do not list empty directories
       #
-      #     @option options [Boolean] :eol (false) show EOL and encoding attributes of files
+      #     @option options [Boolean, nil] :eol (nil) show EOL and encoding attributes of files
       #
-      #     @option options [Boolean] :deduplicate (false) suppress duplicate filenames when showing
+      #     @option options [Boolean, nil] :deduplicate (nil) suppress duplicate filenames when showing
       #       only filenames
       #
       #     @option options [String] :exclude (nil) skip untracked files matching the given pattern
@@ -153,27 +153,27 @@ module Git
       #     @option options [String] :exclude_per_directory (nil) read additional exclude patterns
       #       from the named file in each directory
       #
-      #     @option options [Boolean] :exclude_standard (false) add the standard git exclusions
+      #     @option options [Boolean, nil] :exclude_standard (nil) add the standard git exclusions
       #
-      #     @option options [Boolean] :error_unmatch (false) treat unmatched files as an error
+      #     @option options [Boolean, nil] :error_unmatch (nil) treat unmatched files as an error
       #
       #     @option options [String] :with_tree (nil) pretend paths removed since the named
       #       tree-ish are still present when using `--error-unmatch`
       #
-      #     @option options [Boolean] :full_name (false) force paths to be output relative to the
+      #     @option options [Boolean, nil] :full_name (nil) force paths to be output relative to the
       #       project top-level directory
       #
-      #     @option options [Boolean] :recurse_submodules (false) recursively calls ls-files on each
+      #     @option options [Boolean, nil] :recurse_submodules (nil) recursively calls ls-files on each
       #       active submodule in the repository
       #
-      #     @option options [Boolean, Integer, String] :abbrev (nil) show only a partial prefix of the
+      #     @option options [Boolean, Integer, String, nil] :abbrev (nil) show only a partial prefix of the
       #       object name; pass `true` for the default number of hex digits, or an Integer or String
       #       for a specific prefix length (e.g., `abbrev: 10` or `abbrev: "10"`)
       #
-      #     @option options [Boolean] :debug (false) after each filename, output raw index information
+      #     @option options [Boolean, nil] :debug (nil) after each filename, output raw index information
       #       (ctime data, mtime data, dev, ino, uid, gid, size, flags, flagsx)
       #
-      #     @option options [Boolean] :sparse (false) if the index is sparse, show the sparse directory
+      #     @option options [Boolean, nil] :sparse (nil) if the index is sparse, show the sparse directory
       #       entries rather than expanding to the contained files
       #
       #     @option options [String] :format (nil) a string that interpolates %(fieldname) from

--- a/lib/git/commands/ls_remote.rb
+++ b/lib/git/commands/ls_remote.rb
@@ -90,62 +90,62 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :branches (false) Limit output to refs under `refs/heads/`
+      #     @option options [Boolean, nil] :branches (nil) limit output to refs under `refs/heads/`
       #
       #       Alias: :b
       #
-      #     @option options [Boolean] :heads (false) Limit output to refs under `refs/heads/`
+      #     @option options [Boolean, nil] :heads (nil) limit output to refs under `refs/heads/`
       #
       #       Deprecated: use `:branches` instead. Kept for backward compatibility with
       #       older git versions where `--heads` is the only supported flag.
       #
       #       Alias: :h
       #
-      #     @option options [Boolean] :tags (false) Limit output to refs under `refs/tags/`
+      #     @option options [Boolean, nil] :tags (nil) limit output to refs under `refs/tags/`
       #
       #       Alias: :t
       #
-      #     @option options [Boolean] :refs (false) Exclude peeled tags and pseudorefs
+      #     @option options [Boolean, nil] :refs (nil) exclude peeled tags and pseudorefs
       #       like `HEAD` from the output
       #
-      #     @option options [String] :upload_pack (nil) Full path to `git-upload-pack`
+      #     @option options [String] :upload_pack (nil) full path to `git-upload-pack`
       #       on the remote host
       #
       #       Useful when accessing repositories via SSH where the daemon does not
       #       use the PATH configured by the user.
       #
-      #     @option options [Boolean] :quiet (false) Do not print the remote URL to stderr
+      #     @option options [Boolean, nil] :quiet (nil) do not print the remote URL to stderr
       #
       #       Alias: :q
       #
-      #     @option options [Boolean] :exit_code (false) Exit with status `2` when no
+      #     @option options [Boolean, nil] :exit_code (nil) exit with status `2` when no
       #       matching refs are found in the remote repository
       #
       #       Without this option, the command exits `0` whenever it successfully
       #       communicates with the remote, even if no refs match.
       #
-      #     @option options [Boolean] :get_url (false) Expand and print the remote URL
+      #     @option options [Boolean, nil] :get_url (nil) expand and print the remote URL
       #       (respecting `url.<base>.insteadOf` config) and exit without contacting
       #       the remote
       #
-      #     @option options [String] :sort (nil) Sort output by the given key
+      #     @option options [String] :sort (nil) sort output by the given key
       #
       #       Prefix `-` for descending order. Supports `"version:refname"` or
       #       `"v:refname"`. See `git for-each-ref` for sort key documentation.
       #
-      #     @option options [Boolean] :symref (false) Show the underlying ref pointed to by
+      #     @option options [Boolean, nil] :symref (nil) show the underlying ref pointed to by
       #       symbolic refs
       #
       #       The `upload-pack` protocol currently surfaces only the `HEAD` symref,
       #       so that is typically the only symref shown.
       #
-      #     @option options [String, Array<String>] :server_option (nil) Transmit a
+      #     @option options [String, Array<String>] :server_option (nil) transmit a
       #       string to the server when communicating using protocol version 2
       #
       #       The string must not contain NUL or LF characters. Repeatable by
       #       passing an Array. Alias: :o
       #
-      #     @option options [Numeric] :timeout (nil) Execution timeout in seconds
+      #     @option options [Numeric] :timeout (nil) execution timeout in seconds
       #
       #     @return [Git::CommandLineResult] the result of calling `git ls-remote`
       #

--- a/lib/git/commands/ls_tree.rb
+++ b/lib/git/commands/ls_tree.rb
@@ -71,45 +71,45 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :d (false) show only the named tree entry itself,
+      #     @option options [Boolean, nil] :d (nil) show only the named tree entry itself,
       #       not its children
       #
-      #     @option options [Boolean] :r (false) recurse into sub-trees
+      #     @option options [Boolean, nil] :r (nil) recurse into sub-trees
       #
-      #     @option options [Boolean] :t (false) show tree entries even when going to
+      #     @option options [Boolean, nil] :t (nil) show tree entries even when going to
       #       recurse them
       #
       #       Implies recursive listing (`:r`) in git.
       #
-      #     @option options [Boolean] :long (false) show object size of blob (file)
+      #     @option options [Boolean, nil] :long (nil) show object size of blob (file)
       #       objects
       #
       #       Cannot be combined with `:name_only` or `:object_only`.
       #
       #       Alias: :l
       #
-      #     @option options [Boolean] :z (false) use NUL (`\0`) as line terminator
+      #     @option options [Boolean, nil] :z (nil) use NUL (`\0`) as line terminator
       #       instead of newline, and do not quote filenames
       #
-      #     @option options [Boolean] :name_only (false) list only filenames, one per
+      #     @option options [Boolean, nil] :name_only (nil) list only filenames, one per
       #       line
       #
       #       Cannot be combined with `:object_only` or `:long`.
       #
       #       Alias: :name_status
       #
-      #     @option options [Boolean] :object_only (false) list only the object names
+      #     @option options [Boolean, nil] :object_only (nil) list only the object names
       #       (SHAs), one per line
       #
       #       Cannot be combined with `:name_only` or `:long`.
       #
-      #     @option options [Boolean] :full_name (false) show full path names instead
+      #     @option options [Boolean, nil] :full_name (nil) show full path names instead
       #       of paths relative to the current working directory
       #
-      #     @option options [Boolean] :full_tree (false) do not limit the listing to
+      #     @option options [Boolean, nil] :full_tree (nil) do not limit the listing to
       #       the current working directory; implies `:full_name`
       #
-      #     @option options [Boolean, String] :abbrev (nil) use abbreviated object names
+      #     @option options [Boolean, String, nil] :abbrev (nil) use abbreviated object names
       #
       #       When `true`, uses git's default abbreviated name length. When a string
       #       (e.g. `'8'`), uses exactly that many hex digits.

--- a/lib/git/commands/maintenance/register.rb
+++ b/lib/git/commands/maintenance/register.rb
@@ -49,12 +49,12 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, String] :config_file (false) use a specified
+        #     @option options [Boolean, String, nil] :config_file (nil) use a specified
         #       config file instead of the global config (`--config-file`)
         #
         #       When a String, the path is passed as `--config-file <file>`.
         #
-        #     @option options [Boolean] :no_config_file (false) disable the config file
+        #     @option options [Boolean, nil] :no_config_file (nil) disable the config file
         #       (`--no-config-file`)
         #
         #     @option options [Hash] :env (nil) environment variables to set for the git

--- a/lib/git/commands/maintenance/run.rb
+++ b/lib/git/commands/maintenance/run.rb
@@ -51,33 +51,33 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :auto (false) run tasks only if thresholds are met (`--auto`)
+        #     @option options [Boolean, nil] :auto (nil) run tasks only if thresholds are met (`--auto`)
         #
         #       Not compatible with the `:schedule` option.
         #
-        #     @option options [Boolean] :no_auto (false) disable threshold-based execution (`--no-auto`)
+        #     @option options [Boolean, nil] :no_auto (nil) disable threshold-based execution (`--no-auto`)
         #
-        #     @option options [Boolean] :detach (false) detach the maintenance process from the current terminal
+        #     @option options [Boolean, nil] :detach (nil) detach the maintenance process from the current terminal
         #       (`--detach`)
         #
-        #     @option options [Boolean] :no_detach (false) do not detach the maintenance process (`--no-detach`)
+        #     @option options [Boolean, nil] :no_detach (nil) do not detach the maintenance process (`--no-detach`)
         #
-        #     @option options [Boolean] :scheduled (false) run tasks that are due according to schedule config
+        #     @option options [Boolean, nil] :scheduled (nil) run tasks that are due according to schedule config
         #       (`--scheduled`)
         #
-        #     @option options [Boolean] :no_scheduled (false) do not limit runs to scheduled tasks (`--no-scheduled`)
+        #     @option options [Boolean, nil] :no_scheduled (nil) do not limit runs to scheduled tasks (`--no-scheduled`)
         #
-        #     @option options [Boolean, String] :schedule (false) run tasks only if time conditions are met
+        #     @option options [Boolean, String, nil] :schedule (nil) run tasks only if time conditions are met
         #       (`--schedule`)
         #
         #       When a String (`'hourly'`, `'daily'`, or `'weekly'`), runs only tasks scheduled
         #       for that frequency; the string is emitted as `--schedule=<frequency>`.
         #
-        #     @option options [Boolean] :no_schedule (false) disable schedule-based filtering (`--no-schedule`)
+        #     @option options [Boolean, nil] :no_schedule (nil) disable schedule-based filtering (`--no-schedule`)
         #
-        #     @option options [Boolean] :quiet (false) suppress progress and informational messages (`--quiet`)
+        #     @option options [Boolean, nil] :quiet (nil) suppress progress and informational messages (`--quiet`)
         #
-        #     @option options [Boolean] :no_quiet (false) enable progress and informational messages (`--no-quiet`)
+        #     @option options [Boolean, nil] :no_quiet (nil) enable progress and informational messages (`--no-quiet`)
         #
         #     @option options [Array<String>, String] :task (nil) specify which task(s) to run
         #

--- a/lib/git/commands/maintenance/unregister.rb
+++ b/lib/git/commands/maintenance/unregister.rb
@@ -47,18 +47,18 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, String] :config_file (false) use a specified
+        #     @option options [Boolean, String, nil] :config_file (nil) use a specified
         #       config file instead of the global config (`--config-file`)
         #
         #       When a String, the path is passed as `--config-file <file>`.
         #
-        #     @option options [Boolean] :no_config_file (false) disable the config file
+        #     @option options [Boolean, nil] :no_config_file (nil) disable the config file
         #       (`--no-config-file`)
         #
-        #     @option options [Boolean] :force (false) return success even if repository is not registered
+        #     @option options [Boolean, nil] :force (nil) return success even if repository is not registered
         #       (`--force`)
         #
-        #     @option options [Boolean] :no_force (false) fail if the repository is not registered
+        #     @option options [Boolean, nil] :no_force (nil) fail if the repository is not registered
         #       (`--no-force`)
         #
         #     @option options [Hash] :env (nil) environment variables to set for the git

--- a/lib/git/commands/merge/start.rb
+++ b/lib/git/commands/merge/start.rb
@@ -111,15 +111,15 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :commit (false) perform merge and commit the result (`--commit`)
+        #     @option options [Boolean, nil] :commit (nil) perform merge and commit the result (`--commit`)
         #
-        #     @option options [Boolean] :no_commit (false) do not perform a merge commit (`--no-commit`)
+        #     @option options [Boolean, nil] :no_commit (nil) do not perform a merge commit (`--no-commit`)
         #
-        #     @option options [Boolean] :edit (false) open an editor for the merge commit message (`--edit`)
+        #     @option options [Boolean, nil] :edit (nil) open an editor for the merge commit message (`--edit`)
         #
         #       Alias: `:e`
         #
-        #     @option options [Boolean] :no_edit (false) skip the editor for the merge commit message (`--no-edit`)
+        #     @option options [Boolean, nil] :no_edit (nil) skip the editor for the merge commit message (`--no-edit`)
         #
         #     @option options [String] :cleanup (nil) how the merge message will be cleaned
         #       up before committing
@@ -127,48 +127,50 @@ module Git
         #       Accepted values include `strip`, `whitespace`, `verbatim`,
         #       `scissors`, and `default`. Emits `--cleanup=<mode>`.
         #
-        #     @option options [Boolean] :ff (false) allow fast-forward merges (`--ff`)
+        #     @option options [Boolean, nil] :ff (nil) allow fast-forward merges (`--ff`)
         #
-        #     @option options [Boolean] :no_ff (false) create a merge commit even when fast-forward is
+        #     @option options [Boolean, nil] :no_ff (nil) create a merge commit even when fast-forward is
         #       possible (`--no-ff`)
         #
-        #     @option options [Boolean] :ff_only (false) refuse to merge unless
+        #     @option options [Boolean, nil] :ff_only (nil) refuse to merge unless
         #       fast-forward is possible; emits `--ff-only`
         #
-        #     @option options [Boolean, String] :gpg_sign (false) GPG-sign the resulting
+        #     @option options [Boolean, String, nil] :gpg_sign (nil) GPG-sign the resulting
         #       merge commit (`--gpg-sign`)
         #
         #       Pass a key ID string to select the signing key; pass `true` to use the
         #       committer identity. Alias: `:S`
         #
-        #     @option options [Boolean] :no_gpg_sign (false) countermand commit.gpgSign
+        #     @option options [Boolean, nil] :no_gpg_sign (nil) countermand commit.gpgSign
         #       configuration (`--no-gpg-sign`)
         #
-        #     @option options [Boolean, Integer] :log (false) populate the merge message
+        #     @option options [Boolean, Integer, nil] :log (nil) populate the merge message
         #       with one-line commit descriptions (`--log`)
         #
         #       Pass an Integer `n` to limit to `n` entries (`--log=<n>`).
         #
-        #     @option options [Boolean] :no_log (false) do not list one-line commit descriptions (`--no-log`)
+        #     @option options [Boolean, nil] :no_log (nil) do not list one-line commit descriptions
+        #       (`--no-log`)
         #
-        #     @option options [Boolean] :signoff (false) add a Signed-off-by trailer to the commit message (`--signoff`)
+        #     @option options [Boolean, nil] :signoff (nil) add a Signed-off-by trailer to the commit
+        #       message (`--signoff`)
         #
-        #     @option options [Boolean] :no_signoff (false) remove a Signed-off-by trailer from the
+        #     @option options [Boolean, nil] :no_signoff (nil) remove a Signed-off-by trailer from the
         #       commit message (`--no-signoff`)
         #
-        #     @option options [Boolean] :stat (false) show a diffstat at the end of the merge (`--stat`)
+        #     @option options [Boolean, nil] :stat (nil) show a diffstat at the end of the merge (`--stat`)
         #
-        #     @option options [Boolean] :no_stat (false) suppress the diffstat at the end of the merge (`--no-stat`)
+        #     @option options [Boolean, nil] :no_stat (nil) suppress the diffstat at the end of the merge (`--no-stat`)
         #
-        #     @option options [Boolean] :compact_summary (false) show a compact summary
+        #     @option options [Boolean, nil] :compact_summary (nil) show a compact summary
         #       at the end of the merge; emits `--compact-summary`
         #
-        #     @option options [Boolean] :squash (false) produce working tree and index
+        #     @option options [Boolean, nil] :squash (nil) produce working tree and index
         #       state as if a real merge happened, but do not commit; emits `--squash`
         #
-        #     @option options [Boolean] :verify (false) run pre-merge and commit-msg hooks (`--verify`)
+        #     @option options [Boolean, nil] :verify (nil) run pre-merge and commit-msg hooks (`--verify`)
         #
-        #     @option options [Boolean] :no_verify (false) bypass pre-merge and commit-msg hooks (`--no-verify`)
+        #     @option options [Boolean, nil] :no_verify (nil) bypass pre-merge and commit-msg hooks (`--no-verify`)
         #
         #     @option options [String] :strategy (nil) merge strategy to use
         #       (e.g., `'ort'`, `'recursive'`, `'resolve'`, `'octopus'`, `'ours'`, `'subtree'`)
@@ -181,34 +183,34 @@ module Git
         #       Can be a single value or an array for multiple `--strategy-option` flags.
         #       Emits `--strategy-option=<option>`. Alias: `:X`
         #
-        #     @option options [Boolean] :verify_signatures (false) verify commit signatures
+        #     @option options [Boolean, nil] :verify_signatures (nil) verify commit signatures
         #       on the tip of the side branch (`--verify-signatures`)
         #
-        #     @option options [Boolean] :no_verify_signatures (false) do not verify commit
+        #     @option options [Boolean, nil] :no_verify_signatures (nil) do not verify commit
         #       signatures (`--no-verify-signatures`)
         #
-        #     @option options [Boolean] :quiet (false) operate quietly; emits `--quiet`
+        #     @option options [Boolean, nil] :quiet (nil) operate quietly; emits `--quiet`
         #
         #       Alias: `:q`
         #
-        #     @option options [Boolean] :verbose (false) be verbose; emits `--verbose`
+        #     @option options [Boolean, nil] :verbose (nil) be verbose; emits `--verbose`
         #
         #       Alias: `:v`
         #
-        #     @option options [Boolean] :progress (false) force progress status reporting (`--progress`)
+        #     @option options [Boolean, nil] :progress (nil) force progress status reporting (`--progress`)
         #
-        #     @option options [Boolean] :no_progress (false) suppress progress status reporting (`--no-progress`)
+        #     @option options [Boolean, nil] :no_progress (nil) suppress progress status reporting (`--no-progress`)
         #
-        #     @option options [Boolean] :autostash (false) automatically stash and unstash
+        #     @option options [Boolean, nil] :autostash (nil) automatically stash and unstash
         #       the working tree before and after the operation (`--autostash`)
         #
-        #     @option options [Boolean] :no_autostash (false) do not automatically stash and unstash
+        #     @option options [Boolean, nil] :no_autostash (nil) do not automatically stash and unstash
         #       the working tree (`--no-autostash`)
         #
-        #     @option options [Boolean] :allow_unrelated_histories (false) allow merging
+        #     @option options [Boolean, nil] :allow_unrelated_histories (nil) allow merging
         #       histories that do not share a common ancestor (`--allow-unrelated-histories`)
         #
-        #     @option options [Boolean] :no_allow_unrelated_histories (false) disallow merging
+        #     @option options [Boolean, nil] :no_allow_unrelated_histories (nil) disallow merging
         #       unrelated histories (`--no-allow-unrelated-histories`)
         #
         #     @option options [String] :m (nil) commit message for the merge commit;
@@ -220,16 +222,16 @@ module Git
         #     @option options [String] :file (nil) read the commit message from the given
         #       file; emits `--file=<file>`. Alias: `:F`
         #
-        #     @option options [Boolean] :rerere_autoupdate (false) allow rerere to update
+        #     @option options [Boolean, nil] :rerere_autoupdate (nil) allow rerere to update
         #       the index with the auto-resolved conflict result (`--rerere-autoupdate`)
         #
-        #     @option options [Boolean] :no_rerere_autoupdate (false) prevent rerere from
+        #     @option options [Boolean, nil] :no_rerere_autoupdate (nil) prevent rerere from
         #       auto-updating the index (`--no-rerere-autoupdate`)
         #
-        #     @option options [Boolean] :overwrite_ignore (false) silently overwrite ignored
+        #     @option options [Boolean, nil] :overwrite_ignore (nil) silently overwrite ignored
         #       files from the merge result (`--overwrite-ignore`)
         #
-        #     @option options [Boolean] :no_overwrite_ignore (false) abort if the merge result
+        #     @option options [Boolean, nil] :no_overwrite_ignore (nil) abort if the merge result
         #       would overwrite any ignored files (`--no-overwrite-ignore`)
         #
         #     @return [Git::CommandLineResult] the result of calling `git merge`

--- a/lib/git/commands/merge_base.rb
+++ b/lib/git/commands/merge_base.rb
@@ -57,19 +57,19 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :octopus (false) compute best common
+      #     @option options [Boolean, nil] :octopus (nil) compute best common
       #       ancestor for an n-way merge (intersection of all merge bases)
       #
-      #     @option options [Boolean] :independent (false) list commits not
+      #     @option options [Boolean, nil] :independent (nil) list commits not
       #       reachable from any other; useful for finding minimal merge points
       #
-      #     @option options [Boolean] :is_ancestor (false) check if the first
+      #     @option options [Boolean, nil] :is_ancestor (nil) check if the first
       #       commit is an ancestor of the second; exits 0 if true, 1 if not
       #
-      #     @option options [Boolean] :fork_point (false) find the fork point
+      #     @option options [Boolean, nil] :fork_point (nil) find the fork point
       #       where a branch diverged from another, consulting the reflog
       #
-      #     @option options [Boolean] :all (false) output all merge bases instead
+      #     @option options [Boolean, nil] :all (nil) output all merge bases instead
       #       of just one when multiple equally good bases exist
       #
       #       Alias: :a

--- a/lib/git/commands/mv.rb
+++ b/lib/git/commands/mv.rb
@@ -53,19 +53,19 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :verbose (false) Report the names of files as they are moved
+      #     @option options [Boolean, nil] :verbose (nil) report the names of files as they are moved
       #
       #       Alias: `:v`
       #
-      #     @option options [Boolean] :force (false) Force renaming or moving even if the destination exists
+      #     @option options [Boolean, nil] :force (nil) force renaming or moving even if the destination exists
       #
       #       Alias: `:f`
       #
-      #     @option options [Boolean] :dry_run (false) Do nothing; only show what would happen
+      #     @option options [Boolean, nil] :dry_run (nil) do nothing; only show what would happen
       #
       #       Alias: `:n`
       #
-      #     @option options [Boolean] :k (false) Skip move or rename actions which would lead to an error
+      #     @option options [Boolean, nil] :k (nil) skip move or rename actions which would lead to an error
       #
       #     @return [Git::CommandLineResult] the result of calling `git mv`
       #

--- a/lib/git/commands/name_rev.rb
+++ b/lib/git/commands/name_rev.rb
@@ -65,7 +65,7 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :tags (false) use only tags to name
+      #     @option options [Boolean, nil] :tags (nil) use only tags to name
       #       the commits, not branch names
       #
       #     @option options [String, Array<String>] :refs (nil) only use refs
@@ -74,7 +74,7 @@ module Git
       #       When given multiple times, uses refs whose names match any of the
       #       given shell patterns. Maps to `--refs=<pattern>`.
       #
-      #     @option options [Boolean] :no_refs (false) clear all previously given
+      #     @option options [Boolean, nil] :no_refs (nil) clear all previously given
       #       `--refs` patterns
       #
       #     @option options [String, Array<String>] :exclude (nil) do not use
@@ -83,24 +83,24 @@ module Git
       #       When given multiple times, a ref is excluded when it matches any
       #       of the given patterns. Maps to `--exclude=<pattern>`.
       #
-      #     @option options [Boolean] :no_exclude (false) clear all previously
+      #     @option options [Boolean, nil] :no_exclude (nil) clear all previously
       #       given `--exclude` patterns
       #
-      #     @option options [Boolean] :all (false) list all commits reachable
+      #     @option options [Boolean, nil] :all (nil) list all commits reachable
       #       from all refs
       #
-      #     @option options [Boolean] :annotate_stdin (false) transform stdin by
+      #     @option options [Boolean, nil] :annotate_stdin (nil) transform stdin by
       #       substituting all 40-character SHA-1 hexes with their symbolic
       #       names. Maps to `--annotate-stdin`.
       #
-      #     @option options [Boolean] :name_only (false) print only the symbolic
+      #     @option options [Boolean, nil] :name_only (nil) print only the symbolic
       #       name, not the SHA-1
       #
-      #     @option options [Boolean] :no_undefined (false) die with non-zero
+      #     @option options [Boolean, nil] :no_undefined (nil) die with non-zero
       #       exit code when a reference is undefined, instead of printing
       #       `undefined`
       #
-      #     @option options [Boolean] :always (false) show uniquely abbreviated
+      #     @option options [Boolean, nil] :always (nil) show uniquely abbreviated
       #       commit object as fallback
       #
       #     @return [Git::CommandLineResult] the result of calling

--- a/lib/git/commands/pull.rb
+++ b/lib/git/commands/pull.rb
@@ -129,240 +129,240 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :quiet (false) Suppress all output
+      #     @option options [Boolean, nil] :quiet (nil) suppress all output
       #
       #       Alias: :q
       #
-      #     @option options [Boolean] :verbose (false) Enable verbose output during fetch and merge
+      #     @option options [Boolean, nil] :verbose (nil) enable verbose output during fetch and merge
       #
       #       Alias: :v
       #
-      #     @option options [Boolean, String] :recurse_submodules (false) Control submodule
+      #     @option options [Boolean, String, nil] :recurse_submodules (nil) control submodule
       #       commit fetching (`--recurse-submodules`)
       #
       #       Pass a string such as `'yes'`, `'on-demand'`, or `'no'` for
       #       `--recurse-submodules=<value>`.
       #
-      #     @option options [Boolean] :no_recurse_submodules (false) Disable submodule
+      #     @option options [Boolean, nil] :no_recurse_submodules (nil) disable submodule
       #       commit fetching (`--no-recurse-submodules`)
       #
-      #     @option options [Boolean] :commit (false) Perform the merge and commit the result
+      #     @option options [Boolean, nil] :commit (nil) perform the merge and commit the result
       #       (`--commit`)
       #
-      #     @option options [Boolean] :no_commit (false) Merge but do not commit the result
+      #     @option options [Boolean, nil] :no_commit (nil) merge but do not commit the result
       #       (`--no-commit`)
       #
-      #     @option options [Boolean] :edit (false) Open an editor for the merge commit message
+      #     @option options [Boolean, nil] :edit (nil) open an editor for the merge commit message
       #       (`--edit`)
       #
       #       Alias: :e
       #
-      #     @option options [Boolean] :no_edit (false) Do not open an editor for the merge commit
+      #     @option options [Boolean, nil] :no_edit (nil) do not open an editor for the merge commit
       #       message (`--no-edit`)
       #
-      #     @option options [String] :cleanup (nil) Merge-message cleanup mode
+      #     @option options [String] :cleanup (nil) merge-message cleanup mode
       #
       #       Determines how the merge message is cleaned up before committing.
       #       For example, `'strip'`, `'whitespace'`, `'verbatim'`, `'scissors'`, `'default'`.
       #
-      #     @option options [Boolean] :ff_only (false) Require fast-forward merge or up-to-date HEAD
+      #     @option options [Boolean, nil] :ff_only (nil) require fast-forward merge or up-to-date HEAD
       #
       #       Refuses to merge unless the current HEAD is already up to date or the
       #       merge can be resolved as a fast-forward.
       #
-      #     @option options [Boolean] :ff (false) Allow fast-forward merge (`--ff`)
+      #     @option options [Boolean, nil] :ff (nil) allow fast-forward merge (`--ff`)
       #
-      #     @option options [Boolean] :no_ff (false) Disable fast-forward merge, always creating a
+      #     @option options [Boolean, nil] :no_ff (nil) disable fast-forward merge, always creating a
       #       merge commit (`--no-ff`)
       #
-      #     @option options [Boolean, String] :gpg_sign (false) GPG-sign the resulting merge commit
+      #     @option options [Boolean, String, nil] :gpg_sign (nil) GPG-sign the resulting merge commit
       #       (`--gpg-sign`)
       #
       #       Pass a key-ID string to select the signing key. Alias: :S
       #
-      #     @option options [Boolean] :no_gpg_sign (false) Countermand commit.gpgSign configuration
+      #     @option options [Boolean, nil] :no_gpg_sign (nil) countermand commit.gpgSign configuration
       #       (`--no-gpg-sign`)
       #
-      #     @option options [Boolean, Integer] :log (false) Include one-line descriptions from
+      #     @option options [Boolean, Integer, nil] :log (nil) include one-line descriptions from
       #       the actual commits being merged in log message (`--log`)
       #
       #       Pass an integer for `--log=<n>`.
       #
-      #     @option options [Boolean] :no_log (false) Disable inclusion of one-line descriptions
+      #     @option options [Boolean, nil] :no_log (nil) disable inclusion of one-line descriptions
       #       from merged commits (`--no-log`)
       #
-      #     @option options [Boolean] :signoff (false) Add a `Signed-off-by` trailer to the
+      #     @option options [Boolean, nil] :signoff (nil) add a `Signed-off-by` trailer to the
       #       resulting merge commit message (`--signoff`)
       #
-      #     @option options [Boolean] :no_signoff (false) Remove a `Signed-off-by` trailer from
+      #     @option options [Boolean, nil] :no_signoff (nil) remove a `Signed-off-by` trailer from
       #       the merge commit message (`--no-signoff`)
       #
-      #     @option options [Boolean] :stat (false) Show a diffstat at the end of the merge
+      #     @option options [Boolean, nil] :stat (nil) show a diffstat at the end of the merge
       #
-      #     @option options [Boolean] :no_stat (false) Do not show a diffstat at the end of the merge
+      #     @option options [Boolean, nil] :no_stat (nil) do not show a diffstat at the end of the merge
       #
       #       Alias: :n
       #
-      #     @option options [Boolean] :compact_summary (false) Show a compact summary after the merge
+      #     @option options [Boolean, nil] :compact_summary (nil) show a compact summary after the merge
       #
-      #     @option options [Boolean] :squash (false) Squash pulled commits into a single commit
+      #     @option options [Boolean, nil] :squash (nil) squash pulled commits into a single commit
       #       (`--squash`)
       #
-      #     @option options [Boolean] :no_squash (false) Override `--squash` option (`--no-squash`)
+      #     @option options [Boolean, nil] :no_squash (nil) override `--squash` option (`--no-squash`)
       #
-      #     @option options [Boolean] :verify (false) Run pre-merge and commit-msg hooks
+      #     @option options [Boolean, nil] :verify (nil) run pre-merge and commit-msg hooks
       #       (`--verify`)
       #
-      #     @option options [Boolean] :no_verify (false) Bypass pre-merge and commit-msg hooks
+      #     @option options [Boolean, nil] :no_verify (nil) bypass pre-merge and commit-msg hooks
       #       (`--no-verify`)
       #
-      #     @option options [String] :strategy (nil) Use the given merge strategy
+      #     @option options [String] :strategy (nil) use the given merge strategy
       #
       #       For example, `'ort'`, `'recursive'`, `'resolve'`, `'octopus'`, `'ours'`, `'subtree'`.
       #       Alias: :s
       #
-      #     @option options [String, Array<String>] :strategy_option (nil) Pass option(s) to
+      #     @option options [String, Array<String>] :strategy_option (nil) pass option(s) to
       #       the merge strategy
       #
       #       Can be a single value or array. For example, `'ours'`, `'theirs'`, `'patience'`.
       #       Alias: :X
       #
-      #     @option options [Boolean] :verify_signatures (false) Verify that the tip commit of
+      #     @option options [Boolean, nil] :verify_signatures (nil) verify that the tip commit of
       #       the side branch being merged is signed with a valid key (`--verify-signatures`)
       #
-      #     @option options [Boolean] :no_verify_signatures (false) Do not verify the signature of
+      #     @option options [Boolean, nil] :no_verify_signatures (nil) do not verify the signature of
       #       the side branch tip commit (`--no-verify-signatures`)
       #
-      #     @option options [Boolean] :summary (false) Show a summary after the merge (`--summary`)
+      #     @option options [Boolean, nil] :summary (nil) show a summary after the merge (`--summary`)
       #
-      #     @option options [Boolean] :no_summary (false) Do not show a summary after the merge
+      #     @option options [Boolean, nil] :no_summary (nil) do not show a summary after the merge
       #       (`--no-summary`)
       #
-      #     @option options [Boolean] :autostash (false) Automatically create a temporary stash entry
+      #     @option options [Boolean, nil] :autostash (nil) automatically create a temporary stash entry
       #       before the operation begins (`--autostash`)
       #
-      #     @option options [Boolean] :no_autostash (false) Disable automatic stashing before the
+      #     @option options [Boolean, nil] :no_autostash (nil) disable automatic stashing before the
       #       operation (`--no-autostash`)
       #
-      #     @option options [Boolean] :allow_unrelated_histories (false) Allow pulling from a
+      #     @option options [Boolean, nil] :allow_unrelated_histories (nil) allow pulling from a
       #       repository that shares no common history with the current repository
       #
-      #     @option options [Boolean, String] :rebase (false) Rebase the current branch on
+      #     @option options [Boolean, String, nil] :rebase (nil) rebase the current branch on
       #       top of the upstream branch after fetching (`--rebase`)
       #
       #       Pass a string such as `'merges'` or `'interactive'` for `--rebase=<value>`.
       #       Alias: :r
       #
-      #     @option options [Boolean] :no_rebase (false) Override earlier `--rebase` option
+      #     @option options [Boolean, nil] :no_rebase (nil) override earlier `--rebase` option
       #       (`--no-rebase`)
       #
-      #     @option options [Boolean] :all (false) Fetch all remotes (`--all`)
+      #     @option options [Boolean, nil] :all (nil) fetch all remotes (`--all`)
       #
-      #     @option options [Boolean] :no_all (false) Do not fetch all remotes (`--no-all`)
+      #     @option options [Boolean, nil] :no_all (nil) do not fetch all remotes (`--no-all`)
       #
-      #     @option options [Boolean] :append (false) Append ref names and object names fetched to
+      #     @option options [Boolean, nil] :append (nil) append ref names and object names fetched to
       #       the existing contents of `.git/FETCH_HEAD`
       #
       #       Alias: :a
       #
-      #     @option options [Boolean] :atomic (false) Use an atomic transaction to update local refs
+      #     @option options [Boolean, nil] :atomic (nil) use an atomic transaction to update local refs
       #
-      #     @option options [String] :depth (nil) Limit fetching to the given number of commits
+      #     @option options [String] :depth (nil) limit fetching to the given number of commits
       #
       #       Fetches only the specified number of commits from the tip of each
       #       remote branch history.
       #
-      #     @option options [String] :deepen (nil) Deepen or shorten history of a shallow repository
+      #     @option options [String] :deepen (nil) deepen or shorten history of a shallow repository
       #
-      #     @option options [String] :shallow_since (nil) Deepen or shorten history to include all
+      #     @option options [String] :shallow_since (nil) deepen or shorten history to include all
       #       reachable commits after the given date
       #
-      #     @option options [String, Array<String>] :shallow_exclude (nil) Exclude commits reachable
+      #     @option options [String, Array<String>] :shallow_exclude (nil) exclude commits reachable
       #       from the specified remote branch or tag
       #
       #       Repeatable.
       #
-      #     @option options [Boolean] :unshallow (false) Convert a shallow repository to a complete one
+      #     @option options [Boolean, nil] :unshallow (nil) convert a shallow repository to a complete one
       #
       #       If the source is shallow, fetches as much as possible.
       #
-      #     @option options [Boolean] :update_shallow (false) Accept refs that update `.git/shallow`
+      #     @option options [Boolean, nil] :update_shallow (nil) accept refs that update `.git/shallow`
       #
-      #     @option options [String, Array<String>] :negotiation_tip (nil) Report only commits
+      #     @option options [String, Array<String>] :negotiation_tip (nil) report only commits
       #       reachable from the given tips during negotiation
       #
       #       Repeatable.
       #
-      #     @option options [Boolean] :negotiate_only (false) Do not fetch; only print ancestries
+      #     @option options [Boolean, nil] :negotiate_only (nil) do not fetch; only print ancestries
       #       between the local repository and the remote
       #
-      #     @option options [Boolean] :dry_run (false) Show what would be done without making changes
+      #     @option options [Boolean, nil] :dry_run (nil) show what would be done without making changes
       #
-      #     @option options [Boolean] :porcelain (false) Give the output in a stable, easy-to-parse
+      #     @option options [Boolean, nil] :porcelain (nil) give the output in a stable, easy-to-parse
       #       format for scripts
       #
-      #     @option options [Boolean] :force (false) Override the check for a non-fast-forward update
+      #     @option options [Boolean, nil] :force (nil) override the check for a non-fast-forward update
       #
       #       Alias: :f
       #
-      #     @option options [Boolean] :keep (false) Keep the downloaded pack
+      #     @option options [Boolean, nil] :keep (nil) keep the downloaded pack
       #
       #       Alias: :k
       #
-      #     @option options [Boolean] :prefetch (false) Modify the configured refspec to place
+      #     @option options [Boolean, nil] :prefetch (nil) modify the configured refspec to place
       #       all refs into the `refs/prefetch/` namespace
       #
-      #     @option options [Boolean] :prune (false) Remove remote-tracking references that no longer
+      #     @option options [Boolean, nil] :prune (nil) remove remote-tracking references that no longer
       #       exist on the remote before fetching
       #
       #       Alias: :p
       #
-      #     @option options [Boolean] :tags (false) Fetch all tags from the remote (`--tags`)
+      #     @option options [Boolean, nil] :tags (nil) fetch all tags from the remote (`--tags`)
       #
       #       Alias: :t
       #
-      #     @option options [Boolean] :no_tags (false) Disable automatic tag following
+      #     @option options [Boolean, nil] :no_tags (nil) disable automatic tag following
       #       (`--no-tags`)
       #
-      #     @option options [String, Array<String>] :refmap (nil) Override fetch refspecs for
+      #     @option options [String, Array<String>] :refmap (nil) override fetch refspecs for
       #       remote-tracking branch mapping
       #
       #       Repeatable.
       #
-      #     @option options [String] :jobs (nil) Number of submodules fetched in parallel
+      #     @option options [String] :jobs (nil) number of submodules fetched in parallel
       #
       #       Alias: :j
       #
-      #     @option options [Boolean] :set_upstream (false) Add upstream (tracking) reference for
+      #     @option options [Boolean, nil] :set_upstream (nil) add upstream (tracking) reference for
       #       the current branch
       #
-      #     @option options [String] :upload_pack (nil) Path to `git-upload-pack` on the remote
+      #     @option options [String] :upload_pack (nil) path to `git-upload-pack` on the remote
       #
-      #     @option options [Boolean] :progress (false) Force progress status display (`--progress`)
+      #     @option options [Boolean, nil] :progress (nil) force progress status display (`--progress`)
       #
-      #     @option options [Boolean] :no_progress (false) Suppress progress status display
+      #     @option options [Boolean, nil] :no_progress (nil) suppress progress status display
       #       (`--no-progress`)
       #
-      #     @option options [String, Array<String>] :server_option (nil) Transmit the given
+      #     @option options [String, Array<String>] :server_option (nil) transmit the given
       #       string to the server when communicating using protocol version 2
       #
       #       Repeatable. Alias: :o
       #
-      #     @option options [Boolean] :show_forced_updates (false) Check whether a local branch is
+      #     @option options [Boolean, nil] :show_forced_updates (nil) check whether a local branch is
       #       force-updated during fetch (`--show-forced-updates`)
       #
-      #     @option options [Boolean] :no_show_forced_updates (false) Disable checking for force
+      #     @option options [Boolean, nil] :no_show_forced_updates (nil) disable checking for force
       #       updates (`--no-show-forced-updates`)
       #
-      #     @option options [Boolean] :ipv4 (false) Use IPv4 addresses only, ignoring IPv6 addresses
+      #     @option options [Boolean, nil] :ipv4 (nil) use IPv4 addresses only, ignoring IPv6 addresses
       #
       #       Alias: :'4'
       #
-      #     @option options [Boolean] :ipv6 (false) Use IPv6 addresses only, ignoring IPv4 addresses
+      #     @option options [Boolean, nil] :ipv6 (nil) use IPv6 addresses only, ignoring IPv4 addresses
       #
       #       Alias: :'6'
       #
-      #     @option options [Numeric, nil] :timeout (nil) Timeout in seconds for the command
+      #     @option options [Numeric, nil] :timeout (nil) timeout in seconds for the command
       #
       #       If nil, uses the global timeout from {Git::Config}.
       #

--- a/lib/git/commands/push.rb
+++ b/lib/git/commands/push.rb
@@ -124,112 +124,116 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :all (nil) Push all branches
+      #     @option options [Boolean, nil] :all (nil) push all branches
       #
       #       Alias: :branches
       #
-      #     @option options [Boolean] :mirror (nil) Push all refs under `refs/` to the remote
+      #     @option options [Boolean, nil] :mirror (nil) push all refs under `refs/` to the remote
       #
-      #     @option options [Boolean] :tags (nil) Push all refs under `refs/tags/`
+      #     @option options [Boolean, nil] :tags (nil) push all refs under `refs/tags/`
       #
-      #     @option options [Boolean] :follow_tags (false) push reachable annotated tags (`--follow-tags`)
+      #     @option options [Boolean, nil] :follow_tags (nil) push reachable annotated tags (`--follow-tags`)
       #
-      #     @option options [Boolean] :no_follow_tags (false) do not push reachable annotated tags (`--no-follow-tags`)
+      #     @option options [Boolean, nil] :no_follow_tags (nil) do not push reachable annotated tags
+      #       (`--no-follow-tags`)
       #
-      #     @option options [Boolean] :atomic (false) Use an atomic transaction to update remote refs (`--atomic`)
+      #     @option options [Boolean, nil] :atomic (nil) use an atomic transaction to update remote refs (`--atomic`)
       #
-      #     @option options [Boolean] :no_atomic (false) disable atomic transaction for remote updates (`--no-atomic`)
+      #     @option options [Boolean, nil] :no_atomic (nil) disable atomic transaction for remote updates
+      #       (`--no-atomic`)
       #
-      #     @option options [Boolean] :dry_run (nil) Do not send updates, only report what would be pushed
+      #     @option options [Boolean, nil] :dry_run (nil) do not send updates, only report what would be pushed
       #
       #       Alias: :n
       #
-      #     @option options [Boolean] :porcelain (nil) Produce machine-readable output
+      #     @option options [Boolean, nil] :porcelain (nil) produce machine-readable output
       #
-      #     @option options [String] :receive_pack (nil) Path to the git-receive-pack program on the remote end
+      #     @option options [String] :receive_pack (nil) path to the git-receive-pack program on the remote end
       #
       #       Alias: :exec
       #
-      #     @option options [String] :repo (nil) Use this repository instead of the
+      #     @option options [String] :repo (nil) use this repository instead of the
       #       positional repository argument
       #
       #       Equivalent to the positional `<repository>` argument. If both are given, the
       #       positional argument takes precedence.
       #
-      #     @option options [Boolean] :force (nil) Force updates, overriding the fast-forward check
+      #     @option options [Boolean, nil] :force (nil) force updates, overriding the fast-forward check
       #
       #       Alias: :f
       #
-      #     @option options [Boolean] :delete (nil) Delete all listed refs from the remote repository
+      #     @option options [Boolean, nil] :delete (nil) delete all listed refs from the remote repository
       #
       #       Alias: :d
       #
-      #     @option options [Boolean] :prune (nil) Remove remote branches that have no local counterpart
+      #     @option options [Boolean, nil] :prune (nil) remove remote branches that have no local counterpart
       #
-      #     @option options [Boolean] :quiet (nil) Suppress all output
+      #     @option options [Boolean, nil] :quiet (nil) suppress all output
       #
       #       Alias: :q
       #
-      #     @option options [Boolean] :verbose (nil) Run verbosely
+      #     @option options [Boolean, nil] :verbose (nil) run verbosely
       #
       #       Alias: :v
       #
-      #     @option options [Boolean] :set_upstream (nil) Set upstream tracking for each successfully pushed branch
+      #     @option options [Boolean, nil] :set_upstream (nil) set upstream tracking for each successfully pushed branch
       #
       #       Alias: :u
       #
-      #     @option options [String, Array<String>] :push_option (nil) Transmit one or more server-side options
+      #     @option options [String, Array<String>] :push_option (nil) transmit one or more server-side options
       #
       #       Repeatable. Each occurrence emits a separate `--push-option=<value>` flag.
       #
       #       Alias: :o
       #
-      #     @option options [Boolean, String] :signed (false) GPG-sign the push certificate (`--signed`)
+      #     @option options [Boolean, String, nil] :signed (nil) GPG-sign the push certificate (`--signed`)
       #
       #       When a String (`'true'`, `'false'`, `'if-asked'`), emits `--signed=<value>`.
       #
-      #     @option options [Boolean] :no_signed (false) disable GPG signing of the push certificate (`--no-signed`)
+      #     @option options [Boolean, nil] :no_signed (nil) disable GPG signing of the push certificate (`--no-signed`)
       #
-      #     @option options [Boolean, String] :force_with_lease (false) Refuse force pushes unless the
+      #     @option options [Boolean, String, nil] :force_with_lease (nil) refuse force pushes unless the
       #       remote ref matches the expected value (`--force-with-lease`)
       #
       #       When a String (e.g. `'main:abc123'`), emits `--force-with-lease=<string>`.
       #
-      #     @option options [Boolean] :no_force_with_lease (false) disable force-with-lease (`--no-force-with-lease`)
+      #     @option options [Boolean, nil] :no_force_with_lease (nil) disable force-with-lease (`--no-force-with-lease`)
       #
-      #     @option options [Boolean] :force_if_includes (false) Force pushes only if commits being
+      #     @option options [Boolean, nil] :force_if_includes (nil) force pushes only if commits being
       #       pushed are already in the remote-tracking branch (`--force-if-includes`)
       #
-      #     @option options [Boolean] :no_force_if_includes (false) disable force-if-includes (`--no-force-if-includes`)
+      #     @option options [Boolean, nil] :no_force_if_includes (nil) disable force-if-includes
+      #       (`--no-force-if-includes`)
       #
-      #     @option options [Boolean] :verify (false) run the pre-push hook (`--verify`)
+      #     @option options [Boolean, nil] :verify (nil) run the pre-push hook (`--verify`)
       #
-      #     @option options [Boolean] :no_verify (false) bypass the pre-push hook (`--no-verify`)
+      #     @option options [Boolean, nil] :no_verify (nil) bypass the pre-push hook (`--no-verify`)
       #
-      #     @option options [String] :recurse_submodules (nil) Control whether submodule
+      #     @option options [String] :recurse_submodules (nil) control whether submodule
       #       commits are pushed
       #
       #       Pass a String (`'check'`, `'on-demand'`, `'only'`, `'no'`) to emit
       #       `--recurse-submodules=<value>`. Note: passing `true` is not valid; git requires
       #       an explicit value for this option.
       #
-      #     @option options [Boolean] :no_recurse_submodules (false) disable submodule push (`--no-recurse-submodules`)
+      #     @option options [Boolean, nil] :no_recurse_submodules (nil) disable submodule push
+      #       (`--no-recurse-submodules`)
       #
-      #     @option options [Boolean] :thin (false) Send a "thin" pack to reduce network traffic (`--thin`)
+      #     @option options [Boolean, nil] :thin (nil) send a "thin" pack to reduce network traffic (`--thin`)
       #
-      #     @option options [Boolean] :no_thin (false) send a full pack instead of a thin pack (`--no-thin`)
+      #     @option options [Boolean, nil] :no_thin (nil) send a full pack instead of a thin pack (`--no-thin`)
       #
-      #     @option options [Boolean] :progress (nil) Force progress reporting even when stderr is not a terminal
+      #     @option options [Boolean, nil] :progress (nil) force progress reporting even when stderr is not a terminal
       #
-      #     @option options [Boolean] :ipv4 (nil) Use IPv4 addresses only
+      #     @option options [Boolean, nil] :ipv4 (nil) use IPv4 addresses only
       #
       #       Alias: :"4"
       #
-      #     @option options [Boolean] :ipv6 (nil) Use IPv6 addresses only
+      #     @option options [Boolean, nil] :ipv6 (nil) use IPv6 addresses only
       #
       #       Alias: :"6"
       #
-      #     @option options [Integer] :timeout (nil) Maximum seconds to wait for the command to complete
+      #     @option options [Integer] :timeout (nil) maximum seconds to wait for the command to complete
       #
       #     @return [Git::CommandLineResult] the result of calling `git push`
       #

--- a/lib/git/commands/read_tree.rb
+++ b/lib/git/commands/read_tree.rb
@@ -82,16 +82,16 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :m (false) perform a merge, not just a
+      #     @option options [Boolean, nil] :m (nil) perform a merge, not just a
       #       read
       #
-      #     @option options [Boolean] :trivial (false) restrict three-way merge
+      #     @option options [Boolean, nil] :trivial (nil) restrict three-way merge
       #       to happen only if there is no file-level merging required
       #
-      #     @option options [Boolean] :aggressive (false) resolve a few more
+      #     @option options [Boolean, nil] :aggressive (nil) resolve a few more
       #       three-way merge cases internally beyond the trivial defaults
       #
-      #     @option options [Boolean] :reset (false) same as `-m`, except that
+      #     @option options [Boolean, nil] :reset (nil) same as `-m`, except that
       #       unmerged entries are discarded instead of failing
       #
       #     @option options [String] :prefix (nil) keep the current index
@@ -100,19 +100,19 @@ module Git
       #
       #       Maps to `--prefix=<prefix>`.
       #
-      #     @option options [Boolean] :u (false) after a successful merge,
+      #     @option options [Boolean, nil] :u (nil) after a successful merge,
       #       update the files in the work tree with the result
       #
-      #     @option options [Boolean] :i (false) disable the check with the
+      #     @option options [Boolean, nil] :i (nil) disable the check with the
       #       working tree, meant for creating a merge of trees not directly
       #       related to the current working tree status
       #
-      #     @option options [Boolean] :dry_run (false) check if the command
+      #     @option options [Boolean, nil] :dry_run (nil) check if the command
       #       would error out, without updating the index or files for real
       #
       #       Alias: `:n`
       #
-      #     @option options [Boolean] :v (false) show the progress of checking
+      #     @option options [Boolean, nil] :v (nil) show the progress of checking
       #       files out
       #
       #     @option options [String] :index_output (nil) write the resulting
@@ -120,20 +120,20 @@ module Git
       #
       #       Maps to `--index-output=<file>`.
       #
-      #     @option options [Boolean] :recurse_submodules (false) update the
+      #     @option options [Boolean, nil] :recurse_submodules (nil) update the
       #       content of all active submodules according to the commit
       #       recorded in the superproject (`--recurse-submodules`)
       #
-      #     @option options [Boolean] :no_recurse_submodules (false) disable
+      #     @option options [Boolean, nil] :no_recurse_submodules (nil) disable
       #       recursive submodule update (`--no-recurse-submodules`)
       #
-      #     @option options [Boolean] :no_sparse_checkout (false) disable
+      #     @option options [Boolean, nil] :no_sparse_checkout (nil) disable
       #       sparse checkout support even if `core.sparseCheckout` is true
       #
-      #     @option options [Boolean] :empty (false) empty the index instead of
+      #     @option options [Boolean, nil] :empty (nil) empty the index instead of
       #       reading tree object(s)
       #
-      #     @option options [Boolean] :quiet (false) suppress feedback messages
+      #     @option options [Boolean, nil] :quiet (nil) suppress feedback messages
       #
       #       Alias: `:q`
       #

--- a/lib/git/commands/remote/add.rb
+++ b/lib/git/commands/remote/add.rb
@@ -68,13 +68,13 @@ module Git
         #
         #       Alias: :m
         #
-        #     @option options [Boolean] :fetch (nil) fetch the remote immediately after adding it
+        #     @option options [Boolean, nil] :fetch (nil) fetch the remote immediately after adding it
         #
         #       Alias: :f
         #
-        #     @option options [Boolean] :tags (false) import all tags from the remote (`--tags`)
+        #     @option options [Boolean, nil] :tags (nil) import all tags from the remote (`--tags`)
         #
-        #     @option options [Boolean] :no_tags (false) disable importing tags from the remote (`--no-tags`)
+        #     @option options [Boolean, nil] :no_tags (nil) disable importing tags from the remote (`--no-tags`)
         #
         #     @option options [String] :mirror (nil) set mirror mode
         #

--- a/lib/git/commands/remote/get_url.rb
+++ b/lib/git/commands/remote/get_url.rb
@@ -51,9 +51,9 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :push (nil) query push URLs instead of fetch URLs
+        #     @option options [Boolean, nil] :push (nil) query push URLs instead of fetch URLs
         #
-        #     @option options [Boolean] :all (nil) return all configured URLs instead of only the first one
+        #     @option options [Boolean, nil] :all (nil) return all configured URLs instead of only the first one
         #
         #     @return [Git::CommandLineResult] the result of calling `git remote get-url`
         #

--- a/lib/git/commands/remote/list.rb
+++ b/lib/git/commands/remote/list.rb
@@ -39,7 +39,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :verbose (nil) show remote URLs alongside remote names
+        #     @option options [Boolean, nil] :verbose (nil) show remote URLs alongside remote names
         #
         #       Alias: :v
         #

--- a/lib/git/commands/remote/prune.rb
+++ b/lib/git/commands/remote/prune.rb
@@ -46,7 +46,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :dry_run (nil) report what would be pruned without deleting refs
+        #     @option options [Boolean, nil] :dry_run (nil) report what would be pruned without deleting refs
         #
         #       Alias: :n
         #

--- a/lib/git/commands/remote/rename.rb
+++ b/lib/git/commands/remote/rename.rb
@@ -54,9 +54,9 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :progress (false) enable progress reporting (`--progress`)
+        #     @option options [Boolean, nil] :progress (nil) enable progress reporting (`--progress`)
         #
-        #     @option options [Boolean] :no_progress (false) suppress progress output (`--no-progress`)
+        #     @option options [Boolean, nil] :no_progress (nil) suppress progress output (`--no-progress`)
         #
         #     @return [Git::CommandLineResult] the result of calling `git remote rename`
         #

--- a/lib/git/commands/remote/set_branches.rb
+++ b/lib/git/commands/remote/set_branches.rb
@@ -50,7 +50,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :add (nil) append the given branches instead of replacing them
+        #     @option options [Boolean, nil] :add (nil) append the given branches instead of replacing them
         #
         #     @return [Git::CommandLineResult] the result of calling `git remote set-branches`
         #

--- a/lib/git/commands/remote/set_head.rb
+++ b/lib/git/commands/remote/set_head.rb
@@ -63,11 +63,11 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :auto (nil) detect the remote HEAD by querying the remote
+        #     @option options [Boolean, nil] :auto (nil) detect the remote HEAD by querying the remote
         #
         #       Mutually exclusive with `:delete`. Alias: :a
         #
-        #     @option options [Boolean] :delete (nil) delete the configured remote HEAD symbolic ref
+        #     @option options [Boolean, nil] :delete (nil) delete the configured remote HEAD symbolic ref
         #
         #       Mutually exclusive with `:auto`. Alias: :d
         #

--- a/lib/git/commands/remote/set_url.rb
+++ b/lib/git/commands/remote/set_url.rb
@@ -58,7 +58,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :push (nil) update push URLs instead of fetch URLs
+        #     @option options [Boolean, nil] :push (nil) update push URLs instead of fetch URLs
         #
         #     @return [Git::CommandLineResult] the result of calling `git remote set-url`
         #

--- a/lib/git/commands/remote/set_url_add.rb
+++ b/lib/git/commands/remote/set_url_add.rb
@@ -50,7 +50,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :push (nil) add a push URL instead of a fetch URL
+        #     @option options [Boolean, nil] :push (nil) add a push URL instead of a fetch URL
         #
         #     @return [Git::CommandLineResult] the result of calling `git remote set-url --add`
         #

--- a/lib/git/commands/remote/set_url_delete.rb
+++ b/lib/git/commands/remote/set_url_delete.rb
@@ -51,7 +51,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :push (nil) delete push URLs instead of fetch URLs
+        #     @option options [Boolean, nil] :push (nil) delete push URLs instead of fetch URLs
         #
         #     @return [Git::CommandLineResult] the result of calling `git remote set-url --delete`
         #

--- a/lib/git/commands/remote/show.rb
+++ b/lib/git/commands/remote/show.rb
@@ -52,11 +52,11 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :verbose (nil) show the remote URL after the remote name
+        #     @option options [Boolean, nil] :verbose (nil) show the remote URL after the remote name
         #
         #       Alias: :v
         #
-        #     @option options [Boolean] :n (nil) do not query remote heads with `git ls-remote`
+        #     @option options [Boolean, nil] :n (nil) do not query remote heads with `git ls-remote`
         #
         #       Uses cached information instead of contacting the remote server.
         #

--- a/lib/git/commands/remote/update.rb
+++ b/lib/git/commands/remote/update.rb
@@ -53,11 +53,11 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :verbose (nil) show remote URLs alongside remote names
+        #     @option options [Boolean, nil] :verbose (nil) show remote URLs alongside remote names
         #
         #       Alias: :v
         #
-        #     @option options [Boolean] :prune (nil) prune stale tracking refs while updating remotes
+        #     @option options [Boolean, nil] :prune (nil) prune stale tracking refs while updating remotes
         #
         #       Alias: :p
         #

--- a/lib/git/commands/repack.rb
+++ b/lib/git/commands/repack.rb
@@ -92,24 +92,24 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :a (false) pack all objects into a single pack
+      #     @option options [Boolean, nil] :a (nil) pack all objects into a single pack
       #
       #       When `true`, passes `-a`. Especially useful when packing a repository
       #       used for private development. Use with `:d` to clean up objects.
       #
-      #     @option options [Boolean] :A (false) pack all objects, loosening unreachable
+      #     @option options [Boolean, nil] :A (nil) pack all objects, loosening unreachable
       #       objects when combined with `:d`
       #
       #       When `true`, passes `-A`. Like `:a`, but any unreachable objects in a
       #       previous pack become loose unpacked objects instead of being removed. The
       #       loose unreachable objects are pruned by the next `git gc` invocation.
       #
-      #     @option options [Boolean] :d (false) delete redundant packs after repacking
+      #     @option options [Boolean, nil] :d (nil) delete redundant packs after repacking
       #
       #       When `true`, passes `-d`. After packing, removes any existing packs that
       #       are made redundant by the newly created pack. Also runs `git prune-packed`.
       #
-      #     @option options [Boolean] :cruft (false) pack unreachable objects into a
+      #     @option options [Boolean, nil] :cruft (nil) pack unreachable objects into a
       #       separate cruft pack when combined with `:d`
       #
       #       When `true`, passes `--cruft`. Like `:a`, but any unreachable objects are
@@ -139,29 +139,29 @@ module Git
       #
       #       Passed as `--expire-to=<dir>`. Only useful with `--cruft -d`.
       #
-      #     @option options [Boolean] :l (false) pass `--local` to `git pack-objects`
+      #     @option options [Boolean, nil] :l (nil) pass `--local` to `git pack-objects`
       #
       #       When `true`, passes `-l`. Ignores objects that come from an alternates
       #       object store.
       #
-      #     @option options [Boolean] :f (false) pass `--no-reuse-delta` to
+      #     @option options [Boolean, nil] :f (nil) pass `--no-reuse-delta` to
       #       `git pack-objects`
       #
       #       When `true`, passes `-f`. Forces reconstruction of all pack deltas.
       #
-      #     @option options [Boolean] :F (false) pass `--no-reuse-object` to
+      #     @option options [Boolean, nil] :F (nil) pass `--no-reuse-object` to
       #       `git pack-objects`
       #
       #       When `true`, passes `-F`. Forces reconstruction of all object data, not
       #       just deltas.
       #
-      #     @option options [Boolean] :quiet (false) suppress progress reporting
+      #     @option options [Boolean, nil] :quiet (nil) suppress progress reporting
       #
       #       When `true`, passes `--quiet`.
       #
       #       Alias: `:q`
       #
-      #     @option options [Boolean] :n (false) do not update server information
+      #     @option options [Boolean, nil] :n (nil) do not update server information
       #
       #       When `true`, passes `-n`. Skips running `git update-server-info`, which
       #       updates local catalog files needed to publish the repository
@@ -203,7 +203,7 @@ module Git
       #
       #       Passed as `--filter-to=<dir>`. Only useful with `:filter`.
       #
-      #     @option options [Boolean] :write_bitmap_index (false) write a reachability
+      #     @option options [Boolean, nil] :write_bitmap_index (nil) write a reachability
       #       bitmap index as part of the repack
       #
       #       When `true`, passes `--write-bitmap-index`. Only meaningful when used with
@@ -211,7 +211,7 @@ module Git
       #
       #       Alias: `:b`
       #
-      #     @option options [Boolean] :pack_kept_objects (false) include objects in
+      #     @option options [Boolean, nil] :pack_kept_objects (nil) include objects in
       #       `.keep` files when repacking
       #
       #       When `true`, passes `--pack-kept-objects`. Generally only useful when
@@ -224,7 +224,7 @@ module Git
       #       or an array of pack file names. Each value is passed as a separate
       #       `--keep-pack=<name>` argument.
       #
-      #     @option options [Boolean] :write_midx (false) write a multi-pack index
+      #     @option options [Boolean, nil] :write_midx (nil) write a multi-pack index
       #       containing the non-redundant packs
       #
       #       When `true`, passes `--write-midx`.
@@ -238,7 +238,7 @@ module Git
       #       are not loosened, since they would be immediately pruned by a follow-up
       #       `git prune`.
       #
-      #     @option options [Boolean] :keep_unreachable (false) keep unreachable objects
+      #     @option options [Boolean, nil] :keep_unreachable (nil) keep unreachable objects
       #       in the new packfile rather than removing them
       #
       #       When `true`, passes `--keep-unreachable`. Appends unreachable objects from
@@ -246,7 +246,7 @@ module Git
       #
       #       Alias: `:k`
       #
-      #     @option options [Boolean] :delta_islands (false) pass `--delta-islands` to
+      #     @option options [Boolean, nil] :delta_islands (nil) pass `--delta-islands` to
       #       `git pack-objects`
       #
       #       When `true`, passes `--delta-islands`.
@@ -264,7 +264,7 @@ module Git
       #     @option options [Integer, String] :name_hash_version (nil) pass
       #       `--name-hash-version=<n>` to `git pack-objects`
       #
-      #     @option options [Boolean] :path_walk (false) pass `--path-walk` to
+      #     @option options [Boolean, nil] :path_walk (nil) pass `--path-walk` to
       #       `git pack-objects`
       #
       #     @return [Git::CommandLineResult] the result of calling `git repack`

--- a/lib/git/commands/reset.rb
+++ b/lib/git/commands/reset.rb
@@ -83,35 +83,35 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :soft (false) leave working tree and index unchanged;
+      #     @option options [Boolean, nil] :soft (nil) leave working tree and index unchanged;
       #       reset HEAD to the specified commit
       #
-      #     @option options [Boolean] :mixed (false) reset the index but not the working tree;
+      #     @option options [Boolean, nil] :mixed (nil) reset the index but not the working tree;
       #       default mode when no mode flag is given
       #
-      #     @option options [Boolean] :N (false) mark removed paths as intent-to-add;
+      #     @option options [Boolean, nil] :N (nil) mark removed paths as intent-to-add;
       #       only meaningful alongside `:mixed`
       #
-      #     @option options [Boolean] :hard (false) reset the index and working tree to the
+      #     @option options [Boolean, nil] :hard (nil) reset the index and working tree to the
       #       specified commit; discards all tracked changes since that commit
       #
-      #     @option options [Boolean] :merge (false) reset the index and update files that
+      #     @option options [Boolean, nil] :merge (nil) reset the index and update files that
       #       differ between the commit and HEAD, while preserving uncommitted changes
       #
-      #     @option options [Boolean] :keep (false) reset index entries and update files that
+      #     @option options [Boolean, nil] :keep (nil) reset index entries and update files that
       #       differ between the commit and HEAD; aborts if any such file has local changes
       #
-      #     @option options [Boolean] :quiet (false) suppress all output; report errors only
+      #     @option options [Boolean, nil] :quiet (nil) suppress all output; report errors only
       #       (`--quiet`)
       #
       #       Alias: :q
       #
-      #     @option options [Boolean] :no_quiet (false) do not suppress output (`--no-quiet`)
+      #     @option options [Boolean, nil] :no_quiet (nil) do not suppress output (`--no-quiet`)
       #
-      #     @option options [Boolean] :refresh (false) refresh the index after a mixed reset;
+      #     @option options [Boolean, nil] :refresh (nil) refresh the index after a mixed reset;
       #       enabled by default when omitted (`--refresh`)
       #
-      #     @option options [Boolean] :no_refresh (false) do not refresh the index after a mixed
+      #     @option options [Boolean, nil] :no_refresh (nil) do not refresh the index after a mixed
       #       reset (`--no-refresh`)
       #
       #     @option options [Integer, String] :unified (nil) number of context lines around each diff hunk
@@ -124,14 +124,14 @@ module Git
       #     @option options [String] :pathspec_from_file (nil) read pathspec from the given file;
       #       pass `"-"` to read from standard input
       #
-      #     @option options [Boolean] :pathspec_file_nul (false) delimit pathspec elements with NUL
+      #     @option options [Boolean, nil] :pathspec_file_nul (nil) delimit pathspec elements with NUL
       #       when reading from `:pathspec_from_file`; only meaningful alongside `:pathspec_from_file`
       #
-      #     @option options [Boolean] :recurse_submodules (false) also reset the working tree of
+      #     @option options [Boolean, nil] :recurse_submodules (nil) also reset the working tree of
       #       all active submodules to the commit recorded in the superproject
       #       (`--recurse-submodules`)
       #
-      #     @option options [Boolean] :no_recurse_submodules (false) do not reset submodule
+      #     @option options [Boolean, nil] :no_recurse_submodules (nil) do not reset submodule
       #       working trees (`--no-recurse-submodules`)
       #
       #     @option options [Array<String>] :pathspec (nil) path(s) to reset in the index;

--- a/lib/git/commands/rev_parse.rb
+++ b/lib/git/commands/rev_parse.rb
@@ -114,16 +114,16 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :revs_only (nil) do not output flags
+      #     @option options [Boolean, nil] :revs_only (nil) do not output flags
       #       and parameters not meant for `git rev-list`
       #
-      #     @option options [Boolean] :no_revs (nil) do not output flags and
+      #     @option options [Boolean, nil] :no_revs (nil) do not output flags and
       #       parameters meant for `git rev-list`
       #
-      #     @option options [Boolean] :flags (false) do not output non-flag
+      #     @option options [Boolean, nil] :flags (nil) do not output non-flag
       #       parameters (`--flags`)
       #
-      #     @option options [Boolean] :no_flags (false) do not output flag
+      #     @option options [Boolean, nil] :no_flags (nil) do not output flag
       #       parameters (`--no-flags`)
       #
       #     @option options [String] :default (nil) use this value if no
@@ -132,10 +132,10 @@ module Git
       #     @option options [String] :prefix (nil) behave as if invoked from
       #       this subdirectory of the working tree
       #
-      #     @option options [Boolean] :verify (nil) verify that exactly one
+      #     @option options [Boolean, nil] :verify (nil) verify that exactly one
       #       parameter is provided and that it can be resolved to an object
       #
-      #     @option options [Boolean] :quiet (nil) do not output an error
+      #     @option options [Boolean, nil] :quiet (nil) do not output an error
       #       message if the first argument is not a valid object name;
       #       exit with non-zero status silently
       #
@@ -143,28 +143,28 @@ module Git
       #
       #       Alias: :q
       #
-      #     @option options [Boolean] :sq (nil) output a single line
+      #     @option options [Boolean, nil] :sq (nil) output a single line
       #       properly quoted for shell consumption
       #
-      #     @option options [Boolean, String] :short (nil) shorten the
+      #     @option options [Boolean, String, nil] :short (nil) shorten the
       #       object name to a unique prefix
       #
       #       When `true`, emits `--short` (git default length). When a
       #       String, emits `--short=<length>`.
       #
-      #     @option options [Boolean] :not (nil) prefix object names with
+      #     @option options [Boolean, nil] :not (nil) prefix object names with
       #       `^` and strip `^` from names that already have one
       #
-      #     @option options [Boolean, String] :abbrev_ref (nil) output a
+      #     @option options [Boolean, String, nil] :abbrev_ref (nil) output a
       #       non-ambiguous short name of the object
       #
       #       When `true`, emits `--abbrev-ref`. When a String (`"strict"`
       #       or `"loose"`), emits `--abbrev-ref=<mode>`.
       #
-      #     @option options [Boolean] :symbolic (nil) output object names
+      #     @option options [Boolean, nil] :symbolic (nil) output object names
       #       in a form as close to the original input as possible
       #
-      #     @option options [Boolean] :symbolic_full_name (nil) like
+      #     @option options [Boolean, nil] :symbolic_full_name (nil) like
       #       `:symbolic` but omit non-ref input and show full refnames
       #
       #     @option options [String] :output_object_format (nil) translate
@@ -172,21 +172,21 @@ module Git
       #
       #       Accepted values are `"sha1"`, `"sha256"`, and `"storage"`.
       #
-      #     @option options [Boolean] :all (nil) show all refs found in
+      #     @option options [Boolean, nil] :all (nil) show all refs found in
       #       `refs/`
       #
-      #     @option options [Boolean, String] :branches (nil) show all
+      #     @option options [Boolean, String, nil] :branches (nil) show all
       #       branches
       #
       #       When `true`, emits `--branches`. When a String, emits
       #       `--branches=<pattern>`.
       #
-      #     @option options [Boolean, String] :tags (nil) show all tags
+      #     @option options [Boolean, String, nil] :tags (nil) show all tags
       #
       #       When `true`, emits `--tags`. When a String, emits
       #       `--tags=<pattern>`.
       #
-      #     @option options [Boolean, String] :remotes (nil) show all
+      #     @option options [Boolean, String, nil] :remotes (nil) show all
       #       remote-tracking branches
       #
       #       When `true`, emits `--remotes`. When a String, emits
@@ -209,7 +209,7 @@ module Git
       #       Affects the next `--all` or `--glob` and is cleared after
       #       processing them.
       #
-      #     @option options [Boolean] :local_env_vars (nil) list the
+      #     @option options [Boolean, nil] :local_env_vars (nil) list the
       #       `GIT_*` environment variables local to the repository
       #
       #     @option options [String, Array<String>] :path_format (nil) control
@@ -220,26 +220,26 @@ module Git
       #       given multiple times; each instance affects the arguments
       #       that follow it on the command line.
       #
-      #     @option options [Boolean] :git_dir (nil) show `$GIT_DIR` if
+      #     @option options [Boolean, nil] :git_dir (nil) show `$GIT_DIR` if
       #       defined, otherwise show the path to the `.git` directory
       #
-      #     @option options [Boolean] :absolute_git_dir (nil) like
+      #     @option options [Boolean, nil] :absolute_git_dir (nil) like
       #       `:git_dir` but always output the canonicalized absolute path
       #
-      #     @option options [Boolean] :git_common_dir (nil) show
+      #     @option options [Boolean, nil] :git_common_dir (nil) show
       #       `$GIT_COMMON_DIR` if defined, else `$GIT_DIR`
       #
-      #     @option options [Boolean] :is_inside_git_dir (nil) print
+      #     @option options [Boolean, nil] :is_inside_git_dir (nil) print
       #       `"true"` when the current working directory is below the
       #       repository directory, `"false"` otherwise
       #
-      #     @option options [Boolean] :is_inside_work_tree (nil) print
+      #     @option options [Boolean, nil] :is_inside_work_tree (nil) print
       #       `"true"` when inside the work tree, `"false"` otherwise
       #
-      #     @option options [Boolean] :is_bare_repository (nil) print
+      #     @option options [Boolean, nil] :is_bare_repository (nil) print
       #       `"true"` when the repository is bare, `"false"` otherwise
       #
-      #     @option options [Boolean] :is_shallow_repository (nil) print
+      #     @option options [Boolean, nil] :is_shallow_repository (nil) print
       #       `"true"` when the repository is shallow, `"false"` otherwise
       #
       #     @option options [String] :resolve_git_dir (nil) check if the
@@ -249,23 +249,23 @@ module Git
       #     @option options [String] :git_path (nil) resolve
       #       `"$GIT_DIR/<path>"` taking relocation variables into account
       #
-      #     @option options [Boolean] :show_cdup (nil) show the path of
+      #     @option options [Boolean, nil] :show_cdup (nil) show the path of
       #       the top-level directory relative to the current directory
       #
-      #     @option options [Boolean] :show_prefix (nil) show the path of
+      #     @option options [Boolean, nil] :show_prefix (nil) show the path of
       #       the current directory relative to the top-level directory
       #
-      #     @option options [Boolean] :show_toplevel (nil) show the
+      #     @option options [Boolean, nil] :show_toplevel (nil) show the
       #       absolute path of the top-level directory of the working tree
       #
-      #     @option options [Boolean] :show_superproject_working_tree (nil)
+      #     @option options [Boolean, nil] :show_superproject_working_tree (nil)
       #       show the absolute path of the root of the superproject's
       #       working tree if the current repository is a submodule
       #
-      #     @option options [Boolean] :shared_index_path (nil) show the
+      #     @option options [Boolean, nil] :shared_index_path (nil) show the
       #       path to the shared index file in split index mode
       #
-      #     @option options [Boolean, String] :show_object_format (nil)
+      #     @option options [Boolean, String, nil] :show_object_format (nil)
       #       show the object format (hash algorithm) used for the
       #       repository
       #
@@ -273,7 +273,7 @@ module Git
       #       `"storage"`). When a String (`"storage"`, `"input"`, or
       #       `"output"`), emits `--show-object-format=<mode>`.
       #
-      #     @option options [Boolean] :show_ref_format (nil) show the
+      #     @option options [Boolean, nil] :show_ref_format (nil) show the
       #       reference storage format used for the repository
       #
       #     @option options [String] :since (nil) parse the date string

--- a/lib/git/commands/revert/continue.rb
+++ b/lib/git/commands/revert/continue.rb
@@ -37,12 +37,12 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :edit (false) open the editor for the
+        #     @option options [Boolean, nil] :edit (nil) open the editor for the
         #       commit message (`--edit`)
         #
         #       Alias: `:e`
         #
-        #     @option options [Boolean] :no_edit (false) suppress the editor for
+        #     @option options [Boolean, nil] :no_edit (nil) suppress the editor for
         #       the commit message (`--no-edit`)
         #
         #     @return [Git::CommandLineResult] the result of calling

--- a/lib/git/commands/revert/start.rb
+++ b/lib/git/commands/revert/start.rb
@@ -81,15 +81,15 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :edit (false) open the editor for the
+        #     @option options [Boolean, nil] :edit (nil) open the editor for the
         #       commit message (`--edit`)
         #
         #       Alias: `:e`
         #
-        #     @option options [Boolean] :no_edit (false) suppress the editor for
+        #     @option options [Boolean, nil] :no_edit (nil) suppress the editor for
         #       the commit message (`--no-edit`)
         #
-        #     @option options [Boolean] :no_commit (false) apply changes to index
+        #     @option options [Boolean, nil] :no_commit (nil) apply changes to index
         #       and working tree without committing
         #
         #       Alias: `:n`
@@ -99,21 +99,21 @@ module Git
         #
         #       Alias: `:m`
         #
-        #     @option options [Boolean] :signoff (false) add a `Signed-off-by`
+        #     @option options [Boolean, nil] :signoff (nil) add a `Signed-off-by`
         #       trailer to the commit message (`--signoff`)
         #
         #       Alias: `:s`
         #
-        #     @option options [Boolean] :no_signoff (false) suppress the
+        #     @option options [Boolean, nil] :no_signoff (nil) suppress the
         #       `Signed-off-by` trailer (`--no-signoff`)
         #
-        #     @option options [Boolean, String] :gpg_sign (false) GPG-sign the
+        #     @option options [Boolean, String, nil] :gpg_sign (nil) GPG-sign the
         #       resulting commit (`--gpg-sign`)
         #
         #       When `true`, uses the default key. When a `String`, uses the
         #       specified key ID. Alias: `:S`
         #
-        #     @option options [Boolean] :no_gpg_sign (false) disable GPG signing
+        #     @option options [Boolean, nil] :no_gpg_sign (nil) disable GPG signing
         #       (`--no-gpg-sign`)
         #
         #     @option options [String] :cleanup (nil) commit message cleanup mode
@@ -132,14 +132,14 @@ module Git
         #       Can be a single value or an array for multiple `-X` flags.
         #       Emits `--strategy-option=<option>`. Alias: `:X`
         #
-        #     @option options [Boolean] :rerere_autoupdate (false) allow rerere to
+        #     @option options [Boolean, nil] :rerere_autoupdate (nil) allow rerere to
         #       update the index with the auto-resolved conflict result
         #       (`--rerere-autoupdate`)
         #
-        #     @option options [Boolean] :no_rerere_autoupdate (false) prevent rerere
+        #     @option options [Boolean, nil] :no_rerere_autoupdate (nil) prevent rerere
         #       from auto-updating the index (`--no-rerere-autoupdate`)
         #
-        #     @option options [Boolean] :reference (false) use compact reference
+        #     @option options [Boolean, nil] :reference (nil) use compact reference
         #       format in the revert commit message instead of the full object name
         #
         #     @return [Git::CommandLineResult] the result of calling `git revert`

--- a/lib/git/commands/rm.rb
+++ b/lib/git/commands/rm.rb
@@ -66,30 +66,30 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :force (false) override the up-to-date check and
+      #     @option options [Boolean, nil] :force (nil) override the up-to-date check and
       #       remove files with local modifications
       #
       #       Alias: :f
       #
-      #     @option options [Boolean] :dry_run (false) do not actually remove any files;
+      #     @option options [Boolean, nil] :dry_run (nil) do not actually remove any files;
       #       instead, just show if they exist in the index and would otherwise be removed
       #       by the command
       #
       #       Alias: :n
       #
-      #     @option options [Boolean] :r (false) allow recursive removal when a leading
+      #     @option options [Boolean, nil] :r (nil) allow recursive removal when a leading
       #       directory name is given
       #
-      #     @option options [Boolean] :cached (false) only remove from the index, keeping
+      #     @option options [Boolean, nil] :cached (nil) only remove from the index, keeping
       #       the working tree files
       #
-      #     @option options [Boolean] :ignore_unmatch (false) exit with a zero status
+      #     @option options [Boolean, nil] :ignore_unmatch (nil) exit with a zero status
       #       even if no files matched
       #
-      #     @option options [Boolean] :sparse (false) allow updating index entries outside
+      #     @option options [Boolean, nil] :sparse (nil) allow updating index entries outside
       #       of the sparse-checkout cone
       #
-      #     @option options [Boolean] :quiet (false) suppress the one-line-per-file output
+      #     @option options [Boolean, nil] :quiet (nil) suppress the one-line-per-file output
       #
       #       Alias: :q
       #
@@ -97,7 +97,7 @@ module Git
       #       given file, one pathspec element per line; pass `-` to read from standard
       #       input
       #
-      #     @option options [Boolean] :pathspec_file_nul (false) when used with
+      #     @option options [Boolean, nil] :pathspec_file_nul (nil) when used with
       #       `:pathspec_from_file`, separate pathspec elements with NUL instead of
       #       newlines
       #

--- a/lib/git/commands/show.rb
+++ b/lib/git/commands/show.rb
@@ -196,7 +196,7 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean, String] :pretty (nil) pretty-print commit
+      #     @option options [Boolean, String, nil] :pretty (nil) pretty-print commit
       #       log messages in the given format
       #
       #       Pass `true` for `--pretty` (defaults to `medium`); pass a string like
@@ -205,81 +205,81 @@ module Git
       #     @option options [String] :format (nil) format string passed as
       #       `--format=<format>` (equivalent to `--pretty=tformat:<format>`)
       #
-      #     @option options [Boolean] :abbrev_commit (false) show an abbreviated
+      #     @option options [Boolean, nil] :abbrev_commit (nil) show an abbreviated
       #       commit hash prefix (`--abbrev-commit`)
       #
-      #     @option options [Boolean] :no_abbrev_commit (false) show the full commit
+      #     @option options [Boolean, nil] :no_abbrev_commit (nil) show the full commit
       #       hash (`--no-abbrev-commit`)
       #
-      #     @option options [Boolean] :oneline (false) shorthand for
+      #     @option options [Boolean, nil] :oneline (nil) shorthand for
       #       `--pretty=oneline --abbrev-commit`
       #
       #     @option options [String] :encoding (nil) re-encode the commit log
       #       message in the specified encoding
       #
-      #     @option options [Boolean, Integer] :expand_tabs (false) expand tabs in
+      #     @option options [Boolean, Integer, nil] :expand_tabs (nil) expand tabs in
       #       the log message before showing it
       #
       #       Pass `true` for `--expand-tabs` (tab stop every 8 columns) or an
       #       integer for `--expand-tabs=<n>`.
       #
-      #     @option options [Boolean] :no_expand_tabs (false) disable tab expansion
+      #     @option options [Boolean, nil] :no_expand_tabs (nil) disable tab expansion
       #       (`--no-expand-tabs`)
       #
-      #     @option options [Boolean, String] :notes (false) show notes that annotate
+      #     @option options [Boolean, String, nil] :notes (nil) show notes that annotate
       #       the commit
       #
       #       Pass `true` for `--notes` or a string like `'refs/notes/review'` for
       #       `--notes=<ref>`.
       #
-      #     @option options [Boolean] :no_notes (false) suppress notes output
+      #     @option options [Boolean, nil] :no_notes (nil) suppress notes output
       #       (`--no-notes`)
       #
-      #     @option options [Boolean] :show_notes_by_default (false) show the
+      #     @option options [Boolean, nil] :show_notes_by_default (nil) show the
       #       default notes unless options for displaying specific notes are given
       #
-      #     @option options [Boolean, String] :show_notes (nil) deprecated; use
+      #     @option options [Boolean, String, nil] :show_notes (nil) deprecated; use
       #       `:notes` instead
       #
-      #     @option options [Boolean] :standard_notes (false) deprecated; use `:notes`
+      #     @option options [Boolean, nil] :standard_notes (nil) deprecated; use `:notes`
       #       instead (`--standard-notes`)
       #
-      #     @option options [Boolean] :no_standard_notes (false) deprecated; use
+      #     @option options [Boolean, nil] :no_standard_notes (nil) deprecated; use
       #       `:notes` instead (`--no-standard-notes`)
       #
-      #     @option options [Boolean] :show_signature (false) check the validity
+      #     @option options [Boolean, nil] :show_signature (nil) check the validity
       #       of a signed commit by passing the signature to `gpg --verify`
       #
-      #     @option options [Boolean] :m (false) show diffs for merge commits in
+      #     @option options [Boolean, nil] :m (nil) show diffs for merge commits in
       #       the default format (no output unless `-p` is also given)
       #
-      #     @option options [Boolean] :c (false) produce combined diff output for
+      #     @option options [Boolean, nil] :c (nil) produce combined diff output for
       #       merge commits; shortcut for `--diff-merges=combined -p`
       #
-      #     @option options [Boolean] :cc (false) produce dense combined diff
+      #     @option options [Boolean, nil] :cc (nil) produce dense combined diff
       #       output for merge commits; shortcut for `--diff-merges=dense-combined -p`
       #
-      #     @option options [Boolean] :dd (false) produce diff with respect to
+      #     @option options [Boolean, nil] :dd (nil) produce diff with respect to
       #       first parent; shortcut for `--diff-merges=first-parent -p`
       #
-      #     @option options [Boolean] :remerge_diff (false) produce remerge-diff
+      #     @option options [Boolean, nil] :remerge_diff (nil) produce remerge-diff
       #       output for merge commits; shortcut for `--diff-merges=remerge -p`
       #
-      #     @option options [Boolean] :no_diff_merges (false) disable diff output
+      #     @option options [Boolean, nil] :no_diff_merges (nil) disable diff output
       #       for merge commits; synonym for `--diff-merges=off`
       #
       #     @option options [String] :diff_merges (nil) specify the diff format for
       #       merge commits (`off`, `on`, `first-parent`, `separate`, `combined`,
       #       `dense-combined`, or `remerge`)
       #
-      #     @option options [Boolean] :combined_all_paths (false) show paths from
+      #     @option options [Boolean, nil] :combined_all_paths (nil) show paths from
       #       all parents when generating a combined diff
       #
-      #     @option options [Boolean] :patch (false) generate patch output
+      #     @option options [Boolean, nil] :patch (nil) generate patch output
       #
       #       Alias: :p, :u
       #
-      #     @option options [Boolean] :no_patch (false) suppress all diff output
+      #     @option options [Boolean, nil] :no_patch (nil) suppress all diff output
       #
       #       Alias: :s
       #
@@ -300,28 +300,28 @@ module Git
       #     @option options [String] :output_indicator_context (nil) character to
       #       indicate context lines in the patch
       #
-      #     @option options [Boolean] :raw (false) show a summary of changes in
+      #     @option options [Boolean, nil] :raw (nil) show a summary of changes in
       #       raw diff format
       #
-      #     @option options [Boolean] :patch_with_raw (false) synonym for
+      #     @option options [Boolean, nil] :patch_with_raw (nil) synonym for
       #       `--patch --raw`
       #
-      #     @option options [Boolean] :t (false) show tree objects in the diff
+      #     @option options [Boolean, nil] :t (nil) show tree objects in the diff
       #       output
       #
-      #     @option options [Boolean] :indent_heuristic (false) use the indent
+      #     @option options [Boolean, nil] :indent_heuristic (nil) use the indent
       #       heuristic to improve patch readability (`--indent-heuristic`)
       #
-      #     @option options [Boolean] :no_indent_heuristic (false) disable the indent
+      #     @option options [Boolean, nil] :no_indent_heuristic (nil) disable the indent
       #       heuristic (`--no-indent-heuristic`)
       #
-      #     @option options [Boolean] :minimal (false) spend extra time to produce
+      #     @option options [Boolean, nil] :minimal (nil) spend extra time to produce
       #       the smallest possible diff
       #
-      #     @option options [Boolean] :patience (false) use the patience diff
+      #     @option options [Boolean, nil] :patience (nil) use the patience diff
       #       algorithm
       #
-      #     @option options [Boolean] :histogram (false) use the histogram diff
+      #     @option options [Boolean, nil] :histogram (nil) use the histogram diff
       #       algorithm
       #
       #     @option options [String, Array<String>] :anchored (nil) generate a diff
@@ -333,7 +333,7 @@ module Git
       #     @option options [String] :diff_algorithm (nil) choose a diff algorithm
       #       (`patience`, `minimal`, `histogram`, or `myers`)
       #
-      #     @option options [Boolean, String] :stat (nil) generate a diffstat
+      #     @option options [Boolean, String, nil] :stat (nil) generate a diffstat
       #
       #       Pass `true` for `--stat`; pass a string like `'100,40,10'` for
       #       `--stat=100,40,10`.
@@ -350,16 +350,16 @@ module Git
       #     @option options [Integer, String] :stat_graph_width (nil) limit the
       #       graph width of `--stat` output
       #
-      #     @option options [Boolean] :compact_summary (false) output a condensed
+      #     @option options [Boolean, nil] :compact_summary (nil) output a condensed
       #       summary of extended header information
       #
-      #     @option options [Boolean] :numstat (false) show per-file
+      #     @option options [Boolean, nil] :numstat (nil) show per-file
       #       insertion/deletion counts in decimal notation
       #
-      #     @option options [Boolean] :shortstat (false) output only the aggregate
+      #     @option options [Boolean, nil] :shortstat (nil) output only the aggregate
       #       totals line from `--stat`
       #
-      #     @option options [Boolean, String] :dirstat (nil) output the distribution
+      #     @option options [Boolean, String, nil] :dirstat (nil) output the distribution
       #       of relative amount of changes per sub-directory
       #
       #       Pass `true` for `--dirstat`; pass a string like
@@ -367,59 +367,59 @@ module Git
       #
       #       Alias: :X
       #
-      #     @option options [Boolean] :cumulative (false) synonym for
+      #     @option options [Boolean, nil] :cumulative (nil) synonym for
       #       `--dirstat=cumulative`
       #
-      #     @option options [Boolean, String] :dirstat_by_file (nil) synonym for
+      #     @option options [Boolean, String, nil] :dirstat_by_file (nil) synonym for
       #       `--dirstat=files,...`
       #
-      #     @option options [Boolean] :summary (false) output a condensed summary
+      #     @option options [Boolean, nil] :summary (nil) output a condensed summary
       #       of extended header information
       #
-      #     @option options [Boolean] :patch_with_stat (false) synonym for
+      #     @option options [Boolean, nil] :patch_with_stat (nil) synonym for
       #       `--patch --stat`
       #
-      #     @option options [Boolean] :z (false) use NUL as output field terminators
+      #     @option options [Boolean, nil] :z (nil) use NUL as output field terminators
       #
-      #     @option options [Boolean] :name_only (false) show only the name of each
+      #     @option options [Boolean, nil] :name_only (nil) show only the name of each
       #       changed file
       #
-      #     @option options [Boolean] :name_status (false) show only the name and
+      #     @option options [Boolean, nil] :name_status (nil) show only the name and
       #       status of each changed file
       #
-      #     @option options [Boolean, String] :submodule (nil) specify how
+      #     @option options [Boolean, String, nil] :submodule (nil) specify how
       #       differences in submodules are shown
       #
       #       Pass `true` for `--submodule`; pass a string like `'log'` or `'diff'`
       #       for `--submodule=<format>`.
       #
-      #     @option options [Boolean, String] :color (false) show colored diff
+      #     @option options [Boolean, String, nil] :color (nil) show colored diff
       #
       #       Pass `true` for `--color` or a string like `'always'` for
       #       `--color=always`.
       #
-      #     @option options [Boolean] :no_color (false) disable colored diff output
+      #     @option options [Boolean, nil] :no_color (nil) disable colored diff output
       #       (`--no-color`)
       #
-      #     @option options [Boolean, String] :color_moved (false) color moved lines
+      #     @option options [Boolean, String, nil] :color_moved (nil) color moved lines
       #       differently
       #
       #       Pass `true` for `--color-moved` or a string like `'zebra'` for
       #       `--color-moved=zebra`.
       #
-      #     @option options [Boolean] :no_color_moved (false) disable coloring of
+      #     @option options [Boolean, nil] :no_color_moved (nil) disable coloring of
       #       moved lines (`--no-color-moved`)
       #
-      #     @option options [Boolean, String] :color_moved_ws (false) configure how
+      #     @option options [Boolean, String, nil] :color_moved_ws (nil) configure how
       #       whitespace is handled during move detection
       #
       #       Pass `true` for `--color-moved-ws` or a string like `'ignore-all-space'`
       #       for `--color-moved-ws=ignore-all-space`.
       #
-      #     @option options [Boolean] :no_color_moved_ws (false) disable whitespace
+      #     @option options [Boolean, nil] :no_color_moved_ws (nil) disable whitespace
       #       handling during move detection (`--no-color-moved-ws`)
       #
-      #     @option options [Boolean, String] :word_diff (nil) show a word diff
+      #     @option options [Boolean, String, nil] :word_diff (nil) show a word diff
       #
       #       Pass `true` for `--word-diff`; pass a string like `'color'` for
       #       `--word-diff=color`.
@@ -427,53 +427,53 @@ module Git
       #     @option options [String] :word_diff_regex (nil) use this regex to
       #       decide what a word is
       #
-      #     @option options [Boolean, String] :color_words (nil) equivalent to
+      #     @option options [Boolean, String, nil] :color_words (nil) equivalent to
       #       `--word-diff=color` plus optional regex
       #
-      #     @option options [Boolean] :no_renames (false) turn off rename detection
+      #     @option options [Boolean, nil] :no_renames (nil) turn off rename detection
       #
-      #     @option options [Boolean] :rename_empty (false) use empty blobs as rename
+      #     @option options [Boolean, nil] :rename_empty (nil) use empty blobs as rename
       #       source (`--rename-empty`)
       #
-      #     @option options [Boolean] :no_rename_empty (false) do not use empty blobs
+      #     @option options [Boolean, nil] :no_rename_empty (nil) do not use empty blobs
       #       as rename source (`--no-rename-empty`)
       #
-      #     @option options [Boolean] :check (false) warn if changes introduce
+      #     @option options [Boolean, nil] :check (nil) warn if changes introduce
       #       conflict markers or whitespace errors
       #
       #     @option options [String] :ws_error_highlight (nil) highlight whitespace
       #       errors in `context`, `old`, or `new` lines
       #
-      #     @option options [Boolean] :full_index (false) show full pre- and
+      #     @option options [Boolean, nil] :full_index (nil) show full pre- and
       #       post-image blob object names
       #
-      #     @option options [Boolean] :binary (false) output a binary diff that can
+      #     @option options [Boolean, nil] :binary (nil) output a binary diff that can
       #       be applied with `git apply`
       #
-      #     @option options [Boolean, Integer] :abbrev (nil) show only a partial
+      #     @option options [Boolean, Integer, nil] :abbrev (nil) show only a partial
       #       prefix of object names
       #
       #       Pass `true` for `--abbrev`; pass an integer for `--abbrev=<n>`.
       #
-      #     @option options [Boolean, String] :break_rewrites (nil) break complete
+      #     @option options [Boolean, String, nil] :break_rewrites (nil) break complete
       #       rewrite changes into delete/create pairs
       #
       #       Alias: :B
       #
-      #     @option options [Boolean, String] :find_renames (nil) detect renames,
+      #     @option options [Boolean, String, nil] :find_renames (nil) detect renames,
       #       optionally specifying a similarity threshold
       #
       #       Alias: :M
       #
-      #     @option options [Boolean, String] :find_copies (nil) detect copies as
+      #     @option options [Boolean, String, nil] :find_copies (nil) detect copies as
       #       well as renames
       #
       #       Alias: :C
       #
-      #     @option options [Boolean] :find_copies_harder (false) inspect all files
+      #     @option options [Boolean, nil] :find_copies_harder (nil) inspect all files
       #       as candidates for the source of copy
       #
-      #     @option options [Boolean] :irreversible_delete (false) omit the
+      #     @option options [Boolean, nil] :irreversible_delete (nil) omit the
       #       preimage for deletes
       #
       #       Alias: :D
@@ -493,10 +493,10 @@ module Git
       #     @option options [String] :find_object (nil) look for differences that
       #       change the number of occurrences of an object
       #
-      #     @option options [Boolean] :pickaxe_all (false) when `-S` or `-G` finds
+      #     @option options [Boolean, nil] :pickaxe_all (nil) when `-S` or `-G` finds
       #       a change, show all changes in that changeset
       #
-      #     @option options [Boolean] :pickaxe_regex (false) treat the `-S` string
+      #     @option options [Boolean, nil] :pickaxe_regex (nil) treat the `-S` string
       #       as an extended POSIX regular expression
       #
       #     @option options [String] :O (nil) control the order in which files
@@ -508,37 +508,37 @@ module Git
       #     @option options [String] :rotate_to (nil) move files before the named
       #       file to the end of the output
       #
-      #     @option options [Boolean] :R (false) swap two inputs (reverse diff)
+      #     @option options [Boolean, nil] :R (nil) swap two inputs (reverse diff)
       #
-      #     @option options [Boolean, String] :relative (false) show pathnames
+      #     @option options [Boolean, String, nil] :relative (nil) show pathnames
       #       relative to a subdirectory
       #
       #       Pass `true` for `--relative` or a string for `--relative=<path>`.
       #
-      #     @option options [Boolean] :no_relative (false) show absolute pathnames
+      #     @option options [Boolean, nil] :no_relative (nil) show absolute pathnames
       #       (`--no-relative`)
       #
-      #     @option options [Boolean] :text (false) treat all files as text
+      #     @option options [Boolean, nil] :text (nil) treat all files as text
       #
       #       Alias: :a
       #
-      #     @option options [Boolean] :ignore_cr_at_eol (false) ignore
+      #     @option options [Boolean, nil] :ignore_cr_at_eol (nil) ignore
       #       carriage-return at end of line
       #
-      #     @option options [Boolean] :ignore_space_at_eol (false) ignore changes
+      #     @option options [Boolean, nil] :ignore_space_at_eol (nil) ignore changes
       #       in whitespace at end of line
       #
-      #     @option options [Boolean] :ignore_space_change (false) ignore changes
+      #     @option options [Boolean, nil] :ignore_space_change (nil) ignore changes
       #       in amount of whitespace
       #
       #       Alias: :b
       #
-      #     @option options [Boolean] :ignore_all_space (false) ignore whitespace
+      #     @option options [Boolean, nil] :ignore_all_space (nil) ignore whitespace
       #       when comparing lines
       #
       #       Alias: :w
       #
-      #     @option options [Boolean] :ignore_blank_lines (false) ignore changes
+      #     @option options [Boolean, nil] :ignore_blank_lines (nil) ignore changes
       #       whose lines are all blank
       #
       #     @option options [String, Array<String>] :ignore_matching_lines (nil)
@@ -552,24 +552,24 @@ module Git
       #     @option options [Integer, String] :inter_hunk_context (nil) show the
       #       context between diff hunks, fusing nearby hunks
       #
-      #     @option options [Boolean] :function_context (false) show whole function
+      #     @option options [Boolean, nil] :function_context (nil) show whole function
       #       as context lines for each change
       #
       #       Alias: :W
       #
-      #     @option options [Boolean] :ext_diff (false) allow an external diff helper
+      #     @option options [Boolean, nil] :ext_diff (nil) allow an external diff helper
       #       to be used (`--ext-diff`)
       #
-      #     @option options [Boolean] :no_ext_diff (false) disallow external diff
+      #     @option options [Boolean, nil] :no_ext_diff (nil) disallow external diff
       #       helpers (`--no-ext-diff`)
       #
-      #     @option options [Boolean] :textconv (false) allow external text conversion
+      #     @option options [Boolean, nil] :textconv (nil) allow external text conversion
       #       filters for binary files (`--textconv`)
       #
-      #     @option options [Boolean] :no_textconv (false) disallow external text
+      #     @option options [Boolean, nil] :no_textconv (nil) disallow external text
       #       conversion filters (`--no-textconv`)
       #
-      #     @option options [Boolean, String] :ignore_submodules (nil) ignore
+      #     @option options [Boolean, String, nil] :ignore_submodules (nil) ignore
       #       changes to submodules in the diff
       #
       #       Pass `true` for `--ignore-submodules`; pass a string like `'all'`
@@ -581,19 +581,19 @@ module Git
       #     @option options [String] :dst_prefix (nil) destination prefix for diff
       #       headers (e.g. `'b/'`)
       #
-      #     @option options [Boolean] :no_prefix (false) do not show any source or
+      #     @option options [Boolean, nil] :no_prefix (nil) do not show any source or
       #       destination prefix
       #
-      #     @option options [Boolean] :default_prefix (false) use the default source
+      #     @option options [Boolean, nil] :default_prefix (nil) use the default source
       #       and destination prefixes
       #
       #     @option options [String] :line_prefix (nil) prepend an additional prefix
       #       to every line of output
       #
-      #     @option options [Boolean] :ita_invisible_in_index (false) make
+      #     @option options [Boolean, nil] :ita_invisible_in_index (nil) make
       #       intent-to-add entries appear as new files in `git diff`
       #
-      #     @option options [Boolean] :ita_visible_in_index (false) revert
+      #     @option options [Boolean, nil] :ita_visible_in_index (nil) revert
       #       `--ita-invisible-in-index`
       #
       #     @option options [Integer, String] :max_depth (nil) descend at most this

--- a/lib/git/commands/show_ref/list.rb
+++ b/lib/git/commands/show_ref/list.rb
@@ -104,34 +104,34 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :head (nil) show the HEAD ref even when filtered
+        #     @option options [Boolean, nil] :head (nil) show the HEAD ref even when filtered
         #
-        #     @option options [Boolean] :dereference (nil) dereference annotated tags,
+        #     @option options [Boolean, nil] :dereference (nil) dereference annotated tags,
         #       emitting an extra line per tag whose SHA points to the tagged object
         #
         #       Alias: `:d`
         #
-        #     @option options [Boolean, Integer] :hash (nil) show only the SHA part of each ref
+        #     @option options [Boolean, Integer, nil] :hash (nil) show only the SHA part of each ref
         #
         #       Pass `true` for full-length SHAs or an integer for the abbreviation length
         #       (e.g. `hash: 7`).
         #
         #       Alias: `:s`
         #
-        #     @option options [Boolean, Integer] :abbrev (nil) abbreviate object names
+        #     @option options [Boolean, Integer, nil] :abbrev (nil) abbreviate object names
         #
         #       Pass `true` for the default length or an integer for a specific length.
         #
-        #     @option options [Boolean] :branches (false) limit output to local branches (refs/heads/)
+        #     @option options [Boolean, nil] :branches (nil) limit output to local branches (refs/heads/)
         #
         #       Prefer `:branches` over `:heads` on git >= 2.46; `:heads` emits the deprecated
         #       `--heads` flag.
         #
-        #     @option options [Boolean] :heads (false) limit output to refs under refs/heads/
+        #     @option options [Boolean, nil] :heads (nil) limit output to refs under refs/heads/
         #
         #       Deprecated at the git level in git 2.46. Use `:branches` instead.
         #
-        #     @option options [Boolean] :tags (nil) limit output to refs under refs/tags/
+        #     @option options [Boolean, nil] :tags (nil) limit output to refs under refs/tags/
         #
         #     @option options [Numeric] :timeout (nil) abort the command after this many seconds
         #

--- a/lib/git/commands/show_ref/verify.rb
+++ b/lib/git/commands/show_ref/verify.rb
@@ -84,24 +84,24 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :quiet (nil) suppress all output
+        #     @option options [Boolean, nil] :quiet (nil) suppress all output
         #
         #       Useful when you only care whether the ref exists.
         #
         #       Alias: `:q`
         #
-        #     @option options [Boolean] :dereference (nil) dereference annotated tags,
+        #     @option options [Boolean, nil] :dereference (nil) dereference annotated tags,
         #       emitting an extra `^{}` line per tag
         #
         #       Alias: `:d`
         #
-        #     @option options [Boolean, Integer] :hash (nil) show only the SHA part
+        #     @option options [Boolean, Integer, nil] :hash (nil) show only the SHA part
         #
         #       Pass `true` for full-length SHAs or an integer for abbreviation length.
         #
         #       Alias: `:s`
         #
-        #     @option options [Boolean, Integer] :abbrev (nil) abbreviate object names
+        #     @option options [Boolean, Integer, nil] :abbrev (nil) abbreviate object names
         #
         #       Pass `true` for the default length or an integer for a specific length.
         #

--- a/lib/git/commands/stash/apply.rb
+++ b/lib/git/commands/stash/apply.rb
@@ -46,9 +46,9 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :index (nil) restore the index state as well
+        #     @option options [Boolean, nil] :index (nil) restore the index state as well
         #
-        #     @option options [Boolean] :quiet (nil) suppress informational messages
+        #     @option options [Boolean, nil] :quiet (nil) suppress informational messages
         #
         #       Alias: :q
         #
@@ -60,9 +60,9 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :index (nil) restore the index state as well
+        #     @option options [Boolean, nil] :index (nil) restore the index state as well
         #
-        #     @option options [Boolean] :quiet (nil) suppress informational messages
+        #     @option options [Boolean, nil] :quiet (nil) suppress informational messages
         #
         #       Alias: :q
         #

--- a/lib/git/commands/stash/drop.rb
+++ b/lib/git/commands/stash/drop.rb
@@ -42,7 +42,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :quiet (nil) suppress informational messages
+        #     @option options [Boolean, nil] :quiet (nil) suppress informational messages
         #
         #       Alias: :q
         #
@@ -54,7 +54,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :quiet (nil) suppress informational messages
+        #     @option options [Boolean, nil] :quiet (nil) suppress informational messages
         #
         #       Alias: :q
         #

--- a/lib/git/commands/stash/pop.rb
+++ b/lib/git/commands/stash/pop.rb
@@ -49,9 +49,9 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :index (nil) restore the index state as well
+        #     @option options [Boolean, nil] :index (nil) restore the index state as well
         #
-        #     @option options [Boolean] :quiet (nil) suppress informational messages
+        #     @option options [Boolean, nil] :quiet (nil) suppress informational messages
         #
         #       Alias: :q
         #
@@ -63,9 +63,9 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :index (nil) restore the index state as well
+        #     @option options [Boolean, nil] :index (nil) restore the index state as well
         #
-        #     @option options [Boolean] :quiet (nil) suppress informational messages
+        #     @option options [Boolean, nil] :quiet (nil) suppress informational messages
         #
         #       Alias: :q
         #

--- a/lib/git/commands/stash/push.rb
+++ b/lib/git/commands/stash/push.rb
@@ -58,30 +58,30 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :patch (false) interactively select hunks to stash
+        #     @option options [Boolean, nil] :patch (nil) interactively select hunks to stash
         #
         #       Alias: :p
         #
-        #     @option options [Boolean] :staged (false) stash only staged changes
+        #     @option options [Boolean, nil] :staged (nil) stash only staged changes
         #
         #       Alias: :S
         #
-        #     @option options [Boolean] :keep_index (false) keep staged changes in the index (`--keep-index`)
+        #     @option options [Boolean, nil] :keep_index (nil) keep staged changes in the index (`--keep-index`)
         #
         #       Alias: :k
         #
-        #     @option options [Boolean] :no_keep_index (false) do not preserve staged changes in the index
+        #     @option options [Boolean, nil] :no_keep_index (nil) do not preserve staged changes in the index
         #       (`--no-keep-index`)
         #
-        #     @option options [Boolean] :quiet (false) suppress informational messages
+        #     @option options [Boolean, nil] :quiet (nil) suppress informational messages
         #
         #       Alias: :q
         #
-        #     @option options [Boolean] :include_untracked (false) include untracked files in the stash
+        #     @option options [Boolean, nil] :include_untracked (nil) include untracked files in the stash
         #
         #       Alias: :u
         #
-        #     @option options [Boolean] :all (false) include untracked and ignored files in the stash
+        #     @option options [Boolean, nil] :all (nil) include untracked and ignored files in the stash
         #
         #       Alias: :a
         #
@@ -91,7 +91,7 @@ module Git
         #
         #     @option options [String] :pathspec_from_file (nil) read pathspecs from the given file
         #
-        #     @option options [Boolean] :pathspec_file_nul (false) pathspecs in the file are NUL-separated
+        #     @option options [Boolean, nil] :pathspec_file_nul (nil) pathspecs in the file are NUL-separated
         #
         #     @return [Git::CommandLineResult] the result of calling `git stash push`
         #

--- a/lib/git/commands/stash/show.rb
+++ b/lib/git/commands/stash/show.rb
@@ -60,39 +60,39 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :patch (false) include unified diff patches per file
+        #     @option options [Boolean, nil] :patch (nil) include unified diff patches per file
         #
-        #     @option options [Boolean] :numstat (false) include per-file insertion/deletion counts
+        #     @option options [Boolean, nil] :numstat (nil) include per-file insertion/deletion counts
         #
-        #     @option options [Boolean] :raw (false) include per-file mode/SHA/status metadata
+        #     @option options [Boolean, nil] :raw (nil) include per-file mode/SHA/status metadata
         #
-        #     @option options [Boolean] :shortstat (false) include aggregate totals line
+        #     @option options [Boolean, nil] :shortstat (nil) include aggregate totals line
         #
         #     @option options [Integer, String] :unified (nil) generate diff with <n> lines of context
         #
         #       Alias: :U
         #
-        #     @option options [Boolean] :include_untracked (false) include untracked files (`--include-untracked`)
+        #     @option options [Boolean, nil] :include_untracked (nil) include untracked files (`--include-untracked`)
         #
         #       Alias: :u
         #
-        #     @option options [Boolean] :no_include_untracked (false) exclude untracked files
+        #     @option options [Boolean, nil] :no_include_untracked (nil) exclude untracked files
         #       (`--no-include-untracked`)
         #
-        #     @option options [Boolean] :only_untracked (false) show only untracked files
+        #     @option options [Boolean, nil] :only_untracked (nil) show only untracked files
         #
-        #     @option options [Boolean, Integer] :find_renames (nil) detect renames; optionally pass a
+        #     @option options [Boolean, Integer, nil] :find_renames (nil) detect renames; optionally pass a
         #       similarity threshold (e.g., 50 for 50%). Alias: :M
         #
-        #     @option options [Boolean, Integer] :find_copies (nil) detect copies as well as renames;
+        #     @option options [Boolean, Integer, nil] :find_copies (nil) detect copies as well as renames;
         #       optionally pass a threshold. Alias: :C
         #
-        #     @option options [Boolean] :find_copies_harder (false) inspect all files as copy sources; expensive
+        #     @option options [Boolean, nil] :find_copies_harder (nil) inspect all files as copy sources; expensive
         #
         #     @option options [Integer, String] :inter_hunk_context (nil) show context between diff hunks, up to
         #       <n> lines, fusing hunks that are close to each other
         #
-        #     @option options [Boolean, String] :dirstat (nil) include directory statistics
+        #     @option options [Boolean, String, nil] :dirstat (nil) include directory statistics
         #
         #       Pass `true` for default, or a string like `'lines,cumulative'` for options.
         #
@@ -104,39 +104,39 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :patch (false) include unified diff patches per file
+        #     @option options [Boolean, nil] :patch (nil) include unified diff patches per file
         #
-        #     @option options [Boolean] :numstat (false) include per-file insertion/deletion counts
+        #     @option options [Boolean, nil] :numstat (nil) include per-file insertion/deletion counts
         #
-        #     @option options [Boolean] :raw (false) include per-file mode/SHA/status metadata
+        #     @option options [Boolean, nil] :raw (nil) include per-file mode/SHA/status metadata
         #
-        #     @option options [Boolean] :shortstat (false) include aggregate totals line
+        #     @option options [Boolean, nil] :shortstat (nil) include aggregate totals line
         #
         #     @option options [Integer, String] :unified (nil) generate diff with <n> lines of context
         #
         #       Alias: :U
         #
-        #     @option options [Boolean] :include_untracked (false) include untracked files (`--include-untracked`)
+        #     @option options [Boolean, nil] :include_untracked (nil) include untracked files (`--include-untracked`)
         #
         #       Alias: :u
         #
-        #     @option options [Boolean] :no_include_untracked (false) exclude untracked files
+        #     @option options [Boolean, nil] :no_include_untracked (nil) exclude untracked files
         #       (`--no-include-untracked`)
         #
-        #     @option options [Boolean] :only_untracked (false) show only untracked files
+        #     @option options [Boolean, nil] :only_untracked (nil) show only untracked files
         #
-        #     @option options [Boolean, Integer] :find_renames (nil) detect renames; optionally pass a
+        #     @option options [Boolean, Integer, nil] :find_renames (nil) detect renames; optionally pass a
         #       similarity threshold (e.g., 50 for 50%). Alias: :M
         #
-        #     @option options [Boolean, Integer] :find_copies (nil) detect copies as well as renames;
+        #     @option options [Boolean, Integer, nil] :find_copies (nil) detect copies as well as renames;
         #       optionally pass a threshold. Alias: :C
         #
-        #     @option options [Boolean] :find_copies_harder (false) inspect all files as copy sources; expensive
+        #     @option options [Boolean, nil] :find_copies_harder (nil) inspect all files as copy sources; expensive
         #
         #     @option options [Integer, String] :inter_hunk_context (nil) show context between diff hunks, up to
         #       <n> lines, fusing hunks that are close to each other
         #
-        #     @option options [Boolean, String] :dirstat (nil) include directory statistics
+        #     @option options [Boolean, String, nil] :dirstat (nil) include directory statistics
         #
         #       Pass `true` for default, or a string like `'lines,cumulative'` for options.
         #

--- a/lib/git/commands/stash/store.rb
+++ b/lib/git/commands/stash/store.rb
@@ -50,7 +50,7 @@ module Git
         #
         #       Alias: :m
         #
-        #     @option options [Boolean] :quiet (nil) suppress output
+        #     @option options [Boolean, nil] :quiet (nil) suppress output
         #
         #       Alias: :q
         #

--- a/lib/git/commands/status.rb
+++ b/lib/git/commands/status.rb
@@ -87,71 +87,71 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :short (false) give output in short format
+      #     @option options [Boolean, nil] :short (nil) give output in short format
       #
       #       Alias: :s
       #
-      #     @option options [Boolean] :branch (false) show the branch and tracking info
+      #     @option options [Boolean, nil] :branch (nil) show the branch and tracking info
       #       even in short-format
       #
       #       Alias: :b
       #
-      #     @option options [Boolean] :show_stash (false) show the number of entries
+      #     @option options [Boolean, nil] :show_stash (nil) show the number of entries
       #       currently stashed away
       #
-      #     @option options [Boolean, String] :porcelain (nil) give the output in an
+      #     @option options [Boolean, String, nil] :porcelain (nil) give the output in an
       #       easy-to-parse format for scripts
       #
       #       When `true`, gives porcelain format. When a string (e.g. `'v1'`, `'v2'`),
       #       gives the specified porcelain format version.
       #
-      #     @option options [Boolean] :long (false) give output in long format (the default)
+      #     @option options [Boolean, nil] :long (nil) give output in long format (the default)
       #
-      #     @option options [Boolean] :verbose (false) in addition to names of files that
+      #     @option options [Boolean, nil] :verbose (nil) in addition to names of files that
       #       have been changed, also show the textual changes that are staged
       #
       #       Alias: :v
       #
-      #     @option options [Boolean, String] :untracked_files (nil) show untracked files
+      #     @option options [Boolean, String, nil] :untracked_files (nil) show untracked files
       #
       #       Mode can be `'no'`, `'normal'`, or `'all'`. When `true`, uses the default
       #       mode.
       #
       #       Alias: :u
       #
-      #     @option options [Boolean, String] :ignore_submodules (nil) ignore changes
+      #     @option options [Boolean, String, nil] :ignore_submodules (nil) ignore changes
       #       to submodules
       #
       #       Mode can be `'none'`, `'untracked'`, `'dirty'`, or `'all'`.
       #
-      #     @option options [Boolean, String] :ignored (nil) show ignored files as well
+      #     @option options [Boolean, String, nil] :ignored (nil) show ignored files as well
       #
       #       Mode can be `'traditional'`, `'no'`, or `'matching'`.
       #
-      #     @option options [Boolean] :z (false) terminate entries with NUL instead of
+      #     @option options [Boolean, nil] :z (nil) terminate entries with NUL instead of
       #       newline (`-z`)
       #
       #       Implies `--porcelain=v1`
       #
-      #     @option options [Boolean, String] :column (false) display untracked files in
+      #     @option options [Boolean, String, nil] :column (nil) display untracked files in
       #       columns (`--column`)
       #
       #       Pass `true` for `--column` or a string of options for `--column=<options>`.
       #
-      #     @option options [Boolean] :no_column (false) disable column output (`--no-column`)
+      #     @option options [Boolean, nil] :no_column (nil) disable column output (`--no-column`)
       #
-      #     @option options [Boolean] :ahead_behind (false) show ahead/behind counts for
+      #     @option options [Boolean, nil] :ahead_behind (nil) show ahead/behind counts for
       #       the branch (`--ahead-behind`)
       #
-      #     @option options [Boolean] :no_ahead_behind (false) suppress ahead/behind counts
+      #     @option options [Boolean, nil] :no_ahead_behind (nil) suppress ahead/behind counts
       #       for the branch (`--no-ahead-behind`)
       #
-      #     @option options [Boolean] :renames (false) turn on rename detection (`--renames`)
+      #     @option options [Boolean, nil] :renames (nil) turn on rename detection (`--renames`)
       #
-      #     @option options [Boolean] :no_renames (false) turn off rename detection
+      #     @option options [Boolean, nil] :no_renames (nil) turn off rename detection
       #       (`--no-renames`)
       #
-      #     @option options [Boolean, String] :find_renames (nil) turn on rename detection
+      #     @option options [Boolean, String, nil] :find_renames (nil) turn on rename detection
       #       with optional similarity threshold
       #
       #       When `true`, enables rename detection without a threshold. When a string

--- a/lib/git/commands/symbolic_ref/delete.rb
+++ b/lib/git/commands/symbolic_ref/delete.rb
@@ -49,7 +49,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :quiet (false) suppress error message
+        #     @option options [Boolean, nil] :quiet (nil) suppress error message
         #       when the name is not a symbolic ref
         #
         #       Alias: :q

--- a/lib/git/commands/symbolic_ref/read.rb
+++ b/lib/git/commands/symbolic_ref/read.rb
@@ -67,18 +67,18 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :quiet (false) suppress error message
+        #     @option options [Boolean, nil] :quiet (nil) suppress error message
         #       when the name is not a symbolic ref
         #
         #       Alias: :q
         #
-        #     @option options [Boolean] :short (false) shorten the ref output
+        #     @option options [Boolean, nil] :short (nil) shorten the ref output
         #       (e.g. `refs/heads/main` → `main`)
         #
-        #     @option options [Boolean] :recurse (false) follow chain of symbolic refs
+        #     @option options [Boolean, nil] :recurse (nil) follow chain of symbolic refs
         #       until result no longer points at a symbolic ref (`--recurse`)
         #
-        #     @option options [Boolean] :no_recurse (false) stop after a single level
+        #     @option options [Boolean, nil] :no_recurse (nil) stop after a single level
         #       of dereferencing (`--no-recurse`)
         #
         #     @return [Git::CommandLineResult] the result of calling

--- a/lib/git/commands/tag/create.rb
+++ b/lib/git/commands/tag/create.rb
@@ -68,19 +68,21 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :annotate (false) make an unsigned, annotated tag object
+        #     @option options [Boolean, nil] :annotate (nil) make an unsigned, annotated tag object
         #
         #       Requires a message via `:message` or `:file`.
         #
         #       Alias: :a
         #
-        #     @option options [Boolean] :sign (false) make a GPG-signed tag using the default signing key (`--sign`)
+        #     @option options [Boolean, nil] :sign (nil) make a GPG-signed tag using the default signing
+        #       key (`--sign`)
         #
         #       Requires a message via `:message` or `:file`.
         #
         #       Alias: :s
         #
-        #     @option options [Boolean] :no_sign (false) override `tag.gpgSign` config to disable signing (`--no-sign`)
+        #     @option options [Boolean, nil] :no_sign (nil) override `tag.gpgSign` config to disable
+        #       signing (`--no-sign`)
         #
         #     @option options [String] :local_user (nil) make a cryptographically signed tag using the given key
         #
@@ -88,7 +90,7 @@ module Git
         #
         #       Alias: :u
         #
-        #     @option options [Boolean] :force (false) replace an existing tag with the given name instead of failing
+        #     @option options [Boolean, nil] :force (nil) replace an existing tag with the given name instead of failing
         #
         #       Alias: :f
         #
@@ -105,11 +107,11 @@ module Git
         #
         #       Alias: :F
         #
-        #     @option options [Boolean] :edit (false) open an editor to further edit the tag message (`--edit`)
+        #     @option options [Boolean, nil] :edit (nil) open an editor to further edit the tag message (`--edit`)
         #
         #       Alias: :e
         #
-        #     @option options [Boolean] :no_edit (false) suppress the editor (`--no-edit`)
+        #     @option options [Boolean, nil] :no_edit (nil) suppress the editor (`--no-edit`)
         #
         #     @option options [Hash, Array<Array>] :trailer (nil) add trailers to the tag message
         #
@@ -121,7 +123,7 @@ module Git
         #       Must be one of: `verbatim` (no changes), `whitespace` (remove leading/trailing
         #       whitespace lines), or `strip` (remove whitespace and commentary). Default is `strip`.
         #
-        #     @option options [Boolean] :create_reflog (false) create a reflog for the tag
+        #     @option options [Boolean, nil] :create_reflog (nil) create a reflog for the tag
         #
         #       Enables date-based sha1 expressions such as `tag@{yesterday}`.
         #

--- a/lib/git/commands/tag/list.rb
+++ b/lib/git/commands/tag/list.rb
@@ -74,7 +74,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, Integer] :n (nil) Number of annotation lines to print
+        #     @option options [Boolean, Integer, nil] :n (nil) Number of annotation lines to print
         #
         #       Pass `true` to print the first annotation line, or an integer to print that
         #       many lines. If the tag is not annotated, the commit message is displayed instead.
@@ -86,47 +86,47 @@ module Git
         #       '-refname', 'creatordate', '-creatordate', 'version:refname' (for semantic
         #       version sorting).
         #
-        #     @option options [Boolean, String] :color (nil) Colorize output per colors
+        #     @option options [Boolean, String, nil] :color (nil) Colorize output per colors
         #       specified in `--format`
         #
         #       Pass `true` for `--color`, or one of `'always'`, `'never'`, `'auto'`.
         #
-        #     @option options [Boolean] :ignore_case (false) Sorting and filtering tags are
+        #     @option options [Boolean, nil] :ignore_case (nil) Sorting and filtering tags are
         #       case insensitive
         #
         #       Alias: :i
         #
-        #     @option options [Boolean] :omit_empty (false) Do not print a newline after
+        #     @option options [Boolean, nil] :omit_empty (nil) Do not print a newline after
         #       formatted refs where the format expands to the empty string
         #
-        #     @option options [Boolean, String] :column (false) Display tag listing in columns
+        #     @option options [Boolean, String, nil] :column (nil) Display tag listing in columns
         #
         #       Pass `true` for `--column` or a comma-separated options string
         #       (see `column.tag` configuration for syntax) for `--column=<options>`.
         #
-        #     @option options [Boolean] :no_column (false) disable column output (`--no-column`)
+        #     @option options [Boolean, nil] :no_column (nil) disable column output (`--no-column`)
         #
-        #     @option options [Boolean, String] :contains (nil) List only tags that contain the
+        #     @option options [Boolean, String, nil] :contains (nil) List only tags that contain the
         #       specified commit
         #
         #       Pass `true` to use HEAD, or a commit reference string.
         #
-        #     @option options [Boolean, String] :no_contains (nil) List only tags that don't contain
+        #     @option options [Boolean, String, nil] :no_contains (nil) List only tags that don't contain
         #       the specified commit
         #
         #       Pass `true` to use HEAD, or a commit reference string.
         #
-        #     @option options [Boolean, String] :merged (nil) List only tags whose commits are
+        #     @option options [Boolean, String, nil] :merged (nil) List only tags whose commits are
         #       reachable from the specified commit
         #
         #       Pass `true` to use HEAD, or a commit reference string.
         #
-        #     @option options [Boolean, String] :no_merged (nil) List only tags whose commits are
+        #     @option options [Boolean, String, nil] :no_merged (nil) List only tags whose commits are
         #       not reachable from the specified commit
         #
         #       Pass `true` to use HEAD, or a commit reference string.
         #
-        #     @option options [Boolean, String] :points_at (nil) List only tags that point at the
+        #     @option options [Boolean, String, nil] :points_at (nil) List only tags that point at the
         #       specified object
         #
         #       Pass `true` to use HEAD, or an object reference string.

--- a/lib/git/commands/update_ref/batch.rb
+++ b/lib/git/commands/update_ref/batch.rb
@@ -94,13 +94,13 @@ module Git
         #   @option options [String] :m (nil) a reflog message for each
         #     update
         #
-        #   @option options [Boolean] :no_deref (nil) overwrite refs
+        #   @option options [Boolean, nil] :no_deref (nil) overwrite refs
         #     themselves rather than following symbolic refs
         #
-        #   @option options [Boolean] :z (nil) use NUL-delimited input
+        #   @option options [Boolean, nil] :z (nil) use NUL-delimited input
         #     instead of newline-delimited
         #
-        #   @option options [Boolean] :batch_updates (nil) allow individual updates to fail
+        #   @option options [Boolean, nil] :batch_updates (nil) allow individual updates to fail
         #
         #     When set, each instruction is applied independently; failed instructions are
         #     reported but do not abort the remaining updates. System-level failures (I/O,

--- a/lib/git/commands/update_ref/delete.rb
+++ b/lib/git/commands/update_ref/delete.rb
@@ -72,7 +72,7 @@ module Git
         #     @option options [String] :m (nil) a reflog message for
         #       the deletion
         #
-        #     @option options [Boolean] :no_deref (nil) overwrite the ref
+        #     @option options [Boolean, nil] :no_deref (nil) overwrite the ref
         #       itself rather than following symbolic refs
         #
         #     @option options [Numeric] :timeout (nil) abort the command after this many

--- a/lib/git/commands/update_ref/update.rb
+++ b/lib/git/commands/update_ref/update.rb
@@ -82,10 +82,10 @@ module Git
         #     @option options [String] :m (nil) a reflog message for
         #       the update
         #
-        #     @option options [Boolean] :no_deref (nil) overwrite the ref
+        #     @option options [Boolean, nil] :no_deref (nil) overwrite the ref
         #       itself rather than following symbolic refs
         #
-        #     @option options [Boolean] :create_reflog (nil) create a reflog
+        #     @option options [Boolean, nil] :create_reflog (nil) create a reflog
         #       even if one would not ordinarily be created
         #
         #     @option options [Numeric] :timeout (nil) abort the command after this many

--- a/lib/git/commands/version.rb
+++ b/lib/git/commands/version.rb
@@ -40,7 +40,7 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :build_options (false) include build options in the output
+      #     @option options [Boolean, nil] :build_options (nil) include build options in the output
       #
       #     @return [Git::CommandLineResult] the result of calling `git version`
       #

--- a/lib/git/commands/worktree/add.rb
+++ b/lib/git/commands/worktree/add.rb
@@ -63,7 +63,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, Integer] :force (false) override safety guards
+        #     @option options [Boolean, Integer, nil] :force (nil) override safety guards
         #
         #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit
         #       `--force --force`, which also allows adding worktrees for locked branches.
@@ -74,36 +74,36 @@ module Git
         #
         #     @option options [String] :B (nil) create or reset a branch with this name and check it out
         #
-        #     @option options [Boolean] :detach (false) check out in detached-HEAD state
+        #     @option options [Boolean, nil] :detach (nil) check out in detached-HEAD state
         #
         #       Alias: :d
         #
-        #     @option options [Boolean] :checkout (false) control whether the working tree
+        #     @option options [Boolean, nil] :checkout (nil) control whether the working tree
         #       is checked out after creation (`--checkout`)
         #
-        #     @option options [Boolean] :no_checkout (false) suppress the initial checkout
+        #     @option options [Boolean, nil] :no_checkout (nil) suppress the initial checkout
         #       after worktree creation (`--no-checkout`)
         #
-        #     @option options [Boolean] :guess_remote (false) base new branch on a matching
+        #     @option options [Boolean, nil] :guess_remote (nil) base new branch on a matching
         #       remote-tracking branch when no `commit_ish` is given (`--guess-remote`)
         #
-        #     @option options [Boolean] :no_guess_remote (false) disable guess-remote behavior (`--no-guess-remote`)
+        #     @option options [Boolean, nil] :no_guess_remote (nil) disable guess-remote behavior (`--no-guess-remote`)
         #
-        #     @option options [Boolean] :relative_paths (false) link worktrees using relative paths,
+        #     @option options [Boolean, nil] :relative_paths (nil) link worktrees using relative paths,
         #       overriding the `worktree.useRelativePaths` config option (`--relative-paths`)
         #
-        #     @option options [Boolean] :no_relative_paths (false) use absolute paths for worktree links,
+        #     @option options [Boolean, nil] :no_relative_paths (nil) use absolute paths for worktree links,
         #       overriding the `worktree.useRelativePaths` config option (`--no-relative-paths`)
         #
-        #     @option options [Boolean] :track (false) mark the upstream branch for tracking (`--track`)
+        #     @option options [Boolean, nil] :track (nil) mark the upstream branch for tracking (`--track`)
         #
-        #     @option options [Boolean] :no_track (false) do not mark the upstream branch for tracking (`--no-track`)
+        #     @option options [Boolean, nil] :no_track (nil) do not mark the upstream branch for tracking (`--no-track`)
         #
-        #     @option options [Boolean] :lock (false) lock the worktree immediately after creation
+        #     @option options [Boolean, nil] :lock (nil) lock the worktree immediately after creation
         #
-        #     @option options [Boolean] :orphan (false) create an empty worktree associated with a new unborn branch
+        #     @option options [Boolean, nil] :orphan (nil) create an empty worktree associated with a new unborn branch
         #
-        #     @option options [Boolean] :quiet (false) suppress informational messages
+        #     @option options [Boolean, nil] :quiet (nil) suppress informational messages
         #
         #       Alias: :q
         #

--- a/lib/git/commands/worktree/list.rb
+++ b/lib/git/commands/worktree/list.rb
@@ -36,11 +36,11 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :porcelain (false) produce machine-readable output
+        #     @option options [Boolean, nil] :porcelain (nil) produce machine-readable output
         #
-        #     @option options [Boolean] :z (false) NUL-terminate lines (use with `:porcelain`)
+        #     @option options [Boolean, nil] :z (nil) NUL-terminate lines (use with `:porcelain`)
         #
-        #     @option options [Boolean] :verbose (false) output additional information about worktrees
+        #     @option options [Boolean, nil] :verbose (nil) output additional information about worktrees
         #
         #       Alias: :v
         #

--- a/lib/git/commands/worktree/move.rb
+++ b/lib/git/commands/worktree/move.rb
@@ -43,7 +43,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, Integer] :force (false) allow moving a locked worktree
+        #     @option options [Boolean, Integer, nil] :force (nil) allow moving a locked worktree
         #
         #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit
         #       `--force --force`, which also handles locked or missing destinations.

--- a/lib/git/commands/worktree/prune.rb
+++ b/lib/git/commands/worktree/prune.rb
@@ -41,12 +41,12 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :dry_run (false) report what would be removed
+        #     @option options [Boolean, nil] :dry_run (nil) report what would be removed
         #       without removing anything
         #
         #       Alias: :n
         #
-        #     @option options [Boolean] :verbose (false) report all removals
+        #     @option options [Boolean, nil] :verbose (nil) report all removals
         #
         #       Alias: :v
         #

--- a/lib/git/commands/worktree/remove.rb
+++ b/lib/git/commands/worktree/remove.rb
@@ -40,7 +40,7 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, Integer] :force (false) remove even if the worktree has
+        #     @option options [Boolean, Integer, nil] :force (nil) remove even if the worktree has
         #       uncommitted changes
         #
         #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit `--force --force`,

--- a/lib/git/commands/worktree/repair.rb
+++ b/lib/git/commands/worktree/repair.rb
@@ -48,10 +48,10 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean] :relative_paths (false) link worktrees using relative paths,
+        #     @option options [Boolean, nil] :relative_paths (nil) link worktrees using relative paths,
         #       overriding the `worktree.useRelativePaths` config option (`--relative-paths`)
         #
-        #     @option options [Boolean] :no_relative_paths (false) use absolute paths for worktree links,
+        #     @option options [Boolean, nil] :no_relative_paths (nil) use absolute paths for worktree links,
         #       overriding the `worktree.useRelativePaths` config option (`--no-relative-paths`)
         #
         #       Also causes repair to update linking files if there is an absolute/relative

--- a/lib/git/commands/write_tree.rb
+++ b/lib/git/commands/write_tree.rb
@@ -46,7 +46,7 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @option options [Boolean] :missing_ok (false) disable the check that
+      #     @option options [Boolean, nil] :missing_ok (nil) disable the check that
       #       all objects referenced by the directory exist in the object
       #       database
       #

--- a/lib/git/execution_context.rb
+++ b/lib/git/execution_context.rb
@@ -237,21 +237,21 @@ module Git
     #   @option options_hash [IO, String, #write, nil] :err the destination for
     #     captured stderr
     #
-    #   @option options_hash [Boolean] :normalize true to normalize the output
+    #   @option options_hash [Boolean, nil] :normalize (true) normalize the output
     #     encoding to UTF-8
     #
-    #   @option options_hash [Boolean] :chomp true to remove trailing newlines from
-    #     the output
+    #   @option options_hash [Boolean, nil] :chomp (true) remove trailing newlines
+    #     from the output
     #
-    #   @option options_hash [Boolean] :merge true to merge stdout and stderr into a
-    #     single output
+    #   @option options_hash [Boolean, nil] :merge (false) merge stdout and stderr
+    #     into a single output
     #
     #   @option options_hash [String, nil] :chdir the directory to run the command in
     #
     #   @option options_hash [Hash] :env additional environment variable overrides
     #     for this command
     #
-    #   @option options_hash [Boolean] :raise_on_failure (true) whether to raise on
+    #   @option options_hash [Boolean, nil] :raise_on_failure (true) whether to raise on
     #     non-zero exit
     #
     #   @option options_hash [Numeric, nil] :timeout the maximum seconds to wait for
@@ -344,7 +344,7 @@ module Git
     #   @option options_hash [Hash] :env additional environment variable overrides
     #     for this command
     #
-    #   @option options_hash [Boolean] :raise_on_failure (true) whether to raise on
+    #   @option options_hash [Boolean, nil] :raise_on_failure (true) whether to raise on
     #     non-zero exit
     #
     #   @option options_hash [Numeric, nil] :timeout

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -84,17 +84,21 @@ module Git
       end
     end
 
-    # creates or reinitializes the repository in the current directory
+    # Creates or reinitializes the repository in the current directory
     #
     # This is a low-level method that just runs `git init` with the given options.
     # For full repository initialization including directory creation and path
     # resolution, use Git.init instead.
     #
     # @param opts [Hash] command options
-    # @option opts [Boolean] :bare Create a bare repository
-    # @option opts [String] :initial_branch Use the specified name for the initial branch
-    # @option opts [String] :separate_git_dir Path to put the .git directory (`--separate-git-dir`)
-    # @option opts [String] :repository Deprecated — use :separate_git_dir instead
+    #
+    # @option opts [Boolean, nil] :bare (nil) create a bare repository
+    #
+    # @option opts [String, nil] :initial_branch (nil) use the specified name for the initial branch
+    #
+    # @option opts [String, nil] :separate_git_dir (nil) path to put the .git directory (`--separate-git-dir`)
+    #
+    # @option opts [String, nil] :repository (nil) deprecated — use `:separate_git_dir` instead
     #
     # @return [String] the command output
     #
@@ -115,39 +119,42 @@ module Git
     #
     # @param [Hash] opts the options for this command
     #
-    # @option opts [Boolean] :bare (false) if true, clone as a bare repository
+    # @option opts [Boolean, nil] :bare (nil) if true, clone as a bare repository
     #
-    # @option opts [String] :branch the branch to checkout
+    # @option opts [String, nil] :branch (nil) the branch to checkout
     #
-    # @option opts [String, Array] :config one or more configuration options to set
+    # @option opts [String, Array<String>, nil] :config (nil) one or more configuration options to set
     #
-    # @option opts [Integer] :depth the number of commits back to pull
+    # @option opts [Integer, nil] :depth (nil) the number of commits back to pull
     #
-    # @option opts [String] :filter specify partial clone
+    # @option opts [String, nil] :filter (nil) specify partial clone
     #
-    # @option opts [String, nil] :git_ssh SSH command or binary to use for git over SSH
+    # @option opts [String, nil] :git_ssh (nil) SSH command or binary to use for git over SSH
     #
-    # @option opts [Logger] :log Logger instance to use for git operations
+    # @option opts [Logger, nil] :log (nil) Logger instance to use for git operations
     #
-    # @option opts [String] :mirror set up a mirror of the source repository
+    # @option opts [Boolean, nil] :mirror (nil) set up a mirror of the source repository
     #
-    # @option opts [String] :origin the name of the remote
+    # @option opts [String, nil] :origin (nil) the name of the remote
     #
-    # @option opts [String] :chdir run `git clone` from this directory
+    # @option opts [String, nil] :chdir (nil) run `git clone` from this directory
     #
     #   When given, `directory` (or the repository basename when `directory` is nil)
     #   is resolved relative to `:chdir`, just as if you had `cd`'d into it before
     #   running `git clone`. The returned path is the join of `:chdir` and the
     #   cloned directory path.
     #
-    # @option opts [String] :path Deprecated. Use `:chdir` instead.
+    # @option opts [String] :path deprecated: use `:chdir` instead.
     #
-    # @option opts [String] :remote the name of the remote
+    # @option opts [String] :remote deprecated: use `:origin` instead.
     #
-    # @option opts [Boolean] :recursive after the clone is created, initialize all
-    #    within, using their default settings
+    # @option opts [Boolean, String, Array<String>, nil] :recurse_submodules (nil) initialize
+    #   submodules after cloning; pass `true` for all submodules, or a pathspec string/array
+    #   for a subset
     #
-    # @option opts [Numeric, nil] :timeout the number of seconds to wait for the
+    # @option opts [Boolean, String, Array<String>, nil] :recursive (nil) deprecated: use `:recurse_submodules` instead
+    #
+    # @option opts [Numeric, nil] :timeout (nil) the number of seconds to wait for the
     #   command to complete
     #
     #   See {Git::Lib#command} for more information about :timeout
@@ -196,13 +203,13 @@ module Git
     #
     # @param opts [Hash] the given options
     #
-    # @option opts :all [Boolean]
-    # @option opts :tags [Boolean]
-    # @option opts :contains [Boolean]
-    # @option opts :debug [Boolean]
-    # @option opts :long [Boolean]
-    # @option opts :always [Boolean]
-    # @option opts :exact_match [Boolean]
+    # @option opts [Boolean, nil] :all (nil) use refs from all branches, tags, and remotes
+    # @option opts [Boolean, nil] :tags (nil) consider any tag, not just annotated ones
+    # @option opts [Boolean, nil] :contains (nil) find the tag that comes after the commit
+    # @option opts [Boolean, nil] :debug (nil) enable verbose searching strategy output
+    # @option opts [Boolean, nil] :long (nil) always output the long format
+    # @option opts [Boolean, nil] :always (nil) show uniquely abbreviated commit as a fallback
+    # @option opts [Boolean, nil] :exact_match (nil) only output exact tag matches
     # @option opts :dirty [true, String]
     # @option opts :abbrev [String]
     # @option opts :candidates [String]
@@ -232,9 +239,9 @@ module Git
     # @option opts :count [Integer] the maximum number of commits to return (maps to
     #   max-count)
     #
-    # @option opts :all [Boolean]
+    # @option opts [Boolean, nil] :all (nil) include commits reachable from any ref
     #
-    # @option opts :cherry [Boolean]
+    # @option opts [Boolean, nil] :cherry (nil) omit commits equivalent to cherry-picked commits
     #
     # @option opts :since [String]
     #
@@ -1144,8 +1151,8 @@ module Git
     # @param [String, Array<String>] paths files to be added to the repository (relative to the worktree root)
     # @param [Hash] options
     #
-    # @option options [Boolean] :all Add, modify, and remove index entries to match the worktree
-    # @option options [Boolean] :force Allow adding otherwise ignored files
+    # @option options [Boolean, nil] :all (nil) add, modify, and remove index entries to match the worktree
+    # @option options [Boolean, nil] :force (nil) allow adding otherwise ignored files
     #
     # @return [String] the command output (typically empty on success)
     #
@@ -1158,9 +1165,9 @@ module Git
     # @param path [String, Array<String>] files or directories to remove
     # @param opts [Hash] command options
     #
-    # @option opts [Boolean] :force Force removal, bypassing the up-to-date check. Alias: :f
-    # @option opts [Boolean] :recursive Remove directories and their contents recursively
-    # @option opts [Boolean] :cached Only remove from the index, keeping working tree files
+    # @option opts [Boolean, nil] :force (nil) force removal, bypassing the up-to-date check; alias: `:f`
+    # @option opts [Boolean, nil] :recursive (nil) remove directories and their contents recursively
+    # @option opts [Boolean, nil] :cached (nil) only remove from the index, keeping working tree files
     #
     # @return [String] the command output
     #
@@ -1346,8 +1353,8 @@ module Git
     #
     # @param branches [Array<String>] the name(s) of the branch(es) to delete
     # @param options [Hash] command options (see {Git::Commands::Branch::Delete#call})
-    # @option options [Boolean] :force allow deleting unmerged branches (default: true for backward compatibility)
-    # @option options [Boolean] :remotes delete remote-tracking branches
+    # @option options [Boolean, nil] :force (nil) allow deleting unmerged branches (defaults to `true` when not given)
+    # @option options [Boolean, nil] :remotes (nil) delete remote-tracking branches
     #
     # @return [String] newline-separated list of "Deleted branch <name> (was <sha>)." messages
     #
@@ -1413,19 +1420,19 @@ module Git
     # @param message [String, nil] commit message for merge commit
     # @param opts [Hash] merge options
     #
-    # @option opts [Boolean] :no_commit (nil) stop before creating merge commit
+    # @option opts [Boolean, nil] :no_commit (nil) stop before creating merge commit
     #   (deprecated: use no_commit: true instead)
-    # @option opts [Boolean] :no_ff (nil) create merge commit even for fast-forward
+    # @option opts [Boolean, nil] :no_ff (nil) create merge commit even for fast-forward
     #   (deprecated: use no_ff: true instead)
     # @option opts [String] :m (nil) commit message (deprecated: use message: option)
-    # @option opts [Boolean] :commit (nil) true for --commit (`--commit`)
-    # @option opts [Boolean] :ff (nil) true for --ff (`--ff`)
-    # @option opts [Boolean] :ff_only (nil) only merge if fast-forward possible
-    # @option opts [Boolean] :squash (nil) squash commits into single commit
+    # @option opts [Boolean, nil] :commit (nil) true for --commit (`--commit`)
+    # @option opts [Boolean, nil] :ff (nil) true for --ff (`--ff`)
+    # @option opts [Boolean, nil] :ff_only (nil) only merge if fast-forward possible
+    # @option opts [Boolean, nil] :squash (nil) squash commits into single commit
     # @option opts [String] :message (nil) commit message
     # @option opts [String] :strategy (nil) merge strategy (e.g., 'ort', 'ours')
     # @option opts [String, Array<String>] :strategy_option (nil) strategy-specific options
-    # @option opts [Boolean] :allow_unrelated_histories (nil) allow merging unrelated histories
+    # @option opts [Boolean, nil] :allow_unrelated_histories (nil) allow merging unrelated histories
     #
     # @return [String] the command output
     #
@@ -1447,10 +1454,10 @@ module Git
     #
     #   @param options [Hash] merge-base options
     #
-    #   @option options [Boolean] :octopus (nil) compute best ancestor for n-way merge
-    #   @option options [Boolean] :independent (nil) list commits not reachable from others
-    #   @option options [Boolean] :fork_point (nil) find fork point
-    #   @option options [Boolean] :all (nil) output all merge bases
+    #   @option options [Boolean, nil] :octopus (nil) compute best ancestor for n-way merge
+    #   @option options [Boolean, nil] :independent (nil) list commits not reachable from others
+    #   @option options [Boolean, nil] :fork_point (nil) find fork point
+    #   @option options [Boolean, nil] :all (nil) output all merge bases
     #
     # @return [Array<String>] array of commit SHAs
     #
@@ -1541,16 +1548,16 @@ module Git
     #
     #   @param opts [Hash] options for creating the tag
     #
-    #   @option opts [Boolean] :annotate (nil) create an unsigned, annotated tag object.
+    #   @option opts [Boolean, nil] :annotate (nil) create an unsigned, annotated tag object.
     #     Requires `:message` or `:file`.
     #
     #     Alias: `:a`
     #
-    #   @option opts [Boolean] :sign (nil) create a GPG-signed tag. Requires `:message` or `:file`.
+    #   @option opts [Boolean, nil] :sign (nil) create a GPG-signed tag. Requires `:message` or `:file`.
     #
     #     Alias: `:s`
     #
-    #   @option opts [Boolean] :force (nil) replace an existing tag with the given name.
+    #   @option opts [Boolean, nil] :force (nil) replace an existing tag with the given name.
     #
     #     Alias: `:f`
     #
@@ -1567,16 +1574,16 @@ module Git
     #
     #   @param opts [Hash] options for creating the tag
     #
-    #   @option opts [Boolean] :annotate (nil) create an unsigned, annotated tag object.
+    #   @option opts [Boolean, nil] :annotate (nil) create an unsigned, annotated tag object.
     #     Requires `:message` or `:file`.
     #
     #     Alias: `:a`
     #
-    #   @option opts [Boolean] :sign (nil) create a GPG-signed tag. Requires `:message` or `:file`.
+    #   @option opts [Boolean, nil] :sign (nil) create a GPG-signed tag. Requires `:message` or `:file`.
     #
     #     Alias: `:s`
     #
-    #   @option opts [Boolean] :force (nil) replace an existing tag with the given name.
+    #   @option opts [Boolean, nil] :force (nil) replace an existing tag with the given name.
     #
     #     Alias: `:f`
     #
@@ -1593,7 +1600,7 @@ module Git
     #
     #   @param opts [Hash] options
     #
-    #   @option opts [Boolean] :delete (nil) delete the named tag.
+    #   @option opts [Boolean, nil] :delete (nil) delete the named tag.
     #
     #     Alias: `:d`
     #
@@ -1637,17 +1644,17 @@ module Git
     #
     #   @param options [Hash] push options
     #
-    #   @option options [Boolean] :all (nil) Push all branches
+    #   @option options [Boolean, nil] :all (nil) push all branches
     #
-    #   @option options [Boolean] :mirror (nil) Push all refs
+    #   @option options [Boolean, nil] :mirror (nil) push all refs
     #
-    #   @option options [Boolean] :tags (nil) Push all tags
+    #   @option options [Boolean, nil] :tags (nil) push all tags
     #
-    #   @option options [Boolean] :force (nil) Force updates
+    #   @option options [Boolean, nil] :force (nil) force updates
     #
-    #   @option options [Boolean] :delete (nil) Delete the named remote ref
+    #   @option options [Boolean, nil] :delete (nil) delete the named remote ref
     #
-    #   @option options [String, Array<String>] :push_option (nil) Server-side push option values
+    #   @option options [String, Array<String>] :push_option (nil) server-side push option values
     #
     #   @return [String] the stdout from the final `git push` invocation
     #
@@ -1660,17 +1667,17 @@ module Git
     #
     #   @param options [Hash] push options
     #
-    #   @option options [Boolean] :all (nil) Push all branches
+    #   @option options [Boolean, nil] :all (nil) push all branches
     #
-    #   @option options [Boolean] :mirror (nil) Push all refs
+    #   @option options [Boolean, nil] :mirror (nil) push all refs
     #
-    #   @option options [Boolean] :tags (nil) Push all tags
+    #   @option options [Boolean, nil] :tags (nil) push all tags
     #
-    #   @option options [Boolean] :force (nil) Force updates
+    #   @option options [Boolean, nil] :force (nil) force updates
     #
-    #   @option options [Boolean] :delete (nil) Delete the named remote ref
+    #   @option options [Boolean, nil] :delete (nil) delete the named remote ref
     #
-    #   @option options [String, Array<String>] :push_option (nil) Server-side push option values
+    #   @option options [String, Array<String>] :push_option (nil) server-side push option values
     #
     #   @return [String] the stdout from the final `git push` invocation
     #
@@ -1685,17 +1692,17 @@ module Git
     #
     #   @param options [Hash] push options
     #
-    #   @option options [Boolean] :all (nil) Push all branches
+    #   @option options [Boolean, nil] :all (nil) push all branches
     #
-    #   @option options [Boolean] :mirror (nil) Push all refs
+    #   @option options [Boolean, nil] :mirror (nil) push all refs
     #
-    #   @option options [Boolean] :tags (nil) Push all tags
+    #   @option options [Boolean, nil] :tags (nil) push all tags
     #
-    #   @option options [Boolean] :force (nil) Force updates
+    #   @option options [Boolean, nil] :force (nil) force updates
     #
-    #   @option options [Boolean] :delete (nil) Delete the named remote ref
+    #   @option options [Boolean, nil] :delete (nil) delete the named remote ref
     #
-    #   @option options [String, Array<String>] :push_option (nil) Server-side push option values
+    #   @option options [String, Array<String>] :push_option (nil) server-side push option values
     #
     #   @return [String] the stdout from the final `git push` invocation
     #
@@ -1834,7 +1841,7 @@ module Git
     # @option opts [String] :format archive format — `'tar'`, `'tgz'`, or `'zip'`
     #   (default: `'zip'`)
     #
-    # @option opts [Boolean] :add_gzip wrap the archive in gzip compression
+    # @option opts [Boolean, nil] :add_gzip (nil) wrap the archive in gzip compression
     #
     # @return [String] the path to the written archive file
     #
@@ -2048,17 +2055,17 @@ module Git
     #
     # @option options_hash [IO, String, #write, nil] :err the destination for captured stderr
     #
-    # @option options_hash [Boolean] :normalize true to normalize the output encoding to UTF-8
+    # @option options_hash [Boolean, nil] :normalize (true) normalize the output encoding to UTF-8
     #
-    # @option options_hash [Boolean] :chomp true to remove trailing newlines from the output
+    # @option options_hash [Boolean, nil] :chomp (true) remove trailing newlines from the output
     #
-    # @option options_hash [Boolean] :merge true to merge stdout and stderr into a single output
+    # @option options_hash [Boolean, nil] :merge (false) merge stdout and stderr into a single output
     #
     # @option options_hash [String, nil] :chdir the directory to run the command in
     #
     # @option options_hash [Hash] :env additional environment variable overrides for this command
     #
-    # @option options_hash [Boolean] :raise_on_failure (true) whether to raise on non-zero exit
+    # @option options_hash [Boolean, nil] :raise_on_failure (true) whether to raise on non-zero exit
     #
     # @option options_hash [Numeric, nil] :timeout the maximum seconds to wait for the command to complete
     #
@@ -2077,6 +2084,7 @@ module Git
     #   of a command that exposes `:timeout`.
     #
     # @see Git::CommandLine::Capturing#run
+    #
     # @see #command_line_capturing
     #
     # @return [Git::CommandLineResult] the result of the command
@@ -2127,31 +2135,46 @@ module Git
     # content from cat-file) without creating memory pressure.
     #
     # @overload command_streaming(*args, **options_hash)
+    #
     #   @param args [Array<String>] the git command and its arguments
+    #
     #   @param options_hash [Hash] the options to pass to the command
     #
     # @option options_hash [IO, nil] :in stdin IO object
+    #
     # @option options_hash [#write, nil] :out destination for streamed stdout
+    #
     # @option options_hash [#write, nil] :err an optional additional destination to receive stderr output
     #   in real time. Stderr is always captured internally; when `err:` is supplied, writes are teed
     #   to both the internal buffer and this destination. `result.stderr` always reflects the internal capture.
+    #
     # @option options_hash [String, nil] :chdir the directory to run the command in
+    #
     # @option options_hash [Hash] :env additional environment variable overrides for this command
-    # @option options_hash [Boolean] :raise_on_failure (true) whether to raise on non-zero exit
+    #
+    # @option options_hash [Boolean, nil] :raise_on_failure (true) whether to raise on non-zero exit
+    #
     # @option options_hash [Numeric, nil] :timeout the maximum seconds to wait for the command
+    #
     #   If nil, the global timeout from {Git::Config} is used.
     #
     # @return [Git::CommandLineResult] the result of the command
+    #
     #   `result.stdout` will always be `''` — stdout was streamed to `out:`.
     #   `result.stderr` contains any stderr output captured for diagnostics.
     #
     # @raise [ArgumentError] if an unknown option is passed
+    #
     # @raise [Git::FailedError] if the command failed (when raise_on_failure is true)
+    #
     # @raise [Git::SignaledError] if the command was signaled
+    #
     # @raise [Git::TimeoutError] if the command times out
+    #
     # @raise [Git::ProcessIOError] if an exception was raised while collecting subprocess output
     #
     # @see Git::CommandLine::Streaming#run
+    #
     # @see #command_line_streaming
     #
     def command_streaming(*, **options_hash)

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -92,16 +92,16 @@ module Git
       #
       #   @param options [Hash] options for the checkout command
       #
-      #   @option options [Boolean] :force (false) discard local changes when
+      #   @option options [Boolean, nil] :force (nil) discard local changes when
       #     switching branches
       #
-      #   @option options [Boolean, String] :new_branch (false) when `true`,
+      #   @option options [Boolean, String, nil] :new_branch (nil) when `true`,
       #     creates a new branch named `branch` from `:start_point`; when a
       #     `String`, creates a new branch with that name from `branch`
       #
-      #   @option options [Boolean] :b (false) alias for `:new_branch`
+      #   @option options [Boolean, String, nil] :b (nil) alias for `:new_branch`
       #
-      #   @option options [Boolean] :f (false) alias for `:force`
+      #   @option options [Boolean, nil] :f (nil) alias for `:force`
       #
       #   @option options [String] :start_point the commit or branch to start the
       #     new branch from; used together with `new_branch: true`
@@ -139,9 +139,9 @@ module Git
       #
       #   @param options [Hash] options for the checkout-index command
       #
-      #   @option options [Boolean] :all (false) check out all files in the index
+      #   @option options [Boolean, nil] :all (nil) check out all files in the index
       #
-      #   @option options [Boolean] :force (false) overwrite existing files
+      #   @option options [Boolean, nil] :force (nil) overwrite existing files
       #
       #   @option options [String] :prefix write files under this path prefix
       #     rather than the working directory root

--- a/lib/git/repository/committing.rb
+++ b/lib/git/repository/committing.rb
@@ -44,16 +44,16 @@ module Git
       #
       #   @param options [Hash] options for the commit command
       #
-      #   @option options [Boolean] :all (false) automatically stage modified and
+      #   @option options [Boolean, nil] :all (nil) automatically stage modified and
       #     deleted files before committing
       #
-      #   @option options [Boolean] :amend (false) replace the tip of the current
+      #   @option options [Boolean, nil] :amend (nil) replace the tip of the current
       #     branch with a new commit
       #
-      #   @option options [Boolean] :allow_empty (false) allow committing with no
+      #   @option options [Boolean, nil] :allow_empty (nil) allow committing with no
       #     changes
       #
-      #   @option options [Boolean] :allow_empty_message (false) allow committing
+      #   @option options [Boolean, nil] :allow_empty_message (nil) allow committing
       #     with an empty message
       #
       #   @option options [String] :author (nil) override the commit author in
@@ -61,11 +61,11 @@ module Git
       #
       #   @option options [String] :date (nil) override the author date
       #
-      #   @option options [Boolean] :gpg_sign (false) GPG-sign the commit
+      #   @option options [Boolean, nil] :gpg_sign (nil) GPG-sign the commit
       #
-      #   @option options [Boolean] :no_gpg_sign (false) disable GPG signing
+      #   @option options [Boolean, nil] :no_gpg_sign (nil) disable GPG signing
       #
-      #   @option options [Boolean] :no_verify (false) bypass the pre-commit and
+      #   @option options [Boolean, nil] :no_verify (nil) bypass the pre-commit and
       #     commit-msg hooks
       #
       #   @return [String] git's stdout from the commit

--- a/lib/git/repository/merging.rb
+++ b/lib/git/repository/merging.rb
@@ -58,10 +58,10 @@ module Git
       #
       # @param opts [Hash] additional options forwarded to `git merge`
       #
-      # @option opts [Boolean] :no_commit (false) stop before creating the merge commit
+      # @option opts [Boolean, nil] :no_commit (nil) stop before creating the merge commit
       #   (`--no-commit`)
       #
-      # @option opts [Boolean] :no_ff (false) create a merge commit even when
+      # @option opts [Boolean, nil] :no_ff (nil) create a merge commit even when
       #   fast-forward is possible (`--no-ff`)
       #
       # @option opts [String] :message (nil) commit message
@@ -114,16 +114,16 @@ module Git
       #
       #   @param options [Hash] merge-base options
       #
-      #   @option options [Boolean] :octopus (false) compute the best common
+      #   @option options [Boolean, nil] :octopus (nil) compute the best common
       #     ancestor for an n-way merge (intersection of all merge bases)
       #
-      #   @option options [Boolean] :independent (false) list commits not
+      #   @option options [Boolean, nil] :independent (nil) list commits not
       #     reachable from any other; useful for finding minimal merge points
       #
-      #   @option options [Boolean] :fork_point (false) find the fork point
+      #   @option options [Boolean, nil] :fork_point (nil) find the fork point
       #     where a branch diverged from another, consulting the reflog
       #
-      #   @option options [Boolean] :all (false) output all merge bases instead
+      #   @option options [Boolean, nil] :all (nil) output all merge bases instead
       #     of just the first when multiple equally good bases exist
       #
       #   @return [Array<String>] commit SHAs of the common ancestor(s); empty

--- a/lib/git/repository/staging.rb
+++ b/lib/git/repository/staging.rb
@@ -35,10 +35,10 @@ module Git
       #
       #   @param options [Hash] options for the add command
       #
-      #   @option options [Boolean] :all (false) add, modify, and remove index
+      #   @option options [Boolean, nil] :all (nil) add, modify, and remove index
       #     entries to match the worktree
       #
-      #   @option options [Boolean] :force (false) allow adding otherwise ignored
+      #   @option options [Boolean, nil] :force (nil) allow adding otherwise ignored
       #     files
       #
       #   @return [String] git's stdout from the add
@@ -71,7 +71,7 @@ module Git
       #
       #   @param options [Hash] options for the reset command
       #
-      #   @option options [Boolean] :hard (false) reset the index and working
+      #   @option options [Boolean, nil] :hard (nil) reset the index and working
       #     tree; discards all tracked changes
       #
       #   @return [String] git's stdout from the reset


### PR DESCRIPTION
## Summary

The `flag_option` DSL in `lib/git/commands/arguments.rb` treats `nil` and `false` identically when deciding whether to emit a flag:

```ruby
# arguments.rb
return 0 if value.nil? || value == false
```

Documenting boolean flag options with `[Boolean] :flag (false)` was therefore misleading — callers can pass `nil` or simply omit the keyword argument entirely. This PR changes all `@option` annotations for flag-typed parameters to:

```ruby
# Before
# @option options [Boolean] :verbose (false) Enable verbose output
# @option options [Boolean, String] :recurse (false) Recurse into submodules

# After
# @option options [Boolean, nil] :verbose (nil) Enable verbose output
# @option options [Boolean, String, nil] :recurse (nil) Recurse into submodules
```

## Files Changed

### Library source files (`lib/`)
- All command classes under `lib/git/commands/**/*.rb`
- `lib/git/command_line/capturing.rb`
- `lib/git/base.rb`, `lib/git/lib.rb`
- `lib/git/repository/**/*.rb` (facade modules)

### Skill and reference documentation (`.github/skills/`)
- `command-yard-documentation/SKILL.md` — updated DSL-to-YARD mapping table with explanatory note
- `command-implementation/REFERENCE.md` — updated template examples
- `yard-documentation/SKILL.md` — updated all `@option` examples
- `facade-yard-documentation/SKILL.md` — updated facade examples
- `review-arguments-dsl/CHECKLIST.md` — updated checklist examples

## Notes

- `@return [Boolean]` tags are unaffected (no option name following, semantics are different)
- No runtime behaviour changes — this is documentation only