### PR TITLE
fix(commands/diff): allow exit status 2 for git diff --check whitespace errors

### DIFF
--- a/lib/git/commands/diff.rb
+++ b/lib/git/commands/diff.rb
@@ -151,8 +151,9 @@ module Git
         value_option :path, as_operand: true, repeatable: true
       end
 
-      # git diff exit codes: 0 = no diff, 1 = diff found, 2+ = error
-      allow_exit_status 0..1
+      # Exit codes: 0 = success; with --exit-code: 1 = differences found;
+      # with --check: 2 = whitespace/conflict-marker errors
+      allow_exit_status 0..2
 
       # @!method call(*, **)
       #
@@ -170,7 +171,7 @@ module Git
       #     @raise [ArgumentError] if unsupported options are provided
       #
       #     @raise [Git::FailedError] if git exits outside the allowed range
-      #       (exit code > 1)
+      #       (exit code > 2)
       #
       #     @api public
       #
@@ -195,7 +196,7 @@ module Git
       #     @raise [ArgumentError] if unsupported options are provided
       #
       #     @raise [Git::FailedError] if git exits outside the allowed range
-      #       (exit code > 1)
+      #       (exit code > 2)
       #
       #     @api public
       #
@@ -217,7 +218,7 @@ module Git
       #     @raise [ArgumentError] if unsupported options are provided
       #
       #     @raise [Git::FailedError] if git exits outside the allowed range
-      #       (exit code > 1)
+      #       (exit code > 2)
       #
       #     @api public
       #
@@ -238,7 +239,7 @@ module Git
       #     @raise [ArgumentError] if unsupported options are provided
       #
       #     @raise [Git::FailedError] if git exits outside the allowed range
-      #       (exit code > 1)
+      #       (exit code > 2)
       #
       #     @api public
       #
@@ -647,7 +648,7 @@ module Git
       #     @raise [ArgumentError] if unsupported options are provided
       #
       #     @raise [Git::FailedError] if git exits outside the allowed
-      #       range (exit code > 1)
+      #       range (exit code > 2)
       #
       #     @api public
     end

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -923,7 +923,7 @@ module Git
     #
     # @return [String] the unified diff patch output
     #
-    # @raise [Git::FailedError] if git returns exit code >= 2
+    # @raise [Git::FailedError] if git returns exit code > 2
     #
     # @see Git::Commands::Diff
     #
@@ -955,7 +955,7 @@ module Git
     # @return [Hash] diff statistics with the shape:
     #   `{ total: { insertions:, deletions:, lines:, files: }, files: { ... } }`
     #
-    # @raise [Git::FailedError] if git returns exit code >= 2
+    # @raise [Git::FailedError] if git returns exit code > 2
     #
     # @see Git::Commands::Diff
     #
@@ -992,7 +992,7 @@ module Git
     # @return [Hash] mapping of file paths to status letters
     #   (e.g. `{ "lib/foo.rb" => "M", "README.md" => "A" }`)
     #
-    # @raise [Git::FailedError] if git returns exit code >= 2
+    # @raise [Git::FailedError] if git returns exit code > 2
     #
     # @see Git::Commands::Diff
     #
@@ -1486,7 +1486,7 @@ module Git
     #
     # @return [Array<String>] paths of files with unresolved merge conflicts
     #
-    # @raise [Git::FailedError] if git returns exit code >= 2
+    # @raise [Git::FailedError] if git returns exit code > 2
     #
     # @see Git::Commands::Diff
     #

--- a/spec/integration/git/commands/diff_spec.rb
+++ b/spec/integration/git/commands/diff_spec.rb
@@ -44,5 +44,45 @@ RSpec.describe Git::Commands::Diff, :integration do
         end.to raise_error(Git::FailedError, /nonexistent-ref/)
       end
     end
