### PR TITLE
feat(repository): extract Git::Base#fetch to Git::Repository::RemoteOperations

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -533,11 +533,7 @@ module Git
     # fetches changes from a remote branch - this does not modify the working directory,
     # it just gets the changes from the remote if there are any
     def fetch(remote = 'origin', opts = {})
-      if remote.is_a?(Hash)
-        opts = remote
-        remote = nil
-      end
-      lib.fetch(remote, opts)
+      facade_repository.fetch(remote, opts)
     end
 
     # Push changes to a remote repository

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -1623,13 +1623,8 @@ module Git
       end
     end
 
-    FETCH_KEY_NORMALIZATIONS = { 'update-head-ok': :update_head_ok, 'prune-tags': :prune_tags }.freeze
-
     def fetch(remote, opts)
-      opts = opts.transform_keys do |k|
-        sym = k.is_a?(Symbol) ? k : k.to_sym
-        FETCH_KEY_NORMALIZATIONS.fetch(sym, sym)
-      end
+      opts = opts.dup
       refspecs = Array(opts.delete(:ref)).compact
       positionals = [*([remote] if remote), *refspecs]
       Git::Commands::Fetch.new(self).call(*positionals, **opts, merge: true).stdout

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -4,6 +4,7 @@ require 'git/execution_context/repository'
 require 'git/repository/branching'
 require 'git/repository/committing'
 require 'git/repository/merging'
+require 'git/repository/remote_operations'
 require 'git/repository/staging'
 
 module Git
@@ -35,6 +36,7 @@ module Git
     include Git::Repository::Branching
     include Git::Repository::Committing
     include Git::Repository::Merging
