### PR TITLE
refactor(stash): migrate Git::Stash and Git::Stashes to accept Git::Repository (iter 1 B work)

### DIFF
--- a/lib/git/stash.rb
+++ b/lib/git/stash.rb
@@ -1,13 +1,39 @@
 # frozen_string_literal: true
 
+require 'git/base'
+
 module Git
-  # A stash in a Git repository
+  # Represents a single stash entry in a Git repository
+  #
+  # @example Create a stash and inspect the result
+  #   stash = Git::Stash.new(repo, 'WIP: feature work')
+  #   stash.message  #=> "WIP: feature work"
+  #   stash.saved?   #=> true
+  #
+  # @api public
+  #
   class Stash
     # Initialize a Stash object
     #
-    # @param base [Git::Base] the git repository
+    # When `existing` is `false` (the default), immediately calls {#save} to push
+    # the current working-directory state onto the stash stack.
+    #
+    # @param base [Git::Repository, Git::Base] the git repository
+    #
     # @param message [String] the stash message
-    # @param existing [Boolean] (false) if true, this is an existing stash (don't create)
+    #
+    # @param existing [Boolean] (false) when `true`, wraps an existing stash entry
+    #   without pushing any changes
+    #
+    # @return [void]
+    #
+    # @example Create a new stash entry
+    #   stash = Git::Stash.new(repo, 'WIP: feature work')
+    #   stash.saved?  #=> true
+    #
+    # @example Reference an existing stash without pushing
+    #   stash = Git::Stash.new(repo, 'WIP: feature work', existing: true)
+    #   stash.saved?  #=> nil
     #
     def initialize(base, message, existing: false)
       @base = base
@@ -15,18 +41,67 @@ module Git
       save unless existing
     end
 
+    # Saves the current working-directory state to the stash stack
+    #
+    # @return [Boolean] `true` if changes were stashed, `false` if there were no
+    #   local changes to save
+    #
+    # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    # @example Save changes to the stash stack
+    #   stash = Git::Stash.new(repo, 'WIP', existing: true)
+    #   stash.save  #=> true
+    #
     def save
-      @saved = @base.lib.stash_save(@message)
+      @saved = stash_repository.stash_save(@message)
     end
 
+    # Returns whether the stash was saved successfully
+    #
+    # @return [Boolean, nil] `true` if changes were stashed, `false` if there were no
+    #   local changes, `nil` if {#save} has not been called (e.g. `existing: true`)
+    #
+    # @example Check if changes were stashed
+    #   stash = Git::Stash.new(repo, 'WIP: feature work')
+    #   stash.saved?  #=> true
+    #
     def saved?
       @saved
     end
 
+    # Returns the stash description
+    #
+    # @return [String] the stash message
+    #
+    # @example Read the stash message
+    #   stash = Git::Stash.new(repo, 'WIP: feature work', existing: true)
+    #   stash.message  #=> "WIP: feature work"
+    #
     attr_reader :message
 
+    # Returns the stash description as a string
+    #
+    # @return [String] the stash message
+    #
+    # @example Convert stash to string
+    #   stash = Git::Stash.new(repo, 'WIP: feature work', existing: true)
+    #   stash.to_s  #=> "WIP: feature work"
+    #
     def to_s
       message
+    end
+
+    private
+
+    # Returns the facade interface for stash operations
+    #
+    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
+    # The `is_a?` guard will be removed when {Git::Base} is deleted in Phase 4.
+    #
+    # @return [Git::Repository]
+    #
+    def stash_repository
+      @base.is_a?(Git::Base) ? @base.facade_repository : @base
     end
   end
 end

--- a/lib/git/stashes.rb
+++ b/lib/git/stashes.rb
@@ -1,85 +1,173 @@
 # frozen_string_literal: true
 
+require 'git/base'
+
 module Git
-  # Object that holds all the available stashes
+  # Collection of stash entries for a Git repository
+  #
+  # @example Iterate over stash entries
+  #   git.stashes.each { |s| puts s.message }
+  #
+  # @example Check and apply a stash
+  #   git.stashes.size   #=> 2
+  #   git.stashes.apply
+  #
+  # @api public
   #
   class Stashes
     include Enumerable
 
     # Initialize the stashes collection
     #
-    # @param base [Git::Base] the git repository object
+    # Loads all existing stash entries from the repository at construction time.
+    #
+    # @param base [Git::Repository, Git::Base] the git repository
+    #
+    # @return [void]
+    #
+    # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    # @example Load stashes for a repository
+    #   stashes = Git::Stashes.new(repo)
+    #   stashes.size  #=> 2
     #
     def initialize(base)
       @stashes = []
       @base = base
 
