### PR TITLE
Migrate Git::Object::* to use Git::Repository instead of Git::Base/Git::Lib

### DIFF
--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -4,6 +4,7 @@ require 'git/author'
 require 'git/diff'
 require 'git/errors'
 require 'git/log'
+require 'git/base'
 
 module Git
   # represents a git object
@@ -24,11 +25,11 @@ module Git
       end
 
       def sha
-        @sha ||= @base.lib.rev_parse(@objectish)
+        @sha ||= object_repository.rev_parse(@objectish)
       end
 
       def size
-        @size ||= @base.lib.cat_file_size(@objectish)
+        @size ||= object_repository.cat_file_size(@objectish)
       end
 
       # Returns the raw content of this git object or streams it into a temporary file
@@ -70,9 +71,9 @@ module Git
       #
       def contents(&)
         if block_given?
-          @base.lib.cat_file_contents(@objectish, &)
+          object_repository.cat_file_contents(@objectish, &)
         else
-          @contents ||= @base.lib.cat_file_contents(@objectish)
+          @contents ||= object_repository.cat_file_contents(@objectish)
         end
       end
 
@@ -85,8 +86,7 @@ module Git
       end
 
       def grep(string, path_limiter = nil, opts = {})
-        opts = { object: sha, path_limiter: path_limiter }.merge(opts)
-        @base.lib.grep(string, opts)
+        object_repository.grep(string, path_limiter, opts.merge(object: sha))
       end
 
       def diff(objectish)
@@ -113,7 +113,7 @@ module Git
       #   git.object('v1.0').archive('/tmp/release.zip', format: 'zip')
       #
       def archive(file = nil, opts = {})
-        @base.lib.archive(@objectish, file, opts)
+        object_repository.archive(@objectish, file, opts)
       end
 
       def tree? = false
@@ -123,6 +123,19 @@ module Git
       def commit? = false
 
       def tag? = false
+
+      private
+
+      # Returns the facade interface for git object queries.
+      #
+      # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
+      # The `is_a?` guard will be removed when {Git::Base} is deleted in Phase 4.
+      #
+      # @return [Git::Repository]
+      #
+      def object_repository
+        @base.is_a?(Git::Base) ? @base.facade_repository : @base
+      end
     end
 
     # A Git blob object
@@ -162,11 +175,11 @@ module Git
       alias subdirectories trees
 
       def full_tree
-        @base.lib.full_tree(@objectish)
+        object_repository.full_tree(@objectish)
       end
 
       def depth
-        @base.tree_depth(@objectish)
+        object_repository.tree_depth(@objectish)
       end
 
       def tree?
@@ -180,7 +193,7 @@ module Git
         @trees = {}
         @blobs = {}
 
-        data = @base.lib.ls_tree(@objectish)
+        data = object_repository.ls_tree(@objectish)
 
         data['tree'].each do |key, tree|
           @trees[key] = Git::Object::Tree.new(@base, tree[:sha], tree[:mode])
@@ -214,7 +227,7 @@ module Git
       end
 
       def name
-        @base.lib.name_rev(sha)
+        object_repository.name_rev(sha)
       end
 
       def gtree
@@ -284,7 +297,7 @@ module Git
       def check_commit
         return if @tree
 
-        data = @base.lib.cat_file_commit(@objectish)
+        data = object_repository.cat_file_commit(@objectish)
         from_data(data)
       end
     end
@@ -313,7 +326,8 @@ module Git
       def initialize(base, sha, name = nil)
         if name.nil?
           name = sha
-          sha = base.lib.tag_sha(name)
+          repo = base.is_a?(Git::Base) ? base.facade_repository : base
+          sha = repo.tag_sha(name)
           raise Git::UnexpectedResultError, "Tag '#{name}' does not exist." if sha == ''
         end
 
@@ -325,7 +339,7 @@ module Git
       end
 
       def annotated?
-        @annotated = @annotated.nil? ? (@base.lib.cat_file_type(name) == 'tag') : @annotated
+        @annotated = @annotated.nil? ? (object_repository.cat_file_type(name) == 'tag') : @annotated
       end
 
       def message
@@ -348,7 +362,7 @@ module Git
         return if @loaded
 
         if annotated?
-          tdata = @base.lib.cat_file_tag(@name)
+          tdata = object_repository.cat_file_tag(@name)
           @message = tdata['message'].chomp
           @tagger = Git::Author.new(tdata['tagger'])
         else
@@ -364,7 +378,7 @@ module Git
     def self.new(base, objectish, type = nil, is_tag = false) # rubocop:disable Style/OptionalBooleanParameter
       return new_tag(base, objectish) if is_tag
 
