### PR TITLE
feat(repository): add Git::Repository::StatusOperations#no_commits? facade method

### DIFF
--- a/lib/git/repository/status_operations.rb
+++ b/lib/git/repository/status_operations.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'git/commands/ls_files'
+require 'git/commands/rev_parse'
 require 'git/escaped_path'
 require 'git/repository/shared_private'
 
@@ -16,6 +17,31 @@ module Git
     # @api public
     #
     module StatusOperations
+      # Returns `true` if the repository has no commits yet
+      #
+      # Checks whether `HEAD` can be resolved to a commit object. A brand-new
+      # repository (or one created with `git checkout --orphan`) where no commit
+      # has been made yet will have no commits.
+      #
+      # @example Check whether a repository is empty
+      #   repo.no_commits? #=> true   # freshly initialized, no commits yet
+      #   repo.no_commits? #=> false  # at least one commit exists
+      #
+      # @return [Boolean] `true` when the repository has no commits, `false` otherwise
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status other
+      #   than when the repository has no commits
+      #
+      def no_commits?
+        Git::Commands::RevParse.new(@execution_context).call('HEAD', verify: true)
+        false
+      rescue Git::FailedError => e
+        raise unless e.result.status.exitstatus == 128 &&
+                     e.result.stderr == 'fatal: Needed a single revision'
+
+        true
+      end
+
       # List all files tracked in the index
       #
       # Runs `git ls-files --stage` under the given `location` and returns a

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -43,7 +43,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | `Git::Repository::Diffing` | `lib/git/repository/diffing.rb` | ✅ | `diff_path_status`, `diff_name_status`, `diff_full` |
 | `Git::Repository::ObjectOperations` | `lib/git/repository/object_operations.rb` | ✅ | `rev_parse`, `tree_depth`, `ls_tree`, `grep`, `archive` |
 | `Git::Repository::Logging` | `lib/git/repository/logging.rb` | ✅ | `log`, `full_log_commits` |
-| `Git::Repository::StatusOperations` | `lib/git/repository/status_operations.rb` | ✅ | `ls_files` (delegation to facade deferred — `Git::Base#ls_files` unchanged pending iter 6B) |
+| `Git::Repository::StatusOperations` | `lib/git/repository/status_operations.rb` | ✅ | `ls_files`, `no_commits?` (renamed from `Git::Lib#empty?`; delegations to facade deferred pending iter 6B) |
 
 #### Facade module naming convention
 

--- a/spec/integration/git/repository/status_operations_spec.rb
+++ b/spec/integration/git/repository/status_operations_spec.rb
@@ -5,11 +5,14 @@ require 'git/repository'
 require 'git/repository/status_operations'
 require 'git/execution_context/repository'
 
-# Integration tests for Git::Repository::StatusOperations#ls_files.
+# Integration tests for Git::Repository::StatusOperations.
 #
-# ls_files performs facade-owned post-processing: it parses the raw stdout of
+# #ls_files performs facade-owned post-processing: it parses the raw stdout of
 # `git ls-files --stage` into a structured Ruby hash. This integration test
 # exercises that full parsing pipeline against a real git repository.
+#
+# #no_commits? is a two-outcome facade method that runs real git rev-parse
+# against the HEAD ref, so integration tests verify both outcomes.
 
 RSpec.describe Git::Repository::StatusOperations, :integration do
   include_context 'in an empty repository'
@@ -17,14 +20,14 @@ RSpec.describe Git::Repository::StatusOperations, :integration do
   let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
   let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
 
-  before do
-    write_file('README.md', "# Hello World\n")
-    write_file('lib/git.rb', "# frozen_string_literal: true\n")
-    repo.add(all: true)
-    repo.commit('Initial commit')
-  end
-
   describe '#ls_files' do
+    before do
+      write_file('README.md', "# Hello World\n")
+      write_file('lib/git.rb', "# frozen_string_literal: true\n")
+      repo.add(all: true)
+      repo.commit('Initial commit')
+    end
+
     context 'with no location argument (defaults to all files)' do
       it 'returns a hash of all tracked files with correct per-file metadata' do
         result = described_instance.ls_files
@@ -48,6 +51,26 @@ RSpec.describe Git::Repository::StatusOperations, :integration do
       it 'returns an empty hash' do
         result = described_instance.ls_files('nonexistent/')
         expect(result).to eq({})
+      end
+    end
+  end
+
+  describe '#no_commits?' do
+    context 'when the repository has no commits yet' do
+      it 'returns true' do
+        expect(described_instance.no_commits?).to be(true)
+      end
+    end
+
+    context 'when the repository has at least one commit' do
+      before do
+        write_file('README.md', "# Hello\n")
+        repo.add(all: true)
+        repo.commit('Initial commit')
+      end
+
+      it 'returns false' do
+        expect(described_instance.no_commits?).to be(false)
       end
     end
   end