-      @base.lib.stashes_all.each do |stash|
+      stash_repository.stashes_all.each do |stash|
         message = stash[1]
         @stashes.unshift(Git::Stash.new(@base, message, existing: true))
       end
     end
 
-    # Returns a multi-dimensional Array of elements that have been stash saved
+    # Returns all stash entries as an array of index and message pairs
     #
-    # Array is based on position and name (oldest-first order matching Git::Lib#stashes_all).
+    # Entries are listed in oldest-first order matching {Git::Repository#stashes_all}.
     #
-    # @example Returns Array of items that have been stashed
-    #   git.stashes.all # => [[0, "testing-stash-all"], [1, "another-stash"]]
+    # @example List all stash entries
+    #   git.stashes.all  #=> [[0, "testing-stash-all"], [1, "another-stash"]]
     #
-    # @return [Array<Array(Integer, String)>] array of [index, message] pairs
+    # @return [Array<Array(Integer, String)>] array of `[index, message]` pairs where
+    #   index 0 is the oldest stash
+    #
+    # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
     def all
-      @base.lib.stashes_all
+      stash_repository.stashes_all
     end
 
-    # Save the current working directory state to a new stash
+    # Saves the current working-directory state to a new stash entry
     #
     # @param message [String] the stash message
+    #
     # @return [void]
+    #
+    # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    # @example Save current changes to the stash
+    #   git.stashes.save('WIP: feature work')
+    #   git.stashes.size  #=> 1
     #
     def save(message)
       s = Git::Stash.new(@base, message)
       @stashes.unshift(s) if s.saved?
     end
 
-    # Apply a stash to the working directory
+    # Applies a stash entry to the working directory
     #
     # @param index [Integer, nil] the stash index to apply (default: latest)
-    # @return [String] the name of the applied stash (e.g., 'stash@\\{0}')
+    #
+    # @return [String] the output from the git stash apply command
+    #
+    # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    # @example Apply the most recent stash
+    #   git.stashes.apply
+    #
+    # @example Apply a specific stash by index
+    #   git.stashes.apply(1)
     #
     def apply(index = nil)
-      @base.lib.stash_apply(index)
+      stash_repository.stash_apply(index)
     end
 
-    # Remove all stash entries
+    # Removes all stash entries
     #
     # @return [void]
     #
+    # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    # @example Clear all stashes
+    #   git.stashes.clear
+    #   git.stashes.size  #=> 0
+    #
     def clear
-      @base.lib.stash_clear
+      stash_repository.stash_clear
       @stashes = []
+      nil
     end
 
-    # Return the number of stash entries
+    # Returns the number of stash entries
     #
-    # @return [Integer] number of stashes
+    # @return [Integer] the number of stashes
+    #
+    # @example Check how many stashes exist
+    #   git.stashes.size  #=> 2
     #
     def size
       @stashes.size
     end
 
+    # Iterates over each stash entry in newest-first order
+    #
+    # @example Iterate over stashes
+    #   git.stashes.each { |s| puts s.message }
+    #
+    # @overload each
+    #
+    #   @return [Enumerator<Git::Stash>] an enumerator over stash entries
+    #
+    # @overload each(&block)
+    #
+    #   @yield [stash] each stash entry
+    #
+    #   @yieldparam stash [Git::Stash] the current stash entry
+    #
+    #   @yieldreturn [void]
+    #
+    #   @return [Array<Git::Stash>] the stash entries
+    #
     def each(&)
       @stashes.each(&)
     end
 
-    # Access a stash by index
+    # Returns the stash entry at the given index
     #
-    # @param index [Integer, #to_i] the stash index
-    # @return [Git::Stash, nil] the stash at the given index
+    # Stashes are stored in newest-first order; index 0 is the most recent stash.
+    #
+    # @param index [Integer, #to_i] the stash index (0 = most recent)
+    #
+    # @return [Git::Stash, nil] the stash entry, or `nil` if the index is out of bounds
+    #
+    # @example Access the most recent stash
+    #   git.stashes[0].message  #=> "WIP: feature work"
     #
     def [](index)
       @stashes[index.to_i]
