### PR TITLE
refactor(base): delegate ls_files and config to facade_repository (iter 6b)

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -224,20 +224,11 @@ module Git
 
     # g.config('user.name', 'Scott Chacon') # sets value
     # g.config('user.email', 'email@email.com')  # sets value
-    # g.config('user.email', 'email@email.com', file: 'path/to/custom/config)  # sets value in file
+    # g.config('user.email', 'email@email.com', file: 'path/to/custom/config')  # sets value in file
     # g.config('user.name')  # returns 'Scott Chacon'
     # g.config # returns whole config hash
     def config(name = nil, value = nil, options = {})
-      if name && value
-        # set value
-        lib.config_set(name, value, options)
-      elsif name
-        # return value
-        lib.config_get(name)
-      else
-        # return hash
-        lib.config_list
-      end
+      facade_repository.config(name, value, options)
     end
 
     # Returns a reference to the working directory
@@ -844,7 +835,7 @@ module Git
     end
 
     def ls_files(location = nil)
-      lib.ls_files(location)
+      facade_repository.ls_files(location)
     end
 
     def with_working(work_dir) # :yields: the working directory Pathname

--- a/lib/git/repository/configuring.rb
+++ b/lib/git/repository/configuring.rb
@@ -90,13 +90,21 @@ module Git
 
         # Set a config value by key name
         #
-        # @param execution_context [Git::ExecutionContext] the execution context
+        # @overload config_set(execution_context, name, value, **options)
         #
-        # @param name [String] the dotted config key to write (e.g. `"user.name"`)
+        #   @param execution_context [Git::ExecutionContext] the execution context
         #
-        # @param value [String] the value to assign
+        #   @param name [String] the dotted config key to write (e.g. `"user.name"`)
         #
-        # @return [Git::CommandLineResult] the raw result of `git config <name> <value>`
+        #   @param value [String] the value to assign
+        #
+        #   @param options [Hash] keyword options forwarded to the command
+        #
+        #   @option options [String, nil] :file (nil) path to a custom config file
+        #     to write to instead of the repository's default `.git/config`
+        #
+        #   @return [Git::CommandLineResult] the raw result of
+        #     `git config <name> <value>`
         #
         # @raise [ArgumentError] if unsupported options are provided
         #

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -43,8 +43,8 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | `Git::Repository::Diffing` | `lib/git/repository/diffing.rb` | ✅ | `diff_path_status`, `diff_name_status`, `diff_full` |
 | `Git::Repository::ObjectOperations` | `lib/git/repository/object_operations.rb` | ✅ | `rev_parse`, `tree_depth`, `ls_tree`, `grep`, `archive` |
 | `Git::Repository::Logging` | `lib/git/repository/logging.rb` | ✅ | `log`, `full_log_commits` |
-| `Git::Repository::StatusOperations` | `lib/git/repository/status_operations.rb` | ✅ | `ls_files`, `no_commits?` (renamed from `Git::Lib#empty?`; delegations to facade deferred pending iter 6B) |
-| `Git::Repository::Configuring` | `lib/git/repository/configuring.rb` | ✅ | `config` (delegation deferred — `Git::Base#config` still calls `lib.*`; will delegate in iter 6B) |
+| `Git::Repository::StatusOperations` | `lib/git/repository/status_operations.rb` | ✅ | `ls_files`, `no_commits?` (renamed from `Git::Lib#empty?`), `untracked_files`, `status`; `Git::Base#ls_files` delegates to facade |
+| `Git::Repository::Configuring` | `lib/git/repository/configuring.rb` | ✅ | `config`; `Git::Base#config` delegates to facade |
 
 #### Facade module naming convention
 
@@ -61,9 +61,9 @@ such as `Branch`, `Diff`, `Log`, `Object`, `Remote`, `Status`, `Worktree`, etc.
 
 ### Next Task
 
