### PR TITLE
feat(repository): add Git::Repository#diff_index facade method

### DIFF
--- a/lib/git/repository/diffing.rb
+++ b/lib/git/repository/diffing.rb
@@ -3,6 +3,7 @@
 require 'pathname'
 require 'git/commands/diff'
 require 'git/commands/diff_files'
+require 'git/commands/diff_index'
 require 'git/commands/status'
 require 'git/diff'
 require 'git/diff_path_status'
@@ -423,6 +424,66 @@ module Git
         Git::Commands::Status.new(@execution_context).call
         Private.parse_diff_files_output(
           Git::Commands::DiffFiles.new(@execution_context).call.stdout
+        )
+      end
+
+      # Compares the working tree against the given tree object
+      #
+      # Runs `git diff-index <treeish>` (without `--cached`) to list files that
+      # differ between the given tree object (e.g. a commit or `"HEAD"`) and the
+      # working tree. The index is refreshed via `git status` first so that cached
+      # stat information is up to date.
+      #
+      # This is equivalent to the 4.x `Git::Lib#diff_index` behavior, which also
+      # ran `git diff-index` without `--cached`.
+      #
+      # @note `git diff-index` without `--cached` uses the index as a stat cache:
+      #   any file whose index entry differs from the tree is reported as changed,
+      #   even when the on-disk working-tree content is byte-for-byte identical to
+      #   the tree. A staged change that has been reverted in the working tree will
+      #   therefore still appear in the result (because the index still differs from
+      #   the tree).
+      #
+      # @note The field names in the returned hash are **legacy names** inherited
+      #   from `Git::Lib#diff_index` and appear counterintuitive: `:mode_repo`
+      #   and `:sha_repo` hold **tree (treeish)** values, while `:mode_index` and
+      #   `:sha_index` hold **working tree** values.
+      #
+      # @example List all working-tree files that differ from HEAD
+      #   repo.diff_index('HEAD')
+      #   #=> {
+      #   #     "lib/foo.rb" => {
+      #   #       mode_index: "100644", mode_repo: "100644",
+      #   #       path: "lib/foo.rb", sha_repo: "abc1234",
+      #   #       sha_index: "0000000000000000000000000000000000000000",
+      #   #       type: "M"
+      #   #     }
+      #   #   }
+      #
+      # @param treeish [String] the tree object to compare against (e.g. `'HEAD'`,
+      #   a commit SHA, or a tag name)
+      #
+      # @return [Hash{String => Hash}] a hash keyed by file path
+      #
+      #   Each value is a hash with the following keys (note the legacy naming
+      #   where `:*_repo` holds tree data and `:*_index` holds working tree data):
+      #
+      #   * `:mode_index` [String] the working tree file mode (legacy name)
+      #   * `:mode_repo`  [String] the tree (treeish) file mode (legacy name)
+      #   * `:path`       [String] the file path
+      #   * `:sha_repo`   [String] the SHA of the object in the tree (treeish) (legacy name)
+      #   * `:sha_index`  [String] the SHA of the object in the working tree; all
+      #     zeros when git has not yet computed the working tree blob SHA (legacy name)
+      #   * `:type`       [String] the status code (e.g. `"M"`, `"A"`, `"D"`)
+      #
+      # @raise [Git::FailedError] if git exits outside the allowed range (exit code > 1)
+      #
+      # @see https://git-scm.com/docs/git-diff-index git-diff-index documentation
+      #
+      def diff_index(treeish)
+        Git::Commands::Status.new(@execution_context).call
+        Private.parse_diff_files_output(
+          Git::Commands::DiffIndex.new(@execution_context).call(treeish).stdout
         )
       end
 

--- a/spec/integration/git/repository/diffing_spec.rb
+++ b/spec/integration/git/repository/diffing_spec.rb
@@ -160,4 +160,62 @@ RSpec.describe Git::Repository::Diffing, :integration do
       end
     end
   end
+
+  describe '#diff_index' do
+    context 'when the index matches HEAD (nothing staged)' do
+      it 'returns an empty hash' do
+        result = described_instance.diff_index('HEAD')
+        expect(result).to eq({})
+      end
+    end
+
+    context 'when a tracked file has been modified and staged' do
+      before do
+        write_file('README.md', "# Project\n\nStaged change.\n")
+        repo.add('README.md')
+      end
+
+      it 'returns an entry with all expected keys and correct values' do
+        result = described_instance.diff_index('HEAD')
+        entry = result['README.md']
+        expect(entry).to include(
+          path: 'README.md',
+          type: 'M',
+          mode_index: '100644',
+          mode_repo: '100644'
+        )
+        expect(entry[:sha_repo]).to match(/\A[0-9a-f]+\z/)
+        expect(entry[:sha_index]).to match(/\A[0-9a-f]+\z/)
+      end
+    end
+
+    context 'when a tracked file has been modified but NOT staged' do
+      before do
+        write_file('README.md', "# Project\n\nUnstaged change.\n")
+        # intentionally no repo.add — file is dirty but not staged
+      end
+
+      it 'still returns an entry for the modified file' do
+        result = described_instance.diff_index('HEAD')
+        expect(result).to have_key('README.md')
+        expect(result['README.md']).to include(path: 'README.md', type: 'M')
+      end
+    end
+
+    context 'when a file is staged then the working tree is reverted to match HEAD' do
+      before do
+        # Stage a change so the index differs from the tree
+        write_file('README.md', "# Project\n\nStaged change.\n")
+        repo.add('README.md')
+        # Revert the working-tree file to the HEAD content without unstaging
+        write_file('README.md', "# Project\n\nUpdated content.\n")
+      end
+
+      it 'still reports the file as changed because the index differs from the tree' do
+        result = described_instance.diff_index('HEAD')
+        expect(result).to have_key('README.md')
+        expect(result['README.md']).to include(path: 'README.md', type: 'M')
+      end
+    end
+  end
 end

