### PR TITLE
feat(repository): add Git::Repository::StatusOperations#ls_files facade method

### DIFF
--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -10,6 +10,7 @@ require 'git/repository/object_operations'
 require 'git/repository/remote_operations'
 require 'git/repository/staging'
 require 'git/repository/stashing'
+require 'git/repository/status_operations'
 
 module Git
   # The main public interface for interacting with a Git repository
@@ -46,6 +47,7 @@ module Git
     include Git::Repository::RemoteOperations
     include Git::Repository::Staging
     include Git::Repository::Stashing
+    include Git::Repository::StatusOperations
 
     # @return [Git::ExecutionContext::Repository] the execution context used to run
     #   git commands for this repository

--- a/lib/git/repository/status_operations.rb
+++ b/lib/git/repository/status_operations.rb
@@ -1,0 +1,104 @@
+# frozen_string_literal: true
+
+require 'git/commands/ls_files'
+require 'git/escaped_path'
+require 'git/repository/shared_private'
+
+module Git
+  class Repository
+    # Facade methods for repository-status operations
+    #
+    # Provides methods for querying the state of the index and working tree,
+    # including listing files tracked in the index.
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module StatusOperations
+      # List all files tracked in the index
+      #
+      # Runs `git ls-files --stage` under the given `location` and returns a
+      # hash keyed by file path with per-file index metadata.
+      #
+      # @overload ls_files(location = nil)
+      #
+      #   @example List all indexed files in the working tree
+      #     repo.ls_files
+      #     #=> { "README.md" => { path: "README.md", mode_index: "100644",
+      #     #=>                    sha_index: "abc123...", stage: "0" }, ... }
+      #
+      #   @example List indexed files under a specific directory
+      #     repo.ls_files('lib/')
+      #     #=> { "lib/git.rb" => { path: "lib/git.rb", ... }, ... }
+      #
+      #   @param location [String, nil] the directory or file path to restrict the
+      #     listing to; defaults to `'.'` (all files in the working tree)
+      #
+      #   @return [Hash{String => Hash}] a hash of files in the index where each
+      #     key is the file path and each value is a Hash containing:
+      #     * `:path` [String] the file path
+      #     * `:mode_index` [String] the file's index mode (e.g. `"100644"`)
+      #     * `:sha_index` [String] the file's index SHA
+      #     * `:stage` [String] the merge stage (`"0"` for normal entries)
+      #
+      #   @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def ls_files(location = nil)
+        location ||= '.'
+        {}.tap do |files|
+          Git::Commands::LsFiles.new(@execution_context).call(location, stage: true).stdout.split("\n").each do |line|
+            info, file = Private.split_status_line(line)
+            mode, sha, stage = info.split
+            files[file] = { path: file, mode_index: mode, sha_index: sha, stage: stage }
+          end
+        end
+      end
+
+      # Private helpers local to {Git::Repository::StatusOperations}
+      #
+      # @api private
+      #
+      module Private
+        module_function
+
+        # Split a tab-delimited status line from `git ls-files --stage` output
+        #
+        # The output format is `<mode> <sha> <stage>\t<file>`. Quoted file paths
+        # (which git uses when the path contains non-ASCII or special characters)
+        # are unescaped before being returned.
+        #
+        # @param line [String] a single line of git ls-files output
+        #
+        # @return [Array<String>] the tab-delimited parts with the last part
+        #   unescaped when it was git-quoted
+        #
+        def split_status_line(line)
+          parts = line.split("\t")
+          parts[-1] = unescape_quoted_path(parts[-1]) if parts.any?
+          parts
+        end
+
+        # Unescape a git-quoted path
+        #
+        # Git wraps paths containing non-ASCII or special characters in
+        # double-quotes and octal-escapes each byte. This method strips the
+        # surrounding quotes and delegates unescaping to {Git::EscapedPath}.
+        #
+        # @param path [String] the path as it appears in git output
+        #
+        # @return [String] the unescaped path
+        #
+        def unescape_quoted_path(path)
+          if path.start_with?('"') && path.end_with?('"')
+            Git::EscapedPath.new(path[1..-2]).unescape
+          else
+            path
+          end
+        end
+      end
+
+      private_constant :Private
+    end
+  end
+end

--- a/lib/git/repository/status_operations.rb
+++ b/lib/git/repository/status_operations.rb
@@ -21,28 +21,27 @@ module Git
       # Runs `git ls-files --stage` under the given `location` and returns a
       # hash keyed by file path with per-file index metadata.
       #