--- a/spec/unit/git/repository/status_operations_spec.rb
+++ b/spec/unit/git/repository/status_operations_spec.rb
@@ -8,16 +8,15 @@ RSpec.describe Git::Repository::StatusOperations do
   let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
   let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
 
-  let(:ls_files_command) { instance_double(Git::Commands::LsFiles) }
-
-  before do
-    allow(Git::Commands::LsFiles).to receive(:new).with(execution_context).and_return(ls_files_command)
-  end
-
   describe '#ls_files' do
     subject(:result) { described_instance.ls_files(location) }
 
     let(:location) { nil }
+    let(:ls_files_command) { instance_double(Git::Commands::LsFiles) }
+
+    before do
+      allow(Git::Commands::LsFiles).to receive(:new).with(execution_context).and_return(ls_files_command)
+    end
 
     context 'when no location is given (nil)' do
       it "delegates to LsFiles#call with '.' as the default location" do
@@ -89,6 +88,59 @@ RSpec.describe Git::Repository::StatusOperations do
 
       it 'returns an entry for each file' do
         expect(result.keys).to contain_exactly('a.rb', 'b.sh')
+      end
+    end
+  end
+
+  describe '#no_commits?' do
+    subject(:result) { described_instance.no_commits? }
+
+    let(:rev_parse_command) { instance_double(Git::Commands::RevParse) }
+
+    before do
+      allow(Git::Commands::RevParse).to receive(:new).with(execution_context).and_return(rev_parse_command)
+    end
+
+    context 'when the repository has at least one commit' do
+      it 'delegates to RevParse#call with HEAD and verify: true' do
+        expect(rev_parse_command).to receive(:call).with('HEAD',
+                                                         verify: true).and_return(command_result('abc123def456'))
+        result
+      end
+
+      it 'returns false' do
+        allow(rev_parse_command).to receive(:call).with('HEAD', verify: true).and_return(command_result('abc123def456'))
+        expect(result).to be(false)
+      end
+    end
+
+    context 'when the repository has no commits (exit 128 with expected stderr)' do
+      let(:failed_result) do
+        command_result('', stderr: 'fatal: Needed a single revision', exitstatus: 128)
+      end
+
+      before do
+        allow(rev_parse_command).to receive(:call).with('HEAD', verify: true)
+                                                  .and_raise(Git::FailedError.new(failed_result))
+      end
+
+      it 'returns true' do
+        expect(result).to be(true)
+      end
+    end
+
+    context 'when git rev-parse fails for an unrelated reason' do
+      let(:failed_result) do
+        command_result('', stderr: 'fatal: not a git repository', exitstatus: 128)
+      end
+
+      before do
+        allow(rev_parse_command).to receive(:call).with('HEAD', verify: true)
+                                                  .and_raise(Git::FailedError.new(failed_result))
+      end
+
+      it 're-raises the error' do
+        expect { described_instance.no_commits? }.to raise_error(Git::FailedError, /not a git repository/)
       end
     end
   end


### PR DESCRIPTION
## Summary

Extracts `Git::Lib#empty?` into `Git::Repository::StatusOperations#no_commits?` as part of the v5.0.0 Strangler Fig redesign (Phase 3).

The method is renamed from `empty?` to `no_commits?` to be explicit — it tests whether the repository has no commits, not whether the working tree is empty.

## Implementation

Calls `git rev-parse --verify HEAD` via `Git::Commands::RevParse`. Rescues the specific `Git::FailedError` (exit 128, `"fatal: Needed a single revision"`) that git emits on a repository with no commits and returns `true`; all other `FailedError`s are re-raised.

Per the extraction plan, `Git::Lib#empty?` is **not** updated to delegate — it remains as-is until Phase 4 deletion.

## Tests

- **3 unit examples**: success path → `false`; empty-repo rescue path → `true`; unrelated error → re-raises
- **2 integration examples**: verified against a real git repository (no commits → `true`; after first commit → `false`)

## Changes

- `lib/git/repository/status_operations.rb` — new `#no_commits?` method + `require 'git/commands/rev_parse'`
- `spec/unit/git/repository/status_operations_spec.rb` — new `describe '#no_commits?'` block
- `spec/integration/git/repository/status_operations_spec.rb` — new `describe '#no_commits?'` block
- `redesign/3_architecture_implementation.md` — `StatusOperations` row updated to list `no_commits?`