### PR TITLE
feat(repository): extract full_log_commits to Git::Repository facade

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1001,6 +1001,14 @@ module Git
       Git::Log.new(self, count)
     end
 
+    # Return commits that are within the given revision range
+    #
+    # @param opts [Hash] options for the log query
+    # @return [Array<Hash>] the parsed raw log output for each commit
+    def full_log_commits(opts = {})
+      facade_repository.full_log_commits(opts)
+    end
+
     # returns a Git::Object of the appropriate type
     # you can also call @git.gtree('tree'), but that's
     # just for readability.  If you call @git.gtree('HEAD') it will

--- a/lib/git/log.rb
+++ b/lib/git/log.rb
@@ -160,7 +160,7 @@ module Git
     def run_log_if_dirty
       return unless @dirty
 
-      log_data = @base.lib.full_log_commits(@options)
+      log_data = @base.full_log_commits(@options)
       @commits = log_data.map { |c| Git::Object::Commit.new(@base, c['sha'], c) }
       @dirty = false
     end

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -4,6 +4,7 @@ require 'git/execution_context/repository'
 require 'git/repository/branching'
 require 'git/repository/committing'
 require 'git/repository/diffing'
+require 'git/repository/logging'
 require 'git/repository/merging'
 require 'git/repository/object_operations'
 require 'git/repository/remote_operations'
@@ -39,6 +40,7 @@ module Git
     include Git::Repository::Branching
     include Git::Repository::Committing
     include Git::Repository::Diffing
+    include Git::Repository::Logging
     include Git::Repository::Merging
     include Git::Repository::ObjectOperations
     include Git::Repository::RemoteOperations