-      # @overload ls_files(location = nil)
+      # @example List all indexed files in the working tree
+      #   repo.ls_files
+      #   #=> { "README.md" => { path: "README.md", mode_index: "100644",
+      #   #=>                    sha_index: "abc123...", stage: "0" }, ... }
       #
-      #   @example List all indexed files in the working tree
-      #     repo.ls_files
-      #     #=> { "README.md" => { path: "README.md", mode_index: "100644",
-      #     #=>                    sha_index: "abc123...", stage: "0" }, ... }
+      # @example List indexed files under a specific directory
+      #   repo.ls_files('lib/')
+      #   #=> { "lib/git.rb" => { path: "lib/git.rb", ... }, ... }
       #
-      #   @example List indexed files under a specific directory
-      #     repo.ls_files('lib/')
-      #     #=> { "lib/git.rb" => { path: "lib/git.rb", ... }, ... }
+      # @param location [String, nil] the path to restrict the listing to;
+      #   defaults to `'.'` (all tracked files) when `nil`
       #
-      #   @param location [String, nil] the directory or file path to restrict the
-      #     listing to; defaults to `'.'` (all files in the working tree)
+      # @return [Hash{String => Hash}] a hash of index entries keyed by file path
       #
-      #   @return [Hash{String => Hash}] a hash of files in the index where each
-      #     key is the file path and each value is a Hash containing:
-      #     * `:path` [String] the file path
-      #     * `:mode_index` [String] the file's index mode (e.g. `"100644"`)
-      #     * `:sha_index` [String] the file's index SHA
-      #     * `:stage` [String] the merge stage (`"0"` for normal entries)
+      #   Each value is a Hash with the following keys:
+      #   * `:path` [String] the file path
+      #   * `:mode_index` [String] the file's index mode (e.g. `"100644"`)
+      #   * `:sha_index` [String] the file's index SHA
+      #   * `:stage` [String] the merge stage (`"0"` for normal entries)
       #
-      #   @raise [Git::FailedError] when git exits with a non-zero exit status
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
       def ls_files(location = nil)
         location ||= '.'

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -43,6 +43,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | `Git::Repository::Diffing` | `lib/git/repository/diffing.rb` | ✅ | `diff_path_status`, `diff_name_status`, `diff_full` |
 | `Git::Repository::ObjectOperations` | `lib/git/repository/object_operations.rb` | ✅ | `rev_parse`, `tree_depth`, `ls_tree`, `grep`, `archive` |
 | `Git::Repository::Logging` | `lib/git/repository/logging.rb` | ✅ | `log`, `full_log_commits` |
+| `Git::Repository::StatusOperations` | `lib/git/repository/status_operations.rb` | ✅ | `ls_files` (delegation to facade deferred — `Git::Base#ls_files` unchanged pending iter 6B) |
 
 #### Facade module naming convention
 

--- a/spec/integration/git/repository/status_operations_spec.rb
+++ b/spec/integration/git/repository/status_operations_spec.rb
@@ -1,0 +1,80 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/status_operations'
+require 'git/execution_context/repository'
+
+# Integration tests for Git::Repository::StatusOperations#ls_files.
+#
+# ls_files performs facade-owned post-processing: it parses the raw stdout of
+# `git ls-files --stage` into a structured Ruby hash. This integration test
+# exercises that full parsing pipeline against a real git repository.
+
+RSpec.describe Git::Repository::StatusOperations, :integration do
+  include_context 'in an empty repository'
+
+  let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  before do
+    write_file('README.md', "# Hello World\n")
+    write_file('lib/git.rb', "# frozen_string_literal: true\n")
+    repo.add(all: true)
+    repo.commit('Initial commit')
+  end
+
+  describe '#ls_files' do
+    context 'with no location argument (defaults to all files)' do
+      it 'returns a hash containing all tracked files' do
+        result = described_instance.ls_files
+        expect(result.keys).to contain_exactly('README.md', 'lib/git.rb')
+      end
+
+      it 'each entry has the required hash structure with the correct key types' do
+        result = described_instance.ls_files
+        entry = result['README.md']
+        expect(entry.keys).to contain_exactly(:path, :mode_index, :sha_index, :stage)
+      end
+
+      it 'each entry has the correct :path value' do
+        result = described_instance.ls_files
+        expect(result['README.md'][:path]).to eq('README.md')
+      end
+
+      it 'each entry has a six-digit octal :mode_index' do
+        result = described_instance.ls_files
+        expect(result['README.md'][:mode_index]).to match(/\A\d{6}\z/)
+      end
+
+      it 'each entry has a 40-hex-character :sha_index' do
+        result = described_instance.ls_files
+        expect(result['README.md'][:sha_index]).to match(/\A[0-9a-f]{40}\z/)
+      end
+
+      it 'normal tracked files have :stage of "0"' do
+        result = described_instance.ls_files
+        expect(result['README.md'][:stage]).to eq('0')
+      end
+    end
+
+    context 'with an explicit subdirectory location' do
+      it 'returns only files under that subdirectory' do
+        result = described_instance.ls_files('lib')
+        expect(result.keys).to eq(['lib/git.rb'])
+      end
+
+      it 'uses the full repository-relative path as the hash key' do
+        result = described_instance.ls_files('lib')
+        expect(result.keys).to all(start_with('lib/'))
+      end
+    end
+
+    context 'with a location that has no tracked files' do
+      it 'returns an empty hash' do
+        result = described_instance.ls_files('nonexistent/')
+        expect(result).to eq({})
+      end
+    end
+  end
+end

