### PR TITLE
feat(repository): migrate Git::Log to Git::Repository (iter 4B)

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -998,7 +998,7 @@ module Git
 
     # @return [Git::Log] a log with the specified number of commits
     def log(count = 30)
-      Git::Log.new(self, count)
+      facade_repository.log(count)
     end
 
     # Return commits that are within the given revision range

--- a/lib/git/log.rb
+++ b/lib/git/log.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'git/base'
+
 module Git
   # Builds and executes a `git log` query
   #
@@ -42,7 +44,7 @@ module Git
     #   git = Git.open('.')
     #   Git::Log.new(git)
     #
-    # @param base [Git::Base] the git repository object
+    # @param base [Git::Repository, Git::Base] the git repository object
     # @param max_count [Integer, Symbol, nil] the number of commits to return, or
     #   `:all` or `nil` to return all
     #
@@ -157,10 +159,21 @@ module Git
       self
     end
 
+    # Returns the facade interface for log operations.
+    #
+    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
+    # The `is_a?` guard will be removed when {Git::Base} is deleted in Phase 4.
+    #
+    # @return [Git::Repository]
+    #
+    def log_repository
+      @base.is_a?(Git::Base) ? @base.facade_repository : @base
+    end
+
     def run_log_if_dirty
       return unless @dirty
 
-      log_data = @base.full_log_commits(@options)
+      log_data = log_repository.full_log_commits(@options)
       @commits = log_data.map { |c| Git::Object::Commit.new(@base, c['sha'], c) }
       @dirty = false
     end

--- a/lib/git/repository/logging.rb
+++ b/lib/git/repository/logging.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'git/commands/log'
+require 'git/log'
 require 'git/repository/shared_private'
 
 module Git
@@ -78,6 +79,23 @@ module Git
         call_opts = Private.log_base_call_options(opts, skip: opts[:skip], merges: opts[:merges])
         revision_range_args = Private.log_revision_range_args(opts)
         Private.run_log_command(@execution_context, revision_range_args, call_opts)
+      end
+
+      # Returns a new {Git::Log} query builder scoped to this repository
+      #
+      # @example Build a log query and execute it
+      #   results = repo.log(50).author('Alice').since('2 weeks ago').execute
+      #   results.each { |commit| puts commit.sha }
+      #
+      # @param count [Integer, Symbol, nil] the maximum number of commits to return,
+      #   or `:all` / `nil` to return all commits; passed directly to {Git::Log#initialize}
+      #
+      # @return [Git::Log] a new log query builder
+      #
+      # @see Git::Log
+      #
+      def log(count = 30)
+        Git::Log.new(self, count)
       end
 
       # Internal helpers for {Logging} that should not be mixed into

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -56,9 +56,9 @@ such as `Branch`, `Diff`, `Log`, `Object`, `Remote`, `Status`, `Worktree`, etc.
 
 ### Next Task
 
-**Phase 3 — Iteration 3: `Git::Object::*` (A+B)**
+**Phase 3 — Iteration 5: `Git::Diff` + `Git::DiffStats` (A+B)**
 
