### PR TITLE
feat(repository): add Git::Repository::ObjectOperations with #cat_file_size

### DIFF
--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -5,6 +5,7 @@ require 'git/repository/branching'
 require 'git/repository/committing'
 require 'git/repository/diffing'
 require 'git/repository/merging'
+require 'git/repository/object_operations'
 require 'git/repository/remote_operations'
 require 'git/repository/staging'
 require 'git/repository/stashing'
@@ -39,6 +40,7 @@ module Git
     include Git::Repository::Committing
     include Git::Repository::Diffing
     include Git::Repository::Merging
+    include Git::Repository::ObjectOperations
     include Git::Repository::RemoteOperations
     include Git::Repository::Staging
     include Git::Repository::Stashing

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require 'git/commands/cat_file/raw'
+
+module Git
+  class Repository
+    # Facade methods for raw git object store queries
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module ObjectOperations
+      # Returns the size of a git object in bytes
+      #
+      # @example Get the size of a commit object
+      #   repo.cat_file_size('HEAD') #=> 265
+      #
+      # @example Get the size of a blob by treeish path
+      #   repo.cat_file_size('HEAD:README.md') #=> 14
+      #
+      # @param object [String] the object name (SHA, ref, `HEAD`, treeish path, etc.)
+      #
+      # @return [Integer] the object size in bytes
+      #
+      # @raise [ArgumentError] if `object` starts with a hyphen
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-cat-file git-cat-file documentation
+      #
+      def cat_file_size(object)
+        raise ArgumentError, "Invalid object: '#{object}'" if object&.start_with?('-')
+
+        Git::Commands::CatFile::Raw.new(@execution_context).call(object, s: true).stdout.chomp.to_i
+      end
+    end
+  end
+end

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/object_operations'
+require 'git/execution_context/repository'
+
+RSpec.describe Git::Repository::ObjectOperations, :integration do
+  include_context 'in an empty repository'
+
+  let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  before do
+    write_file('README.md', "# Hello World\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#cat_file_size' do
+    context 'with a commit object' do
+      it 'returns the size of the commit as an Integer' do
+        result = described_instance.cat_file_size('HEAD')
+        expect(result).to be_a(Integer)
+        expect(result).to be_positive
+      end
+    end
+
+    context 'with a blob via treeish path' do
+      it 'returns the size of the blob' do
+        result = described_instance.cat_file_size('HEAD:README.md')
+        expect(result).to eq(File.read(File.join(repo.dir.to_s, 'README.md')).bytesize)
+      end
+    end
+
+    context 'with a tree object' do
+      it 'returns the size of the tree object as an Integer' do
+        tree_sha = repo.lib.rev_parse('HEAD^{tree}')
+        result = described_instance.cat_file_size(tree_sha)
+        expect(result).to be_a(Integer)
+        expect(result).to be_positive
+      end
+    end
+
+    context 'when object starts with a hyphen' do
+      it 'raises ArgumentError without calling git' do
+        expect { described_instance.cat_file_size('--batch') }
+          .to raise_error(ArgumentError, "Invalid object: '--batch'")
+      end
+    end
+
+    context 'when the object does not exist' do
+      it 'raises Git::FailedError' do
+        expect { described_instance.cat_file_size('0000000000000000000000000000000000000000') }
+          .to raise_error(Git::FailedError)
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/object_operations'
+
+# Integration-level coverage for Git::Repository::ObjectOperations#cat_file_size
+# is provided by spec/integration/git/repository/object_operations_spec.rb.
+# The unit specs below cover the facade's own behavior: argument validation and
+# delegation contract. Real git execution is covered by the integration spec.
+
+RSpec.describe Git::Repository::ObjectOperations do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  describe '#cat_file_size' do
+    let(:raw_command) { instance_double(Git::Commands::CatFile::Raw) }
+
+    before do
+      allow(Git::Commands::CatFile::Raw).to receive(:new)
+        .with(execution_context)
+        .and_return(raw_command)
+    end
+
+    context 'with a valid object name' do
+      subject(:result) { described_instance.cat_file_size('HEAD') }
+
+      let(:size_result) { command_result("265\n") }
+
+      it 'constructs Git::Commands::CatFile::Raw with the execution context' do
+        expect(Git::Commands::CatFile::Raw).to receive(:new).with(execution_context).and_return(raw_command)
+        allow(raw_command).to receive(:call).and_return(size_result)
+        result
+      end
+
+      it 'calls Git::Commands::CatFile::Raw#call with the object and s: true' do
+        expect(raw_command).to receive(:call).with('HEAD', s: true).and_return(size_result)
+        result
+      end
+
+      it 'returns the size as an Integer' do
+        allow(raw_command).to receive(:call).with('HEAD', s: true).and_return(size_result)
+        expect(result).to eq(265)
+      end
+    end
+
+    context 'with a treeish path reference' do
+      subject(:result) { described_instance.cat_file_size('HEAD:README.md') }
+
+      let(:size_result) { command_result("14\n") }
+
+      it 'forwards the treeish reference to Git::Commands::CatFile::Raw#call' do
+        expect(raw_command).to receive(:call).with('HEAD:README.md', s: true).and_return(size_result)
+        result
+      end
+
+      it 'returns the size as an Integer' do
+        allow(raw_command).to receive(:call).with('HEAD:README.md', s: true).and_return(size_result)
+        expect(result).to eq(14)
+      end
+    end
+
+    context 'when object starts with a hyphen' do
+      subject(:result) { described_instance.cat_file_size('--batch') }
+
+      it 'raises ArgumentError before calling the command' do
+        expect(Git::Commands::CatFile::Raw).not_to receive(:new)
+        expect { result }.to raise_error(ArgumentError, "Invalid object: '--batch'")
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extracts `Git::Lib#cat_file_size` to `Git::Repository::ObjectOperations#cat_file_size` as part of Phase 3 (iteration 3) of the v5.0.0 architectural redesign.

## Changes

- **New** `lib/git/repository/object_operations.rb` — introduces the `Git::Repository::ObjectOperations` topic module; its first method is `#cat_file_size(object) → Integer`
- **Updated** `lib/git/repository.rb` — requires and includes `ObjectOperations` (inserted alphabetically between `merging` and `remote_operations`)
- **New** `spec/unit/git/repository/object_operations_spec.rb` — 6 unit examples covering argument validation and delegation contract
- **New** `spec/integration/git/repository/object_operations_spec.rb` — 5 integration examples covering commit objects, blob treeish paths, tree objects, invalid arguments, and nonexistent objects

## Design notes

- `Git::Lib#cat_file_size` is **unchanged** — no delegation added, per project decision
- The facade uses `Git::Commands::CatFile::Raw` with `s: true` directly (simpler than the legacy `cat_file_object_meta` batch approach)
- Argument guard replicates the legacy `assert_args_are_not_options` contract: raises `ArgumentError, "Invalid object: '#{object}'"` for options-like inputs
- No options hash / `assert_valid_opts!` needed (single positional argument only)

## Quality gates

- `bundle exec rubocop` — 0 offenses
- `bundle exec rspec spec/unit/git/repository/object_operations_spec.rb` — 6/6 pass
- `bundle exec rspec spec/integration/git/repository/object_operations_spec.rb` — 5/5 pass
- `bundle exec rake yard` — YARD coverage 78.8% (threshold: 75%) ✓