### PR TITLE
feat(repository): migrate Git::Diff to Git::Repository facade

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -978,7 +978,7 @@ module Git
 
     # @return [Git::Diff] a Git::Diff object
     def diff(objectish = 'HEAD', obj2 = nil)
-      Git::Diff.new(self, objectish, obj2)
+      facade_repository.diff(objectish, obj2)
     end
 
     # @return [Git::Object] a Git object

--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -4,10 +4,37 @@ require_relative 'diff_path_status'
 require_relative 'diff_stats'
 
 module Git
-  # object that holds the diff between two commits
+  # Diff between two commits or between a commit and the working tree
+  #
+  # @example Diff between two commits
+  #   diff = repo.diff('HEAD~1', 'HEAD')
+  #   diff.size       # => 3
+  #   diff.insertions # => 20
+  #   diff.deletions  # => 5
+  #
+  # @example Limit diff to a specific path
+  #   diff = repo.diff('HEAD~1', 'HEAD').path('lib/')
+  #
+  # @api public
+  #
   class Diff
     include Enumerable
 
+    # Creates a new Diff
+    #
+    # @example
+    #   diff = Git::Diff.new(base, 'HEAD~1', 'HEAD')
+    #
+    # @param base [Git::Base, Git::Repository] the git repository
+    #
+    # @param from [String, nil] the starting commit ref, or `nil` to compare
+    #   from the index
+    #
+    # @param to [String, nil] the ending commit ref, or `nil` to compare to
+    #   the working tree
+    #
+    # @return [void]
+    #
     def initialize(base, from = nil, to = nil)
       @base = base
       @from = from&.to_s
@@ -16,7 +43,18 @@ module Git
       @path = nil
       @full_diff_files = nil
     end
-    attr_reader :from, :to
+
+    # The starting commit ref
+    #
+    # @return [String, nil] the starting commit ref, or `nil` if not set
+    #
+    attr_reader :from
+
+    # The ending commit ref
+    #
+    # @return [String, nil] the ending commit ref, or `nil` if not set
+    #
+    attr_reader :to
 
     # Limits the diff to the specified path(s)
     #
@@ -33,8 +71,11 @@ module Git
     # @example Remove path filtering (show all files)
     #   diff.path  # or diff.path(nil)
     #
-    # @param paths [String, Pathname] one or more paths to filter the diff. Pass no arguments to remove filtering.
+    # @param paths [String, Pathname] one or more paths to filter the diff;
+    #   pass no arguments to remove filtering
+    #
     # @return [self] returns self for method chaining
+    #
     # @raise [ArgumentError] if any path is an Array (use splatted arguments instead)
     #
     def path(*paths)
@@ -53,21 +94,69 @@ module Git
       self
     end
 
+    # Returns the full diff output as a string
+    #
+    # @example
+    #   diff.patch # => "diff --git a/file.rb b/file.rb\n..."
+    #
+    # @return [String] the raw output of `git diff`
+    #
     def patch
-      @base.lib.diff_full(@from, @to, { path_limiter: @path })
+      if @base.respond_to?(:diff_full)
+        @base.diff_full(@from, @to, path_limiter: @path)
+      else
+        @base.lib.diff_full(@from, @to, { path_limiter: @path })
+      end
     end
     alias to_s patch
 
+    # Returns the diff file info for the given path
+    #
+    # @example
+    #   diff['lib/git.rb'] # => #<Git::Diff::DiffFile ...>
+    #
+    # @param key [String] the file path to look up
+    #
+    # @return [Git::Diff::DiffFile] the diff file object for the given path
+    #
     def [](key)
       process_full
       @full_diff_files.assoc(key)[1]
     end
 
+    # Iterates over each changed file in the diff
+    #
+    # @overload each
+    #   @example Get an enumerator
+    #     diff.each.map(&:path) # => ["lib/git.rb", "README.md"]
+    #
+    #   @return [Enumerator<Git::Diff::DiffFile>] an enumerator over the
+    #     changed files
+    #
+    # @overload each(&block)
+    #   @example Iterate with a block
+    #     diff.each { |file| puts file.path }
+    #
+    #   @yield [file] each changed file in the diff
+    #
+    #   @yieldparam file [Git::Diff::DiffFile] a changed file
+    #
+    #   @yieldreturn [void]
+    #
+    #   @return [Array<Git::Diff::DiffFile>] the array of changed files
+    #
     def each(&)
       process_full
       @full_diff_files.map { |file| file[1] }.each(&)
     end
 
+    # Returns the number of changed files in the diff
+    #
+    # @example
+    #   diff.size # => 3
+    #
+    # @return [Integer] the number of changed files
+    #
     def size
       stats_provider.total[:files]
     end
@@ -76,22 +165,61 @@ module Git
     # DEPRECATED METHODS
     #
 
+    # Returns the path-to-status hash for all changed files in the diff
+    #
+    # @example
+    #   diff.name_status # => { "lib/git.rb" => "M", "README.md" => "A" }
+    #
+    # @return [Hash<String, String>] map of file path to git status letter
+    #
     def name_status
       path_status_provider.to_h
     end
 
+    # Returns the total number of changed lines in the diff
+    #
+    # @example
+    #   diff.lines # => 42
+    #
+    # @return [Integer] the total number of inserted and deleted lines
+    #
     def lines
       stats_provider.lines
     end
 
+    # Returns the total number of deleted lines in the diff
+    #
+    # @example
+    #   diff.deletions # => 10
+    #
+    # @return [Integer] the number of deleted lines
+    #
     def deletions
       stats_provider.deletions
     end
 
+    # Returns the total number of inserted lines in the diff
+    #
+    # @example
+    #   diff.insertions # => 32
+    #
+    # @return [Integer] the number of inserted lines
+    #
     def insertions
       stats_provider.insertions
     end
 
+    # Returns a statistics hash for the diff
+    #
+    # @example
+    #   diff.stats
+    #   # => {
+    #   #   files: { "lib/git.rb" => { insertions: 5, deletions: 2 } },
+    #   #   total: { insertions: 5, deletions: 2, lines: 7 }
+    #   # }
+    #
+    # @return [Hash] statistics including per-file and total insert/delete counts
+    #
     def stats
       {
         files: stats_provider.files,
@@ -99,13 +227,72 @@ module Git
       }
     end
 
-    # The changes for a single file within a diff
+    # Information about a single changed file within a {Git::Diff}
+    #
+    # @example Access diff file information
+    #   diff.each do |file|
+    #     puts file.path
+    #     puts file.binary? ? 'binary' : file.patch
+    #   end
+    #
+    # @api public
+    #
     class DiffFile
-      attr_accessor :patch, :path, :mode, :src, :dst, :type
+      # The raw diff patch text for this file
+      #
+      # @return [String, nil] the patch text
+      #
+      attr_accessor :patch
+
+      # The file path relative to the repository root
+      #
+      # @return [String, nil] the file path
+      #
+      attr_accessor :path
+
+      # The file mode
+      #
+      # @return [String] the octal file mode (e.g. `"100644"`)
+      #
+      attr_accessor :mode
+
+      # The source (pre-change) blob SHA
+      #
+      # @return [String] the source blob SHA
+      #
+      attr_accessor :src
+
+      # The destination (post-change) blob SHA
+      #
+      # @return [String] the destination blob SHA
+      #
+      attr_accessor :dst
+
+      # The type of change
+      #
+      # @return [String] the change type (e.g. `"modified"`, `"new"`, `"deleted"`)
+      #
+      attr_accessor :type
 
       @base = nil
+
+      # Regexp matching a nil blob SHA (all-zero hash of 4 to 40 hex digits)
       NIL_BLOB_REGEXP = /\A0{4,40}\z/
 
+      # Creates a new DiffFile from parsed diff data
+      #
+      # @example
+      #   file = Git::Diff::DiffFile.new(base,
+      #     patch: "diff --git ...", path: 'lib/git.rb',
+      #     mode: '100644', src: 'abc123', dst: 'def456',
+      #     type: 'modified', binary: false)
+      #
+      # @param base [Git::Base, Git::Repository] the git repository
+      #
+      # @param hash [Hash] the parsed diff attributes
+      #
+      # @return [void]
+      #
       def initialize(base, hash)
         @base = base
         @patch = hash[:patch]
@@ -117,10 +304,31 @@ module Git
         @binary = hash[:binary]
       end
 
+      # Returns true if this file is a binary file
+      #
+      # @example
+      #   diff['path/to/image.png'].binary? # => true
+      #
+      # @return [Boolean] `true` if the file is binary, `false` otherwise
+      #
       def binary?
         !!@binary
       end
 
+      # Returns the blob object for this file
+      #
+      # @example Retrieve the destination blob
+      #   file.blob       # => #<Git::Object::Blob ...>
+      #
+      # @example Retrieve the source blob
+      #   file.blob(:src) # => #<Git::Object::Blob ...>
+      #
+      # @param type [Symbol] `:src` to retrieve the source blob, or `:dst`
+      #   (default) for the destination blob
+      #
+      # @return [Git::Object::Blob, nil] the blob object, or `nil` if the blob
+      #   SHA is the null SHA
+      #
       def blob(type = :dst)
         if type == :src && !NIL_BLOB_REGEXP.match(@src)
           @base.object(@src)
