### PR TITLE
feat(repository): add Git::Repository#cat_file_tag facade method

### DIFF
--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -155,7 +155,56 @@ module Git
         Private.process_commit_data(result.stdout.split("\n"), object)
       end
 
-      # Private parsing helpers for {#cat_file_commit}
+      # Returns parsed tag data for the given annotated tag object
+      #
+      # Does not work with lightweight tags. To list all annotated tags in a
+      # repository:
+      #
+      # ```sh
+      # git for-each-ref --format='%(refname:strip=2)' refs/tags | \
+      #   while read tag; do
+      #     git cat-file tag "$tag" >/dev/null 2>&1 && echo "$tag"
+      #   done
+      # ```
+      #
+      # @example Get tag data for an annotated tag
+      #   repo.cat_file_tag('v1.0')
+      #   # => {
+      #   #   'name'    => 'v1.0',
+      #   #   'object'  => 'abc1234...',
+      #   #   'type'    => 'commit',
+      #   #   'tag'     => 'v1.0',
+      #   #   'tagger'  => 'A U Thor <author@example.com> 1234567890 +0000',
+      #   #   'message' => "Release v1.0\n"
+      #   # }
+      #
+      # @param object [String] the annotated tag name or SHA
+      #
+      # @return [Hash] tag data
+      #
+      #   String-keyed hash with the following keys:
+      #
+      #   * `name` — the `object` argument as passed by the caller
+      #   * `object` — the SHA of the tagged object
+      #   * `type` — the type of the tagged object (usually `"commit"`)
+      #   * `tag` — the tag name
+      #   * `tagger` — tagger identity string and timestamp
+      #   * `message` — the tag message (includes trailing newline)
+      #
+      # @raise [ArgumentError] if `object` starts with a hyphen
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-cat-file git-cat-file documentation
+      #
+      def cat_file_tag(object)
+        raise ArgumentError, "Invalid object: '#{object}'" if object&.start_with?('-')
+
+        tdata = Git::Commands::CatFile::Raw.new(@execution_context).call('tag', object).stdout.split("\n")
+        Private.process_tag_data(tdata, object)
+      end
+
+      # Private parsing helpers for {#cat_file_commit} and {#cat_file_tag}
       #
       # @api private
       #
@@ -207,6 +256,26 @@ module Git
             end
           end
           headers
+        end
+
+        # Assembles the tag Hash from parsed lines
+        #
+        # @param data [Array<String>] mutable cat-file output lines, consumed
+        #   in place during header parsing; remaining lines become the message
+        #
+        # @param name [String] the tag name passed by the caller
+        #
+        # @return [Hash] tag data hash with string keys
+        #
+        # @api private
+        #
+        def process_tag_data(data, name)
+          hsh = { 'name' => name }
+          each_cat_file_header(data) do |key, value|
+            hsh[key] = value
+          end
+          hsh['message'] = "#{data.join("\n")}\n"
+          hsh
         end
 
         # Yields parsed header key/value pairs from `git cat-file` output lines

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -184,4 +184,56 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
       end
     end
   end
+
+  describe '#cat_file_tag' do
+    before do
+      repo.add_tag('v1.0', annotate: true, message: 'Release v1.0')
+    end
+
+    context 'with a valid annotated tag' do
+      subject(:result) { described_instance.cat_file_tag('v1.0') }
+
+      it 'returns a Hash' do
+        expect(result).to be_a(Hash)
+      end
+
+      it 'sets name to the tag name passed by the caller' do
+        expect(result['name']).to eq('v1.0')
+      end
+
+      it 'includes the expected keys' do
+        expect(result).to include('name', 'object', 'type', 'tag', 'tagger', 'message')
+      end
+
+      it 'sets type to "commit"' do
+        expect(result['type']).to eq('commit')
+      end
+
+      it 'sets tag to the tag name' do
+        expect(result['tag']).to eq('v1.0')
+      end
+
+      it 'sets message to the tag message with a trailing newline' do
+        expect(result['message']).to eq("Release v1.0\n")
+      end
+
+      it 'sets object to a 40-character SHA' do
+        expect(result['object']).to match(/\A[0-9a-f]{40}\z/)
+      end
+    end
+
+    context 'when object starts with a hyphen' do
+      it 'raises ArgumentError without calling git' do
+        expect { described_instance.cat_file_tag('--all') }
+          .to raise_error(ArgumentError, "Invalid object: '--all'")
+      end
+    end
+
+    context 'when the object does not exist' do
+      it 'raises Git::FailedError' do
+        expect { described_instance.cat_file_tag('nonexistent_tag') }
+          .to raise_error(Git::FailedError)
+      end
+    end
+  end
 end

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -283,4 +283,62 @@ RSpec.describe Git::Repository::ObjectOperations do
       end
     end
   end
