### PR TITLE
feat(repository): add Git::Repository#cat_file_contents facade method

### DIFF
--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'git/commands/cat_file/raw'
+require 'tempfile'
 
 module Git
   class Repository
@@ -11,6 +12,67 @@ module Git
     # @api public
     #
     module ObjectOperations
+      # Returns the raw content of a git object, or streams it into a tempfile
+      #
+      # Without a block, the full content is buffered in memory and returned as a
+      # `String`. With a block, git output is streamed directly to disk without
+      # memory buffering — safe for large blobs.
+      #
+      # @overload cat_file_contents(object)
+      #   Returns the object's raw content as a string.
+      #
+      #   @param object [String] the object name (SHA, ref, `HEAD`, treeish path, etc.)
+      #
+      #   @return [String] the raw content of the object
+      #
+      #   @raise [ArgumentError] if `object` starts with a hyphen
+      #
+      #   @raise [Git::FailedError] if the object does not exist or the command fails
+      #
+      #   @example Get the contents of a blob
+      #     repo.cat_file_contents('HEAD:README.md') # => "This is a README file\n"
+      #
+      # @overload cat_file_contents(object, &block)
+      #   Streams the object's raw content to a temporary file and yields it.
+      #
+      #   Git output is written directly to a file on disk without being buffered in
+      #   memory first, then the file is rewound and yielded to the block. The return
+      #   value is whatever the block returns.
+      #
+      #   @param object [String] the object name (SHA, ref, `HEAD`, treeish path, etc.)
+      #
+      #   @yield [file] the temporary file containing the streamed content, positioned at the start
+      #
+      #   @yieldparam file [File] readable `IO` object positioned at the beginning of the content
+      #
+      #   @yieldreturn [Object] the value to return from this method
+      #
+      #   @return [Object] the value returned by the block
+      #
+      #   @raise [ArgumentError] if `object` starts with a hyphen
+      #
+      #   @raise [Git::FailedError] if the object does not exist or the command fails
+      #
+      #   @example Read a large blob without buffering it in memory
+      #     repo.cat_file_contents('HEAD:large_file.bin') { |f| process(f) }
+      #
+      # @see https://git-scm.com/docs/git-cat-file git-cat-file documentation
+      #
+      def cat_file_contents(object)
+        raise ArgumentError, "Invalid object: '#{object}'" if object&.start_with?('-')
+
+        return Git::Commands::CatFile::Raw.new(@execution_context).call(object, p: true).stdout unless block_given?
+
+        # Stream git output directly to a tempfile to avoid buffering large
+        # object content in memory when a block is given.
+        Tempfile.create do |file|
+          file.binmode
+          Git::Commands::CatFile::Raw.new(@execution_context).call(object, p: true, out: file)
+          file.rewind
+          yield file
+        end
+      end
+
       # Returns the size of a git object in bytes
       #
       # @example Get the size of a commit object

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -19,42 +19,40 @@ module Git
       # memory buffering — safe for large blobs.
       #
       # @overload cat_file_contents(object)
-      #   Returns the object's raw content as a string.
+      #   Returns the object's raw content as a string
+      #
+      #   @example Get the contents of a blob
+      #     repo.cat_file_contents('HEAD:README.md') # => "This is a README file\n"
       #
       #   @param object [String] the object name (SHA, ref, `HEAD`, treeish path, etc.)
       #
       #   @return [String] the raw content of the object
       #
-      #   @raise [ArgumentError] if `object` starts with a hyphen
-      #
-      #   @raise [Git::FailedError] if the object does not exist or the command fails
-      #
-      #   @example Get the contents of a blob
-      #     repo.cat_file_contents('HEAD:README.md') # => "This is a README file\n"
-      #
       # @overload cat_file_contents(object, &block)
-      #   Streams the object's raw content to a temporary file and yields it.
+      #   Streams the object's raw content to a temporary file and yields it
       #
       #   Git output is written directly to a file on disk without being buffered in
       #   memory first, then the file is rewound and yielded to the block. The return
       #   value is whatever the block returns.
       #
+      #   @example Read a large blob without buffering it in memory
+      #     repo.cat_file_contents('HEAD:large_file.bin') { |f| process(f) }
+      #
       #   @param object [String] the object name (SHA, ref, `HEAD`, treeish path, etc.)
       #