@@ -132,6 +340,14 @@ module Git
 
     private
 
+    # Validates that no path argument is an Array
+    #
+    # @param paths [Array] the raw paths array passed to {#path}
+    #
+    # @return [void]
+    #
+    # @raise [ArgumentError] if any element of paths is an Array
+    #
     def validate_paths_not_arrays(paths)
       return unless paths.any?(Array)
 
@@ -140,27 +356,58 @@ module Git
             "Use path('lib/', 'docs/') not path(['lib/', 'docs/'])"
     end
 
+    # Triggers full diff processing if not yet done
+    #
+    # @return [void]
+    #
     def process_full
       return if @full_diff_files
 
       @full_diff_files = process_full_diff
     end
 
+    # Returns a memoized DiffPathStatus provider for this diff
+    #
+    # @return [Git::DiffPathStatus] the path status provider
+    #
     def path_status_provider
       @path_status_provider ||= Git::DiffPathStatus.new(@base, @from, @to, @path)
     end
 
+    # Returns a memoized DiffStats provider for this diff
+    #
+    # @return [Git::DiffStats] the stats provider
+    #
     def stats_provider
       @stats_provider ||= Git::DiffStats.new(@base, @from, @to, @path)
     end
 
+    # Parses the full diff output into DiffFile objects
+    #
+    # @return [Array<Array(String, Git::Diff::DiffFile)>] list of
+    #   `[filename, DiffFile]` pairs
+    #
     def process_full_diff
       FullDiffParser.new(@base, patch).parse
     end
 
-    # A private parser class to process the output of `git diff`
+    # Private parser for `git diff` output
+    #
+    # @example Parse a diff patch
+    #   parser = Git::Diff::FullDiffParser.new(base, patch_text)
+    #   files = parser.parse
+    #
     # @api private
+    #
     class FullDiffParser
+      # Creates a new FullDiffParser
+      #
+      # @param base [Git::Base, Git::Repository] the git repository
+      #
+      # @param patch_text [String] the raw `git diff` output to parse
+      #
+      # @return [void]
+      #
       def initialize(base, patch_text)
         @base = base
         @patch_text = patch_text
@@ -169,6 +416,11 @@ module Git
         @defaults = { mode: '', src: '', dst: '', type: 'modified', binary: false }
       end
 
+      # Parses the diff text into a list of filename/DiffFile pairs
+      #
+      # @return [Array<Array(String, Git::Diff::DiffFile)>] list of
+      #   `[filename, DiffFile]` pairs
+      #
       def parse
         @patch_text.split("\n").each { |line| process_line(line) }
         @final_files.map { |filename, data| [filename, DiffFile.new(@base, data)] }
@@ -176,6 +428,12 @@ module Git
 
       private
 
+      # Dispatches a single diff line to the appropriate handler
+      #
+      # @param line [String] a line from the diff output
+      #
+      # @return [void]
+      #
       def process_line(line)
         if (new_file_match = line.match(%r{\Adiff --git ("?)a/(.+?)\1 ("?)b/(.+?)\3\z}))
           start_new_file(new_file_match, line)
@@ -184,12 +442,26 @@ module Git
         end
       end
 
+      # Starts tracking a new file from a diff header line
+      #
+      # @param match [MatchData] the regex match from the diff header line
+      #
+      # @param line [String] the original diff header line
+      #
+      # @return [void]
+      #
       def start_new_file(match, line)
         filename = Git::EscapedPath.new(match[2]).unescape
         @current_file_data = @defaults.merge({ patch: line, path: filename })
         @final_files[filename] = @current_file_data
       end
 
+      # Appends a diff line to the current file's accumulated data
+      #
+      # @param line [String] a diff line to append
+      #
+      # @return [void]
+      #
       def append_to_current_file(line)
         return unless @current_file_data
 
@@ -200,6 +472,12 @@ module Git
         @current_file_data[:patch] << "\n#{line}"
       end
 
+      # Parses an index line to extract source and destination blob SHAs
+      #
+      # @param line [String] a diff line that may be an index line
+      #
+      # @return [void]
+      #
       def parse_index_line(line)
         return unless (match = line.match(/^index ([0-9a-f]{4,40})\.\.([0-9a-f]{4,40})( ......)*/))
 
@@ -208,6 +486,12 @@ module Git
         @current_file_data[:mode] = match[3].strip if match[3]
       end
 
+      # Parses a file mode line to extract the change type and file mode
+      #
+      # @param line [String] a diff line that may be a file mode line
+      #
+      # @return [void]
+      #
       def parse_file_mode_line(line)
         return unless (match = line.match(/^([[:alpha:]]*?) file mode (......)/))
 
@@ -215,6 +499,12 @@ module Git
         @current_file_data[:mode] = match[2]
       end
 
+      # Marks the current file as binary if this is a binary diff line
+      #
+      # @param line [String] a diff line to check for the binary file marker
+      #
+      # @return [void]
+      #
       def check_for_binary(line)
         @current_file_data[:binary] = true if line.match?(/^Binary files /)
       end

--- a/lib/git/diff_path_status.rb
+++ b/lib/git/diff_path_status.rb
@@ -62,18 +62,25 @@ module Git
     # Lazily fetches and caches the path status from the git lib
     #
     # When constructed with a pre-fetched hash, returns it directly.
+    # When `@base` responds to `#diff_name_status` (e.g. {Git::Repository} or
+    # {Git::Base}, which defines it as an alias for `#diff_path_status`),
+    # delegates directly to that method. Otherwise falls back to the legacy
+    # `@base.lib.diff_path_status` call for duck-typed base objects that only
+    # expose path-status via their lib.
     #
     # @return [Hash{String => String}] a mapping of file paths to status codes
     #
     def fetch_path_status
-      @fetch_path_status ||= @base.lib.diff_path_status(
-        @from, @to, { path_limiter: @path_limiter }
-      )
+      @fetch_path_status ||= if @base.respond_to?(:diff_name_status)
+                               @base.diff_name_status(@from, @to, path_limiter: @path_limiter).to_h
+                             else
+                               @base.lib.diff_path_status(@from, @to, { path_limiter: @path_limiter })
+                             end
     end
 
     # Sets up legacy (base, from, to, path_limiter) instance state
     #
-    # @param base [Git::Base] the git base instance
+    # @param base [Git::Base, Git::Repository] the git base instance
     #
     # @param from [String] the first commit or object to compare
     #

--- a/lib/git/repository/diffing.rb
+++ b/lib/git/repository/diffing.rb
@@ -2,6 +2,7 @@
 
 require 'pathname'
 require 'git/commands/diff'
+require 'git/diff'
 require 'git/diff_path_status'
 require 'git/diff_stats'
 require 'git/escaped_path'
@@ -9,7 +10,7 @@ require 'git/repository/shared_private'
 
 module Git
   class Repository
-    # Mixin that adds diff facade methods
+    # Facade methods for comparing commits and trees using `git diff`
     #
     # Included by {Git::Repository}.
     #
@@ -73,9 +74,9 @@ module Git
       #
       # @raise [ArgumentError] if unsupported options are provided
       #
-      # @raise [ArgumentError] if `obj1` is `nil` but `obj2` is not OR either starts with `"-"`
+      # @raise [ArgumentError] if `obj1` is `nil` but `obj2` is not OR if `obj1` or `obj2` starts with `"-"`
       #
-      # @raise [Git::FailedError] if git exits outside the allowed range (exit code > 1)
+      # @raise [Git::FailedError] if git exits outside the allowed range (exit code > 2)
       #
       # @see https://git-scm.com/docs/git-diff git-diff documentation
       #
@@ -147,8 +148,8 @@ module Git
       #
       # @param opts [Hash] options to filter the diff
       #
-      # @option opts [String, Pathname, Array<String, Pathname>, nil] :path_limiter
-      #   (nil) limit the stats to the given path(s)
+      # @option opts [String, Pathname, Array<String, Pathname>, nil] :path_limiter (nil)
+      #   limit the stats to the given path(s)
       #
       # @return [Hash] per-file insertion and deletion counts plus aggregate totals
       #
@@ -161,10 +162,9 @@ module Git
       #
       # @raise [ArgumentError] if unsupported options are provided
       #
-      # @raise [ArgumentError] if `obj1` is `nil` but `obj2` is not OR either starts with `"-"`
+      # @raise [ArgumentError] if `obj1` is `nil` but `obj2` is not OR if `obj1` or `obj2` starts with `"-"`
       #
-      # @raise [Git::FailedError] if git exits outside the allowed range (exit code >
-      # 1)
+      # @raise [Git::FailedError] if git exits outside the allowed range (exit code > 2)
       #
       # @see https://git-scm.com/docs/git-diff git-diff documentation
       #
