### PR TITLE
feat(repository): extract Git::Lib#archive as Git::Repository::ObjectOperations#archive

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -698,19 +698,25 @@ module Git
     #
     # @param treeish [String] the commit, tag, branch, or tree to archive
     #
-    # @param file [String, nil] destination file path; a temp file is created if `nil`
+    # @param file [String, nil] destination file path; a temp file is created
+    #   if `nil`
     #
-    # @param opts [Hash] archive options (see {Git::Lib#archive})
+    # @param opts [Hash] archive options (see {Git::Repository::ObjectOperations#archive})
     #
     # @return [String] the path to the written archive file
     #
-    # @raise [Git::FailedError] if `git archive` fails
+    # @raise [ArgumentError] if unsupported options are provided
+    #
+    # @raise [ArgumentError] if `file` is an existing directory
+    #
+    # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
     # @example Archive HEAD to a zip file
     #   git.archive('HEAD', '/tmp/release.zip', format: 'zip')
+    #   #=> "/tmp/release.zip"
     #
     def archive(treeish, file = nil, opts = {})
-      object(treeish).archive(file, opts)
+      facade_repository.archive(treeish, file, opts)
     end
 
     # repacks the repository

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -1,10 +1,13 @@
 # frozen_string_literal: true
 
+require 'fileutils'
+require 'git/commands/archive'
 require 'git/commands/cat_file/raw'
 require 'git/commands/grep'
 require 'git/commands/rev_parse'
 require 'git/repository/shared_private'
 require 'tempfile'
+require 'zlib'
 
 module Git
   class Repository
@@ -305,8 +308,103 @@ module Git
         Private.process_grep_result(result)
       end
 
-      # Private parsing helpers for {#cat_file_commit}, {#cat_file_tag}, and
-      # {#grep}
+      # Option keys accepted by {#archive}
+      ARCHIVE_ALLOWED_OPTS = %i[prefix remote path format add_gzip].freeze
+      private_constant :ARCHIVE_ALLOWED_OPTS
+
+      # Create an archive of the repository tree and write it to a file
+      #
+      # Writes the archive content to a file and returns the file path. The
+      # default format is `zip`. Pass `format: 'tar'` for an uncompressed tar
+      # archive, or `format: 'tgz'` for a gzip-compressed tar archive
+      # (equivalent to `format: 'tar'` with `add_gzip: true`).
+      #
+      # When no `file` path is given, a temporary file is created and its path
+      # is returned.
+      #
+      # **File replacement behavior when `file` is given:**
+      #
+      # The archive is first written to a staging file in the same directory as
+      # `file`. This means write permission is required on the parent directory
+      # of `file`, not just on `file` itself. Once the archive is fully written,
+      # the staging file atomically replaces `file` via rename.
+      #
+      # If `file` already exists, only its numeric permission bits are applied to
+      # the new archive; ownership, ACLs, and extended attributes are not
+      # transferred. If `file` does not exist, the archive receives the standard
+      # file creation mode (`0666 & ~umask`). On Windows, `File.chmod` has no
+      # effect, so the archive always receives the default creation mode
+      # regardless of whether `file` already exists.
+      #
+      # If `file` is a symlink that does not point to a directory, the symlink
+      # itself is replaced by the new archive file rather than writing through
+      # the link to its target. A symlink that points to a directory is treated
+      # as a directory and rejected with `ArgumentError`.
+      #
+      # @example Archive HEAD as a zip file
+      #   repo.archive('HEAD', '/tmp/release.zip') #=> "/tmp/release.zip"
+      #
+      # @example Archive a tag as a tar file
+      #   repo.archive('v1.0', '/tmp/release.tar', format: 'tar') #=> "/tmp/release.tar"
+      #
+      # @example Archive with a path prefix applied to every entry
+      #   repo.archive('HEAD', '/tmp/out.tar', format: 'tar', prefix: 'myproject/')
+      #   #=> "/tmp/out.tar"
+      #
+      # @example Archive a subdirectory only
+      #   repo.archive('HEAD', '/tmp/src.tar', format: 'tar', path: 'src/')
+      #   #=> "/tmp/src.tar"
+      #
+      # @param treeish [String] tree-ish to archive — commit SHA, tag, branch
+      #   name, or tree SHA
+      #
+      # @param file [String, nil] (nil) destination file path; when `nil`, a
+      #   unique temporary file is created and its path is returned
+      #
+      # @param opts [Hash] archive options
+      #
+      # @option opts [String] :format ('zip') archive format — `'tar'`, `'zip'`,
+      #   or `'tgz'`; `'tgz'` is internally converted to `'tar'` with gzip
+      #   post-processing
+      #
+      # @option opts [String] :prefix (nil) prefix prepended to every filename
+      #   in the archive; typically ends with `/`
+      #
+      # @option opts [String] :path (nil) path within the tree to include in the
+      #   archive; when given, only files under that path are archived
+      #
+      # @option opts [String] :remote (nil) retrieve the archive from a remote
+      #   repository rather than the local one
+      #
+      # @option opts [Boolean, nil] :add_gzip (nil) apply gzip compression after
+      #   writing the archive; set automatically when `format: 'tgz'` is given
+      #
+      # @return [String] path to the written archive file
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [ArgumentError] if `file` is an existing directory
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-archive git-archive documentation
+      #
+      def archive(treeish, file = nil, opts = {})
+        SharedPrivate.assert_valid_opts!(ARCHIVE_ALLOWED_OPTS, **opts)
+        raise ArgumentError, "#{file.inspect} is a directory" if file && File.directory?(file)
+
+        tmp = Private.write_archive_tmp(@execution_context, treeish, opts, dest_dir: Private.staging_dir_for(file))
+        return tmp unless file
+
+        Private.atomic_replace(tmp, file)
+        file
+      rescue StandardError
+        FileUtils.rm_f(tmp) if tmp
+        raise
+      end
+
+      # Private helpers for {#cat_file_commit}, {#cat_file_tag}, {#grep},
+      # and {#archive}
       #
       # @api private
       #
