### PR TITLE
fix: parse grep output with null delimiters

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -7,6 +7,7 @@ require 'git/command_line'
 require 'git/errors'
 require 'git/parsers/branch'
 require 'git/parsers/fsck'
+require 'git/parsers/grep'
 require 'git/parsers/stash'
 require 'git/parsers/tag'
 require 'git/url'
@@ -801,7 +802,9 @@ module Git
 
       opts = normalize_grep_opts(opts)
       object = opts.delete(:object) || 'HEAD'
-      result = Git::Commands::Grep.new(self).call(object, pattern:, **opts, no_color: true, line_number: true)
+      result = Git::Commands::Grep.new(self).call(
+        object, pattern:, **opts, no_color: true, line_number: true, null: true
+      )
       exitstatus = result.status.exitstatus
 
       # Exit status 1 with empty stderr means no lines matched (not an error)
@@ -2506,13 +2509,7 @@ module Git
     end
 
     def parse_grep_output(lines)
-      lines.each_with_object(Hash.new { |h, k| h[k] = [] }) do |line, hsh|
-        match = line.match(/\A(.*?):(\d+):(.*)/)
-        next unless match
-
-        _full, filename, line_num, text = match.to_a
-        hsh[filename] << [line_num.to_i, text]
-      end
+      Git::Parsers::Grep.parse(lines)
     end
 
     def parse_diff_stats_output(lines)

--- a/lib/git/parsers/grep.rb
+++ b/lib/git/parsers/grep.rb
@@ -31,12 +31,25 @@ module Git
       #
       def parse(lines)
         lines.each_with_object(Hash.new { |h, k| h[k] = [] }) do |line, hsh|
-          match = line.match(/\A(.*?):(\d+):(.*)/)
-          next unless match
+          filename, line_num, text = parse_line(line)
+          next unless filename && line_num && text
 
-          _full, filename, line_num, text = match.to_a
           hsh[filename] << [line_num.to_i, text]
         end
+      end
+
+      def parse_line(line)
+        return line.split("\0", 3) if line.include?("\0")
+
+        parse_colon_delimited_line(line)
+      end
+
+      def parse_colon_delimited_line(line)
+        match = line.match(/\A(.*?):(\d+):(.*)/)
+        return unless match
+
+        _full, filename, line_num, text = match.to_a
+        [filename, line_num, text]
       end
     end
   end

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -463,7 +463,7 @@ module Git
         object = opts.delete(:object) || 'HEAD'
         opts[:pathspec] = Array(path_limiter).map(&:to_s) if path_limiter
         result = Git::Commands::Grep.new(@execution_context).call(
-          object, pattern:, **opts, no_color: true, line_number: true
+          object, pattern:, **opts, no_color: true, line_number: true, null: true
         )
         Private.parse_grep_result(result)
       end

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -632,6 +632,16 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
         foo_matches = result['HEAD:src/foo.rb']
         expect(foo_matches).to include([1, '# TODO: fix this'])
       end
+
+      it 'preserves filenames and text containing colon-number-colon sequences' do
+        write_file('src/foo:42:bar.rb', "matched text:13:still text\n")
+        repo.add('.')
+        repo.commit('Add colon filename')
+
+        result = described_instance.grep('matched')
+
+        expect(result['HEAD:src/foo:42:bar.rb']).to eq([[1, 'matched text:13:still text']])
+      end
     end
 
     context 'with a path_limiter String that restricts results' do

--- a/spec/unit/git/lib_command_spec.rb
+++ b/spec/unit/git/lib_command_spec.rb
@@ -871,14 +871,16 @@ RSpec.describe Git::Lib do
     end
 
     it 'delegates to Grep and returns parsed matches' do
-      output = "HEAD:lib/foo.rb:10:found it\nHEAD:lib/bar.rb:3:found it again\n"
+      output = "HEAD:lib/foo.rb\x0010\x00found it\nHEAD:lib/bar.rb\x003\x00found it again\n"
       allow(grep_command).to receive(:call)
-        .with('HEAD', pattern: 'found', no_color: true, line_number: true)
+        .with('HEAD', pattern: 'found', no_color: true, line_number: true, null: true)
         .and_return(command_result(output, exitstatus: 0))
 
       result = lib.grep('found', object: 'HEAD')
 
