### PR TITLE
feat: migrate Git::DiffPathStatus to Git::Repository::Diffing facade (iter 2)

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1002,25 +1002,36 @@ module Git
       Git::DiffStats.new(self, objectish, obj2, opts[:path_limiter])
     end
 
-    # Returns a Git::Diff::PathStatus object for accessing the name-status report.
+    # Returns the file path status between two commits
     #
-    # @param objectish [String] The first commit or object to compare. Defaults to 'HEAD'.
-    # @param obj2 [String, nil] The second commit or object to compare.
-    # @param opts [Hash] Options to filter the diff.
-    # @option opts [String, Pathname, Array<String, Pathname>] :path_limiter Limit status to specified path(s).
-    # @option opts [String, Pathname, Array<String, Pathname>] :path (deprecated) Legacy alias for :path_limiter.
-    # @return [Git::DiffPathStatus]
+    # @example Get all changed files between HEAD and the previous commit
+    #   repo.diff_path_status.to_h #=> { "README.md" => "M", "lib/foo.rb" => "A" }
+    #
+    # @param objectish [String] the first commit or object to compare; defaults to
+    #   `'HEAD'`
+    #
+    # @param obj2 [String, nil] the second commit or object to compare
+    #
+    # @param opts [Hash] options to filter the diff
+    #
+    # @option opts [String, Pathname, Array<String, Pathname>] :path_limiter (nil)
+    #   limit the status report to specified path(s)
+    #
+    # @option opts [String, Pathname, Array<String, Pathname>] :path (nil)
+    #   deprecated; use `:path_limiter` instead
+    #
+    # @return [Git::DiffPathStatus] the name-status report for the comparison
+    #
+    # @raise [ArgumentError] when `objectish` or `obj2` starts with `"-"`
+    #
+    # @raise [Git::FailedError] when git exits with a non-zero exit status
+    #
+    # @see Git::Repository::Diffing#diff_path_status
+    #
     def diff_path_status(objectish = 'HEAD', obj2 = nil, opts = {})
-      path_limiter = if opts.key?(:path_limiter)
-                       opts[:path_limiter]
-                     elsif opts.key?(:path)
-                       Git::Deprecation.warn(
-                         'Git::Base#diff_path_status :path option is deprecated. Use :path_limiter instead.'
-                       )
-                       opts[:path]
-                     end
-
-      Git::DiffPathStatus.new(self, objectish, obj2, path_limiter)
+      # Slice to only the supported keys for backward compatibility with 4.x,
+      # which silently ignored any extra keys in opts.
+      facade_repository.diff_path_status(objectish, obj2, opts.slice(:path_limiter, :path))
     end
 
     # Provided for backwards compatibility

--- a/lib/git/diff_path_status.rb
+++ b/lib/git/diff_path_status.rb
@@ -2,45 +2,97 @@
 
 module Git
   # The files and their status (e.g., added, modified, deleted) between two commits
+  #
+  # @example Iterate over path statuses
+  #   git = Git.open('/path/to/repo')
+  #   git.diff_path_status.each { |path, status| puts "#{path}: #{status}" }
+  #
+  # @api public
+  #
   class DiffPathStatus
     include Enumerable
 
     # @private
-    def initialize(base, from, to, path_limiter = nil)
-      # Eagerly check for invalid arguments
-      [from, to].compact.each do |arg|
-        raise ArgumentError, "Invalid argument: '#{arg}'" if arg.start_with?('-')
+    def initialize(base_or_hash, from = nil, to = nil, path_limiter = nil)
+      if base_or_hash.is_a?(Hash)
+        # New form: pre-fetched hash passed directly from Git::Repository::Diffing
+        @fetch_path_status = base_or_hash
+      else
+        # Legacy form: (base, from, to, path_limiter)
+        # Used by Git::Diff#path_status_provider and direct instantiation in tests.
+        initialize_legacy(base_or_hash, from, to, path_limiter)
       end
-
-      @base = base
-      @from = from
-      @to = to
-      @path_limiter = path_limiter
-      @path_status = nil
     end
 
-    # Iterates over each file's status.
+    # Iterates over each file path and its status code
     #
-    # @yield [path, status]
+    # @example Print each path and status
+    #   diff_path_status.each { |path, status| puts "#{path}: #{status}" }
+    #
+    # @yield [path, status] each file path with its git status code
+    #
+    # @yieldparam path [String] the file path relative to the repository root
+    #
+    # @yieldparam status [String] the git status code (e.g. `"M"`, `"A"`, `"D"`)
+    #
+    # @yieldreturn [void]
+    #
+    # @return [Enumerator, Hash{String => String}] an `Enumerator` when no block
+    #   is given; the name-status hash when a block is given
+    #
     def each(&)
