### PR TITLE
docs(contributing): document and enforce local development setup (#1297)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,5 +13,7 @@ Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/bl
 - [ ] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
   and verify any AI-assisted changes included in this PR and ensured they meet
   quality, security, and licensing standards.
-- [ ] Tests added/updated as needed and `rake` passes locally.
+- [ ] I ran `bundle exec rake` locally on this branch and it passed (see
+  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
+- [ ] Tests added/updated as needed.
 - [ ] Documentation updated where applicable (README and/or YARD).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,10 +8,16 @@
 - [Summary](#summary)
 - [How to contribute](#how-to-contribute)
 - [How to report an issue or request a feature](#how-to-report-an-issue-or-request-a-feature)
+- [Local development setup](#local-development-setup)
+  - [Prerequisites](#prerequisites)
+  - [Bootstrap the project](#bootstrap-the-project)
+  - [Verify the toolchain](#verify-the-toolchain)
+  - [Contributor validation policy](#contributor-validation-policy)
 - [How to submit a code or documentation change](#how-to-submit-a-code-or-documentation-change)
   - [Commit your changes to a fork of `ruby-git`](#commit-your-changes-to-a-fork-of-ruby-git)
   - [Create a pull request](#create-a-pull-request)
   - [Get your pull request reviewed](#get-your-pull-request-reviewed)
+  - [Before requesting review](#before-requesting-review)
 - [Branch strategy](#branch-strategy)
 - [AI-assisted contributions](#ai-assisted-contributions)
 - [Design philosophy](#design-philosophy)
@@ -76,6 +82,60 @@ To report an issue or request a feature, please [create a `ruby-git` GitHub
 issue](https://github.com/ruby-git/ruby-git/issues/new). Fill in the template as
 thoroughly as possible to describe the issue or feature request.
 
+## Local development setup
+
+Before submitting a change, set up a working local development environment.
+`bin/setup` automates the bootstrap and fails fast with a clear message when a
+prerequisite is missing.
+
+### Prerequisites
+
+| Tool | Required version | Notes |
+| --- | --- | --- |
+| Ruby | `>= 3.2.0` (matches `required_ruby_version` in [`git.gemspec`](git.gemspec)) | A version manager such as [rbenv](https://github.com/rbenv/rbenv), [asdf](https://asdf-vm.com/), [chruby](https://github.com/postmodern/chruby), or [rvm](https://rvm.io/) is recommended so you can match the project's CI matrix. |
+| Bundler | Any 2.x or 4.x | Install with `gem install bundler`. |
+| git | `>= 2.28.0` (matches `git.gemspec` `requirements`) | Older git versions are not supported and the test suite will not pass against them. |
+| Node.js / npm | Optional | Required only to install the local Conventional Commit `commit-msg` hook (Husky + commitlint). If npm is missing, `bin/setup` will warn and continue — CI will still validate commit messages. |
+
+### Bootstrap the project
+
+From the project root, run:
+
+```shell
+bin/setup
+```
+
+`bin/setup` will:
+
+1. Verify the prerequisites above and exit with a non-zero status if any are
+   missing or out of date.
+2. Run `bundle install` to install Ruby gem dependencies.
+3. Run `npm install` (when npm is available) to install the Conventional Commit
+   `commit-msg` hook used by this project (Husky + commitlint). A separate
+   `pre-commit` hook is also installed that blocks direct commits to the
+   protected branches (`main`, `4.x`).
+4. Verify the toolchain by running `bundle exec rake --tasks`.
+
+### Verify the toolchain
+
+Once `bin/setup` succeeds, confirm the full test and lint suite passes locally:
+
+```shell
+bundle exec rake
+```
+
+This is the same default task that runs in CI and is the canonical way to
+validate a change before requesting review.
+
+### Contributor validation policy
+
+Contributors are expected to run `bundle exec rake` locally and confirm it
+passes before requesting review on a pull request — trivial documentation-only
+fixes (e.g., typo corrections in markdown files) are excepted. "CI passed" is
+not a substitute for local validation; it is a backstop. This applies equally to
+human-authored and AI-assisted contributions — see
+[AI-assisted contributions](#ai-assisted-contributions).
+
 ## How to submit a code or documentation change
 
 There is a three-step process for submitting code or documentation changes:
@@ -114,6 +174,20 @@ At least one approval from a project maintainer is required before your pull req
 can be merged. The maintainer is responsible for ensuring that the pull request meets
 [the project's coding standards](#coding-standards).
 
+### Before requesting review
+
+Before moving a pull request out of draft or requesting a review, confirm:
+
+- [ ] `bundle exec rake` passes locally on your branch (see
+  [Local development setup](#local-development-setup)).
+- [ ] New or changed code has accompanying tests under `spec/`
+  (see [Unit tests](#unit-tests)).
+- [ ] Every commit message follows [Conventional Commits](#commit-message-guidelines).
+- [ ] User-facing changes are documented in `README.md` and/or YARD as appropriate.
+
+These checks mirror what reviewers and CI will look for; running them locally
+first keeps the review cycle short.
+
 ## Branch strategy
 
 This project maintains two active branches:
@@ -139,6 +213,13 @@ AI-assisted contributions are welcome. Please review and apply our [AI
 Policy](AI_POLICY.md) before submitting changes. You are responsible for
 understanding and verifying any AI-assisted work included in PRs and ensuring it
 meets our standards for quality, security, and licensing.
+
+The **human submitter** — not the AI agent — is responsible for ensuring that
+`bundle exec rake` passes locally before requesting review. This is true even
+when the change was authored end-to-end by an agent. "The agent ran the tests"
+and "CI is green" are not substitutes for the submitter running
+[the local validation step](#contributor-validation-policy) themselves; CI is a
+backstop, not a primary validation surface.
 
 ## Design philosophy
 
@@ -684,8 +765,11 @@ Commits standard](https://www.conventionalcommits.org/en/v1.0.0/). Commits not
 adhering to this standard will cause the CI build to fail. PRs will not be merged if
 they include non-conventional commits.
 
-A git pre-commit hook may be installed to validate your conventional commit messages
-before pushing them to GitHub by running `bin/setup` in the project root.
+A git `commit-msg` hook (Husky + commitlint) that validates your Conventional
+Commit messages locally is installed automatically as part of the project
+bootstrap — see [Local development setup](#local-development-setup). The hook
+depends on Node.js and npm; if those are not installed, `bin/setup` will warn
+and skip the hook, and commit-message validation will only run in CI.
 
 #### What to know about Conventional Commits
 

--- a/bin/setup
+++ b/bin/setup
@@ -1,13 +1,158 @@
 #!/usr/bin/env bash
+#
+# Bootstrap the ruby-git development environment.
+#
+# This script:
+#   * verifies that the required Ruby and git versions are installed
+#   * installs Ruby gem dependencies via Bundler
+#   * installs the optional Node.js tooling used for the Conventional Commit
+#     commit-msg hook (Husky + commitlint)
+#   * verifies the toolchain by listing the available rake tasks
+#
+# Run this from the project root after cloning the repository.
+
 set -euo pipefail
 IFS=$'\n\t'
-set -vx
 
-bundle install
+GEMSPEC="git.gemspec"
 
-if [ -x "$(command -v npm)" ]; then
-  npm install
-else
-  echo "npm is not installed"
-  echo "Install npm then re-run this script to enable the conventional commit git hook."
+red()   { printf '\033[31m%s\033[0m\n' "$*" >&2; }
+green() { printf '\033[32m%s\033[0m\n' "$*"; }
+warn()  { printf '\033[33m%s\033[0m\n' "$*" >&2; }
+info()  { printf '%s\n' "$*"; }
+
+# Compare two dotted version strings. Returns 0 (true) if $1 >= $2.
+version_ge() {
+  # Use sort -V to get the lower of the two; if it equals $2, then $1 >= $2.
+  [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | head -n1)" = "$2" ]
+}
+
+# Extract the minimum Ruby version from required_ruby_version in the gemspec
+# (e.g., `spec.required_ruby_version = '>= 3.2.0'`). The gemspec is the
+# authoritative source; bin/setup must not duplicate it.
+required_ruby_version() {
+  local v
+  v=$(sed -n "s/^[[:space:]]*spec\.required_ruby_version[[:space:]]*=[[:space:]]*['\"]>=[[:space:]]*\([0-9.]*\)['\"].*/\1/p" "${GEMSPEC}")
+  if [ -z "${v}" ]; then
+    red "ERROR: could not parse required_ruby_version from ${GEMSPEC}."
+    red "       Expected a line like: spec.required_ruby_version = '>= X.Y.Z'"
+    exit 1
+  fi
+  printf '%s' "${v}"
+}
+
+# Extract the minimum git version from the gemspec requirements line
+# (e.g., `spec.requirements = ['git 2.28.0 or greater']`). The gemspec is the
+# authoritative source; bin/setup must not duplicate it.
+required_git_version() {
+  local v
+  v=$(sed -n "s/.*git[[:space:]]\([0-9.][0-9.]*\)[[:space:]]or[[:space:]]greater.*/\1/p" "${GEMSPEC}")
+  if [ -z "${v}" ]; then
+    red "ERROR: could not parse the required git version from ${GEMSPEC}."
+    red "       Expected a line like: spec.requirements = ['git X.Y.Z or greater']"
+    exit 1
+  fi
+  printf '%s' "${v}"
+}
+
+check_ruby() {
+  local required="$1"
+  if ! command -v ruby >/dev/null 2>&1; then
+    red "ERROR: ruby is not installed or not on PATH."
+    red "       ruby-git requires Ruby >= ${required}."
+    red "       See CONTRIBUTING.md → Local development setup for installation guidance."
+    exit 1
+  fi
+
+  local ruby_version
+  ruby_version=$(ruby -e 'print RUBY_VERSION')
+  if ! version_ge "${ruby_version}" "${required}"; then
+    red "ERROR: Ruby ${ruby_version} is too old."
+    red "       ruby-git requires Ruby >= ${required} (per ${GEMSPEC})."
+    red "       Use rbenv, asdf, chruby, or rvm to install a supported version."
+    exit 1
+  fi
+  green "✓ Ruby ${ruby_version} (>= ${required})"
+}
+
+check_git() {
+  local required="$1"
+  if ! command -v git >/dev/null 2>&1; then
+    red "ERROR: git is not installed or not on PATH."
+    red "       ruby-git requires git >= ${required}."
+    exit 1
+  fi
+
+  local git_version
+  # `git --version` prints e.g. "git version 2.43.0" or "git version 2.43.0.windows.1".
+  git_version=$(git --version | awk '{print $3}' | cut -d. -f1-3)
+  if ! version_ge "${git_version}" "${required}"; then
+    red "ERROR: git ${git_version} is too old."
+    red "       ruby-git requires git >= ${required} (per ${GEMSPEC})."
+    exit 1
+  fi
+  green "✓ git ${git_version} (>= ${required})"
+}
+
+check_bundler() {
+  if ! command -v bundle >/dev/null 2>&1; then
+    red "ERROR: bundler is not installed."
+    red "       Install it with: gem install bundler"
+    exit 1
+  fi
+  # `bundle --version` prints either "Bundler version X.Y.Z" or just "X.Y.Z"
+  # depending on the bundler release; handle both.
+  local bundler_version
+  bundler_version=$(bundle --version | awk '{print $NF}')
+  green "✓ bundler ${bundler_version}"
+}
+
+install_gems() {
+  info ""
+  info "Installing Ruby gem dependencies (bundle install)..."
+  bundle install
+}
+
+install_npm_tooling() {
+  info ""
+  if command -v npm >/dev/null 2>&1; then
+    green "✓ npm $(npm --version) found — installing commit-msg hook tooling"
+    npm install
+  else
+    warn "npm is not installed — skipping installation of the Conventional Commit commit-msg hook."
+    warn "Consequence: commit messages will NOT be validated locally before push."
+    warn "             CI will still validate them and fail the build for non-conforming commits."
+    warn "Install Node.js / npm and re-run bin/setup to enable the local hook."
+  fi
+}
+
+verify_toolchain() {
+  info ""
+  info "Verifying the toolchain (bundle exec rake --tasks)..."
+  if ! bundle exec rake --tasks >/dev/null; then
+    red "ERROR: 'bundle exec rake --tasks' failed."
+    red "       The toolchain is not in a working state. Inspect the output above."
+    exit 1
+  fi
+  green "✓ Toolchain verified"
+}
+
+if [ ! -f "${GEMSPEC}" ]; then
+  red "ERROR: ${GEMSPEC} not found. Run bin/setup from the project root."
+  exit 1
 fi
+
+REQUIRED_RUBY_VERSION=$(required_ruby_version)
+REQUIRED_GIT_VERSION=$(required_git_version)
+
+info "Checking prerequisites (minimums read from ${GEMSPEC})..."
+check_ruby "${REQUIRED_RUBY_VERSION}"
+check_git "${REQUIRED_GIT_VERSION}"
+check_bundler
+
+install_gems
+install_npm_tooling
+verify_toolchain
+
+info ""
+green "Setup complete. Run 'bundle exec rake' to execute the full test and lint suite before requesting review."


### PR DESCRIPTION
## Summary

Closes #1297. Makes the local development setup discoverable, reproducible, and enforced — and makes `bin/setup` fail fast with a clear message when prerequisites are missing.

## Changes

### `bin/setup` — hardened bootstrap

- Checks Ruby `>= 3.2.0` (the gemspec's `required_ruby_version`) and exits with a clear message if missing or too old.
- Checks `git --version >= 2.28.0` (per the gemspec `requirements`) and exits with a clear message if missing or too old.
- Checks for `bundler`.
- npm handling is now explicit: when missing, the warning states the consequence ("the Conventional Commit hook will not be installed; CI will still validate commit messages") instead of being silently optional.
- Added a verification step that runs `bundle exec rake --tasks` to confirm the toolchain works end-to-end.
- Removed `set -vx` so the prerequisite-check messages are not buried in trace output.

### `CONTRIBUTING.md` — documented contributor workflow

- New top-level **Local development setup** section covering prerequisites (Ruby, bundler, git, optional Node.js/npm), how to run `bin/setup`, and verifying with `bundle exec rake`.
- New **Before requesting review** subsection under *Get your pull request reviewed* listing the local-validation checklist (rake passes, tests added, conventional commits, docs updated).
- New explicit **Contributor validation policy** sentence with the "trivial doc-only fixes excepted" carve-out so reviewers have something to point to.
- The **AI-assisted contributions** section now states that the human submitter (not the agent) is responsible for ensuring `bundle exec rake` passes locally, and that "CI passed" is not a substitute for local validation.
- The existing `bin/setup` mention under the commit-message guidelines now points at the new *Local development setup* section instead of describing `bin/setup` as just the hook installer.

### `.github/pull_request_template.md`

- Added an explicit checkbox: "I ran `bundle exec rake` locally on this branch and it passed", linked to the new *Local development setup* section.

## Validation

- `bash -n bin/setup` clean; ran `bin/setup` end-to-end on macOS — prerequisite checks pass, gems install, npm hook installs, toolchain verification succeeds.
- `bundle exec rake` passes locally on this branch (RSpec + Test::Unit + RuboCop + YARD coverage 77.8%).

## Notes

- The README already prominently links to `CONTRIBUTING.md` from the *Project Policies* table; the optional README discoverability item from the issue is therefore left as-is.
- The Docker tooling caveat from the issue notes is unchanged — Docker workflow is out of scope.
