### PR TITLE
feat(repository): add Git::Repository#stash_apply facade method

### DIFF
--- a/lib/git/repository/stashing.rb
+++ b/lib/git/repository/stashing.rb
@@ -18,7 +18,7 @@ module Git
       # @return [Boolean] true if changes were stashed, false if there were no
       #   local changes to save
       #
-      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
       # @example Save current changes
       #   repo.stash_save('WIP: feature work')
@@ -28,6 +28,31 @@ module Git
       def stash_save(message) # rubocop:disable Naming/PredicateMethod
         result = Git::Commands::Stash::Push.new(@execution_context).call(message: message)
         !result.stdout.include?('No local changes to save')
+      end
+
+      # Apply a stash to the working directory
+      #
+      # Applies the changes recorded in a stash entry to the working directory
+      # without removing the entry from the stash list. Unlike `git stash pop`,
+      # the stash entry is preserved after applying.
+      #
+      # @example Apply the most recent stash
+      #   repo.stash_apply #=> "HEAD is now at abc1234 Initial commit"
+      #
+      # @example Apply a specific stash entry by reference
+      #   repo.stash_apply('stash@{1}') #=> "HEAD is now at abc1234 Initial commit"
+      #
+      # @param id [String, Integer, nil] the stash identifier (e.g., `'stash@{0}'`,
+      #   `0`) or `nil` to apply the most recent stash entry
+      #
+      # @return [String] the output from the git stash apply command
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stash_apply(id = nil)
+        Git::Commands::Stash::Apply.new(@execution_context).call(id).stdout
       end
     end
   end

--- a/spec/unit/git/repository/stashing_spec.rb
+++ b/spec/unit/git/repository/stashing_spec.rb
@@ -4,13 +4,13 @@ require 'spec_helper'
 require 'git/repository'
 require 'git/repository/stashing'
 
-# Integration-level coverage for Git::Repository::Stashing#stash_save is provided
-# by the underlying command integration test:
-#   spec/integration/git/commands/stash/push_spec.rb
-# The facade delegates to a single Git::Commands::Stash::Push class with no
-# multi-command orchestration. The unit spec below covers the facade's own
-# behavior (Boolean return-value derivation from stdout); the command integration
-# spec covers end-to-end git execution.
+# Integration-level coverage for Git::Repository::Stashing facade methods is
+# provided by the underlying command integration tests:
+#   spec/integration/git/commands/stash/push_spec.rb   (stash_save)
+#   spec/integration/git/commands/stash/apply_spec.rb  (stash_apply)
+# Each facade method delegates to a single Git::Commands::Stash::* class with no
+# multi-command orchestration. The unit specs below cover each facade method's own
+# behavior; the command integration specs cover end-to-end git execution.
 
 RSpec.describe Git::Repository::Stashing do
   let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
@@ -48,6 +48,46 @@ RSpec.describe Git::Repository::Stashing do
       it 'returns false' do
         allow(push_command).to receive(:call).with(message: 'empty').and_return(push_result)
         expect(described_instance.stash_save('empty')).to be(false)
+      end
+    end
+  end
+
+  describe '#stash_apply' do
+    let(:apply_command) { instance_double(Git::Commands::Stash::Apply) }
+    let(:apply_result) { command_result('HEAD is now at abc1234 Initial commit') }
+
+    before do
+      allow(Git::Commands::Stash::Apply).to receive(:new).with(execution_context).and_return(apply_command)
+    end
+
+    context 'when no id is given' do
+      it 'calls Git::Commands::Stash::Apply#call with nil' do
+        expect(apply_command).to receive(:call).with(nil).and_return(apply_result)
+        described_instance.stash_apply
+      end
+
+      it 'returns the stdout string' do
+        allow(apply_command).to receive(:call).with(nil).and_return(apply_result)
+        expect(described_instance.stash_apply).to eq('HEAD is now at abc1234 Initial commit')
+      end
+    end
+
+    context 'when a string stash reference is given' do
+      it 'calls Git::Commands::Stash::Apply#call with the reference' do
+        expect(apply_command).to receive(:call).with('stash@{1}').and_return(apply_result)
+        described_instance.stash_apply('stash@{1}')
+      end
+
+      it 'returns the stdout string' do
+        allow(apply_command).to receive(:call).with('stash@{1}').and_return(apply_result)
+        expect(described_instance.stash_apply('stash@{1}')).to eq('HEAD is now at abc1234 Initial commit')
+      end
+    end
+
+    context 'when an integer index is given' do
+      it 'calls Git::Commands::Stash::Apply#call with the integer' do
+        expect(apply_command).to receive(:call).with(2).and_return(apply_result)
+        described_instance.stash_apply(2)
       end
     end
   end


### PR DESCRIPTION
## Summary

Adds `Git::Repository::Stashing#stash_apply` as part of the iter 1 Strangler Fig migration of stash operations to `Git::Repository`.

## Changes

- **`lib/git/repository/stashing.rb`** — adds `stash_apply(id = nil)` to `Git::Repository::Stashing`. Delegates to `Git::Commands::Stash::Apply` and returns the command stdout as a `String`, preserving the public contract of `Git::Lib#stash_apply`.
- **`spec/unit/git/repository/stashing_spec.rb`** — adds 5 unit examples under `describe '#stash_apply'` covering the default invocation (`nil`), a string stash reference (`'stash@{1}'`), and an integer index. Updates the integration-coverage comment to reference both `push_spec.rb` and `apply_spec.rb`.

## Notes

- `Git::Lib#stash_apply` is left in place (implementation unchanged). Delegation to the new facade method is deferred to the Phase B domain-object migration (iter 1), matching the `stash_save` precedent.
- Integration tests are intentionally omitted — `stash_apply` is a one-line delegator with no facade-level orchestration; `spec/integration/git/commands/stash/apply_spec.rb` already covers end-to-end behaviour.

## Quality gates

All 6 quality gates pass: `test:parallel`, `spec:unit:parallel`, `spec:integration:parallel`, `rubocop`, `yard`, `build`.