### PR TITLE
feat(repository): add Git::Repository#full_tree facade method

### DIFF
--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -4,6 +4,7 @@ require 'fileutils'
 require 'git/commands/archive'
 require 'git/commands/cat_file/raw'
 require 'git/commands/grep'
+require 'git/commands/ls_tree'
 require 'git/commands/rev_parse'
 require 'git/repository/shared_private'
 require 'tempfile'
@@ -238,6 +239,34 @@ module Git
       #
       def rev_parse(objectish)
         Git::Commands::RevParse.new(@execution_context).call(objectish, '--', revs_only: true).stdout
+      end
+
+      # Returns all recursive entries for a given tree object
+      #
+      # Equivalent to running `git ls-tree -r <sha>` and splitting the output on
+      # newlines. Each returned line describes a single file in the tree in the
+      # format produced by `git ls-tree`: `<mode> <type> <object>\t<file>`.
+      #
+      # @example List all files in the tree rooted at HEAD
+      #   repo.full_tree('HEAD^{tree}')
+      #   # => [
+      #   #   "100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tex_dir/ex.txt",
+      #   #   "100644 blob abc1234...\tlib/git.rb"
+      #   # ]
+      #
+      # @param sha [String] the tree SHA or tree-ish specifier to recurse into
+      #
+      # @return [Array<String>] one entry per file, in the format
+      #   `<mode> <type> <object>\t<file>`
+      #
+      #   Returns an empty array for an empty tree.
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-ls-tree git-ls-tree documentation
+      #
+      def full_tree(sha)
+        Git::Commands::LsTree.new(@execution_context).call(sha, r: true).stdout.split("\n")
       end
 
       # Option keys accepted by {#grep}

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -287,6 +287,44 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     end
   end
 
+  describe '#full_tree' do
+    context 'with the tree SHA for a commit containing one file' do
+      it 'returns an Array<String>' do
+        tree_sha = repo.lib.rev_parse('HEAD^{tree}')
+        result = described_instance.full_tree(tree_sha)
+        expect(result).to be_a(Array)
+        expect(result).to all(be_a(String))
+      end
+
+      it 'returns one entry per file in the tree' do
+        tree_sha = repo.lib.rev_parse('HEAD^{tree}')
+        result = described_instance.full_tree(tree_sha)
+        expect(result.size).to eq(1)
+      end
+
+      it 'returns entries in the git ls-tree format <mode> <type> <object>\\t<file>' do
+        tree_sha = repo.lib.rev_parse('HEAD^{tree}')
+        result = described_instance.full_tree(tree_sha)
+        expect(result.first).to match(/\A\d{6} \w+ [0-9a-f]{40}\t\S+\z/)
+      end
+    end
+
+    context 'with a treeish specifier (HEAD^{tree})' do
+      it 'resolves and recurses into the tree' do
+        result = described_instance.full_tree('HEAD^{tree}')
+        expect(result).to be_a(Array)
+        expect(result).not_to be_empty
+      end
+    end
+
+    context 'when the sha does not exist' do
+      it 'raises Git::FailedError' do
+        expect { described_instance.full_tree('0000000000000000000000000000000000000000') }
+          .to raise_error(Git::FailedError)
+      end
+    end
+  end
+
   describe '#archive' do
     context 'with no file argument (temp file)' do
       it 'returns a non-nil String path to a written file' do

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -392,6 +392,54 @@ RSpec.describe Git::Repository::ObjectOperations do
     end
   end
 
+  describe '#full_tree' do
+    let(:ls_tree_command) { instance_double(Git::Commands::LsTree) }
+
+    before do
+      allow(Git::Commands::LsTree).to receive(:new)
+        .with(execution_context)
+        .and_return(ls_tree_command)
+    end
+
+    context 'with a tree SHA' do
+      subject(:result) { described_instance.full_tree('abc1234') }
+
+      let(:tree_output) do
+        "100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tex_dir/ex.txt\n" \
+          "100644 blob abcdef0123456789abcdef0123456789abcdef01\tlib/git.rb\n"
+      end
+      let(:tree_result) { command_result(tree_output) }
+
+      it 'constructs Git::Commands::LsTree with the execution context' do
+        expect(Git::Commands::LsTree).to receive(:new).with(execution_context).and_return(ls_tree_command)
+        allow(ls_tree_command).to receive(:call).and_return(tree_result)
+        result
+      end
+
+      it 'calls Git::Commands::LsTree#call with the sha and r: true' do
+        expect(ls_tree_command).to receive(:call).with('abc1234', r: true).and_return(tree_result)
+        result
+      end
+
+      it 'returns stdout split on newlines as an Array<String>' do
+        allow(ls_tree_command).to receive(:call).with('abc1234', r: true).and_return(tree_result)
+        expect(result).to eq([
+                               "100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tex_dir/ex.txt",
+                               "100644 blob abcdef0123456789abcdef0123456789abcdef01\tlib/git.rb"
+                             ])
+      end
+    end
+
+    context 'when the tree is empty' do
+      subject(:result) { described_instance.full_tree('abc1234') }
+
+      it 'returns an empty Array' do
+        allow(ls_tree_command).to receive(:call).with('abc1234', r: true).and_return(command_result(''))
+        expect(result).to eq([])
+      end
+    end
+  end
+
   describe '#archive' do
     let(:archive_command) { instance_double(Git::Commands::Archive) }
     let(:archive_result) { command_result('') }


### PR DESCRIPTION
## Summary

Extracts `Git::Lib#full_tree` into a new public facade method
`Git::Repository::ObjectOperations#full_tree` as part of the Strangler Fig
migration.

`Git::Lib#full_tree` is **not** delegated to the facade — both
implementations coexist independently during the migration window.

## Changes

### `lib/git/repository/object_operations.rb`

- Add `require 'git/commands/ls_tree'`
- Add `#full_tree(sha)` facade method — calls `git ls-tree -r <sha>` via
  `Git::Commands::LsTree` and returns `Array<String>` (stdout split on
  newlines), preserving the existing return type from `Git::Lib#full_tree`

### `spec/unit/git/repository/object_operations_spec.rb`

- Add unit tests for `#full_tree` covering:
  - `Git::Commands::LsTree` construction with execution context
  - call delegation with `sha` and `r: true`
  - return value (stdout split on `"\n"`)
  - empty-tree case returns `[]`

### `spec/integration/git/repository/object_operations_spec.rb`

- Add integration tests for `#full_tree` covering:
  - returns `Array<String>` with one entry per file
  - each entry matches the `git ls-tree` format `<mode> <type> <object>\t<file>`
  - treeish specifier is resolved correctly
  - non-existent SHA raises `Git::FailedError`

## Pattern

Pattern B (Lib-only, public-by-exposure): `Git::Lib#full_tree` has no
`Git::Base` wrapper. The facade adds the method directly to
`Git::Repository::ObjectOperations`.
