### PR TITLE
fix(branch): delete remote-tracking refs correctly

### DIFF
--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -210,12 +210,8 @@ module Git
 
     # Deletes this branch
     #
-    # **Note:** this method only works correctly for local branches. Calling it on
-    # a remote-tracking branch (one where {#remote} is not `nil`) will attempt to
-    # delete a *local* branch with the same short name rather than the
-    # remote-tracking ref, which is almost certainly not what you want.
-    # See [ruby-git#1280](https://github.com/ruby-git/ruby-git/issues/1280) for
-    # the planned fix.
+    # Remote-tracking branches (one where {#remote} is not `nil`) delete the
+    # local remote-tracking ref; they do not push a deletion to the remote.
     #
     # @example Delete a local branch
     #   git.branch('old-feature').delete
@@ -225,7 +221,11 @@ module Git
     # @raise [Git::Error] if the branch cannot be deleted
     #
     def delete
-      @base.lib.branch_delete(@name)
+      if @remote
+        @base.lib.branch_delete("#{@remote.name}/#{@name}", remotes: true)
+      else
+        @base.lib.branch_delete(@name)
+      end
     end
 
     # Returns true if this is the currently checked-out branch

--- a/spec/integration/git/branch_spec.rb
+++ b/spec/integration/git/branch_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/branch'
+
+RSpec.describe Git::Branch, :integration do
+  include_context 'in an empty repository'
+
+  let(:bare_dir) { Dir.mktmpdir('bare_repo') }
+
+  after do
+    FileUtils.rm_rf(bare_dir)
+  end
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+
+    Git.init(bare_dir, bare: true)
+    repo.add_remote('origin', bare_dir)
+    repo.branch('feature').create
+    repo.push('origin', 'feature')
+  end
+
+  describe '#delete' do
+    context 'with a remote-tracking branch' do
+      it 'deletes the remote-tracking ref without deleting the same-named local branch' do
+        repo.branches['remotes/origin/feature'].delete
+
+        expect(repo.branches.local.map(&:name)).to include('feature')
+        expect(repo.branches.remote.map(&:full)).not_to include('remotes/origin/feature')
+      end
+    end
+  end
+end

--- a/spec/unit/git/branch_spec.rb
+++ b/spec/unit/git/branch_spec.rb
@@ -130,4 +130,56 @@ RSpec.describe Git::Branch do
       end
     end
   end
+
+  describe '#delete' do
+    context 'with a local branch' do
+      let(:branch_info) do
+        Git::BranchInfo.new(
+          refname: 'feature',
+          target_oid: 'abc123',
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      subject(:delete_branch) { described_class.new(base, branch_info).delete }
+
+      it 'deletes the local branch by short name' do
+        expect(lib).to receive(:branch_delete).with('feature').and_return('Deleted branch feature.')
+
+        expect(delete_branch).to eq('Deleted branch feature.')
+      end
+    end
+
+    context 'with a remote-tracking branch' do
+      let(:branch_info) do
+        Git::BranchInfo.new(
+          refname: 'remotes/origin/feature',
+          target_oid: 'abc123',
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      let(:remote_config) { { 'url' => 'https://github.com/test/repo.git' } }
+
+      subject(:delete_branch) { described_class.new(base, branch_info).delete }
+
+      before do
+        allow(lib).to receive(:config_remote).with('origin').and_return(remote_config)
+      end
+
+      it 'deletes the remote-tracking ref instead of a local branch with the same short name' do
+        expect(lib).to receive(:branch_delete)
+          .with('origin/feature', remotes: true)
+          .and_return('Deleted remote-tracking branch origin/feature.')
+
+        expect(delete_branch).to eq('Deleted remote-tracking branch origin/feature.')
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Description

Fixes #1280.

`Git::Branch#delete` now detects branches backed by `refs/remotes/*` and calls `Git::Lib#branch_delete` with the `remotes: true` flag and the `origin/branch` ref name. This deletes the local remote-tracking ref instead of accidentally targeting a same-named local branch.

I added unit coverage for the delegated command arguments and an integration spec proving that deleting `remotes/origin/feature` leaves the local `feature` branch intact.

AI-assisted disclosure: this draft PR was prepared with assistance from OpenAI GPT-5. The changes and test results have been reviewed in this workspace, but I am leaving the human-attestation checklist items unchecked until the human submitter performs the required review/local validation.

Validation run in Ruby 3.4 Docker:

- `bundle exec rspec spec/unit/git/branch_spec.rb` (red before implementation, green after)
- `bundle exec rspec spec/unit/git/branch_spec.rb spec/integration/git/branch_spec.rb`
- `bundle exec rubocop lib/git/branch.rb spec/unit/git/branch_spec.rb spec/integration/git/branch_spec.rb`
- `bundle exec rspec spec/unit/git/branch_spec.rb spec/integration/git/branch_spec.rb spec/unit/git/commands/branch/delete_spec.rb spec/integration/git/commands/branch/delete_spec.rb spec/integration/git/repository/branching_spec.rb`
- `bundle exec rake`
- `npx -p @commitlint/cli -p @commitlint/config-conventional commitlint --from HEAD~1 --to HEAD`
- `git diff HEAD^ --check`

## Checklist

- [ ] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [ ] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).