-      type ||= base.lib.cat_file_type(objectish)
+      type ||= object_repository_for(base).cat_file_type(objectish)
       # TODO: why not handle tag case here too?
       klass =
         case type
@@ -378,6 +392,17 @@ module Git
     private_class_method def self.new_tag(base, objectish)
       Git::Deprecation.warn('Git::Object.new with is_tag argument is deprecated. Use Git::Object::Tag.new instead.')
       Git::Object::Tag.new(base, objectish)
+    end
+
+    # Returns the facade interface for git object queries.
+    #
+    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
+    # The `is_a?` guard will be removed when {Git::Base} is deleted in Phase 4.
+    #
+    # @return [Git::Repository]
+    #
+    private_class_method def self.object_repository_for(base)
+      base.is_a?(Git::Base) ? base.facade_repository : base
     end
   end
 end

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -105,7 +105,7 @@ After all 9 domain-object iterations, **verify facade coverage**: every public `
 | `Git::Stash` | ✅ Complete | iter 1 |
 | `Git::Stashes` | ✅ Complete | iter 1 |
 | `Git::DiffPathStatus` | ✅ Complete | iter 2 |
-| `Git::Object::*` | ⏳ Not started | iter 3 |
+| `Git::Object::*` | ✅ Complete | iter 3 |
 | `Git::Log` | ⏳ Not started | iter 4 |
 | `Git::Diff` | ⏳ Not started | iter 5 |
 | `Git::DiffStats` | ⏳ Not started | iter 5 |

--- a/spec/unit/git/object_spec.rb
+++ b/spec/unit/git/object_spec.rb
@@ -1,0 +1,860 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/object'
+
+# These specs cover Git::Object::* classes, exercising both the Git::Repository
+# (new form) and Git::Base (legacy) polymorphism branches.
+# Full integration via Git::Base is covered by tests/units/test_object.rb (Test::Unit).
+
+RSpec.describe Git::Object::Blob do
+  # Git::Object::Blob is the concrete subclass used to exercise all
+  # Git::Object::AbstractObject instance methods.
+
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:repository) { Git::Repository.new(execution_context: execution_context) }
+  let(:objectish) { 'abc123def456' }
+  let(:described_instance) { described_class.new(repository, objectish) }
+
+  describe '#initialize' do
+    subject(:instance) { described_instance }
+
+    it 'stores the objectish and defaults mode to nil' do
+      expect(instance).to have_attributes(objectish: objectish, mode: nil)
+    end
+
+    context 'with a mode argument' do
+      let(:described_instance) { described_class.new(repository, objectish, '100644') }
+
+      it 'stores the provided mode' do
+        expect(instance).to have_attributes(objectish: objectish, mode: '100644')
+      end
+    end
+  end
+
+  describe '#sha' do
+    subject(:result) { described_instance.sha }
+
+    let(:full_sha) { 'abc123def456full0000000000000000000000000' }
+
+    before do
+      allow(repository).to receive(:rev_parse).with(objectish).and_return(full_sha)
+    end
+
+    it 'resolves the objectish to a full SHA via the repository' do
+      expect(result).to eq(full_sha)
+    end
+
+    it 'caches the result on subsequent calls' do
+      2.times { described_instance.sha }
+      expect(repository).to have_received(:rev_parse).once
+    end
+  end
+
+  describe '#size' do
+    subject(:result) { described_instance.size }
+
+    before do
+      allow(repository).to receive(:cat_file_size).with(objectish).and_return(42)
+    end
+
+    it 'returns the object size in bytes from the repository' do
+      expect(result).to eq(42)
+    end
+
+    context 'when initialized with a Git::Base (legacy path)' do
+      # instance_double is viable: facade_repository is defined on Git::Base
+      # (lib/git/base.rb) and is_a? is verifiable via Kernel.
+      let(:described_instance) { described_class.new(legacy_base, objectish) }
+      let(:legacy_base) { instance_double(Git::Base) }
+
+      before do
+        allow(legacy_base).to receive(:is_a?).with(Git::Base).and_return(true)
+        allow(legacy_base).to receive(:facade_repository).and_return(repository)
+        allow(repository).to receive(:cat_file_size).with(objectish).and_return(99)
+      end
+
+      it 'delegates through the facade_repository of the Git::Base instance' do
+        expect(result).to eq(99)
+      end
+    end
+  end
+
+  describe '#contents' do
+    context 'without a block' do
+      subject(:result) { described_instance.contents }
+
+      before do
+        allow(repository).to receive(:cat_file_contents).with(objectish).and_return("file content\n")
+      end
+
+      it 'returns the raw content string from the repository' do
+        expect(result).to eq("file content\n")
+      end
+
+      it 'caches the result on subsequent calls' do
+        2.times { described_instance.contents }
+        expect(repository).to have_received(:cat_file_contents).once
+      end
+    end
+
+    context 'with a block' do
+      subject(:result) { described_instance.contents { |f| f } }
+
+      let(:file_double) { instance_double(File) }
+
+      before do
+        allow(repository).to receive(:cat_file_contents).with(objectish) do |_obj, &blk|
+          blk.call(file_double)
+        end
+      end
+
+      it 'yields the streamed file to the block and returns the block value' do
+        expect(result).to be(file_double)
+      end
+    end
+  end
+
+  describe '#grep' do
+    subject(:result) { described_instance.grep('TODO', 'lib/', ignore_case: true) }
+
+    let(:grep_result) { { 'lib/foo.rb' => { 42 => 'TODO: fix this' } } }
+
+    before do
+      allow(repository).to receive(:rev_parse).with(objectish).and_return(objectish)
+      allow(repository).to receive(:grep)
+        .with('TODO', 'lib/', hash_including(object: objectish, ignore_case: true))
+        .and_return(grep_result)
+    end
+
+    it 'delegates to the repository with the object SHA and path limiter' do
+      expect(result).to eq(grep_result)
+    end
+  end
+
+  describe '#archive' do
+    subject(:result) { described_instance.archive('/tmp/out.zip', format: 'zip') }
+
+    before do
+      allow(repository).to receive(:archive)
+        .with(objectish, '/tmp/out.zip', { format: 'zip' })
+        .and_return('/tmp/out.zip')
+    end
+
+    it 'delegates to the repository with the objectish, destination, and options' do
+      expect(result).to eq('/tmp/out.zip')
+    end
+  end
+
+  describe '#blob?' do
+    subject(:result) { described_instance.blob? }
+
+    it 'returns true' do
+      expect(result).to be(true)
+    end
+  end
+
+  describe '#contents_array' do
+    subject(:result) { described_instance.contents_array }
+
+    before do
+      allow(repository).to receive(:cat_file_contents).with(objectish).and_return("line1\nline2\nline3")
+    end
+
+    it 'returns the object content split into individual lines' do
+      expect(result).to eq(%w[line1 line2 line3])
+    end
+  end
+
+  describe '#diff' do
+    subject(:result) { described_instance.diff('HEAD') }
+
+    it 'returns a Git::Diff from this objectish to the given objectish' do
+      expect(result).to be_a(Git::Diff)
+      expect(result.from).to eq(objectish)
+      expect(result.to).to eq('HEAD')
+    end
+  end
+
+  describe '#log' do
+    subject(:result) { described_instance.log(10) }
+
+    it 'returns a Git::Log instance' do
+      expect(result).to be_a(Git::Log)
+    end
+  end
+
+  describe '#to_s' do
+    subject(:result) { described_instance.to_s }
+
+    it 'returns the objectish string' do
+      expect(result).to eq(objectish)
+    end
+  end
+
+  describe '#tree?' do
+    subject(:result) { described_instance.tree? }
+
+    it 'returns false' do
+      expect(result).to be(false)
+    end
+  end
+
+  describe '#commit?' do
+    subject(:result) { described_instance.commit? }
+
+    it 'returns false' do
+      expect(result).to be(false)
+    end
+  end
+
+  describe '#tag?' do
+    subject(:result) { described_instance.tag? }
+
+    it 'returns false' do
+      expect(result).to be(false)
+    end
+  end
+end
+
+RSpec.describe Git::Object::Tree do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:repository) { Git::Repository.new(execution_context: execution_context) }
+  let(:tree_sha) { 'treeshaabc123' }
+  let(:described_instance) { described_class.new(repository, tree_sha) }
+
+  describe '#initialize' do
+    subject(:instance) { described_instance }
+
+    it 'stores the objectish and defaults mode to nil' do
+      expect(instance).to have_attributes(objectish: tree_sha, mode: nil)
+    end
+
+    context 'with a mode argument' do
+      let(:described_instance) { described_class.new(repository, tree_sha, '040000') }
+
+      it 'stores the provided mode' do
+        expect(instance).to have_attributes(objectish: tree_sha, mode: '040000')
+      end
+    end
+  end
+
+  describe '#full_tree' do
+    subject(:result) { described_instance.full_tree }
+
+    let(:entries) do
+      [
+        "100644 blob e69de29\tlib/git.rb",
+        "100644 blob abc1234\tREADME.md"
+      ]
+    end
+
+    before do
+      allow(repository).to receive(:full_tree).with(tree_sha).and_return(entries)
+    end
+
+    it 'returns the recursive tree entries from the repository' do
+      expect(result).to eq(entries)
+    end
+  end
+
+  describe '#depth' do
+    subject(:result) { described_instance.depth }
+
+    before do
+      allow(repository).to receive(:tree_depth).with(tree_sha).and_return(3)
+    end
+
+    it 'returns the tree depth from the repository' do
+      expect(result).to eq(3)
+    end
+  end
+
+  describe '#blobs' do
+    subject(:result) { described_instance.blobs }
+
+    let(:ls_tree_data) do
+      {
+        'tree' => {},
+        'blob' => { 'README.md' => { sha: 'blobsha123', mode: '100644' } }
+      }
+    end
+
+    before do
+      allow(repository).to receive(:ls_tree).with(tree_sha).and_return(ls_tree_data)
+    end
+
+    it 'returns a hash of Blob objects keyed by path' do
+      expect(result).to include('README.md' => an_instance_of(Git::Object::Blob))
+    end
+  end
+
+  describe '#files' do
+    subject(:result) { described_instance.files }
+
+    let(:ls_tree_data) do
+      {
+        'tree' => {},
+        'blob' => { 'README.md' => { sha: 'blobsha123', mode: '100644' } }
+      }
+    end
+
+    before do
+      allow(repository).to receive(:ls_tree).with(tree_sha).and_return(ls_tree_data)
+    end
+
+    it 'returns a hash of Blob objects keyed by path' do
+      expect(result).to include('README.md' => an_instance_of(Git::Object::Blob))
+    end
+  end
+
+  describe '#trees' do
+    subject(:result) { described_instance.trees }
+
+    let(:ls_tree_data) do
+      {
+        'tree' => { 'lib' => { sha: 'libsha456', mode: '040000' } },
+        'blob' => {}
+      }
+    end
+
+    before do
+      allow(repository).to receive(:ls_tree).with(tree_sha).and_return(ls_tree_data)
+    end
+
+    it 'returns a hash of sub-Tree objects keyed by path' do
+      expect(result).to include('lib' => an_instance_of(Git::Object::Tree))
+    end
+  end
+
+  describe '#subtrees' do
+    subject(:result) { described_instance.subtrees }
+
+    let(:ls_tree_data) do
+      {
+        'tree' => { 'lib' => { sha: 'libsha456', mode: '040000' } },
+        'blob' => {}
+      }
+    end
+
+    before do
+      allow(repository).to receive(:ls_tree).with(tree_sha).and_return(ls_tree_data)
+    end
+
+    it 'returns a hash of sub-Tree objects keyed by path' do
+      expect(result).to include('lib' => an_instance_of(Git::Object::Tree))
+    end
+  end
+
+  describe '#subdirectories' do
+    subject(:result) { described_instance.subdirectories }
+
+    let(:ls_tree_data) do
+      {
+        'tree' => { 'lib' => { sha: 'libsha456', mode: '040000' } },
+        'blob' => {}
+      }
+    end
+
+    before do
+      allow(repository).to receive(:ls_tree).with(tree_sha).and_return(ls_tree_data)
+    end
+
+    it 'returns a hash of sub-Tree objects keyed by path' do
+      expect(result).to include('lib' => an_instance_of(Git::Object::Tree))
+    end
+  end
+
+  describe '#tree?' do
+    subject(:result) { described_instance.tree? }
+
+    it 'returns true' do
+      expect(result).to be(true)
+    end
+  end
+
+  describe '#children' do
+    subject(:result) { described_instance.children }
+
+    let(:ls_tree_data) do
+      {
+        'tree' => { 'lib' => { sha: 'libsha456', mode: '040000' } },
+        'blob' => { 'README.md' => { sha: 'blobsha123', mode: '100644' } }
+      }
+    end
+
+    before do
+      allow(repository).to receive(:ls_tree).with(tree_sha).and_return(ls_tree_data)
+    end
+
+    it 'returns a merged hash of all blobs and sub-trees keyed by path' do
+      expect(result).to include(
+        'README.md' => an_instance_of(Git::Object::Blob),
+        'lib' => an_instance_of(Git::Object::Tree)
+      )
+    end
+  end
+end
+
+RSpec.describe Git::Object::Commit do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:repository) { Git::Repository.new(execution_context: execution_context) }
+  let(:commit_sha) { 'commitsha123abc' }
+  let(:described_instance) { described_class.new(repository, commit_sha) }
+
+  let(:commit_data) do
+    {
+      'sha' => commit_sha,
+      'tree' => 'treesha456def',
+      'parent' => ['parentsha789ghi'],
+      'author' => 'A U Thor <author@example.com> 1234567890 +0000',
+      'committer' => 'A U Thor <author@example.com> 1234567890 +0000',
+      'message' => "Initial commit\n"
+    }
+  end
+
+  before do
+    allow(repository).to receive(:cat_file_commit).with(commit_sha).and_return(commit_data)
+  end
+
+  describe '#initialize' do
+    subject(:commit) { described_class.new(repository, commit_sha, init) }
+
+    let(:init) { nil }
+
+    context 'without init data (lazy loading)' do
+      it 'stores the objectish without eagerly loading commit data' do
+        commit
+        expect(repository).not_to have_received(:cat_file_commit)
+      end
+    end
+
+    context 'when init data is provided' do
+      let(:init) { commit_data }
+
+      it 'populates commit attributes immediately without calling cat_file_commit' do
+        expect(repository).not_to receive(:cat_file_commit)
+        expect(commit.message).to eq('Initial commit')
+      end
+    end
+  end
+
+  describe '#from_data' do
+    it 'populates all commit attributes from the data hash' do
+      described_instance.from_data(commit_data)
+      expect(described_instance.message).to eq('Initial commit')
+      expect(described_instance.author).to have_attributes(
+        name: 'A U Thor', email: 'author@example.com'
+      )
+      expect(described_instance.gtree.objectish).to eq('treesha456def')
+      expect(described_instance.parents.first.objectish).to eq('parentsha789ghi')
+    end
+  end
+
+  describe '#message' do
+    subject(:result) { described_instance.message }
+
+    it 'returns the commit message with trailing newline stripped' do
+      expect(result).to eq('Initial commit')
+    end
+  end
+
+  describe '#gtree' do
+    subject(:result) { described_instance.gtree }
+
+    it 'returns a Tree object for the commit tree SHA' do
+      expect(result).to be_a(Git::Object::Tree)
+      expect(result.objectish).to eq('treesha456def')
+    end
+  end
+
+  describe '#parents' do
+    subject(:result) { described_instance.parents }
+
+    it 'returns an array of Commit objects for the parent SHAs' do
+      expect(result).to contain_exactly(an_instance_of(Git::Object::Commit))
+      expect(result.first.objectish).to eq('parentsha789ghi')
+    end
+  end
+
+  describe '#name' do
+    subject(:result) { described_instance.name }
+
+    before do
+      allow(repository).to receive(:rev_parse).with(commit_sha).and_return(commit_sha)
+      allow(repository).to receive(:name_rev).with(commit_sha).and_return('main~3')
+    end
+
+    it 'returns a human-readable name for the commit via the repository' do
+      expect(result).to eq('main~3')
+    end
+  end
+
+  describe '#parent' do
+    subject(:result) { described_instance.parent }
+
+    it 'returns the first parent commit' do
+      expect(result).to be_a(Git::Object::Commit)
+      expect(result.objectish).to eq('parentsha789ghi')
+    end
+  end
+
+  describe '#author' do
+    subject(:result) { described_instance.author }
+
+    it 'returns the commit author with correct name and email' do
+      expect(result).to have_attributes(name: 'A U Thor', email: 'author@example.com')
+    end
+  end
+
+  describe '#author_date' do
+    subject(:result) { described_instance.author_date }
+
+    it 'returns the author timestamp' do
+      expect(result).to eq(Time.at(1_234_567_890))
+    end
+  end
+
+  describe '#committer' do
+    subject(:result) { described_instance.committer }
+
+    it 'returns the committer with correct name and email' do
+      expect(result).to have_attributes(name: 'A U Thor', email: 'author@example.com')
+    end
+  end
+
+  describe '#committer_date' do
+    subject(:result) { described_instance.committer_date }
+
+    it 'returns the committer timestamp' do
+      expect(result).to eq(Time.at(1_234_567_890))
+    end
+  end
+
+  describe '#date' do
+    subject(:result) { described_instance.date }
+
+    it 'returns the committer timestamp' do
+      expect(result).to eq(Time.at(1_234_567_890))
+    end
+  end
+
+  describe '#diff_parent' do
+    subject(:result) { described_instance.diff_parent }
+
+    it 'returns a Git::Diff from this commit to its first parent' do
+      expect(result).to be_a(Git::Diff)
+      expect(result.from).to eq(commit_sha)
+      expect(result.to).to eq('parentsha789ghi')
+    end
+  end
+
+  describe '#set_commit' do
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning' do
+      described_instance.set_commit(commit_data)
+      expect(Git::Deprecation).to have_received(:warn).with(a_string_including('deprecated'))
+    end
+
+    it 'populates the commit attributes from the given data hash' do
+      described_instance.set_commit(commit_data)
+      expect(described_instance.message).to eq('Initial commit')
+    end
+  end
+
+  describe '#commit?' do
+    subject(:result) { described_instance.commit? }
+
+    it 'returns true' do
+      expect(result).to be(true)
+    end
+  end
+end
+
+RSpec.describe Git::Object::Tag do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:repository) { Git::Repository.new(execution_context: execution_context) }
+  let(:described_instance) { described_class.new(repository, 'tagsha123abc', 'v1.0') }
+
+  describe '#initialize' do
+    subject(:tag) { described_class.new(base, sha, name) }
+
+    let(:base) { repository }
+    let(:sha) { 'tagsha123abc' }
+    let(:name) { 'v1.0' }
+
+    context 'with name only (two-argument form)' do
+      let(:sha) { 'v1.0' }
+      let(:name) { nil }
+
+      before do
+        allow(repository).to receive(:tag_sha).with('v1.0').and_return('tagsha123abc')
+      end
+
+      it 'resolves the SHA via the repository and stores the name' do
+        expect(tag.objectish).to eq('tagsha123abc')
+        expect(tag.name).to eq('v1.0')
+      end
+    end
+
+    context 'when the tag does not exist' do
+      let(:sha) { 'nonexistent' }
+      let(:name) { nil }
+
+      before do
+        allow(repository).to receive(:tag_sha).with('nonexistent').and_return('')
+      end
+
+      it 'raises Git::UnexpectedResultError' do
+        expect { tag }.to raise_error(Git::UnexpectedResultError, /nonexistent/)
+      end
+    end
+
+    context 'with explicit sha and name (three-argument form)' do
+      it 'does not call tag_sha on the repository' do
+        expect(repository).not_to receive(:tag_sha)
+        tag
+      end
+
+      it 'stores the SHA and name without a lookup' do
+        expect(tag.objectish).to eq('tagsha123abc')
+        expect(tag.name).to eq('v1.0')
+      end
+    end
+
+    context 'with name only and a Git::Base (legacy path)' do
+      # instance_double is viable: facade_repository is defined on Git::Base
+      # (lib/git/base.rb) and is_a? is verifiable via Kernel.
+      let(:base) { legacy_base }
+      let(:sha) { 'v1.0' }
+      let(:name) { nil }
+      let(:legacy_base) { instance_double(Git::Base) }
+
+      before do
+        allow(legacy_base).to receive(:is_a?).with(Git::Base).and_return(true)
+        allow(legacy_base).to receive(:facade_repository).and_return(repository)
+        allow(repository).to receive(:tag_sha).with('v1.0').and_return('tagsha123abc')
+      end
+
+      it 'resolves the SHA via the facade_repository of the Git::Base' do
+        expect(tag.objectish).to eq('tagsha123abc')
+        expect(tag.name).to eq('v1.0')
+      end
+    end
+  end
+
+  describe '#annotated?' do
+    subject(:result) { described_instance.annotated? }
+
+    context 'when the tag object type is "tag" (annotated)' do
+      before do
+        allow(repository).to receive(:cat_file_type).with('v1.0').and_return('tag')
+      end
+
+      it 'returns true' do
+        expect(result).to be(true)
+      end
+    end
+
+    context 'when the tag object type is "commit" (lightweight)' do
+      before do
+        allow(repository).to receive(:cat_file_type).with('v1.0').and_return('commit')
+      end
+
+      it 'returns false' do
+        expect(result).to be(false)
+      end
+    end
+
+    context 'when called multiple times' do
+      before do
+        allow(repository).to receive(:cat_file_type).with('v1.0').and_return('tag')
+      end
+
+      it 'caches the result and does not call cat_file_type again' do
+        2.times { described_instance.annotated? }
+        expect(repository).to have_received(:cat_file_type).once
+      end
+    end
+  end
+
+  describe '#message' do
+    subject(:result) { described_instance.message }
+
+    context 'when the tag is annotated' do
+      let(:tag_data) do
+        {
+          'name' => 'v1.0',
+          'object' => 'commitsha',
+          'type' => 'commit',
+          'tag' => 'v1.0',
+          'tagger' => 'A U Thor <author@example.com> 1234567890 +0000',
+          'message' => "Release v1.0\n"
+        }
+      end
+
+      before do
+        allow(repository).to receive(:cat_file_type).with('v1.0').and_return('tag')
+        allow(repository).to receive(:cat_file_tag).with('v1.0').and_return(tag_data)
+      end
+
+      it 'returns the tag message with trailing newline stripped' do
+        expect(result).to eq('Release v1.0')
+      end
+    end
+
+    context 'when the tag is lightweight (not annotated)' do
+      before do
+        allow(repository).to receive(:cat_file_type).with('v1.0').and_return('commit')
+      end
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when called multiple times (annotated)' do
+      let(:tag_data) do
+        {
+          'name' => 'v1.0',
+          'object' => 'commitsha',
+          'type' => 'commit',
+          'tag' => 'v1.0',
+          'tagger' => 'A U Thor <author@example.com> 1234567890 +0000',
+          'message' => "Release v1.0\n"
+        }
+      end
+
+      before do
+        allow(repository).to receive(:cat_file_type).with('v1.0').and_return('tag')
+        allow(repository).to receive(:cat_file_tag).with('v1.0').and_return(tag_data)
+      end
+
+      it 'caches the tag data and does not re-fetch from repository' do
+        2.times { described_instance.message }
+        expect(repository).to have_received(:cat_file_tag).once
+      end
+    end
+  end
+
+  describe '#tag?' do
+    subject(:result) { described_instance.tag? }
+
+    it 'returns true' do
+      expect(result).to be(true)
+    end
+  end
+
+  describe '#tagger' do
+    subject(:result) { described_instance.tagger }
+
+    context 'when the tag is annotated' do
+      let(:tag_data) do
+        {
+          'name' => 'v1.0',
+          'object' => 'commitsha',
+          'type' => 'commit',
+          'tag' => 'v1.0',
+          'tagger' => 'A U Thor <author@example.com> 1234567890 +0000',
+          'message' => "Release v1.0\n"
+        }
+      end
+
+      before do
+        allow(repository).to receive(:cat_file_type).with('v1.0').and_return('tag')
+        allow(repository).to receive(:cat_file_tag).with('v1.0').and_return(tag_data)
+      end
+
+      it 'returns the tag creator with correct name and email' do
+        expect(result).to have_attributes(name: 'A U Thor', email: 'author@example.com')
+      end
+    end
+  end
+end
+
+RSpec.describe Git::Object do
+  describe '.new' do
+    let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+    let(:repository) { Git::Repository.new(execution_context: execution_context) }
+
+    context 'when type is provided' do
+      context 'with type "commit"' do
+        subject(:result) { described_class.new(repository, 'HEAD', 'commit') }
+
+        it 'creates a Commit without calling cat_file_type' do
+          expect(repository).not_to receive(:cat_file_type)
+          expect(result).to be_a(Git::Object::Commit)
+        end
+      end
+
+      context 'with type "blob"' do
+        subject(:result) { described_class.new(repository, 'HEAD:file.txt', 'blob') }
+
+        it 'creates a Blob' do
+          expect(result).to be_a(Git::Object::Blob)
+        end
+      end
+
+      context 'with type "tree"' do
+        subject(:result) { described_class.new(repository, 'HEAD^{tree}', 'tree') }
+
+        it 'creates a Tree' do
+          expect(result).to be_a(Git::Object::Tree)
+        end
+      end
+    end
+
+    context 'when type is not provided' do
+      subject(:result) { described_class.new(repository, 'HEAD') }
+
+      before do
+        allow(repository).to receive(:cat_file_type).with('HEAD').and_return('commit')
+      end
+
+      it 'calls cat_file_type on the repository to determine the object type' do
+        expect(result).to be_a(Git::Object::Commit)
+      end
+    end
+
+    context 'when is_tag is true (deprecated form)' do
+      before do
+        allow(repository).to receive(:tag_sha).with('v1.0').and_return('tagsha123abc')
+        allow(Git::Deprecation).to receive(:warn)
+      end
+
+      it 'creates a Tag via the deprecated new_tag path and emits a deprecation warning' do
+        result = described_class.new(repository, 'v1.0', nil, true)
+        expect(result).to be_a(Git::Object::Tag)
+        expect(Git::Deprecation).to have_received(:warn).with(a_string_including('deprecated'))
+      end
+    end
+
+    context 'when type does not match any known object type' do
+      it 'raises NoMethodError due to nil class' do
+        expect { described_class.new(repository, 'abc123', 'unknown') }
+          .to raise_error(NoMethodError, /undefined method [`']new[`'].*nil/)
+      end
+    end
+
+    context 'when base is a Git::Base (legacy path)' do
+      # instance_double is viable: facade_repository is defined on Git::Base
+      # (lib/git/base.rb) and is_a? is verifiable via Kernel.
+      subject(:result) { described_class.new(legacy_base, 'HEAD') }
+
+      let(:legacy_base) { instance_double(Git::Base) }
+
+      before do
+        allow(legacy_base).to receive(:is_a?).with(Git::Base).and_return(true)
+        allow(legacy_base).to receive(:facade_repository).and_return(repository)
+        allow(repository).to receive(:cat_file_type).with('HEAD').and_return('commit')
+      end
+
+      it 'determines the object type via the facade_repository of the Git::Base' do
+        expect(result).to be_a(Git::Object::Commit)
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -942,7 +942,7 @@ RSpec.describe Git::Repository::ObjectOperations do
     context 'with an output path that does not yet exist' do
       let(:new_dest) { File.join(Dir.tmpdir, "archive_unit_new_#{Process.pid}.zip") }
 
