### PR TITLE
feat(repository): add Git::Repository#cat_file_commit facade method

### DIFF
--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -52,7 +52,7 @@ module Git
       #
       # @raise [ArgumentError] if `object` starts with a hyphen
       #
-      # @raise [Git::FailedError] if the object does not exist or the command fails
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
       # @see https://git-scm.com/docs/git-cat-file git-cat-file documentation
       #
@@ -94,6 +94,129 @@ module Git
 
         Git::Commands::CatFile::Raw.new(@execution_context).call(object, s: true).stdout.chomp.to_i
       end
+
+      # Returns parsed commit data for the given git object
+      #
+      # @example Get commit data for HEAD
+      #   repo.cat_file_commit('HEAD')
+      #   # => {
+      #   #   'sha'       => 'HEAD',
+      #   #   'tree'      => 'def5678...',
+      #   #   'parent'    => ['ghi9012...'],
+      #   #   'author'    => 'A U Thor <author@example.com> 1234567890 +0000',
+      #   #   'committer' => 'A U Thor <author@example.com> 1234567890 +0000',
+      #   #   'message'   => "Initial commit\n"
+      #   # }
+      #
+      # @param object [String] the object name (SHA, ref, `HEAD`, etc.)
+      #
+      # @return [Hash] commit data
+      #
+      #   String-keyed hash with the following keys:
+      #
+      #   * `tree` — the tree SHA
+      #   * `parent` — Array of parent SHAs (empty for the root commit)
+      #   * `author` — author identity string and timestamp
+      #   * `committer` — committer identity string and timestamp
+      #   * `message` — the commit message (includes trailing newline)
+      #   * `gpgsig` — the cryptographic signature (signed commits only)
+      #   * `sha` — the `object` argument as passed by the caller
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-cat-file git-cat-file documentation
+      #
+      def cat_file_commit(object)
+        result = Git::Commands::CatFile::Raw.new(@execution_context).call('commit', object)
+        Private.process_commit_data(result.stdout.split("\n"), object)
+      end
+
+      # Private parsing helpers for {#cat_file_commit}
+      #
+      # @api private
+      #
+      module Private
+        module_function
+
+        # Matches a single `git cat-file` header line
+        #
+        # @api private
+        #
+        CAT_FILE_HEADER_LINE = /\A(?<key>\w+) (?<value>.*)\z/
+
+        # Assembles the commit Hash from parsed lines
+        #
+        # @param data [Array<String>] mutable cat-file output lines, consumed
+        #   in place during header parsing
+        #
+        # @param sha [String] the object name passed by the caller
+        #
+        # @return [Hash] commit data hash with string keys
+        #
+        # @api private
+        #
+        def process_commit_data(data, sha)
+          headers = process_commit_headers(data)
+          message = "#{data.join("\n")}\n"
+          { 'sha' => sha, 'message' => message }.merge(headers)
+        end
+
+        # Extracts and returns headers from the front of `data`
+        #
+        # Mutates `data` in place, consuming header lines and the blank
+        # separator line. After the call `data` contains only message lines.
+        #
+        # @param data [Array<String>] mutable cat-file output lines
+        #
+        # @return [Hash] parsed header key/value pairs; `parent` is always
+        #   an Array
+        #
+        # @api private
+        #
+        def process_commit_headers(data)
+          headers = { 'parent' => [] }
+          each_cat_file_header(data) do |key, value|
+            if key == 'parent'
+              headers['parent'] << value
+            else
+              headers[key] = value
+            end
+          end
+          headers
+        end
+
+        # Yields parsed header key/value pairs from `git cat-file` output lines
+        #
+        # Consumes header lines from the front of `data` until a blank line is
+        # encountered. Continuation lines that begin with a space are folded
+        # into the previous header value using newline separators.
+        #
+        # @param data [Array<String>] mutable output lines from a cat-file response
+        #
+        # @yield [key, value] each parsed header pair
+        #
+        # @yieldparam key [String] header field name
+        #
+        # @yieldparam value [String] unfolded header value text
+        #
+        # @yieldreturn [void]
+        #
+        # @return [void]
+        #
+        # @raise [NoMethodError] if `data` contains non-string entries
+        #
+        # @api private
+        #
+        def each_cat_file_header(data)
+          while (match = CAT_FILE_HEADER_LINE.match(data.shift))
+            key = match[:key]
+            value_lines = [match[:value]]
+            value_lines << data.shift.lstrip while data.first.start_with?(' ')
+            yield key, value_lines.join("\n")
+          end
+        end
+      end
+      private_constant :Private
     end
   end
 end

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -104,4 +104,49 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
       end
     end
   end
+
+  describe '#cat_file_commit' do
+    context 'with HEAD' do
+      subject(:result) { described_instance.cat_file_commit('HEAD') }
+
+      it 'returns a Hash' do
+        expect(result).to be_a(Hash)
+      end
+
+      it 'sets sha to the requested object name' do
+        expect(result['sha']).to eq('HEAD')
+      end
+
+      it 'includes tree, parent, author, committer, and message keys' do
+        expect(result).to include('tree', 'parent', 'author', 'committer', 'message')
+      end
+
+      it 'sets parent to an Array' do
+        expect(result['parent']).to be_a(Array)
+      end
+
+      it 'sets message with a trailing newline' do
+        expect(result['message']).to end_with("\n")
+      end
+
+      it 'sets message to the commit message used when the commit was created' do
+        expect(result['message']).to eq("Initial commit\n")
+      end
+    end
+
+    context 'when called with a commit SHA' do
+      it 'sets sha to the given SHA string' do
+        sha = repo.lib.rev_parse('HEAD')
+        result = described_instance.cat_file_commit(sha)
+        expect(result['sha']).to eq(sha)
+      end
+    end
+
+    context 'when the object does not exist' do
+      it 'raises Git::FailedError' do
+        expect { described_instance.cat_file_commit('0000000000000000000000000000000000000000') }
+          .to raise_error(Git::FailedError)
+      end
+    end
+  end
 end

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -151,4 +151,79 @@ RSpec.describe Git::Repository::ObjectOperations do
       end
     end
   end