+
+    context 'with --check option' do
+      attr_reader :check_repo_dir, :check_command
+
+      before(:all) do
+        @check_repo_dir = Dir.mktmpdir
+        check_repo = Git.init(@check_repo_dir, initial_branch: 'main')
+        check_repo.config('user.email', 'test@example.com')
+        check_repo.config('user.name', 'Test User')
+        check_repo.config('commit.gpgsign', 'false')
+
+        # Initial commit with clean content
+        File.write(File.join(@check_repo_dir, 'file.txt'), "clean content\n")
+        check_repo.add('file.txt')
+        check_repo.commit('Initial commit')
+        check_repo.add_tag('check_clean')
+
+        # Commit that introduces trailing whitespace
+        File.write(File.join(@check_repo_dir, 'file.txt'), "trailing whitespace   \n")
+        check_repo.add('file.txt')
+        check_repo.commit('Add trailing whitespace')
+        check_repo.add_tag('check_dirty')
+
+        @check_command = described_class.new(check_repo.lib)
+      end
+
+      after(:all) do
+        FileUtils.rm_rf(@check_repo_dir) if @check_repo_dir
+      end
+
+      it 'returns exit code 0 when no whitespace issues are found' do
+        result = check_command.call('check_clean', 'check_clean', check: true)
+        expect(result.status.exitstatus).to eq(0)
+      end
+
+      it 'returns exit code 2 when whitespace issues are found' do
+        result = check_command.call('check_clean', 'check_dirty', check: true)
+        expect(result.status.exitstatus).to eq(2)
+      end
+    end
   end
 end

--- a/spec/unit/git/commands/diff_spec.rb
+++ b/spec/unit/git/commands/diff_spec.rb
@@ -1070,9 +1070,19 @@ RSpec.describe Git::Commands::Diff do
         expect(result.status.exitstatus).to eq(1)
       end
 
-      it 'raises FailedError with exit code 2' do
+      it 'returns successfully with exit code 2' do
+        expect_command_capturing('diff', '--check')
+          .and_return(command_result("file.rb:3: trailing whitespace.\n", exitstatus: 2))
+
+        result = command.call(check: true)
+
+        expect(result).to be_a(Git::CommandLineResult)
+        expect(result.status.exitstatus).to eq(2)
+      end
+
+      it 'raises FailedError with exit code 3' do
         expect_command_capturing('diff')
-          .and_return(command_result('', stderr: 'fatal: bad revision', exitstatus: 2))
+          .and_return(command_result('', stderr: 'fatal: bad revision', exitstatus: 3))
 
         expect { command.call }
           .to raise_error(Git::FailedError, /bad revision/)


### PR DESCRIPTION
## Summary

`git diff --check` exits with code **2** (not 1) when it finds whitespace or conflict-marker errors. The previous `allow_exit_status 0..1` caused `Git::FailedError` to be raised whenever `check: true` was used and issues were found — even though that is the normal, expected result from `--check`.

## Changes

### `lib/git/commands/diff.rb`

- Expand `allow_exit_status` from `0..1` to `0..2`
- Update comment to document the three semantic exit codes:
  - 0 — no differences / no check issues
  - 1 — differences found (with `--exit-code`)
  - 2 — whitespace/conflict-marker issues found (with `--check`)
- Update all `@raise [Git::FailedError]` overload docs from "exit code > 1" to "exit code > 2"

### `spec/unit/git/commands/diff_spec.rb`

- Update the exit-code-2 example from expecting `FailedError` to verifying it returns successfully
- Add an exit-code-3 example that confirms `FailedError` is still raised for codes above the allowed range

### `spec/integration/git/commands/diff_spec.rb`

- Add a `with --check option` context with its own isolated repository
- Empirically verify exit code 0 (no whitespace issues) and exit code 2 (trailing whitespace found)

## Exit code semantics

Exit codes 1 and 2 are intentional semantic exits from git. Git consistently uses 128+ for fatal/usage errors, so expanding the allowed range to `0..2` does not risk silently swallowing real failures.