### PR TITLE
feat(repository): add Git::Repository#diff_numstat facade method

### DIFF
--- a/lib/git/repository/diffing.rb
+++ b/lib/git/repository/diffing.rb
@@ -71,6 +71,74 @@ module Git
         Private.extract_patch_text(result.stdout)
       end
 
+      # Option keys accepted by {#diff_numstat}
+      #
+      # @return [Array<Symbol>]
+      #
+      # @api private
+      #
+      DIFF_NUMSTAT_ALLOWED_OPTS = %i[path_limiter].freeze
+      private_constant :DIFF_NUMSTAT_ALLOWED_OPTS
+
+      # Returns per-file insertion/deletion counts and totals between two commits
+      #
+      # Compares two commits (or a commit against the index/working tree) using
+      # `git diff --numstat` and returns a structured hash of per-file insertion
+      # and deletion line counts together with aggregate totals.
+      #
+      # @example Get numstat for the most recent commit
+      #   repo.diff_numstat
+      #   #=> { total: { insertions: 5, deletions: 2, lines: 7, files: 1 },
+      #   #     files: { "lib/foo.rb" => { insertions: 5, deletions: 2 } } }
+      #
+      # @example Compare two specific commits
+      #   repo.diff_numstat('abc1234', 'def5678')
+      #
+      # @example Limit the stats to a sub-path
+      #   repo.diff_numstat('HEAD~1', 'HEAD', path_limiter: 'lib/')
+      #
+      # @param obj1 [String] the first commit or object to compare; defaults to
+      #   `'HEAD'`
+      #
+      # @param obj2 [String, nil] the second commit or object to compare
+      #
+      #   When `nil`, the comparison is against the index or working tree.
+      #
+      # @param opts [Hash] options to filter the diff
+      #
+      # @option opts [String, Pathname, Array<String, Pathname>, nil] :path_limiter (nil)
+      #   limit the stats to the given path(s)
+      #
+      # @return [Hash] per-file insertion and deletion counts plus aggregate totals
+      #
+      #   ```
+      #   {
+      #     total: { insertions: Integer, deletions: Integer, lines: Integer, files: Integer },
+      #     files: { "path/to/file" => { insertions: Integer, deletions: Integer } }
+      #   }
+      #   ```
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [ArgumentError] if `obj1` or `obj2` starts with `"-"`
+      #
+      # @raise [Git::FailedError] if git exits outside the allowed range (exit code > 1)
+      #
+      # @see https://git-scm.com/docs/git-diff git-diff documentation
+      #
+      def diff_numstat(obj1 = 'HEAD', obj2 = nil, opts = {})
+        SharedPrivate.assert_valid_opts!(DIFF_NUMSTAT_ALLOWED_OPTS, **opts)
+        Private.validate_ref_arguments!(obj1, obj2)
+        pathspecs = Private.normalize_pathspecs(opts[:path_limiter], 'path limiter')
+        result = Git::Commands::Diff.new(@execution_context).call(
+          *[obj1, obj2].compact,
+          numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: pathspecs
+        )
+        Private.parse_numstat_output(result.stdout)
+      end
+
       # Option keys accepted by {#diff_path_status}
       #
       # @return [Array<Symbol>]
@@ -285,6 +353,77 @@ module Git
             path = status_and_paths.length > 2 ? status_and_paths[2] : status_and_paths[1]
             memo[unescape_quoted_path(path)] = status
           end
