### PR TITLE
feat(repository): add Git::Repository::StatusOperations#status facade factory

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1030,7 +1030,7 @@ module Git
 
     # @return [Git::Status] a status object
     def status
-      Git::Status.new(self)
+      facade_repository.status
     end
 
     # @return [Git::Object::Tag] a tag object

--- a/lib/git/repository/status_operations.rb
+++ b/lib/git/repository/status_operations.rb
@@ -3,7 +3,7 @@
 require 'git/commands/ls_files'
 require 'git/commands/rev_parse'
 require 'git/escaped_path'
-require 'git/repository/shared_private'
+require 'git/status'
 
 module Git
   class Repository
@@ -66,6 +66,32 @@ module Git
         ).stdout.split("\n").map { |f| Private.unescape_quoted_path(f) }
       end
 
+      # Returns a {Git::Status} object describing the working tree and index state
+      #
+      # Constructs a {Git::Status} for this repository by collecting information from
+      # `git ls-files --stage`, `git ls-files --others`, `git diff-files`, and
+      # `git diff-index HEAD` (the last only when at least one commit exists). The
+      # result identifies which files have been modified, added, deleted, or are
+      # untracked.
+      #
+      # @example Check which files are modified
+      #   repo.status.changed #=> { "lib/foo.rb" => <Git::Status::StatusFile ...> }
+      #
+      # @example Check for untracked files
+      #   repo.status.untracked #=> { "new_file.rb" => <Git::Status::StatusFile ...> }
+      #
+      # @example Iterate over all status files
+      #   repo.status.each { |file| puts "#{file.path}: #{file.type}" }
+      #
+      # @return [Git::Status] the status of the repository
+      #
+      # @raise [Git::FailedError] if any underlying git command exits with a
+      #   non-zero exit status
+      #
+      def status
+        Git::Status.new(self)
+      end
+
       # List all files tracked in the index
       #
       # Runs `git ls-files --stage` under the given `location` and returns a
@@ -115,7 +141,8 @@ module Git
         #
         # The output format is `<mode> <sha> <stage>\t<file>`. Quoted file paths
         # (which git uses when the path contains non-ASCII or special characters)
-        # are unescaped before being returned.
+        # are unescaped before being returned. `line` is assumed to be non-empty
+        # because `git ls-files --stage` never emits blank lines.
         #
         # @param line [String] a single line of git ls-files output
         #
@@ -124,7 +151,7 @@ module Git
         #
         def split_status_line(line)
           parts = line.split("\t")
-          parts[-1] = unescape_quoted_path(parts[-1]) if parts.any?
+          parts[-1] = unescape_quoted_path(parts[-1])
           parts
         end
 

--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -12,37 +12,112 @@ module Git
   class Status
     include Enumerable
 
-    # @param base [Git::Base] The base git object
+    # Create a new Status for the given repository
+    #
+    # @param base [Git::Base, Git::Repository] the git object backing this status
+    #
     def initialize(base)
       @base = base
       # The factory returns a hash of file paths to StatusFile objects.
       @files = StatusFileFactory.new(base).construct_files
     end
 
-    # File status collections, memoized for performance.
+    # Return files modified in the index and/or working tree
+    #
+    # Includes both staged modifications (index vs HEAD) and unstaged modifications
+    # (working tree vs index).
+    #
+    # @return [Hash{String => Git::Status::StatusFile}] changed files keyed by path
+    #
     def changed   = @changed ||= select_files { |f| f.type == 'M' }
+
+    # Return files added to the index that are not yet in HEAD
+    #
+    # @return [Hash{String => Git::Status::StatusFile}] added files keyed by path
+    #
     def added     = @added ||= select_files { |f| f.type == 'A' }
+
+    # Return files deleted from the index
+    #
+    # @return [Hash{String => Git::Status::StatusFile}] deleted files keyed by path
+    #
     def deleted   = @deleted ||= select_files { |f| f.type == 'D' }
-    # This works with `true` or `nil`
+
+    # Return files present in the working tree but not tracked by git
+    #
+    # @return [Hash{String => Git::Status::StatusFile}] untracked files keyed by path
+    #
     def untracked = @untracked ||= select_files(&:untracked)
 
