### PR TITLE
feat(repository): Extract #rev_parse to Git::Repository::ObjectOperations

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -868,7 +868,7 @@ module Git
     #   git.rev_parse('v2.4:/doc/index.html')
     #
     def rev_parse(objectish)
-      lib.rev_parse(objectish)
+      facade_repository.rev_parse(objectish)
     end
 
     # For backwards compatibility

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'git/commands/cat_file/raw'
+require 'git/commands/rev_parse'
 require 'tempfile'
 
 module Git
@@ -105,7 +106,8 @@ module Git
       #
       # @param object [String] the object name (SHA, ref, `HEAD`, treeish path, etc.)
       #
-      # @return [String] the object type — one of `"blob"`, `"commit"`, `"tag"`, or `"tree"`
+      # @return [String] the object type — one of `"blob"`, `"commit"`,
+      #   `"tag"`, or `"tree"`
       #
       # @raise [ArgumentError] if `object` starts with a hyphen
       #
@@ -202,6 +204,35 @@ module Git
 
         tdata = Git::Commands::CatFile::Raw.new(@execution_context).call('tag', object).stdout.split("\n")
         Private.process_tag_data(tdata, object)
+      end
+
+      # Resolve a revision specifier to its full object ID
+      #
+      # Passes the given revision specifier to `git rev-parse` and returns the
+      # full object ID.
+      #
+      # @example Resolve HEAD to its full object ID
+      #   repo.rev_parse('HEAD') #=> "9b9b31e704c0b85ffdd8d2af2ded85170a5af87d"
+      #
+      # @example Resolve an abbreviated SHA
+      #   repo.rev_parse('9b9b31e') #=> "9b9b31e704c0b85ffdd8d2af2ded85170a5af87d"
+      #
+      # @example Resolve a tree object via rev-parse syntax
+      #   repo.rev_parse('HEAD^{tree}') #=> "94c827875e2cadb8bc8d4cdd900f19aa9e8634c7"
+      #
+      # @param objectish [String] the revision specifier to resolve (branch name,
+      #   tag, abbreviated SHA, refspec, etc.)
+      #
+      # @return [String] the full object ID of the resolved object
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-rev-parse git-rev-parse documentation
+      #
+      # @see https://git-scm.com/docs/git-rev-parse#_specifying_revisions Valid ways to specify revisions
+      #
+      def rev_parse(objectish)
+        Git::Commands::RevParse.new(@execution_context).call(objectish, '--', revs_only: true).stdout
       end
 
       # Private parsing helpers for {#cat_file_commit} and {#cat_file_tag}

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -251,4 +251,39 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
       end
     end
   end
+
+  describe '#rev_parse' do
+    context 'with HEAD' do
+      it 'returns a 40-character lowercase hex SHA' do
+        result = described_instance.rev_parse('HEAD')
+        expect(result).to match(/\A[0-9a-f]{40}\z/)
+      end
+
+      it 'returns a String' do
+        expect(described_instance.rev_parse('HEAD')).to be_a(String)
+      end
+    end
+
+    context 'with an abbreviated SHA' do
+      it 'expands the abbreviated SHA to the full 40-character SHA' do
+        full_sha = repo.lib.rev_parse('HEAD')
+        abbreviated = full_sha[0, 7]
+        expect(described_instance.rev_parse(abbreviated)).to eq(full_sha)
+      end
+    end
+
+    context 'with a tree object via rev-parse syntax' do
+      it 'resolves the tree SHA' do
+        result = described_instance.rev_parse('HEAD^{tree}')
+        expect(result).to match(/\A[0-9a-f]{40}\z/)
+      end
+    end
+
+    context 'when the revision is unknown' do
+      it 'raises Git::FailedError' do
+        expect { described_instance.rev_parse('NOTFOUND') }
+          .to raise_error(Git::FailedError)
+      end
+    end
+  end
 end

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -341,4 +341,54 @@ RSpec.describe Git::Repository::ObjectOperations do
       end
     end
   end
