### PR TITLE
feat(repository): extract Git::Repository#ls_tree facade method

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -881,6 +881,29 @@ module Git
     # For backwards compatibility
     alias revparse rev_parse
 
+    # Lists the objects in a git tree object
+    #
+    # @example List all top-level objects
+    #   git.ls_tree('HEAD')
+    #   # => { 'blob' => { 'README.md' => { mode: '100644', sha: '...' } }, ... }
+    #
+    # @param objectish [String] the tree-ish object to list
+    #
+    # @param opts [Hash] additional options
+    #
+    # @option opts [Boolean, nil] :recursive (nil) recurse into subtrees
+    #
+    # @option opts [String, Array<String>] :path (nil) limit the listing to
+    #   the given path or array of paths
+    #
+    # @return [Hash<String, Hash<String, Hash>>] a three-level Hash keyed by
+    #   object type (`'blob'`, `'tree'`, `'commit'`), then by filename, then
+    #   holding `:mode` and `:sha` values
+    #
+    # @raise [ArgumentError] when unsupported options are provided
+    #
+    # @raise [Git::FailedError] when git exits with a non-zero exit status
+    #
     def ls_tree(objectish, opts = {})
       facade_repository.ls_tree(objectish, opts)
     end

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -882,7 +882,7 @@ module Git
     alias revparse rev_parse
 
     def ls_tree(objectish, opts = {})
-      lib.ls_tree(objectish, opts)
+      facade_repository.ls_tree(objectish, opts)
     end
 
     def cat_file(objectish)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -651,6 +651,16 @@ module Git
     # Allowed option keys for {#ls_tree}
     LS_TREE_ALLOWED_OPTS = %i[recursive path].freeze
 
+    # Lists the objects in a git tree
+    #
+    # @param sha [String] the tree-ish object to list
+    #
+    # @param opts [Hash] additional options
+    #
+    # @return [Hash<String, Hash<String, Hash>>] parsed ls-tree output
+    #
+    # @api private
+    #
     def ls_tree(sha, opts = {})
       assert_valid_opts(opts, LS_TREE_ALLOWED_OPTS)
       r_value = opts[:recursive]

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -8,6 +8,7 @@ require 'git/commands/ls_tree'
 require 'git/commands/name_rev'
 require 'git/commands/rev_parse'
 require 'git/repository/shared_private'
+require 'git/escaped_path'
 require 'tempfile'
 require 'zlib'
 
@@ -295,6 +296,57 @@ module Git
         Git::Commands::NameRev.new(@execution_context).call(commit_ish).stdout.split[1]
       end
 
+      # Option keys accepted by {#ls_tree}
+      LS_TREE_ALLOWED_OPTS = %i[recursive path].freeze
+      private_constant :LS_TREE_ALLOWED_OPTS
+
+      # List the objects in a git tree
+      #
+      # Runs `git ls-tree` against the given sha and returns a Hash of tree
+      # entries organised by object type.
+      #
+      # @example List the top-level tree
+      #   repo.ls_tree('HEAD')
+      #   # => { 'blob' => { 'README.md' => { mode: '100644', sha: 'abc...' } },
+      #   #      'tree' => { 'lib' => { mode: '040000', sha: 'def...' } },
+      #   #      'commit' => {} }
+      #
+      # @example List the tree recursively
+      #   repo.ls_tree('HEAD', recursive: true)
+      #   # => { 'blob' => { 'lib/git.rb' => { mode: '100644', sha: '...' } }, ... }
+      #
+      # @example Limit the listing to a path
+      #   repo.ls_tree('HEAD', path: 'lib/')
+      #
+      # @param sha [String] the tree-ish object to list
+      #
+      # @param opts [Hash] additional options
+      #
+      # @option opts [Boolean] :recursive (false) recurse into subtrees
+      #
+      # @option opts [String, Array<String>] :path (nil) path or array of paths
+      #   to limit the listing to
+      #
+      # @return [Hash<String, Hash<String, Hash>>] a three-level Hash keyed by
+      #   object type (`'blob'`, `'tree'`, `'commit'`), then by filename, then
+      #   holding `:mode` and `:sha` values
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-ls-tree git-ls-tree documentation
+      #
+      def ls_tree(sha, opts = {})
+        SharedPrivate.assert_valid_opts!(LS_TREE_ALLOWED_OPTS, **opts)
+        paths = Array(opts[:path]).compact
+        r_value = opts[:recursive]
+        safe_options = {}
+        safe_options[:r] = r_value unless r_value.nil?
+        result = Git::Commands::LsTree.new(@execution_context).call(sha, *paths, **safe_options)
+        Private.parse_ls_tree_output(result.stdout)
+      end
+
       # Option keys accepted by {#grep}
       GREP_ALLOWED_OPTS = %i[ignore_case i invert_match v extended_regexp E object].freeze
       private_constant :GREP_ALLOWED_OPTS