@@ -241,9 +241,7 @@ module Git
       #
       # @raise [ArgumentError] if unsupported options are provided
       #
-      # @raise [ArgumentError] if `obj1` is `nil` but `obj2` is not
-      #
-      # @raise [ArgumentError] if `obj1` or `obj2` starts with `"-"`
+      # @raise [ArgumentError] if `obj1` is `nil` but `obj2` is not OR if `obj1` or `obj2` starts with `"-"`
       #
       # @see #diff_numstat
       #
@@ -254,6 +252,41 @@ module Git
         raise ArgumentError, 'Invalid arguments: obj1 is nil but obj2 is not' if obj1.nil? && !obj2.nil?
 
         Git::DiffStats.new(self, obj1, obj2, opts[:path_limiter])
+      end
+
+      # Returns a lazy {Git::Diff} object for the comparison between two trees
+      #
+      # Compares (1) two commits, (2) a commit against the working tree, or (3) the
+      # index against the working tree. The returned {Git::Diff} is lazy — it does
+      # not run any git commands until an accessor method (e.g., {Git::Diff#patch},
+      # {Git::Diff#each}) is called.
+      #
+      # Use {Git::Diff#path} to limit the diff to a sub-path after construction.
+      #
+      # @example Get the diff since HEAD
+      #   diff = repo.diff
+      #   diff.patch  #=> "diff --git a/lib/foo.rb ..."
+      #
+      # @example Compare two specific commits
+      #   repo.diff('abc1234', 'def5678').patch
+      #
+      # @example Limit to a sub-path
+      #   repo.diff('HEAD~1', 'HEAD').path('lib/').patch
+      #
+      # @example Get unstaged changes (index vs. working tree)
+      #   repo.diff(nil).patch
+      #
+      # @param obj1 [String, nil] the first commit or object to compare; defaults to
+      #   `'HEAD'`
+      #
+      # @param obj2 [String, nil] the second commit or object to compare
+      #
+      # @return [Git::Diff] a lazy diff object for the comparison
+      #
+      # @see https://git-scm.com/docs/git-diff git-diff documentation
+      #
+      def diff(obj1 = 'HEAD', obj2 = nil)
+        Git::Diff.new(self, obj1, obj2)
       end
 
       # Option keys accepted by {#diff_path_status}
@@ -319,9 +352,9 @@ module Git
       #
       # @raise [ArgumentError] if unsupported options are provided
       #
-      # @raise [ArgumentError] if `from` is `nil` but `to` is not OR either starts with `"-"`
+      # @raise [ArgumentError] if `from` is `nil` but `to` is not OR if `from` or `to` starts with `"-"`
       #
-      # @raise [Git::FailedError] if git exits outside the allowed range (exit code > 1)
+      # @raise [Git::FailedError] if git exits outside the allowed range (exit code > 2)
       #
       # @see https://git-scm.com/docs/git-diff git-diff documentation
       #

--- a/spec/integration/git/repository/diffing_spec.rb
+++ b/spec/integration/git/repository/diffing_spec.rb
@@ -6,11 +6,17 @@ require 'git/repository/diffing'
 require 'git/execution_context/repository'
 
 # Integration tests for Git::Repository::Diffing facade methods that perform
-# facade-owned post-processing of real git output (extract_patch_text strips
-# numstat/shortstat lines before returning the patch text). Methods that are
-# pure single-command delegators without post-processing (diff_path_status /
-# diff_name_status) are covered by the command's own integration tests:
-#   tests/units/test_diff_path_status.rb
+# facade-owned post-processing of real git output:
+#   - #diff_full: extract_patch_text strips numstat/shortstat lines before
+#     returning the patch text
+#   - #diff_numstat: parse_numstat_output parses combined numstat/shortstat
+#     output into a structured hash
+#
+# Methods with facade-owned parsing covered by the legacy test suite
+# (Git::Base delegates to the facade, so coverage is end-to-end):
+#   tests/units/test_diff_path_status.rb covers #diff_path_status /
+#   #diff_name_status, which parse raw diff output via
+#   Private.extract_name_status_from_raw.
 #
 # #diff_stats is a lazy factory delegator (no facade-owned post-processing)
 # and is covered by:

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -96,4 +96,36 @@ RSpec.describe Git::Base do
       expect(result).to be(diff_stats_result)
     end
   end
+
+  describe '#diff' do
+    subject(:result) { described_instance.diff(objectish, obj2) }
+
+    let(:described_instance) { described_class.new }
+    let(:objectish) { 'HEAD~1' }
+    let(:obj2) { 'HEAD' }
+    let(:facade_repository) { instance_double(Git::Repository) }
+    let(:diff_result) { instance_double(Git::Diff) }
+
+    before do
+      allow(described_instance).to receive(:facade_repository).and_return(facade_repository)
+    end
+
+    it 'delegates to facade_repository.diff with objectish and obj2' do
+      expect(facade_repository).to receive(:diff).with(objectish, obj2).and_return(diff_result)
+      expect(result).to be(diff_result)
+    end
+
+    context 'when called with default arguments' do
+      subject(:result) { described_instance.diff }
+
+      before do
+        allow(facade_repository).to receive(:diff).with('HEAD', nil).and_return(diff_result)
+      end
+
+      it 'delegates to facade_repository.diff with HEAD and nil' do
+        expect(facade_repository).to receive(:diff).with('HEAD', nil).and_return(diff_result)
+        result
+      end
+    end
+  end
 end

--- a/spec/unit/git/diff_path_status_spec.rb
+++ b/spec/unit/git/diff_path_status_spec.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/diff_path_status'
+require 'git/repository'
+
+RSpec.describe Git::DiffPathStatus do
+  let(:name_status_hash) { { 'lib/foo.rb' => 'M', 'lib/bar.rb' => 'A' } }
+
+  let(:repository_base)      { instance_double(Git::Repository) }
+  let(:diff_name_status_obj) { instance_double(described_class, to_h: name_status_hash) }
+
+  let(:legacy_lib)  { double('legacy_lib') }
+  let(:legacy_base) { double('legacy_base', lib: legacy_lib) }
+
+  before do
+    allow(repository_base).to receive(:diff_name_status).and_return(diff_name_status_obj)
+    allow(legacy_lib).to receive(:diff_path_status).and_return(name_status_hash)
+  end
+
+  describe '#initialize' do
+    context 'with the hash form' do
+      it 'accepts a pre-fetched name-status hash and returns it via to_h' do
+        expect(described_class.new(name_status_hash).to_h).to eq(name_status_hash)
+      end
+    end
+
+    context 'with the legacy form' do
+      it 'raises ArgumentError when from starts with a dash' do
+        expect { described_class.new(repository_base, '-bad-ref', 'HEAD') }
+          .to raise_error(ArgumentError, /Invalid argument/)
+      end
+
+      it 'raises ArgumentError when to starts with a dash' do
+        expect { described_class.new(repository_base, 'HEAD', '-bad-ref') }
+          .to raise_error(ArgumentError, /Invalid argument/)
+      end
+    end
+  end
+
+  describe '#to_h' do
+    context 'when base responds to :diff_name_status (Git::Repository form)' do
+      subject(:result) { described_class.new(repository_base, 'HEAD~1', 'HEAD').to_h }
+
+      it 'calls diff_name_status with from, to, and path_limiter: nil' do
+        expect(repository_base).to receive(:diff_name_status)
+          .with('HEAD~1', 'HEAD', path_limiter: nil)
+          .and_return(diff_name_status_obj)
+        result
+      end
+
+      it 'returns the name-status hash' do
+        expect(result).to eq(name_status_hash)
+      end
+
+      context 'when path_limiter is given' do
+        it 'forwards path_limiter to diff_name_status' do
+          expect(repository_base).to receive(:diff_name_status)
+            .with('HEAD~1', 'HEAD', path_limiter: 'lib/')
+            .and_return(diff_name_status_obj)
+          described_class.new(repository_base, 'HEAD~1', 'HEAD', 'lib/').to_h
+        end
+      end
+
+      context 'when obj2 is nil' do
+        it 'passes nil as the second positional argument to diff_name_status' do
+          expect(repository_base).to receive(:diff_name_status)
+            .with('HEAD', nil, path_limiter: nil)
+            .and_return(diff_name_status_obj)
+          described_class.new(repository_base, 'HEAD', nil).to_h
+        end
+      end
+
+      it 'memoizes the result across multiple to_h calls' do
+        expect(repository_base).to receive(:diff_name_status).once.and_return(diff_name_status_obj)
+        status = described_class.new(repository_base, 'HEAD', nil)
+        status.to_h
+        status.to_h
+      end
+    end
+
+    context 'when base does not respond to :diff_name_status (legacy Git::Base form)' do
+      subject(:result) { described_class.new(legacy_base, 'HEAD~1', 'HEAD').to_h }
+
+      it 'calls base.lib.diff_path_status with from, to, and path_limiter option' do
+        expect(legacy_lib).to receive(:diff_path_status)
+          .with('HEAD~1', 'HEAD', { path_limiter: nil })
+          .and_return(name_status_hash)
+        result
+      end
+
+      it 'returns the name-status hash' do
+        expect(result).to eq(name_status_hash)
+      end
+
+      context 'when path_limiter is given' do
+        it 'forwards path_limiter to base.lib.diff_path_status' do
+          expect(legacy_lib).to receive(:diff_path_status)
+            .with('HEAD~1', 'HEAD', { path_limiter: 'lib/' })
+            .and_return(name_status_hash)
+          described_class.new(legacy_base, 'HEAD~1', 'HEAD', 'lib/').to_h
+        end
+      end
+    end
+  end
+
+  describe '#each' do
+    it 'yields each path and status pair' do
+      pairs = described_class.new(repository_base, 'HEAD~1', 'HEAD').map { |path, status| [path, status] }
+      expect(pairs).to eq([['lib/foo.rb', 'M'], ['lib/bar.rb', 'A']])
+    end
+
+    it 'returns an Enumerator when no block is given' do
+      result = described_class.new(repository_base, 'HEAD~1', 'HEAD').each
+      expect(result).to be_a(Enumerator)
+    end
+  end
+end

