### PR TITLE
feat(repository): add Git::Repository#cat_file_type facade method

### DIFF
--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -95,6 +95,30 @@ module Git
         Git::Commands::CatFile::Raw.new(@execution_context).call(object, s: true).stdout.chomp.to_i
       end
 
+      # Returns the type of a git object
+      #
+      # @example Get the type of a commit reference
+      #   repo.cat_file_type('HEAD') #=> "commit"
+      #
+      # @example Get the type of a blob via treeish path
+      #   repo.cat_file_type('HEAD:README.md') #=> "blob"
+      #
+      # @param object [String] the object name (SHA, ref, `HEAD`, treeish path, etc.)
+      #
+      # @return [String] the object type — one of `"blob"`, `"commit"`, `"tag"`, or `"tree"`
+      #
+      # @raise [ArgumentError] if `object` starts with a hyphen
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-cat-file git-cat-file documentation
+      #
+      def cat_file_type(object)
+        raise ArgumentError, "Invalid object: '#{object}'" if object&.start_with?('-')
+
+        Git::Commands::CatFile::Raw.new(@execution_context).call(object, t: true).stdout.chomp
+      end
+
       # Returns parsed commit data for the given git object
       #
       # @example Get commit data for HEAD

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -105,6 +105,41 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     end
   end
 
+  describe '#cat_file_type' do
+    context 'with a commit reference' do
+      it 'returns "commit"' do
+        expect(described_instance.cat_file_type('HEAD')).to eq('commit')
+      end
+    end
+
+    context 'with a tree reference' do
+      it 'returns "tree"' do
+        tree_sha = repo.lib.rev_parse('HEAD^{tree}')
+        expect(described_instance.cat_file_type(tree_sha)).to eq('tree')
+      end
+    end
+
+    context 'with a blob via treeish path' do
+      it 'returns "blob"' do
+        expect(described_instance.cat_file_type('HEAD:README.md')).to eq('blob')
+      end
+    end
+
+    context 'when object starts with a hyphen' do
+      it 'raises ArgumentError without calling git' do
+        expect { described_instance.cat_file_type('--batch') }
+          .to raise_error(ArgumentError, "Invalid object: '--batch'")
+      end
+    end
+
+    context 'when the object does not exist' do
+      it 'raises Git::FailedError' do
+        expect { described_instance.cat_file_type('0000000000000000000000000000000000000000') }
+          .to raise_error(Git::FailedError)
+      end
+    end
+  end
+
   describe '#cat_file_commit' do
     context 'with HEAD' do
       subject(:result) { described_instance.cat_file_commit('HEAD') }

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -152,6 +152,63 @@ RSpec.describe Git::Repository::ObjectOperations do
     end
   end
 
+  describe '#cat_file_type' do
+    let(:raw_command) { instance_double(Git::Commands::CatFile::Raw) }
+
+    before do
+      allow(Git::Commands::CatFile::Raw).to receive(:new)
+        .with(execution_context)
+        .and_return(raw_command)
+    end
+
+    context 'with a commit reference' do
+      subject(:result) { described_instance.cat_file_type('HEAD') }
+
+      let(:type_result) { command_result("commit\n") }
+
+      it 'constructs Git::Commands::CatFile::Raw with the execution context' do
+        expect(Git::Commands::CatFile::Raw).to receive(:new).with(execution_context).and_return(raw_command)
+        allow(raw_command).to receive(:call).and_return(type_result)
+        result
+      end
+
+      it 'calls Git::Commands::CatFile::Raw#call with the object and t: true' do
+        expect(raw_command).to receive(:call).with('HEAD', t: true).and_return(type_result)
+        result
+      end
+
+      it 'returns the type as a String with no trailing newline' do
+        allow(raw_command).to receive(:call).with('HEAD', t: true).and_return(type_result)
+        expect(result).to eq('commit')
+      end
+    end
+
+    context 'with a treeish path reference to a blob' do
+      subject(:result) { described_instance.cat_file_type('HEAD:README.md') }
+
+      let(:blob_result) { command_result("blob\n") }
+
+      it 'forwards the treeish reference to Git::Commands::CatFile::Raw#call' do
+        expect(raw_command).to receive(:call).with('HEAD:README.md', t: true).and_return(blob_result)
+        result
+      end
+
+      it 'returns "blob"' do
+        allow(raw_command).to receive(:call).with('HEAD:README.md', t: true).and_return(blob_result)
+        expect(result).to eq('blob')
+      end
+    end
+
+    context 'when object starts with a hyphen' do
+      subject(:result) { described_instance.cat_file_type('--batch') }
+
+      it 'raises ArgumentError before calling the command' do
+        expect(Git::Commands::CatFile::Raw).not_to receive(:new)
+        expect { result }.to raise_error(ArgumentError, "Invalid object: '--batch'")
+      end
+    end
+  end
+
   describe '#cat_file_commit' do
     let(:raw_command) { instance_double(Git::Commands::CatFile::Raw) }
 


### PR DESCRIPTION
## Summary

Extracts `Git::Lib#cat_file_type` to a new `Git::Repository#cat_file_type` facade method on `Git::Repository::ObjectOperations`, continuing the v5.0.0 Strangler Fig migration.

### What changed

**`lib/git/repository/object_operations.rb`**

Adds `#cat_file_type(object)` between the sibling `#cat_file_size` and `#cat_file_commit` methods. The implementation calls `Git::Commands::CatFile::Raw` with the `-t` flag, consistent with how `#cat_file_size` uses the `-s` flag.

```ruby
def cat_file_type(object)
  raise ArgumentError, "Invalid object: '#{object}'" if object&.start_with?('-')

  Git::Commands::CatFile::Raw.new(@execution_context).call(object, t: true).stdout.chomp
end
```

### Source pattern

**Pattern B** (lib-only, public-by-exposure) — `Git::Lib#cat_file_type` is accessible via `g.lib.cat_file_type(...)`. `Git::Lib` does not yet have a `@repository` reference, so delegation in `Git::Lib` is deferred (same as the sibling `cat_file_contents`, `cat_file_size`, and `cat_file_commit` methods).

### Public contract preserved

| | Legacy | Facade |
|---|---|---|
| Signature | `cat_file_type(object)` | `cat_file_type(object)` |
| Return type | `String` | `String` |
| Raises on hyphen | `ArgumentError` (via `assert_args_are_not_options`) | `ArgumentError` |
| Raises on git failure | `Git::FailedError` | `Git::FailedError` |

### Tests added

- **Unit** (`spec/unit/git/repository/object_operations_spec.rb`): verifies command construction with `execution_context`, delegation with `t: true`, chomp of trailing newline, and `ArgumentError` for hyphen-prefixed objects
- **Integration** (`spec/integration/git/repository/object_operations_spec.rb`): verifies `"commit"`, `"tree"`, and `"blob"` return values against a real git repository, plus the `ArgumentError` and `Git::FailedError` error cases

### Quality gates

All quality gates pass:
- `bundle exec rake rubocop` — 0 offenses
- `bundle exec rspec spec/unit/git/repository/object_operations_spec.rb` — 25 examples, 0 failures
- `bundle exec rspec spec/integration/git/repository/object_operations_spec.rb` — 24 examples, 0 failures
- `bundle exec rake yard` — passes (79.0% ≥ 75% threshold, 0 example failures)
