### PR TITLE
feat(repository): extract Git::Base#revert to Git::Repository::Merging

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -498,7 +498,7 @@ module Git
     #   :no_edit
     #
     def revert(commitish = nil, opts = {})
-      lib.revert(commitish, opts)
+      facade_repository.revert(commitish, **opts)
     end
 
     # commits all pending changes in the index file to the git repository

--- a/lib/git/repository/merging.rb
+++ b/lib/git/repository/merging.rb
@@ -4,6 +4,7 @@ require 'tempfile'
 require 'git/commands/diff'
 require 'git/commands/merge/start'
 require 'git/commands/merge_base'
+require 'git/commands/revert/start'
 require 'git/commands/show'
 require 'git/repository/shared_private'
 
@@ -186,6 +187,51 @@ module Git
             end
           end
         end
+      end
+
+      # Option keys accepted by {#revert}
+      #
+      # Derived from the 4.x option map for `Git::Lib#revert`.
+      REVERT_ALLOWED_OPTS = %i[no_edit].freeze
+      private_constant :REVERT_ALLOWED_OPTS
+
+      # Revert one or more existing commits by creating new commits that undo
+      # the changes those commits introduced
+      #
+      # The working tree must be clean before calling this method. By default
+      # the editor is suppressed (`--no-edit`) so the commit message is taken
+      # from git's default revert message without prompting.
+      #
+      # @example Revert the most recent commit
+      #   repo.revert('HEAD')
+      #
+      # @example Revert a specific commit by SHA
+      #   repo.revert('abc1234')
+      #
+      # @example Revert a range of commits
+      #   repo.revert('HEAD~3..HEAD~1')
+      #
+      # @example Revert without suppressing the editor
+      #   repo.revert('HEAD', no_edit: false)
+      #
+      # @param commitish [String, nil] the commit, ref, or rev range to revert;
+      #   see `gitrevisions(7)` for accepted forms
+      #
+      # @param opts [Hash] additional options forwarded to `git revert`
+      #
+      # @option opts [Boolean, nil] :no_edit (true) suppress the commit-message
+      #   editor (`--no-edit`); pass `false` to open the editor
+      #
+      # @return [String] git's stdout from the revert command
+      #
+      # @raise [ArgumentError] when unsupported options are provided
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def revert(commitish = nil, opts = {})
+        SharedPrivate.assert_valid_opts!(REVERT_ALLOWED_OPTS, **opts)
+        opts = { no_edit: true }.merge(opts)
+        Git::Commands::Revert::Start.new(@execution_context).call(commitish, **opts).stdout
       end
 
       # Private helpers local to {Git::Repository::Merging}

--- a/lib/git/repository/merging.rb
+++ b/lib/git/repository/merging.rb
@@ -215,7 +215,8 @@ module Git
       #   repo.revert('HEAD', no_edit: false)
       #
       # @param commitish [String, nil] the commit, ref, or rev range to revert;
-      #   see `gitrevisions(7)` for accepted forms
+      #   see `gitrevisions(7)` for accepted forms; defaults to `'HEAD'` when
+      #   `nil`
       #
       # @param opts [Hash] additional options forwarded to `git revert`
       #
@@ -229,6 +230,7 @@ module Git
       # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def revert(commitish = nil, opts = {})
+        commitish = 'HEAD' if commitish.nil?
         SharedPrivate.assert_valid_opts!(REVERT_ALLOWED_OPTS, **opts)
         opts = { no_edit: true }.merge(opts)
         Git::Commands::Revert::Start.new(@execution_context).call(commitish, **opts).stdout

--- a/spec/integration/git/repository/merging_spec.rb
+++ b/spec/integration/git/repository/merging_spec.rb
@@ -362,13 +362,40 @@ RSpec.describe Git::Repository::Merging, :integration do
   end
 
   # ---------------------------------------------------------------------------
-  # #revert — no integration test
-  #
-  # Git::Repository::Merging#revert is a single-command facade whose only
-  # pre-processing is the pure-Ruby `no_edit: true` default and option
-  # allowlisting. Both are proven by unit tests. The end-to-end git behavior
-  # is already covered by:
-  #   - tests/units/test_index_ops.rb#test_revert (legacy Test::Unit)
-  #   - spec/unit/git/commands/revert/start_spec.rb (command integration)
+  # #revert
   # ---------------------------------------------------------------------------