--- a/lib/git/repository/logging.rb
+++ b/lib/git/repository/logging.rb
@@ -1,0 +1,229 @@
+# frozen_string_literal: true
+
+require 'git/commands/log'
+require 'git/repository/shared_private'
+
+module Git
+  class Repository
+    # Facade methods for querying commit history
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module Logging
+      FULL_LOG_COMMITS_ALLOWED_OPTS = %i[
+        count all cherry since until grep author between object path_limiter skip merges
+      ].freeze
+      private_constant :FULL_LOG_COMMITS_ALLOWED_OPTS
+
+      # Returns commits within the given revision range
+      #
+      # @overload full_log_commits(opts = {})
+      #
+      #   @example Return commits from all refs
+      #     repo.full_log_commits(all: true).first['sha']
+      #     #=> "a1b2c3d4..."
+      #
+      #   @example Return commits between two revisions
+      #     repo.full_log_commits(between: ['v1.0.0', 'HEAD']).map { |c| c['sha'] }
+      #     #=> ["d4e5f6...", "a1b2c3..."]
+      #
+      #   @param opts [Hash] options for the log query
+      #
+      #   @option opts [Integer, nil] :count (nil) maximum number of commits to return
+      #
+      #   @option opts [Boolean, nil] :all (nil) include commits reachable from any ref
+      #
+      #   @option opts [Boolean, nil] :cherry (nil) omit commits equivalent to cherry-picked commits
+      #
+      #   @option opts [String] :since (nil) include commits newer than this date expression
+      #
+      #   @option opts [String] :until (nil) include commits older than this date expression
+      #
+      #   @option opts [String] :grep (nil) only include commits whose message matches this pattern
+      #
+      #   @option opts [String] :author (nil) only include commits whose author matches this pattern
+      #
+      #   @option opts [Array<String>] :between (nil) revision range as two commit-ish values
+      #
+      #     When both `:between` and `:object` are provided, `:between` takes precedence.
+      #
+      #   @option opts [String] :object (nil) single revision range expression for git log
+      #
+      #     Ignored when `:between` is provided.
+      #
+      #   @option opts [String, Pathname, Array<String, Pathname>] :path_limiter (nil)
+      #     only include commits that impact files from the specified path(s)
+      #
+      #   @option opts [Integer] :skip (nil) skip this many commits before output
+      #
+      #   @option opts [Boolean, nil] :merges (nil) include only merge commits
+      #
+      #   @return [Array<Hash>] the parsed raw log output for each commit
+      #
+      #   @raise [ArgumentError] if unsupported options are provided
+      #
+      #   @raise [ArgumentError] if `:count` is not an Integer
+      #
+      #   @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      #   @see https://git-scm.com/docs/git-log git-log
+      #
+      def full_log_commits(opts = {})
+        SharedPrivate.assert_valid_opts!(FULL_LOG_COMMITS_ALLOWED_OPTS, **opts)
+        Private.validate_log_count_option!(opts)
+        Private.validate_log_between_option!(opts)
+
+        call_opts = Private.log_base_call_options(opts, skip: opts[:skip], merges: opts[:merges])
+        revision_range_args = Private.log_revision_range_args(opts)
+        Private.run_log_command(@execution_context, revision_range_args, call_opts)
+      end
+
+      # Internal helpers for {Logging} that should not be mixed into
+      # {Git::Repository} instances
+      #
+      # @api private
+      #
+      module Private
+        module_function
+
+        def validate_log_count_option!(opts)
+          return if opts[:count].nil? || opts[:count].is_a?(Integer)
+
+          raise ArgumentError, "The log count option must be an Integer but was #{opts[:count].inspect}"
+        end
+
+        def validate_log_between_option!(opts)
+          between = opts[:between]
+          return if between.nil?
+          return if between.is_a?(Array) && between.length == 2 && between.none?(&:nil?)
+
+          raise ArgumentError,
+                "The log between option must be an Array with exactly two non-nil values but was #{between.inspect}"
+        end
+
+        def log_revision_range_args(opts)
+          if opts[:between]
+            ["#{opts[:between][0]}..#{opts[:between][1]}"]
+          elsif opts[:object].is_a?(String)
+            [opts[:object]]
+          else
+            []
+          end
+        end
+
+        def log_base_call_options(opts, extra = {})
+          {
+            all: opts[:all],
+            cherry: opts[:cherry],
+            since: opts[:since],
+            until: opts[:until],
+            grep: opts[:grep],
+            author: opts[:author],
+            max_count: opts[:count],
+            path: opts[:path_limiter] ? Array(opts[:path_limiter]) : nil
+          }.merge(extra).compact
+        end
+
+        def run_log_command(execution_context, revision_range_args, call_opts)
+          log_or_empty_on_unborn do
+            result = Git::Commands::Log.new(execution_context).call(
+              *revision_range_args,
+              no_color: true,
+              pretty: 'raw',
+              **call_opts
+            )
+            RawLogParser.new(result.stdout.split("\n")).parse
+          end
+        end
+
+        def log_or_empty_on_unborn
+          yield
+        rescue Git::FailedError => e
+          raise unless e.result.status.exitstatus == 128 &&
+                       e.result.stderr =~ /does not have any commits yet/
+
+          []
+        end
+
+        # Parser for `git log --pretty=raw` output into commit hashes
+        #
+        # @api private
+        #
+        class RawLogParser
+          def initialize(lines)
+            @lines = lines
+            @commits = []
+            @current_commit = nil
+            @in_message = false
+            @last_metadata_key = nil
+          end
+
+          # Parse raw `git log --pretty=raw` lines into commit hashes
+          #
+          # @return [Array<Hash>] the parsed commits in command output order
+          #
+          def parse
+            @lines.each { |line| process_line(line.chomp) }
+            finalize_commit
+            @commits
+          end
+
+          private
+
+          def process_line(line)
+            if line.empty?
+              @in_message = !@in_message
+              return
+            end
+
+            @in_message = false if @in_message && !line.start_with?('    ')
+
+            @in_message ? process_message_line(line) : process_metadata_line(line)
+          end
+
+          def process_message_line(line)
+            @current_commit['message'] << "#{line[4..]}\n"
+          end
+
+          def process_metadata_line(line)
+            if line.start_with?(' ') && @last_metadata_key
+              @current_commit[@last_metadata_key] << "\n#{line[1..]}"
+              return
+            end
+
+            key, *value = line.split
+            value = value.join(' ')
+            @last_metadata_key = nil
+            dispatch_metadata_key(key, value)
+          end
+
+          def dispatch_metadata_key(key, value)
+            case key
+            when 'commit'
+              start_new_commit(value)
+            when 'parent'
+              @current_commit['parent'] << value
+            else
+              @current_commit[key] = value
+              @last_metadata_key = key
+            end
+          end
+
+          def start_new_commit(sha)
+            finalize_commit
+            @current_commit = { 'sha' => sha, 'message' => +'', 'parent' => [] }
+            @last_metadata_key = nil
+          end
+
+          def finalize_commit
+            @commits << @current_commit if @current_commit
+          end
+        end
+        private_constant :RawLogParser
+      end
+      private_constant :Private
+    end
+  end
+end