+    end
+
+    private
+
+    # Returns the facade interface for stash operations
+    #
+    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
+    # The `is_a?` guard will be removed when {Git::Base} is deleted in Phase 4.
+    #
+    # @return [Git::Repository]
+    #
+    def stash_repository
+      @base.is_a?(Git::Base) ? @base.facade_repository : @base
     end
   end
 end

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -39,6 +39,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | `Git::Repository::Branching` | `lib/git/repository/branching.rb` | ✅ | `checkout`, `checkout_file`, `checkout_index`, `current_branch`, `local_branch?`, `remote_branch?`, `branch?` |
 | `Git::Repository::Merging` | `lib/git/repository/merging.rb` | ✅ | `merge`, `revert`, `each_conflict`; `merge_base` wraps the returned SHA strings in `Git::Object::Commit.new(self, ...)` instances |
 | `Git::Repository::RemoteOperations` | `lib/git/repository/remote_operations.rb` | ✅ | `fetch`, `pull`, `push`, `add_remote`, `remove_remote` |
+| `Git::Repository::Stashing` | `lib/git/repository/stashing.rb` | ✅ | `stash_save`, `stash_apply`, `stash_clear`, `stashes_all` |
 
 #### Facade module naming convention
 
@@ -55,9 +56,11 @@ such as `Branch`, `Diff`, `Log`, `Object`, `Remote`, `Status`, `Worktree`, etc.
 
 ### Next Task
 
-**Phase 3 — Domain object migration (interleaved A→B iterations)**
+**Phase 3 — Iteration 2: `Git::DiffPathStatus` (A+B)**
 