@@ -364,6 +462,175 @@ module Git
           end
         end
 
+        # Resolve the staging directory for a git archive temp file
+        #
+        # Always returns `Dir.tmpdir` when `file` is nil, or the parent
+        # directory of `file` otherwise. Staging the temp file in the same
+        # directory as the destination keeps both paths on the same filesystem
+        # so that {#atomic_replace} can use an atomic rename that
+        # requires no extra disk space.
+        #
+        # @param file [String, nil] the explicit destination path, or nil
+        #
+        # @return [String] directory path to pass to `Tempfile.create`
+        #
+        # @api private
+        #
+        def staging_dir_for(file)
+          return Dir.tmpdir unless file
+
+          File.dirname(File.expand_path(file))
+        end
+
+        # Write a git archive to a fresh temporary file and return its path
+        #
+        # Always writes to a new temporary file so that on error the caller's
+        # destination file is never truncated. Format and gzip post-processing
+        # are determined from `opts` via {#parse_archive_format_options}.
+        #
+        # @param execution_context [Git::ExecutionContext] for the git command
+        # @param treeish [String] tree-ish passed to `git archive`
+        # @param opts [Hash] caller-supplied options (read-only)
+        # @param dest_dir [String] directory for the staging temp file; use
+        #   {#staging_dir_for} to select the optimal directory for the destination
+        #
+        # @return [String] path to the populated temporary file
+        #
+        # @api private
+        #
+        def write_archive_tmp(execution_context, treeish, opts, dest_dir: Dir.tmpdir)
+          format, gzip = parse_archive_format_options(opts)
+          tmp_file = create_archive_tempfile(execution_context, treeish, opts, format, dest_dir)
+          apply_gzip(tmp_file.path) if gzip
+          tmp_file.path
+        rescue StandardError
+          tmp_file.close unless tmp_file.nil? || tmp_file.closed?
+          FileUtils.rm_f(tmp_file.path) if tmp_file
+          raise
+        end
+
+        # Create a staging file, write the archive into it, close it, and return it
+        #
+        # Uses `Tempfile.create` (not `Tempfile.new`) so that no GC finalizer is
+        # registered on the returned object — the file path remains valid after this
+        # method returns and after the caller stores only the path string.
+        #
+        # @param execution_context [Git::ExecutionContext] for the git command
+        # @param treeish [String] tree-ish passed to `git archive`
+        # @param opts [Hash] caller-supplied options (read-only; used for :prefix,
+        #   :remote, and :path)
+        # @param format [String] archive format string (e.g. `'zip'` or `'tar'`)
+        # @param dest_dir [String] directory in which to create the temp file
+        #
+        # @return [File] the closed file containing the archive
+        #
+        # @api private
+        #
+        def create_archive_tempfile(execution_context, treeish, opts, format, dest_dir)
+          tmp_file = Tempfile.create('archive', dest_dir).tap(&:binmode)
+          run_archive_command(execution_context, treeish, opts, format, tmp_file)
+          tmp_file.close
+          tmp_file
+        rescue StandardError
+          tmp_file&.close
+          FileUtils.rm_f(tmp_file.path) if tmp_file
+          raise
+        end
+
+        # Invoke `git archive` and stream output into `tmp_file`
+        #
+        # @param execution_context [Git::ExecutionContext] for the git command
+        # @param treeish [String] tree-ish passed to `git archive`
+        # @param opts [Hash] caller-supplied options (read-only; used for :prefix,
+        #   :remote, and :path)
+        # @param format [String] archive format to pass to `git archive --format`
+        # @param tmp_file [File] open, binary-mode IO to write archive data to
+        #
+        # @return [Git::CommandLineResult] the result of the git command
+        #
+        # @api private
+        #
+        def run_archive_command(execution_context, treeish, opts, format, tmp_file)
+          command_opts = opts.slice(:prefix, :remote).merge(format: format)
+          path_args = opts[:path] ? [opts[:path]] : []
+          Git::Commands::Archive.new(execution_context).call(treeish, *path_args, **command_opts, out: tmp_file)
+        end
+
+        # Atomically rename the staging file `src` to `dest`, replacing any
+        # existing file at `dest`. Both paths must be on the same filesystem
+        # (guaranteed when `src` is created by {#staging_dir_for}).
+        #
+        # Before the rename, the staging file's permissions are set to the
+        # existing file's numeric mode (if `dest` already existed) or to
+        # `0666 & ~umask` (standard creation mode) for new files. The chmod
+        # is applied to `src` before the rename so that, if chmod fails, `src`
+        # is still present and can be cleaned up by the rescue. Only the
+        # numeric permission bits are carried over; ownership, ACLs, and
+        # extended attributes from an existing `dest` are not preserved.
+        #
+        # If `dest` is a symlink, the symlink itself is replaced by the renamed
+        # staging file rather than writing through the link to its target.
+        #
+        # @param src [String] staging file path to rename; removed on success
+        # @param dest [String] destination file path
+        #
+        # @return [void]
+        #
+        # @api private
+        #
+        def atomic_replace(src, dest)
+          mode = File.exist?(dest) ? (File.stat(dest).mode & 0o777) : (0o666 & ~File.umask)
+          File.chmod(mode, src)
+          File.rename(src, dest)
+        rescue StandardError
+          FileUtils.rm_f(src)
+          raise
+        end
+
+        # Determine the archive format and whether to apply gzip post-processing
+        #
+        # The `tgz` pseudo-format is not understood by `git archive` directly;
+        # it is converted to `tar` and the gzip flag is set so that {#archive}
+        # applies gzip compression after the archive is written.
+        #
+        # @param opts [Hash] caller-supplied options hash (read-only)
+        #
+        # @return [Array(String, Boolean)] a two-element array `[format, gzip]`
+        #
+        #   `format` is the string to pass to `git archive --format`; `gzip` is
+        #   `true` when the caller should apply gzip post-processing after writing
+        #   the archive.
+        #
+        # @api private
+        #
+        def parse_archive_format_options(opts)
+          format = opts[:format] || 'zip'
+          gzip = opts[:add_gzip] == true || format == 'tgz'
+          [format == 'tgz' ? 'tar' : format, gzip]
+        end
+
+        # Apply gzip compression to the given file in place
+        #
+        # Streams from the source file through a {Zlib::GzipWriter} into a sibling
+        # temporary file, then replaces the original.  Peak memory is proportional
+        # to the stream buffer rather than the full archive size.
+        #
+        # @param file [String] path to the file to compress in place
+        #
+        # @return [void]
+        #
+        # @api private
+        #
+        def apply_gzip(file)
+          gz_tmp = Tempfile.create('archive_gz', File.dirname(file)).tap(&:close).path
+          Zlib::GzipWriter.open(gz_tmp) { |gz| File.open(file, 'rb') { |f| IO.copy_stream(f, gz) } }
+          FileUtils.rm_f(file)
+          File.rename(gz_tmp, file)
+        rescue StandardError
+          FileUtils.rm_f(gz_tmp) if gz_tmp
+          raise
+        end
+
         # Assembles the commit Hash from parsed lines
         #
         # @param data [Array<String>] mutable cat-file output lines, consumed