--- a/spec/integration/git/repository/logging_spec.rb
+++ b/spec/integration/git/repository/logging_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/logging'
+require 'git/execution_context/repository'
+
+RSpec.describe Git::Repository::Logging, :integration do
+  include_context 'in an empty repository'
+
+  let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  describe '#full_log_commits' do
+    context 'when the repository has no commits' do
+      it 'returns an empty array' do
+        expect(described_instance.full_log_commits).to eq([])
+      end
+    end
+
+    context 'when the repository has commits' do
+      let(:first_sha) { repo.lib.rev_parse('HEAD~1').strip }
+
+      before do
+        write_file('README.md', "line one\n")
+        repo.add('README.md')
+        repo.commit('Initial commit')
+
+        write_file('CHANGELOG.md', "entry\n")
+        repo.add('CHANGELOG.md')
+        repo.commit('Add changelog')
+      end
+
+      it 'returns parsed commit hashes with expected keys' do
+        result = described_instance.full_log_commits
+
+        expect(result).to all(include('sha', 'tree', 'author', 'committer', 'message', 'parent'))
+        expect(result.first['message']).to eq("Add changelog\n")
+        expect(result.first['parent']).to be_a(Array)
+      end
+
+      it 'supports the between option' do
+        result = described_instance.full_log_commits(between: [first_sha, 'HEAD'])
+
+        expect(result.length).to eq(1)
+        expect(result.first['message']).to eq("Add changelog\n")
+      end
+
+      it 'supports the path_limiter option' do
+        result = described_instance.full_log_commits(path_limiter: 'README.md')
+
+        expect(result.length).to eq(1)
+        expect(result.first['message']).to eq("Initial commit\n")
+      end
+    end
+  end
+end

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -26,4 +26,22 @@ RSpec.describe Git::Base do
       end
     end
   end
+
+  describe '#full_log_commits' do
+    subject(:result) { described_instance.full_log_commits(opts) }
+
+    let(:described_instance) { described_class.new }
+    let(:opts) { { count: 3 } }
+    let(:facade_repository) { instance_double(Git::Repository) }
+    let(:log_data) { [{ 'sha' => 'abc123' }] }
+
+    before do
+      allow(described_instance).to receive(:facade_repository).and_return(facade_repository)
+    end
+
+    it 'delegates to facade_repository with opts and returns the facade result' do
+      expect(facade_repository).to receive(:full_log_commits).with(opts).and_return(log_data)
+      expect(result).to eq(log_data)
+    end
+  end
 end