+
+  describe '#revert' do
+    before do
+      write_file('feature.txt', "feature content\n")
+      repo.add('feature.txt')
+      repo.commit('Add feature file')
+    end
+
+    let(:head_sha) { repo.log(1).execute.first.sha }
+
+    it 'returns a String' do
+      result = described_instance.revert(head_sha)
+      expect(result).to be_a(String)
+    end
+
+    it 'creates a new revert commit' do
+      sha = head_sha
+      log_before = repo.log(10_000).execute.count
+      described_instance.revert(sha)
+      expect(repo.log(10_000).execute.count).to eq(log_before + 1)
+    end
+
+    it 'undoes the file addition introduced by the reverted commit' do
+      sha = head_sha
+      described_instance.revert(sha)
+      expect(File.exist?(File.join(repo_dir, 'feature.txt'))).to be(false)
+    end
+
+    it 'treats a nil commitish as HEAD and reverts HEAD' do
+      log_before = repo.log(10_000).execute.count
+      described_instance.revert(nil)
+      expect(repo.log(10_000).execute.count).to eq(log_before + 1)
+    end
+  end
 end

--- a/spec/integration/git/repository/merging_spec.rb
+++ b/spec/integration/git/repository/merging_spec.rb
@@ -360,4 +360,15 @@ RSpec.describe Git::Repository::Merging, :integration do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #revert — no integration test
+  #
+  # Git::Repository::Merging#revert is a single-command facade whose only
+  # pre-processing is the pure-Ruby `no_edit: true` default and option
+  # allowlisting. Both are proven by unit tests. The end-to-end git behavior
+  # is already covered by:
+  #   - tests/units/test_index_ops.rb#test_revert (legacy Test::Unit)
+  #   - spec/unit/git/commands/revert/start_spec.rb (command integration)
+  # ---------------------------------------------------------------------------
 end

--- a/spec/unit/git/repository/merging_spec.rb
+++ b/spec/unit/git/repository/merging_spec.rb
@@ -532,16 +532,16 @@ RSpec.describe Git::Repository::Merging do
       end
     end
 
-    # --- nil commitish --------------------------------------------------------
+    # --- nil commitish defaults to HEAD ---------------------------------------
 
     context 'with a nil commitish' do
       subject(:result) { described_instance.revert(nil) }
 
       let(:revert_result) { command_result('') }
 
-      it 'passes nil as the commit positional argument' do
+      it 'maps nil to HEAD and calls Revert::Start#call with HEAD' do
         expect(revert_start_command)
-          .to receive(:call).with(nil, no_edit: true).and_return(revert_result)
+          .to receive(:call).with('HEAD', no_edit: true).and_return(revert_result)
         result
       end
     end

