### PR TITLE
feat(repository): add Git::Repository#branch_new facade method

### DIFF
--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'pathname'
+require 'git/commands/branch/create'
 require 'git/commands/branch/delete'
 require 'git/commands/branch/list'
 require 'git/commands/branch/show_current'
@@ -219,6 +220,47 @@ module Git
       #
       def branch?(branch)
         local_branch?(branch) || remote_branch?(branch)
+      end
+
+      # Option keys accepted by {#branch_new}
+      #
+      BRANCH_NEW_ALLOWED_OPTS = %i[].freeze
+      private_constant :BRANCH_NEW_ALLOWED_OPTS
+
+      # Create a new branch
+      #
+      # @overload branch_new(branch, start_point = nil, options = {})
+      #
+      #   @example Create a new branch from the current HEAD
+      #     repo.branch_new('feature')
+      #
+      #   @example Create a new branch from a specific commit or branch
+      #     repo.branch_new('feature', 'main')
+      #
+      #   @param branch [String] the name of the branch to create
+      #
+      #   @param start_point [String, nil] the commit, branch, or tag to start the
+      #     new branch from; defaults to the current HEAD when `nil`
+      #
+      #   @param options [Hash] reserved; must be empty — no options are currently
+      #     supported
+      #
+      #   @return [void]
+      #
+      # @raise [ArgumentError] when unsupported options are provided
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def branch_new(branch, start_point = nil, options = {})
+        if start_point.is_a?(Hash) && options.empty?
+          options = start_point
+          start_point = nil
+        end
+
+        SharedPrivate.assert_valid_opts!(BRANCH_NEW_ALLOWED_OPTS, **options)
+        Git::Commands::Branch::Create.new(@execution_context).call(branch, start_point, **options)
+
+        nil
       end
 
       # Option keys accepted by {#branch_delete}

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -206,6 +206,50 @@ RSpec.describe Git::Repository::Branching, :integration do
   end
 
   # ---------------------------------------------------------------------------
+  # #branch_new
+  # ---------------------------------------------------------------------------
+
+  describe '#branch_new' do
+    context 'without a start_point' do
+      it 'creates the branch from the current HEAD' do
+        head_sha = repo.revparse('HEAD')
+        described_instance.branch_new('new-feature')
+        expect(described_instance.local_branch?('new-feature')).to be(true)
+        expect(repo.revparse('new-feature')).to eq(head_sha)
+      end
+
+      it 'returns nil' do
+        expect(described_instance.branch_new('new-feature')).to be_nil
+      end
+    end
+
+    context 'with a start_point' do
+      # let! eagerly captures the SHA before the inner before block adds a second commit
+      let!(:initial_sha) { repo.log(1).execute.first.sha }
+
+      before do
+        write_file('CHANGES.md', "changes\n")
+        repo.add('CHANGES.md')
+        repo.commit('Second commit')
+      end
+
+      it 'creates the branch at the given start_point' do
+        described_instance.branch_new('from-initial', initial_sha)
+        expect(described_instance.local_branch?('from-initial')).to be(true)
+        expect(repo.revparse('from-initial')).to eq(initial_sha)
+      end
+    end
+
+    context 'when the branch already exists' do
+      before { described_instance.branch_new('duplicate') }
+
+      it 'raises Git::FailedError' do
+        expect { described_instance.branch_new('duplicate') }.to raise_error(Git::FailedError, /duplicate/)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # #branch_delete
   # ---------------------------------------------------------------------------
   #

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -443,6 +443,73 @@ RSpec.describe Git::Repository::Branching do
   end
 
   # ---------------------------------------------------------------------------
+  # #branch_new
+  # ---------------------------------------------------------------------------
+
+  describe '#branch_new' do
+    let(:create_command) { instance_double(Git::Commands::Branch::Create) }
+
+    before do
+      allow(Git::Commands::Branch::Create)
+        .to receive(:new).with(execution_context).and_return(create_command)
+    end
+
+    context 'without a start_point' do
+      subject(:result) { described_instance.branch_new('feature') }
+
+      it 'delegates to Git::Commands::Branch::Create#call with the branch name and nil start_point' do
+        expect(create_command).to receive(:call).with('feature', nil)
+        result
+      end
+
+      it 'returns nil' do
+        allow(create_command).to receive(:call).with('feature', nil)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'with a start_point' do
+      subject(:result) { described_instance.branch_new('feature', 'main') }
+
+      it 'delegates to Git::Commands::Branch::Create#call with the branch name and start_point' do
+        expect(create_command).to receive(:call).with('feature', 'main')
+        result
+      end
+
+      it 'returns nil' do
+        allow(create_command).to receive(:call).with('feature', 'main')
+        expect(result).to be_nil
+      end
+    end
+
+    context 'option whitelisting' do
+      subject(:result) { described_instance.branch_new('feature', nil, bogus: true) }
+
+      it 'raises ArgumentError for unsupported options' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+
+      it 'does not call the command' do
+        expect(create_command).not_to receive(:call)
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+
+    context 'when options are passed as the second argument (no start_point)' do
+      subject(:result) { described_instance.branch_new('feature', bogus: true) }
+
+      it 'raises ArgumentError for unsupported options' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+
+      it 'does not call the command' do
+        expect(create_command).not_to receive(:call)
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # #branch_delete
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Adds `Git::Repository::Branching#branch_new` as a facade method in the `Git::Repository` layer.

This is part of the **v5.0.0 Strangler Fig architectural redesign** — progressively extracting `Git::Lib` functionality into clean, well-tested `Git::Repository::*` facade methods.

---

## What Changed

### New facade method

**`Git::Repository::Branching#branch_new(branch, start_point = nil, options = {})`**

- Delegates to `Git::Commands::Branch` to create a new branch
- Preserves the 5.x public API contract
- `BRANCH_NEW_ALLOWED_OPTS = [].freeze` — no options supported, consistent with 4.x behaviour

### Files changed

| File | Change |
|------|--------|
| `lib/git/repository/branching.rb` | New `#branch_new` facade method implementation |
| `spec/unit/git/repository/branching_spec.rb` | Unit tests (stubbed, no real git) |
| `spec/integration/git/repository/branching_spec.rb` | Integration tests (real git operations) |

---

## What Was NOT Changed (Intentional)

- **`Git::Lib#branch_new`** — left untouched; the delegation step (wiring `Git::Base` → `Git::Repository`) is a separate step per the redesign plan
- **`Git::Base`** — not modified; backward-compatible delegation is handled in a follow-up step

This PR represents the **facade implementation step only**, following the Strangler Fig pattern.

---

## Tests

- Unit tests: stub `Git::Commands::Branch` and verify correct delegation
- Integration tests: exercise real git branch creation end-to-end
- All tests passing (`bundle exec rake default` clean)
