### PR TITLE
feat(repository): add Git::Repository::Diffing#diff_files facade method

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1166,6 +1166,22 @@ module Git
       facade_repository.diff_path_status(objectish, obj2, opts.slice(:path_limiter, :path))
     end
 
+    # Compares the index and the working directory
+    #
+    # @example List all files with unstaged changes
+    #   repo.diff_files #=> { "lib/foo.rb" => { mode_index: "100644", ... } }
+    #
+    # @return [Hash{String => Hash}] a hash keyed by file path; see
+    #   {Git::Repository::Diffing#diff_files} for the full key list
+    #
+    # @raise [Git::FailedError] if git exits outside the allowed range (exit code > 1)
+    #
+    # @see Git::Repository::Diffing#diff_files
+    #
+    def diff_files
+      facade_repository.diff_files
+    end
+
     # Alias for {#diff_path_status}; provided for backward compatibility
     #
     # @return [Git::DiffPathStatus] the name-status report for the comparison

--- a/lib/git/repository/diffing.rb
+++ b/lib/git/repository/diffing.rb
@@ -2,6 +2,8 @@
 
 require 'pathname'
 require 'git/commands/diff'
+require 'git/commands/diff_files'
+require 'git/commands/status'
 require 'git/diff'
 require 'git/diff_path_status'
 require 'git/diff_stats'
@@ -378,6 +380,52 @@ module Git
       # @see #diff_path_status
       alias diff_name_status diff_path_status
 
+      # Compares the index and the working directory
+      #
+      # Runs `git diff-files` to list files that differ between the index
+      # (staging area) and the working directory. These are changes that have
+      # been made to tracked files but not yet staged.
+      #
+      # @note The field names in the returned hash are **legacy names** inherited
+      #   from `Git::Lib#diff_files` and appear counterintuitive: `:mode_repo`
+      #   and `:sha_repo` hold **index (staging area)** values, while
+      #   `:mode_index` and `:sha_index` hold **working tree** values.
+      #
+      # @example List all files with unstaged changes
+      #   repo.diff_files
+      #   #=> {
+      #   #     "lib/foo.rb" => {
+      #   #       mode_index: "100644", mode_repo: "100644",
+      #   #       path: "lib/foo.rb", sha_repo: "abc1234",
+      #   #       sha_index: "0000000000000000000000000000000000000000",
+      #   #       type: "M"
+      #   #     }
+      #   #   }
+      #
+      # @return [Hash{String => Hash}] a hash keyed by file path
+      #
+      #   Each value is a hash with the following keys (note the legacy naming
+      #   where `:*_repo` holds index data and `:*_index` holds working tree data):
+      #
+      #   * `:mode_index` [String] the working tree file mode (legacy name)
+      #   * `:mode_repo`  [String] the index (staging area) file mode (legacy name)
+      #   * `:path`       [String] the file path
+      #   * `:sha_repo`   [String] the SHA of the object in the index (staging area) (legacy name)
+      #   * `:sha_index`  [String] the SHA of the object in the working tree; all
+      #     zeros when git has not computed the working tree blob SHA (legacy name)
+      #   * `:type`       [String] the status code (e.g. `"M"`, `"A"`, `"D"`)
+      #
+      # @raise [Git::FailedError] if git exits outside the allowed range (exit code > 1)
+      #
+      # @see https://git-scm.com/docs/git-diff-files git-diff-files documentation
+      #
+      def diff_files
+        Git::Commands::Status.new(@execution_context).call
+        Private.parse_diff_files_output(
+          Git::Commands::DiffFiles.new(@execution_context).call.stdout
+        )
+      end
+
       # Private helpers local to {Git::Repository::Diffing}
       #
       # @api private
@@ -484,6 +532,66 @@ module Git
           return if pathspecs.all? { |p| p.is_a?(String) || p.is_a?(Pathname) }
 
           raise ArgumentError, "Invalid #{arg_name}: must be a String, Pathname, or Array of Strings/Pathnames"