-      #   @yield [file] the temporary file containing the streamed content, positioned at the start
+      #   @yield [file] the temporary file containing the streamed content,
+      #     positioned at the start
       #
-      #   @yieldparam file [File] readable `IO` object positioned at the beginning of the content
+      #   @yieldparam file [File] readable `IO` object positioned at the beginning
+      #     of the content
       #
       #   @yieldreturn [Object] the value to return from this method
       #
       #   @return [Object] the value returned by the block
       #
-      #   @raise [ArgumentError] if `object` starts with a hyphen
+      # @raise [ArgumentError] if `object` starts with a hyphen
       #
-      #   @raise [Git::FailedError] if the object does not exist or the command fails
-      #
-      #   @example Read a large blob without buffering it in memory
-      #     repo.cat_file_contents('HEAD:large_file.bin') { |f| process(f) }
+      # @raise [Git::FailedError] if the object does not exist or the command fails
       #
       # @see https://git-scm.com/docs/git-cat-file git-cat-file documentation
       #

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -17,6 +17,54 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     repo.commit('Initial commit')
   end
 
+  describe '#cat_file_contents' do
+    context 'with a blob via treeish path' do
+      it 'returns the raw content of the blob as a String' do
+        result = described_instance.cat_file_contents('HEAD:README.md')
+        expect(result).to be_a(String)
+        expect(result).to include('# Hello World')
+      end
+    end
+
+    context 'with a commit object' do
+      it 'returns the raw content of the commit as a String' do
+        result = described_instance.cat_file_contents('HEAD')
+        expect(result).to be_a(String)
+        expect(result).to include('tree ')
+        expect(result).to include('author ')
+      end
+    end
+
+    context 'with a block' do
+      it 'yields a File positioned at the start of the content' do
+        yielded_content = nil
+        described_instance.cat_file_contents('HEAD:README.md') do |f|
+          yielded_content = f.read
+        end
+        expect(yielded_content).to eq("# Hello World\n")
+      end
+
+      it 'returns the value returned by the block' do
+        result = described_instance.cat_file_contents('HEAD:README.md') { |_f| :my_value }
+        expect(result).to eq(:my_value)
+      end
+    end
+
+    context 'when object starts with a hyphen' do
+      it 'raises ArgumentError without calling git' do
+        expect { described_instance.cat_file_contents('--batch') }
+          .to raise_error(ArgumentError, "Invalid object: '--batch'")
+      end
+    end
+
+    context 'when the object does not exist' do
+      it 'raises Git::FailedError' do
+        expect { described_instance.cat_file_contents('0000000000000000000000000000000000000000') }
+          .to raise_error(Git::FailedError)
+      end
+    end
+  end
+
   describe '#cat_file_size' do
     context 'with a commit object' do
       it 'returns the size of the commit as an Integer' do

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -4,14 +4,96 @@ require 'spec_helper'
 require 'git/repository'
 require 'git/repository/object_operations'
 
-# Integration-level coverage for Git::Repository::ObjectOperations#cat_file_size
-# is provided by spec/integration/git/repository/object_operations_spec.rb.
+# Integration-level coverage for Git::Repository::ObjectOperations is
+# provided by spec/integration/git/repository/object_operations_spec.rb.
 # The unit specs below cover the facade's own behavior: argument validation and
 # delegation contract. Real git execution is covered by the integration spec.
 
 RSpec.describe Git::Repository::ObjectOperations do
   let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
   let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  describe '#cat_file_contents' do