--- a/spec/unit/git/diff_spec.rb
+++ b/spec/unit/git/diff_spec.rb
@@ -1,0 +1,138 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/diff'
+require 'git/repository'
+
+RSpec.describe Git::Diff do
+  let(:patch_text) do
+    "diff --git a/lib/foo.rb b/lib/foo.rb\n--- a/lib/foo.rb\n+++ b/lib/foo.rb\n@@ -1 +1 @@\n-old\n+new\n"
+  end
+
+  let(:repository_base) { instance_double(Git::Repository) }
+
+  # Duck-type collaborator: the legacy path models any base that exposes #lib
+  # but does NOT itself respond to #diff_full. No single concrete class in the
+  # codebase matches this interface (Git::Base defines #diff_full directly), so
+  # instance_double cannot be used here.
+  let(:legacy_lib)  { double('Git::Lib') }
+  let(:legacy_base) { double('legacy_base', lib: legacy_lib) }
+
+  before do
+    allow(repository_base).to receive(:diff_full).and_return(patch_text)
+    allow(legacy_lib).to receive(:diff_full).and_return(patch_text)
+  end
+
+  let(:described_instance) { described_class.new(repository_base, 'HEAD~1', 'HEAD') }
+
+  describe '#initialize' do
+    subject(:instance) { described_instance }
+
+    it 'stores all constructor arguments as readable attributes' do
+      expect(instance).to have_attributes(from: 'HEAD~1', to: 'HEAD')
+    end
+  end
+
+  describe '#path' do
+    subject(:result) { described_instance.path(*paths) }
+
+    let(:paths) { [] }
+
+    context 'when called with no arguments' do
+      it 'returns self for chaining' do
+        expect(result).to be(described_instance)
+      end
+    end
+
+    context 'when called with a single path' do
+      let(:paths) { ['lib/'] }
+
+      it 'returns self for chaining' do
+        expect(result).to be(described_instance)
+      end
+    end
+
+    context 'when called with multiple paths' do
+      let(:paths) { ['lib/', 'docs/'] }
+
+      it 'returns self for chaining' do
+        expect(result).to be(described_instance)
+      end
+    end
+
+    context 'when an Array is passed as an argument' do
+      let(:paths) { [['lib/', 'docs/']] }
+
+      it 'raises ArgumentError explaining splatted argument usage' do
+        expect { result }.to raise_error(ArgumentError, /path expects individual arguments/)
+      end
+    end
+  end
+
+  describe '#patch' do
+    context 'when base responds to :diff_full (Git::Repository form)' do
+      subject(:result) { described_class.new(repository_base, 'HEAD~1', 'HEAD').patch }
+
+      it 'calls diff_full with from, to, and path_limiter: nil' do
+        expect(repository_base).to receive(:diff_full)
+          .with('HEAD~1', 'HEAD', path_limiter: nil)
+          .and_return(patch_text)
+        result
+      end
+
+      it 'returns the patch text' do
+        expect(result).to eq(patch_text)
+      end
+
+      context 'when a path filter has been set' do
+        it 'forwards the path to diff_full as path_limiter' do
+          expect(repository_base).to receive(:diff_full)
+            .with('HEAD~1', 'HEAD', path_limiter: 'lib/')
+            .and_return(patch_text)
+          described_class.new(repository_base, 'HEAD~1', 'HEAD').path('lib/').patch
+        end
+      end
+
+      context 'when obj2 is nil' do
+        it 'passes nil as the second positional argument to diff_full' do
+          expect(repository_base).to receive(:diff_full)
+            .with('HEAD', nil, path_limiter: nil)
+            .and_return(patch_text)
+          described_class.new(repository_base, 'HEAD', nil).patch
+        end
+      end
+    end
+
+    context 'when base does not respond to :diff_full (legacy Git::Base form)' do
+      subject(:result) { described_class.new(legacy_base, 'HEAD~1', 'HEAD').patch }
+
+      it 'calls base.lib.diff_full with from, to, and path_limiter option' do
+        expect(legacy_lib).to receive(:diff_full)
+          .with('HEAD~1', 'HEAD', { path_limiter: nil })
+          .and_return(patch_text)
+        result
+      end
+
+      it 'returns the patch text' do
+        expect(result).to eq(patch_text)
+      end
+
+      context 'when a path filter has been set' do
+        it 'forwards the path to base.lib.diff_full as path_limiter' do
+          expect(legacy_lib).to receive(:diff_full)
+            .with('HEAD~1', 'HEAD', { path_limiter: 'lib/' })
+            .and_return(patch_text)
+          described_class.new(legacy_base, 'HEAD~1', 'HEAD').path('lib/').patch
+        end
+      end
+    end
+  end
+
+  describe '#to_s' do
+    subject(:result) { described_instance.to_s }
+
+    it 'is an alias for patch' do
+      expect(result).to eq(patch_text)
+    end
+  end
+end

--- a/spec/unit/git/repository/diffing_spec.rb
+++ b/spec/unit/git/repository/diffing_spec.rb
@@ -1,16 +1,15 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
-require 'git/diff_stats'
 require 'git/repository'
 require 'git/repository/diffing'
 
 # Integration coverage for Git::Repository::Diffing:
-#   spec/integration/git/repository/diffing_spec.rb covers #diff_full, which
-#   has facade-owned post-processing (extract_patch_text strips numstat/shortstat
-#   lines before returning the patch text).
-#   tests/units/test_diff_path_status.rb covers diff_path_status / diff_name_status,
-#   which are pure single-command delegators with no post-processing.
+#   spec/integration/git/repository/diffing_spec.rb covers #diff_full and
+#   #diff_numstat, which have facade-owned post-processing.
+#   tests/units/test_diff_path_status.rb covers #diff_path_status /
+#   #diff_name_status end-to-end (via Git::Base, which delegates to the facade);
+#   both methods parse raw diff output via Private.extract_name_status_from_raw.
 #   tests/units/test_diff_stats.rb covers #diff_stats, which is a lazy factory
 #   delegator (no facade-owned post-processing).
 
@@ -25,6 +24,12 @@ RSpec.describe Git::Repository::Diffing do
   end
 
   describe '#diff_full' do
+    subject(:result) { described_instance.diff_full(obj1, obj2, **opts) }
+
+    let(:obj1) { 'HEAD' }
+    let(:obj2) { nil }
+    let(:opts) { {} }
+
     let(:patch_text) do
       "diff --git a/lib/foo.rb b/lib/foo.rb\n" \
         "index abc1234..def5678 100644\n" \
@@ -38,15 +43,6 @@ RSpec.describe Git::Repository::Diffing do
     let(:diff_result) { command_result(patch_text) }
 
     context 'when called with default arguments' do
-      before do
-        allow(diff_command).to receive(:call).with(
-          'HEAD',
-          patch: true, numstat: true, shortstat: true,
-          src_prefix: 'a/', dst_prefix: 'b/',
-          path: nil
-        ).and_return(diff_result)
-      end
-
       it 'calls the command with HEAD and patch format options' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
@@ -54,15 +50,19 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: nil
         ).and_return(diff_result)
-        described_instance.diff_full
+        subject
       end
 
       it 'returns the patch text extracted from the command output' do
-        expect(described_instance.diff_full).to eq(patch_text)
+        allow(diff_command).to receive(:call).and_return(diff_result)
+        is_expected.to eq(patch_text)
       end
     end
 
     context 'when called with explicit obj1 and obj2' do
+      let(:obj1) { 'abc1234' }
+      let(:obj2) { 'def5678' }
+
       it 'passes both refs as positional arguments to the command' do
         expect(diff_command).to receive(:call).with(
           'abc1234', 'def5678',
@@ -70,11 +70,13 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: nil
         ).and_return(diff_result)
