### PR TITLE
feat(repository): add Git::Repository#stashes_all facade method

### DIFF
--- a/lib/git/repository/stashing.rb
+++ b/lib/git/repository/stashing.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'git/commands/stash'
+require 'git/parsers/stash'
 
 module Git
   class Repository
@@ -11,6 +12,34 @@ module Git
     # @api public
     #
     module Stashing
+      # Returns all stash entries as an array of index and message pairs
+      #
+      # Lists all stash entries in the repository ordered from oldest to newest.
+      # The index is a sequential number starting from 0 for the oldest stash. The
+      # message is the stash description with the leading branch prefix (e.g.
+      # `"On main:"` or `"WIP on main:"`) stripped.
+      #
+      # @example List all stashes (oldest first)
+      #   repo.stashes_all #=> [[0, "Fix bug"], [1, "Add feature"]]
+      #
+      # @return [Array<Array(Integer, String)>] array of `[index, message]` pairs
+      #   where index is the sequential position (0 is oldest) and message is the
+      #   stash description with the branch prefix stripped
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stashes_all
+        result = Git::Commands::Stash::List.new(@execution_context).call
+        stashes = Git::Parsers::Stash.parse_list(result.stdout)
+        stashes.reverse.each_with_index.map do |info, i|
+          match_data = info.message.match(/^[^:]+:(.*)$/)
+          message = match_data ? match_data[1].strip : info.message
+          [i, message]
+        end
+      end
+
       # Save the current working directory and index state to a new stash
       #
       # @param message [String] the stash message

