### PR TITLE
Refactor update_ref through Git::Repository facade

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -831,7 +831,7 @@ module Git
     end
 
     def update_ref(branch, commit)
-      branch(branch).update_ref(commit)
+      facade_repository.update_ref(branch, commit)
     end
 
     def ls_files(location = nil)

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -8,13 +8,14 @@ require 'git/commands/branch/show_current'
 require 'git/commands/checkout/branch'
 require 'git/commands/checkout/files'
 require 'git/commands/checkout_index'
+require 'git/commands/update_ref/update'
 require 'git/parsers/branch'
 require 'git/repository/shared_private'
 
 module Git
   class Repository
-    # Facade methods for branching operations: checking out, switching branches,
-    # querying the current branch, and deleting branches
+    # Facade methods for branching operations: creating, checking out, querying,
+    # deleting, and updating branches
     #
     # Included by {Git::Repository}.
     #
@@ -394,6 +395,40 @@ module Git
         Git::Parsers::Branch.parse_list(result.stdout)
       end
 
+      # Update a branch ref to point to a new commit
+      #
+      # Derives the full ref from the `branch` argument:
+      #
+      # - `remotes/<remote>/<name>` or `refs/remotes/<remote>/<name>` →
+      #   writes to `refs/remotes/<remote>/<name>` (remote-tracking branch)
+      # - Any other value → writes to `refs/heads/<branch>` (local branch)
+      #
+      # @overload update_ref(branch, commit)
+      #
+      #   @example Advance a local branch to the current HEAD
+      #     repo.update_ref('feature', repo.rev_parse('HEAD'))
+      #
+      #   @example Reset a local branch to an older commit
+      #     repo.update_ref('main', 'abc1234def5678')
+      #
+      #   @example Update a remote-tracking branch ref
+      #     repo.update_ref('remotes/origin/main', 'abc1234def5678')
+      #
+      #   @param branch [String] a short local branch name (e.g. `'main'`) or a
+      #     remote-tracking branch name with a `remotes/<remote>/` or
+      #     `refs/remotes/<remote>/` prefix (e.g. `'remotes/origin/main'`)
+      #
+      #   @param commit [String] the commit SHA to point the branch at
+      #
+      #   @return [Git::CommandLineResult] the result of calling `git update-ref`
+      #
+      #   @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def update_ref(branch, commit)
+        ref = Private.build_update_ref(branch)
+        Git::Commands::UpdateRef::Update.new(@execution_context).call(ref, commit)
+      end
+
       # Private helpers local to {Git::Repository::Branching}
       #
       # @api private
@@ -471,6 +506,27 @@ module Git
           return if pathspecs.all? { |path| path.is_a?(String) || path.is_a?(Pathname) }
 
           raise ArgumentError, "Invalid #{arg_name}: must be a String, Pathname, or Array of Strings/Pathnames"
+        end
+
+        # Builds the full git ref string from a branch name argument
+        #
+        # Mirrors the routing logic of `Git::Branch#update_ref` for backward
+        # compatibility:
+        #
+        # - `remotes/<remote>/<name>` or `refs/remotes/<remote>/<name>` →
+        #   `refs/remotes/<remote>/<name>`
+        # - Any other value → `refs/heads/<branch>`
+        #
+        # @param branch [String] a short local branch name or a remote-tracking
+        #   branch name with a `remotes/` or `refs/remotes/` prefix
+        #
+        # @return [String] the full git ref string
+        #
+        # @api private
+        #
+        def build_update_ref(branch)
+          match = branch.match(%r{\A(?:refs/)?remotes/([^/]+)/(.+)\z})
+          match ? "refs/remotes/#{match[1]}/#{match[2]}" : "refs/heads/#{branch}"
         end
       end
       private_constant :Private

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -36,7 +36,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | ------ | ---- | ------------------------------ | --------------------- |
 | `Git::Repository::Staging` | `lib/git/repository/staging.rb` | ✅ | `add`, `reset` |
 | `Git::Repository::Committing` | `lib/git/repository/committing.rb` | ✅ | `commit`, `commit_all`, `write_tree`; `commit_tree` and `write_and_commit_tree` wrap the SHA result in `Git::Object::Commit.new(self, ...)` |