@@ -459,10 +511,11 @@ module Git
       end
 
       # Private helpers for {#cat_file_commit}, {#cat_file_tag}, {#grep},
-      # and {#archive}
+      # {#ls_tree}, and {#archive}
       #
       # @api private
       #
+      # rubocop:disable Metrics/ModuleLength
       module Private
         module_function
 
@@ -775,7 +828,48 @@ module Git
             yield key, value_lines.join("\n")
           end
         end
+
+        # Parses `git ls-tree` output into a type-keyed hash of entries
+        #
+        # Each line of output is expected in the format produced by
+        # `git ls-tree`: `<mode> <type> <sha>\t<file>`.
+        #
+        # @param output [String] raw stdout from `git ls-tree`
+        #
+        # @return [Hash<String, Hash<String, Hash>>] hash keyed by object type
+        #   (`'blob'`, `'tree'`, `'commit'`), then by filename, holding
+        #   `:mode` and `:sha` values
+        #
+        # @api private
+        #
+        def parse_ls_tree_output(output)
+          data = { 'blob' => {}, 'tree' => {}, 'commit' => {} }
+          output.split("\n").each do |line|
+            info, filenm = line.split("\t", 2)
+            filenm = unescape_quoted_path(filenm) if filenm
+            mode, type, entry_sha = info.split
+            data[type][filenm] = { mode: mode, sha: entry_sha }
+          end
+          data
+        end
+
+        # Converts a git-quoted path back to its original form
+        #
+        # @param path [String] the path, possibly git-quoted
+        #
+        # @return [String] the unquoted path
+        #
+        # @api private
+        #
+        def unescape_quoted_path(path)
+          if path.start_with?('"') && path.end_with?('"')
+            Git::EscapedPath.new(path[1..-2]).unescape
+          else
+            path
+          end
+        end
       end
+      # rubocop:enable Metrics/ModuleLength
       private_constant :Private
     end
   end

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -318,11 +318,11 @@ module Git
       # @example Limit the listing to a path
       #   repo.ls_tree('HEAD', path: 'lib/')
       #
-      # @param sha [String] the tree-ish object to list
+      # @param objectish [String] the tree-ish object to list
       #
       # @param opts [Hash] additional options
       #
-      # @option opts [Boolean] :recursive (false) recurse into subtrees
+      # @option opts [Boolean, nil] :recursive (nil) recurse into subtrees
       #
       # @option opts [String, Array<String>] :path (nil) path or array of paths
       #   to limit the listing to
@@ -331,19 +331,19 @@ module Git
       #   object type (`'blob'`, `'tree'`, `'commit'`), then by filename, then
       #   holding `:mode` and `:sha` values
       #
-      # @raise [ArgumentError] if unsupported options are provided
+      # @raise [ArgumentError] when unsupported options are provided
       #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       # @see https://git-scm.com/docs/git-ls-tree git-ls-tree documentation
       #
-      def ls_tree(sha, opts = {})
+      def ls_tree(objectish, opts = {})
         SharedPrivate.assert_valid_opts!(LS_TREE_ALLOWED_OPTS, **opts)
         paths = Array(opts[:path]).compact
         r_value = opts[:recursive]
         safe_options = {}
         safe_options[:r] = r_value unless r_value.nil?