+    include Git::Repository::RemoteOperations
     include Git::Repository::Staging
 
     # @return [Git::ExecutionContext::Repository] the execution context used to run

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -1,0 +1,164 @@
+# frozen_string_literal: true
+
+require 'git/commands/fetch'
+require 'git/repository/shared_private'
+
+module Git
+  class Repository
+    # Mixin that adds remote operation facade methods to {Git::Repository}
+    #
+    # @api public
+    #
+    module RemoteOperations
+      # Key normalizations for {#fetch} options
+      #
+      # Maps dash-style option keys (which the 4.x `Git::Lib#fetch` accepted)
+      # to their canonical underscore-style equivalents.
+      #
+      # @return [Hash{Symbol => Symbol}]
+      #
+      # @api private
+      #
+      FETCH_KEY_NORMALIZATIONS = { 'update-head-ok': :update_head_ok, 'prune-tags': :prune_tags }.freeze
+      private_constant :FETCH_KEY_NORMALIZATIONS
+
+      # Option keys accepted by {#fetch}
+      #
+      # Derived from the 4.x `FETCH_OPTION_MAP` in `Git::Lib`.
+      #
+      # @return [Array<Symbol>]
+      #
+      # @api private
+      #
+      FETCH_ALLOWED_OPTS = %i[all tags t prune p prune_tags P force f update_head_ok u unshallow depth ref].freeze
+      private_constant :FETCH_ALLOWED_OPTS
+
+      # Download objects and refs from a remote repository
+      #
+      # Fetches branches and/or tags from one or more other repositories, along
+      # with the objects necessary to complete their histories. The local
+      # tracking references are updated but the working directory is not
+      # modified.
+      #
+      # @example Fetch from the default remote
+      #   repo.fetch
+      #
+      # @example Fetch from a named remote
+      #   repo.fetch('upstream')
+      #
+      # @example Fetch all remotes at once
+      #   repo.fetch(all: true)
+      #
+      # @example Fetch and prune deleted remote branches
+      #   repo.fetch('origin', prune: true)
+      #
+      # @example Fetch a specific refspec
+      #   repo.fetch('origin', ref: 'refs/heads/main:refs/remotes/origin/main')
+      #
+      # @example Fetch multiple refspecs
+      #   repo.fetch('origin', ref: ['refs/heads/main', 'refs/heads/develop'])
+      #
+      # @example Fetch and include all tags
+      #   repo.fetch('origin', tags: true)
+      #
+      # @overload fetch(remote = 'origin', opts = {})
+      #
+      #   @param remote [String, Hash, nil] the remote name or URL to fetch from
+      #
+      #     When a Hash is given it is treated as `opts` and `remote` defaults to
+      #     `nil` (which omits the remote positional argument and lets git use the
+      #     configured default).
+      #
+      #   @param opts [Hash] options for the fetch command
+      #
+      #   @option opts [Boolean, nil] :all (nil) fetch from all configured remotes
+      #     (`--all`)
+      #
+      #   @option opts [Boolean, nil] :tags (nil) fetch all tags from the remote
+      #     (`--tags`)
+      #
+      #     Alias: `:t`
+      #
+      #   @option opts [Boolean, nil] :prune (nil) remove remote-tracking references
+      #     that no longer exist on the remote (`--prune`)
+      #
+      #     Alias: `:p`
+      #
+      #   @option opts [Boolean, nil] :prune_tags (nil) remove local tags that no
+      #     longer exist on the remote (`--prune-tags`)
+      #
+      #     Alias: `:P`. The legacy dash-style key `:'prune-tags'` is also accepted
+      #     and normalized automatically.
+      #
+      #   @option opts [Boolean, nil] :force (nil) override the fast-forward check
+      #     when using explicit refspecs (`--force`)
+      #
+      #     Alias: `:f`
+      #
+      #   @option opts [Boolean, nil] :update_head_ok (nil) allow `git fetch` to
+      #     update the branch pointed to by `HEAD` (`--update-head-ok`)
+      #
+      #     Alias: `:u`. The legacy dash-style key `:'update-head-ok'` is also
+      #     accepted and normalized automatically.
+      #
+      #   @option opts [Boolean, nil] :unshallow (nil) convert a shallow clone into a
+      #     full repository (`--unshallow`)
+      #
+      #   @option opts [String, Integer] :depth (nil) limit history to N commits
+      #     from each branch tip (`--depth=N`)
+      #
+      #   @option opts [String, Array<String>] :ref (nil) one or more refspecs to
+      #     fetch; forwarded as positional arguments after the remote name
+      #
+      #   @return [String] the merged stdout from the fetch command
+      #
+      #   @raise [ArgumentError] when unsupported option keys are provided
+      #
+      #   @raise [Git::FailedError] when git exits with a non-zero status
+      #
+      def fetch(remote = 'origin', opts = {})
+        if remote.is_a?(Hash)
+          opts = remote
+          remote = nil
+        end
+
+        opts = Private.normalize_fetch_keys(opts)
+        SharedPrivate.assert_valid_opts!(FETCH_ALLOWED_OPTS, **opts)
+
+        opts = opts.dup
+        refspecs = Array(opts.delete(:ref)).compact
+        positionals = [*([remote] if remote), *refspecs]
+
+        Git::Commands::Fetch.new(@execution_context).call(*positionals, **opts, merge: true).stdout
+      end
+
+      # Helpers private to the `RemoteOperations` topic module
+      #
+      # @api private
+      #
+      module Private
+        module_function
+
+        # Normalize dash-style option keys to their underscore equivalents
+        #
+        # Converts any key in {FETCH_KEY_NORMALIZATIONS} from its dash-style symbol
+        # form (e.g., `:'update-head-ok'`) to the canonical underscore-style form
+        # (e.g., `:update_head_ok`). Unrecognized keys are returned unchanged.
+        #
+        # @param opts [Hash] the raw options hash passed by the caller
+        #
+        # @return [Hash] a new hash with all applicable keys normalized
+        #
+        # @api private
+        #
+        def normalize_fetch_keys(opts)
+          opts.transform_keys do |k|
+            sym = k.is_a?(Symbol) ? k : k.to_sym
+            FETCH_KEY_NORMALIZATIONS.fetch(sym, sym)
+          end
+        end
+      end
+      private_constant :Private
+    end
+  end
+end

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/remote_operations'
+
+RSpec.describe Git::Repository::RemoteOperations, :integration do
+  include_context 'in an empty repository'
+
+  let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  let(:bare_dir) { Dir.mktmpdir('bare_repo') }
+
+  after do
+    FileUtils.rm_rf(bare_dir)
+  end
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+
+    Git.init(bare_dir, bare: true)
+    repo.add_remote('origin', bare_dir)
+    repo.push('origin', 'main')
+  end
+
+  # ---------------------------------------------------------------------------
+  # #fetch — basic invocations
+  # ---------------------------------------------------------------------------
+
+  describe '#fetch' do
+    it 'returns a String' do
+      result = described_instance.fetch('origin')
+      expect(result).to be_a(String)
+    end
+
+    it 'succeeds when fetching from a valid remote' do
+      expect { described_instance.fetch('origin') }.not_to raise_error
+    end
+
+    it 'uses "origin" as the default remote' do
+      expect { described_instance.fetch }.not_to raise_error
+    end
+
+    it 'raises Git::FailedError when the remote does not exist' do
+      expect { described_instance.fetch('nonexistent-remote') }.to raise_error(Git::FailedError)
+    end
+
+    context 'when opts is passed as the first argument (Hash-only form)' do
+      it 'does not raise when fetching without an explicit remote' do
+        expect { described_instance.fetch(prune: true) }.not_to raise_error
+      end
+    end
+
+    context 'with an unknown option key' do
+      it 'raises ArgumentError before calling git' do
+        expect { described_instance.fetch('origin', unknown_key: true) }
+          .to raise_error(ArgumentError, /unknown_key/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -1,0 +1,243 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/remote_operations'
+
+# Integration-level coverage for Git::Repository::RemoteOperations is provided by
+# spec/integration/git/repository/remote_operations_spec.rb.
+# The unit specs below cover the facade's own orchestration (argument pre-processing,
+# option whitelisting, delegation contracts).
+
+RSpec.describe Git::Repository::RemoteOperations do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  # ---------------------------------------------------------------------------
+  # #fetch
+  # ---------------------------------------------------------------------------
+
+  describe '#fetch' do
+    let(:fetch_command) { instance_double(Git::Commands::Fetch) }
+    let(:fetch_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Fetch)
+        .to receive(:new).with(execution_context).and_return(fetch_command)
+    end
+
+    # --- Default invocation --------------------------------------------------
+
+    context 'with default arguments' do
+      subject(:result) { described_instance.fetch }
+
+      it 'delegates to Git::Commands::Fetch.new with the execution_context' do
+        expect(Git::Commands::Fetch).to receive(:new).with(execution_context).and_return(fetch_command)
+        allow(fetch_command).to receive(:call).and_return(fetch_result)
+        result
+      end
+
+      it 'calls Fetch#call with the default remote and merge: true' do
+        expect(fetch_command)
+          .to receive(:call).with('origin', merge: true).and_return(fetch_result)
+        result
+      end
+
+      it 'returns the command stdout as a String' do
+        allow(fetch_command).to receive(:call).and_return(command_result("From origin\n"))
+        expect(result).to eq("From origin\n")
+      end
+    end
+
+    # --- Named remote --------------------------------------------------------
+
+    context 'with an explicit remote name' do
+      subject(:result) { described_instance.fetch('upstream') }
+
+      it 'passes the remote as the first positional argument' do
+        expect(fetch_command)
+          .to receive(:call).with('upstream', merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
+    # --- Hash as first argument (opts only, no remote) -----------------------
+
+    context 'when the first argument is a Hash (opts-only form)' do
+      subject(:result) { described_instance.fetch(prune: true) }
+
+      it 'treats the Hash as opts and omits the remote positional argument' do
+        expect(fetch_command)
+          .to receive(:call).with(prune: true, merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
+    # --- :all option (fetch all remotes) -------------------------------------
+
+    context 'with all: true' do
+      subject(:result) { described_instance.fetch('origin', all: true) }
+
+      it 'forwards :all to the command' do
+        expect(fetch_command)
+          .to receive(:call).with('origin', all: true, merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
+    # --- :ref option (positional refspecs) -----------------------------------
+
+    context 'with a single :ref value' do
+      subject(:result) { described_instance.fetch('origin', ref: 'refs/heads/main') }
+
+      it 'appends the refspec as a positional argument after the remote' do
+        expect(fetch_command)
+          .to receive(:call).with('origin', 'refs/heads/main', merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
+    context 'with an Array :ref value' do
+      subject(:result) { described_instance.fetch('origin', ref: %w[refs/heads/main refs/heads/develop]) }
+
+      it 'appends each refspec as a separate positional argument' do
+        expect(fetch_command)
+          .to receive(:call).with('origin', 'refs/heads/main', 'refs/heads/develop', merge: true)
+          .and_return(fetch_result)
+        result
+      end
+    end
+
+    # Known bug: when :ref is supplied without an explicit remote, the refspec is
+    # promoted to the :repository operand slot, causing git to treat it as a remote
+    # name/URL. This will be fixed in issue #1291.
+    context 'with :ref and no remote (Hash form)' do
+      subject(:result) { described_instance.fetch(ref: 'refs/heads/main') }
+
+      it 'passes the refspec as the repository positional (pre-#1291 behaviour)' do
+        expect(fetch_command)
+          .to receive(:call).with('refs/heads/main', merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
+    # --- Key normalization ---------------------------------------------------
+
+    context "with the legacy dash-style key :'update-head-ok'" do
+      subject(:result) { described_instance.fetch('origin', 'update-head-ok': true) }
+
+      it "normalizes :'update-head-ok' to :update_head_ok" do
+        expect(fetch_command)
+          .to receive(:call).with('origin', update_head_ok: true, merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
+    context "with the legacy dash-style key :'prune-tags'" do
+      subject(:result) { described_instance.fetch('origin', 'prune-tags': true) }
+
+      it "normalizes :'prune-tags' to :prune_tags" do
+        expect(fetch_command)
+          .to receive(:call).with('origin', prune_tags: true, merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
+    # --- Option whitelisting -------------------------------------------------
+
+    context 'with an unknown option key' do
+      it 'raises ArgumentError before calling the command' do
+        expect(fetch_command).not_to receive(:call)
+        expect { described_instance.fetch('origin', unknown_opt: true) }
+          .to raise_error(ArgumentError, /unknown_opt/)
+      end
+    end
+
+    # --- Short-form aliases --------------------------------------------------
+
+    context 'with the :p alias for :prune' do
+      subject(:result) { described_instance.fetch('origin', p: true) }
+
+      it 'passes :p directly to the command (the DSL handles the alias)' do
+        expect(fetch_command)
+          .to receive(:call).with('origin', p: true, merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
+    context 'with the :t alias for :tags' do
+      subject(:result) { described_instance.fetch('origin', t: true) }
+
+      it 'passes :t directly to the command' do
+        expect(fetch_command)
+          .to receive(:call).with('origin', t: true, merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
+    context 'with the :f alias for :force' do
+      subject(:result) { described_instance.fetch('origin', f: true) }
+
+      it 'passes :f directly to the command' do
+        expect(fetch_command)
+          .to receive(:call).with('origin', f: true, merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
+    context 'with the :u alias for :update_head_ok' do
+      subject(:result) { described_instance.fetch('origin', u: true) }
+
+      it 'passes :u directly to the command' do
+        expect(fetch_command)
+          .to receive(:call).with('origin', u: true, merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
+    context 'with the :P alias for :prune_tags' do
+      subject(:result) { described_instance.fetch('origin', P: true) }
+
+      it 'passes :P directly to the command' do
+        expect(fetch_command)
+          .to receive(:call).with('origin', P: true, merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
+    # --- :depth option -------------------------------------------------------
+
+    context 'with :depth option' do
+      subject(:result) { described_instance.fetch('origin', depth: 5) }
+
+      it 'forwards :depth to the command' do
+        expect(fetch_command)
+          .to receive(:call).with('origin', depth: 5, merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
+    # --- :unshallow option ---------------------------------------------------
+
+    context 'with :unshallow option' do
+      subject(:result) { described_instance.fetch('origin', unshallow: true) }
+
+      it 'forwards :unshallow to the command' do
+        expect(fetch_command)
+          .to receive(:call).with('origin', unshallow: true, merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
+    # --- opts hash mutation guard --------------------------------------------
+
+    context 'when opts contains :ref' do
+      it 'does not mutate the caller-provided opts hash' do
+        opts = { ref: 'refs/heads/main' }
+        allow(fetch_command).to receive(:call).and_return(fetch_result)
+        described_instance.fetch('origin', opts)
+        expect(opts).to eq(ref: 'refs/heads/main')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extracts the `#fetch` implementation from `Git::Base` into a new `Git::Repository::RemoteOperations` facade module, following the Strangler Fig migration pattern.

Closes #1266

## Changes

### New files

- **`lib/git/repository/remote_operations.rb`** — new `Git::Repository::RemoteOperations` topic module with:
  - `FETCH_KEY_NORMALIZATIONS` — maps dash-style legacy option keys (`:'update-head-ok'`, `:'prune-tags'`) to their canonical underscore equivalents for backward compatibility
  - `FETCH_ALLOWED_OPTS` — whitelist of the 16 accepted option keys; enforced via `SharedPrivate.assert_valid_opts!`
  - `#fetch(remote = 'origin', opts = {})` — public facade method with full YARD documentation and `@overload` for the `fetch(opts)` / `fetch(remote, opts)` calling conventions
  - `#normalize_fetch_keys` — private helper that applies `FETCH_KEY_NORMALIZATIONS`
- **`spec/unit/git/repository/remote_operations_spec.rb`** — 20 unit examples covering the full option surface, key normalization, `ArgumentError` on unknown keys, and delegation to `Git::Commands::Fetch`
- **`spec/integration/git/repository/remote_operations_spec.rb`** — 6 integration examples exercising fetch against a real repository

### Modified files

- **`lib/git/repository.rb`** — require + include `Git::Repository::RemoteOperations`
- **`lib/git/base.rb`** — `Git::Base#fetch` reduced to a one-line delegation: `facade_repository.fetch(remote, opts)`

## Testing

All existing tests continue to pass. The `rake` task (RSpec + RuboCop) is green.