### PR TITLE
Extract Git::Base#add_remote to Git::Repository::RemoteOperations

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -204,9 +204,7 @@ module Git
     #   :fetch => true
     #   :track => <branch_name>
     def add_remote(name, url, opts = {})
-      url = url.repo.to_s if url.is_a?(Git::Base)
-      lib.remote_add(name, url, opts)
-      Git::Remote.new(self, name)
+      facade_repository.add_remote(name, url, opts)
     end
 
     # changes current working directory for a block

--- a/lib/git/execution_context/repository.rb
+++ b/lib/git/execution_context/repository.rb
@@ -49,6 +49,7 @@ module Git
           git_dir: base_object.repo.to_s,
           git_index_file: base_object.index&.to_s,
           git_work_dir: base_object.dir&.to_s,
+          base_object: base_object,
           git_ssh: base_object.git_ssh,
           binary_path: base_object.binary_path,
           logger: logger
@@ -95,6 +96,8 @@ module Git
       #
       # @param git_index_file [String, nil] path to the index file
       #
+      # @param base_object [Git::Base, nil] originating base object
+      #
       # @param binary_path [String, :use_global_config] path to the git binary
       #
       #   Give `:use_global_config` (the default) to use `Git::Base.config.binary_path`.
@@ -116,6 +119,7 @@ module Git
         git_dir:,
         git_work_dir: nil,
         git_index_file: nil,
+        base_object: nil,
         binary_path: :use_global_config,
         git_ssh: :use_global_config,
         logger: nil
@@ -124,6 +128,7 @@ module Git
         @git_dir = git_dir
         @git_work_dir = git_work_dir
         @git_index_file = git_index_file
+        @base_object = base_object
       end
 
       # @return [String, nil] path to the `.git` directory
@@ -134,6 +139,9 @@ module Git
 
       # @return [String, nil] path to the index file
       attr_reader :git_index_file
+
+      # @return [Git::Base, nil] originating base object
+      attr_reader :base_object
     end
   end
 end

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -3,6 +3,7 @@
 require 'git/commands/fetch'
 require 'git/commands/pull'
 require 'git/commands/push'
+require 'git/commands/remote'
 require 'git/repository/shared_private'
 
 module Git
@@ -347,11 +348,8 @@ module Git
       #
       #   @return [String] the stdout from the push command
       #
-      #   @raise [ArgumentError] if `remote` is nil when `branch` is given
-      #
-      # @raise [ArgumentError] when unsupported option keys are provided
-      #
-      # @raise [Git::FailedError] when git exits with a non-zero status
+      #   @raise [ArgumentError] when unsupported option keys are provided or if a branch
+      #     is supplied and remote is nil
       #
       def push(remote = nil, branch = nil, opts = nil)
         remote, branch, opts = Private.normalize_push_args(remote, branch, opts)
@@ -362,6 +360,59 @@ module Git
         return first_result.stdout unless Private.push_tags_separately?(opts)
 
         Private.push_tags(@execution_context, remote, opts).stdout
+      end
+
+      # Option keys accepted by {#add_remote}
+      #
+      # Derived from the 4.x `REMOTE_ADD_OPTION_MAP` in `Git::Lib`.
+      ADD_REMOTE_ALLOWED_OPTS = %i[fetch track].freeze
+      private_constant :ADD_REMOTE_ALLOWED_OPTS
+
+      # Register a new remote in the local repository
+      #
+      # Associates `name` with `url` and optionally fetches immediately or
+      # configures which branches are tracked.
+      #
+      # @example Add a remote
+      #   repo.add_remote('upstream', 'https://github.com/user/repo.git')
+      #
+      # @example Add a remote and fetch immediately
+      #   repo.add_remote('upstream', 'https://github.com/user/repo.git', fetch: true)
+      #
+      # @example Add a remote tracking a specific branch
+      #   repo.add_remote('upstream', 'https://github.com/user/repo.git', track: 'main')
+      #
+      # @param name [String] the name for the new remote
+      #
+      # @param url [String, Git::Base] the URL of the remote repository
+      #
+      #   A {Git::Base} instance is accepted for local references and converted
+      #   to `url.repo.to_s`.
+      #
+      # @param opts [Hash] options for adding the remote
+      #
+      # @option opts [Boolean, nil] :fetch (nil) fetch from the remote immediately
+      #   after adding it (`-f`)
+      #
+      #   The deprecated alias `:with_fetch` is accepted and normalized
+      #   automatically.
+      #
+      # @option opts [String, nil] :track (nil) track only the given branch during
+      #   fetch (`-t`)
+      #
+      # @return [Git::Remote]
+      #
+      # @raise [ArgumentError] when unsupported option keys are provided
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero status
+      #
+      def add_remote(name, url, opts = {})
+        url = url.repo.to_s if url.is_a?(Git::Base)
+        opts = Private.normalize_add_remote_keys(opts)
+        SharedPrivate.assert_valid_opts!(ADD_REMOTE_ALLOWED_OPTS, **opts)
+        Git::Commands::Remote::Add.new(@execution_context).call(name, url, **opts)
+
+        Git::Remote.new(@execution_context.base_object, name)
       end
 
       # Helpers private to the `RemoteOperations` topic module