+        end
+
+        # Parses raw `git diff-files` output into a file-keyed hash
+        #
+        # Each output line has the format:
+        #   `:old_mode new_mode old_sha new_sha status\tpath`
+        #
+        # The leading colon on `old_mode` is stripped when building
+        # the `:mode_repo` value.
+        #
+        # @param stdout [String] raw stdout from {Git::Commands::DiffFiles#call}
+        #
+        # @return [Hash{String => Hash}] a hash keyed by file path where each
+        #   value has keys `:mode_index`, `:mode_repo`, `:path`, `:sha_repo`,
+        #   `:sha_index`, and `:type`
+        #
+        def parse_diff_files_output(stdout)
+          stdout.split("\n").each_with_object({}) do |line, memo|
+            next if line.empty?
+
+            tab_pos = line.index("\t")
+            next unless tab_pos
+
+            path, entry = parse_diff_files_line(line, tab_pos)
+            memo[path] = entry
+          end
+        end
+
+        # Parses a single raw `git diff-files` output line into a path/entry pair
+        #
+        # @param line [String] a single non-empty line containing a tab character
+        # @param tab_pos [Integer] the index of the first tab in the line
+        #
+        # @return [Array(String, Hash)] two-element array of `[path, entry_hash]`
+        #
+        def parse_diff_files_line(line, tab_pos)
+          path = unescape_quoted_path(line[(tab_pos + 1)..])
+          parts = line[0, tab_pos].split
+          [path, build_diff_files_entry(path, parts)]
+        end
+
+        # Builds a single file-info hash for {#parse_diff_files_output}
+        #
+        # @param path [String] the file path
+        # @param parts [Array<String>] the whitespace-split fields from the info
+        #   portion of the diff-files line: `[mode_src, mode_dest, sha_src,
+        #   sha_dest, type]`
+        #
+        # @return [Hash] entry hash with keys `:mode_index`, `:mode_repo`, `:path`,
+        #   `:sha_repo`, `:sha_index`, `:type`
+        #
+        def build_diff_files_entry(path, parts)
+          {
+            mode_index: parts[1],
+            mode_repo: parts[0].to_s[1, 7],
+            path: path,
+            sha_repo: parts[2],
+            sha_index: parts[3],
+            type: parts[4]
+          }
         end
 
         # Extracts name-status data from `--raw` diff output lines

--- a/spec/integration/git/repository/diffing_spec.rb
+++ b/spec/integration/git/repository/diffing_spec.rb
@@ -105,4 +105,59 @@ RSpec.describe Git::Repository::Diffing, :integration do
       end
     end
   end
+
+  describe '#diff_files' do
+    context 'when there are no unstaged changes' do
+      it 'returns an empty hash' do
+        result = described_instance.diff_files
+        expect(result).to eq({})
+      end
+    end
+
+    context 'when a tracked file has been modified but not staged' do
+      before do
+        write_file('README.md', "# Project\n\nModified but not staged.\n")
+      end
+
+      it 'returns an entry for the modified file with correct path, type, modes, and SHA markers' do
+        result = described_instance.diff_files
+        expect(result).to have_key('README.md')
+        entry = result['README.md']
+        expect(entry).to include(
+          path: 'README.md',
+          type: 'M',
+          mode_index: '100644',
+          mode_repo: '100644'
+        )
+        expect(entry[:sha_repo]).to match(/\A[0-9a-f]+\z/)
+        expect(entry[:sha_index]).to match(/\A0+\z/)
+      end
+    end
+
+    context 'when a tracked file is renamed in the working tree (unstaged)' do
+      # git diff-files only iterates over index entries — it has no visibility
+      # into untracked files. A working-tree rename therefore cannot produce a
+      # two-path "Rxx old_path\tnew_path" line; it shows the original path as
+      # deleted (D) and ignores the new untracked file entirely.
+      before do
+        FileUtils.mv(File.join(repo_dir, 'README.md'), File.join(repo_dir, 'RENAMED.md'))
+      end
+
+      it 'reports the original path as deleted, not as a rename entry' do
+        result = described_instance.diff_files
+        expect(result).to have_key('README.md')
+        expect(result['README.md']).to include(type: 'D')
+      end
+
+      it 'does not include the new path (it is untracked)' do
+        result = described_instance.diff_files
+        expect(result).not_to have_key('RENAMED.md')
+      end
+
+      it 'returns only one entry (no spurious two-path artefacts)' do
+        result = described_instance.diff_files
+        expect(result.size).to eq(1)
+      end
+    end
+  end
 end

--- a/spec/unit/git/repository/diffing_spec.rb
+++ b/spec/unit/git/repository/diffing_spec.rb
@@ -382,7 +382,7 @@ RSpec.describe Git::Repository::Diffing do
 
       it 'unescapes the git-quoted path in the returned files hash' do
         allow(diff_command).to receive(:call).and_return(command_result(quoted_stdout))
-        expect(result[:files]).to have_key('état.rb')
+        expect(result[:files]).to eq('état.rb' => { insertions: 5, deletions: 2 })
       end
     end
 
@@ -832,6 +832,106 @@ RSpec.describe Git::Repository::Diffing do
           .with(described_instance, nil, nil)
           .and_return(diff_instance)
         subject
