### PR TITLE
fix(remote_operations): raise ArgumentError when :ref is supplied without an explicit remote (#1291)

### DIFF
--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -110,19 +110,18 @@ module Git
       #     from each branch tip (`--depth=N`)
       #
       #   @option opts [String, Array<String>] :ref (nil) one or more refspecs to
-      #     fetch; forwarded as positional arguments after the remote name
+      #     fetch; forwarded as positional arguments after the remote name. An
+      #     explicit `remote` is required when `:ref` is given.
       #
       #   @return [String] the merged stdout from the fetch command
       #
-      #   @raise [ArgumentError] when unsupported option keys are provided
+      #   @raise [ArgumentError] when unsupported option keys are provided or `:ref`
+      #     is supplied without an explicit remote
       #
       #   @raise [Git::FailedError] when git exits with a non-zero status
       #
       def fetch(remote = 'origin', opts = {})
-        if remote.is_a?(Hash)
-          opts = remote
-          remote = nil
-        end
+        remote, opts = Private.resolve_fetch_target(remote, opts)
 
         opts = Private.normalize_fetch_keys(opts)
         SharedPrivate.assert_valid_opts!(FETCH_ALLOWED_OPTS, **opts)
@@ -371,6 +370,33 @@ module Git
       #
       module Private
         module_function
+
+        # Resolve the (remote, opts) pair for {#fetch}, supporting the hash-only form
+        #
+        # `fetch` may be called as `fetch(remote, opts)` or `fetch(opts)`. When a bare
+        # options hash is passed the remote is treated as nil. A `:ref` is only
+        # meaningful with an explicit remote, so requesting one without a remote (it
+        # would otherwise be silently promoted to the remote-name slot) is rejected.
+        #
+        # @param remote [String, Hash, nil] the remote name, or an options hash
+        # @param opts [Hash] the options hash when remote is given positionally
+        #
+        # @return [Array(String, Hash), Array(nil, Hash)] the resolved remote and opts
+        #
+        # @raise [ArgumentError] when :ref is supplied without an explicit remote
+        #
+        # @api private
+        #
+        def resolve_fetch_target(remote, opts)
+          if remote.is_a?(Hash)
+            opts = remote
+            remote = nil
+          end
+
+          raise ArgumentError, ':ref requires an explicit remote' if remote.nil? && opts.key?(:ref)
+
+          [remote, opts]
+        end
 
         # Normalize dash-style option keys to their underscore equivalents
         #

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -108,16 +108,12 @@ RSpec.describe Git::Repository::RemoteOperations do
       end
     end
 
-    # Known bug: when :ref is supplied without an explicit remote, the refspec is
-    # promoted to the :repository operand slot, causing git to treat it as a remote
-    # name/URL. This will be fixed in issue #1291.
     context 'with :ref and no remote (Hash form)' do
       subject(:result) { described_instance.fetch(ref: 'refs/heads/main') }
 
-      it 'passes the refspec as the repository positional (pre-#1291 behaviour)' do
-        expect(fetch_command)
-          .to receive(:call).with('refs/heads/main', merge: true).and_return(fetch_result)
-        result
+      it 'raises ArgumentError instead of promoting the refspec to the :repository slot' do
+        expect(Git::Commands::Fetch).not_to receive(:new)
+        expect { result }.to raise_error(ArgumentError, /:ref requires an explicit remote/)
       end
     end
 


### PR DESCRIPTION
Closes #1291.

`Git::Repository::RemoteOperations#fetch` shifts a single hash argument into `opts` and sets `remote = nil`. The subsequent `positionals = [*([remote] if remote), *refspecs]` then leaves the refspec as the first positional, which the command layer binds to the `:repository` operand. `git fetch refs/heads/main` is then interpreted as a remote name and fails with "does not appear to be a git repository".

Adds the guard suggested in the issue: if `remote` is nil after the hash shift and `:ref` is present, raise `ArgumentError` with a hint pointing at the two-arg form.

The existing pre-fix unit test in `spec/unit/git/repository/remote_operations_spec.rb` documented the buggy behaviour and explicitly tagged itself for removal here; it now asserts the `ArgumentError` instead and verifies the command layer is never reached.