+        end
+
+        # Parses combined `--numstat --shortstat` output into an insertions/deletions hash
+        #
+        # Strips the trailing shortstat summary line and empty lines, parses the
+        # remaining numstat lines, and returns a structured hash with per-file
+        # stats and aggregated totals.
+        #
+        # @param output [String] raw stdout from `git diff --numstat --shortstat`
+        #
+        # @return [Hash] per-file insertion and deletion counts plus aggregate totals
+        #
+        #   ```
+        #   {
+        #     total: { insertions: Integer, deletions: Integer, lines: Integer, files: Integer },
+        #     files: { "path/to/file" => { insertions: Integer, deletions: Integer } }
+        #   }
+        #   ```
+        #
+        def parse_numstat_output(output)
+          file_stats = extract_numstat_lines(output).map { |line| parse_numstat_line(line) }
+          { total: build_numstat_totals(file_stats), files: build_numstat_files(file_stats) }
+        end
+
+        # Builds the `:total` sub-hash for {#parse_numstat_output}
+        #
+        # @param file_stats [Array<Hash>] per-file stats from {#parse_numstat_line}
+        #
+        # @return [Hash] aggregate totals
+        #
+        #   `{ insertions: Integer, deletions: Integer, lines: Integer, files: Integer }`
+        #
+        def build_numstat_totals(file_stats)
+          insertions = file_stats.sum { |s| s[:insertions] }
+          deletions  = file_stats.sum { |s| s[:deletions] }
+          { insertions: insertions, deletions: deletions,
+            lines: insertions + deletions, files: file_stats.size }
+        end
+
+        # Builds the `:files` sub-hash for {#parse_numstat_output}
+        #
+        # @param file_stats [Array<Hash>] per-file stats from {#parse_numstat_line}
+        #
+        # @return [Hash{String => Hash}] per-file insertion and deletion counts
+        #
+        def build_numstat_files(file_stats)
+          file_stats.to_h { |s| [s[:filename], s.slice(:insertions, :deletions)] }
+        end
+
+        # Filters raw numstat+shortstat output to only the numstat lines
+        #
+        # @param output [String] combined command output
+        #
+        # @return [Array<String>] only the numstat lines (no empties, no shortstat line)
+        #
+        def extract_numstat_lines(output)
+          output.split("\n").reject { |l| l.empty? || l.match?(/^\s*\d+\s+files?\s+changed/) }
+        end
+
+        # Parses a single `--numstat` line into a stats hash
+        #
+        # Numstat lines have the format `<insertions>\t<deletions>\t<path>`.
+        # Quoted paths (containing non-ASCII or special characters) are unescaped.
+        #
+        # @param line [String] a single numstat output line
+        #
+        # @return [Hash] `{ filename: String, insertions: Integer, deletions: Integer }`
+        #
+        def parse_numstat_line(line)
+          insertions_s, deletions_s, filename = line.split("\t", 3)
+          { filename: unescape_quoted_path(filename), insertions: insertions_s.to_i, deletions: deletions_s.to_i }
         end
 
         # Unescapes a git-quoted path (e.g. `"quoted_file_\\342\\230\\240"`)

--- a/spec/integration/git/repository/diffing_spec.rb
+++ b/spec/integration/git/repository/diffing_spec.rb
@@ -18,22 +18,22 @@ RSpec.describe Git::Repository::Diffing, :integration do
   let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
   let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
 
