### PR TITLE
refactor(repository): rename Internal to SharedPrivate

### DIFF
--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -6,7 +6,7 @@ require 'git/commands/branch/show_current'
 require 'git/commands/checkout/branch'
 require 'git/commands/checkout/files'
 require 'git/commands/checkout_index'
-require 'git/repository/internal'
+require 'git/repository/shared_private'
 
 module Git
   class Repository
@@ -43,7 +43,7 @@ module Git
       #   @return [String] the current branch name, or `'HEAD'` when in detached
       #     HEAD state
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #   @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def current_branch
         result = Git::Commands::Branch::ShowCurrent.new(@execution_context).call
@@ -65,7 +65,7 @@ module Git
       #
       #   @return [String] git's stdout from the checkout
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #   @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def checkout_file(version, file)
         Git::Commands::Checkout::Files.new(@execution_context).call(version, pathspec: [file]).stdout
@@ -108,9 +108,9 @@ module Git
       #
       #   @return [String] git's stdout from the checkout
       #
-      # @raise [ArgumentError] if unsupported options are provided
+      #   @raise [ArgumentError] when unsupported options are provided
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #   @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def checkout(branch = nil, options = {})
         if branch.is_a?(Hash) && options.empty?
@@ -118,9 +118,9 @@ module Git
           branch = nil
         end
 
-        Git::Repository::Internal.assert_valid_opts!(CHECKOUT_ALLOWED_OPTS, **options)
+        SharedPrivate.assert_valid_opts!(CHECKOUT_ALLOWED_OPTS, **options)
 
-        target, translated_opts = translate_checkout_opts(branch, options)
+        target, translated_opts = Private.translate_checkout_opts(branch, options)
         Git::Commands::Checkout::Branch.new(@execution_context).call(target, **translated_opts).stdout
       end
 
@@ -146,19 +146,19 @@ module Git
       #   @option options [String] :prefix write files under this path prefix
       #     rather than the working directory root
       #
-      #   @option options [String, Pathname, Array<String, Pathname>] :path_limiter limit the check
-      #     out to the given path(s)
+      #   @option options [String, Pathname, Array<String, Pathname>] :path_limiter
+      #     limit the check out to the given path(s)
       #
       #   @return [String] git's stdout from the checkout-index command
       #
-      # @raise [ArgumentError] if unsupported options are provided
+      #   @raise [ArgumentError] when unsupported options are provided
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #   @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def checkout_index(options = {})
-        Git::Repository::Internal.assert_valid_opts!(CHECKOUT_INDEX_ALLOWED_OPTS, **options)
+        SharedPrivate.assert_valid_opts!(CHECKOUT_INDEX_ALLOWED_OPTS, **options)
 
-        paths = normalize_pathspecs(options[:path_limiter], 'path_limiter')
+        paths = Private.normalize_pathspecs(options[:path_limiter], 'path_limiter')
         keyword_opts = options.except(:path_limiter)
         Git::Commands::CheckoutIndex.new(@execution_context).call(*paths.to_a, **keyword_opts).stdout
       end
@@ -174,7 +174,7 @@ module Git
       #
       #   @return [Boolean] `true` if the branch exists locally, `false` otherwise
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #   @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def local_branch?(branch)
         result = Git::Commands::Branch::List.new(@execution_context).call(branch, format: '%(refname:short)')
@@ -196,7 +196,7 @@ module Git
       #   @return [Boolean] `true` if a remote-tracking branch with that short name
       #     exists, `false` otherwise
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #   @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def remote_branch?(branch)
         result = Git::Commands::Branch::List.new(@execution_context)
@@ -216,66 +216,92 @@ module Git
       #   @return [Boolean] `true` if the branch exists locally or remotely,
       #     `false` otherwise
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #   @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def branch?(branch)
         local_branch?(branch) || remote_branch?(branch)
       end
 
-      private
+      # Private helpers local to {Git::Repository::Branching}
+      #
+      # @api private
+      module Private
+        module_function
 
