### PR TITLE
fix: preserve colon-number filenames in grep results

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -7,6 +7,7 @@ require 'git/command_line'
 require 'git/errors'
 require 'git/parsers/branch'
 require 'git/parsers/fsck'
+require 'git/parsers/grep'
 require 'git/parsers/stash'
 require 'git/parsers/tag'
 require 'git/url'
@@ -801,7 +802,9 @@ module Git
 
       opts = normalize_grep_opts(opts)
       object = opts.delete(:object) || 'HEAD'
-      result = Git::Commands::Grep.new(self).call(object, pattern:, **opts, no_color: true, line_number: true)
+      result = Git::Commands::Grep.new(self).call(
+        object, pattern:, **opts, no_color: true, line_number: true, null: true
+      )
       exitstatus = result.status.exitstatus
 
       # Exit status 1 with empty stderr means no lines matched (not an error)
@@ -810,7 +813,7 @@ module Git
       # Exit status 1 with non-empty stderr is a real error (e.g. bad object reference)
       raise Git::FailedError, result if exitstatus == 1
 
-      parse_grep_output(result.stdout.split("\n"))
+      parse_grep_output(result.stdout)
     end
 
     # Validate that the given arguments cannot be mistaken for a command-line option
@@ -2505,14 +2508,8 @@ module Git
       opts
     end
 
-    def parse_grep_output(lines)
-      lines.each_with_object(Hash.new { |h, k| h[k] = [] }) do |line, hsh|
-        match = line.match(/\A(.*?):(\d+):(.*)/)
-        next unless match
-
-        _full, filename, line_num, text = match.to_a
-        hsh[filename] << [line_num.to_i, text]
-      end
+    def parse_grep_output(output)
+      Git::Parsers::Grep.parse(output)
     end
 
     def parse_diff_stats_output(lines)

--- a/lib/git/parsers/grep.rb
+++ b/lib/git/parsers/grep.rb
@@ -4,9 +4,8 @@ module Git
   module Parsers
     # Parser for `git grep` output
     #
-    # Provides a class method that transforms raw `git grep` output lines into
-    # a structured Hash consumed by the `Git::Repository::ObjectOperations`
-    # facade.
+    # Provides a class method that transforms raw `git grep --null` output into a
+    # structured Hash consumed by the `Git::Repository::ObjectOperations` facade.
     #
     # This parser is a pure text transformer with no exit-status logic. The
     # calling facade is responsible for interpreting the command's exit status
@@ -17,24 +16,24 @@ module Git
     module Grep
       module_function
 
-      # Parse `git grep --line-number --no-color` output lines into a match hash
+      # Parse `git grep --line-number --null --no-color` output into a match hash
       #
-      # Each line is expected in the format produced by
-      # `git grep --line-number --no-color`: `treeish:filename:linenum:text`.
+      # With `--null`, git separates the path and line number fields with NUL
+      # bytes: `treeish:filename\0linenum\0text\n`. This keeps filenames that
+      # contain `:<digits>:` from being confused with the line-number delimiter.
       #
-      # @param lines [Array<String>] output lines from `git grep`
+      # @param output [String] raw output from `git grep --null --line-number`
       #
       # @return [Hash<String, Array<Array(Integer, String)>>] hash mapping
       #   `"treeish:filename"` keys to arrays of `[line_number, text]` pairs
       #
       # @api private
       #
-      def parse(lines)
-        lines.each_with_object(Hash.new { |h, k| h[k] = [] }) do |line, hsh|
-          match = line.match(/\A(.*?):(\d+):(.*)/)
-          next unless match
+      def parse(output)
+        output.each_line.with_object(Hash.new { |h, k| h[k] = [] }) do |line, hsh|
+          filename, line_num, text = line.chomp.split("\0", 3)
+          next unless text && line_num&.match?(/\A\d+\z/)
 
-          _full, filename, line_num, text = match.to_a
           hsh[filename] << [line_num.to_i, text]
         end
       end

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -463,7 +463,7 @@ module Git
         object = opts.delete(:object) || 'HEAD'
         opts[:pathspec] = Array(path_limiter).map(&:to_s) if path_limiter
         result = Git::Commands::Grep.new(@execution_context).call(
-          object, pattern:, **opts, no_color: true, line_number: true
+          object, pattern:, **opts, no_color: true, line_number: true, null: true
         )
         Private.parse_grep_result(result)
       end