+  before do
+    write_file('README.md', "# Project\n\nInitial content.\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+
+    write_file('lib/main.rb', "# frozen_string_literal: true\n\nmodule Main\nend\n")
+    repo.add('lib/main.rb')
+    repo.commit('Add main library')
+
+    write_file('README.md', "# Project\n\nUpdated content.\n")
+    write_file('lib/main.rb', "# frozen_string_literal: true\n\nmodule Main\n  VERSION = '1.0.0'\nend\n")
+    repo.add(all: true)
+    repo.commit('Update readme and main')
+  end
+
   describe '#diff_full' do
-    before do
-      write_file('README.md', "# Project\n\nInitial content.\n")
-      repo.add('README.md')
-      repo.commit('Initial commit')
-
-      write_file('lib/main.rb', "# frozen_string_literal: true\n\nmodule Main\nend\n")
-      repo.add('lib/main.rb')
-      repo.commit('Add main library')
-
-      write_file('README.md', "# Project\n\nUpdated content.\n")
-      write_file('lib/main.rb', "# frozen_string_literal: true\n\nmodule Main\n  VERSION = '1.0.0'\nend\n")
-      repo.add(all: true)
-      repo.commit('Update readme and main')
-    end
-
     context 'with explicit obj1 and obj2 that differ' do
       it 'returns the unified diff patch text for those commits' do
         result = described_instance.diff_full('HEAD~1', 'HEAD')
@@ -55,6 +55,43 @@ RSpec.describe Git::Repository::Diffing, :integration do
       it 'returns an empty string' do
         result = described_instance.diff_full('HEAD', 'HEAD')
         expect(result).to eq('')
+      end
+    end
+  end
+
+  describe '#diff_numstat' do
+    # HEAD~1 = "Add main library" (adds lib/main.rb)
+    # HEAD   = "Update readme and main" (modifies both README.md and lib/main.rb)
+    #
+    # Expected diff HEAD~1..HEAD:
+    #   README.md    : -"Initial content." +"Updated content." → 1 insertion, 1 deletion
+    #   lib/main.rb  : +"  VERSION = '1.0.0'" → 1 insertion, 0 deletions
+    #   total        : insertions=2, deletions=1, lines=3, files=2
+
+    context 'when comparing two refs that differ' do
+      it 'returns correct per-file stats and aggregated totals' do
+        result = described_instance.diff_numstat('HEAD~1', 'HEAD')
+        expect(result[:total]).to eq(insertions: 2, deletions: 1, lines: 3, files: 2)
+        expect(result[:files]['README.md']).to eq(insertions: 1, deletions: 1)
+        expect(result[:files]['lib/main.rb']).to eq(insertions: 1, deletions: 0)
+      end
+    end
+
+    context 'when there are no changes between the compared refs' do
+      it 'returns zero totals and an empty files hash' do
+        result = described_instance.diff_numstat('HEAD', 'HEAD')
+        expect(result).to eq(
+          total: { insertions: 0, deletions: 0, lines: 0, files: 0 },
+          files: {}
+        )
+      end
+    end
+
+    context 'when path_limiter filters to a specific file' do
+      it 'returns stats only for that file' do
+        result = described_instance.diff_numstat('HEAD~1', 'HEAD', path_limiter: 'README.md')
+        expect(result[:total]).to eq(insertions: 1, deletions: 1, lines: 2, files: 1)
+        expect(result[:files].keys).to eq(['README.md'])
       end
     end
   end

--- a/spec/unit/git/repository/diffing_spec.rb
+++ b/spec/unit/git/repository/diffing_spec.rb
@@ -193,6 +193,192 @@ RSpec.describe Git::Repository::Diffing do
     end
   end
 
+  describe '#diff_numstat' do
+    # Multi-file numstat stdout fixture; includes an empty line between numstat
+    # entries to exercise the l.empty? branch inside extract_numstat_lines.
+    let(:numstat_stdout) do
+      "5\t2\tlib/foo.rb\n\n3\t1\tlib/bar.rb\n 2 files changed, 8 insertions(+), 3 deletions(-)\n"
+    end
+
+    let(:diff_numstat_result) { command_result(numstat_stdout) }
+
+    context 'when called with default arguments' do
+      it 'calls the command with HEAD and numstat format options' do
+        expect(diff_command).to receive(:call).with(
+          'HEAD',
+          numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_numstat_result)
+        described_instance.diff_numstat
+      end
+
+      it 'returns a hash with per-file stats and aggregated totals' do
+        allow(diff_command).to receive(:call).with(
+          'HEAD',
+          numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_numstat_result)
+        expect(described_instance.diff_numstat).to eq(
+          total: { insertions: 8, deletions: 3, lines: 11, files: 2 },
+          files: {
+            'lib/foo.rb' => { insertions: 5, deletions: 2 },
+            'lib/bar.rb' => { insertions: 3, deletions: 1 }
+          }
+        )
+      end
+    end
+
+    context 'when called with explicit obj1 and obj2' do
+      it 'passes both refs as positional arguments to the command' do
+        expect(diff_command).to receive(:call).with(
+          'abc1234', 'def5678',
+          numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_numstat_result)
+        described_instance.diff_numstat('abc1234', 'def5678')
+      end
+    end
+
+    context 'when called with only obj1' do
+      it 'passes only obj1 as a positional argument to the command' do
+        expect(diff_command).to receive(:call).with(
+          'abc1234',
+          numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_numstat_result)
+        described_instance.diff_numstat('abc1234')
+      end
+    end
+
+    context 'when path_limiter is a single String' do
+      it 'wraps the path_limiter in an Array and forwards it to the command' do
+        expect(diff_command).to receive(:call).with(
+          'HEAD',
+          numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: ['lib/']
+        ).and_return(diff_numstat_result)
+        described_instance.diff_numstat('HEAD', nil, path_limiter: 'lib/')
+      end
+    end
+
+    context 'when path_limiter is an Array of paths' do
+      it 'forwards the Array as-is to the command' do
+        expect(diff_command).to receive(:call).with(
+          'HEAD',
+          numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: ['lib/', 'spec/']
+        ).and_return(diff_numstat_result)
+        described_instance.diff_numstat('HEAD', nil, path_limiter: ['lib/', 'spec/'])
+      end
+    end
+
+    context 'when path_limiter is a Pathname' do
+      it 'converts the Pathname to a String and forwards it to the command' do
+        expect(diff_command).to receive(:call).with(
+          'HEAD',
+          numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: ['lib/']
+        ).and_return(diff_numstat_result)
+        described_instance.diff_numstat('HEAD', nil, path_limiter: Pathname.new('lib/'))
+      end
+    end
+
+    context 'when path_limiter is nil' do
+      it 'sends path: nil to the command' do
+        expect(diff_command).to receive(:call).with(
+          'HEAD',
+          numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_numstat_result)
+        described_instance.diff_numstat('HEAD', nil, path_limiter: nil)
+      end
+    end
+
+    context 'when path_limiter is an empty String' do
+      it 'normalizes to nil and sends path: nil to the command' do
+        expect(diff_command).to receive(:call).with(
+          'HEAD',
+          numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_numstat_result)
+        described_instance.diff_numstat('HEAD', nil, path_limiter: '')
+      end
+    end
+
+    context 'when an unknown option is provided' do
+      it 'raises an ArgumentError naming the unknown key' do
+        expect { described_instance.diff_numstat('HEAD', nil, bogus: true) }
+          .to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+
+    context 'when obj1 starts with a dash' do
+      it 'raises an ArgumentError naming the invalid argument' do
+        expect { described_instance.diff_numstat('-bad-ref') }
+          .to raise_error(ArgumentError, /Invalid argument/)
+      end
+    end
+
+    context 'when obj2 starts with a dash' do
+      it 'raises an ArgumentError naming the invalid argument' do
+        expect { described_instance.diff_numstat('HEAD', '-bad-ref') }
+          .to raise_error(ArgumentError, /Invalid argument/)
+      end
+    end
+
+    context 'when the command output is empty (no changed files)' do
+      let(:diff_numstat_result) { command_result('') }
+
+      before do
+        allow(diff_command).to receive(:call).with(
+          'HEAD',
+          numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_numstat_result)
+      end
+
+      it 'returns zero totals and an empty files hash' do
+        expect(described_instance.diff_numstat).to eq(
+          total: { insertions: 0, deletions: 0, lines: 0, files: 0 },
+          files: {}
+        )
+      end
+    end
+
+    context 'when the numstat output contains a git-quoted non-ASCII path' do
+      # Git quotes paths with non-ASCII characters, escaping each byte in octal.
+      # "\\303\\251" is the git octal encoding of "é" (U+00E9, UTF-8: 0xC3 0xA9).
+      let(:quoted_stdout) do
+        "5\t2\t\"\\303\\251tat.rb\"\n 1 file changed, 5 insertions(+), 2 deletions(-)\n"
+      end
+      let(:diff_numstat_result) { command_result(quoted_stdout) }
+
+      before do
+        allow(diff_command).to receive(:call).with(
+          'HEAD',
+          numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_numstat_result)
+      end
+
+      it 'unescapes the git-quoted path in the returned files hash' do
+        result = described_instance.diff_numstat
+        expect(result[:files]).to have_key('état.rb')
+      end
+    end
+  end
+
   describe '#diff_path_status' do
     let(:raw_output) do
       ":100644 100644 abc1234 def5678 M\tlib/foo.rb\n" \


### PR DESCRIPTION
## Summary

Adds `Git::Repository#diff_numstat` to `Git::Repository::Diffing` as part of Phase 3, Iteration 5 (Phase A) of the architectural redesign (#1299).

This method provides the raw per-file insertion/deletion counts that underpin `Git::DiffStats`. It is deliberately named `diff_numstat` (not `diff_stats`) to avoid a future naming conflict with the `diff_stats` factory method that will return a `Git::DiffStats` domain object in Iteration 5 Phase B.

## Source pattern

**Pattern B** — `Git::Lib#diff_stats` is the implementation source. There is no `Git::Base#diff_numstat` counterpart, so no `Git::Base` delegation wrapper was added (per the redesign convention: new API surface lives only on `Git::Repository`).

## Changes

- `lib/git/repository/diffing.rb` — new public method `#diff_numstat` + private helpers (`parse_numstat_output`, `build_numstat_totals`, `build_numstat_files`, `extract_numstat_lines`, `parse_numstat_line`) in `Diffing::Private`
- `spec/unit/git/repository/diffing_spec.rb` — 15 new unit examples covering all argument variants, option whitelisting, ref validation, parsing edge cases, and empty-diff handling
- `spec/integration/git/repository/diffing_spec.rb` — 3 new integration examples (two differing refs, no-change refs, path_limiter filtering)

## Quality gates

- ✅ 100% line and branch coverage for `diff_numstat` and its private helpers
- ✅ Full `bundle exec rake` pass (Minitest + RSpec + RuboCop + YARD)