### PR TITLE
Extract remove_remote to repository remote operations

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -655,7 +655,7 @@ module Git
     #
     # @git.remove_remote('scott_git')
     def remove_remote(name)
-      lib.remote_remove(name)
+      facade_repository.remove_remote(name)
     end
 
     # returns an array of all Git::Tag objects for this repository

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -4,6 +4,7 @@ require 'git/commands/fetch'
 require 'git/commands/pull'
 require 'git/commands/push'
 require 'git/commands/remote'
+
 require 'git/repository/shared_private'
 
 module Git
@@ -413,6 +414,25 @@ module Git
         Git::Commands::Remote::Add.new(@execution_context).call(name, url, **opts)
 
         Git::Remote.new(@execution_context.base_object, name)
+      end
+
+      # Removes a remote from this repository
+      #
+      # Deletes the remote named `name` along with its associated configuration,
+      # tracking references, and remote-tracking branches.
+      #
+      # @example Remove a remote named 'upstream'
+      #   repo.remove_remote('upstream')
+      #
+      # @param name [String] the name of the remote to remove
+      #
+      # @return [Git::CommandLineResult] the result of calling `git remote remove`
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero status, for example
+      #   when `name` does not refer to an existing remote
+      #
+      def remove_remote(name)
+        Git::Commands::Remote::Remove.new(@execution_context).call(name)
       end
 
       # Helpers private to the `RemoteOperations` topic module

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -187,4 +187,25 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #remove_remote
+  # ---------------------------------------------------------------------------
+
+  describe '#remove_remote' do
+    it 'removes the named remote' do
+      described_instance.remove_remote('origin')
+      expect(repo.remotes.map(&:name)).not_to include('origin')
+    end
+
+    it 'returns a Git::CommandLineResult' do
+      result = described_instance.remove_remote('origin')
+      expect(result).to be_a(Git::CommandLineResult)
+    end
+
+    it 'raises Git::FailedError when the remote does not exist' do
+      expect { described_instance.remove_remote('nonexistent') }
+        .to raise_error(Git::FailedError)
+    end
+  end
 end

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -682,4 +682,37 @@ RSpec.describe Git::Repository::RemoteOperations do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #remove_remote
+  # ---------------------------------------------------------------------------
+
+  describe '#remove_remote' do
+    let(:remove_command) { instance_double(Git::Commands::Remote::Remove) }
+    let(:remove_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Remote::Remove)
+        .to receive(:new).with(execution_context).and_return(remove_command)
+    end
+
+    subject(:result) { described_instance.remove_remote('upstream') }
+
+    it 'delegates to Git::Commands::Remote::Remove.new with the execution_context' do
+      expect(Git::Commands::Remote::Remove)
+        .to receive(:new).with(execution_context).and_return(remove_command)
+      allow(remove_command).to receive(:call).and_return(remove_result)
+      result
+    end
+
+    it 'calls Remove#call with the remote name' do
+      expect(remove_command).to receive(:call).with('upstream').and_return(remove_result)
+      result
+    end
+
+    it 'returns the Git::CommandLineResult' do
+      allow(remove_command).to receive(:call).and_return(remove_result)
+      expect(result).to be(remove_result)
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- delegate `Git::Base#remove_remote` to `Git::Repository#remove_remote`
- add `Git::Repository#remove_remote` in `Git::Repository::RemoteOperations`
- add unit and integration coverage for the new facade behavior

## Why
This continues the architecture migration by moving remote operations behind the repository facade while preserving `Git::Base` behavior.

## Changes
- updated `lib/git/base.rb`
- added facade method in `lib/git/repository/remote_operations.rb`
- added tests in:
  - `spec/unit/git/repository/remote_operations_spec.rb`
  - `spec/integration/git/repository/remote_operations_spec.rb`