-| `Git::Repository::Branching` | `lib/git/repository/branching.rb` | ✅ | `checkout`, `checkout_file`, `checkout_index`, `current_branch`, `local_branch?`, `remote_branch?`, `branch?`, `branch_delete`, `branch_new`, `branch_contains` |
+| `Git::Repository::Branching` | `lib/git/repository/branching.rb` | ✅ | `checkout`, `checkout_file`, `checkout_index`, `current_branch`, `local_branch?`, `remote_branch?`, `branch?`, `branch_delete`, `branch_new`, `branch_contains`, `branches_all`, `update_ref` |
 | `Git::Repository::Merging` | `lib/git/repository/merging.rb` | ✅ | `merge`, `revert`, `each_conflict`; `merge_base` wraps the returned SHA strings in `Git::Object::Commit.new(self, ...)` instances |
 | `Git::Repository::RemoteOperations` | `lib/git/repository/remote_operations.rb` | ✅ | `fetch`, `pull`, `push`, `add_remote`, `remove_remote`, `config_remote` |
 | `Git::Repository::Stashing` | `lib/git/repository/stashing.rb` | ✅ | `stash_save`, `stash_apply`, `stash_clear`, `stashes_all` |

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -410,4 +410,28 @@ RSpec.describe Git::Repository::Branching, :integration do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #update_ref
+  # ---------------------------------------------------------------------------
+
+  describe '#update_ref' do
+    before do
+      repo.branch('feature').create
+      write_file('CHANGES.md', "changes\n")
+      repo.add('CHANGES.md')
+      repo.commit('Second commit')
+    end
+
+    it 'points the branch ref at the given commit SHA' do
+      new_sha = repo.revparse('HEAD')
+      described_instance.update_ref('feature', new_sha)
+      expect(repo.revparse('refs/heads/feature')).to eq(new_sha)
+    end
+
+    it 'returns a Git::CommandLineResult' do
+      result = described_instance.update_ref('feature', repo.revparse('HEAD'))
+      expect(result).to be_a(Git::CommandLineResult)
+    end
+  end
 end

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -738,4 +738,62 @@ RSpec.describe Git::Repository::Branching do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #update_ref
+  # ---------------------------------------------------------------------------
+
+  describe '#update_ref' do
+    subject(:result) { described_instance.update_ref('feature', 'abc1234') }
+
+    let(:update_ref_command) { instance_double(Git::Commands::UpdateRef::Update) }
+    let(:update_ref_result) { command_result }
+
+    before do
+      allow(Git::Commands::UpdateRef::Update)
+        .to receive(:new).with(execution_context).and_return(update_ref_command)
+      allow(update_ref_command)
+        .to receive(:call).with('refs/heads/feature', 'abc1234').and_return(update_ref_result)
+    end
+
+    it 'constructs the full ref from the branch name and delegates to Git::Commands::UpdateRef::Update#call' do
+      expect(update_ref_command)
+        .to receive(:call).with('refs/heads/feature', 'abc1234').and_return(update_ref_result)
+      result
+    end
+
+    it 'returns the Git::CommandLineResult from the command' do
+      expect(result).to eq(update_ref_result)
+    end
+
+    context 'when branch is a remotes/<remote>/<name> remote-tracking branch name' do
+      subject(:result) { described_instance.update_ref('remotes/origin/main', 'abc1234') }
+
+      before do
+        allow(update_ref_command)
+          .to receive(:call).with('refs/remotes/origin/main', 'abc1234').and_return(update_ref_result)
+      end
+
+      it 'routes to refs/remotes/<remote>/<name> for backward compatibility' do
+        expect(update_ref_command)
+          .to receive(:call).with('refs/remotes/origin/main', 'abc1234').and_return(update_ref_result)
+        result
+      end
+    end
+
+    context 'when branch is a refs/remotes/<remote>/<name> remote-tracking branch name' do
+      subject(:result) { described_instance.update_ref('refs/remotes/origin/main', 'abc1234') }
+
+      before do
+        allow(update_ref_command)
+          .to receive(:call).with('refs/remotes/origin/main', 'abc1234').and_return(update_ref_result)
+      end
+
+      it 'routes to refs/remotes/<remote>/<name> for backward compatibility' do
+        expect(update_ref_command)
+          .to receive(:call).with('refs/remotes/origin/main', 'abc1234').and_return(update_ref_result)
+        result
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary
This PR migrates `update_ref` to the repository facade architecture and updates related docs/tests.

## What changed
- Added `Git::Repository::Branching#update_ref` facade method.
- Added/updated unit and integration tests for `Git::Repository::Branching#update_ref`.
- Updated `Git::Base#update_ref` to delegate to `Git::Repository`.
- Updated the implementation plan entry in `redesign/3_architecture_implementation.md`.

## Why
This continues the facade extraction effort by moving public behavior behind `Git::Repository`, reducing direct `Git::Lib` coupling in `Git::Base` while preserving behavior with test coverage.