-        described_instance.diff_full('abc1234', 'def5678')
+        subject
       end
     end
 
     context 'when called with only obj1' do
+      let(:obj1) { 'abc1234' }
+
       it 'passes only obj1 as a positional argument to the command' do
         expect(diff_command).to receive(:call).with(
           'abc1234',
@@ -82,11 +84,13 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: nil
         ).and_return(diff_result)
-        described_instance.diff_full('abc1234')
+        subject
       end
     end
 
     context 'when path_limiter is a single String' do
+      let(:opts) { { path_limiter: 'lib/' } }
+
       it 'wraps the path_limiter in an Array and forwards it to the command' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
@@ -94,11 +98,13 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: ['lib/']
         ).and_return(diff_result)
-        described_instance.diff_full('HEAD', nil, path_limiter: 'lib/')
+        subject
       end
     end
 
     context 'when path_limiter is an Array of paths' do
+      let(:opts) { { path_limiter: ['lib/', 'spec/'] } }
+
       it 'forwards the Array as-is to the command' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
@@ -106,11 +112,13 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: ['lib/', 'spec/']
         ).and_return(diff_result)
-        described_instance.diff_full('HEAD', nil, path_limiter: ['lib/', 'spec/'])
+        subject
       end
     end
 
     context 'when path_limiter is a Pathname' do
+      let(:opts) { { path_limiter: Pathname.new('lib/') } }
+
       it 'converts the Pathname to a String and forwards it to the command' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
@@ -118,11 +126,13 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: ['lib/']
         ).and_return(diff_result)
-        described_instance.diff_full('HEAD', nil, path_limiter: Pathname.new('lib/'))
+        subject
       end
     end
 
     context 'when path_limiter is nil' do
+      let(:opts) { { path_limiter: nil } }
+
       it 'sends path: nil to the command' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
@@ -130,11 +140,13 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: nil
         ).and_return(diff_result)
-        described_instance.diff_full('HEAD', nil, path_limiter: nil)
+        subject
       end
     end
 
     context 'when path_limiter is an empty String' do
+      let(:opts) { { path_limiter: '' } }
+
       it 'normalizes to nil and sends path: nil to the command' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
@@ -142,75 +154,79 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: nil
         ).and_return(diff_result)
-        described_instance.diff_full('HEAD', nil, path_limiter: '')
+        subject
       end
     end
 
-    context 'when path_limiter contains an invalid type' do
-      it 'raises an ArgumentError naming the path limiter' do
-        expect { described_instance.diff_full('HEAD', nil, path_limiter: 123) }
-          .to raise_error(ArgumentError, /Invalid path limiter/)
-      end
-    end
+    context 'when obj1 is nil and obj2 is nil' do
+      let(:obj1) { nil }
 
-    context 'when obj1 is nil but obj2 is not' do
-      it 'raises an ArgumentError' do
-        expect { described_instance.diff_full(nil, 'def5678') }
-          .to raise_error(ArgumentError, /obj1 is nil but obj2 is not/)
-      end
-    end
-
-    context 'when an unknown option is provided' do
-      it 'raises an ArgumentError naming the unknown key' do
-        expect { described_instance.diff_full('HEAD', nil, bogus: true) }
-          .to raise_error(ArgumentError, /Unknown options: bogus/)
+      it 'passes no positional arguments to the command' do
+        expect(diff_command).to receive(:call).with(
+          patch: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_result)
+        subject
       end
     end
 
     context 'when the command output includes numstat/shortstat lines before the patch' do
       let(:combined_output) { "1\t2\tlib/foo.rb\n 1 file changed, 1 insertion(+)\n#{patch_text}" }
-      let(:diff_result) { command_result(combined_output) }
-
-      before do
-        allow(diff_command).to receive(:call).with(
-          'HEAD',
-          patch: true, numstat: true, shortstat: true,
-          src_prefix: 'a/', dst_prefix: 'b/',
-          path: nil
-        ).and_return(diff_result)
-      end
 
       it 'strips the numstat/shortstat lines and returns only the patch text' do
-        expect(described_instance.diff_full).to eq(patch_text)
+        allow(diff_command).to receive(:call).and_return(command_result(combined_output))
+        is_expected.to eq(patch_text)
       end
     end
 
     context 'when the command output does not contain "diff --git" (no changes)' do
-      let(:diff_result) { command_result('') }
-
-      before do
-        allow(diff_command).to receive(:call).with(
-          'HEAD',
-          patch: true, numstat: true, shortstat: true,
-          src_prefix: 'a/', dst_prefix: 'b/',
-          path: nil
-        ).and_return(diff_result)
-      end
-
       it 'returns the output unchanged' do
-        expect(described_instance.diff_full).to eq('')
+        allow(diff_command).to receive(:call).and_return(command_result(''))
+        is_expected.to eq('')
+      end
+    end
+
+    context 'when an unknown option is provided' do
+      let(:opts) { { bogus: true } }
+
+      it 'raises an ArgumentError naming the unknown key' do
+        expect { subject }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+
+    context 'when path_limiter contains an invalid type' do
+      let(:opts) { { path_limiter: 123 } }
+
+      it 'raises an ArgumentError naming the path limiter' do
+        expect { subject }.to raise_error(ArgumentError, /Invalid path limiter/)
+      end
+    end
+
+    context 'when obj1 is nil but obj2 is not' do
+      let(:obj1) { nil }
+      let(:obj2) { 'def5678' }
+
+      it 'raises an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError, /obj1 is nil but obj2 is not/)
       end
     end
   end
 
   describe '#diff_numstat' do
+    subject(:result) { described_instance.diff_numstat(obj1, obj2, **opts) }
+
+    let(:obj1) { 'HEAD' }
+    let(:obj2) { nil }
+    let(:opts) { {} }
+
     # Multi-file numstat stdout fixture; includes an empty line between numstat
-    # entries to exercise the l.empty? branch inside extract_numstat_lines.
+    # entries to verify that blank lines in command output are handled correctly.
     let(:numstat_stdout) do
       "5\t2\tlib/foo.rb\n\n3\t1\tlib/bar.rb\n 2 files changed, 8 insertions(+), 3 deletions(-)\n"
     end
 
-    let(:diff_numstat_result) { command_result(numstat_stdout) }
+    let(:diff_result) { command_result(numstat_stdout) }
 
     context 'when called with default arguments' do
       it 'calls the command with HEAD and numstat format options' do
@@ -219,18 +235,13 @@ RSpec.describe Git::Repository::Diffing do
           numstat: true, shortstat: true,
           src_prefix: 'a/', dst_prefix: 'b/',
           path: nil
-        ).and_return(diff_numstat_result)
-        described_instance.diff_numstat
+        ).and_return(diff_result)
+        subject
       end
 
       it 'returns a hash with per-file stats and aggregated totals' do
-        allow(diff_command).to receive(:call).with(
-          'HEAD',
-          numstat: true, shortstat: true,
-          src_prefix: 'a/', dst_prefix: 'b/',
-          path: nil
-        ).and_return(diff_numstat_result)
-        expect(described_instance.diff_numstat).to eq(
+        allow(diff_command).to receive(:call).and_return(diff_result)
+        is_expected.to eq(
           total: { insertions: 8, deletions: 3, lines: 11, files: 2 },
           files: {
             'lib/foo.rb' => { insertions: 5, deletions: 2 },
@@ -241,117 +252,121 @@ RSpec.describe Git::Repository::Diffing do
     end
 
     context 'when called with explicit obj1 and obj2' do
+      let(:obj1) { 'abc1234' }
+      let(:obj2) { 'def5678' }
+
       it 'passes both refs as positional arguments to the command' do
         expect(diff_command).to receive(:call).with(
           'abc1234', 'def5678',
           numstat: true, shortstat: true,
           src_prefix: 'a/', dst_prefix: 'b/',
           path: nil
-        ).and_return(diff_numstat_result)
-        described_instance.diff_numstat('abc1234', 'def5678')
+        ).and_return(diff_result)
+        subject
       end
     end
 
     context 'when called with only obj1' do
+      let(:obj1) { 'abc1234' }
+
       it 'passes only obj1 as a positional argument to the command' do
         expect(diff_command).to receive(:call).with(
           'abc1234',
           numstat: true, shortstat: true,
           src_prefix: 'a/', dst_prefix: 'b/',
           path: nil
-        ).and_return(diff_numstat_result)
-        described_instance.diff_numstat('abc1234')
+        ).and_return(diff_result)
+        subject
       end
     end
 
     context 'when path_limiter is a single String' do
+      let(:opts) { { path_limiter: 'lib/' } }
+
       it 'wraps the path_limiter in an Array and forwards it to the command' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
           numstat: true, shortstat: true,
           src_prefix: 'a/', dst_prefix: 'b/',
           path: ['lib/']
-        ).and_return(diff_numstat_result)
-        described_instance.diff_numstat('HEAD', nil, path_limiter: 'lib/')
+        ).and_return(diff_result)
+        subject
       end
     end
 
     context 'when path_limiter is an Array of paths' do