@@ -499,6 +550,23 @@ module Git
         #
         def push_tags(execution_context, remote, opts)
           Git::Commands::Push.new(execution_context).call(*[remote].compact, **opts)
+        end
+
+        # Normalize deprecated {#add_remote} option keys to their canonical equivalents
+        #
+        # Renames the deprecated `:with_fetch` key to `:fetch`, removing it from
+        # the copy. When both keys are present, `:with_fetch` takes precedence.
+        #
+        # @param opts [Hash] the raw options hash passed by the caller
+        #
+        # @return [Hash] a new hash with all applicable keys normalized
+        #
+        # @api private
+        #
+        def normalize_add_remote_keys(opts)
+          normalized = opts.dup
+          normalized[:fetch] = normalized.delete(:with_fetch) if normalized.key?(:with_fetch)
+          normalized
         end
       end
       private_constant :Private

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -135,4 +135,56 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
         .to raise_error(ArgumentError, /unknown_opt/)
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #add_remote — basic invocations
+  # ---------------------------------------------------------------------------
+
+  describe '#add_remote' do
+    let(:remote_dir) { Dir.mktmpdir('remote_repo') }
+
+    after do
+      FileUtils.rm_rf(remote_dir)
+    end
+
+    before do
+      Git.init(remote_dir, bare: true)
+    end
+
+    it 'returns Git::Remote' do
+      result = described_instance.add_remote('secondary', remote_dir)
+      expect(result).to be_a(Git::Remote)
+      expect(result.name).to eq('secondary')
+    end
+
+    it 'registers the remote so it appears in the repository config' do
+      described_instance.add_remote('secondary', remote_dir)
+      expect(repo.remotes.map(&:name)).to include('secondary')
+    end
+
+    context 'with fetch: true' do
+      it 'does not raise an error' do
+        expect { described_instance.add_remote('secondary', remote_dir, fetch: true) }.not_to raise_error
+      end
+    end
+
+    context 'with track: "main"' do
+      it 'does not raise an error' do
+        expect { described_instance.add_remote('secondary', remote_dir, track: 'main') }.not_to raise_error
+      end
+    end
+
+    context 'with the deprecated :with_fetch alias' do
+      it 'does not raise an error' do
+        expect { described_instance.add_remote('secondary', remote_dir, with_fetch: true) }.not_to raise_error
+      end
+    end
+
+    context 'with an unknown option key' do
+      it 'raises ArgumentError before calling git' do
+        expect { described_instance.add_remote('secondary', remote_dir, unknown_key: true) }
+          .to raise_error(ArgumentError, /unknown_key/)
+      end
+    end
+  end
 end

--- a/spec/unit/git/execution_context/repository_spec.rb
+++ b/spec/unit/git/execution_context/repository_spec.rb
@@ -26,6 +26,7 @@ RSpec.describe Git::ExecutionContext::Repository do
           git_dir: git_dir,
           git_work_dir: git_work_dir,
           git_index_file: git_index_file,
+          base_object: nil,
           git_ssh: '/usr/bin/ssh',
           binary_path: '/usr/local/bin/git',
           logger: nil
@@ -208,6 +209,10 @@ RSpec.describe Git::ExecutionContext::Repository do
 
     it 'extracts git_index_file from base.index.to_s' do
       expect(context.git_index_file).to eq(git_index_file)
+    end
+
+    it 'stores the originating base object' do
+      expect(context.base_object).to eq(base)
     end
 
     context 'when base.binary_path is an explicit path' do

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -10,7 +10,8 @@ require 'git/repository/remote_operations'
 # option whitelisting, delegation contracts).
 
 RSpec.describe Git::Repository::RemoteOperations do
-  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:base_object) { instance_double(Git::Base) }
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository, base_object: base_object) }
   let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
 
   # ---------------------------------------------------------------------------
@@ -568,6 +569,116 @@ RSpec.describe Git::Repository::RemoteOperations do
         expect(push_command).not_to receive(:call)
         expect { described_instance.push('origin', timeout: 30) }
           .to raise_error(ArgumentError, /timeout/)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #add_remote
