### PR TITLE
feat(repository): add Git::Repository#name_rev facade method

### DIFF
--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -5,6 +5,7 @@ require 'git/commands/archive'
 require 'git/commands/cat_file/raw'
 require 'git/commands/grep'
 require 'git/commands/ls_tree'
+require 'git/commands/name_rev'
 require 'git/commands/rev_parse'
 require 'git/repository/shared_private'
 require 'tempfile'
@@ -267,6 +268,31 @@ module Git
       #
       def full_tree(sha)
         Git::Commands::LsTree.new(@execution_context).call(sha, r: true).stdout.split("\n")
+      end
+
+      # Find the first symbolic name for a commit-ish
+      #
+      # @example Find the symbolic name for a commit
+      #   repo.name_rev('abc123') #=> "main~5"
+      #
+      # @example Returns nil when the commit-ish has no symbolic name
+      #   repo.name_rev('0000000000000000000000000000000000000000') #=> nil
+      #
+      # @param commit_ish [String] the commit-ish to find the symbolic name of
+      #
+      # @return [String, nil] the first symbolic name, or nil if no symbolic name
+      #   was found
+      #
+      # @raise [ArgumentError] if commit_ish starts with a hyphen
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero status
+      #
+      # @see https://git-scm.com/docs/git-name-rev git-name-rev documentation
+      #
+      def name_rev(commit_ish)
+        raise ArgumentError, "Invalid commit_ish: '#{commit_ish}'" if commit_ish&.start_with?('-')
+
+        Git::Commands::NameRev.new(@execution_context).call(commit_ish).stdout.split[1]
       end
 
       # Option keys accepted by {#grep}

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -275,17 +275,17 @@ module Git
       # @example Find the symbolic name for a commit
       #   repo.name_rev('abc123') #=> "main~5"
       #
-      # @example Returns nil when the commit-ish has no symbolic name
-      #   repo.name_rev('0000000000000000000000000000000000000000') #=> nil
+      # @example Find the symbolic name for HEAD
+      #   repo.name_rev('HEAD') #=> "main"
       #
       # @param commit_ish [String] the commit-ish to find the symbolic name of
       #
-      # @return [String, nil] the first symbolic name, or nil if no symbolic name
-      #   was found
+      # @return [String, nil] the first symbolic name, or nil if stdout contains
+      #   fewer than two words
       #
       # @raise [ArgumentError] if commit_ish starts with a hyphen
       #
-      # @raise [Git::FailedError] if git exits with a non-zero status
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
       # @see https://git-scm.com/docs/git-name-rev git-name-rev documentation
       #

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -325,6 +325,37 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     end
   end
 
+  describe '#name_rev' do
+    context 'with a commit SHA that has a symbolic name' do
+      it 'returns a String' do
+        sha = repo.lib.rev_parse('HEAD')
+        result = described_instance.name_rev(sha)
+        expect(result).to be_a(String)
+      end
+
+      it 'returns the symbolic name without a trailing newline' do
+        sha = repo.lib.rev_parse('HEAD')
+        result = described_instance.name_rev(sha)
+        expect(result).not_to end_with("\n")
+      end
+    end
+
+    context 'with a branch ref that resolves to a commit' do
+      it 'returns a non-nil String' do
+        result = described_instance.name_rev('HEAD')
+        expect(result).to be_a(String)
+        expect(result).not_to be_empty
+      end
+    end
+
+    context 'when commit_ish starts with a hyphen' do
+      it 'raises ArgumentError without calling git' do
+        expect { described_instance.name_rev('--tags') }
+          .to raise_error(ArgumentError, "Invalid commit_ish: '--tags'")
+      end
+    end
+  end
+
   describe '#archive' do
     context 'with no file argument (temp file)' do
       it 'returns a non-nil String path to a written file' do

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -440,6 +440,56 @@ RSpec.describe Git::Repository::ObjectOperations do
     end
   end
 
+  describe '#name_rev' do
+    let(:name_rev_command) { instance_double(Git::Commands::NameRev) }
+
+    before do
+      allow(Git::Commands::NameRev).to receive(:new)
+        .with(execution_context)
+        .and_return(name_rev_command)
+    end
+
+    context 'with a valid commit SHA' do
+      subject(:result) { described_instance.name_rev('abc1234') }
+
+      let(:name_rev_result) { command_result("abc1234 main~5\n") }
+
+      it 'constructs Git::Commands::NameRev with the execution context' do
+        expect(Git::Commands::NameRev).to receive(:new).with(execution_context).and_return(name_rev_command)
+        allow(name_rev_command).to receive(:call).and_return(name_rev_result)
+        result
+      end
+
+      it 'calls Git::Commands::NameRev#call with the commit_ish' do
+        expect(name_rev_command).to receive(:call).with('abc1234').and_return(name_rev_result)
+        result
+      end
+
+      it 'returns the symbolic name (second word of stdout)' do
+        allow(name_rev_command).to receive(:call).with('abc1234').and_return(name_rev_result)
+        expect(result).to eq('main~5')
+      end
+    end
+
+    context 'when stdout has only one word (no symbolic name found)' do
+      subject(:result) { described_instance.name_rev('deadbeef') }
+
+      it 'returns nil' do
+        allow(name_rev_command).to receive(:call).with('deadbeef').and_return(command_result("deadbeef\n"))
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when commit_ish starts with a hyphen' do
+      subject(:result) { described_instance.name_rev('--tags') }
+
+      it 'raises ArgumentError before calling the command' do
+        expect(Git::Commands::NameRev).not_to receive(:new)
+        expect { result }.to raise_error(ArgumentError, "Invalid commit_ish: '--tags'")
+      end
+    end
+  end
+
   describe '#archive' do
     let(:archive_command) { instance_double(Git::Commands::Archive) }
     let(:archive_result) { command_result('') }


### PR DESCRIPTION
## Summary

Extracts `name_rev` from `Git::Lib` into the v5.0.0 redesign layer by adding `Git::Repository#name_rev` as a facade method on `Git::Repository::ObjectOperations`.

This is a **Pattern B** extraction (Git::Lib-only — no `Git::Base` wrapper exists for `name_rev`), following the Strangler Fig migration plan.

## Changes

### `lib/git/repository/object_operations.rb`
- Added `require 'git/commands/name_rev'`
- Added `#name_rev(commit_ish)` facade method with:
  - `ArgumentError` guard against options-style arguments (strings starting with `-`)
  - Delegates to the already-existing `Git::Commands::NameRev`
  - YARD documentation with two `@example` tags, `@param`, `@return`, `@raise`, and `@see`

### `spec/unit/git/repository/object_operations_spec.rb`
- Added `describe '#name_rev'` with 5 examples covering:
  - Returns the second word of stdout (the symbolic name)
  - Returns `nil` when stdout has only one word
  - Raises `ArgumentError` when `commit_ish` starts with a hyphen

### `spec/integration/git/repository/object_operations_spec.rb`
- Added `describe '#name_rev'` with 4 examples covering:
  - Returns a `String` for a commit SHA with a symbolic name
  - Returns a non-nil `String` for a branch ref
  - Raises `ArgumentError` when `commit_ish` starts with a hyphen

## Notes

- `Git::Lib#name_rev` is left unchanged (it will be removed in Phase 4 along with all of `Git::Lib`)
- `Git::Commands::NameRev` pre-existed this change; no modifications needed
- `Git::Repository` already includes `ObjectOperations`; no changes to `repository.rb` needed
