### PR TITLE
fix: support annotated tags with an empty message

### DIFF
--- a/lib/git/commands/tag/create.rb
+++ b/lib/git/commands/tag/create.rb
@@ -41,7 +41,7 @@ module Git
           flag_option %i[sign s], negatable: true
           value_option %i[local_user u], inline: true
           flag_option %i[force f]
-          value_option %i[message m], inline: true
+          value_option %i[message m], inline: true, allow_empty: true
           value_option %i[file F], inline: true
           flag_option %i[edit e], negatable: true
           key_value_option :trailer, key_separator: ': '

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -301,10 +301,10 @@ module Git
         # @api private
         #
         def each_cat_file_header(data)
-          while (match = CAT_FILE_HEADER_LINE.match(data.shift))
+          while (line = data.shift) && (match = CAT_FILE_HEADER_LINE.match(line))
             key = match[:key]
             value_lines = [match[:value]]
-            value_lines << data.shift.lstrip while data.first.start_with?(' ')
+            value_lines << data.shift.lstrip while data.first&.start_with?(' ')
             yield key, value_lines.join("\n")
           end
         end

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -235,5 +235,20 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
           .to raise_error(Git::FailedError)
       end
     end
+
+    context 'with an annotated tag whose message is empty' do
+      before do
+        repo.add_tag('v2.0', annotate: true, message: '')
+      end
+
+      it 'returns a Hash without raising NoMethodError' do
+        expect { described_instance.cat_file_tag('v2.0') }.not_to raise_error
+      end
+
+      it 'sets message to a single newline' do
+        result = described_instance.cat_file_tag('v2.0')
+        expect(result['message']).to eq("\n")
+      end
+    end
   end
 end


### PR DESCRIPTION
## Summary

Fixes two bugs that caused `cat_file_tag` to raise `NoMethodError` when called on an annotated tag created with an empty message.

### Root causes

**1. `Tag::Create` silently dropped `message: ''`**

The `value_option %i[message m]` definition used the default `allow_empty: false`, so passing `message: ''` produced no `--message=` flag. With `--annotate` present but no message source, git exited 128 with `fatal: no tag message?`.

**Fix:** Added `allow_empty: true` to the `message` option in `Tag::Create`.

**2. `each_cat_file_header` crashed on empty-message tag output**

Git outputs only headers followed by a single trailing `\n` for empty-message annotated tags — there is no blank separator line. This caused `data.shift` to return `nil` mid-loop, then `nil.start_with?(' ')` raised `NoMethodError`.

**Fix:** Changed the outer `while` to short-circuit when `data` is empty, and used safe navigation (`&.start_with?`) on the inner continuation-line check.

## Commits

- `fix(commands)`: allow empty string for Tag::Create message option
- `fix(repository)`: cat_file_tag handles annotated tags with an empty message

## Tests

Added two integration examples under `#cat_file_tag` for the empty-message case:
- returns a Hash without raising `NoMethodError`
- sets `message` to `"\n"`