--- a/spec/unit/git/repository/merging_spec.rb
+++ b/spec/unit/git/repository/merging_spec.rb
@@ -493,4 +493,103 @@ RSpec.describe Git::Repository::Merging do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #revert
+  # ---------------------------------------------------------------------------
+
+  describe '#revert' do
+    let(:revert_start_command) { instance_double(Git::Commands::Revert::Start) }
+
+    before do
+      allow(Git::Commands::Revert::Start)
+        .to receive(:new).with(execution_context).and_return(revert_start_command)
+    end
+
+    # --- Default invocation ---------------------------------------------------
+
+    context 'with a commit SHA' do
+      subject(:result) { described_instance.revert('abc1234') }
+
+      let(:revert_result) { command_result("[main 1234abc] Revert \"first commit\"\n") }
+
+      it 'delegates to Git::Commands::Revert::Start.new with the execution_context' do
+        expect(Git::Commands::Revert::Start).to receive(:new).with(execution_context).and_return(revert_start_command)
+        allow(revert_start_command).to receive(:call).and_return(revert_result)
+        result
+      end
+
+      it 'calls Revert::Start#call with the commit and no_edit: true' do
+        expect(revert_start_command)
+          .to receive(:call).with('abc1234', no_edit: true).and_return(revert_result)
+        result
+      end
+
+      it 'returns the command stdout as a String' do
+        allow(revert_start_command)
+          .to receive(:call).with('abc1234', no_edit: true).and_return(revert_result)
+        expect(result).to eq("[main 1234abc] Revert \"first commit\"\n")
+      end
+    end
+
+    # --- nil commitish --------------------------------------------------------
+
+    context 'with a nil commitish' do
+      subject(:result) { described_instance.revert(nil) }
+
+      let(:revert_result) { command_result('') }
+
+      it 'passes nil as the commit positional argument' do
+        expect(revert_start_command)
+          .to receive(:call).with(nil, no_edit: true).and_return(revert_result)
+        result
+      end
+    end
+
+    # --- no_edit default can be overridden -----------------------------------
+
+    context 'with no_edit: false' do
+      subject(:result) { described_instance.revert('abc1234', no_edit: false) }
+
+      let(:revert_result) { command_result('') }
+
+      it 'passes no_edit: false through to Revert::Start#call, overriding the default' do
+        expect(revert_start_command)
+          .to receive(:call).with('abc1234', no_edit: false).and_return(revert_result)
+        result
+      end
+    end
+
+    # --- no_edit: true explicit (same as default) ----------------------------
+
+    context 'with no_edit: true explicitly' do
+      subject(:result) { described_instance.revert('abc1234', no_edit: true) }
+
+      let(:revert_result) { command_result('') }
+
+      it 'passes no_edit: true to Revert::Start#call' do
+        expect(revert_start_command)
+          .to receive(:call).with('abc1234', no_edit: true).and_return(revert_result)
+        result
+      end
+    end
+
+    # --- Option whitelisting --------------------------------------------------
+
+    context 'option whitelisting' do
+      it 'raises ArgumentError for an unknown option key' do
+        expect { described_instance.revert('abc1234', bogus: true) }
+          .to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+
+      it 'does not call Revert::Start when an unknown option is given' do
+        expect(revert_start_command).not_to receive(:call)
+        begin
+          described_instance.revert('abc1234', bogus: true)
+        rescue ArgumentError
+          # expected
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Extracts `Git::Base#revert` into `Git::Repository::Merging` as part of Issue #1266 (Phase 3, Task 4 — expand `Git::Repository` facade modules).

Closes #1266 (partial — marks the `revert` checkbox in `Git::Repository::Merging`)

## Changes

### `lib/git/repository/merging.rb`
- Added `require 'git/commands/revert/start'`
- Added `REVERT_ALLOWED_OPTS = %i[no_edit].freeze` constant (derived from the 4.x `REVERT_ALLOWED_OPTS` in `Git::Lib`) with `private_constant`
- Added `#revert(commitish = nil, opts = {})` facade method with YARD docs:
  - Maps `nil` commitish to `'HEAD'` so `revert()` reverts the current HEAD
  - Whitelists options via `SharedPrivate.assert_valid_opts!`
  - Applies `no_edit: true` default (preserving existing `Git::Lib#revert` behaviour)
  - Delegates to `Git::Commands::Revert::Start`

### `spec/unit/git/repository/merging_spec.rb`
- Added `describe '#revert'` block covering:
  - Default invocation (commit SHA → `no_edit: true` default applied)
  - `nil` commitish maps to `'HEAD'`
  - `no_edit: false` override
  - `no_edit: true` explicit
  - Option whitelisting (`ArgumentError` on unknown key; command not called)

### `spec/integration/git/repository/merging_spec.rb`
- Added `describe '#revert'` integration tests covering:
  - Returns a String
  - Creates a new revert commit (log count increases by 1)
  - Undoes the file addition introduced by the reverted commit
  - `nil` commitish reverts HEAD (nil→HEAD behaviour)

### `lib/git/base.rb`
- `Git::Base#revert` now delegates to `facade_repository.revert(commitish, **opts)` instead of `lib.revert(commitish, opts)`

## Testing

- 53 unit examples, 0 failures (`spec/unit/git/repository/merging_spec.rb`)
- 29 integration examples, 0 failures (`spec/integration/git/repository/merging_spec.rb`)
- Legacy `test_index_ops` (7 tests, 42 assertions, 0 failures)
- `rubocop`: 4 files inspected, no offenses