-      # Translates legacy checkout options to the new command interface.
-      #
-      # Legacy callers passed combinations like:
-      #   checkout('branch', new_branch: true, start_point: 'main')
-      # which should map to:
-      #   checkout('main', b: 'branch')
-      #
-      # @param branch [String, nil] the branch argument passed to {#checkout}
-      # @param options [Hash] the raw options passed to {#checkout}
-      # @return [Array] a two-element tuple +[target, options]+ where +target+ is
-      #   the branch or commit to check out (+String+ or +nil+) and +options+ is
-      #   a +Hash+ of translated keyword arguments for
-      #   +Git::Commands::Checkout::Branch#call+
-      #
-      def translate_checkout_opts(branch, options)
-        if options[:new_branch] == true || options[:b] == true
-          [options[:start_point], options.except(:new_branch, :b, :start_point).merge(b: branch)]
-        elsif options[:new_branch].is_a?(String)
-          [branch, options.except(:new_branch).merge(b: options[:new_branch])]
-        else
-          [branch, options]
+        # Translates legacy checkout options to the new command interface
+        #
+        # Legacy callers passed combinations like:
+        #   checkout('branch', new_branch: true, start_point: 'main')
+        # which should map to:
+        #   checkout('main', b: 'branch')
+        #
+        # @param branch [String, nil] the branch argument passed to {#checkout}
+        #
+        # @param options [Hash] the raw options passed to {#checkout}
+        #
+        # @return [Array] a two-element tuple `[target, options]` containing the
+        #   translated checkout arguments
+        #
+        #   `target` (`String` or `nil`) is the branch or commit to check out.
+        #   `options` is a `Hash` of keyword arguments for
+        #   `Git::Commands::Checkout::Branch#call`
+        #
+        # @api private
+        #
+        def translate_checkout_opts(branch, options)
+          if options[:new_branch] == true || options[:b] == true
+            [options[:start_point], options.except(:new_branch, :b, :start_point).merge(b: branch)]
+          elsif options[:new_branch].is_a?(String)
+            [branch, options.except(:new_branch).merge(b: options[:new_branch])]
+          else
+            [branch, options]
+          end
+        end
+
+        # Normalizes path specifications for Git commands
+        #
+        # @param pathspecs [String, Pathname, Array<String, Pathname>, nil]
+        #   the path(s) to normalize
+        #
+        # @param arg_name [String] the argument name used in error messages
+        #
+        # @return [Array<String>, nil] the normalized paths, or `nil` if none are valid
+        #
+        # @raise [ArgumentError] when any path is not a `String` or `Pathname`
+        #
+        # @api private
+        #
+        def normalize_pathspecs(pathspecs, arg_name)
+          return nil unless pathspecs
+
+          normalized = Array(pathspecs)
+          validate_pathspec_types(normalized, arg_name)
+
+          normalized = normalized.map(&:to_s).reject(&:empty?)
+          return nil if normalized.empty?
+
+          normalized
+        end
+
+        # Raises an error if any element of `pathspecs` is not a `String` or `Pathname`
+        #
+        # @param pathspecs [Array] the path elements to validate
+        #
+        # @param arg_name [String] the argument name used in error messages
+        #
+        # @return [void]
+        #
+        # @raise [ArgumentError] when any element is not a `String` or `Pathname`
+        #
+        # @api private
+        #
+        def validate_pathspec_types(pathspecs, arg_name)
+          return if pathspecs.all? { |path| path.is_a?(String) || path.is_a?(Pathname) }
+
+          raise ArgumentError, "Invalid #{arg_name}: must be a String, Pathname, or Array of Strings/Pathnames"
         end
       end
-
-      # Normalizes path specifications for Git commands.
-      #
-      # @param pathspecs [String, Pathname, Array<String, Pathname>, nil]
-      # @param arg_name [String] used in error messages
-      # @return [Array<String>, nil]
-      # @raise [ArgumentError] if any path is not a String or Pathname
-      #
-      def normalize_pathspecs(pathspecs, arg_name)
-        return nil unless pathspecs
-
-        normalized = Array(pathspecs)
-        validate_pathspec_types(normalized, arg_name)
-
-        normalized = normalized.map(&:to_s).reject(&:empty?)
-        return nil if normalized.empty?
-
-        normalized
-      end
-
-      # @param pathspecs [Array]
-      # @param arg_name [String]
-      # @raise [ArgumentError] if any element is not a String or Pathname
-      #
-      def validate_pathspec_types(pathspecs, arg_name)
-        return if pathspecs.all? { |path| path.is_a?(String) || path.is_a?(Pathname) }
-
-        raise ArgumentError, "Invalid #{arg_name}: must be a String, Pathname, or Array of Strings/Pathnames"
-      end
+      private_constant :Private
     end
   end
 end

--- a/lib/git/repository/committing.rb
+++ b/lib/git/repository/committing.rb
@@ -3,7 +3,7 @@
 require 'git/commands/commit'
 require 'git/commands/commit_tree'
 require 'git/commands/write_tree'
-require 'git/repository/internal'
+require 'git/repository/shared_private'
 
 module Git
   class Repository