--- a/spec/unit/git/repository/diffing_spec.rb
+++ b/spec/unit/git/repository/diffing_spec.rb
@@ -935,4 +935,82 @@ RSpec.describe Git::Repository::Diffing do
       end
     end
   end
+
+  describe '#diff_index' do
+    subject(:result) { described_instance.diff_index(treeish) }
+
+    let(:treeish) { 'HEAD' }
+    let(:status_command) { instance_double(Git::Commands::Status) }
+    let(:diff_index_command) { instance_double(Git::Commands::DiffIndex) }
+    let(:status_result) { command_result }
+    let(:diff_index_stdout) { '' }
+    let(:diff_index_result) { command_result(diff_index_stdout) }
+
+    before do
+      allow(Git::Commands::Status).to receive(:new).with(execution_context).and_return(status_command)
+      allow(status_command).to receive(:call).and_return(status_result)
+      allow(Git::Commands::DiffIndex).to receive(:new).with(execution_context).and_return(diff_index_command)
+      allow(diff_index_command).to receive(:call).with(treeish).and_return(diff_index_result)
+    end
+
+    it 'calls Git::Commands::Status#call before Git::Commands::DiffIndex#call' do
+      expect(status_command).to receive(:call).ordered
+      expect(diff_index_command).to receive(:call).with(treeish).ordered.and_return(diff_index_result)
+      subject
+    end
+
+    it 'calls Git::Commands::DiffIndex#call with the treeish argument' do
+      expect(diff_index_command).to receive(:call).with(treeish).and_return(diff_index_result)
+      subject
+    end
+
+    context 'when stdout is empty' do
+      it 'returns an empty hash' do
+        is_expected.to eq({})
+      end
+    end
+
+    context 'when stdout contains a single modified file' do
+      let(:diff_index_stdout) do
+        ":100644 100644 abc1234 def5678 M\tlib/foo.rb\n"
+      end
+
+      it 'returns a hash keyed by the file path with all expected fields' do
+        is_expected.to eq(
+          'lib/foo.rb' => {
+            mode_index: '100644',
+            mode_repo: '100644',
+            path: 'lib/foo.rb',
+            sha_repo: 'abc1234',
+            sha_index: 'def5678',
+            type: 'M'
+          }
+        )
+      end
+    end
+
+    context 'when stdout contains multiple files' do
+      let(:diff_index_stdout) do
+        ":100644 100644 abc1234 def5678 M\tlib/foo.rb\n" \
+          ":100644 100644 111aaaa 222bbbb A\tlib/bar.rb\n"
+      end
+
+      it 'returns an entry for each file' do
+        expect(result.keys).to contain_exactly('lib/foo.rb', 'lib/bar.rb')
+      end
+    end
+
+    context 'when stdout contains a git-quoted non-ASCII path' do
+      # Git octal-encodes non-ASCII bytes; "\\303\\251" is the octal encoding
+      # of "é" (U+00E9, UTF-8 bytes: 0xC3 0xA9).
+      let(:diff_index_stdout) do
+        ":100644 100644 abc1234 def5678 M\t\"\\303\\251tat.rb\"\n"
+      end
+
+      it 'unescapes the quoted path in the hash key and :path value' do
+        expect(result).to have_key('état.rb')
+        expect(result['état.rb'][:path]).to eq('état.rb')
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Extracts `Git::Lib#diff_index(treeish)` into a new `Git::Repository::Diffing#diff_index` facade method as part of the v5.0.0 Strangler Fig migration.

`Git::Lib#diff_index` is a Pattern B (lib-only) method with no `Git::Base` wrapper. It compares the **working tree** against a given tree object using `git diff-index` (without `--cached`), returning a `Hash{String => Hash}` of per-file diff entries — the same structure as the sibling `#diff_files` method.

> **Note on naming:** despite the method name containing "index", `git diff-index` without `--cached` compares the *working tree* to the given tree object (not the staging area). The `--cached` flag is what switches the comparison to staged-only output. The 4.x implementation did not pass `--cached`, and this facade preserves that contract.

## Changes

- **`lib/git/repository/diffing.rb`** — adds `require 'git/commands/diff_index'` and implements `Git::Repository::Diffing#diff_index(treeish)`, reusing the existing `Private.parse_diff_files_output` helper. Step 6 (delegation in `Git::Lib`) is intentionally deferred.
- **`spec/unit/git/repository/diffing_spec.rb`** — adds `describe '#diff_index'` covering: Status refresh ordering, delegation with `treeish` arg, empty stdout, all 6 expected hash keys, multiple files, and git-quoted non-ASCII paths.
- **`spec/integration/git/repository/diffing_spec.rb`** — adds `describe '#diff_index'` covering: nothing staged → empty hash; staged file → correct entry with all expected keys; unstaged modification → entry still appears (confirming working-tree comparison).

## Public contract preserved

```ruby
# Legacy (remains unchanged):
Git::Lib#diff_index(treeish) → Hash{String => Hash}

# New facade (identical contract):
Git::Repository::Diffing#diff_index(treeish) → Hash{String => Hash}
```

## Quality gates

- RuboCop: ✅ clean
- RSpec: ✅ 92 examples, 0 failures
- YARD: ✅ 0 warnings