### PR TITLE
refactor(base): delegate push to repository facade

### DIFF
--- a/.github/skills/facade-yard-documentation/SKILL.md
+++ b/.github/skills/facade-yard-documentation/SKILL.md
@@ -254,6 +254,20 @@ See the general
 [YARD Documentation — Documenting anonymous splats with `@overload`](../yard-documentation/SKILL.md#documenting-anonymous-splats-with-overload)
 for the underlying rule.
 
+Decision rules for facade methods:
+
+- Use `@overload` when the method uses anonymous `*`, `**`, or `...`
+- Use `@overload` when call shapes differ meaningfully (different params and/or
+  return contracts)
+- Skip `@overload` only when a single named signature fully describes the API
+
+When using `@overload`, place tags as follows:
+
+- Put `@param`, `@option`, and `@return` in overload blocks
+- Put overload-specific `@raise` only in the relevant overload block
+- Put shared `@raise` once at top level
+- Do not duplicate the same `@raise` at both levels
+
 ### Return type rules
 
 The `@return` annotation must reflect the **public contract** of the facade
@@ -289,6 +303,12 @@ documented contract is to expose raw results.
   [ArgumentError]` line that names the constraint.
 - Do **not** enumerate specific git failure causes (no "if the branch doesn't
   exist", no "if the working tree is dirty"). Use the generic form.
+
+Scope `@raise` tags by call-shape:
+
+- Shared across all overloads: keep as one top-level `@raise`
+- Specific to one or more overloads: keep only in those overload blocks
+- Never duplicate identical `@raise` tags at both top level and overload level
 
 ### Cross-referencing the implementation
 
@@ -369,6 +389,9 @@ For each facade module file, run through these checks in order:
 - [ ] `@return` matches the actual return value type per [Return type
   rules](#return-type-rules)
 - [ ] `@raise` tags follow [`@raise` rules](#raise-rules)
+- [ ] shared `@raise` tags are top-level; overload-specific `@raise` tags are in
+  the relevant overload only
+- [ ] no duplicate identical `@raise` appears at both top level and overload level
 - [ ] `@see` tags appear at the end and are limited to non-obvious cross-links
 
 ### 3. Formatting consistency

--- a/.github/skills/yard-documentation/SKILL.md
+++ b/.github/skills/yard-documentation/SKILL.md
@@ -512,9 +512,15 @@ Follow the YARD documentation templates below. Use the **standard template** whe
 method has a single call signature. Use the **overload template** when a method has
 distinct call signatures with different parameters or return types.
 
-**Do NOT mix top-level `@param`/`@return`/`@raise` with `@overload` blocks** — YARD
-silently ignores top-level tags when overloads are present. In both templates
-below, include only the tags that apply to the method.
+When `@overload` blocks are present:
+
+- Keep `@param`, `@option`, and `@return` inside overload blocks only
+- Keep overload-specific `@raise` inside the relevant overload block
+- Keep shared `@raise` at top level only once (do not duplicate inside overloads)
+- Keep non-signature tags (`@note`, `@deprecated`, `@see`, `@api`) at top level
+
+Avoid duplicating the same `@raise` at both top level and overload level. This
+causes conflicting or noisy generated docs.
 
 **Trigger: always use `@overload` when the signature contains `*`, `**`, or `...`**
 
@@ -634,6 +640,21 @@ at the top level:
 def method_name(name, options = {})
 end
 ```
+
+### Overload decision matrix
+
+Use this matrix to decide whether to use `@overload` and where to place tags:
+
+| Method signature or behavior | Documentation form |
+| --- | --- |
+| Single named signature, no `*`/`**`/`...` | Standard template (no `@overload`) |
+| Uses anonymous `*`, `**`, or `...` | `@overload` required |
+| Multiple call shapes (different params and/or return types) | One `@overload` per shape |
+| Shared errors across all call shapes | Top-level `@raise` once |
+| Error only for specific call shape | `@raise` only in that overload |
+
+For overload docs, keep `@param`/`@option`/`@return` in overload blocks. Use
+top-level `@raise` only for errors that apply to every overload.
 
 ### Documenting anonymous splats with `@overload`
 

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -556,13 +556,13 @@ module Git
     #
     #   @option options [String, Array<String>] :push_option (nil) push options to transmit
     #
-    #   @return [Void]
+    #   @return [String] the stdout output from the push command
     #
     #   @raise [Git::FailedError] if the push fails
     #   @raise [ArgumentError] if a branch is given without a remote
     #
     def push(*, **)
-      lib.push(*, **)
+      facade_repository.push(*, **)
     end
 
     # merges one or more branches into the current working branch

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -2,6 +2,7 @@
 
 require 'git/commands/fetch'
 require 'git/commands/pull'
+require 'git/commands/push'
 require 'git/repository/shared_private'
 
 module Git
@@ -198,6 +199,172 @@ module Git
           .stdout
       end
 
+      # Option keys accepted by {#push}
+      #
+      # Derived from the 4.x `PUSH_OPTION_MAP` in `Git::Lib`.
+      #
+      # @return [Array<Symbol>]
+      #
+      # @api private
+      #
+      PUSH_ALLOWED_OPTS = %i[mirror delete force f push_option all tags].freeze
+      private_constant :PUSH_ALLOWED_OPTS
+
+      # Push refs to a remote repository
+      #
+      # @example Push using the current branch's default remote and push configuration
+      #   repo.push
+      #
+      # @example Push to a named remote
+      #   repo.push('origin')
+      #
+      # @example Force-push the current branch to a named remote
+      #   repo.push('origin', force: true)
+      #
+      # @example Push a specific branch to a named remote
+      #   repo.push('origin', 'main')
+      #
+      # @example Push a branch and all tags to a named remote
+      #   repo.push('origin', 'main', tags: true)
+      #
+      # @example Push all branches to a named remote
+      #   repo.push('origin', all: true)
+      #
+      # @example Mirror all refs to a named remote
+      #   repo.push('origin', mirror: true)
+      #
+      # @overload push(options = {})
+      #   Push using the current branch's default remote and push configuration
+      #
+      #   @param options [Hash] push options (see option list below)
+      #
+      #   @option options [Boolean, nil] :all (nil) push all branches (`--all`)
+      #
+      #   @option options [Boolean, nil] :mirror (nil) push all refs under
+      #     `refs/` to the remote (`--mirror`)
+      #
+      #     When `:tags` is also given, the separate tags push is suppressed.
+      #
+      #   @option options [Boolean, nil] :tags (nil) push all refs under
+      #     `refs/tags/` in a second `git push` invocation (`--tags`)
+      #
+      #     When `:mirror` is also given, the tags push is suppressed because
+      #     `--mirror` already includes tags.
+      #
+      #   @option options [Boolean, nil] :force (nil) force updates,
+      #     overriding the fast-forward check (`--force`)
+      #
+      #     Alias: `:f`
+      #
+      #   @option options [Boolean, nil] :delete (nil) delete the named refs
+      #     from the remote (`--delete`)
+      #
+      #   @option options [String, Array<String>] :push_option (nil) one or
+      #     more server-side push option values (`--push-option=<value>`,
+      #     repeatable)
+      #
+      #   @return [String] the stdout from the push command
+      #
+      # @overload push(remote, options = {})
+      #   Push to the given remote using the current branch's default push configuration
+      #
+      #   @param remote [String] the remote name or URL to push to
+      #
+      #   @param options [Hash] push options (see option list below)
+      #
+      #   @option options [Boolean, nil] :all (nil) push all branches (`--all`)
+      #
+      #   @option options [Boolean, nil] :mirror (nil) push all refs under
+      #     `refs/` to the remote (`--mirror`)
+      #
+      #     When `:tags` is also given, the separate tags push is suppressed.
+      #
+      #   @option options [Boolean, nil] :tags (nil) push all refs under
+      #     `refs/tags/` in a second `git push` invocation (`--tags`)
+      #
+      #     When `:mirror` is also given, the tags push is suppressed because
+      #     `--mirror` already includes tags.
+      #
+      #   @option options [Boolean, nil] :force (nil) force updates,
+      #     overriding the fast-forward check (`--force`)
+      #
+      #     Alias: `:f`
+      #
+      #   @option options [Boolean, nil] :delete (nil) delete the named refs
+      #     from the remote (`--delete`)
+      #
+      #   @option options [String, Array<String>] :push_option (nil) one or
+      #     more server-side push option values (`--push-option=<value>`,
+      #     repeatable)
+      #
+      #   @return [String] the stdout from the push command
+      #
+      # @overload push(remote, branch, options = {})
+      #   Push a branch or refspec to the given remote
+      #
+      #   @param remote [String] the remote name or URL to push to
+      #
+      #   @param branch [String] the branch name or refspec to push
+      #
+      #   @param options [Hash] push options (see option list below)
+      #
+      #   @option options [Boolean, nil] :all (nil) push all branches (`--all`)
+      #
+      #   @option options [Boolean, nil] :mirror (nil) push all refs under
+      #     `refs/` to the remote (`--mirror`)
+      #
+      #     When `:tags` is also given, the separate tags push is suppressed.
+      #
+      #   @option options [Boolean, nil] :tags (nil) push all refs under
+      #     `refs/tags/` in a second `git push` invocation (`--tags`)
+      #
+      #     When `:mirror` is also given, the tags push is suppressed because
+      #     `--mirror` already includes tags.
+      #
+      #   @option options [Boolean, nil] :force (nil) force updates,
+      #     overriding the fast-forward check (`--force`)
+      #
+      #     Alias: `:f`
+      #
+      #   @option options [Boolean, nil] :delete (nil) delete the named refs
+      #     from the remote (`--delete`)
+      #
+      #   @option options [String, Array<String>] :push_option (nil) one or
+      #     more server-side push option values (`--push-option=<value>`,
+      #     repeatable)
+      #
+      #   @return [String] the stdout from the push command
+      #
+      #   @raise [ArgumentError] if `remote` is nil when `branch` is given
+      #
+      # @overload push(remote, branch, tags)
+      #   Backward-compatible shorthand for `push(remote, branch, tags: tags)`
+      #
+      #   @param remote [String] the remote name or URL to push to
+      #
+      #   @param branch [String] the branch name or refspec to push
+      #
+      #   @param tags [Boolean] whether to push all tags; equivalent to `tags: tags`
+      #
+      #   @return [String] the stdout from the push command
+      #
+      #   @raise [ArgumentError] if `remote` is nil when `branch` is given
+      #
+      # @raise [ArgumentError] when unsupported option keys are provided
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero status
+      #
+      def push(remote = nil, branch = nil, opts = nil)
+        remote, branch, opts = Private.normalize_push_args(remote, branch, opts)
+        SharedPrivate.assert_valid_opts!(PUSH_ALLOWED_OPTS, **opts)
+        raise ArgumentError, 'remote is required if branch is specified' if !remote && branch
+
+        first_result = Private.push_refs(@execution_context, remote, branch, opts)
+        return first_result.stdout unless Private.push_tags_separately?(opts)
+
+        Private.push_tags(@execution_context, remote, opts).stdout
+      end
+
       # Helpers private to the `RemoteOperations` topic module
       #
       # @api private
@@ -222,6 +389,90 @@ module Git
             sym = k.is_a?(Symbol) ? k : k.to_sym
             FETCH_KEY_NORMALIZATIONS.fetch(sym, sym)
           end
+        end
+
+        # Normalize the flexible argument list accepted by {RemoteOperations#push}
+        #
+        # Handles three call forms:
+        # - `push(opts)` — Hash promoted from `remote` position
+        # - `push(remote, opts)` — Hash promoted from `branch` position
+        # - `push(remote, branch, true|false)` — Boolean `opts` converted to
+        #   `{ tags: opts }` for backward compatibility
+        #
+        # @param remote [String, Hash, nil] remote name, URL, or opts hash
+        # @param branch [String, Hash, nil] branch/refspec, or opts hash
+        # @param opts [Hash, Boolean, nil] options hash or legacy Boolean shorthand
+        #
+        # @return [Array(String|nil, String|nil, Hash)] normalized [remote, branch, opts]
+        #
+        # @api private
+        #
+        def normalize_push_args(remote, branch, opts)
+          if branch.is_a?(Hash)
+            opts = branch
+            branch = nil
+          elsif remote.is_a?(Hash)
+            opts = remote
+            remote = nil
+          end
+
+          opts ||= {}
+
+          # Backwards compatibility for `push(remote, branch, true)` to push tags
+          # without requiring the caller to use keyword arguments
+
+          opts = { tags: opts } if [true, false].include?(opts)
+          [remote, branch, opts]
+        end
+
+        # Issue the refs push (first push when `:tags` is given separately)
+        #
+        # Strips `:tags` from the options so that only refs — not tags — are pushed
+        # in this first call. Tags are pushed in a separate call when
+        # {push_tags_separately?} is true.
+        #
+        # @param execution_context [Git::ExecutionContext::Repository]
+        # @param remote [String, nil] remote name or URL
+        # @param branch [String, nil] branch or refspec
+        # @param opts [Hash] push options (`:tags` key will be stripped)
+        #
+        # @return [Git::CommandLineResult]
+        #
+        # @api private
+        #
+        def push_refs(execution_context, remote, branch, opts)
+          positionals = [remote, branch].compact
+          Git::Commands::Push.new(execution_context).call(*positionals, **opts.except(:tags))
+        end
+
+        # Return true when tags must be pushed in a second separate invocation
+        #
+        # Tags are pushed separately when `:tags` is truthy AND `:mirror` is not set.
+        # When `:mirror` is set, the mirror push already includes all refs and tags,
+        # so a second tags-only call would be redundant.
+        #
+        # @param opts [Hash] the normalized push options
+        #
+        # @return [Boolean]
+        #
+        # @api private
+        #
+        def push_tags_separately?(opts)
+          opts[:tags] && !opts[:mirror]
+        end
+
+        # Issue the tags push (second push when `:tags` is requested without `:mirror`)
+        #
+        # @param execution_context [Git::ExecutionContext::Repository]
+        # @param remote [String, nil] remote name or URL
+        # @param opts [Hash] push options (`:tags` key included to emit `--tags`)
+        #
+        # @return [Git::CommandLineResult]
+        #
+        # @api private
+        #
+        def push_tags(execution_context, remote, opts)
+          Git::Commands::Push.new(execution_context).call(*[remote].compact, **opts)
         end
       end
       private_constant :Private

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -63,6 +63,51 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   end
 
   # ---------------------------------------------------------------------------
+  # #push — basic invocations
+  # ---------------------------------------------------------------------------
+
+  describe '#push' do
+    it 'returns a String' do
+      result = described_instance.push('origin', 'main')
+      expect(result).to be_a(String)
+    end
+
+    it 'succeeds when pushing to a valid remote' do
+      expect { described_instance.push('origin', 'main') }.not_to raise_error
+    end
+
+    it 'raises Git::FailedError when the remote does not exist' do
+      expect { described_instance.push('nonexistent-remote', 'main') }
+        .to raise_error(Git::FailedError)
+    end
+
+    context 'when branch is specified without a remote' do
+      it 'raises ArgumentError' do
+        expect { described_instance.push(nil, 'main') }
+          .to raise_error(ArgumentError, /remote is required/)
+      end
+    end
+
+    context 'with an unknown option key' do
+      it 'raises ArgumentError before calling git' do
+        expect { described_instance.push('origin', 'main', unknown_key: true) }
+          .to raise_error(ArgumentError, /unknown_key/)
+      end
+    end
+
+    context 'with tags: true' do
+      before do
+        repo.add_tag('v1.0')
+      end
+
+      it 'pushes refs and tags and returns a String' do
+        result = described_instance.push('origin', 'main', tags: true)
+        expect(result).to be_a(String)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # #pull — basic invocations
   # ---------------------------------------------------------------------------
 

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -242,6 +242,8 @@ RSpec.describe Git::Repository::RemoteOperations do
   end
 
   # ---------------------------------------------------------------------------
+
+  # ---------------------------------------------------------------------------
   # #pull
   # ---------------------------------------------------------------------------
 
@@ -301,7 +303,7 @@ RSpec.describe Git::Repository::RemoteOperations do
       end
     end
 
-    # --- Branch without remote -----------------------------------------------
+    # --- Branch without remote ----------------------------------------------
 
     context 'when branch is specified without a remote' do
       it 'raises ArgumentError before calling the command' do
@@ -311,7 +313,7 @@ RSpec.describe Git::Repository::RemoteOperations do
       end
     end
 
-    # --- :allow_unrelated_histories option -----------------------------------
+    # --- :allow_unrelated_histories option ----------------------------------
 
     context 'with allow_unrelated_histories: true' do
       subject(:result) { described_instance.pull('origin', 'main', allow_unrelated_histories: true) }
@@ -332,6 +334,244 @@ RSpec.describe Git::Repository::RemoteOperations do
         expect(pull_command).not_to receive(:call)
         expect { described_instance.pull('origin', nil, unknown_opt: true) }
           .to raise_error(ArgumentError, /unknown_opt/)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #push
+  # ---------------------------------------------------------------------------
+
+  describe '#push' do
+    let(:push_command) { instance_double(Git::Commands::Push) }
+    let(:push_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Push)
+        .to receive(:new).with(execution_context).and_return(push_command)
+    end
+
+    # --- Default invocation (no args) ---------------------------------------
+
+    context 'with no arguments' do
+      subject(:result) { described_instance.push }
+
+      it 'delegates to Git::Commands::Push.new with the execution_context' do
+        expect(Git::Commands::Push).to receive(:new).with(execution_context).and_return(push_command)
+        allow(push_command).to receive(:call).and_return(push_result)
+        result
+      end
+
+      it 'calls Push#call with no positional args and no options' do
+        expect(push_command).to receive(:call).with(no_args).and_return(push_result)
+        result
+      end
+
+      it 'returns the command stdout as a String' do
+        allow(push_command).to receive(:call).and_return(command_result("To origin\n"))
+        expect(result).to eq("To origin\n")
+      end
+    end
+
+    # --- Named remote only ---------------------------------------------------
+
+    context 'with an explicit remote name' do
+      subject(:result) { described_instance.push('upstream') }
+
+      it 'passes the remote as the first positional argument' do
+        expect(push_command).to receive(:call).with('upstream').and_return(push_result)
+        result
+      end
+    end
+
+    # --- Named remote + branch ----------------------------------------------
+
+    context 'with a remote and branch' do
+      subject(:result) { described_instance.push('origin', 'main') }
+
+      it 'passes both remote and branch as positional arguments' do
+        expect(push_command).to receive(:call).with('origin', 'main').and_return(push_result)
+        result
+      end
+    end
+
+    # --- Hash as first argument (opts-only, no remote) ----------------------
+
+    context 'when the first argument is a Hash (opts-only form)' do
+      subject(:result) { described_instance.push(force: true) }
+
+      it 'treats the Hash as opts and omits the remote positional argument' do
+        expect(push_command).to receive(:call).with(force: true).and_return(push_result)
+        result
+      end
+    end
+
+    # --- Hash as second argument (remote + opts form) -----------------------
+
+    context 'when the second argument is a Hash (remote + opts form)' do
+      subject(:result) { described_instance.push('origin', force: true) }
+
+      it 'treats the Hash as opts and passes only the remote positionally' do
+        expect(push_command).to receive(:call).with('origin', force: true).and_return(push_result)
+        result
+      end
+    end
+
+    # --- :tags option (two-push orchestration) ------------------------------
+
+    context 'with tags: true' do
+      let(:first_result) { command_result('first push') }
+      let(:second_result) { command_result('tags push') }
+
+      it 'issues two Git::Commands::Push calls' do
+        expect(push_command).to receive(:call).with('origin', 'main').and_return(first_result)
+        expect(push_command).to receive(:call).with('origin', tags: true).and_return(second_result)
+        described_instance.push('origin', 'main', tags: true)
+      end
+
+      it 'returns the stdout from the tags push (second call)' do
+        allow(push_command).to receive(:call).with('origin', 'main').and_return(first_result)
+        allow(push_command).to receive(:call).with('origin', tags: true).and_return(second_result)
+        expect(described_instance.push('origin', 'main', tags: true)).to eq('tags push')
+      end
+    end
+
+    # --- :mirror + :tags (single-push, tags suppressed) ---------------------
+
+    context 'with mirror: true and tags: true' do
+      let(:mirror_result) { command_result('mirror push') }
+
+      it 'issues only one Git::Commands::Push call (mirror subsumes tags)' do
+        expect(push_command).to receive(:call).once.with('origin', 'main', mirror: true).and_return(mirror_result)
+        described_instance.push('origin', 'main', mirror: true, tags: true)
+      end
+
+      it 'returns the stdout from the single mirror push' do
+        allow(push_command).to receive(:call).with('origin', 'main', mirror: true).and_return(mirror_result)
+        expect(described_instance.push('origin', 'main', mirror: true, tags: true)).to eq('mirror push')
+      end
+    end
+
+    # --- :all + :tags (two-push orchestration) ------------------------------
+
+    context 'with all: true and tags: true' do
+      let(:all_result) { command_result('all push') }
+      let(:all_tags_result) { command_result('all tags push') }
+
+      it 'issues two Git::Commands::Push calls' do
+        expect(push_command).to receive(:call).with('origin', all: true).and_return(all_result)
+        expect(push_command).to receive(:call).with('origin', all: true, tags: true).and_return(all_tags_result)
+        described_instance.push('origin', all: true, tags: true)
+      end
+
+      it 'returns the stdout from the tags push (second call)' do
+        allow(push_command).to receive(:call).with('origin', all: true).and_return(all_result)
+        allow(push_command).to receive(:call).with('origin', all: true, tags: true).and_return(all_tags_result)
+        expect(described_instance.push('origin', all: true, tags: true)).to eq('all tags push')
+      end
+    end
+
+    # --- Legacy Boolean shorthand (backward compatibility) ------------------
+
+    context 'with Boolean true as third argument (legacy shorthand)' do
+      let(:refs_result) { command_result('refs') }
+      let(:tags_result) { command_result('tags') }
+
+      it 'converts the Boolean to tags: true and issues two calls' do
+        expect(push_command).to receive(:call).with('origin', 'main').and_return(refs_result)
+        expect(push_command).to receive(:call).with('origin', tags: true).and_return(tags_result)
+        described_instance.push('origin', 'main', true)
+      end
+    end
+
+    context 'with Boolean false as third argument (legacy shorthand)' do
+      it 'converts the Boolean to tags: false and issues one call (no tags)' do
+        expect(push_command).to receive(:call).once.with('origin', 'main').and_return(push_result)
+        described_instance.push('origin', 'main', false)
+      end
+    end
+
+    # --- :force option -------------------------------------------------------
+
+    context 'with force: true' do
+      it 'forwards :force to the Push command' do
+        expect(push_command)
+          .to receive(:call).with('origin', 'main', force: true).and_return(push_result)
+        described_instance.push('origin', 'main', force: true)
+      end
+    end
+
+    # --- :f alias ------------------------------------------------------------
+
+    context 'with f: true (alias for :force)' do
+      it 'forwards :f to the Push command' do
+        expect(push_command)
+          .to receive(:call).with('origin', 'main', f: true).and_return(push_result)
+        described_instance.push('origin', 'main', f: true)
+      end
+    end
+
+    # --- :delete option ------------------------------------------------------
+
+    context 'with delete: true' do
+      it 'forwards :delete to the Push command' do
+        expect(push_command)
+          .to receive(:call).with('origin', 'main', delete: true).and_return(push_result)
+        described_instance.push('origin', 'main', delete: true)
+      end
+    end
+
+    # --- :push_option --------------------------------------------------------
+
+    context 'with a single :push_option value' do
+      it 'forwards :push_option to the Push command' do
+        expect(push_command)
+          .to receive(:call).with('origin', push_option: 'ci.skip').and_return(push_result)
+        described_instance.push('origin', push_option: 'ci.skip')
+      end
+    end
+
+    context 'with an Array :push_option value' do
+      it 'forwards the full Array to the Push command' do
+        expect(push_command)
+          .to receive(:call).with('origin', push_option: %w[foo bar]).and_return(push_result)
+        described_instance.push('origin', push_option: %w[foo bar])
+      end
+    end
+
+    # --- branch without remote raises ---------------------------------------
+
+    context 'when branch is given without a remote' do
+      it 'raises ArgumentError before calling the command' do
+        expect(push_command).not_to receive(:call)
+        expect { described_instance.push(nil, 'main') }
+          .to raise_error(ArgumentError, /remote is required/)
+      end
+    end
+
+    # --- Option whitelisting -------------------------------------------------
+
+    context 'with an unknown option key' do
+      it 'raises ArgumentError before calling the command' do
+        expect(push_command).not_to receive(:call)
+        expect { described_instance.push('origin', unknown_key: true) }
+          .to raise_error(ArgumentError, /unknown_key/)
+      end
+    end
+
+    context 'with :branches option (supported by command but not 4.x facade)' do
+      it 'raises ArgumentError' do
+        expect(push_command).not_to receive(:call)
+        expect { described_instance.push('origin', branches: true) }
+          .to raise_error(ArgumentError, /branches/)
+      end
+    end
+
+    context 'with :timeout option (supported by command but not 4.x facade)' do
+      it 'raises ArgumentError' do
+        expect(push_command).not_to receive(:call)
+        expect { described_instance.push('origin', timeout: 30) }
+          .to raise_error(ArgumentError, /timeout/)
       end
     end
   end

--- a/tests/units/test_push.rb
+++ b/tests/units/test_push.rb
@@ -68,13 +68,14 @@ class TestPush < Test::Unit::TestCase
   test 'push with tags: true does a second tags push and returns its stdout' do
     in_temp_dir do
       git = Git.init('.', initial_branch: 'master')
-      push_cmd = Git::Commands::Push.new(git.lib)
+      execution_context = git.send(:facade_repository).execution_context
+      push_cmd = Git::Commands::Push.new(execution_context)
 
       status = Struct.new(:success?, :exitstatus, :signaled?).new(true, 0, false)
       first_result = Git::CommandLineResult.new(%w[git push], status, 'first push', '')
       second_result = Git::CommandLineResult.new(%w[git push], status, 'tags push', '')
 
-      Git::Commands::Push.expects(:new).with(git.lib).twice.returns(push_cmd)
+      Git::Commands::Push.expects(:new).with(execution_context).twice.returns(push_cmd)
       push_cmd.expects(:call).with('origin', 'master').returns(first_result)
       push_cmd.expects(:call).with('origin', tags: true).returns(second_result)
 
@@ -85,12 +86,13 @@ class TestPush < Test::Unit::TestCase
   test 'push with mirror: true and tags: true silently drops tags push' do
     in_temp_dir do
       git = Git.init('.', initial_branch: 'master')
-      push_cmd = Git::Commands::Push.new(git.lib)
+      execution_context = git.send(:facade_repository).execution_context
+      push_cmd = Git::Commands::Push.new(execution_context)
 
       status = Struct.new(:success?, :exitstatus, :signaled?).new(true, 0, false)
       result = Git::CommandLineResult.new(%w[git push], status, 'mirror push', '')
 
-      Git::Commands::Push.expects(:new).with(git.lib).once.returns(push_cmd)
+      Git::Commands::Push.expects(:new).with(execution_context).once.returns(push_cmd)
       push_cmd.expects(:call).with('origin', 'master', mirror: true).returns(result)
 
       assert_equal('mirror push', git.push('origin', 'master', mirror: true, tags: true))
@@ -100,13 +102,14 @@ class TestPush < Test::Unit::TestCase
   test 'push with all: true and tags: true allows the mutually exclusive combination' do
     in_temp_dir do
       git = Git.init('.', initial_branch: 'master')
-      push_cmd = Git::Commands::Push.new(git.lib)
+      execution_context = git.send(:facade_repository).execution_context
+      push_cmd = Git::Commands::Push.new(execution_context)
 
       status = Struct.new(:success?, :exitstatus, :signaled?).new(true, 0, false)
       first_result = Git::CommandLineResult.new(%w[git push], status, 'all push', '')
       second_result = Git::CommandLineResult.new(%w[git push], status, 'all tags push', '')
 
-      Git::Commands::Push.expects(:new).with(git.lib).twice.returns(push_cmd)
+      Git::Commands::Push.expects(:new).with(execution_context).twice.returns(push_cmd)
       push_cmd.expects(:call).with('origin', all: true).returns(first_result)
       push_cmd.expects(:call).with('origin', all: true, tags: true).returns(second_result)
 


### PR DESCRIPTION
## Summary
- add `Git::Repository::RemoteOperations#push` to handle push execution through the repository facade
- delegate `Git::Base#push` to the new facade method
- update unit and integration coverage for the extracted push path

## Notes
- branch is clean and ready for review
- changes are limited to the push remote operations extraction