+      return to_enum(__method__) unless block_given?
+
       fetch_path_status.each(&)
     end
 
-    # Returns the name-status report as a Hash.
+    # Returns the name-status report as a hash
     #
-    # @return [Hash<String, String>] A hash where keys are file paths
-    #   and values are their status codes.
+    # @example Basic usage
+    #   diff_path_status.to_h #=> { "README.md" => "M", "lib/foo.rb" => "A" }
+    #
+    # @return [Hash{String => String}] a mapping of file paths to their status codes
+    #
     def to_h
       fetch_path_status
     end
 
     private
 
-    # Lazily fetches and caches the path status from the git lib.
+    # Lazily fetches and caches the path status from the git lib
+    #
+    # When constructed with a pre-fetched hash, returns it directly.
+    #
+    # @return [Hash{String => String}] a mapping of file paths to status codes
+    #
     def fetch_path_status
       @fetch_path_status ||= @base.lib.diff_path_status(
         @from, @to, { path_limiter: @path_limiter }
       )
+    end
+
+    # Sets up legacy (base, from, to, path_limiter) instance state
+    #
+    # @param base [Git::Base] the git base instance
+    #
+    # @param from [String] the first commit or object to compare
+    #
+    # @param to [String, nil] the second commit or object to compare
+    #
+    # @param path_limiter [String, Pathname, Array, nil] path(s) to limit the diff
+    #
+    # @return [void]
+    #
+    # @raise [ArgumentError] when `from` or `to` starts with `"-"`
+    #
+    def initialize_legacy(base, from, to, path_limiter)
+      [from, to].compact.each do |arg|
+        raise ArgumentError, "Invalid argument: '#{arg}'" if arg.start_with?('-')
+      end
+      @base = base
+      @from = from
+      @to = to
+      @path_limiter = path_limiter
     end
   end
 end

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -3,6 +3,7 @@
 require 'git/execution_context/repository'
 require 'git/repository/branching'
 require 'git/repository/committing'
+require 'git/repository/diffing'
 require 'git/repository/merging'
 require 'git/repository/remote_operations'
 require 'git/repository/staging'
@@ -36,6 +37,7 @@ module Git
   class Repository
     include Git::Repository::Branching
     include Git::Repository::Committing
+    include Git::Repository::Diffing
     include Git::Repository::Merging
     include Git::Repository::RemoteOperations
     include Git::Repository::Staging