-      expect(grep_command).to have_received(:call).with('HEAD', pattern: 'found', no_color: true, line_number: true)
+      expect(grep_command).to have_received(:call).with(
+        'HEAD', pattern: 'found', no_color: true, line_number: true, null: true
+      )
       expect(result).to eq(
         'HEAD:lib/foo.rb' => [[10, 'found it']],
         'HEAD:lib/bar.rb' => [[3, 'found it again']]
@@ -887,7 +889,7 @@ RSpec.describe Git::Lib do
 
     it 'returns {} when exit status is 1 and stderr is empty (no matches)' do
       allow(grep_command).to receive(:call)
-        .with('HEAD', pattern: 'nomatch', no_color: true, line_number: true)
+        .with('HEAD', pattern: 'nomatch', no_color: true, line_number: true, null: true)
         .and_return(command_result('', exitstatus: 1))
 
       result = lib.grep('nomatch')
@@ -897,7 +899,7 @@ RSpec.describe Git::Lib do
 
     it 'raises Git::FailedError when exit status is 1 and stderr is non-empty (real error)' do
       allow(grep_command).to receive(:call)
-        .with('HEAD', pattern: 'search', no_color: true, line_number: true)
+        .with('HEAD', pattern: 'search', no_color: true, line_number: true, null: true)
         .and_return(command_result('', stderr: 'fatal: bad object HEAD', exitstatus: 1))
 
       expect { lib.grep('search') }.to raise_error(Git::FailedError) do |error|
@@ -907,13 +909,13 @@ RSpec.describe Git::Lib do
 
     it 'forwards :path_limiter as :pathspec to the Grep command' do
       allow(grep_command).to receive(:call)
-        .with('HEAD', pattern: 'search', pathspec: 'lib/**', no_color: true, line_number: true)
+        .with('HEAD', pattern: 'search', pathspec: 'lib/**', no_color: true, line_number: true, null: true)
         .and_return(command_result('', exitstatus: 0))
 
       lib.grep('search', path_limiter: 'lib/**')
 
       expect(grep_command).to have_received(:call)
-        .with('HEAD', pattern: 'search', pathspec: 'lib/**', no_color: true, line_number: true)
+        .with('HEAD', pattern: 'search', pathspec: 'lib/**', no_color: true, line_number: true, null: true)
     end
 
     it 'rejects unknown options' do

--- a/spec/unit/git/parsers/grep_spec.rb
+++ b/spec/unit/git/parsers/grep_spec.rb
@@ -33,6 +33,18 @@ RSpec.describe Git::Parsers::Grep do
       end
     end
 
+    context 'with NUL-delimited output' do
+      subject(:result) do
+        described_class.parse(["HEAD:src/foo:42:bar.rb\x005\x00matched text:13:still text"])
+      end
+
+      it 'preserves filenames and text containing colon-number-colon sequences' do
+        expect(result).to eq(
+          'HEAD:src/foo:42:bar.rb' => [[5, 'matched text:13:still text']]
+        )
+      end
+    end
+
     context 'with matches in multiple files' do
       subject(:result) do
         described_class.parse([

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -1004,7 +1004,7 @@ RSpec.describe Git::Repository::ObjectOperations do
     context 'with a pattern and no options' do
       subject(:result) { described_instance.grep('TODO') }
 
-      let(:grep_output) { "HEAD:src/foo.rb:12:# TODO: fix this\n" }
+      let(:grep_output) { "HEAD:src/foo.rb\x0012\x00# TODO: fix this\n" }
       let(:grep_result) { command_result(grep_output) }
 
       it 'constructs Git::Commands::Grep with the execution context' do
@@ -1013,9 +1013,9 @@ RSpec.describe Git::Repository::ObjectOperations do
         result
       end
 
-      it 'calls Git::Commands::Grep#call with HEAD, the pattern, no_color, and line_number' do
+      it 'calls Git::Commands::Grep#call with HEAD, the pattern, no_color, line_number, and null' do
         expect(grep_command).to receive(:call)
-          .with('HEAD', pattern: 'TODO', no_color: true, line_number: true)
+          .with('HEAD', pattern: 'TODO', no_color: true, line_number: true, null: true)
           .and_return(grep_result)
         result
       end
@@ -1041,7 +1041,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'forwards pathspec as an Array to the command' do
         expect(grep_command).to receive(:call)
-          .with('HEAD', pattern: 'TODO', pathspec: ['src/'], no_color: true, line_number: true)
+          .with('HEAD', pattern: 'TODO', pathspec: ['src/'], no_color: true, line_number: true, null: true)
           .and_return(command_result(''))
         result
       end
@@ -1052,7 +1052,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'forwards pathspec as the same Array to the command' do
         expect(grep_command).to receive(:call)
-          .with('HEAD', pattern: 'TODO', pathspec: ['src/', 'lib/'], no_color: true, line_number: true)
+          .with('HEAD', pattern: 'TODO', pathspec: ['src/', 'lib/'], no_color: true, line_number: true, null: true)
           .and_return(command_result(''))
         result
       end
@@ -1063,7 +1063,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'uses the given object instead of HEAD' do
         expect(grep_command).to receive(:call)
-          .with('abc1234', pattern: 'TODO', no_color: true, line_number: true)
+          .with('abc1234', pattern: 'TODO', no_color: true, line_number: true, null: true)
           .and_return(command_result(''))
         result
       end
@@ -1074,7 +1074,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'forwards ignore_case to the command' do
         expect(grep_command).to receive(:call)
-          .with('HEAD', pattern: 'todo', ignore_case: true, no_color: true, line_number: true)
+          .with('HEAD', pattern: 'todo', ignore_case: true, no_color: true, line_number: true, null: true)
           .and_return(command_result(''))
         result
       end
@@ -1085,7 +1085,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'forwards :i to the command' do
         expect(grep_command).to receive(:call)
-          .with('HEAD', pattern: 'todo', i: true, no_color: true, line_number: true)
+          .with('HEAD', pattern: 'todo', i: true, no_color: true, line_number: true, null: true)
           .and_return(command_result(''))
         result
       end
@@ -1096,7 +1096,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'forwards invert_match to the command' do
         expect(grep_command).to receive(:call)
-          .with('HEAD', pattern: 'TODO', invert_match: true, no_color: true, line_number: true)
+          .with('HEAD', pattern: 'TODO', invert_match: true, no_color: true, line_number: true, null: true)
           .and_return(command_result(''))
         result
       end
@@ -1107,7 +1107,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'forwards extended_regexp to the command' do
         expect(grep_command).to receive(:call)
-          .with('HEAD', pattern: 'foo|bar', extended_regexp: true, no_color: true, line_number: true)
+          .with('HEAD', pattern: 'foo|bar', extended_regexp: true, no_color: true, line_number: true, null: true)
           .and_return(command_result(''))
         result
       end


### PR DESCRIPTION
# Description

Fixes #1324 by making repository grep calls request NUL-delimited output from git and by parsing the file\0line\0text format. This keeps filenames such as `src/foo:42:bar.rb` from being split at the wrong colon sequence, while preserving matched text containing `:13:`.

The legacy `Git::Lib#grep` parser now delegates to `Git::Parsers::Grep` so both grep paths share the same output parsing.

AI assistance disclosure: this PR was assisted by OpenAI GPT-5. I reviewed the generated changes in this checkout and verified them with the checks below.

## Checklist

- [x] I reviewed and applied the project AI Policy. The AI-assisted changes were inspected and validated for quality, security, and licensing concerns.
- [ ] The human submitter has run `bundle exec rake` locally on this branch before moving this PR out of draft.
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable. No README/YARD update was needed because this fixes internal parsing behavior without changing the public API.

## Validation

- `bundle exec rspec spec/unit/git/parsers/grep_spec.rb spec/unit/git/repository/object_operations_spec.rb spec/unit/git/lib_command_spec.rb spec/integration/git/repository/object_operations_spec.rb` passed: 300 examples, 0 failures.
- `bundle exec rubocop lib/git/lib.rb lib/git/parsers/grep.rb lib/git/repository/object_operations.rb spec/unit/git/parsers/grep_spec.rb spec/unit/git/repository/object_operations_spec.rb spec/unit/git/lib_command_spec.rb spec/integration/git/repository/object_operations_spec.rb` passed: 7 files inspected, no offenses.
- `bundle exec rake` passed in a Ruby 3.4 Docker container: Test::Unit, RSpec unit/integration, RuboCop, YARD, YARD examples, and gem build.
- `npx commitlint --from HEAD~1 --to HEAD` passed.
