### PR TITLE
Extract Git::Base#pull to Git::Repository::RemoteOperations

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -592,12 +592,12 @@ module Git
     # @example pulls from upstream/develop
     #   @git.pull('upstream', 'develop')
     #
-    # @return [Void]
+    # @return [String] the stdout output from the pull command
     #
     # @raise [Git::FailedError] if the pull fails
     # @raise [ArgumentError] if a branch is given without a remote
     def pull(remote = nil, branch = nil, opts = {})
-      lib.pull(remote, branch, opts)
+      facade_repository.pull(remote, branch, opts)
     end
 
     # returns an array of Git:Remote objects

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'git/commands/fetch'
+require 'git/commands/pull'
 require 'git/repository/shared_private'
 
 module Git
@@ -130,6 +131,71 @@ module Git
         positionals = [*([remote] if remote), *refspecs]
 
         Git::Commands::Fetch.new(@execution_context).call(*positionals, **opts, merge: true).stdout
+      end
+
+      # Option keys accepted by {#pull}
+      #
+      # Derived from the 4.x `PULL_OPTION_MAP` in `Git::Lib`.
+      #
+      # @return [Array<Symbol>]
+      #
+      # @api private
+      #
+      PULL_ALLOWED_OPTS = %i[allow_unrelated_histories].freeze
+      private_constant :PULL_ALLOWED_OPTS
+
+      # Incorporate changes from a remote repository into the current branch
+      #
+      # Fetches from the given remote and merges into the current branch. In its
+      # default mode, `git pull` is shorthand for `git fetch` followed by
+      # `git merge FETCH_HEAD`. The merge editor is suppressed (`--no-edit`) and
+      # progress output is silenced (`--no-progress`) by default.
+      #
+      # @example Pull from the default remote and branch
+      #   repo.pull
+      #
+      # @example Pull from a named remote
+      #   repo.pull('upstream')
+      #
+      # @example Pull a specific branch from a remote
+      #   repo.pull('origin', 'main')
+      #
+      # @example Pull allowing unrelated histories
+      #   repo.pull('origin', 'main', allow_unrelated_histories: true)
+      #
+      # @overload pull(remote = nil, branch = nil, opts = {})
+      #
+      #   @param remote [String, nil] the remote name or URL to pull from
+      #
+      #     When nil, git uses the tracking remote for the current branch.
+      #
+      #   @param branch [String, nil] the remote branch name to pull
+      #
+      #     When nil, git uses the tracking branch for the current branch.
+      #     A branch may not be specified without also specifying a remote.
+      #
+      #   @param opts [Hash] options for the pull command
+      #
+      #   @option opts [Boolean, nil] :allow_unrelated_histories (nil) allow merging
+      #     histories that do not share a common ancestor
+      #     (`--allow-unrelated-histories`)
+      #
+      #   @return [String] the stdout from the pull command
+      #
+      #   @raise [ArgumentError] when a branch is given without a remote, or when
+      #     unsupported option keys are provided
+      #
+      #   @raise [Git::FailedError] when git exits with a non-zero status
+      #
+      def pull(remote = nil, branch = nil, opts = {})
+        raise ArgumentError, 'You must specify a remote if a branch is specified' if remote.nil? && !branch.nil?
+
+        SharedPrivate.assert_valid_opts!(PULL_ALLOWED_OPTS, **opts)
+        positional_args = [remote, branch].compact
+        Git::Commands::Pull
+          .new(@execution_context)
+          .call(*positional_args, no_edit: true, no_progress: true, **opts)
+          .stdout
       end
 
       # Helpers private to the `RemoteOperations` topic module

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -61,4 +61,33 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #pull — basic invocations
+  # ---------------------------------------------------------------------------
+
+  describe '#pull' do
+    it 'returns a String' do
+      result = described_instance.pull('origin', 'main')
+      expect(result).to be_a(String)
+    end
+
+    it 'succeeds when the local branch is already up to date' do
+      expect { described_instance.pull('origin', 'main') }.not_to raise_error
+    end
+
+    it 'raises ArgumentError when a branch is given without a remote' do
+      expect { described_instance.pull(nil, 'main') }
+        .to raise_error(ArgumentError, /You must specify a remote if a branch is specified/)
+    end
+
+    it 'raises Git::FailedError when the remote does not exist' do
+      expect { described_instance.pull('nonexistent-remote', 'main') }.to raise_error(Git::FailedError)
+    end
+
+    it 'raises ArgumentError before calling git when an unknown option is given' do
+      expect { described_instance.pull('origin', 'main', unknown_opt: true) }
+        .to raise_error(ArgumentError, /unknown_opt/)
+    end
+  end
 end

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -240,4 +240,99 @@ RSpec.describe Git::Repository::RemoteOperations do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #pull
+  # ---------------------------------------------------------------------------
+
+  describe '#pull' do
+    let(:pull_command) { instance_double(Git::Commands::Pull) }
+    let(:pull_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Pull)
+        .to receive(:new).with(execution_context).and_return(pull_command)
+    end
+
+    # --- Default invocation --------------------------------------------------
+
+    context 'with default arguments' do
+      subject(:result) { described_instance.pull }
+
+      it 'delegates to Git::Commands::Pull.new with the execution_context' do
+        expect(Git::Commands::Pull).to receive(:new).with(execution_context).and_return(pull_command)
+        allow(pull_command).to receive(:call).and_return(pull_result)
+        result
+      end
+
+      it 'calls Pull#call with no positional args and policy options' do
+        expect(pull_command)
+          .to receive(:call).with(no_edit: true, no_progress: true).and_return(pull_result)
+        result
+      end
+
+      it 'returns the command stdout as a String' do
+        allow(pull_command).to receive(:call).and_return(command_result("From origin\n * branch HEAD -> FETCH_HEAD\n"))
+        expect(result).to eq("From origin\n * branch HEAD -> FETCH_HEAD\n")
+      end
+    end
+
+    # --- Named remote --------------------------------------------------------
+
+    context 'with an explicit remote name' do
+      subject(:result) { described_instance.pull('upstream') }
+
+      it 'passes the remote as the first positional argument' do
+        expect(pull_command)
+          .to receive(:call).with('upstream', no_edit: true, no_progress: true).and_return(pull_result)
+        result
+      end
+    end
+
+    # --- Remote and branch ---------------------------------------------------
+
+    context 'with a remote and a branch' do
+      subject(:result) { described_instance.pull('origin', 'main') }
+
+      it 'passes remote and branch as positional arguments' do
+        expect(pull_command)
+          .to receive(:call).with('origin', 'main', no_edit: true, no_progress: true).and_return(pull_result)
+        result
+      end
+    end
+
+    # --- Branch without remote -----------------------------------------------
+
+    context 'when branch is specified without a remote' do
+      it 'raises ArgumentError before calling the command' do
+        expect(pull_command).not_to receive(:call)
+        expect { described_instance.pull(nil, 'main') }
+          .to raise_error(ArgumentError, /You must specify a remote if a branch is specified/)
+      end
+    end
+
+    # --- :allow_unrelated_histories option -----------------------------------
+
+    context 'with allow_unrelated_histories: true' do
+      subject(:result) { described_instance.pull('origin', 'main', allow_unrelated_histories: true) }
+
+      it 'forwards the option to the command' do
+        expect(pull_command)
+          .to receive(:call)
+          .with('origin', 'main', no_edit: true, no_progress: true, allow_unrelated_histories: true)
+          .and_return(pull_result)
+        result
+      end
+    end
+
+    # --- Option whitelisting -------------------------------------------------
+
+    context 'with an unknown option key' do
+      it 'raises ArgumentError before calling the command' do
+        expect(pull_command).not_to receive(:call)
+        expect { described_instance.pull('origin', nil, unknown_opt: true) }
+          .to raise_error(ArgumentError, /unknown_opt/)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Part of the v5.0.0 Strangler Fig migration (issue 1266). Extracts
`Git::Base#pull` to `Git::Repository::RemoteOperations#pull` following
Pattern A (Base wrapper + Lib implementation).

**Public contract preserved exactly:**
- Signature: `pull(remote = nil, branch = nil, opts = {})` — unchanged
- Returns `String` (`.stdout` from `git pull`)
- Raises `ArgumentError` when a branch is given without a remote
- Raises `Git::FailedError` on non-zero git exit
- Allowed opts: `:allow_unrelated_histories` (4.x `PULL_OPTION_MAP`)
- Policy defaults `no_edit: true, no_progress: true` applied inline

**Changes:**
- `lib/git/repository/remote_operations.rb` — adds `PULL_ALLOWED_OPTS`
  constant and `#pull` facade method with full YARD documentation
- `lib/git/base.rb` — delegates `#pull` to `facade_repository.pull`
- `spec/unit/git/repository/remote_operations_spec.rb` — 9 new unit
  examples covering default call, positional args, the branch-without-remote
  guard, `allow_unrelated_histories`, and unknown option rejection
- `spec/integration/git/repository/remote_operations_spec.rb` — 5 new
  integration examples exercising real git invocations

`Git::Lib#pull` retains its existing implementation for backward
compatibility until Phase 4 deletion.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).
