### PR TITLE
docs(skills): enforce *_ALLOWED_OPTS proximity rule in facade skills

### DIFF
--- a/.github/skills/extract-facade-from-base-lib/SKILL.md
+++ b/.github/skills/extract-facade-from-base-lib/SKILL.md
@@ -514,6 +514,9 @@ of Git::Base#<method_name>.
 - [ ] **`assert_valid_opts!` used.** The facade calls
   `Git::Repository::Internal.assert_valid_opts!(ALLOWED_OPTS, **)` before
   forwarding to the command.
+- [ ] **`*_ALLOWED_OPTS` placement correct.** Each `<METHOD>_ALLOWED_OPTS`
+  constant is declared **immediately before** the public facade method that
+  uses it (not grouped at the top of the module, not inside `Private`).
 - [ ] **YARD docs complete.** Each allowed option has an `@option` tag with
   type, name, default, and description. `@param`, `@return`, `@raise` are
   present and accurate.

--- a/.github/skills/facade-implementation/SKILL.md
+++ b/.github/skills/facade-implementation/SKILL.md
@@ -201,6 +201,8 @@ This skill supports three modes. Determine which mode applies before starting:
      `SharedPrivate.assert_valid_opts!(allowed, **)` — do **not**
      also `slice`; see [Option
      whitelisting](REFERENCE.md#option-whitelisting-preventing-api-expansion))
+   - places each `<METHOD>_ALLOWED_OPTS` constant **immediately before** the
+     method that uses it (not grouped at the top of the module)
    - handles defaults and deprecations explicitly, not by relying on command
      internals
 
@@ -235,6 +237,7 @@ For **review** mode, produce:
 | Orchestration via `@execution_context` | Pass/Fail | ... |
 | Argument pre-processing complete | Pass/Fail | ... |
 | Option whitelisting (where required) | Pass/Fail | ... |
+| `*_ALLOWED_OPTS` placed immediately before its method | Pass/Fail | ... |
 | Return value matches documented contract | Pass/Fail | ... |
 | Parser/result-class wiring correct | Pass/Fail | ... |
 | YARD docs complete | Pass/Fail | ... |


### PR DESCRIPTION
## Summary

Add explicit checks and guidance requiring that each `*_ALLOWED_OPTS` constant be placed **immediately before** the first public facade method that uses it — not grouped with other constants at the top of the module.

## Changes

- **`facade-implementation/SKILL.md`** — Step 4 review bullet: add sub-bullet noting the constant must be placed immediately before its method; review output table: add `*_ALLOWED_OPTS placed immediately before its method` row
- **`extract-facade-from-base-lib/SKILL.md`** — R4 checklist: add `*_ALLOWED_OPTS placement correct` checkbox

## Context

The authoritative rule ("Place the constant immediately before the method definition") already existed in `facade-implementation/REFERENCE.md` (option-whitelisting section). These changes propagate it into the review checklists where violations would be caught during code review.