--- a/spec/integration/git/repository/stashing_spec.rb
+++ b/spec/integration/git/repository/stashing_spec.rb
@@ -1,0 +1,78 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/stashing'
+require 'git/execution_context/repository'
+
+RSpec.describe Git::Repository::Stashing, :integration do
+  include_context 'in an empty repository'
+
+  let(:facade_execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
+  let(:described_instance) { Git::Repository.new(execution_context: facade_execution_context) }
+
+  before do
+    write_file('file.txt', 'initial content')
+    repo.add('file.txt')
+    repo.commit('Initial commit')
+  end
+
+  describe '#stashes_all' do
+    context 'when there are no stash entries' do
+      it 'returns an empty array' do
+        expect(described_instance.stashes_all).to eq([])
+      end
+    end
+
+    context 'when there is one stash entry with a branch prefix' do
+      before do
+        write_file('file.txt', 'modified content')
+        repo.lib.stash_save('my feature work')
+      end
+
+      it 'returns a single-element array with index 0' do
+        result = described_instance.stashes_all
+        expect(result.length).to eq(1)
+        expect(result.first.first).to eq(0)
+      end
+
+      it 'strips the branch prefix from the message' do
+        result = described_instance.stashes_all
+        # Git prefixes the message: "On main: my feature work"
+        # The facade strips the "On main:" prefix
+        expect(result.first.last).to eq('my feature work')
+      end
+    end
+
+    context 'when there are multiple stash entries' do
+      before do
+        write_file('file.txt', 'change for stash 1')
+        repo.lib.stash_save('first change')
+
+        write_file('file.txt', 'change for stash 2')
+        repo.lib.stash_save('second change')
+      end
+
+      it 'returns entries in oldest-first order' do
+        result = described_instance.stashes_all
+
+        expect(result.length).to eq(2)
+        expect(result.map(&:first)).to eq([0, 1])
+        expect(result.map(&:last)).to eq(['first change', 'second change'])
+      end
+    end
+
+    context 'when a stash message contains a colon (e.g. "saving: work")' do
+      before do
+        write_file('file.txt', 'modified content')
+        repo.lib.stash_save('saving: work')
+      end
+
+      it 'strips only the branch prefix and keeps the rest of the message' do
+        result = described_instance.stashes_all
+        # Git stores: "On main: saving: work"; facade strips "On main:" → "saving: work"
+        expect(result.first.last).to eq('saving: work')
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository/stashing_spec.rb
+++ b/spec/unit/git/repository/stashing_spec.rb
@@ -22,6 +22,94 @@ RSpec.describe Git::Repository::Stashing do
     allow(Git::Commands::Stash::Push).to receive(:new).with(execution_context).and_return(push_command)
   end
 
+  describe '#stashes_all' do
+    let(:list_command) { instance_double(Git::Commands::Stash::List) }
+
+    before do
+      allow(Git::Commands::Stash::List).to receive(:new).with(execution_context).and_return(list_command)
+    end
+
+    context 'when there are no stash entries' do
+      let(:list_result) { command_result('') }
+      let(:stash_infos) { [] }
+
+      before do
+        allow(list_command).to receive(:call).with(no_args).and_return(list_result)
+        allow(Git::Parsers::Stash).to receive(:parse_list).with('').and_return(stash_infos)
+      end
+
+      it 'returns an empty array' do
+        expect(described_instance.stashes_all).to eq([])
+      end
+    end
+
+    context 'when there are stash entries with branch-prefixed messages' do
+      let(:list_result) { command_result('fixture') }
+      let(:stash_info_older) { instance_double(Git::StashInfo, message: 'On main: Fix bug') }
+      let(:stash_info_newer) { instance_double(Git::StashInfo, message: 'On main: Add feature') }
+      # parse_list returns newest-first; reversed to oldest-first
+      let(:stash_infos) { [stash_info_newer, stash_info_older] }
+
+      before do
+        allow(list_command).to receive(:call).with(no_args).and_return(list_result)
+        allow(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return(stash_infos)
+      end
+
+      it 'constructs Git::Commands::Stash::List with the execution context' do
+        expect(Git::Commands::Stash::List).to receive(:new).with(execution_context).and_return(list_command)
+        allow(list_command).to receive(:call).and_return(list_result)
+        described_instance.stashes_all
+      end
+
+      it 'calls Git::Commands::Stash::List#call with no arguments' do
+        expect(list_command).to receive(:call).with(no_args).and_return(list_result)
+        described_instance.stashes_all
+      end
+
+      it 'passes the command stdout to Git::Parsers::Stash.parse_list' do
+        expect(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return(stash_infos)
+        described_instance.stashes_all
+      end
+
+      it 'returns stash entries in oldest-first order with sequential indices' do
+        expect(described_instance.stashes_all).to eq([[0, 'Fix bug'], [1, 'Add feature']])
+      end
+
+      it 'strips the branch prefix from the message' do
+        result = described_instance.stashes_all
+        expect(result.map(&:last)).to eq(['Fix bug', 'Add feature'])
+      end
+    end
+
+    context 'when a stash entry has no branch prefix (custom message)' do
+      let(:list_result) { command_result('fixture') }
+      let(:stash_info) { instance_double(Git::StashInfo, message: 'custom message') }
+
+      before do
+        allow(list_command).to receive(:call).and_return(list_result)
+        allow(Git::Parsers::Stash).to receive(:parse_list).and_return([stash_info])
+      end
+
+      it 'returns the message unchanged' do
+        expect(described_instance.stashes_all).to eq([[0, 'custom message']])
+      end
+    end
+
+    context 'when a stash entry has a message with an internal colon (e.g. "saving: note")' do
+      let(:list_result) { command_result('fixture') }
+      let(:stash_info) { instance_double(Git::StashInfo, message: 'On main: saving: note') }
+
+      before do
+        allow(list_command).to receive(:call).and_return(list_result)
+        allow(Git::Parsers::Stash).to receive(:parse_list).and_return([stash_info])
+      end
+
+      it 'strips only the first prefix, keeping subsequent colons in the message' do
+        expect(described_instance.stashes_all).to eq([[0, 'saving: note']])
+      end
+    end
+  end
+
   describe '#stash_save' do
     context 'when there are local changes to save' do
       let(:push_result) { command_result('Saved working directory and index state On main: WIP: feature work') }


### PR DESCRIPTION
## Summary

Adds `Git::Repository::Stashing#stashes_all` as part of the v5.0.0 Strangler Fig migration (`redesign/3_architecture_implementation.md`).

The new facade method:
- Calls `Git::Commands::Stash::List` to retrieve stash output
- Delegates parsing to `Git::Parsers::Stash.parse_list`
- Converts the result to the legacy `Array<Array(Integer, String)>` format (oldest-first, branch prefix stripped from messages) for API compatibility

`Git::Lib#stashes_all` is **not** changed — it continues to call the same commands and parser directly. No delegation plumbing was added since `Git::Lib` will be deleted in Phase 4.

## Changes

- `lib/git/repository/stashing.rb` — adds `#stashes_all` facade method; adds `require 'git/parsers/stash'`
- `spec/unit/git/repository/stashing_spec.rb` — adds unit specs for `#stashes_all` (empty repo, branch-prefixed messages, no prefix, colon in message)
- `spec/integration/git/repository/stashing_spec.rb` — new file; integration specs for `#stashes_all` (empty, one stash, multiple stashes, colon in message)