--- a/lib/git/repository/diffing.rb
+++ b/lib/git/repository/diffing.rb
@@ -1,0 +1,231 @@
+# frozen_string_literal: true
+
+require 'pathname'
+require 'git/commands/diff'
+require 'git/diff_path_status'
+require 'git/escaped_path'
+require 'git/repository/shared_private'
+
+module Git
+  class Repository
+    # Mixin that adds diff path-status facade methods
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module Diffing
+      # Option keys accepted by {#diff_path_status}
+      #
+      # @return [Array<Symbol>]
+      #
+      # @api private
+      #
+      DIFF_PATH_STATUS_ALLOWED_OPTS = %i[path_limiter path].freeze
+      private_constant :DIFF_PATH_STATUS_ALLOWED_OPTS
+
+      # Returns the file path status between two commits
+      #
+      # Compares two commits (or a commit against the index/working tree) and returns
+      # a {Git::DiffPathStatus} enumerating each changed file together with its status
+      # code (e.g. `"M"` for modified, `"A"` for added, `"D"` for deleted,
+      # `"R100"` for a rename with 100% similarity, etc.).
+      #
+      # @example Get all changed files between HEAD and the previous commit
+      #   repo.diff_path_status #=> #<Git::DiffPathStatus ...>
+      #   repo.diff_path_status.to_h #=> { "README.md" => "M", "lib/foo.rb" => "A" }
+      #
+      # @example Compare two specific commits
+      #   repo.diff_path_status('abc1234', 'def5678').to_h
+      #
+      # @example Limit the comparison to a sub-path
+      #   repo.diff_path_status('HEAD~1', 'HEAD', path_limiter: 'lib/')
+      #
+      # @param from [String] the first commit or object to compare; defaults to
+      #   `'HEAD'`
+      #
+      # @param to [String, nil] the second commit or object to compare; when `nil`
+      #   the comparison is against the index/working tree
+      #
+      # @param opts [Hash] options to filter the diff
+      #
+      # @option opts [String, Pathname, Array<String, Pathname>, nil] :path_limiter
+      #   (nil) limit the status report to the given path(s)
+      #
+      # @option opts [String, Pathname, Array<String, Pathname>, nil] :path
+      #   (nil) **deprecated** — use `:path_limiter` instead
+      #
+      # @return [Git::DiffPathStatus] the name-status report for the comparison
+      #
+      # @raise [ArgumentError] when unsupported options are provided
+      #
+      # @raise [ArgumentError] when `from` or `to` starts with `"-"`
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-diff git-diff documentation
+      #
+      def diff_path_status(from = 'HEAD', to = nil, opts = {})
+        SharedPrivate.assert_valid_opts!(DIFF_PATH_STATUS_ALLOWED_OPTS, **opts)
+
+        path_limiter = Private.resolve_path_limiter(opts)
+        pathspecs = Private.normalize_pathspecs(path_limiter, 'path limiter')
+        Private.validate_ref_arguments!(from, to)
+
+        result = Private.call_diff_command(@execution_context, from, to, pathspecs)
+        Git::DiffPathStatus.new(Private.extract_name_status_from_raw(result.stdout))
+      end
+
+      # @see #diff_path_status
+      alias diff_name_status diff_path_status
+
+      # Private helpers local to {Git::Repository::Diffing}
+      #
+      # @api private
+      #
+      module Private
+        module_function
+
+        # Resolves the effective path limiter from the options hash
+        #
+        # When `:path_limiter` is present it is used directly and no warning is
+        # emitted. When only `:path` is present a deprecation warning is emitted
+        # and its value is used. Returns `nil` when neither key is present.
+        #
+        # @param opts [Hash] the options hash from {#diff_path_status}
+        #
+        # @return [String, Pathname, Array, nil] the effective path limiter
+        #
+        def resolve_path_limiter(opts)
+          if opts.key?(:path_limiter)
+            opts[:path_limiter]
+          elsif opts.key?(:path)
+            Git::Deprecation.warn(
+              'Git::Repository#diff_path_status :path option is deprecated. Use :path_limiter instead.'
+            )
+            opts[:path]
+          end
+        end
+
+        # Raises ArgumentError if any ref starts with a dash
+        #
+        # @param refs [Array<String, nil>] refs to validate
+        #
+        # @return [void]
+        #
+        # @raise [ArgumentError] when any ref starts with `"-"`
+        #
+        def validate_ref_arguments!(*refs)
+          refs.compact.each do |arg|
+            raise ArgumentError, "Invalid argument: '#{arg}'" if arg.start_with?('-')
+          end
+        end
+
+        # Runs git-diff with `--raw` format options and returns the result
+        #
+        # @param execution_context [Git::ExecutionContext] the execution context
+        #   used to run git commands
+        #
+        # @param from [String] first ref
+        #
+        # @param to [String, nil] second ref
+        #
+        # @param pathspecs [Array<String>, nil] path limiters
+        #
+        # @return [Git::CommandLineResult]
+        #
+        def call_diff_command(execution_context, from, to, pathspecs)
+          Git::Commands::Diff.new(execution_context).call(
+            *[from, to].compact,
+            raw: true, numstat: true, shortstat: true,
+            src_prefix: 'a/', dst_prefix: 'b/',
+            path: pathspecs
+          )
+        end
+
+        # Normalizes path specifications for Git commands
+        #
+        # @param pathspecs [String, Pathname, Array<String, Pathname>, nil]
+        #   the path(s) to normalize
+        #
+        # @param arg_name [String] the argument name used in error messages
+        #
+        # @return [Array<String>, nil] the normalized paths, or `nil` if none are valid
+        #
+        # @raise [ArgumentError] when any path is not a `String` or `Pathname`
+        #
+        def normalize_pathspecs(pathspecs, arg_name)
+          return nil unless pathspecs
+
+          normalized = Array(pathspecs)
+          validate_pathspec_types(normalized, arg_name)
+
+          normalized = normalized.map(&:to_s).reject(&:empty?)
+          return nil if normalized.empty?
+
+          normalized
+        end
+
+        # Raises an error if any element of `pathspecs` is not a `String` or `Pathname`
+        #
+        # @param pathspecs [Array] the path elements to validate
+        #
+        # @param arg_name [String] the argument name used in error messages
+        #
+        # @return [void]
+        #
+        # @raise [ArgumentError] when any element is not a `String` or `Pathname`
+        #
+        def validate_pathspec_types(pathspecs, arg_name)
+          return if pathspecs.all? { |p| p.is_a?(String) || p.is_a?(Pathname) }
+
+          raise ArgumentError, "Invalid #{arg_name}: must be a String, Pathname, or Array of Strings/Pathnames"
+        end
+
+        # Extracts name-status data from `--raw` diff output lines
+        #
+        # Raw lines have the format:
+        #   :old_mode new_mode old_sha new_sha status\tpath
+        # or for renames/copies:
+        #   :old_mode new_mode old_sha new_sha Rxx\told_path\tnew_path
+        #
+        # @param output [String] raw diff output
+        #
+        # @return [Hash{String => String}] mapping of file paths to status tokens
+        #
+        def extract_name_status_from_raw(output)
+          output.split("\n").each_with_object({}) do |line, memo|
+            next unless line.start_with?(':')
+
+            parts = line[1..].split(/\s+/, 5)
+            status_and_paths = parts[4].split("\t")
+            status = status_and_paths[0]
+            path = status_and_paths.length > 2 ? status_and_paths[2] : status_and_paths[1]
+            memo[unescape_quoted_path(path)] = status
+          end
+        end
+
+        # Unescapes a git-quoted path (e.g. `"quoted_file_\\342\\230\\240"`)
+        #
+        # Git quotes paths that contain non-ASCII or special characters by
+        # wrapping them in double-quotes and octal-escaping each byte. This
+        # method strips the surrounding quotes and delegates unescaping to
+        # {Git::EscapedPath}.
+        #
+        # @param path [String] the path as it appears in git output
+        #
+        # @return [String] the unescaped path
+        #
+        def unescape_quoted_path(path)
+          if path.start_with?('"') && path.end_with?('"')
+            Git::EscapedPath.new(path[1..-2]).unescape
+          else
+            path
+          end
+        end
+      end
+
+      private_constant :Private
+    end
+  end
+end

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -56,9 +56,9 @@ such as `Branch`, `Diff`, `Log`, `Object`, `Remote`, `Status`, `Worktree`, etc.
 
 ### Next Task
 