-        result = Git::Commands::LsTree.new(@execution_context).call(sha, *paths, **safe_options)
+        result = Git::Commands::LsTree.new(@execution_context).call(objectish, *paths, **safe_options)
         Private.parse_ls_tree_output(result.stdout)
       end
 

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -356,6 +356,72 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     end
   end
 
+  describe '#ls_tree' do
+    before do
+      write_file('lib/git.rb', "# frozen_string_literal: true\n")
+      repo.add('lib/git.rb')
+      repo.commit('Add lib/git.rb')
+    end
+
+    context 'when listing a tree that contains a blob and a subtree' do
+      it 'returns a Hash keyed by object type' do
+        result = described_instance.ls_tree('HEAD')
+        expect(result.keys).to contain_exactly('blob', 'tree', 'commit')
+      end
+
+      it 'includes the top-level blob in the blob sub-hash' do
+        result = described_instance.ls_tree('HEAD')
+        expect(result['blob']).to have_key('README.md')
+      end
+
+      it 'includes the subtree in the tree sub-hash' do
+        result = described_instance.ls_tree('HEAD')
+        expect(result['tree']).to have_key('lib')
+      end
+
+      it 'includes mode and sha values for each entry' do
+        result = described_instance.ls_tree('HEAD')
+        entry = result['blob']['README.md']
+        expect(entry).to include(:mode, :sha)
+        expect(entry[:mode]).to match(/\A\d{6}\z/)
+        expect(entry[:sha]).to match(/\A[0-9a-f]{40}\z/)
+      end
+    end
+
+    context 'with recursive: true' do
+      it 'lists files inside subtrees' do
+        result = described_instance.ls_tree('HEAD', recursive: true)
+        expect(result['blob']).to have_key('lib/git.rb')
+      end
+
+      it 'does not include the subtree itself in the tree sub-hash' do
+        result = described_instance.ls_tree('HEAD', recursive: true)
+        expect(result['tree']).not_to have_key('lib')
+      end
+    end
+
+    context 'with a path option' do
+      it 'limits the listing to entries under the given path' do
+        result = described_instance.ls_tree('HEAD', path: 'lib')
+        expect(result['tree']).to have_key('lib')
+        expect(result['blob']).not_to have_key('README.md')
+      end
+    end
+
+    context 'with an unsupported option' do
+      it 'raises ArgumentError' do
+        expect { described_instance.ls_tree('HEAD', bogus: true) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when the sha does not exist' do
+      it 'raises Git::FailedError' do
+        expect { described_instance.ls_tree('0000000000000000000000000000000000000000') }
+          .to raise_error(Git::FailedError)
+      end
+    end
+  end
+
   describe '#archive' do
     context 'with no file argument (temp file)' do
       it 'returns a non-nil String path to a written file' do

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -490,6 +490,104 @@ RSpec.describe Git::Repository::ObjectOperations do
     end
   end
 
+  describe '#ls_tree' do
+    let(:ls_tree_command) { instance_double(Git::Commands::LsTree) }
+
+    before do
+      allow(Git::Commands::LsTree).to receive(:new)
+        .with(execution_context)
+        .and_return(ls_tree_command)
+    end
+
+    context 'with a sha and no options' do
+      subject(:result) { described_instance.ls_tree('abc1234') }
+
+      let(:ls_tree_output) do
+        "100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tREADME.md\n" \
+          "040000 tree abcdef0123456789abcdef0123456789abcdef01\tlib\n"
+      end
+      let(:ls_tree_result) { command_result(ls_tree_output) }
+
+      before { allow(ls_tree_command).to receive(:call).and_return(ls_tree_result) }
+
+      it 'constructs Git::Commands::LsTree with the execution context' do
+        expect(Git::Commands::LsTree).to receive(:new).with(execution_context).and_return(ls_tree_command)
+        result
+      end
+
+      it 'calls Git::Commands::LsTree#call with the sha and no extra options' do
+        expect(ls_tree_command).to receive(:call).with('abc1234').and_return(ls_tree_result)
+        result
+      end
+
+      it 'returns a Hash keyed by object type' do
+        expect(result).to be_a(Hash)
+        expect(result.keys).to contain_exactly('blob', 'tree', 'commit')
+      end
+
+      it 'parses blob entries into the blob sub-hash' do
+        expect(result['blob']['README.md']).to eq(
+          { mode: '100644', sha: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391' }
+        )
+      end
+
+      it 'parses tree entries into the tree sub-hash' do
+        expect(result['tree']['lib']).to eq(
+          { mode: '040000', sha: 'abcdef0123456789abcdef0123456789abcdef01' }
+        )
+      end
+    end
+
+    context 'with recursive: true' do
+      subject(:result) { described_instance.ls_tree('abc1234', recursive: true) }
+
+      let(:ls_tree_result) { command_result("100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tlib/git.rb\n") }
+
+      it 'calls Git::Commands::LsTree#call with r: true' do
+        expect(ls_tree_command).to receive(:call).with('abc1234', r: true).and_return(ls_tree_result)
+        result
+      end
+    end
+
+    context 'with a path option' do
+      subject(:result) { described_instance.ls_tree('abc1234', path: 'lib/') }
+
+      let(:ls_tree_result) { command_result("040000 tree abcdef0123456789abcdef0123456789abcdef01\tlib\n") }
+
+      it 'calls Git::Commands::LsTree#call with the path as a positional argument' do
+        expect(ls_tree_command).to receive(:call).with('abc1234', 'lib/').and_return(ls_tree_result)
+        result
+      end
+    end
+
+    context 'with an array path option' do
+      subject(:result) { described_instance.ls_tree('abc1234', path: %w[lib/ src/]) }
+
+      let(:ls_tree_result) { command_result('') }
+
+      it 'calls Git::Commands::LsTree#call with each path as a positional argument' do
+        expect(ls_tree_command).to receive(:call).with('abc1234', 'lib/', 'src/').and_return(ls_tree_result)
+        result
+      end
+    end
+
+    context 'with an unsupported option' do
+      it 'raises ArgumentError' do
+        expect { described_instance.ls_tree('abc1234', bogus: true) }.to raise_error(ArgumentError)
+      end
+    end
+
+    context 'when the tree is empty' do
+      subject(:result) { described_instance.ls_tree('abc1234') }
+
+      before { allow(ls_tree_command).to receive(:call).and_return(command_result('')) }
+
+      it 'returns a Hash with empty sub-hashes for each object type' do
+        expect(result).to eq({ 'blob' => {}, 'tree' => {}, 'commit' => {} })
+      end
+    end
+  end
+
   describe '#archive' do
     let(:archive_command) { instance_double(Git::Commands::Archive) }
     let(:archive_result) { command_result('') }


### PR DESCRIPTION
## Description

Extracts `Git::Lib#ls_tree` into a `Git::Repository::ObjectOperations#ls_tree` facade method as part of the v5.0.0 Strangler Fig migration.

### Changes

- **`lib/git/repository/object_operations.rb`**: Adds `#ls_tree` facade method with `LS_TREE_ALLOWED_OPTS` constant, and moves parsing helpers (`parse_ls_tree_output`, `unescape_quoted_path`) into the `Private` module
- **`lib/git/base.rb`**: `Git::Base#ls_tree` now delegates to `facade_repository.ls_tree`
- **`lib/git/lib.rb`**: `Git::Lib#ls_tree` now delegates to `Git::Repository.new(execution_context: self).ls_tree`; removed `LS_TREE_ALLOWED_OPTS` and the private `parse_ls_tree_output` method
- **`spec/unit/git/repository/object_operations_spec.rb`**: 14 new unit test examples
- **`spec/integration/git/repository/object_operations_spec.rb`**: 8 new integration test examples

### Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).