@@ -70,9 +70,9 @@ module Git
       #
       #   @return [String] git's stdout from the commit
       #
-      # @raise [ArgumentError] if unsupported options are provided
+      #   @raise [ArgumentError] when unsupported options are provided
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #   @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def commit(message = nil, **opts)
         if opts.key?(:add_all)
@@ -80,7 +80,7 @@ module Git
           opts[:all] = opts.delete(:add_all)
         end
 
-        Git::Repository::Internal.assert_valid_opts!(COMMIT_ALLOWED_OPTS, **opts)
+        SharedPrivate.assert_valid_opts!(COMMIT_ALLOWED_OPTS, **opts)
 
         call_opts = { no_edit: true }
         call_opts[:message] = message if message
@@ -94,7 +94,7 @@ module Git
       #
       # @overload commit_all(message, **options)
       #
-      #   @example
+      #   @example Commit all changes with a message
       #     repo.commit_all('Update everything')
       #
       #   @param message [String] the commit message
@@ -103,9 +103,9 @@ module Git
       #
       #   @return [String] git's stdout from the commit
       #
-      # @raise [ArgumentError] if unsupported options are provided
+      #   @raise [ArgumentError] when unsupported options are provided
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #   @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def commit_all(*, **)
         commit(*, all: true, **)
@@ -140,12 +140,12 @@ module Git
       #
       #   @return [String] the SHA of the newly created commit object
       #
-      # @raise [ArgumentError] if unsupported options are provided
+      #   @raise [ArgumentError] when unsupported options are provided
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #   @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def commit_tree(tree, **opts)
-        Git::Repository::Internal.assert_valid_opts!(COMMIT_TREE_ALLOWED_OPTS, **opts)
+        SharedPrivate.assert_valid_opts!(COMMIT_TREE_ALLOWED_OPTS, **opts)
 
         opts[:p] = opts.delete(:parents) if opts.key?(:parents)
         opts[:p] = opts.delete(:parent) if opts.key?(:parent)
@@ -157,12 +157,12 @@ module Git
 
       # Write the current index to a tree object in the object store
       #
-      # @example
+      # @example Get the tree SHA of the current index
       #   tree_sha = repo.write_tree
       #
       # @return [String] the SHA of the tree object written
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def write_tree
         Git::Commands::WriteTree.new(@execution_context).call.stdout
@@ -174,14 +174,14 @@ module Git
       #
       # @overload write_and_commit_tree(**options)
       #
-      #   @example
+      #   @example Commit the current index as a snapshot
       #     commit_sha = repo.write_and_commit_tree(message: 'snapshot')
       #
       #   @param options [Hash] options forwarded to {#commit_tree}
       #
       #   @return [String] the SHA of the newly created commit object
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #   @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def write_and_commit_tree(**)
         commit_tree(write_tree, **)

--- a/lib/git/repository/merging.rb
+++ b/lib/git/repository/merging.rb
@@ -5,7 +5,7 @@ require 'git/commands/diff'
 require 'git/commands/merge/start'
 require 'git/commands/merge_base'
 require 'git/commands/show'
-require 'git/repository/internal'
+require 'git/repository/shared_private'
 
 module Git
   class Repository
@@ -76,12 +76,12 @@ module Git
       #
       # @return [String] git's stdout from the merge command
       #
-      # @raise [ArgumentError] if unsupported options are provided
+      # @raise [ArgumentError] when unsupported options are provided
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def merge(branch, message = nil, opts = {})
-        Git::Repository::Internal.assert_valid_opts!(MERGE_ALLOWED_OPTS, **opts)
+        SharedPrivate.assert_valid_opts!(MERGE_ALLOWED_OPTS, **opts)
 
         # Dup so callers who reuse the same opts hash are not affected
         opts = opts.dup
@@ -132,14 +132,14 @@ module Git
       #   @return [Array<String>] commit SHAs of the common ancestor(s); empty
       #     when no common ancestor exists or `--fork-point` finds none
       #
-      # @raise [ArgumentError] if unsupported options are provided
+      #   @raise [ArgumentError] when unsupported options are provided
       #
-      # @raise [Git::FailedError] if `git merge-base` exits outside the allowed
-      #   range (exit code > 1)
+      #   @raise [Git::FailedError] when `git merge-base` exits outside the
+      #     allowed range (exit code > 1)
       #
       def merge_base(*args)
         opts = args.last.is_a?(Hash) ? args.pop : {}