+
+  describe '#cat_file_commit' do
+    let(:raw_command) { instance_double(Git::Commands::CatFile::Raw) }
+
+    before do
+      allow(Git::Commands::CatFile::Raw).to receive(:new)
+        .with(execution_context)
+        .and_return(raw_command)
+    end
+
+    context 'with a single-parent commit' do
+      subject(:result) { described_instance.cat_file_commit('HEAD') }
+
+      let(:commit_body) do
+        "tree abc123\nparent def456\nauthor A <a@example.com> 1 +0000\n" \
+          "committer A <a@example.com> 1 +0000\n\nInitial commit\n"
+      end
+      let(:commit_result) { command_result(commit_body) }
+
+      it 'constructs Git::Commands::CatFile::Raw with the execution context' do
+        expect(Git::Commands::CatFile::Raw).to receive(:new).with(execution_context).and_return(raw_command)
+        allow(raw_command).to receive(:call).and_return(commit_result)
+        result
+      end
+
+      it 'calls Git::Commands::CatFile::Raw#call with type commit and the object' do
+        expect(raw_command).to receive(:call).with('commit', 'HEAD').and_return(commit_result)
+        result
+      end
+
+      it 'returns a Hash with the expected commit data' do
+        allow(raw_command).to receive(:call).with('commit', 'HEAD').and_return(commit_result)
+        expect(result).to include(
+          'sha' => 'HEAD',
+          'tree' => 'abc123',
+          'parent' => ['def456'],
+          'author' => 'A <a@example.com> 1 +0000',
+          'committer' => 'A <a@example.com> 1 +0000',
+          'message' => "Initial commit\n"
+        )
+      end
+    end
+
+    context 'with a root commit (no parent lines)' do
+      subject(:result) { described_instance.cat_file_commit('abc123') }
+
+      let(:commit_body) do
+        "tree def456\nauthor A <a@example.com> 1 +0000\n" \
+          "committer A <a@example.com> 1 +0000\n\nRoot commit\n"
+      end
+
+      it 'returns an empty parent array' do
+        allow(raw_command).to receive(:call)
+          .with('commit', 'abc123')
+          .and_return(command_result(commit_body))
+        expect(result).to include('parent' => [])
+      end
+    end
+
+    context 'with a merge commit (multiple parents)' do
+      subject(:result) { described_instance.cat_file_commit('HEAD') }
+
+      let(:commit_body) do
+        "tree abc123\nparent def456\nparent ghi789\nauthor A <a@example.com> 1 +0000\n" \
+          "committer A <a@example.com> 1 +0000\n\nMerge branch 'feature'\n"
+      end
+
+      it 'returns all parent SHAs in the parent array' do
+        allow(raw_command).to receive(:call)
+          .with('commit', 'HEAD')
+          .and_return(command_result(commit_body))
+        expect(result).to include('parent' => %w[def456 ghi789])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Extracts `cat_file_commit` from `Git::Lib` to `Git::Repository::ObjectOperations` as part of the v5.0.0 Strangler Fig migration (Pattern B — Lib-only, public-by-exposure).

`Git::Lib#cat_file_commit` and its `commit_data` alias are left unchanged. Callers currently using `g.lib.cat_file_commit` will need to migrate to `g.repository.cat_file_commit` before Phase 4.

## Changes

### `lib/git/repository/object_operations.rb`

- Adds `#cat_file_commit(object)` facade method delegating to `Git::Commands::CatFile::Raw` and returning a `Hash` with string keys (`sha`, `tree`, `parent`, `author`, `committer`, `message`, and optional `gpgsig`). Signature and return type are identical to the legacy `Git::Lib#cat_file_commit`.
- Adds a `Private` module (with `private_constant`) containing the three parsing helpers migrated from `Git::Lib`: `process_commit_data`, `process_commit_headers`, and `each_cat_file_header`. These are called as singleton methods from within `ObjectOperations` and are not mixed into `Git::Repository`.
- Fixes an existing YARD issue on `cat_file_contents`: updates `@raise [Git::FailedError]` to use the canonical generic wording per the yard-documentation skill.

### `spec/unit/git/repository/object_operations_spec.rb`

- Adds `describe '#cat_file_commit'` covering single-parent, root commit (no parent), and merge commit (multiple parents) cases — verifying command construction, `#call` arguments, and the parsed `Hash` return value.

### `spec/integration/git/repository/object_operations_spec.rb`

- Adds `describe '#cat_file_commit'` integration tests verifying the end-to-end `Hash` shape, `sha` passthrough, key presence, `parent` type, message trailing newline, and failure on a non-existent object. Integration tests are warranted here because the facade performs its own parsing rather than delegating to a `Git::Parsers::*` class.