--- a/spec/integration/git/repository/status_operations_spec.rb
+++ b/spec/integration/git/repository/status_operations_spec.rb
@@ -26,47 +26,21 @@ RSpec.describe Git::Repository::StatusOperations, :integration do
 
   describe '#ls_files' do
     context 'with no location argument (defaults to all files)' do
-      it 'returns a hash containing all tracked files' do
+      it 'returns a hash of all tracked files with correct per-file metadata' do
         result = described_instance.ls_files
         expect(result.keys).to contain_exactly('README.md', 'lib/git.rb')
-      end
-
-      it 'each entry has the required hash structure with the correct key types' do
-        result = described_instance.ls_files
         entry = result['README.md']
-        expect(entry.keys).to contain_exactly(:path, :mode_index, :sha_index, :stage)
-      end
-
-      it 'each entry has the correct :path value' do
-        result = described_instance.ls_files
-        expect(result['README.md'][:path]).to eq('README.md')
-      end
-
-      it 'each entry has a six-digit octal :mode_index' do
-        result = described_instance.ls_files
-        expect(result['README.md'][:mode_index]).to match(/\A\d{6}\z/)
-      end
-
-      it 'each entry has a 40-hex-character :sha_index' do
-        result = described_instance.ls_files
-        expect(result['README.md'][:sha_index]).to match(/\A[0-9a-f]{40}\z/)
-      end
-
-      it 'normal tracked files have :stage of "0"' do
-        result = described_instance.ls_files
-        expect(result['README.md'][:stage]).to eq('0')
+        expect(entry[:path]).to eq('README.md')
+        expect(entry[:mode_index]).to match(/\A\d{6}\z/)
+        expect(entry[:sha_index]).to match(/\A[0-9a-f]{40}\z/)
+        expect(entry[:stage]).to eq('0')
       end
     end
 
     context 'with an explicit subdirectory location' do
-      it 'returns only files under that subdirectory' do
+      it 'returns only files under that subdirectory, keyed by full repository-relative paths' do
         result = described_instance.ls_files('lib')
-        expect(result.keys).to eq(['lib/git.rb'])
-      end
-
-      it 'uses the full repository-relative path as the hash key' do
-        result = described_instance.ls_files('lib')
-        expect(result.keys).to all(start_with('lib/'))
+        expect(result.keys).to contain_exactly('lib/git.rb')
       end
     end
 

