### PR TITLE
ci: add spec:unit hang diagnostics for JRuby (#1286)

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,8 +5,16 @@
 $stdout.sync = true
 $stderr.sync = true
 
+# On JRuby, print a loading-phase marker so that CI logs can distinguish a hang
+# during file loading from a hang during a specific test. Without this, a hang
+# before the first RSpec example produces no output at all.
+warn "[spec_helper] JRuby #{RUBY_VERSION}: beginning spec_helper load" if RUBY_ENGINE == 'jruby'
+
 # Load support files
-Dir[File.join(__dir__, 'support', '**', '*.rb')].each { |f| require f }
+Dir[File.join(__dir__, 'support', '**', '*.rb')].each do |f|
+  warn "[spec_helper] requiring #{f}" if RUBY_ENGINE == 'jruby'
+  require f
+end
 
 # Configure RSpec
 RSpec.configure do |config|
@@ -135,6 +143,8 @@ if SIMPLECOV_ENABLED
 end
 
 require 'git'
+
+warn '[spec_helper] spec_helper fully loaded' if RUBY_ENGINE == 'jruby'
 
 # Helper to create a mock CommandLineResult for use in specs
 #

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -10,6 +10,10 @@ end
 # Run only unit specs (mocked, fast)
 RSpec::Core::RakeTask.new('spec:unit') do |t|
   t.pattern = 'spec/unit/**/*_spec.rb'
+  # On JRuby, use 'documentation' formatter so each test name is printed before
+  # it runs. When the suite hangs, the last printed line identifies the blocking
+  # test. Mirrors the same diagnostic added to spec:integration in PR #1274.
+  t.rspec_opts = '--format documentation' if RUBY_ENGINE == 'jruby'
 end
 
 # Run only integration specs (real git, slower)


### PR DESCRIPTION
## Summary

All three collected build logs for issue #1286 confirm the hang occurs in `rake spec:unit`, not `spec:integration`. The JRuby rspec command line is printed and then the process stalls silently until the 15-minute timeout — producing zero diagnostic output.

## Changes

### `tasks/rspec.rake`

Enable `--format documentation` for `spec:unit` on JRuby, mirroring the same flag already applied to `spec:integration` in PR #1274. When the hang is during test execution, the last printed test name identifies the blocking example.

### `spec/spec_helper.rb`

Add JRuby-only `$stderr.puts` markers at three checkpoints:

- `[spec_helper] beginning spec_helper load` — printed immediately; if this never appears, the hang is in JVM/RSpec startup before `spec_helper` is required
- `[spec_helper] requiring <file>` — printed before each support file; if this hangs mid-list, a specific support file is responsible
- `[spec_helper] spec_helper fully loaded` — printed after `require 'git'` and SimpleCov; if the beginning marker appears but this one doesn't, the hang is inside `require 'git'` or the SimpleCov block

## How the diagnostics will be used

On the next JRuby hang, the last line printed to stderr will pinpoint exactly which phase stalled — making the root cause unambiguous.

Closes #1286