-    # Predicate methods to check the status of a specific file.
+    # Return `true` if `file` has been modified in the index or working tree
+    #
+    # @param file [String] the repository-relative path to check
+    #
+    # @return [Boolean] `true` if the file has been modified
+    #
     def changed?(file)   = file_in_collection?(:changed, file)
+
+    # Return `true` if `file` has been added to the index
+    #
+    # @param file [String] the repository-relative path to check
+    #
+    # @return [Boolean] `true` if the file has been added
+    #
     def added?(file)     = file_in_collection?(:added, file)
+
+    # Return `true` if `file` has been deleted from the index
+    #
+    # @param file [String] the repository-relative path to check
+    #
+    # @return [Boolean] `true` if the file has been deleted
+    #
     def deleted?(file)   = file_in_collection?(:deleted, file)
+
+    # Return `true` if `file` is not tracked by git
+    #
+    # @param file [String] the repository-relative path to check
+    #
+    # @return [Boolean] `true` if the file is untracked
+    #
     def untracked?(file) = file_in_collection?(:untracked, file)
 
-    # Access a status file by path, or iterate over all status files.
+    # Return the {Git::Status::StatusFile} for the given path
+    #
+    # @param file [String] the repository-relative path
+    #
+    # @return [Git::Status::StatusFile, nil] the status file, or `nil` if not found
+    #
     def [](file) = @files[file]
+
+    # Iterate over all status files
+    #
+    # @yield [file] each {Git::Status::StatusFile} in the repository
+    #
+    # @yieldparam file [Git::Status::StatusFile] a single file's status
+    #
+    # @return [Enumerator<Git::Status::StatusFile>] if no block is given
+    #
+    # @return [Array<Git::Status::StatusFile>] if a block is given
+    #
     def each(&) = @files.values.each(&)
 
-    # Returns a formatted string representation of the status.
+    # Return a formatted multi-line string representation of the status
+    #
+    # @return [String] one indented block per file showing its SHA, mode, type,
+    #   stage, and untracked flag
+    #
     def pretty
       map { |file| pretty_file(file) }.join << "\n"
     end
 
     private
 
+    # Format a single file's status as an indented multi-line string
+    #
+    # @param file [Git::Status::StatusFile] the file to format
+    #
+    # @return [String] the formatted status block for this file
+    #
     def pretty_file(file)
       <<~FILE
         #{file.path}
@@ -54,10 +129,26 @@ module Git
       FILE
     end
 
+    # Return a hash of files for which the block returns a truthy value
+    #
+    # @yield [file] each {Git::Status::StatusFile} in the repository
+    #
+    # @yieldparam file [Git::Status::StatusFile] a single file's status
+    #
+    # @return [Hash{String => Git::Status::StatusFile}] matching files keyed by path
+    #
     def select_files(&block)
       @files.select { |_path, file| block.call(file) }
     end
 
+    # Return `true` if `file_path` exists in the named status collection
+    #
+    # @param collection_name [Symbol] the collection to check (e.g. `:changed`)
+    #
+    # @param file_path [String] the repository-relative path to look up
+    #
+    # @return [Boolean] `true` if the path is present in the collection
+    #
     def file_in_collection?(collection_name, file_path)
       collection = public_send(collection_name)
       if ignore_case?
@@ -67,12 +158,25 @@ module Git
       end
     end
 
+    # Return a memoized set of downcased keys for the named collection
+    #
+    # @param collection_name [Symbol] the collection whose keys to downcase
+    #
+    # @return [Set<String>] the lowercased path keys
+    #
     def downcased_keys(collection_name)
       @_downcased_keys ||= {}
       @_downcased_keys[collection_name] ||=
         public_send(collection_name).keys.to_set(&:downcase)
     end
 
+    # Return `true` when git is configured to ignore filename case
+    #
+    # Reads `core.ignoreCase` from the repository config. Returns `false` if
+    # the config value is absent or if reading it raises {Git::FailedError}.
+    #
+    # @return [Boolean] `true` when `core.ignoreCase` is `"true"`
+    #
     def ignore_case?
       return @_ignore_case if defined?(@_ignore_case)
 