-      after { File.unlink(new_dest) if File.exist?(new_dest) }
+      after { FileUtils.rm_f(new_dest) }
 
       it 'archives to the new destination path' do
         result = described_instance.archive('HEAD', new_dest)
@@ -952,7 +952,8 @@ RSpec.describe Git::Repository::ObjectOperations do
 
     context 'when creating the staging temp file raises before assignment' do
       before do
-        allow(Tempfile).to receive(:create).with('archive', anything).and_raise(Errno::ENOSPC, 'No space left on device')
+        allow(Tempfile).to receive(:create).with('archive', anything)
+                                           .and_raise(Errno::ENOSPC, 'No space left on device')
       end
 
       it 'propagates the error' do
@@ -963,7 +964,8 @@ RSpec.describe Git::Repository::ObjectOperations do
     context 'when creating the gzip temp file raises before assignment' do
       before do
         allow(Tempfile).to receive(:create).and_call_original
-        allow(Tempfile).to receive(:create).with('archive_gz', anything).and_raise(Errno::ENOSPC, 'No space left on device')
+        allow(Tempfile).to receive(:create).with('archive_gz', anything)
+                                           .and_raise(Errno::ENOSPC, 'No space left on device')
       end
 
       it 'propagates the error' do


### PR DESCRIPTION
## Summary