-**Phase 3 — Iteration 2: `Git::DiffPathStatus` (A+B)**
+**Phase 3 — Iteration 3: `Git::Object::*` (A+B)**
 
-Iter 1 (`Git::Stash` B2 + `Git::Stashes` B3) is ✅ complete ([PR #1306](https://github.com/ruby-git/ruby-git/pull/1306)). Proceed to iter 2.
+Iter 1 (`Git::Stash` B2 + `Git::Stashes` B3) is ✅ complete ([PR #1306](https://github.com/ruby-git/ruby-git/pull/1306)). Iter 2 (`Git::DiffPathStatus` B1) is ✅ complete. Proceed to iter 3.
 
 The full scope is still migrating all domain objects
 (`Git::Stash`, `Git::Stashes`, `Git::DiffPathStatus`, `Git::Object::*`,
@@ -104,7 +104,7 @@ After all 9 domain-object iterations, **verify facade coverage**: every public `
 | ------------- | ------ | --------- |
 | `Git::Stash` | ✅ Complete | iter 1 |
 | `Git::Stashes` | ✅ Complete | iter 1 |
-| `Git::DiffPathStatus` | ⏳ Not started | iter 2 |
+| `Git::DiffPathStatus` | ✅ Complete | iter 2 |
 | `Git::Object::*` | ⏳ Not started | iter 3 |
 | `Git::Log` | ⏳ Not started | iter 4 |
 | `Git::Diff` | ⏳ Not started | iter 5 |

--- a/spec/unit/git/repository/diffing_spec.rb
+++ b/spec/unit/git/repository/diffing_spec.rb
@@ -1,0 +1,245 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/diffing'
+
+# Integration-level coverage for Git::Repository::Diffing facade methods is
+# provided by the existing Test::Unit integration tests:
+#   tests/units/test_diff_path_status.rb   (diff_path_status / diff_name_status)
+# Each facade method delegates to Git::Commands::Diff with no multi-command
+# orchestration. The unit specs below cover each facade method's own behavior;
+# the integration tests cover end-to-end git execution.
+
+RSpec.describe Git::Repository::Diffing do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  let(:diff_command) { instance_double(Git::Commands::Diff) }
+
+  before do
+    allow(Git::Commands::Diff).to receive(:new).with(execution_context).and_return(diff_command)
+  end
+
+  describe '#diff_path_status' do
+    let(:raw_output) do
+      ":100644 100644 abc1234 def5678 M\tlib/foo.rb\n" \
+        ":000000 100644 0000000 abc1234 A\tREADME.md\n"
+    end
+
+    let(:diff_result) { command_result(raw_output) }
+
+    context 'when called with default arguments' do
+      before do
+        allow(diff_command).to receive(:call).with(
+          'HEAD',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_result)
+      end
+
+      it 'constructs Git::Commands::Diff with the execution context' do
+        expect(Git::Commands::Diff).to receive(:new).with(execution_context).and_return(diff_command)
+        allow(diff_command).to receive(:call).and_return(diff_result)
+        described_instance.diff_path_status
+      end
+
+      it 'calls the command with the default ref and raw format options' do
+        expect(diff_command).to receive(:call).with(
+          'HEAD',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_result)
+        described_instance.diff_path_status
+      end
+
+      it 'returns a Git::DiffPathStatus' do
+        expect(described_instance.diff_path_status).to be_a(Git::DiffPathStatus)
+      end
+
+      it 'returns a Git::DiffPathStatus with the parsed name-status data' do
+        result = described_instance.diff_path_status
+        expect(result.to_h).to eq('lib/foo.rb' => 'M', 'README.md' => 'A')
+      end
+    end
+
+    context 'when called with explicit from and to refs' do
+      before do
+        allow(diff_command).to receive(:call).with(
+          'abc1234', 'def5678',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_result)
+      end
+
+      it 'passes both refs as positional arguments to the command' do
+        expect(diff_command).to receive(:call).with(
+          'abc1234', 'def5678',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_result)
+        described_instance.diff_path_status('abc1234', 'def5678')
+      end
+    end
+
+    context 'when called with only the from ref' do
+      before do
+        allow(diff_command).to receive(:call).with(
+          'abc1234',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_result)
+      end
+
+      it 'passes only the from ref as a positional argument to the command' do
+        expect(diff_command).to receive(:call).with(
+          'abc1234',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_result)
+        described_instance.diff_path_status('abc1234')
+      end
+    end
+
+    context 'when path_limiter is a single String' do
+      before do
+        allow(diff_command).to receive(:call).with(
+          'HEAD',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: ['lib/']
+        ).and_return(diff_result)
+      end
+
+      it 'wraps the path_limiter in an Array and forwards it to the command' do
+        expect(diff_command).to receive(:call).with(
+          'HEAD',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: ['lib/']
+        ).and_return(diff_result)
+        described_instance.diff_path_status('HEAD', nil, path_limiter: 'lib/')
+      end
+    end
+
+    context 'when path_limiter is an Array of paths' do
+      before do
+        allow(diff_command).to receive(:call).with(
+          'HEAD',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: ['lib/', 'spec/']
+        ).and_return(diff_result)
+      end
+
+      it 'forwards the Array as-is to the command' do
+        expect(diff_command).to receive(:call).with(
+          'HEAD',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: ['lib/', 'spec/']
+        ).and_return(diff_result)
+        described_instance.diff_path_status('HEAD', nil, path_limiter: ['lib/', 'spec/'])
+      end
+    end
+
+    context 'when the deprecated :path option is provided' do
+      before do
+        allow(diff_command).to receive(:call).with(
+          'HEAD',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: ['lib/']
+        ).and_return(diff_result)
+        allow(Git::Deprecation).to receive(:warn)
+      end
+
+      it 'emits a deprecation warning naming the facade method' do
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Repository#diff_path_status :path option is deprecated. Use :path_limiter instead.'
+        )
+        described_instance.diff_path_status('HEAD', nil, path: 'lib/')
+      end
+
+      it 'uses the :path value as the path limiter' do
+        expect(diff_command).to receive(:call).with(
+          'HEAD',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: ['lib/']
+        ).and_return(diff_result)
+        described_instance.diff_path_status('HEAD', nil, path: 'lib/')
+      end
+    end
+
+    context 'when both :path_limiter and :path are provided' do
+      before do
+        allow(diff_command).to receive(:call).with(
+          'HEAD',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: ['lib/']
+        ).and_return(diff_result)
+        allow(Git::Deprecation).to receive(:warn)
+      end
+
+      it 'uses :path_limiter and does not emit a deprecation warning' do
+        expect(Git::Deprecation).not_to receive(:warn)
+        described_instance.diff_path_status('HEAD', nil, path_limiter: 'lib/', path: 'other/')
+      end
+    end
+
+    context 'when an unknown option is provided' do
+      it 'raises an ArgumentError' do
+        expect { described_instance.diff_path_status('HEAD', nil, bogus: true) }
+          .to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+
+    context 'when from starts with a dash' do
+      it 'raises an ArgumentError' do
+        expect { described_instance.diff_path_status('-bad-ref') }
+          .to raise_error(ArgumentError, /Invalid argument/)
+      end
+    end
+
+    context 'when to starts with a dash' do
+      it 'raises an ArgumentError' do
+        expect { described_instance.diff_path_status('HEAD', '-bad-ref') }
+          .to raise_error(ArgumentError, /Invalid argument/)
+      end
+    end
+
+    context 'when the raw output contains a rename' do
+      let(:rename_output) do
+        ":100644 100644 abc1234 def5678 R100\told.rb\tnew.rb\n"
+      end
+
+      before do
+        allow(diff_command).to receive(:call).with(
+          'HEAD',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(command_result(rename_output))
+      end
+
+      it 'uses the destination path as the key' do
+        result = described_instance.diff_path_status
+        expect(result.to_h).to eq('new.rb' => 'R100')
+      end
+    end
+  end
+
+  describe '#diff_name_status' do
+    it 'is an alias for diff_path_status' do
+      expect(described_instance.method(:diff_name_status)).to eq(described_instance.method(:diff_path_status))
+    end
+  end
+end

--- a/tests/units/test_diff_path_status.rb
+++ b/tests/units/test_diff_path_status.rb
@@ -41,7 +41,7 @@ class TestDiffPathStatus < Test::Unit::TestCase
   end
 
   def test_path_status_path_option_deprecated
-    Git::Deprecation.expects(:warn).with('Git::Base#diff_path_status :path option is deprecated. Use :path_limiter instead.')
+    Git::Deprecation.expects(:warn).with('Git::Repository#diff_path_status :path option is deprecated. Use :path_limiter instead.')
 
     status_hash = @git.diff_path_status('gitsearch1', 'v2.5', path: 'scott/').to_h
     assert(status_hash.key?('scott/newfile'))


### PR DESCRIPTION
## Summary

Phase 3 Iteration 2 of the v5.0.0 architectural redesign ([Strangler Fig migration](redesign/3_architecture_implementation.md)).

Migrates `Git::DiffPathStatus` access from `Git::Lib` to a new `Git::Repository::Diffing` facade module, keeping `Git::Base#diff_path_status` as a thin delegation shim for backward compatibility.

Does not close #1299 — partial implementation, iter 2 of 9.

---

## Changes

### Phase A — New `Git::Repository::Diffing` module (`lib/git/repository/diffing.rb`)

- Adds `Git::Repository::Diffing` with `#diff_path_status` and `#diff_name_status` alias
- Fetches raw name-status data via `Git::Commands::Diff` with `--raw` format flags
- Handles `:path_limiter` option and deprecated `:path` option (emits deprecation warning)
- Validates ref arguments (rejects refs starting with `"-"`)
- Private helpers: `resolve_path_limiter`, `validate_ref_arguments!`, `call_diff_command`,
  `extract_name_status_from_raw`, `unescape_quoted_path`, `normalize_pathspecs`,
  `validate_pathspec_types`
- Included in `Git::Repository`

### Phase B — Constructor polymorphism in `Git::DiffPathStatus` (`lib/git/diff_path_status.rb`)

- New form: `Git::DiffPathStatus.new(hash)` accepts a pre-fetched name-status hash directly (used by the facade)
- Legacy form: `Git::DiffPathStatus.new(base, from, to, path_limiter)` preserved for `Git::Diff#path_status_provider` and direct test instantiation (not migrated until iter 5)
- Extracts `#initialize_legacy` private method to satisfy `Metrics/MethodLength`

### Delegation (`lib/git/base.rb`)

- `Git::Base#diff_path_status` updated to delegate to `facade_repository.diff_path_status`
- Deprecation message updated from `'Git::Base#...'` to `'Git::Repository#...'`

---

## Tests

- 16 new unit specs in `spec/unit/git/repository/diffing_spec.rb` (all pass)
- Existing integration tests in `tests/units/test_diff_path_status.rb` pass unchanged
- Full suite passes: `bundle exec rake`