+      end
+    end
+  end
+
+  describe '#diff_files' do
+    subject(:result) { described_instance.diff_files }
+
+    let(:status_command) { instance_double(Git::Commands::Status) }
+    let(:diff_files_command) { instance_double(Git::Commands::DiffFiles) }
+    let(:status_result) { command_result }
+    let(:diff_files_stdout) { '' }
+    let(:diff_files_result) { command_result(diff_files_stdout) }
+
+    before do
+      allow(Git::Commands::Status).to receive(:new).with(execution_context).and_return(status_command)
+      allow(status_command).to receive(:call).and_return(status_result)
+      allow(Git::Commands::DiffFiles).to receive(:new).with(execution_context).and_return(diff_files_command)
+      allow(diff_files_command).to receive(:call).and_return(diff_files_result)
+    end
+
+    it 'calls Git::Commands::Status#call before Git::Commands::DiffFiles#call' do
+      expect(status_command).to receive(:call).ordered
+      expect(diff_files_command).to receive(:call).ordered.and_return(diff_files_result)
+      subject
+    end
+
+    it 'calls Git::Commands::DiffFiles#call with no arguments' do
+      expect(diff_files_command).to receive(:call).with(no_args).and_return(diff_files_result)
+      subject
+    end
+
+    context 'when stdout is empty' do
+      it 'returns an empty hash' do
+        is_expected.to eq({})
+      end
+    end
+
+    context 'when stdout contains a single modified file' do
+      let(:diff_files_stdout) do
+        ":100644 100644 abc1234 def5678 M\tlib/foo.rb\n"
+      end
+
+      it 'returns a hash keyed by the file path with all expected fields' do
+        is_expected.to eq(
+          'lib/foo.rb' => {
+            mode_index: '100644',
+            mode_repo: '100644',
+            path: 'lib/foo.rb',
+            sha_repo: 'abc1234',
+            sha_index: 'def5678',
+            type: 'M'
+          }
+        )
+      end
+    end
+
+    context 'when stdout contains multiple files' do
+      let(:diff_files_stdout) do
+        ":100644 100644 abc1234 def5678 M\tlib/foo.rb\n" \
+          ":100644 100644 111aaaa 222bbbb A\tlib/bar.rb\n"
+      end
+
+      it 'returns an entry for each file' do
+        expect(result.keys).to contain_exactly('lib/foo.rb', 'lib/bar.rb')
+      end
+    end
+
+    context 'when stdout contains empty lines' do
+      let(:diff_files_stdout) do
+        ":100644 100644 abc1234 def5678 M\tlib/foo.rb\n" \
+          "\n" \
+          ":100644 100644 111aaaa 222bbbb A\tlib/bar.rb\n"
+      end
+
+      it 'skips empty lines and returns entries for non-empty lines only' do
+        expect(result.keys).to contain_exactly('lib/foo.rb', 'lib/bar.rb')
+      end
+    end
+
+    context 'when stdout contains a line without a tab character' do
+      let(:diff_files_stdout) do
+        "some-header-line-without-tab\n" \
+          ":100644 100644 abc1234 def5678 M\tlib/foo.rb\n"
+      end
+
+      it 'skips lines without a tab and returns only parseable lines' do
+        expect(result.keys).to contain_exactly('lib/foo.rb')
+      end
+    end
+
+    context 'when stdout contains a git-quoted non-ASCII path' do
+      # Git octal-encodes non-ASCII bytes; "\\303\\251" is the octal encoding
+      # of "é" (U+00E9, UTF-8 bytes: 0xC3 0xA9).
+      let(:diff_files_stdout) do
+        ":100644 100644 abc1234 def5678 M\t\"\\303\\251tat.rb\"\n"
+      end
+
+      it 'unescapes the quoted path in the hash key and :path value' do
+        expect(result).to have_key('état.rb')
+        expect(result['état.rb'][:path]).to eq('état.rb')
       end
     end
   end


### PR DESCRIPTION
## Description

Adds `Git::Repository::Diffing#diff_files` as the facade-layer equivalent of `Git::Lib#diff_files`. This is the first step of Phase 3 Iteration 6 (`feat/migrate-status-to-repository`) in the architectural redesign.

`diff_files` compares the working tree against the index and returns a hash keyed by file path, where each value contains `:mode_index`, `:mode_repo`, `:path`, `:sha_repo`, `:sha_index`, and `:type`.

`Git::Base#diff_files` now delegates to the facade. `Git::Lib#diff_files` is **not** modified — `Git::Status` continues to use it directly until the full Status migration in iter 6.

### Implementation

- `Git::Repository::Diffing#diff_files` — new public facade method; calls `Git::Commands::Status` (index refresh) then `Git::Commands::DiffFiles`, parses stdout via `Private.parse_diff_files_output`
- `Private.parse_diff_files_output` / `Private.parse_diff_files_line` / `Private.build_diff_files_entry` — new private helpers that split the raw `git diff-files` output into a file-keyed hash
- `Git::Base#diff_files` — delegates to `facade_repository.diff_files`

### Tests

- **81 examples, 0 failures** (65 unit + 16 integration)
- Unit tests cover: Status called before DiffFiles (ordered), empty stdout → `{}`, single/multiple files, empty/no-tab lines skipped, non-ASCII quoted paths unescaped
- Integration tests cover: no unstaged changes → `{}`; modified file → entry with all 6 keys; SHA format validated

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed.
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (YARD docs complete for all new public and private methods).