+      let(:opts) { { path_limiter: ['lib/', 'spec/'] } }
+
       it 'forwards the Array as-is to the command' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
           numstat: true, shortstat: true,
           src_prefix: 'a/', dst_prefix: 'b/',
           path: ['lib/', 'spec/']
-        ).and_return(diff_numstat_result)
-        described_instance.diff_numstat('HEAD', nil, path_limiter: ['lib/', 'spec/'])
+        ).and_return(diff_result)
+        subject
       end
     end
 
     context 'when path_limiter is a Pathname' do
+      let(:opts) { { path_limiter: Pathname.new('lib/') } }
+
       it 'converts the Pathname to a String and forwards it to the command' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
           numstat: true, shortstat: true,
           src_prefix: 'a/', dst_prefix: 'b/',
           path: ['lib/']
-        ).and_return(diff_numstat_result)
-        described_instance.diff_numstat('HEAD', nil, path_limiter: Pathname.new('lib/'))
+        ).and_return(diff_result)
+        subject
       end
     end
 
     context 'when path_limiter is nil' do
+      let(:opts) { { path_limiter: nil } }
+
       it 'sends path: nil to the command' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
           numstat: true, shortstat: true,
           src_prefix: 'a/', dst_prefix: 'b/',
           path: nil
-        ).and_return(diff_numstat_result)
-        described_instance.diff_numstat('HEAD', nil, path_limiter: nil)
+        ).and_return(diff_result)
+        subject
       end
     end
 
     context 'when path_limiter is an empty String' do
+      let(:opts) { { path_limiter: '' } }
+
       it 'normalizes to nil and sends path: nil to the command' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
           numstat: true, shortstat: true,
           src_prefix: 'a/', dst_prefix: 'b/',
           path: nil
-        ).and_return(diff_numstat_result)
-        described_instance.diff_numstat('HEAD', nil, path_limiter: '')
+        ).and_return(diff_result)
+        subject
       end
     end
 
-    context 'when an unknown option is provided' do
-      it 'raises an ArgumentError naming the unknown key' do
-        expect { described_instance.diff_numstat('HEAD', nil, bogus: true) }
-          .to raise_error(ArgumentError, /Unknown options: bogus/)
-      end
-    end
+    context 'when obj1 is nil and obj2 is nil' do
+      let(:obj1) { nil }
 
-    context 'when obj1 is nil but obj2 is not' do
-      it 'raises an ArgumentError' do
-        expect { described_instance.diff_numstat(nil, 'def5678') }
-          .to raise_error(ArgumentError, /obj1 is nil but obj2 is not/)
+      it 'passes no positional arguments to the command' do
+        expect(diff_command).to receive(:call).with(
+          numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_result)
+        subject
       end
     end
 
     context 'when the command output is empty (no changed files)' do
-      let(:diff_numstat_result) { command_result('') }
-
-      before do
-        allow(diff_command).to receive(:call).with(
-          'HEAD',
-          numstat: true, shortstat: true,
-          src_prefix: 'a/', dst_prefix: 'b/',
-          path: nil
-        ).and_return(diff_numstat_result)
-      end
-
       it 'returns zero totals and an empty files hash' do
-        expect(described_instance.diff_numstat).to eq(
+        allow(diff_command).to receive(:call).and_return(command_result(''))
+        is_expected.to eq(
           total: { insertions: 0, deletions: 0, lines: 0, files: 0 },
           files: {}
         )
@@ -364,25 +379,46 @@ RSpec.describe Git::Repository::Diffing do
       let(:quoted_stdout) do
         "5\t2\t\"\\303\\251tat.rb\"\n 1 file changed, 5 insertions(+), 2 deletions(-)\n"
       end
-      let(:diff_numstat_result) { command_result(quoted_stdout) }
-
-      before do
-        allow(diff_command).to receive(:call).with(
-          'HEAD',
-          numstat: true, shortstat: true,
-          src_prefix: 'a/', dst_prefix: 'b/',
-          path: nil
-        ).and_return(diff_numstat_result)
-      end
 
       it 'unescapes the git-quoted path in the returned files hash' do
-        result = described_instance.diff_numstat
+        allow(diff_command).to receive(:call).and_return(command_result(quoted_stdout))
         expect(result[:files]).to have_key('état.rb')
+      end
+    end
+
+    context 'when an unknown option is provided' do
+      let(:opts) { { bogus: true } }
+
+      it 'raises an ArgumentError naming the unknown key' do
+        expect { subject }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+
+    context 'when path_limiter contains an invalid type' do
+      let(:opts) { { path_limiter: 123 } }
+
+      it 'raises an ArgumentError naming the path limiter' do
+        expect { subject }.to raise_error(ArgumentError, /Invalid path limiter/)
+      end
+    end
+
+    context 'when obj1 is nil but obj2 is not' do
+      let(:obj1) { nil }
+      let(:obj2) { 'def5678' }
+
+      it 'raises an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError, /obj1 is nil but obj2 is not/)
       end
     end
   end
 
   describe '#diff_path_status' do
+    subject(:result) { described_instance.diff_path_status(from, to, **opts) }
+
+    let(:from) { 'HEAD' }
+    let(:to) { nil }
+    let(:opts) { {} }
+
     let(:raw_output) do
       ":100644 100644 abc1234 def5678 M\tlib/foo.rb\n" \
         ":000000 100644 0000000 abc1234 A\tREADME.md\n"
@@ -391,15 +427,6 @@ RSpec.describe Git::Repository::Diffing do
     let(:diff_result) { command_result(raw_output) }
 
     context 'when called with default arguments' do
-      before do
-        allow(diff_command).to receive(:call).with(
-          'HEAD',
-          raw: true, numstat: true, shortstat: true,
-          src_prefix: 'a/', dst_prefix: 'b/',
-          path: nil
-        ).and_return(diff_result)
-      end
-
       it 'calls the command with the default ref and raw format options' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
@@ -407,17 +434,20 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: nil
         ).and_return(diff_result)
-        described_instance.diff_path_status
+        subject
       end
 
       it 'returns a Git::DiffPathStatus with the parsed name-status data' do
-        result = described_instance.diff_path_status
+        allow(diff_command).to receive(:call).and_return(diff_result)
         expect(result).to be_a(Git::DiffPathStatus)
         expect(result.to_h).to eq('lib/foo.rb' => 'M', 'README.md' => 'A')
       end
     end
 
     context 'when called with explicit from and to refs' do
+      let(:from) { 'abc1234' }
+      let(:to) { 'def5678' }
+
       it 'passes both refs as positional arguments to the command' do
         expect(diff_command).to receive(:call).with(
           'abc1234', 'def5678',
@@ -425,11 +455,13 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: nil
         ).and_return(diff_result)
-        described_instance.diff_path_status('abc1234', 'def5678')
+        subject
       end
     end
 
     context 'when called with only the from ref' do
+      let(:from) { 'abc1234' }
+
       it 'passes only the from ref as a positional argument to the command' do
         expect(diff_command).to receive(:call).with(
           'abc1234',
@@ -437,11 +469,13 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: nil
         ).and_return(diff_result)
-        described_instance.diff_path_status('abc1234')
+        subject
       end
     end
 
     context 'when path_limiter is a single String' do
+      let(:opts) { { path_limiter: 'lib/' } }
+
       it 'wraps the path_limiter in an Array and forwards it to the command' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
@@ -449,11 +483,13 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: ['lib/']
         ).and_return(diff_result)
-        described_instance.diff_path_status('HEAD', nil, path_limiter: 'lib/')
+        subject
       end
     end
 
     context 'when path_limiter is an Array of paths' do
+      let(:opts) { { path_limiter: ['lib/', 'spec/'] } }
+
       it 'forwards the Array as-is to the command' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
@@ -461,11 +497,13 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: ['lib/', 'spec/']
         ).and_return(diff_result)
-        described_instance.diff_path_status('HEAD', nil, path_limiter: ['lib/', 'spec/'])
+        subject
       end
     end
 
     context 'when path_limiter is a Pathname' do
+      let(:opts) { { path_limiter: Pathname.new('lib/') } }
+
       it 'converts the Pathname to a String and forwards it to the command' do
         expect(diff_command).to receive(:call).with(
           'HEAD',
@@ -473,11 +511,94 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: ['lib/']
         ).and_return(diff_result)