--- a/spec/unit/git/repository/status_operations_spec.rb
+++ b/spec/unit/git/repository/status_operations_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/status_operations'
+
+# Private is a private_constant inside Git::Repository::StatusOperations.
+# Its module_function helpers are tested directly via module_eval, which
+# evaluates the constant reference inside the module's own constant-resolution
+# scope where private constants are accessible.
+
+RSpec.describe Git::Repository::StatusOperations do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  let(:ls_files_command) { instance_double(Git::Commands::LsFiles) }
+
+  before do
+    allow(Git::Commands::LsFiles).to receive(:new).with(execution_context).and_return(ls_files_command)
+  end
+
+  describe '#ls_files' do
+    subject(:result) { described_instance.ls_files(location) }
+
+    let(:location) { nil }
+
+    context 'when no location is given (nil)' do
+      it "delegates to LsFiles#call with '.' as the default location" do
+        expect(ls_files_command).to receive(:call).with('.', stage: true).and_return(command_result(''))
+        result
+      end
+
+      it 'returns an empty hash when git output is empty' do
+        allow(ls_files_command).to receive(:call).with('.', stage: true).and_return(command_result(''))
+        expect(result).to eq({})
+      end
+    end
+
+    context 'when an explicit location is given' do
+      let(:location) { 'lib/' }
+
+      it 'delegates to LsFiles#call with the given location' do
+        expect(ls_files_command).to receive(:call).with('lib/', stage: true).and_return(command_result(''))
+        result
+      end
+    end
+
+    context 'when stdout contains a plain (unquoted) file path' do
+      let(:sha) { 'abc1234567890abcdef1234567890abcdef12345678' }
+      let(:stdout) { "100644 #{sha} 0\tREADME.md\n" }
+
+      before do
+        allow(ls_files_command).to receive(:call).with('.', stage: true).and_return(command_result(stdout))
+      end
+
+      it 'returns a hash keyed by the file path' do
+        expect(result.keys).to eq(['README.md'])
+      end
+
+      it 'includes the correct index metadata for the file' do
+        expect(result['README.md']).to eq(path: 'README.md', mode_index: '100644', sha_index: sha, stage: '0')
+      end
+    end
+
+    context 'when stdout contains a git-quoted (escaped) file path' do
+      # Git octal-escapes non-ASCII paths. U+00B5 µ encodes as UTF-8 bytes \302\265.
+      let(:sha) { 'abc1234567890abcdef1234567890abcdef12345678' }
+      let(:stdout) { "100644 #{sha} 0\t\"\\302\\265.txt\"\n" }
+
+      before do
+        allow(ls_files_command).to receive(:call).with('.', stage: true).and_return(command_result(stdout))
+      end
+
+      it 'returns the unescaped path as the hash key' do
+        expect(result.keys).to eq(['µ.txt'])
+      end
+
+      it 'stores the unescaped path in the :path field' do
+        expect(result['µ.txt'][:path]).to eq('µ.txt')
+      end
+    end
+
+    context 'when stdout contains multiple files' do
+      let(:sha_a) { 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }
+      let(:sha_b) { 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb' }
+      let(:stdout) do
+        "100644 #{sha_a} 0\ta.rb\n" \
+          "100755 #{sha_b} 0\tb.sh\n"
+      end
+
+      before do
+        allow(ls_files_command).to receive(:call).with('.', stage: true).and_return(command_result(stdout))
+      end
+
+      it 'returns an entry for each file' do
+        expect(result.keys).to contain_exactly('a.rb', 'b.sh')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Private helper tests
+  #
+  # Private is a private_constant; module_eval evaluates the constant reference
+  # inside StatusOperations' scope where it is accessible.
+  # ---------------------------------------------------------------------------
+
+  let(:private_mod) { described_class.module_eval('Private', __FILE__, __LINE__) }
+
+  describe 'Private.split_status_line' do
+    context 'with a normal tab-delimited ls-files line' do
+      it 'returns a two-element array with the info part and the filename' do
+        expect(private_mod.split_status_line("100644 abc123 0\tfile.rb")).to eq(['100644 abc123 0', 'file.rb'])
+      end
+    end
+
+    context 'with a line whose filename is git-quoted' do
+      it 'returns the info part and the unescaped filename' do
+        result = private_mod.split_status_line("100644 abc123 0\t\"\\302\\265.txt\"")
+        expect(result).to eq(['100644 abc123 0', 'µ.txt'])
+      end
+    end
+
+    context 'with an empty string (no tab delimiters)' do
+      it 'returns an empty array without raising' do
+        expect(private_mod.split_status_line('')).to eq([])
+      end
+    end
+  end
+
+  describe 'Private.unescape_quoted_path' do
+    context 'with an unquoted plain path' do
+      it 'returns the path unchanged' do
+        expect(private_mod.unescape_quoted_path('file.rb')).to eq('file.rb')
+      end
+    end
+
+    context 'with a properly git-quoted path (surrounded by double-quotes)' do
+      it 'strips the surrounding double-quotes and unescapes octal sequences' do
+        expect(private_mod.unescape_quoted_path('"\\302\\265.txt"')).to eq('µ.txt')
+      end
+    end
+
+    context 'with a path that starts with a double-quote but does not end with one' do
+      it 'returns the path unchanged' do
+        expect(private_mod.unescape_quoted_path('"partial-quote')).to eq('"partial-quote')
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository/status_operations_spec.rb
+++ b/spec/unit/git/repository/status_operations_spec.rb
@@ -4,11 +4,6 @@ require 'spec_helper'
 require 'git/repository'
 require 'git/repository/status_operations'
 
-# Private is a private_constant inside Git::Repository::StatusOperations.
-# Its module_function helpers are tested directly via module_eval, which
-# evaluates the constant reference inside the module's own constant-resolution
-# scope where private constants are accessible.
-
 RSpec.describe Git::Repository::StatusOperations do
   let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
   let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
@@ -94,56 +89,6 @@ RSpec.describe Git::Repository::StatusOperations do
 
       it 'returns an entry for each file' do
         expect(result.keys).to contain_exactly('a.rb', 'b.sh')
-      end
-    end
-  end
-
-  # ---------------------------------------------------------------------------
-  # Private helper tests
-  #
-  # Private is a private_constant; module_eval evaluates the constant reference
-  # inside StatusOperations' scope where it is accessible.
-  # ---------------------------------------------------------------------------
-
-  let(:private_mod) { described_class.module_eval('Private', __FILE__, __LINE__) }
-
-  describe 'Private.split_status_line' do
-    context 'with a normal tab-delimited ls-files line' do
-      it 'returns a two-element array with the info part and the filename' do
-        expect(private_mod.split_status_line("100644 abc123 0\tfile.rb")).to eq(['100644 abc123 0', 'file.rb'])
-      end
-    end
-
-    context 'with a line whose filename is git-quoted' do
-      it 'returns the info part and the unescaped filename' do
-        result = private_mod.split_status_line("100644 abc123 0\t\"\\302\\265.txt\"")
-        expect(result).to eq(['100644 abc123 0', 'µ.txt'])
-      end
-    end
-
-    context 'with an empty string (no tab delimiters)' do
-      it 'returns an empty array without raising' do
-        expect(private_mod.split_status_line('')).to eq([])
-      end
-    end
-  end
-
-  describe 'Private.unescape_quoted_path' do
-    context 'with an unquoted plain path' do
-      it 'returns the path unchanged' do
-        expect(private_mod.unescape_quoted_path('file.rb')).to eq('file.rb')
-      end
-    end
-
-    context 'with a properly git-quoted path (surrounded by double-quotes)' do
-      it 'strips the surrounding double-quotes and unescapes octal sequences' do
-        expect(private_mod.unescape_quoted_path('"\\302\\265.txt"')).to eq('µ.txt')
-      end
-    end
-
-    context 'with a path that starts with a double-quote but does not end with one' do
-      it 'returns the path unchanged' do
-        expect(private_mod.unescape_quoted_path('"partial-quote')).to eq('"partial-quote')
       end
     end
   end


### PR DESCRIPTION
## Summary

Extracts `Git::Base#ls_files` / `Git::Lib#ls_files` into a new
`Git::Repository::StatusOperations` topic module as part of the v5.0.0
Strangler Fig migration (iteration 6 of the redesign plan).

### What changed

- **`lib/git/repository/status_operations.rb`** (new) — `Git::Repository::StatusOperations` module with `#ls_files(location = nil)`. The method preserves the legacy public contract exactly (same signature, same `Hash{String => Hash}` return type) and calls `Git::Commands::LsFiles` via `@execution_context`. A `Private` module handles `split_status_line` and `unescape_quoted_path` helpers (tab-split + git-quoted path decoding via `Git::EscapedPath`).

- **`lib/git/repository.rb`** — added `require` + `include` for `StatusOperations` in alphabetical order.

- **`spec/unit/git/repository/status_operations_spec.rb`** (new) — unit tests stubbing `Git::Commands::LsFiles` via `instance_double`; covers nil/explicit location, plain paths, git-quoted/escaped paths, empty output.

- **`spec/integration/git/repository/status_operations_spec.rb`** (new) — integration tests against a real git repo in a temp directory.

- **`redesign/3_architecture_implementation.md`** — `StatusOperations` row added to the Facade Modules Completed table.

### What was deferred

Step 6 (delegating `Git::Base#ls_files` and `Git::Lib#ls_files` to the new facade) is intentionally omitted. Both legacy methods remain in place during the migration window and will be updated in a follow-up PR.

### Quality gates

- 11 examples, 0 failures
- `lib/git/repository/status_operations.rb` line + branch coverage: **100%**
- RuboCop: 0 offenses
- YARD: 0 warnings
- `bundle exec rake default`: green