@@ -418,9 +685,7 @@ module Git
         #
         def process_tag_data(data, name)
           hsh = { 'name' => name }
-          each_cat_file_header(data) do |key, value|
-            hsh[key] = value
-          end
+          each_cat_file_header(data) { |key, value| hsh[key] = value }
           hsh['message'] = "#{data.join("\n")}\n"
           hsh
         end

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -287,6 +287,134 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     end
   end
 
+  describe '#archive' do
+    context 'with no file argument (temp file)' do
+      it 'returns a non-nil String path to a written file' do
+        result = described_instance.archive('HEAD')
+        expect(result).to be_a(String)
+        expect(File.size(result)).to be_positive
+      ensure
+        File.delete(result) if result && File.exist?(result)
+      end
+    end
+
+    context 'with an explicit output file' do
+      let(:tmpfile) do
+        t = Tempfile.new('archive_test')
+        t.close # Release the handle so File.rename can atomically replace this path on all platforms
+        t
+      end
+
+      after { tmpfile.close! }
+
+      context 'with a commit treeish and a zip format' do
+        it 'returns the given file path' do
+          result = described_instance.archive('HEAD', tmpfile.path, format: 'zip')
+          expect(result).to eq(tmpfile.path)
+        end
+
+        it 'writes a non-empty file' do
+          described_instance.archive('HEAD', tmpfile.path, format: 'zip')
+          expect(File.size(tmpfile.path)).to be_positive
+        end
+      end
+
+      context 'with a tar format' do
+        it 'writes a non-empty archive file' do
+          described_instance.archive('HEAD', tmpfile.path, format: 'tar')
+          expect(File.size(tmpfile.path)).to be_positive
+        end
+      end
+
+      context 'with a tgz format' do
+        it 'writes a gzip-compressed archive file' do
+          described_instance.archive('HEAD', tmpfile.path, format: 'tgz')
+          expect(File.size(tmpfile.path)).to be_positive
+          # Verify the file is a valid gzip stream
+          Zlib::GzipReader.open(tmpfile.path, &:read)
+        end
+      end
+
+      context 'with a prefix option' do
+        it 'writes a non-empty archive file' do
+          described_instance.archive('HEAD', tmpfile.path, format: 'tar', prefix: 'myproject/')
+          expect(File.size(tmpfile.path)).to be_positive
+        end
+      end
+
+      context 'with add_gzip: true' do
+        it 'writes a gzip-compressed archive file' do
+          described_instance.archive('HEAD', tmpfile.path, format: 'tar', add_gzip: true)
+          expect(File.size(tmpfile.path)).to be_positive
+          Zlib::GzipReader.open(tmpfile.path, &:read)
+        end
+      end
+
+      context 'with an unknown option' do
+        it 'raises ArgumentError without calling git' do
+          expect { described_instance.archive('HEAD', tmpfile.path, bad_opt: true) }
+            .to raise_error(ArgumentError)
+        end
+      end
+
+      context 'when the destination already exists with specific permissions' do
+        before { skip 'POSIX file modes are not supported on Windows' if Gem.win_platform? }
+        before { File.chmod(0o640, tmpfile.path) }
+
+        it 'preserves the existing file mode on the written archive' do
+          described_instance.archive('HEAD', tmpfile.path, format: 'zip')
+          expect(File.stat(tmpfile.path).mode & 0o777).to eq(0o640)
+        end
+      end
+
+      context 'when the archive command fails' do
+        it 'leaves the existing destination file intact' do
+          File.write(tmpfile.path, 'original content')
+          expect { described_instance.archive('invalid-sha-does-not-exist', tmpfile.path) }
+            .to raise_error(Git::FailedError)
+          expect(File.read(tmpfile.path)).to eq('original content')
+        end
+      end
+
+      context 'when dest is a symlink to an existing non-directory file' do
+        let(:link_target) { Tempfile.new('archive_target').tap(&:close) }
+        let(:link_path) do
+          File.join(File.dirname(tmpfile.path), "archive_symlink_#{Process.pid}")
+        end
+
+        before do
+          File.symlink(link_target.path, link_path)
+        rescue NotImplementedError, SystemCallError
+          skip 'Symlinks are not supported or not permitted on this platform'
+        end
+
+        after do
+          File.unlink(link_path) if File.exist?(link_path) || File.symlink?(link_path)
+          link_target.close!
+        end
+
+        it 'replaces the symlink with a regular archive file' do
+          described_instance.archive('HEAD', link_path, format: 'zip')
+          expect(File.symlink?(link_path)).to be(false)
+          expect(File.size(link_path)).to be_positive
+        end
+
+        it 'does not modify the symlink target' do
+          target_size_before = File.size(link_target.path)
+          described_instance.archive('HEAD', link_path, format: 'zip')
+          expect(File.size(link_target.path)).to eq(target_size_before)
+        end
+      end
+    end
+
+    context 'with a directory path as file' do
+      it 'raises ArgumentError without creating an archive file' do
+        expect { described_instance.archive('HEAD', Dir.tmpdir) }
+          .to raise_error(ArgumentError, /is a directory/)
+      end
+    end
+  end
+
   describe '#grep' do
     before do
       write_file('src/foo.rb', "# TODO: fix this\nsome other line\n")

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -392,6 +392,144 @@ RSpec.describe Git::Repository::ObjectOperations do
     end
   end
 