-Iter 1 (`Git::Stash` B2 + `Git::Stashes` B3) is ✅ complete ([PR #1306](https://github.com/ruby-git/ruby-git/pull/1306)). Iter 2 (`Git::DiffPathStatus` B1) is ✅ complete. Proceed to iter 3.
+Iter 1 (`Git::Stash` B2 + `Git::Stashes` B3) is ✅ complete ([PR #1306](https://github.com/ruby-git/ruby-git/pull/1306)). Iter 2 (`Git::DiffPathStatus` B1) is ✅ complete. Iter 3 (`Git::Object::*`) is ✅ complete. Iter 4 (`Git::Log` A+B) is ✅ complete ([PR #1327](https://github.com/ruby-git/ruby-git/pull/1327) + `feat/migrate-log-to-repository`). Proceed to iter 5.
 
 The full scope is still migrating all domain objects
 (`Git::Stash`, `Git::Stashes`, `Git::DiffPathStatus`, `Git::Object::*`,
@@ -106,7 +106,7 @@ After all 9 domain-object iterations, **verify facade coverage**: every public `
 | `Git::Stashes` | ✅ Complete | iter 1 |
 | `Git::DiffPathStatus` | ✅ Complete | iter 2 |
 | `Git::Object::*` | ✅ Complete | iter 3 |
-| `Git::Log` | ⏳ Not started | iter 4 |
+| `Git::Log` | ✅ Complete | iter 4 |
 | `Git::Diff` | ⏳ Not started | iter 5 |
 | `Git::DiffStats` | ⏳ Not started | iter 5 |
 | `Git::Status` | ⏳ Not started | iter 6 |

--- a/spec/integration/git/repository/logging_spec.rb
+++ b/spec/integration/git/repository/logging_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'git/log'
 require 'git/repository'
 require 'git/repository/logging'
 require 'git/execution_context/repository'
@@ -51,6 +52,42 @@ RSpec.describe Git::Repository::Logging, :integration do
 
         expect(result.length).to eq(1)
         expect(result.first['message']).to eq("Initial commit\n")
+      end
+    end
+  end
+
+  describe '#log' do
+    context 'when the repository has commits' do
+      before do
+        write_file('README.md', "line one\n")
+        repo.add('README.md')
+        repo.commit('Initial commit')
+
+        write_file('CHANGELOG.md', "entry\n")
+        repo.add('CHANGELOG.md')
+        repo.commit('Add changelog')
+      end
+
+      it 'returns a Git::Log that executes to a result containing Git::Object::Commit entries' do
+        result = described_instance.log.execute
+
+        expect(result).to be_a(Git::Log::Result)
+        expect(result.size).to eq(2)
+        expect(result).to all(be_a(Git::Object::Commit))
+      end
+
+      it 'respects count when set via the fluent interface' do
+        result = described_instance.log(1).execute
+
+        expect(result.size).to eq(1)
+        expect(result.first.message.strip).to eq('Add changelog')
+      end
+
+      it 'returns commits in reverse-chronological order' do
+        result = described_instance.log.execute
+
+        expect(result.first.message.strip).to eq('Add changelog')
+        expect(result.last.message.strip).to eq('Initial commit')
       end
     end
   end

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -44,4 +44,36 @@ RSpec.describe Git::Base do
       expect(result).to eq(log_data)
     end
   end
+
+  describe '#log' do
+    subject(:result) { described_instance.log(count) }
+
+    let(:described_instance) { described_class.new }
+    let(:count) { 5 }
+    let(:facade_repository) { instance_double(Git::Repository) }
+    let(:log_instance) { instance_double(Git::Log) }
+
+    before do
+      allow(described_instance).to receive(:facade_repository).and_return(facade_repository)
+      allow(facade_repository).to receive(:log).with(count).and_return(log_instance)
+    end
+
+    it 'delegates to facade_repository.log with count and returns the result' do
+      expect(facade_repository).to receive(:log).with(count).and_return(log_instance)
+      expect(result).to be(log_instance)
+    end
+
+    context 'with default count' do
+      subject(:result) { described_instance.log }
+
+      before do
+        allow(facade_repository).to receive(:log).with(30).and_return(log_instance)
+      end
+
+      it 'passes 30 as the default count' do
+        expect(facade_repository).to receive(:log).with(30).and_return(log_instance)
+        expect(result).to be(log_instance)
+      end
+    end
+  end
 end

--- a/spec/unit/git/log_spec.rb
+++ b/spec/unit/git/log_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/log'
+require 'git/repository'
+require 'git/object'
+
+RSpec.describe Git::Log do
+  describe '#initialize' do
+    context 'when base is a Git::Repository' do
+      subject(:log) { described_class.new(repository, 10) }
+
+      let(:repository) { instance_double(Git::Repository) }
+
+      it 'accepts Git::Repository without raising' do
+        expect { log }.not_to raise_error
+      end
+    end
+
+    context 'when base is a Git::Base (legacy)' do
+      subject(:log) { described_class.new(base, 10) }
+
+      let(:base) { instance_double(Git::Base) }
+
+      it 'accepts Git::Base without raising' do
+        expect { log }.not_to raise_error
+      end
+    end
+
+    context 'when max_count defaults to 30' do
+      subject(:log) { described_class.new(repository) }
+
+      let(:repository) { instance_double(Git::Repository) }
+      let(:commit_data) { [] }
+
+      before do
+        allow(repository).to receive(:full_log_commits).with(hash_including(count: 30)).and_return(commit_data)
+      end
+
+      it 'forwards count: 30 to full_log_commits on execute' do
+        expect(repository).to receive(:full_log_commits).with(hash_including(count: 30)).and_return(commit_data)
+        log.execute
+      end
+    end
+  end
+
+  describe '#execute' do
+    let(:commit_data) do
+      [{
+        'sha' => 'abc123', 'tree' => 'def456', 'parent' => [],
+        'author' => 'A', 'committer' => 'B', 'message' => 'msg'
+      }]
+    end
+
+    context 'when base is a Git::Repository' do
+      subject(:result) { log.execute }
+
+      let(:repository) { instance_double(Git::Repository) }
+      let(:log) { described_class.new(repository) }
+
+      before do
+        allow(repository).to receive(:full_log_commits).and_return(commit_data)
+        allow(Git::Object::Commit).to receive(:new).with(repository, 'abc123', commit_data.first)
+                                                   .and_return(instance_double(Git::Object::Commit))
+      end
+
+      it 'calls full_log_commits directly on the repository' do
+        expect(repository).to receive(:full_log_commits).and_return(commit_data)
+        result
+      end
+
+      it 'returns a Git::Log::Result' do
+        expect(result).to be_a(Git::Log::Result)
+      end
+    end
+
+    context 'when base is a Git::Base (legacy)' do
+      subject(:result) { log.execute }
+
+      let(:base) { instance_double(Git::Base) }
+      let(:facade_repository) { instance_double(Git::Repository) }
+      let(:log) { described_class.new(base) }
+
+      before do
+        allow(base).to receive(:is_a?).with(Git::Base).and_return(true)
+        allow(base).to receive(:facade_repository).and_return(facade_repository)
+        allow(facade_repository).to receive(:full_log_commits).and_return(commit_data)
+        allow(Git::Object::Commit).to receive(:new).with(base, 'abc123', commit_data.first)
+                                                   .and_return(instance_double(Git::Object::Commit))
+      end
+
+      it 'routes full_log_commits through facade_repository' do
+        expect(facade_repository).to receive(:full_log_commits).and_return(commit_data)
+        result
+      end
+
+      it 'passes base (not facade_repository) to Git::Object::Commit.new' do
+        expect(Git::Object::Commit).to receive(:new).with(base, 'abc123', commit_data.first)
+                                                    .and_return(instance_double(Git::Object::Commit))
+        result
+      end
+
+      it 'returns a Git::Log::Result' do
+        expect(result).to be_a(Git::Log::Result)
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository/logging_spec.rb
+++ b/spec/unit/git/repository/logging_spec.rb
@@ -2,6 +2,7 @@
 
 require 'spec_helper'
 require 'pathname'
+require 'git/log'
 require 'git/repository'
 require 'git/repository/logging'
 
@@ -272,6 +273,31 @@ RSpec.describe Git::Repository::Logging do
         it 'raises ArgumentError with an explanatory message' do
           expect { result }.to raise_error(ArgumentError, /must be an Integer but was false/)
         end
+      end
+    end
+  end
+
+  describe '#log' do
+    subject(:result) { described_instance.log(count) }
+
+    let(:count) { 30 }
+    let(:log_instance) { instance_double(Git::Log) }
+
+    before do
+      allow(Git::Log).to receive(:new).with(described_instance, count).and_return(log_instance)
+    end
+
+    it 'constructs Git::Log with self and the given count and returns it' do
+      expect(Git::Log).to receive(:new).with(described_instance, count).and_return(log_instance)
+      expect(result).to be(log_instance)
+    end
+
+    context 'with default count' do
+      subject(:result) { described_instance.log }
+
+      it 'passes 30 as the default count' do
+        expect(Git::Log).to receive(:new).with(described_instance, 30).and_return(log_instance)
+        expect(result).to be(log_instance)
       end
     end
   end


### PR DESCRIPTION
## Summary

Completes Iteration 4 of the domain-object migration ([issue #1299](https://github.com/ruby-git/ruby-git/issues/1299)) by migrating `Git::Log` to accept `Git::Repository` via constructor polymorphism and adding the `log` factory to `Git::Repository::Logging`.

## Changes

### `lib/git/repository/logging.rb`

- Adds `require 'git/log'`
- Adds `Git::Repository::Logging#log(count = 30)` factory that constructs and returns `Git::Log.new(self, count)`, enabling callers to build fluent log queries directly against a `Git::Repository` instance

### `lib/git/log.rb`

- Updates `@param base` YARD tag from `[Git::Base]` → `[Git::Repository, Git::Base]`
- Adds private `log_repository` helper using the `is_a?(Git::Base)` guard pattern (mirrors `Git::Stash#stash_repository` from iter 1)
- Updates `run_log_if_dirty` to call `log_repository.full_log_commits` instead of `@base.full_log_commits`, so `Git::Log` correctly routes through `Git::Repository` when it holds one directly

### `lib/git/base.rb`

- Updates `Git::Base#log` to delegate to `facade_repository.log(count)` instead of constructing `Git::Log.new(self, count)` directly

## Tests

- **`spec/unit/git/log_spec.rb`** (new): covers constructor polymorphism, verifies that the `Git::Repository` path calls `full_log_commits` directly on the repository, the `Git::Base` path routes through `facade_repository`, and `Git::Object::Commit.new` receives `@base` in both paths
- **`spec/unit/git/repository/logging_spec.rb`**: extends with `#log` factory tests — verifies `Git::Log.new(self, count)` is constructed with the facade instance and the given count
- **`spec/integration/git/repository/logging_spec.rb`**: adds end-to-end `#log` tests against a real git repository — asserts `Git::Log::Result` is returned containing `Git::Object::Commit` entries in reverse-chronological order; count limiting via fluent interface works
- **`spec/unit/git/base_spec.rb`**: adds `#log` delegation test verifying `facade_repository.log(count)` is called and its result returned

## Design Notes

- The `is_a?(Git::Base)` polymorphism guard in `log_repository` is consistent with the pattern established in iter 1 (`Git::Stash#stash_repository`) and iter 3 (`Git::Object::AbstractObject#object_repository`). The guard will be removed in the Phase 4 cleanup PR once `Git::Base` is deleted.
- `Git::Object::Commit.new(@base, ...)` continues to receive `@base` unmodified (not `log_repository`). `Git::Object::*` was already migrated in iter 3 and its `object_repository` helper handles both types.
- `Git::Object::AbstractObject#log` (which calls `Git::Log.new(@base, count)`) requires no changes — once `Git::Log` accepts both types, that call works for both `Git::Base` and `Git::Repository` values of `@base`.