-        described_instance.diff_path_status('HEAD', nil, path_limiter: Pathname.new('lib/'))
+        subject
+      end
+    end
+
+    context 'when path_limiter is nil' do
+      let(:opts) { { path_limiter: nil } }
+
+      it 'sends path: nil to the command' do
+        expect(diff_command).to receive(:call).with(
+          'HEAD',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_result)
+        subject
+      end
+    end
+
+    context 'when path_limiter is an empty String' do
+      let(:opts) { { path_limiter: '' } }
+
+      it 'normalizes to nil and sends path: nil to the command' do
+        expect(diff_command).to receive(:call).with(
+          'HEAD',
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_result)
+        subject
+      end
+    end
+
+    context 'when the raw output contains a rename' do
+      let(:rename_output) do
+        ":100644 100644 abc1234 def5678 R100\told.rb\tnew.rb\n"
+      end
+
+      it 'uses the destination path as the key' do
+        allow(diff_command).to receive(:call).and_return(command_result(rename_output))
+        expect(result.to_h).to eq('new.rb' => 'R100')
+      end
+    end
+
+    context 'when the raw output contains non-raw-diff header lines' do
+      let(:mixed_output) do
+        "1\t0\tlib/foo.rb\n" \
+          ":100644 100644 abc1234 def5678 M\tlib/foo.rb\n"
+      end
+
+      it 'skips non-raw-diff lines and parses only raw-diff lines' do
+        allow(diff_command).to receive(:call).and_return(command_result(mixed_output))
+        expect(result.to_h).to eq('lib/foo.rb' => 'M')
+      end
+    end
+
+    context 'when the raw output contains a git-quoted path' do
+      let(:quoted_output) { ":000000 100644 0000000 abc1234 A\t\"new_file.rb\"\n" }
+
+      it 'unescapes the git-quoted path' do
+        allow(diff_command).to receive(:call).and_return(command_result(quoted_output))
+        expect(result.to_h).to eq('new_file.rb' => 'A')
+      end
+    end
+
+    context 'when from is nil and to is nil' do
+      let(:from) { nil }
+
+      it 'passes no positional arguments to the command' do
+        expect(diff_command).to receive(:call).with(
+          raw: true, numstat: true, shortstat: true,
+          src_prefix: 'a/', dst_prefix: 'b/',
+          path: nil
+        ).and_return(diff_result)
+        subject
+      end
+    end
+
+    context 'when an unknown option is provided' do
+      let(:opts) { { bogus: true } }
+
+      it 'raises an ArgumentError naming the unknown key' do
+        expect { subject }.to raise_error(ArgumentError, /Unknown options: bogus/)
       end
     end
 
     context 'when the deprecated :path option is provided' do
+      let(:opts) { { path: 'lib/' } }
+
       before do
         allow(diff_command).to receive(:call).with(
           'HEAD',
@@ -492,7 +613,7 @@ RSpec.describe Git::Repository::Diffing do
         expect(Git::Deprecation).to receive(:warn).with(
           'Git::Repository#diff_path_status :path option is deprecated. Use :path_limiter instead.'
         )
-        described_instance.diff_path_status('HEAD', nil, path: 'lib/')
+        subject
       end
 
       it 'uses the :path value as the path limiter' do
@@ -502,11 +623,13 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: ['lib/']
         ).and_return(diff_result)
-        described_instance.diff_path_status('HEAD', nil, path: 'lib/')
+        subject
       end
     end
 
     context 'when both :path_limiter and :path are provided' do
+      let(:opts) { { path_limiter: 'lib/', path: 'other/' } }
+
       it 'uses :path_limiter and does not emit a deprecation warning' do
         expect(Git::Deprecation).not_to receive(:warn)
         expect(diff_command).to receive(:call).with(
@@ -515,163 +638,200 @@ RSpec.describe Git::Repository::Diffing do
           src_prefix: 'a/', dst_prefix: 'b/',
           path: ['lib/']
         ).and_return(diff_result)
-        described_instance.diff_path_status('HEAD', nil, path_limiter: 'lib/', path: 'other/')
+        subject
       end
     end
 
-    context 'when an unknown option is provided' do
-      it 'raises an ArgumentError naming the unknown key' do
-        expect { described_instance.diff_path_status('HEAD', nil, bogus: true) }
-          .to raise_error(ArgumentError, /Unknown options: bogus/)
+    context 'when path_limiter contains an invalid type' do
+      let(:opts) { { path_limiter: 123 } }
+
+      it 'raises an ArgumentError naming the path limiter' do
+        expect { subject }.to raise_error(ArgumentError, /Invalid path limiter/)
       end
     end
 
     context 'when from is nil but to is not' do
+      let(:from) { nil }
+      let(:to) { 'def5678' }
+
       it 'raises an ArgumentError' do
-        expect { described_instance.diff_path_status(nil, 'def5678') }
-          .to raise_error(ArgumentError, /`from` is nil but `to` is not/)
-      end
-    end
-
-    context 'when the raw output contains a rename' do
-      let(:rename_output) do
-        ":100644 100644 abc1234 def5678 R100\told.rb\tnew.rb\n"
-      end
-      let(:diff_result) { command_result(rename_output) }
-
-      before do
-        allow(diff_command).to receive(:call).with(
-          'HEAD',
-          raw: true, numstat: true, shortstat: true,
-          src_prefix: 'a/', dst_prefix: 'b/',
-          path: nil
-        ).and_return(diff_result)
-      end
-
-      it 'uses the destination path as the key' do
-        result = described_instance.diff_path_status
-        expect(result.to_h).to eq('new.rb' => 'R100')
-      end
-    end
-
-    context 'when the raw output contains non-raw-diff header lines' do
-      let(:mixed_output) do
-        "1\t0\tlib/foo.rb\n" \
-          ":100644 100644 abc1234 def5678 M\tlib/foo.rb\n"
-      end
-      let(:diff_result) { command_result(mixed_output) }
-
-      before do
-        allow(diff_command).to receive(:call).with(
-          'HEAD',
-          raw: true, numstat: true, shortstat: true,
-          src_prefix: 'a/', dst_prefix: 'b/',
-          path: nil
-        ).and_return(diff_result)
-      end
-
-      it 'skips non-raw-diff lines and parses only raw-diff lines' do
-        result = described_instance.diff_path_status
-        expect(result.to_h).to eq('lib/foo.rb' => 'M')
-      end
-    end
-
-    context 'when the raw output contains a git-quoted path' do
-      let(:quoted_output) { ":000000 100644 0000000 abc1234 A\t\"new_file.rb\"\n" }
-      let(:diff_result) { command_result(quoted_output) }
-
-      before do
-        allow(diff_command).to receive(:call).with(
-          'HEAD',
-          raw: true, numstat: true, shortstat: true,
-          src_prefix: 'a/', dst_prefix: 'b/',
-          path: nil
-        ).and_return(diff_result)
-      end
-
-      it 'unescapes the git-quoted path' do
-        result = described_instance.diff_path_status
-        expect(result.to_h).to eq('new_file.rb' => 'A')
+        expect { subject }.to raise_error(ArgumentError, /`from` is nil but `to` is not/)
       end
     end
   end
 
   describe '#diff_name_status' do
-    it 'returns the same result as diff_path_status when called with the same arguments' do
-      allow(diff_command).to receive(:call).and_return(command_result)
-      expect(described_instance.diff_name_status.to_h).to eq(
-        described_instance.diff_path_status.to_h
-      )
+    subject(:result) { described_instance.diff_name_status }
+
+    let(:raw_output) { ":100644 100644 abc1234 def5678 M\tlib/foo.rb\n" }
+    let(:diff_result) { command_result(raw_output) }
+
+    it 'delegates to the diff command with the default ref and raw format options' do
+      expect(diff_command).to receive(:call).with(
+        'HEAD',
+        raw: true, numstat: true, shortstat: true,
+        src_prefix: 'a/', dst_prefix: 'b/',
+        path: nil
+      ).and_return(diff_result)
+      subject
+    end
+
+    it 'returns a Git::DiffPathStatus' do
+      allow(diff_command).to receive(:call).and_return(diff_result)
+      expect(result).to be_a(Git::DiffPathStatus)
     end
   end
 
   describe '#diff_stats' do
+    subject(:result) { described_instance.diff_stats(obj1, obj2, **opts) }
+
+    let(:obj1) { 'HEAD' }
+    let(:obj2) { nil }
+    let(:opts) { {} }
+
     let(:diff_stats_instance) { instance_double(Git::DiffStats) }
 
     context 'when called with default arguments' do
-      before do
-        allow(Git::DiffStats).to receive(:new).and_return(diff_stats_instance)
-      end
-
       it 'constructs a Git::DiffStats with self, HEAD, nil, and no path limiter' do
         expect(Git::DiffStats).to receive(:new)
           .with(described_instance, 'HEAD', nil, nil)
           .and_return(diff_stats_instance)
-        described_instance.diff_stats
+        subject
       end
 
       it 'returns the Git::DiffStats instance' do
-        expect(described_instance.diff_stats).to be(diff_stats_instance)
+        allow(Git::DiffStats).to receive(:new).and_return(diff_stats_instance)
+        is_expected.to be(diff_stats_instance)
       end
     end
 
     context 'when called with explicit obj1 and obj2' do
+      let(:obj1) { 'abc1234' }
+      let(:obj2) { 'def5678' }
+
       it 'passes both refs to Git::DiffStats.new' do
         expect(Git::DiffStats).to receive(:new)
           .with(described_instance, 'abc1234', 'def5678', nil)
           .and_return(diff_stats_instance)