@@ -87,10 +191,58 @@ module Git
   class Status
     # Represents a single file's status in the git repository. Each instance
     # holds information about a file's state in the index and working tree.
+    #
+    # @api public
+    #
     class StatusFile
-      attr_reader :path, :type, :stage, :mode_index, :mode_repo,
-                  :sha_index, :sha_repo, :untracked
+      # The repository-relative file path
+      #
+      # @return [String] the path
+      attr_reader :path
 
+      # The change type for this file
+      #
+      # @return [String, nil] `"M"` for modified, `"A"` for added, `"D"` for deleted,
+      #   or `nil` when not applicable
+      attr_reader :type
+
+      # The merge stage for this file
+      #
+      # @return [String, nil] `"0"` for normal entries, or a non-zero value during
+      #   a merge conflict
+      attr_reader :stage
+
+      # The file mode recorded in the index
+      #
+      # @return [String, nil] the octal file mode (e.g. `"100644"`), or `nil`
+      attr_reader :mode_index
+
+      # The file mode recorded in HEAD
+      #
+      # @return [String, nil] the octal file mode (e.g. `"100644"`), or `nil`
+      attr_reader :mode_repo
+
+      # The SHA of the index version of this file
+      #
+      # @return [String, nil] the SHA-1 hex digest, or `nil` if unavailable
+      attr_reader :sha_index
+
+      # The SHA of the HEAD version of this file
+      #
+      # @return [String, nil] the SHA-1 hex digest, or `nil` if unavailable
+      attr_reader :sha_repo
+
+      # Whether this file is untracked
+      #
+      # @return [Boolean, nil] `true` when the file is not tracked by git
+      attr_reader :untracked
+
+      # Initialize a new StatusFile with the given git object and data hash
+      #
+      # @param base [Git::Base, Git::Repository] the git object
+      #
+      # @param hash [Hash] raw status data for this file
+      #
       def initialize(base, hash)
         @base       = base
         @path       = hash[:path]
@@ -103,7 +255,14 @@ module Git
         @untracked  = hash[:untracked]
       end
 
-      # Returns a Git::Object::Blob for either the index or repo version of the file.
+      # Return a blob object for the index or repo version of this file
+      #
+      # @param type [Symbol] `:index` (default) for the index version, or
+      #   `:repo` for the HEAD version
+      #
+      # @return [Git::Object::Blob, nil] the blob object, or `nil` if no SHA
+      #   is available for the requested version
+      #
       def blob(type = :index)
         sha = type == :repo ? sha_repo : (sha_index || sha_repo)
         @base.object(sha) if sha
@@ -116,15 +275,31 @@ module Git
   class Status
     # A factory class responsible for fetching git status data and building
     # a hash of StatusFile objects.
+    #
     # @api private
+    #
     class StatusFileFactory
+      # Create a new factory backed by the given git object
+      #
+      # When `base` is a {Git::Repository} (which exposes `#diff_index`
+      # directly), it is used as the data provider. When `base` is a
+      # {Git::Base} (the legacy path), `base.lib` is used instead.
+      #
+      # @param base [Git::Base, Git::Repository] the git object used as the
+      #   status data provider
+      #
       def initialize(base)
         @base = base
-        @lib = base.lib
+        # When base is Git::Repository (which exposes #diff_index directly),
+        # use it as the data provider. Otherwise use base.lib (legacy path).
+        @provider = base.respond_to?(:diff_index) ? base : base.lib
       end
 
-      # Gathers all status data and builds a hash of file paths to
-      # StatusFile objects.
+      # Gather all status data and build a hash of file paths to StatusFile objects
+      #
+      # @return [Hash{String => Git::Status::StatusFile}] file paths mapped to
+      #   their status objects
+      #
       def construct_files
         files_data = fetch_all_files_data
         files_data.transform_values do |data|
@@ -134,33 +309,56 @@ module Git
 
       private
 
-      # Fetches and merges status information from multiple git commands.
+      # Fetch and merge status information from multiple git commands
+      #
+      # @return [Hash{String => Hash}] raw per-file status data keyed by path
+      #
       def fetch_all_files_data
-        files = @lib.ls_files # Start with files tracked in the index.
+        files = @provider.ls_files # Start with files tracked in the index.
         merge_untracked_files(files)
         merge_modified_files(files)
         merge_head_diffs(files)
         files
       end
 