+  describe '#archive' do
+    let(:archive_command) { instance_double(Git::Commands::Archive) }
+    let(:archive_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Archive).to receive(:new)
+        .with(execution_context)
+        .and_return(archive_command)
+      allow(archive_command).to receive(:call).and_return(archive_result)
+    end
+
+    context 'with no file path (temp file path)' do
+      subject(:result) { described_instance.archive('HEAD').tap { |p| @tmp_archive = p } }
+
+      after { File.unlink(@tmp_archive) if @tmp_archive && File.exist?(@tmp_archive) }
+
+      it 'returns a non-nil String path' do
+        expect(result).to be_a(String)
+      end
+    end
+
+    context 'with an explicit output file' do
+      let(:tmpfile) do
+        t = Tempfile.new(['archive_unit', '.zip'])
+        t.close # Release the handle so File.rename can atomically replace this path on all platforms
+        t
+      end
+
+      after { tmpfile.close! }
+
+      context 'with a treeish and an explicit file path' do
+        subject(:result) { described_instance.archive('HEAD', tmpfile.path) }
+
+        it 'constructs Git::Commands::Archive with the execution context' do
+          expect(Git::Commands::Archive).to receive(:new).with(execution_context).and_return(archive_command)
+          result
+        end
+
+        it 'calls Git::Commands::Archive#call with treeish, format: zip, and an out: File' do
+          expect(archive_command).to receive(:call)
+            .with('HEAD', format: 'zip', out: instance_of(File))
+            .and_return(archive_result)
+          result
+        end
+
+        it 'returns the given file path' do
+          expect(result).to eq(tmpfile.path)
+        end
+      end
+
+      context 'with format: tar' do
+        subject(:result) { described_instance.archive('HEAD', tmpfile.path, format: 'tar') }
+
+        it 'calls Git::Commands::Archive#call with format: tar' do
+          expect(archive_command).to receive(:call)
+            .with('HEAD', format: 'tar', out: instance_of(File))
+            .and_return(archive_result)
+          result
+        end
+      end
+
+      context 'with format: tgz' do
+        subject(:result) { described_instance.archive('v1.0', tmpfile.path, format: 'tgz') }
+
+        it 'converts tgz to tar when calling Git::Commands::Archive#call' do
+          expect(archive_command).to receive(:call)
+            .with('v1.0', format: 'tar', out: instance_of(File))
+            .and_return(archive_result)
+          result
+        end
+      end
+
+      context 'with add_gzip: true' do
+        subject(:result) { described_instance.archive('HEAD', tmpfile.path, add_gzip: true) }
+
+        it 'calls Git::Commands::Archive#call with format: zip (unchanged by add_gzip)' do
+          expect(archive_command).to receive(:call)
+            .with('HEAD', format: 'zip', out: instance_of(File))
+            .and_return(archive_result)
+          result
+        end
+
+        it 'returns the given file path' do
+          expect(result).to eq(tmpfile.path)
+        end
+      end
+
+      context 'with a prefix option' do
+        subject(:result) { described_instance.archive('HEAD', tmpfile.path, format: 'tar', prefix: 'myproject/') }
+
+        it 'forwards prefix to Git::Commands::Archive#call' do
+          expect(archive_command).to receive(:call)
+            .with('HEAD', format: 'tar', prefix: 'myproject/', out: instance_of(File))
+            .and_return(archive_result)
+          result
+        end
+      end
+
+      context 'with a path option' do
+        subject(:result) { described_instance.archive('HEAD', tmpfile.path, format: 'tar', path: 'src/') }
+
+        it 'passes path as a positional argument to Git::Commands::Archive#call' do
+          expect(archive_command).to receive(:call)
+            .with('HEAD', 'src/', format: 'tar', out: instance_of(File))
+            .and_return(archive_result)
+          result
+        end
+      end
+
+      context 'with a remote option' do
+        subject(:result) { described_instance.archive('HEAD', tmpfile.path, remote: 'origin') }
+
+        it 'forwards remote to Git::Commands::Archive#call' do
+          expect(archive_command).to receive(:call)
+            .with('HEAD', format: 'zip', remote: 'origin', out: instance_of(File))
+            .and_return(archive_result)
+          result
+        end
+      end
+
+      context 'with an unknown option' do
+        subject(:result) { described_instance.archive('HEAD', tmpfile.path, unknown_opt: true) }
+
+        it 'raises ArgumentError before calling Git::Commands::Archive' do
+          expect(Git::Commands::Archive).not_to receive(:new)
+          expect { result }.to raise_error(ArgumentError)
+        end
+      end
+    end
+
+    context 'with a directory path as file' do
+      it 'raises ArgumentError before calling Git::Commands::Archive' do
+        expect(Git::Commands::Archive).not_to receive(:new)
+        expect { described_instance.archive('HEAD', Dir.tmpdir) }.to raise_error(ArgumentError, /is a directory/)
+      end
+    end
+  end
+
   describe '#grep' do
     let(:grep_command) { instance_double(Git::Commands::Grep) }
 