+    let(:raw_command) { instance_double(Git::Commands::CatFile::Raw) }
+
+    before do
+      allow(Git::Commands::CatFile::Raw).to receive(:new)
+        .with(execution_context)
+        .and_return(raw_command)
+    end
+
+    context 'without a block' do
+      subject(:result) { described_instance.cat_file_contents('HEAD:README.md') }
+
+      let(:contents_result) { command_result("# Hello\n") }
+
+      it 'constructs Git::Commands::CatFile::Raw with the execution context' do
+        expect(Git::Commands::CatFile::Raw).to receive(:new).with(execution_context).and_return(raw_command)
+        allow(raw_command).to receive(:call).and_return(contents_result)
+        result
+      end
+
+      it 'calls Git::Commands::CatFile::Raw#call with the object and p: true' do
+        expect(raw_command).to receive(:call).with('HEAD:README.md', p: true).and_return(contents_result)
+        result
+      end
+
+      it 'returns the stdout of the command as a String' do
+        allow(raw_command).to receive(:call).with('HEAD:README.md', p: true).and_return(contents_result)
+        expect(result).to eq("# Hello\n")
+      end
+    end
+
+    context 'with a block' do
+      it 'constructs Git::Commands::CatFile::Raw with the execution context' do
+        expect(Git::Commands::CatFile::Raw).to receive(:new).with(execution_context).and_return(raw_command)
+        allow(raw_command).to receive(:call) do |_object, **kwargs|
+          kwargs[:out].write('content')
+          command_result('')
+        end
+        described_instance.cat_file_contents('HEAD') { |_f| nil }
+      end
+
+      it 'calls Git::Commands::CatFile::Raw#call with object, p: true, and an out: File' do
+        expect(raw_command).to receive(:call)
+          .with('HEAD', p: true, out: instance_of(File))
+          .and_return(command_result(''))
+        described_instance.cat_file_contents('HEAD') { |_f| nil }
+      end
+
+      it 'streams content to a tempfile and yields the rewound file' do
+        allow(raw_command).to receive(:call) do |_object, **kwargs|
+          kwargs[:out].write('streamed content')
+          command_result('')
+        end
+
+        yielded = nil
+        described_instance.cat_file_contents('HEAD') { |f| yielded = f.read }
+
+        expect(yielded).to eq('streamed content')
+      end
+
+      it 'returns the value returned by the block' do
+        allow(raw_command).to receive(:call) do |_object, **kwargs|
+          kwargs[:out].write('')
+          command_result('')
+        end
+
+        result = described_instance.cat_file_contents('HEAD') { |_f| :block_return_value }
+
+        expect(result).to eq(:block_return_value)
+      end
+    end
+
+    context 'when object starts with a hyphen' do
+      subject(:result) { described_instance.cat_file_contents('--batch') }
+
+      it 'raises ArgumentError before calling the command' do
+        expect(Git::Commands::CatFile::Raw).not_to receive(:new)
+        expect { result }.to raise_error(ArgumentError, "Invalid object: '--batch'")
+      end
+    end
+  end
 
   describe '#cat_file_size' do
     let(:raw_command) { instance_double(Git::Commands::CatFile::Raw) }


### PR DESCRIPTION
## Summary

Extracts `Git::Repository::ObjectOperations#cat_file_contents` from `Git::Lib`
as part of the v5.0.0 Strangler Fig migration.

## Source pattern

**Pattern B** — `Git::Lib`-only (public-by-exposure via `g.lib.cat_file_contents`).
No `Git::Base#cat_file_contents` wrapper exists.

## What changed

### `lib/git/repository/object_operations.rb`

Added `#cat_file_contents` to the existing `Git::Repository::ObjectOperations`
module:

- **Without a block** — validates the object argument against leading hyphens, then
  delegates to `Git::Commands::CatFile::Raw` with `p: true` and returns raw stdout
  as a `String`.
- **With a block** — streams git output directly to a `Tempfile` (opened in
  `binmode`) to avoid buffering large blobs in memory, then rewinds the file and
  yields it to the caller. Returns the value the block returns.
- Raises `ArgumentError` when `object` starts with a hyphen.
- Raises `Git::FailedError` when git exits non-zero.

Also added `require 'tempfile'` at the top of the module file (needed by the
block path).

### Spec files

- `spec/unit/git/repository/object_operations_spec.rb` — unit tests covering the
  delegation contract for both the non-block and block paths, and the
  `ArgumentError` guard.
- `spec/integration/git/repository/object_operations_spec.rb` — integration tests
  exercising both paths against a real git repository.

## Not changed

`Git::Lib#cat_file_contents` is unchanged. It continues to call
`Git::Commands::CatFile::Raw` directly without delegating to the facade.
`Git::Lib` will be deleted in Phase 4 of the redesign.

## Quality gates

- `bundle exec rubocop` — ✅ no offenses
- `bundle exec rspec spec/unit/git/repository/object_operations_spec.rb` — ✅ 14 examples, 0 failures
- `bundle exec rspec spec/integration/git/repository/object_operations_spec.rb` — ✅ 11 examples, 0 failures
- `bundle exec rake yard` — ✅ YARD coverage above threshold