+      # Merge untracked working-tree files into `files`
+      #
+      # @param files [Hash] the in-progress files hash to update in place
+      #
+      # @return [void]
+      #
       def merge_untracked_files(files)
-        @lib.untracked_files.each do |file|
+        @provider.untracked_files.each do |file|
           files[file] = { path: file, untracked: true }
         end
       end
 
+      # Merge index-versus-working-tree diff data into `files`
+      #
+      # @param files [Hash] the in-progress files hash to update in place
+      #
+      # @return [void]
+      #
       def merge_modified_files(files)
         # Merge changes between the index and the working directory.
-        @lib.diff_files.each do |path, data|
+        @provider.diff_files.each do |path, data|
           (files[path] ||= {}).merge!(data)
         end
       end
 
+      # Merge HEAD-versus-index diff data into `files`, if commits exist
+      #
+      # @param files [Hash] the in-progress files hash to update in place
+      #
+      # @return [void]
+      #
       def merge_head_diffs(files)
-        return if @lib.empty?
+        # Git::Repository exposes #no_commits?; Git::Lib exposes #empty?.
+        is_empty = @provider.respond_to?(:no_commits?) ? @provider.no_commits? : @provider.empty?
+        return if is_empty
 
         # Merge changes between HEAD and the index.
-        @lib.diff_index('HEAD').each do |path, data|
+        @provider.diff_index('HEAD').each do |path, data|
           (files[path] ||= {}).merge!(data)
         end
       end

--- a/spec/integration/git/repository/status_operations_spec.rb
+++ b/spec/integration/git/repository/status_operations_spec.rb
@@ -75,9 +75,49 @@ RSpec.describe Git::Repository::StatusOperations, :integration do
     end
   end
 
-  # #untracked_files performs facade-owned post-processing: it splits raw stdout
-  # by newlines and unescapes git-quoted paths. Integration tests verify this
-  # pipeline against a real git repository.
+  # #status performs multi-command orchestration: it runs git ls-files --stage,
+  # git ls-files --others --exclude-standard, git diff-files, and (when commits
+  # exist) git diff-index HEAD. The integration test verifies the end-to-end
+  # return value against a real git repository.
+  describe '#status' do
+    context 'when the repository has no commits yet' do
+      it 'returns a Git::Status instance' do
+        expect(described_instance.status).to be_a(Git::Status)
+      end
+    end
+
+    context 'when the repository has at least one commit' do
+      before do
+        write_file('README.md', "# Hello\n")
+        repo.add(all: true)
+        repo.commit('Initial commit')
+      end
+
+      it 'returns a Git::Status instance' do
+        expect(described_instance.status).to be_a(Git::Status)
+      end
+
+      context 'when an untracked file exists' do
+        before { write_file('untracked.rb', 'content') }
+
+        it 'includes the untracked file in status.untracked' do
+          expect(described_instance.status.untracked.keys).to include('untracked.rb')
+        end
+      end
+
+      context 'when a tracked file is modified in the index' do
+        before do
+          write_file('README.md', "# Changed\n")
+          repo.add('README.md')
+        end
+
+        it 'includes the file in status.changed' do
+          expect(described_instance.status.changed.keys).to include('README.md')
+        end
+      end
+    end
+  end
+
   describe '#untracked_files' do
     context 'when there are no untracked files' do
       it 'returns an empty array' do

--- a/spec/unit/git/repository/status_operations_spec.rb
+++ b/spec/unit/git/repository/status_operations_spec.rb
@@ -212,25 +212,22 @@ RSpec.describe Git::Repository::StatusOperations do
     end
   end
 
