### PR TITLE
refactor: extract output parsers from ObjectOperations::Private to Git::Parsers (issue #1322 PR 1)

### DIFF
--- a/lib/git/parsers/cat_file.rb
+++ b/lib/git/parsers/cat_file.rb
@@ -1,0 +1,111 @@
+# frozen_string_literal: true
+
+module Git
+  module Parsers
+    # Parser for `git cat-file` commit and tag output
+    #
+    # Provides class methods that transform raw `git cat-file` output lines into
+    # structured Hash objects consumed by the `Git::Repository::ObjectOperations`
+    # facade.
+    #
+    # @api private
+    #
+    module CatFile
+      module_function
+
+      # Matches a single `git cat-file` header line
+      #
+      # @api private
+      #
+      CAT_FILE_HEADER_LINE = /\A(?<key>\w+) (?<value>.*)\z/
+
+      # Parse `git cat-file commit` output into a structured Hash
+      #
+      # @param lines [Array<String>] mutable cat-file output lines, consumed
+      #   in place during header parsing
+      #
+      # @param sha [String] the object name passed by the caller
+      #
+      # @return [Hash] commit data hash with string keys
+      #
+      # @api private
+      #
+      def parse_commit(lines, sha)
+        headers = parse_commit_headers(lines)
+        message = "#{lines.join("\n")}\n"
+        { 'sha' => sha, 'message' => message }.merge(headers)
+      end
+
+      # Parse `git cat-file tag` output into a structured Hash
+      #
+      # @param lines [Array<String>] mutable cat-file output lines, consumed
+      #   in place during header parsing; remaining lines become the message
+      #
+      # @param name [String] the tag name passed by the caller
+      #
+      # @return [Hash] tag data hash with string keys
+      #
+      # @api private
+      #
+      def parse_tag(lines, name)
+        hsh = { 'name' => name }
+        each_header(lines) { |key, value| hsh[key] = value }
+        hsh['message'] = "#{lines.join("\n")}\n"
+        hsh
+      end
+
+      # Extracts and returns commit headers from the front of `lines`
+      #
+      # Mutates `lines` in place, consuming header lines and the blank
+      # separator line. After the call `lines` contains only message lines.
+      #
+      # @param lines [Array<String>] mutable cat-file output lines
+      #
+      # @return [Hash] parsed header key/value pairs; `parent` is always
+      #   an Array
+      #
+      # @api private
+      #
+      def parse_commit_headers(lines)
+        headers = { 'parent' => [] }
+        each_header(lines) do |key, value|
+          if key == 'parent'
+            headers['parent'] << value
+          else
+            headers[key] = value
+          end
+        end
+        headers
+      end
+
+      # Yields parsed header key/value pairs from `git cat-file` output lines
+      #
+      # Consumes header lines from the front of `lines` until a blank line is
+      # encountered. Continuation lines that begin with a space are folded
+      # into the previous header value using newline separators.
+      #
+      # @param lines [Array<String>] mutable output lines from a cat-file response
+      #
+      # @yield [key, value] each parsed header pair
+      #
+      # @yieldparam key [String] header field name
+      #
+      # @yieldparam value [String] unfolded header value text
+      #
+      # @yieldreturn [void]
+      #
+      # @return [void]
+      #
+      # @api private
+      #
+      def each_header(lines)
+        while (line = lines.shift) && (match = CAT_FILE_HEADER_LINE.match(line))
+          key = match[:key]
+          value_lines = [match[:value]]
+          value_lines << lines.shift.lstrip while lines.first&.start_with?(' ')
+          yield key, value_lines.join("\n")
+        end
+      end
+    end
+  end
+end

--- a/lib/git/parsers/grep.rb
+++ b/lib/git/parsers/grep.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+module Git
+  module Parsers
+    # Parser for `git grep` output
+    #
+    # Provides a class method that transforms raw `git grep` output lines into
+    # a structured Hash consumed by the `Git::Repository::ObjectOperations`
+    # facade.
+    #
+    # This parser is a pure text transformer with no exit-status logic. The
+    # calling facade is responsible for interpreting the command's exit status
+    # before delegating output parsing to this class.
+    #
+    # @api private
+    #
+    module Grep
+      module_function
+
+      # Parse `git grep --line-number --no-color` output lines into a match hash
+      #
+      # Each line is expected in the format produced by
+      # `git grep --line-number --no-color`: `treeish:filename:linenum:text`.
+      #
+      # @param lines [Array<String>] output lines from `git grep`
+      #
+      # @return [Hash<String, Array<Array(Integer, String)>>] hash mapping
+      #   `"treeish:filename"` keys to arrays of `[line_number, text]` pairs
+      #
+      # @api private
+      #
+      def parse(lines)
+        lines.each_with_object(Hash.new { |h, k| h[k] = [] }) do |line, hsh|
+          match = line.match(/\A(.*?):(\d+):(.*)/)
+          next unless match
+
+          _full, filename, line_num, text = match.to_a
+          hsh[filename] << [line_num.to_i, text]
+        end
+      end
+    end
+  end
+end

--- a/lib/git/parsers/ls_tree.rb
+++ b/lib/git/parsers/ls_tree.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+require 'git/escaped_path'
+
+module Git
+  module Parsers
+    # Parser for `git ls-tree` output
+    #
+    # Provides a class method that transforms raw `git ls-tree` output into a
+    # structured Hash consumed by the `Git::Repository::ObjectOperations` facade.
+    #
+    # @api private
+    #
+    module LsTree
+      module_function
+
+      # Parse `git ls-tree` output into a type-keyed hash of entries
+      #
+      # Each line of output is expected in the format produced by
+      # `git ls-tree`: `<mode> <type> <sha>\t<file>`.
+      #
+      # @param output [String] raw stdout from `git ls-tree`
+      #
+      # @return [Hash<String, Hash<String, Hash>>] hash keyed by object type
+      #   (`'blob'`, `'tree'`, `'commit'`), then by filename, holding
+      #   `:mode` and `:sha` values
+      #
+      # @api private
+      #
+      def parse(output)
+        data = { 'blob' => {}, 'tree' => {}, 'commit' => {} }
+        output.split("\n").each do |line|
+          info, filenm = line.split("\t", 2)
+          filenm = unescape_path(filenm) if filenm
+          mode, type, entry_sha = info.split
+          data[type][filenm] = { mode: mode, sha: entry_sha }
+        end
+        data
+      end
+
+      # Converts a git-quoted path back to its original form
+      #
+      # @param path [String] the path, possibly git-quoted
+      #
+      # @return [String] the unquoted path
+      #
+      # @api private
+      #
+      def unescape_path(path)
+        if path.start_with?('"') && path.end_with?('"')
+          Git::EscapedPath.new(path[1..-2]).unescape
+        else
+          path
+        end
+      end
+    end
+  end
+end

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -7,6 +7,9 @@ require 'git/commands/grep'
 require 'git/commands/ls_tree'
 require 'git/commands/name_rev'
 require 'git/commands/rev_parse'
+require 'git/parsers/cat_file'
+require 'git/parsers/grep'
+require 'git/parsers/ls_tree'
 require 'git/repository/shared_private'
 require 'git/escaped_path'
 require 'tempfile'
@@ -162,7 +165,7 @@ module Git
       #
       def cat_file_commit(object)
         result = Git::Commands::CatFile::Raw.new(@execution_context).call('commit', object)
-        Private.process_commit_data(result.stdout.split("\n"), object)
+        Git::Parsers::CatFile.parse_commit(result.stdout.split("\n"), object)
       end
 
       # Returns parsed tag data for the given annotated tag object
@@ -211,7 +214,7 @@ module Git
         raise ArgumentError, "Invalid object: '#{object}'" if object&.start_with?('-')
 
         tdata = Git::Commands::CatFile::Raw.new(@execution_context).call('tag', object).stdout.split("\n")
-        Private.process_tag_data(tdata, object)
+        Git::Parsers::CatFile.parse_tag(tdata, object)
       end
 
       # Resolve a revision specifier to its full object ID
@@ -366,7 +369,7 @@ module Git
         safe_options = {}
         safe_options[:r] = r_value unless r_value.nil?
         result = Git::Commands::LsTree.new(@execution_context).call(objectish, *paths, **safe_options)
-        Private.parse_ls_tree_output(result.stdout)
+        Git::Parsers::LsTree.parse(result.stdout)
       end
 
       # Option keys accepted by {#grep}
@@ -434,8 +437,20 @@ module Git
         result = Git::Commands::Grep.new(@execution_context).call(
           object, pattern:, **opts, no_color: true, line_number: true
         )
-        Private.process_grep_result(result)
+        parse_grep_result(result)
       end
+
+      private
+
+      def parse_grep_result(result)
+        exitstatus = result.status.exitstatus
+        return {} if exitstatus == 1 && result.stderr.empty?
+        raise Git::FailedError, result if exitstatus == 1
+
+        Git::Parsers::Grep.parse(result.stdout.split("\n"))
+      end
+
+      public
 
       # Option keys accepted by {#archive}
       ARCHIVE_ALLOWED_OPTS = %i[prefix remote path format add_gzip].freeze
@@ -532,65 +547,12 @@ module Git
         raise
       end
 
-      # Private helpers for {#cat_file_commit}, {#cat_file_tag}, {#grep},
-      # {#ls_tree}, and {#archive}
+      # Private helpers for {#archive}
       #
       # @api private
       #
-      # rubocop:disable Metrics/ModuleLength
       module Private
         module_function
-
-        # Matches a single `git cat-file` header line
-        #
-        # @api private
-        #
-        CAT_FILE_HEADER_LINE = /\A(?<key>\w+) (?<value>.*)\z/
-
-        # Interprets a `Git::Commands::Grep` result and returns parsed matches
-        #
-        # Exit status 1 with empty stderr means no lines matched — returns `{}`.
-        # Exit status 1 with non-empty stderr is a real error and raises.
-        # Exit status 0 parses the output lines.
-        #
-        # @param result [Git::CommandLineResult] the result from the grep command
-        #
-        # @return [Hash<String, Array<Array(Integer, String)>>] parsed match hash
-        #
-        # @raise [Git::FailedError] if exit status is 1 and stderr is non-empty
-        #
-        # @api private
-        #
-        def process_grep_result(result)
-          exitstatus = result.status.exitstatus
-          return {} if exitstatus == 1 && result.stderr.empty?
-
-          raise Git::FailedError, result if exitstatus == 1
-
-          parse_grep_output(result.stdout.split("\n"))
-        end
-
-        # Parses `git grep` output lines into a filename-keyed hash of matches
-        #
-        # Each line is expected in the format produced by
-        # `git grep --line-number --no-color`: `treeish:filename:linenum:text`.
-        #
-        # @param lines [Array<String>] output lines from `git grep`
-        #
-        # @return [Hash<String, Array<Array(Integer, String)>>] hash mapping
-        #   `"treeish:filename"` keys to arrays of `[line_number, text]` pairs
-        #
-        # @api private
-        #
-        def parse_grep_output(lines)
-          lines.each_with_object(Hash.new { |h, k| h[k] = [] }) do |line, hsh|
-            match = line.match(/\A(.*?):(\d+):(.*)/)
-            next unless match
-
-            _full, filename, line_num, text = match.to_a
-            hsh[filename] << [line_num.to_i, text]
-          end
-        end
 
         # Resolve the staging directory for a git archive temp file
         #
@@ -760,138 +722,7 @@ module Git
           FileUtils.rm_f(gz_tmp) if gz_tmp
           raise
         end
-
-        # Assembles the commit Hash from parsed lines
-        #
-        # @param data [Array<String>] mutable cat-file output lines, consumed
-        #   in place during header parsing
-        #
-        # @param sha [String] the object name passed by the caller
-        #
-        # @return [Hash] commit data hash with string keys
-        #
-        # @api private
-        #
-        def process_commit_data(data, sha)
-          headers = process_commit_headers(data)
-          message = "#{data.join("\n")}\n"
-          { 'sha' => sha, 'message' => message }.merge(headers)
-        end
-
-        # Extracts and returns headers from the front of `data`
-        #
-        # Mutates `data` in place, consuming header lines and the blank
-        # separator line. After the call `data` contains only message lines.
-        #
-        # @param data [Array<String>] mutable cat-file output lines
-        #
-        # @return [Hash] parsed header key/value pairs; `parent` is always
-        #   an Array
-        #
-        # @api private
-        #
-        def process_commit_headers(data)
-          headers = { 'parent' => [] }
-          each_cat_file_header(data) do |key, value|
-            if key == 'parent'
-              headers['parent'] << value
-            else
-              headers[key] = value
-            end
-          end
-          headers
-        end
-
-        # Assembles the tag Hash from parsed lines
-        #
-        # @param data [Array<String>] mutable cat-file output lines, consumed
-        #   in place during header parsing; remaining lines become the message
-        #
-        # @param name [String] the tag name passed by the caller
-        #
-        # @return [Hash] tag data hash with string keys
-        #
-        # @api private
-        #
-        def process_tag_data(data, name)
-          hsh = { 'name' => name }
-          each_cat_file_header(data) { |key, value| hsh[key] = value }
-          hsh['message'] = "#{data.join("\n")}\n"
-          hsh
-        end
-
-        # Yields parsed header key/value pairs from `git cat-file` output lines
-        #
-        # Consumes header lines from the front of `data` until a blank line is
-        # encountered. Continuation lines that begin with a space are folded
-        # into the previous header value using newline separators.
-        #
-        # @param data [Array<String>] mutable output lines from a cat-file response
-        #
-        # @yield [key, value] each parsed header pair
-        #
-        # @yieldparam key [String] header field name
-        #
-        # @yieldparam value [String] unfolded header value text
-        #
-        # @yieldreturn [void]
-        #
-        # @return [void]
-        #
-        # @raise [NoMethodError] if `data` contains non-string entries
-        #
-        # @api private
-        #
-        def each_cat_file_header(data)
-          while (line = data.shift) && (match = CAT_FILE_HEADER_LINE.match(line))
-            key = match[:key]
-            value_lines = [match[:value]]
-            value_lines << data.shift.lstrip while data.first&.start_with?(' ')
-            yield key, value_lines.join("\n")
-          end
-        end
-
-        # Parses `git ls-tree` output into a type-keyed hash of entries
-        #
-        # Each line of output is expected in the format produced by
-        # `git ls-tree`: `<mode> <type> <sha>\t<file>`.
-        #
-        # @param output [String] raw stdout from `git ls-tree`
-        #
-        # @return [Hash<String, Hash<String, Hash>>] hash keyed by object type
-        #   (`'blob'`, `'tree'`, `'commit'`), then by filename, holding
-        #   `:mode` and `:sha` values
-        #
-        # @api private
-        #
-        def parse_ls_tree_output(output)
-          data = { 'blob' => {}, 'tree' => {}, 'commit' => {} }
-          output.split("\n").each do |line|
-            info, filenm = line.split("\t", 2)
-            filenm = unescape_quoted_path(filenm) if filenm
-            mode, type, entry_sha = info.split
-            data[type][filenm] = { mode: mode, sha: entry_sha }
-          end
-          data
-        end
-
-        # Converts a git-quoted path back to its original form
-        #
-        # @param path [String] the path, possibly git-quoted
-        #
-        # @return [String] the unquoted path
-        #
-        # @api private
-        #
-        def unescape_quoted_path(path)
-          if path.start_with?('"') && path.end_with?('"')
-            Git::EscapedPath.new(path[1..-2]).unescape
-          else
-            path
-          end
-        end
       end
-      # rubocop:enable Metrics/ModuleLength
       private_constant :Private
     end
   end

--- a/spec/unit/git/parsers/cat_file_spec.rb
+++ b/spec/unit/git/parsers/cat_file_spec.rb
@@ -1,0 +1,173 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/parsers/cat_file'
+
+RSpec.describe Git::Parsers::CatFile do
+  describe '.parse_commit' do
+    context 'with a single-parent commit' do
+      subject(:result) do
+        lines = [
+          'tree abc123',
+          'parent def456',
+          'author A <a@example.com> 1 +0000',
+          'committer A <a@example.com> 1 +0000',
+          '',
+          'Initial commit'
+        ]
+        described_class.parse_commit(lines, 'HEAD')
+      end
+
+      it 'includes sha set to the passed object name' do
+        expect(result['sha']).to eq('HEAD')
+      end
+
+      it 'includes the tree SHA' do
+        expect(result['tree']).to eq('abc123')
+      end
+
+      it 'includes the parent SHA as a single-element Array' do
+        expect(result['parent']).to eq(['def456'])
+      end
+
+      it 'includes the author string' do
+        expect(result['author']).to eq('A <a@example.com> 1 +0000')
+      end
+
+      it 'includes the committer string' do
+        expect(result['committer']).to eq('A <a@example.com> 1 +0000')
+      end
+
+      it 'includes the commit message with a trailing newline' do
+        expect(result['message']).to eq("Initial commit\n")
+      end
+    end
+
+    context 'with a root commit (no parent lines)' do
+      subject(:result) do
+        lines = [
+          'tree def456',
+          'author A <a@example.com> 1 +0000',
+          'committer A <a@example.com> 1 +0000',
+          '',
+          'Root commit'
+        ]
+        described_class.parse_commit(lines, 'abc123')
+      end
+
+      it 'returns an empty parent Array' do
+        expect(result['parent']).to eq([])
+      end
+
+      it 'includes the commit message' do
+        expect(result['message']).to eq("Root commit\n")
+      end
+    end
+
+    context 'with a merge commit (multiple parents)' do
+      subject(:result) do
+        lines = [
+          'tree abc123',
+          'parent def456',
+          'parent ghi789',
+          'author A <a@example.com> 1 +0000',
+          'committer A <a@example.com> 1 +0000',
+          '',
+          "Merge branch 'feature'"
+        ]
+        described_class.parse_commit(lines, 'HEAD')
+      end
+
+      it 'returns all parent SHAs in the parent Array' do
+        expect(result['parent']).to eq(%w[def456 ghi789])
+      end
+    end
+
+    context 'with a signed commit (gpgsig header with continuation lines)' do
+      subject(:result) do
+        lines = [
+          'tree abc123',
+          'parent def456',
+          'author A <a@example.com> 1 +0000',
+          'committer A <a@example.com> 1 +0000',
+          'gpgsig -----BEGIN PGP SIGNATURE-----',
+          ' iQEzBAABCAAdFiEE...',
+          ' -----END PGP SIGNATURE-----',
+          '',
+          'Signed commit message'
+        ]
+        described_class.parse_commit(lines, 'HEAD')
+      end
+
+      it 'folds the multi-line gpgsig header into a single value with embedded newlines' do
+        expect(result['gpgsig']).to eq(
+          "-----BEGIN PGP SIGNATURE-----\niQEzBAABCAAdFiEE...\n-----END PGP SIGNATURE-----"
+        )
+      end
+
+      it 'does not include the signature text in the commit message' do
+        expect(result['message']).to eq("Signed commit message\n")
+      end
+    end
+  end
+
+  describe '.parse_tag' do
+    context 'with a standard annotated tag' do
+      subject(:result) do
+        lines = [
+          'object deadbeef',
+          'type commit',
+          'tag v1.0',
+          'tagger A <a@example.com> 1 +0000',
+          '',
+          'Release v1.0'
+        ]
+        described_class.parse_tag(lines, 'v1.0')
+      end
+
+      it 'includes name set to the passed tag name' do
+        expect(result['name']).to eq('v1.0')
+      end
+
+      it 'includes the object SHA' do
+        expect(result['object']).to eq('deadbeef')
+      end
+
+      it 'includes the object type' do
+        expect(result['type']).to eq('commit')
+      end
+
+      it 'includes the tag name header' do
+        expect(result['tag']).to eq('v1.0')
+      end
+
+      it 'includes the tagger string' do
+        expect(result['tagger']).to eq('A <a@example.com> 1 +0000')
+      end
+
+      it 'includes the message with a trailing newline' do
+        expect(result['message']).to eq("Release v1.0\n")
+      end
+    end
+
+    context 'with a multi-line tag message' do
+      subject(:result) do
+        lines = [
+          'object deadbeef',
+          'type commit',
+          'tag v2.0',
+          'tagger A <a@example.com> 1 +0000',
+          '',
+          'First line',
+          '',
+          'Second paragraph'
+        ]
+        described_class.parse_tag(lines, 'v2.0')
+      end
+
+      it 'includes the full message with all lines and a trailing newline' do
+        expect(result['message']).to eq("First line\n\nSecond paragraph\n")
+      end
+    end
+  end
+end

--- a/spec/unit/git/parsers/grep_spec.rb
+++ b/spec/unit/git/parsers/grep_spec.rb
@@ -1,0 +1,70 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/parsers/grep'
+
+RSpec.describe Git::Parsers::Grep do
+  describe '.parse' do
+    context 'with a single matching line' do
+      subject(:result) { described_class.parse(['HEAD:src/foo.rb:12:# TODO: fix this']) }
+
+      it 'returns a Hash keyed by treeish:filename' do
+        expect(result.keys).to eq(['HEAD:src/foo.rb'])
+      end
+
+      it 'maps the key to an array containing [line_number, text]' do
+        expect(result['HEAD:src/foo.rb']).to eq([[12, '# TODO: fix this']])
+      end
+    end
+
+    context 'with multiple matches in the same file' do
+      subject(:result) do
+        described_class.parse([
+                                'HEAD:src/foo.rb:12:# TODO: fix this',
+                                'HEAD:src/foo.rb:34:# TODO: also this'
+                              ])
+      end
+
+      it 'groups both matches under the same key' do
+        expect(result['HEAD:src/foo.rb']).to eq([
+                                                  [12, '# TODO: fix this'],
+                                                  [34, '# TODO: also this']
+                                                ])
+      end
+    end
+
+    context 'with matches in multiple files' do
+      subject(:result) do
+        described_class.parse([
+                                'HEAD:src/foo.rb:12:# TODO: fix this',
+                                'HEAD:lib/bar.rb:5:# TODO: and this'
+                              ])
+      end
+
+      it 'returns a Hash with one key per unique treeish:filename' do
+        expect(result.keys).to contain_exactly('HEAD:src/foo.rb', 'HEAD:lib/bar.rb')
+      end
+
+      it 'maps each key to its own match array' do
+        expect(result['HEAD:src/foo.rb']).to eq([[12, '# TODO: fix this']])
+        expect(result['HEAD:lib/bar.rb']).to eq([[5, '# TODO: and this']])
+      end
+    end
+
+    context 'with empty input' do
+      subject(:result) { described_class.parse([]) }
+
+      it 'returns an empty Hash' do
+        expect(result).to eq({})
+      end
+    end
+
+    context 'with lines that do not match the expected format' do
+      subject(:result) { described_class.parse(['this line has no colon-number pattern']) }
+
+      it 'ignores non-matching lines and returns an empty Hash' do
+        expect(result).to eq({})
+      end
+    end
+  end
+end

--- a/spec/unit/git/parsers/ls_tree_spec.rb
+++ b/spec/unit/git/parsers/ls_tree_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/parsers/ls_tree'
+
+RSpec.describe Git::Parsers::LsTree do
+  describe '.parse' do
+    context 'with a blob entry' do
+      subject(:result) do
+        described_class.parse("100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tREADME.md\n")
+      end
+
+      it 'returns a Hash with blob, tree, and commit top-level keys' do
+        expect(result.keys).to contain_exactly('blob', 'tree', 'commit')
+      end
+
+      it 'includes the blob entry keyed by filename' do
+        expect(result['blob']['README.md']).to eq(
+          { mode: '100644', sha: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391' }
+        )
+      end
+
+      it 'returns empty hashes for tree and commit' do
+        expect(result['tree']).to eq({})
+        expect(result['commit']).to eq({})
+      end
+    end
+
+    context 'with a tree entry' do
+      subject(:result) do
+        described_class.parse("040000 tree abcdef0123456789abcdef0123456789abcdef01\tlib\n")
+      end
+
+      it 'includes the tree entry keyed by directory name' do
+        expect(result['tree']['lib']).to eq(
+          { mode: '040000', sha: 'abcdef0123456789abcdef0123456789abcdef01' }
+        )
+      end
+    end
+
+    context 'with a commit (submodule) entry' do
+      subject(:result) do
+        described_class.parse("160000 commit cafebabe0000000000000000000000000000cafe\tsubmodule\n")
+      end
+
+      it 'includes the commit entry keyed by submodule name' do
+        expect(result['commit']['submodule']).to eq(
+          { mode: '160000', sha: 'cafebabe0000000000000000000000000000cafe' }
+        )
+      end
+    end
+
+    context 'with a git-quoted (backslash-escaped) path' do
+      subject(:result) do
+        # Git quotes paths that contain special characters (e.g., spaces or
+        # non-ASCII) by wrapping them in double quotes and backslash-escaping
+        # internal characters.
+        described_class.parse("100644 blob abc1234\t\"path with spaces\"\n")
+      end
+
+      it 'unescapes the path' do
+        expect(result['blob'].keys).to eq(['path with spaces'])
+      end
+    end
+
+    context 'with multiple entries of different types' do
+      subject(:result) do
+        output = <<~OUTPUT
+          100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391\tREADME.md
+          040000 tree abcdef0123456789abcdef0123456789abcdef01\tlib
+        OUTPUT
+        described_class.parse(output)
+      end
+
+      it 'groups blob and tree entries under their respective type keys' do
+        expect(result['blob'].keys).to eq(['README.md'])
+        expect(result['tree'].keys).to eq(['lib'])
+      end
+    end
+
+    context 'with empty output' do
+      subject(:result) { described_class.parse('') }
+
+      it 'returns a Hash with empty sub-hashes for each object type' do
+        expect(result).to eq({ 'blob' => {}, 'tree' => {}, 'commit' => {} })
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -3,6 +3,9 @@
 require 'spec_helper'
 require 'git/repository'
 require 'git/repository/object_operations'
+require 'git/parsers/cat_file'
+require 'git/parsers/grep'
+require 'git/parsers/ls_tree'
 
 # Integration-level coverage for Git::Repository::ObjectOperations is
 # provided by spec/integration/git/repository/object_operations_spec.rb.
@@ -226,60 +229,33 @@ RSpec.describe Git::Repository::ObjectOperations do
           "committer A <a@example.com> 1 +0000\n\nInitial commit\n"
       end
       let(:commit_result) { command_result(commit_body) }
+      let(:parsed_commit) { { 'sha' => 'HEAD', 'tree' => 'abc123', 'parent' => ['def456'] } }
 
       it 'constructs Git::Commands::CatFile::Raw with the execution context' do
         expect(Git::Commands::CatFile::Raw).to receive(:new).with(execution_context).and_return(raw_command)
         allow(raw_command).to receive(:call).and_return(commit_result)
+        allow(Git::Parsers::CatFile).to receive(:parse_commit).and_return(parsed_commit)
         result
       end
 
       it 'calls Git::Commands::CatFile::Raw#call with type commit and the object' do
         expect(raw_command).to receive(:call).with('commit', 'HEAD').and_return(commit_result)
+        allow(Git::Parsers::CatFile).to receive(:parse_commit).and_return(parsed_commit)
         result
       end
 
-      it 'returns a Hash with the expected commit data' do
+      it 'delegates to Git::Parsers::CatFile.parse_commit with split lines and the object name' do
         allow(raw_command).to receive(:call).with('commit', 'HEAD').and_return(commit_result)
-        expect(result).to include(
-          'sha' => 'HEAD',
-          'tree' => 'abc123',
-          'parent' => ['def456'],
-          'author' => 'A <a@example.com> 1 +0000',
-          'committer' => 'A <a@example.com> 1 +0000',
-          'message' => "Initial commit\n"
-        )
-      end
-    end
-
-    context 'with a root commit (no parent lines)' do
-      subject(:result) { described_instance.cat_file_commit('abc123') }
-
-      let(:commit_body) do
-        "tree def456\nauthor A <a@example.com> 1 +0000\n" \
-          "committer A <a@example.com> 1 +0000\n\nRoot commit\n"
+        expect(Git::Parsers::CatFile).to receive(:parse_commit)
+          .with(commit_body.split("\n"), 'HEAD')
+          .and_return(parsed_commit)
+        result
       end
 
-      it 'returns an empty parent array' do
-        allow(raw_command).to receive(:call)
-          .with('commit', 'abc123')
-          .and_return(command_result(commit_body))
-        expect(result).to include('parent' => [])
-      end
-    end
-
-    context 'with a merge commit (multiple parents)' do
-      subject(:result) { described_instance.cat_file_commit('HEAD') }
-
-      let(:commit_body) do
-        "tree abc123\nparent def456\nparent ghi789\nauthor A <a@example.com> 1 +0000\n" \
-          "committer A <a@example.com> 1 +0000\n\nMerge branch 'feature'\n"
-      end
-
-      it 'returns all parent SHAs in the parent array' do
-        allow(raw_command).to receive(:call)
-          .with('commit', 'HEAD')
-          .and_return(command_result(commit_body))
-        expect(result).to include('parent' => %w[def456 ghi789])
+      it 'returns the value from Git::Parsers::CatFile.parse_commit' do
+        allow(raw_command).to receive(:call).with('commit', 'HEAD').and_return(commit_result)
+        allow(Git::Parsers::CatFile).to receive(:parse_commit).and_return(parsed_commit)
+        expect(result).to eq(parsed_commit)
       end
     end
   end
@@ -299,36 +275,33 @@ RSpec.describe Git::Repository::ObjectOperations do
       let(:tag_body) do
         "object deadbeef\ntype commit\ntag v1.0\ntagger A <a@example.com> 1 +0000\n\nRelease v1.0"
       end
+      let(:parsed_tag) { { 'name' => 'v1.0', 'object' => 'deadbeef', 'type' => 'commit' } }
 
       it 'constructs Git::Commands::CatFile::Raw with the execution context' do
         expect(Git::Commands::CatFile::Raw).to receive(:new).with(execution_context).and_return(raw_command)
         allow(raw_command).to receive(:call).and_return(command_result(tag_body))
+        allow(Git::Parsers::CatFile).to receive(:parse_tag).and_return(parsed_tag)
         result
       end
 
       it 'calls Git::Commands::CatFile::Raw#call with type tag and the object' do
         expect(raw_command).to receive(:call).with('tag', 'v1.0').and_return(command_result(tag_body))
+        allow(Git::Parsers::CatFile).to receive(:parse_tag).and_return(parsed_tag)
         result
       end
 
-      it 'returns a Hash with name set to the object argument' do
+      it 'delegates to Git::Parsers::CatFile.parse_tag with split lines and the object name' do
         allow(raw_command).to receive(:call).with('tag', 'v1.0').and_return(command_result(tag_body))
-        expect(result['name']).to eq('v1.0')
+        expect(Git::Parsers::CatFile).to receive(:parse_tag)
+          .with(tag_body.split("\n"), 'v1.0')
+          .and_return(parsed_tag)
+        result
       end
 
-      it 'returns a Hash with the parsed tag headers' do
+      it 'returns the value from Git::Parsers::CatFile.parse_tag' do
         allow(raw_command).to receive(:call).with('tag', 'v1.0').and_return(command_result(tag_body))
-        expect(result).to include(
-          'object' => 'deadbeef',
-          'type' => 'commit',
-          'tag' => 'v1.0',
-          'tagger' => 'A <a@example.com> 1 +0000'
-        )
-      end
-
-      it 'returns a Hash with message including a trailing newline' do
-        allow(raw_command).to receive(:call).with('tag', 'v1.0').and_return(command_result(tag_body))
-        expect(result['message']).to eq("Release v1.0\n")
+        allow(Git::Parsers::CatFile).to receive(:parse_tag).and_return(parsed_tag)
+        expect(result).to eq(parsed_tag)
       end
     end
 
@@ -552,34 +525,36 @@ RSpec.describe Git::Repository::ObjectOperations do
           "040000 tree abcdef0123456789abcdef0123456789abcdef01\tlib\n"
       end
       let(:ls_tree_result) { command_result(ls_tree_output) }
+      let(:parsed_tree) do
+        {
+          'blob' => { 'README.md' => { mode: '100644', sha: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391' } },
+          'tree' => { 'lib' => { mode: '040000', sha: 'abcdef0123456789abcdef0123456789abcdef01' } },
+          'commit' => {}
+        }
+      end
 
       before { allow(ls_tree_command).to receive(:call).and_return(ls_tree_result) }
 
       it 'constructs Git::Commands::LsTree with the execution context' do
         expect(Git::Commands::LsTree).to receive(:new).with(execution_context).and_return(ls_tree_command)
+        allow(Git::Parsers::LsTree).to receive(:parse).and_return(parsed_tree)
         result
       end
 
       it 'calls Git::Commands::LsTree#call with the sha and no extra options' do
         expect(ls_tree_command).to receive(:call).with('abc1234').and_return(ls_tree_result)
+        allow(Git::Parsers::LsTree).to receive(:parse).and_return(parsed_tree)
         result
       end
 
-      it 'returns a Hash keyed by object type' do
-        expect(result).to be_a(Hash)
-        expect(result.keys).to contain_exactly('blob', 'tree', 'commit')
+      it 'delegates to Git::Parsers::LsTree.parse with the stdout' do
+        expect(Git::Parsers::LsTree).to receive(:parse).with(ls_tree_output).and_return(parsed_tree)
+        result
       end
 
-      it 'parses blob entries into the blob sub-hash' do
-        expect(result['blob']['README.md']).to eq(
-          { mode: '100644', sha: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391' }
-        )
-      end
-
-      it 'parses tree entries into the tree sub-hash' do
-        expect(result['tree']['lib']).to eq(
-          { mode: '040000', sha: 'abcdef0123456789abcdef0123456789abcdef01' }
-        )
+      it 'returns the value from Git::Parsers::LsTree.parse' do
+        allow(Git::Parsers::LsTree).to receive(:parse).and_return(parsed_tree)
+        expect(result).to eq(parsed_tree)
       end
     end
 
@@ -799,9 +774,19 @@ RSpec.describe Git::Repository::ObjectOperations do
         result
       end
 
-      it 'returns a Hash keyed by treeish:filename with [line_number, text] arrays' do
+      it 'delegates to Git::Parsers::Grep.parse with the output lines' do
         allow(grep_command).to receive(:call).and_return(grep_result)
-        expect(result).to eq('HEAD:src/foo.rb' => [[12, '# TODO: fix this']])
+        expect(Git::Parsers::Grep).to receive(:parse)
+          .with(grep_output.split("\n"))
+          .and_return('HEAD:src/foo.rb' => [[12, '# TODO: fix this']])
+        result
+      end
+
+      it 'returns the value from Git::Parsers::Grep.parse' do
+        allow(grep_command).to receive(:call).and_return(grep_result)
+        parsed = { 'HEAD:src/foo.rb' => [[12, '# TODO: fix this']] }
+        allow(Git::Parsers::Grep).to receive(:parse).and_return(parsed)
+        expect(result).to eq(parsed)
       end
     end
 


### PR DESCRIPTION
## Summary

Part 1 of #1322: extracts the three output-parsing concerns from `Git::Repository::ObjectOperations::Private` into dedicated, pure-function parser modules under `Git::Parsers`.

## New Parser Modules

| Module | Command output parsed |
|---|---|
| `Git::Parsers::CatFile` | `git cat-file commit` and `git cat-file tag` |
| `Git::Parsers::Grep` | `git grep --line-number --no-color` |
| `Git::Parsers::LsTree` | `git ls-tree` |

Each module uses `module_function` so its methods are callable as `Module.method_name` without a receiver instance, consistent with the other parsers in the `Git::Parsers` namespace (`Tag`, `Diff`, `Fsck`, `Stash`, `Branch`).

## Changes

### New files

- `lib/git/parsers/cat_file.rb` — commit and tag output parsers
- `lib/git/parsers/grep.rb` — grep line transformer
- `lib/git/parsers/ls_tree.rb` — ls-tree entry parser
- `spec/unit/git/parsers/cat_file_spec.rb` — 18 examples
- `spec/unit/git/parsers/grep_spec.rb` — 7 examples
- `spec/unit/git/parsers/ls_tree_spec.rb` — 8 examples

### Modified files

- `lib/git/repository/object_operations.rb`
  - Added `require` calls for the three new parser modules
  - Facade methods delegate to `Git::Parsers::CatFile`, `Git::Parsers::Grep`, `Git::Parsers::LsTree`
  - `grep` method's exit-status check extracted into a private `#parse_grep_result` helper (keeps `#grep` within RuboCop Metrics thresholds without disabling any cops)
  - `Private` module retains only the seven archive I/O helpers — now comfortably within `Metrics/ModuleLength`; the `rubocop:disable` suppression comment is removed

- `spec/unit/git/repository/object_operations_spec.rb`
  - Replaced raw parse-result assertions with delegation tests (stubs the parser module, verifies correct arguments and return value)
  - Parser implementation details are now covered by the dedicated parser specs

## Motivation

Removes the `rubocop:disable Metrics/ModuleLength` suppression from `Private` by moving the code that caused the length violation into purpose-built, testable units.
