### PR TITLE
Extract tree_depth into Repository facade

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -881,6 +881,23 @@ module Git
     # For backwards compatibility
     alias revparse rev_parse
 
+    # Returns the number of entries in a git tree object
+    #
+    # @example Count recursive entries in the HEAD tree
+    #   git.tree_depth('HEAD^{tree}') #=> 42
+    #
+    # @param objectish [String] the tree-ish object to recurse into
+    #
+    # @return [Integer] the number of entries in the recursive tree listing
+    #
+    # @raise [Git::FailedError] when git exits with a non-zero exit status
+    #
+    # @see Git::Repository::ObjectOperations#tree_depth
+    #
+    def tree_depth(objectish)
+      facade_repository.tree_depth(objectish)
+    end
+
     # Lists the objects in a git tree object
     #
     # @example List all top-level objects

--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -166,7 +166,7 @@ module Git
       end
 
       def depth
-        @base.lib.tree_depth(@objectish)
+        @base.tree_depth(@objectish)
       end
 
       def tree?

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -245,9 +245,9 @@ module Git
 
       # Returns all recursive entries for a given tree object
       #
-      # Equivalent to running `git ls-tree -r <sha>` and splitting the output on
-      # newlines. Each returned line describes a single file in the tree in the
-      # format produced by `git ls-tree`: `<mode> <type> <object>\t<file>`.
+      # Equivalent to running `git ls-tree -r <objectish>` and splitting the
+      # output on newlines. Each returned line describes a single entry in the
+      # tree in the format produced by `git ls-tree`: `<mode> <type> <object>\t<file>`.
       #
       # @example List all files in the tree rooted at HEAD
       #   repo.full_tree('HEAD^{tree}')
@@ -256,9 +256,10 @@ module Git
       #   #   "100644 blob abc1234...\tlib/git.rb"
       #   # ]
       #
-      # @param sha [String] the tree SHA or tree-ish specifier to recurse into
+      # @param objectish [String] the tree SHA or tree-ish specifier to recurse
+      #   into
       #
-      # @return [Array<String>] one entry per file, in the format
+      # @return [Array<String>] one entry per path, in the format
       #   `<mode> <type> <object>\t<file>`
       #
       #   Returns an empty array for an empty tree.
@@ -267,8 +268,29 @@ module Git
       #
       # @see https://git-scm.com/docs/git-ls-tree git-ls-tree documentation
       #
-      def full_tree(sha)
-        Git::Commands::LsTree.new(@execution_context).call(sha, r: true).stdout.split("\n")
+      def full_tree(objectish)
+        Git::Commands::LsTree.new(@execution_context).call(objectish, r: true).stdout.split("\n")
+      end
+
+      # Returns the number of entries in a tree
+      #
+      # Runs `git ls-tree -r <objectish>` and counts output lines.
+      # This matches `Git::Lib#tree_depth` behavior in the 4.x branch.
+      #
+      # @example Count entries in the tree rooted at HEAD
+      #   repo.tree_depth('HEAD^{tree}') #=> 42
+      #
+      # @param objectish [String] the tree SHA or tree-ish specifier to recurse
+      #   into
+      #
+      # @return [Integer] the number of entries in the recursive tree listing
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-ls-tree git-ls-tree documentation
+      #
+      def tree_depth(objectish)
+        Git::Commands::LsTree.new(@execution_context).call(objectish, r: true).stdout.each_line.count
       end
 
       # Find the first symbolic name for a commit-ish

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -325,6 +325,36 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     end
   end
 
+  describe '#tree_depth' do
+    context 'with the tree SHA for a commit containing one file' do
+      it 'returns the recursive entry count as an Integer' do
+        tree_sha = repo.lib.rev_parse('HEAD^{tree}')
+        result = described_instance.tree_depth(tree_sha)
+        expect(result).to be_a(Integer)
+      end
+
+      it 'returns one for the initial repository tree' do
+        tree_sha = repo.lib.rev_parse('HEAD^{tree}')
+        result = described_instance.tree_depth(tree_sha)
+        expect(result).to eq(1)
+      end
+    end
+
+    context 'with a treeish specifier (HEAD^{tree})' do
+      it 'returns a positive count' do
+        result = described_instance.tree_depth('HEAD^{tree}')
+        expect(result).to be_positive
+      end
+    end
+
+    context 'when the sha does not exist' do
+      it 'raises Git::FailedError' do
+        expect { described_instance.tree_depth('0000000000000000000000000000000000000000') }
+          .to raise_error(Git::FailedError)
+      end
+    end
+  end
+
   describe '#name_rev' do
     context 'with a commit SHA that has a symbolic name' do
       it 'returns a String' do

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -440,6 +440,51 @@ RSpec.describe Git::Repository::ObjectOperations do
     end
   end
 
+  describe '#tree_depth' do
+    let(:ls_tree_command) { instance_double(Git::Commands::LsTree) }
+
+    before do
+      allow(Git::Commands::LsTree).to receive(:new)
+        .with(execution_context)
+        .and_return(ls_tree_command)
+    end
+
+    context 'with a tree SHA' do
+      subject(:result) { described_instance.tree_depth('abc1234') }
+
+      let(:tree_output) do
+        "100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tex_dir/ex.txt\n" \
+          "100644 blob abcdef0123456789abcdef0123456789abcdef01\tlib/git.rb\n"
+      end
+      let(:tree_result) { command_result(tree_output) }
+
+      it 'constructs Git::Commands::LsTree with the execution context' do
+        expect(Git::Commands::LsTree).to receive(:new).with(execution_context).and_return(ls_tree_command)
+        allow(ls_tree_command).to receive(:call).and_return(tree_result)
+        result
+      end
+
+      it 'calls Git::Commands::LsTree#call with the sha and r: true' do
+        expect(ls_tree_command).to receive(:call).with('abc1234', r: true).and_return(tree_result)
+        result
+      end
+
+      it 'returns the number of recursive tree entries as an Integer' do
+        allow(ls_tree_command).to receive(:call).with('abc1234', r: true).and_return(tree_result)
+        expect(result).to eq(2)
+      end
+    end
+
+    context 'when the tree is empty' do
+      subject(:result) { described_instance.tree_depth('abc1234') }
+
+      it 'returns 0' do
+        allow(ls_tree_command).to receive(:call).with('abc1234', r: true).and_return(command_result(''))
+        expect(result).to eq(0)
+      end
+    end
+  end
+
   describe '#name_rev' do
     let(:name_rev_command) { instance_double(Git::Commands::NameRev) }
 


### PR DESCRIPTION
# Summary
- Added `Git::Repository::ObjectOperations#tree_depth` returning the recursive entry count from `git ls-tree -r` output (`stdout.each_line.count`)
- Added `Git::Base#tree_depth` delegating to facade
- Updated `Git::Object::Tree#depth` to call `Git::Base#tree_depth`
- Added unit/integration specs for repository object_operations `tree_depth`

# Notes
- `Git::Lib` was intentionally not modified per request
- Facade behavior matches `Git::Lib#tree_depth` in 4.x (recursive `ls-tree` entry count)

# Validation
- bundle exec rspec spec/unit/git/repository/object_operations_spec.rb
- bundle exec rspec spec/integration/git/repository/object_operations_spec.rb
- bundle exec bin/test test_object
- bundle exec rubocop lib/git/repository/object_operations.rb lib/git/base.rb lib/git/object.rb spec/unit/git/repository/object_operations_spec.rb spec/integration/git/repository/object_operations_spec.rb
- bundle exec rake yard