-**Phase 3 — Iteration 6: `Git::Status` (A+B)**
+**Phase 3 — Iteration 7: `Git::Branch` + `Git::Remote`**
 
-Iter 1 (`Git::Stash` B2 + `Git::Stashes` B3) is ✅ complete ([PR #1306](https://github.com/ruby-git/ruby-git/pull/1306)). Iter 2 (`Git::DiffPathStatus` B1) is ✅ complete. Iter 3 (`Git::Object::*`) is ✅ complete. Iter 4 (`Git::Log` A+B) is ✅ complete ([PR #1327](https://github.com/ruby-git/ruby-git/pull/1327)). Iter 5 (`Git::Diff` + `Git::DiffStats` A+B) is ✅ complete (`feat/migrate-diff-to-repository`). Proceed to iter 6.
+Iter 1 (`Git::Stash` B2 + `Git::Stashes` B3) is ✅ complete ([PR #1306](https://github.com/ruby-git/ruby-git/pull/1306)). Iter 2 (`Git::DiffPathStatus` B1) is ✅ complete. Iter 3 (`Git::Object::*`) is ✅ complete. Iter 4 (`Git::Log` A+B) is ✅ complete ([PR #1327](https://github.com/ruby-git/ruby-git/pull/1327)). Iter 5 (`Git::Diff` + `Git::DiffStats` A+B) is ✅ complete (`feat/migrate-diff-to-repository`). Iter 6 (`Git::Status` A+B) is ✅ complete (`feat/migrate-status-to-repository` + `feat/iter6b-delegate-ls-files-config`). Proceed to iter 7.
 
 The full scope is still migrating all domain objects
 (`Git::Stash`, `Git::Stashes`, `Git::DiffPathStatus`, `Git::Object::*`,
@@ -114,7 +114,7 @@ After all 9 domain-object iterations, **verify facade coverage**: every public `
 | `Git::Log` | ✅ Complete | iter 4 |
 | `Git::Diff` | ✅ Complete | iter 5 |
 | `Git::DiffStats` | ✅ Complete | iter 5 |
-| `Git::Status` | ⏳ Not started | iter 6 |
+| `Git::Status` | ✅ Complete | iter 6 |
 | `Git::Branch` | ⏳ Not started | iter 7 |
 | `Git::Remote` | ⏳ Not started | iter 7 |
 | `Git::Branches` | ⏳ Not started | iter 8 |

--- a/spec/integration/git/repository/configuring_spec.rb
+++ b/spec/integration/git/repository/configuring_spec.rb
@@ -5,15 +5,18 @@ require 'git/repository'
 require 'git/repository/configuring'
 require 'git/execution_context/repository'
 
-# Integration tests for Git::Repository::Configuring are warranted for one key reason:
+# Integration tests for Git::Repository::Configuring.
 #
 # #config (list mode) performs facade-owned post-processing: it parses the raw
 # stdout of `git config --list` into a Ruby Hash. A real git invocation is
 # needed to confirm the parsing handles actual git output correctly.
 #
-# Note: dedicated integration tests for Git::Commands::ConfigOptionSyntax::Get,
-# ::Set, and ::List already exist under
-# spec/integration/git/commands/config_option_syntax/{get,set,list}_spec.rb.
+# Single-command get and set modes are covered by dedicated command integration
+# tests under spec/integration/git/commands/config_option_syntax/{get,set,list}_spec.rb.
+# Error-path assertions and argument-forwarding tests are skipped here because
+# they test command behavior, not the facade. The set→get round-trip test is
+# retained to confirm the facade's dispatch logic routes both modes correctly
+# end-to-end against real git.
 
 RSpec.describe Git::Repository::Configuring, :integration do
   include_context 'in an empty repository'
@@ -35,43 +38,10 @@ RSpec.describe Git::Repository::Configuring, :integration do
       end
     end
 
-    context 'when called with a key name' do
-      it 'returns the configured value as a String' do
-        result = described_instance.config('user.name')
-        expect(result).to eq('Test User')
-      end
-
-      it 'raises Git::FailedError for a nonexistent key' do
-        expect { described_instance.config('nonexistent.key') }
-          .to raise_error(Git::FailedError, /config/)
-      end
-    end
-
     context 'when called with name and value' do
       it 'sets the value and a subsequent get returns the new value' do
         described_instance.config('user.name', 'NewName')
         expect(described_instance.config('user.name')).to eq('NewName')
-      end
-
-      it 'returns a Git::CommandLineResult' do
-        result = described_instance.config('user.name', 'NewName')
-        expect(result).to be_a(Git::CommandLineResult)
-      end
-
-      context 'with the file: option pointing to a custom config file' do
-        let(:custom_config_path) { File.join(repo_dir, 'custom.config') }
-
-        it 'writes the value to the custom file' do
-          described_instance.config('user.name', 'CustomName', file: custom_config_path)
-          config_content = File.read(custom_config_path)
-          expect(config_content).to include('CustomName')
-        end
-
-        it 'does not modify the default .git/config for the written key' do
-          expect do
-            described_instance.config('user.name', 'CustomName', file: custom_config_path)
-          end.not_to(change { described_instance.config('user.name') })
-        end
       end
     end
   end

--- a/spec/unit/git/repository/configuring_spec.rb
+++ b/spec/unit/git/repository/configuring_spec.rb
@@ -90,8 +90,9 @@ RSpec.describe Git::Repository::Configuring do
     end
 
     context 'when called with name and value' do
-      subject(:result) { described_instance.config('user.name', 'Alice') }
+      subject(:result) { described_instance.config('user.name', 'Alice', options) }
 
+      let(:options) { {} }
       let(:set_command) { instance_double(Git::Commands::ConfigOptionSyntax::Set) }
       let(:set_result) { command_result('') }
 
@@ -111,7 +112,7 @@ RSpec.describe Git::Repository::Configuring do
       end
 
       context 'with the file: option' do
-        subject(:result) { described_instance.config('user.name', 'Alice', file: '/path/to/config') }
+        let(:options) { { file: '/path/to/config' } }
 
         it 'forwards the file option to Git::Commands::ConfigOptionSyntax::Set#call' do
           expect(set_command)
@@ -121,7 +122,7 @@ RSpec.describe Git::Repository::Configuring do
       end
 
       context 'with an unknown option' do
-        subject(:result) { described_instance.config('user.name', 'Alice', bogus: true) }
+        let(:options) { { bogus: true } }
 
         it 'raises ArgumentError' do
           expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)


### PR DESCRIPTION
## Summary

Completes iteration 6b of the Phase 3 Strangler Fig migration. `Git::Base#ls_files` and `Git::Base#config` now delegate to `facade_repository` (the `Git::Repository` facade), removing the last direct `Git::Lib` calls for these two methods from `Git::Base`.

## Changes

- **`lib/git/base.rb`**: `#ls_files` calls `facade_repository.ls_files(location)`; `#config` calls `facade_repository.config(name, value, options)`. Both methods retain their existing public signatures.
- **`lib/git/repository/configuring.rb`**: YARD docs reviewed and fixed — added `@overload` to `Private#config_set` for the anonymous `**` parameter.
- **`redesign/3_architecture_implementation.md`**: Facade table updated; `Git::Status` marked complete; Next Task advanced to iter 7 (`Git::Branch` + `Git::Remote`).
- **`spec/unit/git/repository/configuring_spec.rb`**: Refactored nested context subjects to use `let(:options)`.
- **`spec/integration/git/repository/configuring_spec.rb`**: Removed over-specified integration tests; retained list-mode parsing and set→get round-trip.

## Test Coverage

100% line and branch coverage on `configuring.rb` and `status_operations.rb`. Full suite: 0 failures, 0 RuboCop offenses.

## Breaking Changes

None.