-The next major piece of Phase 3 is migrating all domain objects
+Iter 1 (`Git::Stash` B2 + `Git::Stashes` B3) is ✅ complete ([PR #1306](https://github.com/ruby-git/ruby-git/pull/1306)). Proceed to iter 2.
+
+The full scope is still migrating all domain objects
 (`Git::Stash`, `Git::Stashes`, `Git::DiffPathStatus`, `Git::Object::*`,
 `Git::Log`, `Git::Diff`, `Git::DiffStats`, `Git::Status`,
 `Git::Branch`, `Git::Remote`, `Git::Branches`, `Git::Worktree`, `Git::Worktrees`)
@@ -99,8 +102,8 @@ After all 9 domain-object iterations, **verify facade coverage**: every public `
 
 | Domain Object | Status | Iteration |
 | ------------- | ------ | --------- |
-| `Git::Stash` | ⏳ Not started | iter 1 |
-| `Git::Stashes` | ⏳ Not started | iter 1 |
+| `Git::Stash` | ✅ Complete | iter 1 |
+| `Git::Stashes` | ✅ Complete | iter 1 |
 | `Git::DiffPathStatus` | ⏳ Not started | iter 2 |
 | `Git::Object::*` | ⏳ Not started | iter 3 |
 | `Git::Log` | ⏳ Not started | iter 4 |

--- a/spec/unit/git/stash_spec.rb
+++ b/spec/unit/git/stash_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::Stash do
+  # Git::Stash accepts either Git::Repository (new form) or Git::Base (legacy) as base.
+  # These specs cover the Git::Repository path; the Git::Base path is exercised by the
+  # legacy integration tests in tests/units/test_stashes.rb.
+
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:repository) { Git::Repository.new(execution_context: execution_context) }
+
+  describe '#initialize' do
+    context 'when base is Git::Repository and existing: false (default)' do
+      before do
+        allow(repository).to receive(:stash_save).with('test message').and_return(true)
+      end
+
+      it 'calls stash_save on the repository with the message' do
+        expect(repository).to receive(:stash_save).with('test message')
+        described_class.new(repository, 'test message')
+      end
+    end
+
+    context 'when base is Git::Repository and existing: true' do
+      it 'does not call stash_save' do
+        expect(repository).not_to receive(:stash_save)
+        described_class.new(repository, 'test message', existing: true)
+      end
+    end
+  end
+
+  describe '#saved?' do
+    context 'when base is Git::Repository and stash_save returns true (changes saved)' do
+      before do
+        allow(repository).to receive(:stash_save).with('test message').and_return(true)
+      end
+
+      subject(:stash) { described_class.new(repository, 'test message') }
+
+      it 'returns true' do
+        expect(stash.saved?).to be(true)
+      end
+    end
+
+    context 'when base is Git::Repository and stash_save returns false (no changes to save)' do
+      before do
+        allow(repository).to receive(:stash_save).with('test message').and_return(false)
+      end
+
+      subject(:stash) { described_class.new(repository, 'test message') }
+
+      it 'returns false' do
+        expect(stash.saved?).to be(false)
+      end
+    end
+
+    context 'when existing: true (stash was pre-existing, save not called)' do
+      subject(:stash) { described_class.new(repository, 'test message', existing: true) }
+
+      it 'returns nil' do
+        expect(stash.saved?).to be_nil
+      end
+    end
+  end
+
+  describe '#message' do
+    before do
+      allow(repository).to receive(:stash_save).with('my message').and_return(true)
+    end
+
+    subject(:stash) { described_class.new(repository, 'my message') }
+
+    it 'returns the stash message' do
+      expect(stash.message).to eq('my message')
+    end
+  end
+
+  describe '#to_s' do
+    before do
+      allow(repository).to receive(:stash_save).with('my message').and_return(true)
+    end
+
+    subject(:stash) { described_class.new(repository, 'my message') }
+
+    it 'returns the stash message' do
+      expect(stash.to_s).to eq('my message')
+    end
+  end
+end

--- a/spec/unit/git/stashes_spec.rb
+++ b/spec/unit/git/stashes_spec.rb
@@ -3,10 +3,14 @@
 require 'spec_helper'
 
 RSpec.describe Git::Stashes do
-  let(:base) { double('Git::Base') }
-  let(:lib) { double('Git::Lib') }
+  # Git::Stashes accepts either Git::Repository (new form) or Git::Base (legacy).
+  # These specs cover the Git::Repository path; the Git::Base path is exercised by
+  # the legacy integration tests in tests/units/test_stashes.rb.
 
-  # Git::Lib#stashes_all returns stashes in oldest-first order
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:repository) { Git::Repository.new(execution_context: execution_context) }
+
+  # Git::Repository#stashes_all returns stashes in oldest-first order
   let(:mocked_stashes_all_result) do
     [
       [0, 'abc1234 Test'],
@@ -15,13 +19,12 @@ RSpec.describe Git::Stashes do
   end
 
   before do
-    allow(base).to receive(:lib).and_return(lib)
-    allow(lib).to receive(:stashes_all).and_return(mocked_stashes_all_result)
+    allow(repository).to receive(:stashes_all).and_return(mocked_stashes_all_result)
   end
 
   describe '#initialize' do
     it 'loads stashes from the repository' do
-      stashes = described_class.new(base)
+      stashes = described_class.new(repository)
       expect(stashes.size).to eq(2)
     end
 
@@ -29,15 +32,15 @@ RSpec.describe Git::Stashes do
       stash_double = double('Stash', saved?: true)
       allow(Git::Stash).to receive(:new).and_return(stash_double)
 
-      described_class.new(base)
+      described_class.new(repository)
 
-      expect(Git::Stash).to have_received(:new).with(base, 'abc1234 Test', existing: true)
-      expect(Git::Stash).to have_received(:new).with(base, 'def5678 Work', existing: true)
+      expect(Git::Stash).to have_received(:new).with(repository, 'abc1234 Test', existing: true)
+      expect(Git::Stash).to have_received(:new).with(repository, 'def5678 Work', existing: true)
     end
   end
 
   describe '#all' do
-    subject(:stashes) { described_class.new(base) }
+    subject(:stashes) { described_class.new(repository) }
 
     it 'returns an array of [index, message] pairs' do
       result = stashes.all
@@ -45,7 +48,7 @@ RSpec.describe Git::Stashes do
       expect(result).to eq(mocked_stashes_all_result)
     end
 
-    it 'returns stashes in oldest-first order matching Git::Lib#stashes_all' do
+    it 'returns stashes in oldest-first order matching Git::Repository#stashes_all' do
       result = stashes.all
       # Index 0 should be the oldest stash (first in the reflog)
       # Index 1 should be the newer stash
@@ -53,11 +56,11 @@ RSpec.describe Git::Stashes do
       expect(result[1]).to eq([1, 'def5678 Work'])
     end
 
-    it 'returns fresh data from the repository' do
+    it 'returns fresh data from the repository on each call' do
       stashes
 
       new_data = [[0, 'new stash']]
-      allow(lib).to receive(:stashes_all).and_return(new_data)
+      allow(repository).to receive(:stashes_all).and_return(new_data)
 
       result = stashes.all
       expect(result).to eq(new_data)
@@ -65,7 +68,7 @@ RSpec.describe Git::Stashes do
   end
 
   describe '#each' do
-    subject(:stashes) { described_class.new(base) }
+    subject(:stashes) { described_class.new(repository) }
 
     before do
       allow(Git::Stash).to receive(:new).and_wrap_original do |_method, _base, message, **_kwargs|
@@ -94,7 +97,7 @@ RSpec.describe Git::Stashes do
   end
 
   describe '#[]' do
-    subject(:stashes) { described_class.new(base) }
+    subject(:stashes) { described_class.new(repository) }
 
     before do
       allow(Git::Stash).to receive(:new).and_wrap_original do |_method, _base, message, **_kwargs|
@@ -117,7 +120,7 @@ RSpec.describe Git::Stashes do
   end
 
   describe '#size' do
-    subject(:stashes) { described_class.new(base) }
+    subject(:stashes) { described_class.new(repository) }
 
     before do
       allow(Git::Stash).to receive(:new).and_return(double('Stash', saved?: true))
@@ -129,36 +132,36 @@ RSpec.describe Git::Stashes do
   end
 
   describe '#clear' do
-    subject(:stashes) { described_class.new(base) }
+    subject(:stashes) { described_class.new(repository) }
 
     before do
       allow(Git::Stash).to receive(:new).and_return(double('Stash', saved?: true))
-      allow(lib).to receive(:stash_clear)
+      allow(repository).to receive(:stash_clear)
     end
 
-    it 'clears all stashes' do
+    it 'clears all stashes by calling stash_clear on the repository' do
       stashes.clear
-      expect(lib).to have_received(:stash_clear)
+      expect(repository).to have_received(:stash_clear)
       expect(stashes.size).to eq(0)
     end
   end
 
   describe '#apply' do
-    subject(:stashes) { described_class.new(base) }
+    subject(:stashes) { described_class.new(repository) }
 
     before do
       allow(Git::Stash).to receive(:new).and_return(double('Stash', saved?: true))
-      allow(lib).to receive(:stash_apply)
+      allow(repository).to receive(:stash_apply)
     end
 
     it 'applies the stash at the given index' do
       stashes.apply(1)
-      expect(lib).to have_received(:stash_apply).with(1)
+      expect(repository).to have_received(:stash_apply).with(1)
     end
 
     it 'applies the latest stash when no index given' do
       stashes.apply
-      expect(lib).to have_received(:stash_apply).with(nil)
+      expect(repository).to have_received(:stash_apply).with(nil)
     end
   end
 end


### PR DESCRIPTION
## Summary

Iteration 1 Phase B of the domain-object migration (see [redesign/3_architecture_implementation.md](redesign/3_architecture_implementation.md) and [issue #1299](https://github.com/ruby-git/ruby-git/issues/1299)).

Both `Git::Stash` and `Git::Stashes` now accept a `Git::Repository` as their `base` argument in addition to the legacy `Git::Base`, using constructor polymorphism via a private `stash_repository` helper.

## Changes

### `Git::Stash` (B2)

- Replace `@base.lib.stash_save(@message)` with `stash_repository.stash_save(@message)` in `#save`.
- Add private `stash_repository` helper: returns `@base` directly when it is a `Git::Repository`, falls back to `@base.facade_repository` for legacy `Git::Base` callers.
- Add `spec/unit/git/stash_spec.rb` (7 examples) covering the `Git::Repository` path.

### `Git::Stashes` (B3)

- Replace `@base.lib.stashes_all`, `@base.lib.stash_apply`, `@base.lib.stash_clear` with `stash_repository.*` equivalents.
- Add the same private `stash_repository` helper.
- Update `spec/unit/git/stashes_spec.rb` (15 examples) to use a real `Git::Repository` instance with a stubbed `ExecutionContext::Repository` instead of `Git::Base`/`Lib` doubles.

## Backward Compatibility

For legacy `Git::Base` callers the `is_a?(Git::Base)` guard routes through `@base.facade_repository` rather than `@base.lib.*` directly. The behavior is functionally equivalent: the facade delegates to the same `Git::Commands::Stash::*` classes and produces identical results. The guard will be removed in the Phase 4 cleanup PR (step C3: "remove `is_a?(Git::Base)` polymorphism guards").

The legacy integration tests in `tests/units/test_stashes.rb` (5 tests) confirm this end-to-end.

## Quality Gates

- `bundle exec rspec spec/unit/git/stash_spec.rb` — 7 examples, 0 failures
- `bundle exec rspec spec/unit/git/stashes_spec.rb` — 15 examples, 0 failures
- `bundle exec rspec spec/unit/` — 4521 examples, 0 failures
- `bundle exec ruby -Itests tests/units/test_stashes.rb` — 5 tests, 0 failures
- `bundle exec rake default` — all tasks pass (rubocop, yard, build)