-        described_instance.diff_stats('abc1234', 'def5678')
+        subject
       end
     end
 
     context 'when called with only obj1' do
+      let(:obj1) { 'abc1234' }
+
       it 'passes obj1 and nil as obj2 to Git::DiffStats.new' do
         expect(Git::DiffStats).to receive(:new)
           .with(described_instance, 'abc1234', nil, nil)
           .and_return(diff_stats_instance)
-        described_instance.diff_stats('abc1234')
+        subject
       end
     end
 
     context 'when path_limiter is a String' do
+      let(:opts) { { path_limiter: 'lib/' } }
+
       it 'passes the path_limiter to Git::DiffStats.new' do
         expect(Git::DiffStats).to receive(:new)
           .with(described_instance, 'HEAD', nil, 'lib/')
           .and_return(diff_stats_instance)
-        described_instance.diff_stats('HEAD', nil, path_limiter: 'lib/')
+        subject
       end
     end
 
     context 'when path_limiter is nil' do
+      let(:opts) { { path_limiter: nil } }
+
       it 'passes nil as path_limiter to Git::DiffStats.new' do
         expect(Git::DiffStats).to receive(:new)
           .with(described_instance, 'HEAD', nil, nil)
           .and_return(diff_stats_instance)
-        described_instance.diff_stats('HEAD', nil, path_limiter: nil)
+        subject
+      end
+    end
+
+    context 'when obj1 is nil and obj2 is nil' do
+      let(:obj1) { nil }
+
+      it 'constructs Git::DiffStats with self, nil, nil, and no path limiter' do
+        expect(Git::DiffStats).to receive(:new)
+          .with(described_instance, nil, nil, nil)
+          .and_return(diff_stats_instance)
+        subject
       end
     end
 
     context 'when an unknown option is provided' do
+      let(:opts) { { bogus: true } }
+
       it 'raises an ArgumentError naming the unknown key' do
-        expect { described_instance.diff_stats('HEAD', nil, bogus: true) }
-          .to raise_error(ArgumentError, /Unknown options: bogus/)
+        expect { subject }.to raise_error(ArgumentError, /Unknown options: bogus/)
       end
     end
 
     context 'when obj1 is nil but obj2 is not' do
+      let(:obj1) { nil }
+      let(:obj2) { 'def5678' }
+
       it 'raises an ArgumentError' do
-        expect { described_instance.diff_stats(nil, 'def5678') }
-          .to raise_error(ArgumentError, /obj1 is nil but obj2 is not/)
+        expect { subject }.to raise_error(ArgumentError, /obj1 is nil but obj2 is not/)
+      end
+    end
+  end
+
+  describe '#diff' do
+    subject(:result) { described_instance.diff(obj1, obj2) }
+
+    let(:obj1) { 'HEAD' }
+    let(:obj2) { nil }
+
+    let(:diff_instance) { instance_double(Git::Diff) }
+
+    context 'when called with default arguments' do
+      it 'constructs a Git::Diff with self, HEAD, and nil' do
+        expect(Git::Diff).to receive(:new)
+          .with(described_instance, 'HEAD', nil)
+          .and_return(diff_instance)
+        subject
+      end
+
+      it 'returns the Git::Diff instance' do
+        allow(Git::Diff).to receive(:new).and_return(diff_instance)
+        is_expected.to be(diff_instance)
+      end
+    end
+
+    context 'when called with explicit obj1 and obj2' do
+      let(:obj1) { 'abc1234' }
+      let(:obj2) { 'def5678' }
+
+      it 'passes both refs to Git::Diff.new' do
+        expect(Git::Diff).to receive(:new)
+          .with(described_instance, 'abc1234', 'def5678')
+          .and_return(diff_instance)
+        subject
+      end
+    end
+
+    context 'when called with only obj1' do
+      let(:obj1) { 'abc1234' }
+
+      it 'passes obj1 and nil as obj2 to Git::Diff.new' do
+        expect(Git::Diff).to receive(:new)
+          .with(described_instance, 'abc1234', nil)
+          .and_return(diff_instance)
+        subject
+      end
+    end
+
+    context 'when called with nil obj1' do
+      let(:obj1) { nil }
+
+      it 'constructs Git::Diff with self, nil, and nil' do
+        expect(Git::Diff).to receive(:new)
+          .with(described_instance, nil, nil)
+          .and_return(diff_instance)
+        subject
       end
     end
   end

--- a/tests/units/test_diff.rb
+++ b/tests/units/test_diff.rb
@@ -61,7 +61,14 @@ class TestDiff < Test::Unit::TestCase
   end
 
   def test_diff_path_empty_array
-    @git.lib.expects(:diff_full).with('gitsearch1', 'v2.5', { path_limiter: nil }).returns('')
+    status = Struct.new(:success?, :exitstatus) { def exitstatus = 0 }.new(true)
+    result = Git::CommandLineResult.new(%w[git diff], status, '', '')
+    diff_cmd = mock('diff_cmd')
+    Git::Commands::Diff.expects(:new).with(instance_of(Git::ExecutionContext::Repository)).returns(diff_cmd)
+    diff_cmd.expects(:call).with('gitsearch1', 'v2.5',
+                                 patch: true, numstat: true, shortstat: true,
+                                 src_prefix: 'a/', dst_prefix: 'b/',
+                                 path: nil).returns(result)
 
     d = @git.diff('gitsearch1', 'v2.5').path
     d.patch

--- a/tests/units/test_diff_path_status.rb
+++ b/tests/units/test_diff_path_status.rb
@@ -66,8 +66,8 @@ class TestDiffPathStatus < Test::Unit::TestCase
   def test_path_status_with_empty_path_array
     status = Struct.new(:success?, :exitstatus) { def exitstatus = 0 }.new(true)
     result = Git::CommandLineResult.new(%w[git diff], status, '', '')
-    diff_cmd = Git::Commands::Diff.new(@git.lib)
-    Git::Commands::Diff.expects(:new).with(@git.lib).returns(diff_cmd)
+    diff_cmd = mock('diff_cmd')
+    Git::Commands::Diff.expects(:new).with(instance_of(Git::ExecutionContext::Repository)).returns(diff_cmd)
     diff_cmd.expects(:call).with('gitsearch1', 'v2.5',
                                  raw: true, numstat: true, shortstat: true,
                                  src_prefix: 'a/', dst_prefix: 'b/',


### PR DESCRIPTION
## Summary

Completes the Strangler Fig migration of `Git::Diff` (and its supporting classes) so that `Git::Base#diff` now routes through the `Git::Repository` facade. This is the second PR in the iter 5 Phase B series (the first, which migrated `Git::DiffStats`, has already been merged).

## Changes

### `lib/git/diff_path_status.rb` — constructor polymorphism

`DiffPathStatus#fetch_path_status` now detects whether `@base` responds to `#diff_name_status` (i.e. is a `Git::Repository`) and calls it directly instead of going through the legacy `@base.lib.diff_path_status(...)`. Mirrors the identical pattern already used in `Git::DiffStats#fetch_stats`.

### `lib/git/diff.rb` — `#patch` polymorphism

`Git::Diff#patch` now detects whether `@base` responds to `#diff_full` (i.e. is a `Git::Repository`) and calls `@base.diff_full(from, to, path_limiter: @path)` directly. After this change, all four `Git::Diff` data paths work correctly when the base is a `Git::Repository`:

| Path | Method | Already worked? |
|---|---|---|
| `#patch` | `diff_full` | ❌ → fixed here |
| `#path_status_provider` | `diff_name_status` via `DiffPathStatus` | ❌ → fixed above |
| `#stats_provider` | `diff_numstat` via `DiffStats` | ✅ already polymorphic |
| `DiffFile#blob` | `object(sha)` | ✅ already exists on facade |

### `lib/git/repository/diffing.rb` — `#diff` factory

Adds `Git::Repository::Diffing#diff(obj1 = 'HEAD', obj2 = nil)` which constructs a `Git::Diff` with `self` (the `Git::Repository`) as base.

### `lib/git/base.rb` — delegation

`Git::Base#diff` now delegates to `facade_repository.diff(objectish, obj2)` — a one-liner matching the delegation pattern established for `diff_stats` and other migrated methods.

## Tests

- **New** `spec/unit/git/diff_path_status_spec.rb` — unit tests for both `Git::Repository` and legacy routing paths, path_limiter forwarding, and memoization
- **New** `spec/unit/git/diff_spec.rb` — unit tests for `#patch` in both `Git::Repository` and legacy contexts
- **Extended** `spec/unit/git/repository/diffing_spec.rb` — `describe '#diff'` group covering factory construction and delegation
- **Extended** `spec/unit/git/base_spec.rb` — verifies `Base#diff` delegates to `facade_repository.diff`
- Existing `tests/units/test_diff.rb` and `test_diff_path_status.rb` integration tests continue to pass end-to-end