### PR TITLE
feat(repository): add Git::Repository#stash_clear facade method

### DIFF
--- a/lib/git/repository/stashing.rb
+++ b/lib/git/repository/stashing.rb
@@ -54,6 +54,25 @@ module Git
       def stash_apply(id = nil)
         Git::Commands::Stash::Apply.new(@execution_context).call(id).stdout
       end
+
+      # Remove all stash entries
+      #
+      # Removes all entries from the stash list. Use with caution as this
+      # operation cannot be undone.
+      #
+      # @return [String] the output from the git stash clear command
+      #   (typically empty)
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @example Clear all stashes
+      #   repo.stash_clear #=> ""
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stash_clear
+        Git::Commands::Stash::Clear.new(@execution_context).call.stdout
+      end
     end
   end
 end

--- a/spec/unit/git/repository/stashing_spec.rb
+++ b/spec/unit/git/repository/stashing_spec.rb
@@ -91,4 +91,23 @@ RSpec.describe Git::Repository::Stashing do
       end
     end
   end
+
+  describe '#stash_clear' do
+    let(:clear_command) { instance_double(Git::Commands::Stash::Clear) }
+    let(:clear_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Stash::Clear).to receive(:new).with(execution_context).and_return(clear_command)
+    end
+
+    it 'calls Git::Commands::Stash::Clear with the execution context' do
+      expect(clear_command).to receive(:call).with(no_args).and_return(clear_result)
+      described_instance.stash_clear
+    end
+
+    it 'returns the stdout string' do
+      allow(clear_command).to receive(:call).and_return(clear_result)
+      expect(described_instance.stash_clear).to eq('')
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Extracts `stash_clear` from `Git::Lib` into the `Git::Repository::Stashing` facade module as part of the Phase 3 domain-object migration (iter 1).

The facade method delegates to `Git::Commands::Stash::Clear` and returns the `String` stdout, preserving the public contract of `Git::Lib#stash_clear`.

## Changes

- `lib/git/repository/stashing.rb` — add `#stash_clear` facade method
- `spec/unit/git/repository/stashing_spec.rb` — add unit tests for `#stash_clear`

## Testing

- Unit tests added covering:
  - delegation to `Git::Commands::Stash::Clear` with the correct execution context
  - return value is the stdout `String`
- No integration tests added — `stash_clear` is a true one-line delegator; end-to-end coverage is provided by the command's own integration tests (same rationale as `stash_save` and `stash_apply`)
- All quality gates pass: `test:parallel`, `spec:unit:parallel`, `spec:integration:parallel`, `rubocop`, `yard`, `build`

## Context

Part of the Phase 3 architectural redesign tracked in issue 1299. This completes the Phase A facade methods for `Git::Repository::Stashing` needed by iter 1 (`stash_save` and `stash_apply` were already in place).