-  # COVERAGE-ONLY: Exercises the `if parts.any?` false-branch guard in
-  # Private#split_status_line. This branch cannot be safely reached through the
-  # public #ls_files API: although `stdout.split("\n")` can produce empty-string
-  # elements (via consecutive newlines), git ls-files never emits such output, and
-  # if it did, ls_files would immediately crash with NoMethodError on `nil.split`
-  # before the guard has any effect. ObjectSpace is the only way to exercise this
-  # branch and maintain 100% branch coverage without changing production code.
-  describe 'Private.split_status_line' do
-    # Access the Private module via ObjectSpace to bypass the private_constant
-    # restriction. Private is a module_function module used internally by
-    # StatusOperations.
-    let(:private_module) do
-      ObjectSpace.each_object(Module).find { |m| m.name == 'Git::Repository::StatusOperations::Private' }
+  describe '#status' do
+    subject(:result) { described_instance.status }
+
+    let(:status) { instance_double(Git::Status) }
+
+    before do
+      allow(Git::Status).to receive(:new).with(described_instance).and_return(status)
     end
 
-    context 'when the line is empty (parts.any? is false)' do
-      it 'returns an empty array' do
-        expect(private_module.split_status_line('')).to eq([])
-      end
+    it 'constructs Git::Status with the repository instance as the base' do
+      expect(Git::Status).to receive(:new).with(described_instance).and_return(status)
+      result
+    end
+
+    it 'returns the Git::Status instance' do
+      expect(result).to eq(status)
     end
   end
 end