### PR DESCRIPTION
## Summary

Extracts `Git::Lib#archive` to a new `#archive` facade method on
`Git::Repository::ObjectOperations`, following the v5.0.0 Strangler Fig
migration pattern.

## Changes

### `lib/git/repository/object_operations.rb`

- Added `require 'git/commands/archive'` and `require 'zlib'`
- Added `ARCHIVE_ALLOWED_OPTS` constant (`%i[prefix remote path format add_gzip]`)
- Added `#archive(treeish, file = nil, opts = {})` facade method that:
  - Whitelists options via `SharedPrivate.assert_valid_opts!`
  - Creates a temporary file when no `file` is given
  - Parses format options (handles `tgz` → `tar` + gzip post-processing)
  - Streams the archive via `Git::Commands::Archive` with `out: f`
  - Applies gzip post-processing when needed
  - Returns the file path
- Added three private helpers to `Private` module (`temp_file_name`, `parse_archive_format_options`, `apply_gzip`) ported from `Git::Lib`
- Updated `Private` module doc comment to include `{#archive}`

### `lib/git/base.rb`

- Updated `#archive` to delegate to `facade_repository.archive(treeish, file, opts)` (was: `object(treeish).archive(file, opts)`)
- Updated YARD docs to reference the facade and use canonical `@raise` wording