-        Git::Repository::Internal.assert_valid_opts!(MERGE_BASE_ALLOWED_OPTS, **opts)
+        SharedPrivate.assert_valid_opts!(MERGE_BASE_ALLOWED_OPTS, **opts)
         result = Git::Commands::MergeBase.new(@execution_context).call(*args, **opts)
         result.stdout.lines.map(&:strip).reject(&:empty?)
       end
@@ -160,6 +160,13 @@ module Git
       #     puts File.read(their_version)
       #   end
       #
+      # @return [Array<String>] the list of unmerged file paths
+      #
+      # @raise [Git::FailedError] when `git diff --cached` exits with a non-zero status
+      #
+      # @yield [file, your_version, their_version] passes conflict details for
+      #   each unmerged file
+      #
       # @yieldparam file [String] path to the conflicting file, relative to the
       #   working tree
       #
@@ -169,53 +176,72 @@ module Git
       # @yieldparam their_version [String] path to a temporary file containing the
       #   stage-3 (theirs) content for the conflicting file
       #
-      # @return [Array<String>] the list of unmerged file paths
-      #
-      # @raise [Git::FailedError] if `git diff --cached` exits with a non-zero status
+      # @yieldreturn [void]
       #
       def each_conflict
-        unmerged_paths.each do |file_path|
-          write_staged_file(file_path, 2) do |your_file|
-            write_staged_file(file_path, 3) do |their_file|
+        Private.unmerged_paths(@execution_context).each do |file_path|
+          Private.write_staged_file(@execution_context, file_path, 2) do |your_file|
+            Private.write_staged_file(@execution_context, file_path, 3) do |their_file|
               yield(file_path, your_file.path, their_file.path)
             end
           end
         end
       end
 
-      private
-
-      STAGE_PREFIXES = { 2 => 'YOUR-', 3 => 'THEIR-' }.freeze
-      private_constant :STAGE_PREFIXES
-
-      # Returns the list of file paths with unresolved merge conflicts
-      #
-      # @return [Array<String>] unmerged file paths
+      # Private helpers local to {Git::Repository::Merging}
       #
       # @api private
-      #
-      def unmerged_paths
-        result = Git::Commands::Diff.new(@execution_context).call(cached: true)
-        result.stdout.split("\n").filter_map do |line|
-          ::Regexp.last_match(1) if line =~ /^\* Unmerged path (.*)/
-        end
-      end
+      module Private
+        # Tempfile name prefixes for staged content, keyed by git stage index
+        STAGE_PREFIXES = { 2 => 'YOUR-', 3 => 'THEIR-' }.freeze
 
-      # Creates a Tempfile with the staged content for +file_path+ at +stage+
-      # and yields the open IO object to the block.
-      #
-      # @param file_path [String] repository-relative path to the conflicting file
-      # @param stage [Integer] git stage index (2 = ours, 3 = theirs)
-      #
-      # @api private
-      #
-      def write_staged_file(file_path, stage)
-        Tempfile.create([STAGE_PREFIXES[stage], File.basename(file_path)]) do |f|
-          Git::Commands::Show.new(@execution_context).call(":#{stage}:#{file_path}", out: f)
-          f.flush
-          yield f
+        module_function
+
+        # Returns the list of file paths with unresolved merge conflicts
+        #
+        # @param execution_context [Git::ExecutionContext] the execution context
+        #   used to run git commands
+        #
+        # @return [Array<String>] unmerged file paths
+        #
+        # @api private
+        #
+        def unmerged_paths(execution_context)
+          result = Git::Commands::Diff.new(execution_context).call(cached: true)
+          result.stdout.split("\n").filter_map do |line|
+            ::Regexp.last_match(1) if line =~ /^\* Unmerged path (.*)/
+          end
+        end
+
+        # Creates a Tempfile with the staged content for `file_path` at `stage`
+        # and yields the open IO object to the block
+        #
+        # @param execution_context [Git::ExecutionContext] the execution context
+        #   used to run git commands
+        #
+        # @param file_path [String] repository-relative path to the conflicting file
+        #
+        # @param stage [Integer] git stage index (2 = ours, 3 = theirs)
+        #
+        # @yield [f] yields the open Tempfile containing the staged content
+        #
+        # @yieldparam f [Tempfile] open IO object for the staged content
+        #
+        # @yieldreturn [void]
+        #
+        # @return [void]
+        #
+        # @api private
+        #
+        def write_staged_file(execution_context, file_path, stage)
+          Tempfile.create([STAGE_PREFIXES[stage], File.basename(file_path)]) do |f|
+            Git::Commands::Show.new(execution_context).call(":#{stage}:#{file_path}", out: f)
+            f.flush
+            yield f
+          end
         end
       end