--- a/spec/unit/git/status_spec.rb
+++ b/spec/unit/git/status_spec.rb
@@ -1,0 +1,159 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/status'
+require 'git/repository'
+
+# Unit tests for Git::Status::StatusFileFactory polymorphism.
+#
+# The factory has two provider paths:
+#   1. Git::Repository path — when base responds to :diff_index (has it as a
+#      facade method), the factory uses base directly as the provider.
+#   2. Legacy Git::Base path — when base does not respond to :diff_index, the
+#      factory falls back to base.lib.
+#
+# Each path has two sub-branches in #merge_head_diffs:
+#   - When the provider reports no commits (no_commits? / empty? is true), the
+#     factory skips the diff_index call entirely.
+#   - When there are commits, the factory calls diff_index('HEAD') to merge
+#     HEAD diffs into the status hash.
+RSpec.describe Git::Status::StatusFileFactory do
+  describe '#construct_files' do
+    subject(:result) { described_class.new(base).construct_files }
+
+    context 'when base is a Git::Repository (responds to :diff_index)' do
+      let(:base) { instance_double(Git::Repository) }
+
+      before do
+        allow(base).to receive(:ls_files).and_return({})
+        allow(base).to receive(:untracked_files).and_return([])
+        allow(base).to receive(:diff_files).and_return({})
+        # instance_double(Git::Repository) already responds to :diff_index
+        # because the real class defines it. This stub provides a return value
+        # for any call that reaches it (overridden with specific expectations
+        # in nested contexts).
+        allow(base).to receive(:diff_index).and_return({})
+      end
+
+      context 'when no_commits? returns true (repository has no commits)' do
+        before do
+          allow(base).to receive(:no_commits?).and_return(true)
+        end
+
+        it 'does not call diff_index' do
+          # not_to receive overrides the outer allow for this example
+          expect(base).not_to receive(:diff_index)
+          result
+        end
+
+        it 'returns an empty hash when no files are present' do
+          expect(result).to eq({})
+        end
+      end
+
+      context 'when no_commits? returns false (repository has commits)' do
+        before do
+          allow(base).to receive(:no_commits?).and_return(false)
+          # Override outer allow to verify HEAD is passed
+          allow(base).to receive(:diff_index).with('HEAD').and_return({})
+        end
+
+        it 'calls diff_index with HEAD' do
+          expect(base).to receive(:diff_index).with('HEAD').and_return({})
+          result
+        end
+
+        it 'returns an empty hash when all data is empty' do
+          expect(result).to eq({})
+        end
+      end
+
+      context 'when provider methods return non-empty data and no_commits? is false' do
+        let(:sha_index) { 'aaaa1234567890abcdef1234567890abcdef1234' }
+        let(:sha_repo)  { 'bbbb1234567890abcdef1234567890abcdef1234' }
+
+        before do
+          allow(base).to receive(:ls_files).and_return(
+            'a.rb' => { path: 'a.rb', mode_index: '100644', sha_index: sha_index, stage: '0' }
+          )
+          allow(base).to receive(:untracked_files).and_return(['new.rb'])
+          allow(base).to receive(:diff_files).and_return(
+            'a.rb' => { path: 'a.rb', type: 'M', mode_index: '100644', mode_repo: '100644',
+                        sha_index: sha_index, sha_repo: sha_repo }
+          )
+          allow(base).to receive(:no_commits?).and_return(false)
+          allow(base).to receive(:diff_index).with('HEAD').and_return(
+            'b.rb' => { path: 'b.rb', type: 'A', mode_index: '100644', mode_repo: '000000',
+                        sha_index: sha_repo, sha_repo: nil }
+          )
+        end
+
+        it 'returns a hash whose values are all StatusFile instances' do
+          expect(result.values).to all(be_a(Git::Status::StatusFile))
+        end
+
+        it 'includes the untracked file with untracked: true' do
+          expect(result['new.rb']).to be_a(Git::Status::StatusFile)
+          expect(result['new.rb'].untracked).to be(true)
+        end
+
+        it 'merges diff_files data into files from ls_files' do
+          expect(result['a.rb'].type).to eq('M')
+        end
+
+        it 'merges diff_index data for files not already in ls_files' do
+          expect(result['b.rb']).to be_a(Git::Status::StatusFile)
+          expect(result['b.rb'].type).to eq('A')
+        end
+      end
+    end
+
+    context 'when base is a legacy Git::Base (does not respond to :diff_index)' do
+      # Plain doubles are used here because:
+      # - base must NOT respond to :diff_index to exercise the legacy code path;
+      #   instance_double(Git::Base) would verify against the real class, which
+      #   may include modules that define :diff_index, making the test brittle.
+      # - lib_double represents Git::Lib, a large class not loaded in this spec;
+      #   a plain double avoids pulling in that dependency.
+      let(:lib_double) { double('lib') }                           # plain double: Git::Lib not loaded in this spec
+      let(:base)       { double('legacy_base', lib: lib_double) }  # plain double: must NOT respond to :diff_index
+
+      before do
+        allow(lib_double).to receive(:ls_files).and_return({})
+        allow(lib_double).to receive(:untracked_files).and_return([])
+        allow(lib_double).to receive(:diff_files).and_return({})
+      end
+
+      context 'when empty? returns true (repository has no commits)' do
+        before do
+          allow(lib_double).to receive(:empty?).and_return(true)
+        end
+
+        it 'does not call diff_index' do
+          expect(lib_double).not_to receive(:diff_index)
+          result
+        end
+
+        it 'returns an empty hash' do
+          expect(result).to eq({})
+        end
+      end
+
+      context 'when empty? returns false (repository has commits)' do
+        before do
+          allow(lib_double).to receive(:empty?).and_return(false)
+          allow(lib_double).to receive(:diff_index).with('HEAD').and_return({})
+        end
+
+        it 'calls diff_index with HEAD on the lib provider' do
+          expect(lib_double).to receive(:diff_index).with('HEAD').and_return({})
+          result
+        end
+
+        it 'returns an empty hash when all data is empty' do
+          expect(result).to eq({})
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Migrates `Git::Base#status` into the `Git::Repository` facade layer as part of the v5.0.0 Strangler Fig architectural redesign (Iter 6).

### Changes

- **`lib/git/repository/status_operations.rb`** — adds `#status` factory method returning `Git::Status.new(self)`.
- **`lib/git/status.rb`** — makes `StatusFileFactory` polymorphic: accepts either a `Git::Repository` instance (detected via `respond_to?(:diff_index)`) or a legacy `Git::Base` instance (falls back to `base.lib`). The `no_commits?` check also routes through the appropriate interface.
- **`lib/git/base.rb`** — `#status` now delegates to `facade_repository.status`.

### Tests

- Unit tests: `StatusFileFactory` polymorphism branches (both `Git::Repository` and `Git::Base` paths, both `no_commits?`/`empty?` branches).
- Integration tests: `#status` with untracked file, changed file, and no-commits repo scenarios.
- 100% line and branch coverage for `status_operations.rb` with no `:nocov:` annotations.

### Design Notes

`Private.split_status_line` previously had a defensive `if parts.any?` guard. Since `git ls-files --stage` never emits blank lines and `"".split("\n")` returns `[]` (so the loop is never entered for empty output), that branch was provably unreachable. It was removed rather than annotated with `:nocov:`.