--- a/spec/unit/git/repository/logging_spec.rb
+++ b/spec/unit/git/repository/logging_spec.rb
@@ -1,0 +1,278 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'pathname'
+require 'git/repository'
+require 'git/repository/logging'
+
+# Integration-level coverage for Git::Repository::Logging is provided by:
+#   spec/integration/git/repository/logging_spec.rb
+# The unit specs below cover facade-owned option validation, argument shaping,
+# unborn-branch handling, and parser edge cases.
+
+RSpec.describe Git::Repository::Logging do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  describe '#full_log_commits' do
+    subject(:result) { described_instance.full_log_commits(opts) }
+
+    let(:opts) { {} }
+    let(:log_command) { instance_double(Git::Commands::Log) }
+
+    before do
+      allow(Git::Commands::Log).to receive(:new).with(execution_context).and_return(log_command)
+    end
+
+    context 'with no options' do
+      let(:raw_output) do
+        <<~RAW
+          commit aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+          tree tttttttttttttttttttttttttttttttttttttttt
+          parent pppppppppppppppppppppppppppppppppppppppp
+          author A <a@example.com> 1 +0000
+          committer A <a@example.com> 1 +0000
+
+              first message
+          commit bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+          tree uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu
+          author B <b@example.com> 2 +0000
+          committer B <b@example.com> 2 +0000
+
+              second message
+        RAW
+      end
+
+      it 'calls the command with parser-contract options and returns parsed commits' do
+        expect(log_command).to receive(:call).with(no_color: true, pretty: 'raw').and_return(command_result(raw_output))
+
+        expect(result).to eq(
+          [
+            {
+              'sha' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              'tree' => 'tttttttttttttttttttttttttttttttttttttttt',
+              'parent' => ['pppppppppppppppppppppppppppppppppppppppp'],
+              'author' => 'A <a@example.com> 1 +0000',
+              'committer' => 'A <a@example.com> 1 +0000',
+              'message' => "first message\n"
+            },
+            {
+              'sha' => 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+              'tree' => 'uuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuuu',
+              'parent' => [],
+              'author' => 'B <b@example.com> 2 +0000',
+              'committer' => 'B <b@example.com> 2 +0000',
+              'message' => "second message\n"
+            }
+          ]
+        )
+      end
+    end
+
+    context 'with a signed commit that includes multiline gpgsig metadata' do
+      let(:expected_gpgsig) do
+        <<~SIG.chomp
+          -----BEGIN PGP SIGNATURE-----
+          iQIzBAABCAAdFiEEXAMPLEKEYLINEONE
+          =ABCD
+          -----END PGP SIGNATURE-----
+        SIG
+      end
+
+      let(:raw_output) do
+        <<~RAW
+          commit cccccccccccccccccccccccccccccccccccccccc
+          tree tttttttttttttttttttttttttttttttttttttttt
+          author C <c@example.com> 3 +0000
+          committer C <c@example.com> 3 +0000
+          gpgsig -----BEGIN PGP SIGNATURE-----
+           iQIzBAABCAAdFiEEXAMPLEKEYLINEONE
+           =ABCD
+           -----END PGP SIGNATURE-----
+
+              signed commit message
+        RAW
+      end
+
+      it 'folds gpgsig continuation lines into a single gpgsig field' do
+        allow(log_command).to receive(:call).with(no_color: true, pretty: 'raw').and_return(command_result(raw_output))
+
+        expect(result).to eq(
+          [
+            {
+              'sha' => 'cccccccccccccccccccccccccccccccccccccccc',
+              'tree' => 'tttttttttttttttttttttttttttttttttttttttt',
+              'parent' => [],
+              'author' => 'C <c@example.com> 3 +0000',
+              'committer' => 'C <c@example.com> 3 +0000',
+              'gpgsig' => expected_gpgsig,
+              'message' => "signed commit message\n"
+            }
+          ]
+        )
+      end
+    end
+
+    context 'with all documented options and a between revision range' do
+      let(:opts) do
+        {
+          count: 2,
+          all: true,
+          cherry: true,
+          since: '2024-01-01',
+          until: '2024-01-31',
+          grep: 'fix',
+          author: 'Jane',
+          between: %w[v1.0.0 HEAD],
+          path_limiter: Pathname('README.md'),
+          skip: 1,
+          merges: true
+        }
+      end
+
+      it 'forwards mapped options and normalizes path_limiter to an array' do
+        expect(log_command).to receive(:call).with(
+          'v1.0.0..HEAD',
+          no_color: true,
+          pretty: 'raw',
+          all: true,
+          cherry: true,
+          since: '2024-01-01',
+          until: '2024-01-31',
+          grep: 'fix',
+          author: 'Jane',
+          max_count: 2,
+          path: [Pathname('README.md')],
+          skip: 1,
+          merges: true
+        ).and_return(command_result(''))
+
+        expect(result).to eq([])
+      end
+    end
+
+    context 'with object as a String' do
+      let(:opts) { { object: 'main~2..main' } }
+
+      it 'passes object as the positional revision range argument' do
+        expect(log_command).to receive(:call).with('main~2..main', no_color: true, pretty: 'raw').and_return(
+          command_result('')
+        )
+
+        expect(result).to eq([])
+      end
+    end
+
+    context 'with both between and object' do
+      let(:opts) { { between: %w[v1.0.0 HEAD], object: 'ignored' } }
+
+      it 'uses between and ignores object' do
+        expect(log_command).to receive(:call).with('v1.0.0..HEAD', no_color: true, pretty: 'raw').and_return(
+          command_result('')
+        )
+
+        expect(result).to eq([])
+      end
+    end
+
+    context 'with object as a non-String' do
+      let(:opts) { { object: :head } }
+
+      it 'does not pass a positional revision range argument' do
+        expect(log_command).to receive(:call).with(no_color: true, pretty: 'raw').and_return(command_result(''))
+
+        expect(result).to eq([])
+      end
+    end
+
+    context 'when git reports an unborn branch' do
+      it 'returns an empty array for exit status 128 with the unborn-repository message' do
+        failed_result = command_result('',
+                                       stderr: "fatal: your current branch 'main' does not have any commits yet",
+                                       exitstatus: 128)
+        allow(log_command).to receive(:call).and_raise(Git::FailedError, failed_result)
+
+        expect(result).to eq([])
+      end
+    end
+
+    context 'when git fails for another reason with exit status 128' do
+      it 're-raises Git::FailedError' do
+        failed_result = command_result('', stderr: 'fatal: bad default revision', exitstatus: 128)
+        allow(log_command).to receive(:call).and_raise(Git::FailedError, failed_result)
+
+        expect { result }.to raise_error(Git::FailedError, /bad default revision/)
+      end
+    end
+
+    context 'when git reports the unborn message with a non-128 exit status' do
+      it 're-raises Git::FailedError' do
+        failed_result = command_result('', stderr: 'fatal: does not have any commits yet', exitstatus: 1)
+        allow(log_command).to receive(:call).and_raise(Git::FailedError, failed_result)
+
+        expect { result }.to raise_error(Git::FailedError, /does not have any commits yet/)
+      end
+    end
+
+    context 'option whitelisting' do
+      context 'with unknown options' do
+        let(:opts) { { bogus: true } }
+
+        it 'raises ArgumentError for an unknown option key' do
+          expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+        end
+      end
+    end
+
+    context 'input validation' do
+      context 'with between as a non-array' do
+        let(:opts) { { between: 'main..HEAD' } }
+
+        it 'raises ArgumentError with an explanatory message' do
+          expect { result }.to raise_error(
+            ArgumentError,
+            /must be an Array with exactly two non-nil values but was "main\.\.HEAD"/
+          )
+        end
+      end
+
+      context 'with between as an array of the wrong length' do
+        let(:opts) { { between: ['HEAD'] } }
+
+        it 'raises ArgumentError with an explanatory message' do
+          expect { result }.to raise_error(
+            ArgumentError,
+            /must be an Array with exactly two non-nil values but was \["HEAD"\]/
+          )
+        end
+      end
+
+      context 'with between containing nil' do
+        let(:opts) { { between: ['HEAD~1', nil] } }
+
+        it 'raises ArgumentError with an explanatory message' do
+          expect { result }.to raise_error(
+            ArgumentError,
+            /must be an Array with exactly two non-nil values but was \["HEAD~1", nil\]/
+          )
+        end
+      end
+
+      context 'with a non-integer count' do
+        let(:opts) { { count: '5' } }
+
+        it 'raises ArgumentError with an explanatory message' do
+          expect { result }.to raise_error(ArgumentError, /must be an Integer but was "5"/)
+        end
+      end
+
+      context 'with count set to false' do
+        let(:opts) { { count: false } }
+
+        it 'raises ArgumentError with an explanatory message' do
+          expect { result }.to raise_error(ArgumentError, /must be an Integer but was false/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Extracts `full_log_commits` from `Git::Lib` into a new `Git::Repository::Logging` facade module, following the Strangler Fig architectural migration pattern.

## Changes

### `lib/git/repository/logging.rb` (new)

Adds `Git::Repository::Logging` with a `#full_log_commits` facade method. The implementation includes:

- `FULL_LOG_COMMITS_ALLOWED_OPTS` whitelist enforced via `SharedPrivate.assert_valid_opts!`
- Input validation for `:count` (must be Integer) and `:between` (must be a two-element non-nil Array)
- Argument pre-processing: maps `:count` → `max_count`, normalises `:path_limiter` to an Array, computes the revision range from `:between` or `:object`
- Unborn-branch handling: returns `[]` on exit status 128 with the "does not have any commits yet" message
- Internal `RawLogParser` class that parses `git log --pretty=raw` output into `Array<Hash>`, including multi-line `gpgsig` continuation lines

### `lib/git/repository.rb`

Includes `Git::Repository::Logging`.

### `lib/git/base.rb`

Delegates `Git::Base#full_log_commits` to `facade_repository.full_log_commits`.

## Tests

- **Unit** (`spec/unit/git/repository/logging_spec.rb`): covers default invocation, all documented options, revision-range variants (`between`, `object`, both), gpgsig multi-line parsing, unborn-branch handling, option whitelisting, and all input-validation error paths.
- **Integration** (`spec/integration/git/repository/logging_spec.rb`): exercises the full stack against a real git repository — empty repo, commit structure, `between`, and `path_limiter` options.
- **Delegation** (`spec/unit/git/base_spec.rb`): verifies `Git::Base#full_log_commits` delegates to the facade.