Migrates `Git::Object::AbstractObject` and all its subclasses (`Blob`, `Tree`,
`Commit`, `Tag`) — plus the `Git::Object` factory — off the legacy
`Git::Base`/`Git::Lib` layer and onto the `Git::Repository` facade, as required
by the v5.0.0 architectural redesign (Strangler Fig migration).

## Changes

### `lib/git/object.rb`

Adds two routing helpers that accept either a `Git::Repository` (new path) or a
`Git::Base` (legacy path, kept until Phase 4 cleanup):

- `AbstractObject#object_repository` — instance helper; returns the facade for
  object queries (`rev_parse`, `cat_file_*`, `grep`, `archive`, `ls_tree`, etc.)
- `Git::Object.object_repository_for` — class-level helper used by the `.new`
  factory

Replaces all `@base.lib.*` calls with `object_repository.*` delegating directly
to `Git::Repository` facade methods:

| Class | Methods migrated |
|-------|-----------------|
| `AbstractObject` | `rev_parse`, `cat_file_size`, `cat_file_contents`, `grep`, `archive` |
| `Tree` | `full_tree`, `tree_depth`, `ls_tree` |
| `Commit` | `name_rev`, `cat_file_commit` |
| `Tag` | `tag_sha`, `cat_file_type`, `cat_file_tag` |
| `Git::Object` factory | `cat_file_type` |

`Git::Diff` and `Git::Log` construction still receives `@base` for
Iterations 4–5 compatibility; recursive `Tree`/`Blob`/`Commit` constructors
continue to forward `@base` for polymorphic reuse.

### `spec/unit/git/object_spec.rb` (new)

Full unit test suite (67 examples, 100% line + branch coverage) covering:

- All migrated `Git::Repository` paths for every public method on each subclass
- Lazy-loading and caching behaviour (`sha`, `contents`, `annotated?`, `check_tag`)
- The two-argument and three-argument `Tag#initialize` forms
- The `is_tag` deprecated factory path with deprecation-warning assertion
- `Git::Base` legacy polymorphism branches via `instance_double(Git::Base)`

### `spec/unit/git/repository/object_operations_spec.rb`

Minor style fixes (line-length, `FileUtils.rm_f` cleanup) to pass RuboCop.

### `redesign/3_architecture_implementation.md`

Marks the `Git::Object::*` migration task as complete.
