### PR TITLE
feat(repository): add Git::Repository::Stashing#stash_save facade method

### DIFF
--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -6,6 +6,7 @@ require 'git/repository/committing'
 require 'git/repository/merging'
 require 'git/repository/remote_operations'
 require 'git/repository/staging'
+require 'git/repository/stashing'
 
 module Git
   # The main public interface for interacting with a Git repository
@@ -38,6 +39,7 @@ module Git
     include Git::Repository::Merging
     include Git::Repository::RemoteOperations
     include Git::Repository::Staging
+    include Git::Repository::Stashing
 
     # @return [Git::ExecutionContext::Repository] the execution context used to run
     #   git commands for this repository

--- a/lib/git/repository/stashing.rb
+++ b/lib/git/repository/stashing.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require 'git/commands/stash'
+
+module Git
+  class Repository
+    # Facade methods for stash operations
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module Stashing
+      # Save the current working directory and index state to a new stash
+      #
+      # @param message [String] the stash message
+      #
+      # @return [Boolean] true if changes were stashed, false if there were no
+      #   local changes to save
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      # @example Save current changes
+      #   repo.stash_save('WIP: feature work')
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stash_save(message) # rubocop:disable Naming/PredicateMethod
+        result = Git::Commands::Stash::Push.new(@execution_context).call(message: message)
+        !result.stdout.include?('No local changes to save')
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository/stashing_spec.rb
+++ b/spec/unit/git/repository/stashing_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/stashing'
+
+# Integration-level coverage for Git::Repository::Stashing#stash_save is provided
+# by the underlying command integration test:
+#   spec/integration/git/commands/stash/push_spec.rb
+# The facade delegates to a single Git::Commands::Stash::Push class with no
+# multi-command orchestration. The unit spec below covers the facade's own
+# behavior (Boolean return-value derivation from stdout); the command integration
+# spec covers end-to-end git execution.
+
+RSpec.describe Git::Repository::Stashing do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  let(:push_command) { instance_double(Git::Commands::Stash::Push) }
+
+  before do
+    allow(Git::Commands::Stash::Push).to receive(:new).with(execution_context).and_return(push_command)
+  end
+
+  describe '#stash_save' do
+    context 'when there are local changes to save' do
+      let(:push_result) { command_result('Saved working directory and index state On main: WIP: feature work') }
+
+      it 'calls Git::Commands::Stash::Push with the given message' do
+        expect(push_command).to receive(:call).with(message: 'WIP: feature work').and_return(push_result)
+        described_instance.stash_save('WIP: feature work')
+      end
+
+      it 'returns true' do
+        allow(push_command).to receive(:call).with(message: 'WIP: feature work').and_return(push_result)
+        expect(described_instance.stash_save('WIP: feature work')).to be(true)
+      end
+    end
+
+    context 'when there are no local changes to save' do
+      let(:push_result) { command_result('No local changes to save') }
+
+      it 'calls Git::Commands::Stash::Push with the given message' do
+        expect(push_command).to receive(:call).with(message: 'empty').and_return(push_result)
+        described_instance.stash_save('empty')
+      end
+
+      it 'returns false' do
+        allow(push_command).to receive(:call).with(message: 'empty').and_return(push_result)
+        expect(described_instance.stash_save('empty')).to be(false)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds `Git::Repository::Stashing#stash_save` as the first facade method in
the new `Git::Repository::Stashing` topic module, as part of Phase 3 of the
v5.0.0 architectural redesign (Strangler Fig migration of `Git::Base` /
`Git::Lib` into `Git::Repository`).

This is a Pattern B extraction: `Git::Lib#stash_save` has no `Git::Base`
wrapper and is called publicly via `g.lib.stash_save(message)` and
internally by `Git::Stash#save`. The `Git::Lib` method is left intact for
now; it will be updated to delegate to the facade in a later PR when
`Git::Stash` itself migrates.

## Changes

- **`lib/git/repository/stashing.rb`** (new) — `Git::Repository::Stashing`
  module with `#stash_save(message)`. Delegates to
  `Git::Commands::Stash::Push` and derives a `Boolean` return value from
  the command stdout (preserving the 4.x contract).
- **`lib/git/repository.rb`** — `require` + `include` for the new module.
- **`spec/unit/git/repository/stashing_spec.rb`** (new) — 4 unit examples
  covering both `true` (changes stashed) and `false` (no local changes)
  return values, and verifying `message:` forwarding to the command.

## Testing

- 4 new unit examples, all passing.
- No integration tests added — `#stash_save` is a single-command delegator
  with a trivial pure-Ruby post-processing step; `Git::Commands::Stash::Push`
  already has integration test coverage for the underlying git invocation.
- Full `bundle exec rake` suite passes (0 failures, YARD ≥ 75%).
