### PR TITLE
feat(repository): extract Git::Repository#branches_all from Git::Lib

### DIFF
--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -8,6 +8,7 @@ require 'git/commands/branch/show_current'
 require 'git/commands/checkout/branch'
 require 'git/commands/checkout/files'
 require 'git/commands/checkout_index'
+require 'git/parsers/branch'
 require 'git/repository/shared_private'
 
 module Git
@@ -362,6 +363,35 @@ module Git
         Git::Commands::Branch::List.new(@execution_context)
                                    .call(*[pattern].compact, contains: commit, no_color: true)
                                    .stdout
+      end
+
+      # Returns all local and remote-tracking branches as structured objects
+      #
+      # @overload branches_all()
+      #
+      #   @example List all branches
+      #     repo.branches_all
+      #     # => [#<data Git::BranchInfo refname="main", current=true, ...>,
+      #     #     #<data Git::BranchInfo refname="remotes/origin/main", current=false, ...>]
+      #
+      #   @example Find the currently checked-out branch
+      #     repo.branches_all.find(&:current)
+      #
+      #   @example List only local branches
+      #     repo.branches_all.reject(&:remote?)
+      #
+      #   @return [Array<Git::BranchInfo>] parsed branch information for every
+      #     local and remote-tracking branch
+      #
+      #     Returns an empty array when the repository has no branches.
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def branches_all
+        result = Git::Commands::Branch::List.new(@execution_context).call(
+          all: true, format: Git::Parsers::Branch::FORMAT_STRING
+        )
+        Git::Parsers::Branch.parse_list(result.stdout)
       end
 
       # Private helpers local to {Git::Repository::Branching}

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -342,4 +342,72 @@ RSpec.describe Git::Repository::Branching, :integration do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #branches_all
+  # ---------------------------------------------------------------------------
+  #
+  # branches_all delegates parsing to Git::Parsers::Branch.parse_list, which
+  # means the integration tests verify the end-to-end Ruby return value against
+  # real git output.
+
+  describe '#branches_all' do
+    context 'when only a local branch exists' do
+      it 'returns an Array of Git::BranchInfo' do
+        result = described_instance.branches_all
+        expect(result).to be_an(Array)
+        expect(result).to all(be_a(Git::BranchInfo))
+      end
+
+      it 'includes the current branch' do
+        current = described_instance.current_branch
+        refnames = described_instance.branches_all.map(&:refname)
+        expect(refnames).to include(current)
+      end
+
+      it 'marks exactly one branch as current' do
+        result = described_instance.branches_all
+        current_branches = result.select(&:current)
+        expect(current_branches.length).to eq(1)
+      end
+    end
+
+    context 'when a remote-tracking branch exists' do
+      let(:bare_dir) { Dir.mktmpdir('bare_repo') }
+
+      after { FileUtils.rm_rf(bare_dir) }
+
+      before do
+        Git.init(bare_dir, bare: true)
+        repo.add_remote('origin', bare_dir)
+        repo.push('origin', 'main')
+      end
+
+      it 'returns an Array of Git::BranchInfo that includes the remote-tracking branch' do
+        result = described_instance.branches_all
+        expect(result).to be_an(Array)
+        expect(result).to all(be_a(Git::BranchInfo))
+        expect(result.any?(&:remote?)).to be(true)
+      end
+
+      it 'includes both local and remote-tracking branches' do
+        refnames = described_instance.branches_all.map(&:refname)
+        expect(refnames).to include('main')
+        expect(refnames.any? { |r| r.start_with?('remotes/origin/') }).to be(true)
+      end
+    end
+
+    context 'when in detached HEAD state' do
+      before do
+        sha = repo.log(1).execute.first.sha
+        repo.lib.checkout(sha)
+      end
+
+      it 'returns an Array of Git::BranchInfo' do
+        result = described_instance.branches_all
+        expect(result).to be_an(Array)
+        expect(result).to all(be_a(Git::BranchInfo))
+      end
+    end
+  end
 end

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -676,4 +676,66 @@ RSpec.describe Git::Repository::Branching do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #branches_all
+  # ---------------------------------------------------------------------------
+
+  describe '#branches_all' do
+    subject(:result) { described_instance.branches_all }
+
+    let(:branch_list_command) { instance_double(Git::Commands::Branch::List) }
+    let(:branch_list_result) do
+      command_result("refs/heads/main|abc1234|*|||\nrefs/remotes/origin/main|abc1234||||\n")
+    end
+    let(:parsed_branches) do
+      [
+        instance_double(Git::BranchInfo, refname: 'main', current: true),
+        instance_double(Git::BranchInfo, refname: 'remotes/origin/main', current: false)
+      ]
+    end
+
+    before do
+      allow(Git::Commands::Branch::List)
+        .to receive(:new).with(execution_context).and_return(branch_list_command)
+    end
+
+    context 'when the repository has branches' do
+      it 'calls Branch::List#call then Git::Parsers::Branch.parse_list in order and returns the parsed result' do
+        expect(branch_list_command).to(
+          receive(:call)
+            .with(all: true, format: Git::Parsers::Branch::FORMAT_STRING)
+            .and_return(branch_list_result)
+            .ordered
+        )
+        expect(Git::Parsers::Branch).to(
+          receive(:parse_list)
+            .with(branch_list_result.stdout)
+            .and_return(parsed_branches)
+            .ordered
+        )
+        expect(result).to eq(parsed_branches)
+      end
+    end
+
+    context 'when the repository has no branches (empty stdout)' do
+      let(:branch_list_result) { command_result('') }
+
+      it 'calls Branch::List#call and Git::Parsers::Branch.parse_list with empty stdout and returns an empty array' do
+        expect(branch_list_command).to(
+          receive(:call)
+            .with(all: true, format: Git::Parsers::Branch::FORMAT_STRING)
+            .and_return(branch_list_result)
+            .ordered
+        )
+        expect(Git::Parsers::Branch).to(
+          receive(:parse_list)
+            .with('')
+            .and_return([])
+            .ordered
+        )
+        expect(result).to eq([])
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Extracts `Git::Lib#branches_all` into a new public facade method `Git::Repository::Branching#branches_all` as part of the v5.0.0 Strangler Fig migration.

`Git::Lib` is `@api private` and is not updated to delegate to the facade (per the extraction plan — Step 6 skipped intentionally). The existing `Git::Lib#branches_all` implementation remains in place for internal consumers.

## What Changed

### New facade method

Added `Git::Repository::Branching#branches_all` in `lib/git/repository/branching.rb`:

```ruby
def branches_all
  result = Git::Commands::Branch::List.new(@execution_context).call(
    all: true, format: Git::Parsers::Branch::FORMAT_STRING
  )
  Git::Parsers::Branch.parse_list(result.stdout)
end
```

Returns `Array<Git::BranchInfo>` — structured data objects with named fields (`refname`, `current`, `target_oid`, `upstream`, `worktree`, `symref`).

### Tests

- **Unit tests** (`spec/unit/git/repository/branching_spec.rb`): stubs `Git::Commands::Branch::List` and `Git::Parsers::Branch.parse_list`; verifies the delegation contract and return value.
- **Integration tests** (`spec/integration/git/repository/branching_spec.rb`): exercises real git in temp repos across three scenarios:
  - When only a local branch exists
  - When a remote-tracking branch exists
  - When in detached HEAD state

## Notes

The `Array<Git::BranchInfo>` return type (vs. the 4.x plain `Array<Array>`) was already present on `main` before this PR — this facade faithfully mirrors the existing `Git::Lib` implementation.