### `spec/unit/git/repository/object_operations_spec.rb`

- Added unit tests for `#archive` covering:
  - Delegation contract (command construction, call arguments)
  - Default zip format
  - `format: 'tar'` forwarded as-is
  - `format: 'tgz'` converted to `tar` in the command call
  - `prefix:` forwarded to the command
  - `path:` passed as a positional argument
  - `remote:` forwarded to the command
  - Unknown option raises `ArgumentError` before the command is constructed

### `spec/integration/git/repository/object_operations_spec.rb`

- Added integration tests for `#archive` covering:
  - Zip format writes a non-empty file and returns the file path
  - No-file argument uses a temp file
  - Tar format writes a non-empty file
  - Tgz format produces a valid gzip stream
  - Prefix option writes a non-empty archive
  - Unknown option raises `ArgumentError`

## Migration pattern

**Source pattern:** Pattern A — `Git::Base` wrapper that delegates through `Git::Object::AbstractObject#archive` to `Git::Lib#archive`.

**After migration:**
- `Git::Base#archive` → `facade_repository.archive(treeish, file, opts)` ✅
- `Git::Lib#archive` remains in place (not yet delegating; follows convention established by other extractions in this codebase)

## Quality gates

All pass:

- `bundle exec rake spec:unit:parallel` — 0 failures
- `bundle exec rake spec:integration:parallel` — 0 failures  
- `bundle exec rake test:parallel` — 0 failures (including `test_archive` legacy tests)
- `bundle exec rake rubocop` — no offenses
- `bundle exec rake yard` — coverage 79.1% (above 75% threshold); example tests all pass