@@ -700,7 +700,7 @@ module Git
           return {} if exitstatus == 1 && result.stderr.empty?
           raise Git::FailedError, result if exitstatus == 1
 
-          Git::Parsers::Grep.parse(result.stdout.split("\n"))
+          Git::Parsers::Grep.parse(result.stdout)
         end
 
         # Resolve the staging directory for a git archive temp file

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -634,6 +634,24 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
       end
     end
 
+    context 'with a filename containing colon-number-colon text' do
+      before do
+        skip 'Colon characters are not supported in Windows filenames' if Gem.win_platform?
+
+        write_file('src/foo:42:bar.rb', "# TODO: colon filename\n")
+        repo.add('.')
+        repo.commit('Add colon-number filename')
+      end
+
+      it 'keeps the full filename in the grep result key' do
+        result = described_instance.grep('TODO', 'src/foo:42:bar.rb')
+
+        expect(result).to eq(
+          'HEAD:src/foo:42:bar.rb' => [[1, '# TODO: colon filename']]
+        )
+      end
+    end
+
     context 'with a path_limiter String that restricts results' do
       it 'returns only matches under the given path' do
         result = described_instance.grep('TODO', 'src/foo.rb')

--- a/spec/unit/git/lib_command_spec.rb
+++ b/spec/unit/git/lib_command_spec.rb
@@ -871,14 +871,17 @@ RSpec.describe Git::Lib do
     end
 
     it 'delegates to Grep and returns parsed matches' do
-      output = "HEAD:lib/foo.rb:10:found it\nHEAD:lib/bar.rb:3:found it again\n"
+      nul = "\0"
+      output = "HEAD:lib/foo.rb#{nul}10#{nul}found it\nHEAD:lib/bar.rb#{nul}3#{nul}found it again\n"
       allow(grep_command).to receive(:call)
-        .with('HEAD', pattern: 'found', no_color: true, line_number: true)
+        .with('HEAD', pattern: 'found', no_color: true, line_number: true, null: true)
         .and_return(command_result(output, exitstatus: 0))
 
       result = lib.grep('found', object: 'HEAD')
 