+      private_constant :Private
     end
   end
 end

--- a/lib/git/repository/shared_private.rb
+++ b/lib/git/repository/shared_private.rb
@@ -5,12 +5,16 @@ module Git
     # Internal helpers shared by `Git::Repository::*` topic modules
     #
     # Methods defined here use `module_function` so they are callable as
-    # `Git::Repository::Internal.foo(...)` from any topic module without being
-    # added to `Git::Repository`'s instance namespace via `include`.
+    # `SharedPrivate.foo(...)` from any topic module within `Git::Repository`
+    # without being added to `Git::Repository`'s instance namespace via `include`.
+    #
+    # The constant is declared `private_constant` so it is inaccessible from
+    # outside the `Git::Repository` class body; callers inside topic modules use
+    # the short unqualified form `SharedPrivate.foo(...)`.
     #
     # @api private
     #
-    module Internal
+    module SharedPrivate
       module_function
 
       # Validate that `options` contains only keys listed in `allowed`
@@ -23,7 +27,7 @@ module Git
       # @example Reject an undocumented option
       #   ADD_ALLOWED_OPTS = %i[all force].freeze
       #
-      #   Git::Repository::Internal.assert_valid_opts!(ADD_ALLOWED_OPTS, bogus: true)
+      #   SharedPrivate.assert_valid_opts!(ADD_ALLOWED_OPTS, bogus: true)
       #   #=> raises ArgumentError: Unknown options: bogus
       #
       # @param allowed [Array<Symbol>] the keys permitted by the facade method
@@ -41,5 +45,7 @@ module Git
         raise ArgumentError, "Unknown options: #{unknown.join(', ')}"
       end
     end
+
+    private_constant :SharedPrivate
   end
 end

--- a/lib/git/repository/staging.rb
+++ b/lib/git/repository/staging.rb
@@ -2,7 +2,7 @@
 
 require 'git/commands/add'
 require 'git/commands/reset'
-require 'git/repository/internal'
+require 'git/repository/shared_private'
 
 module Git
   class Repository
@@ -43,12 +43,12 @@ module Git
       #
       #   @return [String] git's stdout from the add
       #
-      # @raise [ArgumentError] if unsupported options are provided
+      #   @raise [ArgumentError] when unsupported options are provided
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #   @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def add(paths = '.', **)
-        Git::Repository::Internal.assert_valid_opts!(ADD_ALLOWED_OPTS, **)
+        SharedPrivate.assert_valid_opts!(ADD_ALLOWED_OPTS, **)
         Git::Commands::Add.new(@execution_context).call(*Array(paths), **).stdout
       end
 
@@ -76,12 +76,12 @@ module Git
       #
       #   @return [String] git's stdout from the reset
       #
-      # @raise [ArgumentError] if unsupported options are provided
+      #   @raise [ArgumentError] when unsupported options are provided
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #   @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def reset(commitish = nil, **)
-        Git::Repository::Internal.assert_valid_opts!(RESET_ALLOWED_OPTS, **)
+        SharedPrivate.assert_valid_opts!(RESET_ALLOWED_OPTS, **)
         Git::Commands::Reset.new(@execution_context).call(commitish, **).stdout
       end
     end


### PR DESCRIPTION
## Summary

Renames `Git::Repository::Internal` to `Git::Repository::SharedPrivate`, establishing the two-level naming convention for private implementation helpers across all `Git::Repository::*` facade modules.

Closes #1282

## Changes

- **Rename** `lib/git/repository/internal.rb` → `lib/git/repository/shared_private.rb`
- **Rename** module `Git::Repository::Internal` → `Git::Repository::SharedPrivate` throughout
- **Add** `private_constant :SharedPrivate` inside `class Repository` in the new file, so fully-qualified external references raise a `NameError` at runtime
- **Update** all call sites to use the short unqualified form `SharedPrivate.foo(...)` (in `branching.rb`, `committing.rb`, `merging.rb`, `staging.rb`)
- **Update** `require` in `lib/git/repository.rb` to load the renamed file

## Design

The two-level helper pattern is:

| Scope | Pattern |
| --- | --- |
| Shared across multiple `Git::Repository::*` modules | `Git::Repository::SharedPrivate` (non-included sibling module) |
| Private to a single `Git::Repository::*` module | Nested `module Private` inside that topic module |

`SharedPrivate` is not `include`d — callers use it directly via `SharedPrivate.method_name(...)`. The `private_constant` declaration prevents external code from referencing it with a fully-qualified path.