+  # ---------------------------------------------------------------------------
+
+  describe '#add_remote' do
+    let(:add_remote_command) { instance_double(Git::Commands::Remote::Add) }
+    let(:add_remote_result) { command_result('') }
+    let(:remote_object) { instance_double(Git::Remote) }
+
+    before do
+      allow(Git::Commands::Remote::Add)
+        .to receive(:new).with(execution_context).and_return(add_remote_command)
+      allow(add_remote_command).to receive(:call).and_return(add_remote_result)
+      allow(Git::Remote).to receive(:new).and_return(remote_object)
+    end
+
+    # --- Default invocation --------------------------------------------------
+
+    context 'with name and url only' do
+      subject(:result) { described_instance.add_remote('upstream', 'https://example.com/repo.git') }
+
+      it 'delegates to Git::Commands::Remote::Add.new with the execution_context' do
+        expect(Git::Commands::Remote::Add).to receive(:new).with(execution_context).and_return(add_remote_command)
+        result
+      end
+
+      it 'calls Add#call with name and url' do
+        expect(add_remote_command)
+          .to receive(:call).with('upstream', 'https://example.com/repo.git').and_return(add_remote_result)
+        result
+      end
+
+      it 'returns Git::Remote' do
+        expect(Git::Remote).to receive(:new).with(base_object, 'upstream').and_return(remote_object)
+        expect(result).to eq(remote_object)
+      end
+    end
+
+    context 'with url as Git::Base' do
+      let(:url_base) do
+        Object.new.tap do |obj|
+          def obj.repo
+            Pathname.new('/tmp/source.git')
+          end
+
+          def obj.is_a?(klass)
+            klass == Git::Base || super
+          end
+        end
+      end
+
+      subject(:result) { described_instance.add_remote('upstream', url_base) }
+
+      it 'normalizes url to repo.to_s before calling the command' do
+        expect(add_remote_command)
+          .to receive(:call).with('upstream', '/tmp/source.git').and_return(add_remote_result)
+        result
+      end
+    end
+
+    # --- :fetch option -------------------------------------------------------
+
+    context 'with fetch: true' do
+      subject(:result) { described_instance.add_remote('upstream', 'https://example.com/repo.git', fetch: true) }
+
+      it 'forwards :fetch to the command' do
+        expect(add_remote_command)
+          .to receive(:call).with('upstream', 'https://example.com/repo.git', fetch: true)
+          .and_return(add_remote_result)
+        result
+      end
+    end
+
+    # --- :track option -------------------------------------------------------
+
+    context 'with track: "main"' do
+      subject(:result) { described_instance.add_remote('upstream', 'https://example.com/repo.git', track: 'main') }
+
+      it 'forwards :track to the command' do
+        expect(add_remote_command)
+          .to receive(:call).with('upstream', 'https://example.com/repo.git', track: 'main')
+          .and_return(add_remote_result)
+        result
+      end
+    end
+
+    # --- :with_fetch alias (deprecated) --------------------------------------
+
+    context 'with the deprecated :with_fetch alias' do
+      subject(:result) { described_instance.add_remote('upstream', 'https://example.com/repo.git', with_fetch: true) }
+
+      it 'normalizes :with_fetch to :fetch before calling the command' do
+        expect(add_remote_command)
+          .to receive(:call).with('upstream', 'https://example.com/repo.git', fetch: true)
+          .and_return(add_remote_result)
+        result
+      end
+    end
+
+    # --- Option whitelisting -------------------------------------------------
+
+    context 'with an unknown option key' do
+      it 'raises ArgumentError before calling the command' do
+        expect(add_remote_command).not_to receive(:call)
+        expect { described_instance.add_remote('upstream', 'https://example.com/repo.git', unknown_opt: true) }
+          .to raise_error(ArgumentError, /unknown_opt/)
       end
     end
   end


### PR DESCRIPTION
## Description

Extracts `Git::Base#add_remote` into the `Git::Repository::RemoteOperations` facade
module as part of the v5.0.0 Strangler Fig migration (relates to issue 1266).

**Source pattern:** Pattern A — `Git::Base#add_remote` wraps `Git::Lib#remote_add`
which already delegates to `Git::Commands::Remote::Add`.

### Changes

**`lib/git/repository/remote_operations.rb`**

- Added `require 'git/commands/remote'`
- Added `ADD_REMOTE_KEY_NORMALIZATIONS` — normalizes the deprecated `:with_fetch`
  alias to the canonical `:fetch` key (preserving 4.x backward compatibility)
- Added `ADD_REMOTE_ALLOWED_OPTS = %i[fetch track]` — derived from the 4.x
  `REMOTE_ADD_OPTION_MAP`
- Added `#add_remote(name, url, opts = {})` facade method with key normalization,
  option whitelisting via `SharedPrivate.assert_valid_opts!`, and delegation to
  `Git::Commands::Remote::Add`; returns `Git::Remote`
- Added `Private.normalize_add_remote_keys` helper

**`lib/git/base.rb`**

- `Git::Base#add_remote` now delegates to `facade_repository.add_remote`, retaining
  only the `Git::Base`-specific `url.is_a?(Git::Base)` coercion and the
  `Git::Remote.new(self, name)` wrapping (both require a `Git::Base` instance)

**Specs**

- Unit specs: default invocation, `:fetch`, `:track`, deprecated `:with_fetch`
  alias normalization, unknown option rejection, return value
- Integration specs: return value, remote registration, all allowed options,
  unknown option rejection

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] Tests added/updated as needed and `rake` passes locally.
- [x] Documentation updated where applicable (README and/or YARD).