-      expect(grep_command).to have_received(:call).with('HEAD', pattern: 'found', no_color: true, line_number: true)
+      expect(grep_command).to have_received(:call).with(
+        'HEAD', pattern: 'found', no_color: true, line_number: true, null: true
+      )
       expect(result).to eq(
         'HEAD:lib/foo.rb' => [[10, 'found it']],
         'HEAD:lib/bar.rb' => [[3, 'found it again']]
@@ -887,7 +890,7 @@ RSpec.describe Git::Lib do
 
     it 'returns {} when exit status is 1 and stderr is empty (no matches)' do
       allow(grep_command).to receive(:call)
-        .with('HEAD', pattern: 'nomatch', no_color: true, line_number: true)
+        .with('HEAD', pattern: 'nomatch', no_color: true, line_number: true, null: true)
         .and_return(command_result('', exitstatus: 1))
 
       result = lib.grep('nomatch')
@@ -897,7 +900,7 @@ RSpec.describe Git::Lib do
 
     it 'raises Git::FailedError when exit status is 1 and stderr is non-empty (real error)' do
       allow(grep_command).to receive(:call)
-        .with('HEAD', pattern: 'search', no_color: true, line_number: true)
+        .with('HEAD', pattern: 'search', no_color: true, line_number: true, null: true)
         .and_return(command_result('', stderr: 'fatal: bad object HEAD', exitstatus: 1))
 
       expect { lib.grep('search') }.to raise_error(Git::FailedError) do |error|
@@ -907,13 +910,13 @@ RSpec.describe Git::Lib do
 
     it 'forwards :path_limiter as :pathspec to the Grep command' do
       allow(grep_command).to receive(:call)
-        .with('HEAD', pattern: 'search', pathspec: 'lib/**', no_color: true, line_number: true)
+        .with('HEAD', pattern: 'search', pathspec: 'lib/**', no_color: true, line_number: true, null: true)
         .and_return(command_result('', exitstatus: 0))
 
       lib.grep('search', path_limiter: 'lib/**')
 
       expect(grep_command).to have_received(:call)
-        .with('HEAD', pattern: 'search', pathspec: 'lib/**', no_color: true, line_number: true)
+        .with('HEAD', pattern: 'search', pathspec: 'lib/**', no_color: true, line_number: true, null: true)
     end
 
     it 'rejects unknown options' do

--- a/spec/unit/git/parsers/grep_spec.rb
+++ b/spec/unit/git/parsers/grep_spec.rb
@@ -6,7 +6,9 @@ require 'git/parsers/grep'
 RSpec.describe Git::Parsers::Grep do
   describe '.parse' do
     context 'with a single matching line' do
-      subject(:result) { described_class.parse(['HEAD:src/foo.rb:12:# TODO: fix this']) }
+      subject(:result) { described_class.parse("HEAD:src/foo.rb#{nul}12#{nul}# TODO: fix this\n") }
+
+      let(:nul) { "\0" }
 
       it 'returns a Hash keyed by treeish:filename' do
         expect(result.keys).to eq(['HEAD:src/foo.rb'])
@@ -19,11 +21,13 @@ RSpec.describe Git::Parsers::Grep do
 
     context 'with multiple matches in the same file' do
       subject(:result) do
-        described_class.parse([
-                                'HEAD:src/foo.rb:12:# TODO: fix this',
-                                'HEAD:src/foo.rb:34:# TODO: also this'
-                              ])
+        described_class.parse(
+          "HEAD:src/foo.rb#{nul}12#{nul}# TODO: fix this\n" \
+          "HEAD:src/foo.rb#{nul}34#{nul}# TODO: also this\n"
+        )
       end
+
+      let(:nul) { "\0" }
 
       it 'groups both matches under the same key' do
         expect(result['HEAD:src/foo.rb']).to eq([
@@ -33,13 +37,26 @@ RSpec.describe Git::Parsers::Grep do
       end
     end
 
+    context 'with a matching filename containing a colon-number-colon pattern' do
+      subject(:result) do
+        nul = "\0"
+        described_class.parse("HEAD:src/foo:42:bar.rb#{nul}5#{nul}matched text\n")
+      end
+
+      it 'preserves the filename' do
+        expect(result).to eq('HEAD:src/foo:42:bar.rb' => [[5, 'matched text']])
+      end
+    end
+
     context 'with matches in multiple files' do
       subject(:result) do
-        described_class.parse([
-                                'HEAD:src/foo.rb:12:# TODO: fix this',
-                                'HEAD:lib/bar.rb:5:# TODO: and this'
-                              ])
+        described_class.parse(
+          "HEAD:src/foo.rb#{nul}12#{nul}# TODO: fix this\n" \
+          "HEAD:lib/bar.rb#{nul}5#{nul}# TODO: and this\n"
+        )
       end
+
+      let(:nul) { "\0" }
 
       it 'returns a Hash with one key per unique treeish:filename' do
         expect(result.keys).to contain_exactly('HEAD:src/foo.rb', 'HEAD:lib/bar.rb')
@@ -52,7 +69,7 @@ RSpec.describe Git::Parsers::Grep do
     end
 
     context 'with empty input' do
-      subject(:result) { described_class.parse([]) }
+      subject(:result) { described_class.parse('') }
 
       it 'returns an empty Hash' do
         expect(result).to eq({})
@@ -60,7 +77,7 @@ RSpec.describe Git::Parsers::Grep do
     end
 
     context 'with lines that do not match the expected format' do
-      subject(:result) { described_class.parse(['this line has no colon-number pattern']) }
+      subject(:result) { described_class.parse("this line has no NUL delimiters\n") }
 
       it 'ignores non-matching lines and returns an empty Hash' do
         expect(result).to eq({})

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -1004,7 +1004,8 @@ RSpec.describe Git::Repository::ObjectOperations do
     context 'with a pattern and no options' do
       subject(:result) { described_instance.grep('TODO') }
 
-      let(:grep_output) { "HEAD:src/foo.rb:12:# TODO: fix this\n" }
+      let(:nul) { "\0" }
+      let(:grep_output) { "HEAD:src/foo.rb#{nul}12#{nul}# TODO: fix this\n" }
       let(:grep_result) { command_result(grep_output) }
 
       it 'constructs Git::Commands::Grep with the execution context' do
@@ -1015,15 +1016,15 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'calls Git::Commands::Grep#call with HEAD, the pattern, no_color, and line_number' do
         expect(grep_command).to receive(:call)
-          .with('HEAD', pattern: 'TODO', no_color: true, line_number: true)
+          .with('HEAD', pattern: 'TODO', no_color: true, line_number: true, null: true)
           .and_return(grep_result)
         result
       end
 
-      it 'delegates to Git::Parsers::Grep.parse with the output lines' do
+      it 'delegates to Git::Parsers::Grep.parse with the raw output' do
         allow(grep_command).to receive(:call).and_return(grep_result)
         expect(Git::Parsers::Grep).to receive(:parse)
-          .with(grep_output.split("\n"))
+          .with(grep_output)
           .and_return('HEAD:src/foo.rb' => [[12, '# TODO: fix this']])
         result
       end
@@ -1041,7 +1042,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'forwards pathspec as an Array to the command' do
         expect(grep_command).to receive(:call)
-          .with('HEAD', pattern: 'TODO', pathspec: ['src/'], no_color: true, line_number: true)
+          .with('HEAD', pattern: 'TODO', pathspec: ['src/'], no_color: true, line_number: true, null: true)
           .and_return(command_result(''))
         result
       end
@@ -1052,7 +1053,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'forwards pathspec as the same Array to the command' do
         expect(grep_command).to receive(:call)
-          .with('HEAD', pattern: 'TODO', pathspec: ['src/', 'lib/'], no_color: true, line_number: true)
+          .with('HEAD', pattern: 'TODO', pathspec: ['src/', 'lib/'], no_color: true, line_number: true, null: true)
           .and_return(command_result(''))
         result
       end
@@ -1063,7 +1064,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'uses the given object instead of HEAD' do
         expect(grep_command).to receive(:call)
-          .with('abc1234', pattern: 'TODO', no_color: true, line_number: true)
+          .with('abc1234', pattern: 'TODO', no_color: true, line_number: true, null: true)
           .and_return(command_result(''))
         result
       end
@@ -1074,7 +1075,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'forwards ignore_case to the command' do
         expect(grep_command).to receive(:call)
-          .with('HEAD', pattern: 'todo', ignore_case: true, no_color: true, line_number: true)
+          .with('HEAD', pattern: 'todo', ignore_case: true, no_color: true, line_number: true, null: true)
           .and_return(command_result(''))
         result
       end
@@ -1085,7 +1086,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'forwards :i to the command' do
         expect(grep_command).to receive(:call)
-          .with('HEAD', pattern: 'todo', i: true, no_color: true, line_number: true)
+          .with('HEAD', pattern: 'todo', i: true, no_color: true, line_number: true, null: true)
           .and_return(command_result(''))
         result
       end
@@ -1096,7 +1097,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'forwards invert_match to the command' do
         expect(grep_command).to receive(:call)
-          .with('HEAD', pattern: 'TODO', invert_match: true, no_color: true, line_number: true)
+          .with('HEAD', pattern: 'TODO', invert_match: true, no_color: true, line_number: true, null: true)
           .and_return(command_result(''))
         result
       end
@@ -1107,7 +1108,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'forwards extended_regexp to the command' do
         expect(grep_command).to receive(:call)
-          .with('HEAD', pattern: 'foo|bar', extended_regexp: true, no_color: true, line_number: true)
+          .with('HEAD', pattern: 'foo|bar', extended_regexp: true, no_color: true, line_number: true, null: true)
           .and_return(command_result(''))
         result
       end


### PR DESCRIPTION
## Summary
- run public grep calls with `--null` so git separates path and line fields unambiguously
- add a NUL-delimited grep parser for `treeish:filename\0line\0text` output
- cover filenames containing `:<digits>:` at parser and repository integration levels

Closes #1324.

## Verification
- `PATH="/opt/homebrew/opt/ruby/bin:$PATH" bundle exec rspec spec/unit/git/parsers/grep_spec.rb spec/integration/git/repository/object_operations_spec.rb --format progress` -> 100 examples, 0 failures
- `PATH="/opt/homebrew/opt/ruby/bin:$PATH" bundle exec rubocop lib/git/parsers/grep.rb lib/git/repository/object_operations.rb lib/git/lib.rb spec/unit/git/parsers/grep_spec.rb spec/integration/git/repository/object_operations_spec.rb` -> 5 files inspected, no offenses detected

## AI-assisted work
This patch was prepared with AI assistance and manually reviewed. I verified the failure first with a spec for the colon-number filename case, then reran the targeted specs and style checks locally.