+
+  describe '#cat_file_tag' do
+    let(:raw_command) { instance_double(Git::Commands::CatFile::Raw) }
+
+    before do
+      allow(Git::Commands::CatFile::Raw).to receive(:new)
+        .with(execution_context)
+        .and_return(raw_command)
+    end
+
+    context 'with a valid annotated tag' do
+      subject(:result) { described_instance.cat_file_tag('v1.0') }
+
+      let(:tag_body) do
+        "object deadbeef\ntype commit\ntag v1.0\ntagger A <a@example.com> 1 +0000\n\nRelease v1.0"
+      end
+
+      it 'constructs Git::Commands::CatFile::Raw with the execution context' do
+        expect(Git::Commands::CatFile::Raw).to receive(:new).with(execution_context).and_return(raw_command)
+        allow(raw_command).to receive(:call).and_return(command_result(tag_body))
+        result
+      end
+
+      it 'calls Git::Commands::CatFile::Raw#call with type tag and the object' do
+        expect(raw_command).to receive(:call).with('tag', 'v1.0').and_return(command_result(tag_body))
+        result
+      end
+
+      it 'returns a Hash with name set to the object argument' do
+        allow(raw_command).to receive(:call).with('tag', 'v1.0').and_return(command_result(tag_body))
+        expect(result['name']).to eq('v1.0')
+      end
+
+      it 'returns a Hash with the parsed tag headers' do
+        allow(raw_command).to receive(:call).with('tag', 'v1.0').and_return(command_result(tag_body))
+        expect(result).to include(
+          'object' => 'deadbeef',
+          'type' => 'commit',
+          'tag' => 'v1.0',
+          'tagger' => 'A <a@example.com> 1 +0000'
+        )
+      end
+
+      it 'returns a Hash with message including a trailing newline' do
+        allow(raw_command).to receive(:call).with('tag', 'v1.0').and_return(command_result(tag_body))
+        expect(result['message']).to eq("Release v1.0\n")
+      end
+    end
+
+    context 'when object starts with a hyphen' do
+      subject(:result) { described_instance.cat_file_tag('--all') }
+
+      it 'raises ArgumentError before calling the command' do
+        expect(Git::Commands::CatFile::Raw).not_to receive(:new)
+        expect { result }.to raise_error(ArgumentError, "Invalid object: '--all'")
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Extracts `Git::Lib#cat_file_tag` to a new `Git::Repository::ObjectOperations#cat_file_tag` facade method as part of the v5.0.0 Strangler Fig architectural redesign.

**Source pattern:** B (`Git::Lib`-only, public-by-exposure — no `Git::Base` wrapper exists)

**Underlying command class:** `Git::Commands::CatFile::Raw` (already existed)

## Changes

### `lib/git/repository/object_operations.rb`

- Adds `#cat_file_tag(object)` facade method to `Git::Repository::ObjectOperations`
- Adds `Private.process_tag_data(data, name)` helper to the existing `Private` module,
  reusing `Private.each_cat_file_header` (already present for `#cat_file_commit`)
- Updates the `Private` module YARD summary to reference both `#cat_file_commit`
  and `#cat_file_tag`

### `spec/unit/git/repository/object_operations_spec.rb`

- Adds `describe '#cat_file_tag'` block covering:
  - delegation contract (command constructed with `execution_context`, called with
    `'tag', object`)
  - header parsing and `name`/`message` assembly
  - `ArgumentError` when `object` starts with a hyphen

### `spec/integration/git/repository/object_operations_spec.rb`

- Adds `describe '#cat_file_tag'` block covering:
  - all expected hash keys present
  - `type`, `tag`, `message` values are correct
  - `object` is a 40-character SHA
  - `ArgumentError` on hyphen-prefixed input
  - `Git::FailedError` on a nonexistent tag

## Quality gates

All quality gates pass:

- `bundle exec rspec spec/unit/git/repository/object_operations_spec.rb spec/integration/git/repository/object_operations_spec.rb` — 64 examples, 0 failures
- `bundle exec rake spec:unit:parallel` — 4568 examples, 0 failures
- `bundle exec rubocop` on changed files — no offenses
- `bundle exec rake yard` — no warnings, coverage 79.0% (threshold 75%)