+
+  describe '#rev_parse' do
+    let(:rev_parse_command) { instance_double(Git::Commands::RevParse) }
+
+    before do
+      allow(Git::Commands::RevParse).to receive(:new)
+        .with(execution_context)
+        .and_return(rev_parse_command)
+    end
+
+    context 'with a valid revision specifier' do
+      subject(:result) { described_instance.rev_parse('HEAD') }
+
+      let(:sha) { '9b9b31e704c0b85ffdd8d2af2ded85170a5af87d' }
+      let(:rev_parse_result) { command_result(sha) }
+
+      it 'constructs Git::Commands::RevParse with the execution context' do
+        expect(Git::Commands::RevParse).to receive(:new).with(execution_context).and_return(rev_parse_command)
+        allow(rev_parse_command).to receive(:call).and_return(rev_parse_result)
+        result
+      end
+
+      it 'calls Git::Commands::RevParse#call with the revision, "--", and revs_only: true' do
+        expect(rev_parse_command).to receive(:call).with('HEAD', '--', revs_only: true).and_return(rev_parse_result)
+        result
+      end
+
+      it 'returns the stdout of the command as a String' do
+        allow(rev_parse_command).to receive(:call).with('HEAD', '--', revs_only: true).and_return(rev_parse_result)
+        expect(result).to eq(sha)
+      end
+    end
+
+    context 'with an abbreviated SHA' do
+      subject(:result) { described_instance.rev_parse('9b9b31e') }
+
+      let(:sha) { '9b9b31e704c0b85ffdd8d2af2ded85170a5af87d' }
+      let(:rev_parse_result) { command_result(sha) }
+
+      it 'calls Git::Commands::RevParse#call with the abbreviated SHA' do
+        expect(rev_parse_command).to receive(:call).with('9b9b31e', '--', revs_only: true).and_return(rev_parse_result)
+        result
+      end
+
+      it 'returns the full SHA' do
+        allow(rev_parse_command).to receive(:call).with('9b9b31e', '--', revs_only: true).and_return(rev_parse_result)
+        expect(result).to eq(sha)
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Extracts `Git::Base#rev_parse` / `Git::Lib#rev_parse` to a new
`Git::Repository::ObjectOperations#rev_parse` facade method as part of the
v5.0.0 Strangler Fig redesign migration.

## Migration source

**Pattern A** — `Git::Base` wrapper + `Git::Lib` implementation:

```ruby
# lib/git/base.rb
def rev_parse(objectish)
  lib.rev_parse(objectish)
end

# lib/git/lib.rb
def rev_parse(revision)
  Git::Commands::RevParse.new(self).call(revision, '--', revs_only: true).stdout
end
```

## Changes

### `lib/git/repository/object_operations.rb`

- Added `require 'git/commands/rev_parse'`
- Added `Git::Repository::ObjectOperations#rev_parse(objectish)` facade method
  with full YARD documentation and `@see` links to git-rev-parse documentation

### `lib/git/base.rb`

- `Git::Base#rev_parse` now delegates to `facade_repository.rev_parse(objectish)`
  (preserves the legacy public contract; `Git::Lib#rev_parse` retains its
  own implementation until `Git::Lib` is deleted in Phase 4)

### `spec/unit/git/repository/object_operations_spec.rb`

- Added unit tests for `#rev_parse` covering construction with execution context,
  correct call arguments, and return value

### `spec/integration/git/repository/object_operations_spec.rb`

- Added integration tests for `#rev_parse` covering HEAD, abbreviated SHA
  expansion, tree object resolution, and `Git::FailedError` on unknown revision

## Quality gates

- All 4573 unit specs pass (0 failures)
- All 607 integration specs pass (0 failures, 8 pendings)
- RuboCop: 0 offenses across 631 files
- Legacy tests: test_lib, test_object, test_branch — 0 failures
