### PR TITLE
Migrate Git::Branch and Git::Remote to Repository Facade

### DIFF
--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'git/base'
 require_relative 'branch_info'
 
 module Git
@@ -28,7 +29,7 @@ module Git
     # by {Git::Remote#branch} use the `<remote>/<branch>` form (e.g.
     # `'origin/main'`) which does **not** populate {#remote}.
     #
-    # @example
+    # @example Local and remote-tracking branch full refnames
     #   git.branch('main').full                  #=> 'main'
     #   git.branch('remotes/origin/main').full   #=> 'remotes/origin/main'
     #
@@ -43,7 +44,7 @@ module Git
     # branches and for remote-tracking branches in `<remote>/<branch>` form
     # (such as those returned by {Git::Remote#branch}).
     #
-    # @example
+    # @example Local and remote-tracking branches
     #   git.branch('main').remote                  #=> nil
     #   git.branch('remotes/origin/main').remote   #=> #<Git::Remote 'origin'>
     #   git.remote('origin').branch('main').remote #=> nil  # uses 'origin/main' form
@@ -57,7 +58,7 @@ module Git
     # For both local and remote-tracking branches this is the bare branch
     # name (e.g. `'main'` rather than `'remotes/origin/main'`).
     #
-    # @example
+    # @example Local and remote-tracking branch short names
     #   git.branch('main').name                  #=> 'main'
     #   git.branch('remotes/origin/main').name   #=> 'main'
     #
@@ -67,15 +68,19 @@ module Git
 
     # Initialize a new Branch object
     #
-    # @api private
+    # @param base [Git::Base, Git::Repository] the git repository
     #
-    # @note Use {Git::Base#branch} or {Git::Base#branches} instead of constructing directly
-    #
-    # @param base [Git::Base] the git repository
+    #   Accepts either a {Git::Base} (legacy) or a {Git::Repository} (new form).
+    #   The `is_a?(Git::Base)` guard will be removed when {Git::Base} is deleted
+    #   in Phase 4.
     #
     # @param branch_info_or_name [Git::BranchInfo, String] branch info object or name string
     #
     #   Passing a BranchInfo is preferred; String support is for backward compatibility.
+    #
+    # @note Use {Git::Base#branch} or {Git::Base#branches} instead of constructing directly
+    #
+    # @api private
     #
     def initialize(base, branch_info_or_name)
       @base = base
@@ -95,7 +100,7 @@ module Git
     # @return [Git::Object] the commit at the tip of this branch
     #
     def gcommit
-      @gcommit ||= @base.gcommit(@full)
+      @gcommit ||= branch_repository.gcommit(@full)
       @gcommit
     end
 
@@ -109,7 +114,7 @@ module Git
     # @return [Git::Stashes] the stash list
     #
     def stashes
-      @stashes ||= Git::Stashes.new(@base)
+      @stashes ||= Git::Stashes.new(branch_repository)
     end
 
     # Checks out this branch, attempting to create it first if it does not already exist
@@ -133,7 +138,7 @@ module Git
     #
     def checkout
       check_if_create
-      @base.checkout(@full)
+      branch_repository.checkout(@full)
     end
 
     # Archives this branch and writes the result to a file
@@ -153,7 +158,7 @@ module Git
     # @raise [Git::FailedError] if `git archive` fails
     #
     def archive(file, opts = {})
-      @base.lib.archive(@full, file, opts)
+      branch_repository.archive(@full, file, opts)
     end
 
     # Checks out this branch for the duration of a block, then restores the original branch
@@ -184,14 +189,14 @@ module Git
     # @raise [Git::FailedError] if any of the underlying git operations (checkout, commit, reset) fail
     #
     def in_branch(message = 'in branch work')
-      old_current = @base.lib.branch_current
+      old_current = branch_repository.current_branch
       checkout
       if yield
-        @base.commit_all(message)
+        branch_repository.commit_all(message)
       else
-        @base.reset(nil, hard: true)
+        branch_repository.reset(nil, hard: true)
       end
-      @base.checkout(old_current)
+      branch_repository.checkout(old_current)
     end
 
     # Creates this branch if it does not already exist
@@ -222,9 +227,9 @@ module Git
     #
     def delete
       if @remote
-        @base.lib.branch_delete("#{@remote.name}/#{@name}", remotes: true)
+        branch_repository.branch_delete("#{@remote.name}/#{@name}", remotes: true)
       else
-        @base.lib.branch_delete(@name)
+        branch_repository.branch_delete(@name)
       end
     end
 
@@ -244,7 +249,7 @@ module Git
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
     def current # rubocop:disable Naming/PredicateMethod
-      @base.lib.branch_current == @name
+      branch_repository.current_branch == @name
     end
 
     # Returns true if this branch contains the given commit
@@ -264,7 +269,7 @@ module Git
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
     def contains?(commit)
-      !@base.lib.branch_contains(commit, name).empty?
+      !branch_repository.branch_contains(commit, name).empty?
     end
 
     # Merges a branch into this branch, or merges this branch into the current branch
@@ -301,13 +306,13 @@ module Git
     def merge(branch = nil, message = nil)
       if branch
         in_branch do
-          @base.merge(branch, message)
+          branch_repository.merge(branch, message)
           false
         end
         # merge a branch into this one
       else
         # merge this branch into the current one
-        @base.merge(@name)
+        branch_repository.merge(@name)
       end
     end
 
@@ -333,9 +338,9 @@ module Git
     #
     def update_ref(commit)
       if @remote
-        @base.lib.update_ref("refs/remotes/#{@remote.name}/#{@name}", commit)
+        branch_repository.update_ref("remotes/#{@remote.name}/#{@name}", commit)
       else
-        @base.lib.update_ref("refs/heads/#{@name}", commit)
+        branch_repository.update_ref(@name, commit)
       end
     end
 
@@ -454,9 +459,23 @@ module Git
     # @return [nil]
     #
     def check_if_create
-      @base.lib.branch_new(@name)
+      branch_repository.branch_new(@name)
     rescue StandardError
       nil
+    end
+
+    # Resolves the {Git::Repository} for this branch
+    #
+    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
+    # The `is_a?(Git::Base)` guard will be removed when {Git::Base} is deleted
+    # in Phase 4.
+    #
+    # @return [Git::Repository]
+    #
+    # @api private
+    #
+    def branch_repository
+      @base.is_a?(Git::Base) ? @base.facade_repository : @base
     end
   end
 end

--- a/lib/git/remote.rb
+++ b/lib/git/remote.rb
@@ -1,47 +1,163 @@
 # frozen_string_literal: true
 
+require 'git/base'
+require 'git/branch'
+require 'git/branch_info'
+
 module Git
   # A remote in a Git repository
+  #
+  # Remote objects provide access to remote metadata and operations like fetch,
+  # merge, and remove. They should be obtained via {Git::Base#remote} or the
+  # `remote` factory method on a `Git::Repository` instance, not constructed
+  # directly.
+  #
+  # @example Getting a remote
+  #   git = Git.open('.')
+  #   remote = git.remote('origin')
+  #   remote.fetch
+  #
+  # @api public
+  #
   class Remote
-    attr_accessor :name, :url, :fetch_opts
+    # The name of this remote (e.g. `'origin'`)
+    #
+    # @return [String] the remote name
+    #
+    attr_accessor :name
 
+    # The URL of this remote
+    #
+    # @return [String, nil] the remote URL
+    #
+    attr_accessor :url
+
+    # The fetch refspec for this remote
+    #
+    # @return [String, nil] the fetch options string
+    #
+    attr_accessor :fetch_opts
+
+    # Initialize a new Remote object
+    #
+    # @param base [Git::Base, Git::Repository] the git repository
+    #
+    #   Accepts either a {Git::Base} (legacy) or a {Git::Repository} (new form).
+    #   The `is_a?(Git::Base)` guard will be removed when {Git::Base} is deleted
+    #   in Phase 4.
+    #
+    # @param name [String] the remote name (e.g. `'origin'`)
+    #
+    # @note Use {Git::Base#remote} or the `remote` factory method on a
+    #   `Git::Repository` instance instead of constructing directly
+    #
+    # @api private
+    #
     def initialize(base, name)
       @base = base
-      config = @base.lib.config_remote(name)
+      config = remote_repository.config_remote(name)
       @name = name
       @url = config['url']
       @fetch_opts = config['fetch']
     end
 
+    # Fetches from this remote
+    #
+    # @example Fetch from origin
+    #   git.remote('origin').fetch
+    #
+    # @param opts [Hash] fetch options (see {Git::Base#fetch})
+    #
+    # @return [String] git's stdout from the fetch
+    #
+    # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
     def fetch(opts = {})
-      @base.fetch(@name, opts)
+      remote_repository.fetch(@name, opts)
     end
 
-    # merge this remote locally
-    def merge(branch = @base.current_branch)
+    # Merges this remote into the given (or current) local branch
+    #
+    # @example Merge origin/main into the current branch
+    #   git.remote('origin').merge('main')
+    #
+    # @param branch [String] the local branch to merge into (defaults to current branch)
+    #
+    # @return [String] git's stdout from the merge
+    #
+    # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    def merge(branch = nil)
+      branch ||= remote_repository.current_branch
       remote_tracking_branch = "#{@name}/#{branch}"
-      @base.merge(remote_tracking_branch)
+      remote_repository.merge(remote_tracking_branch)
     end
 
-    def branch(branch = @base.current_branch)
+    # Returns a {Git::Branch} object for the given branch on this remote
+    #
+    # @example Get the remote-tracking branch object
+    #   git.remote('origin').branch('main')  #=> #<Git::Branch 'origin/main'>
+    #
+    # @param branch [String] the branch name on this remote (defaults to current branch)
+    #
+    # @return [Git::Branch] a branch object representing `<remote>/<branch>`
+    #
+    def branch(branch = nil)
+      branch ||= remote_repository.current_branch
       remote_tracking_branch = "#{@name}/#{branch}"
-      branch_info = Git::BranchInfo.new(
-        refname: remote_tracking_branch,
+      branch_info = build_branch_info(remote_tracking_branch)
+      Git::Branch.new(@base, branch_info)
+    end
+
+    # Removes this remote from the repository
+    #
+    # @example Remove the upstream remote
+    #   git.remote('upstream').remove
+    #
+    # @return [Git::CommandLineResult] the result of `git remote remove`
+    #
+    # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    def remove
+      remote_repository.remove_remote(@name)
+    end
+
+    # Returns the name of this remote as a string
+    #
+    # @example Get the remote name as a string
+    #   git.remote('origin').to_s  #=> 'origin'
+    #
+    # @return [String] the remote name
+    #
+    def to_s
+      @name
+    end
+
+    private
+
+    # Resolves the {Git::Repository} for this remote
+    #
+    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
+    # The `is_a?(Git::Base)` guard will be removed when {Git::Base} is deleted
+    # in Phase 4.
+    #
+    # @return [Git::Repository]
+    #
+    # @api private
+    #
+    def remote_repository
+      @base.is_a?(Git::Base) ? @base.facade_repository : @base
+    end
+
+    def build_branch_info(refname)
+      Git::BranchInfo.new(
+        refname: refname,
         target_oid: nil,
         current: false,
         worktree: false,
         symref: nil,
         upstream: nil
       )
-      Git::Branch.new(@base, branch_info)
-    end
-
-    def remove
-      @base.lib.remote_remove(@name)
-    end
-
-    def to_s
-      @name
     end
   end
 end

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'pathname'
+require 'git/branch'
+require 'git/branch_info'
 require 'git/commands/branch/create'
 require 'git/commands/branch/delete'
 require 'git/commands/branch/list'
@@ -105,7 +107,7 @@ module Git
       #
       #   @option options [Boolean, nil] :f (nil) alias for `:force`
       #
-      #   @option options [String] :start_point the commit or branch to start the
+      #   @option options [String, nil] :start_point (nil) the commit or branch to start the
       #     new branch from; used together with `new_branch: true`
       #
       #   @return [String] git's stdout from the checkout
@@ -427,6 +429,32 @@ module Git
       def update_ref(branch, commit)
         ref = Private.build_update_ref(branch)
         Git::Commands::UpdateRef::Update.new(@execution_context).call(ref, commit)
+      end
+
+      # Returns a {Git::Branch} object for the given branch name
+      #
+      # @example Get a branch object for 'main'
+      #   repo.branch('main')  #=> #<Git::Branch 'main'>
+      #
+      # @example Get a branch object for the current branch
+      #   repo.branch  #=> #<Git::Branch 'main'>
+      #
+      # @param branch_name [String] the branch name (defaults to the current branch)
+      #
+      # @return [Git::Branch] the branch object
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def branch(branch_name = current_branch)
+        branch_info = Git::BranchInfo.new(
+          refname: branch_name,
+          target_oid: nil,
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+        Git::Branch.new(self, branch_info)
       end
 
       # Private helpers local to {Git::Repository::Branching}

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -5,12 +5,15 @@ require 'git/commands/fetch'
 require 'git/commands/pull'
 require 'git/commands/push'
 require 'git/commands/remote'
+require 'git/remote'
 
 require 'git/repository/shared_private'
 
 module Git
   class Repository
     # Mixin that adds remote operation facade methods to {Git::Repository}
+    #
+    # Included by {Git::Repository}.
     #
     # @api public
     #
@@ -350,8 +353,11 @@ module Git
       #
       #   @return [String] the stdout from the push command
       #
-      #   @raise [ArgumentError] when unsupported option keys are provided or if a branch
-      #     is supplied and remote is nil
+      #   @raise [ArgumentError] if a branch is given and remote is nil
+      #
+      # @raise [ArgumentError] when unsupported option keys are provided
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def push(remote = nil, branch = nil, opts = nil)
         remote, branch, opts = Private.normalize_push_args(remote, branch, opts)
@@ -402,7 +408,7 @@ module Git
       # @option opts [String, nil] :track (nil) track only the given branch during
       #   fetch (`-t`)
       #
-      # @return [Git::Remote]
+      # @return [Git::Remote] the newly added remote
       #
       # @raise [ArgumentError] when unsupported option keys are provided
       #
@@ -414,7 +420,7 @@ module Git
         SharedPrivate.assert_valid_opts!(ADD_REMOTE_ALLOWED_OPTS, **opts)
         Git::Commands::Remote::Add.new(@execution_context).call(name, url, **opts)
 
-        Git::Remote.new(@execution_context.base_object, name)
+        Git::Remote.new(self, name)
       end
 
       # Removes a remote from this repository
@@ -429,8 +435,7 @@ module Git
       #
       # @return [Git::CommandLineResult] the result of calling `git remote remove`
       #
-      # @raise [Git::FailedError] when git exits with a non-zero status, for example
-      #   when `name` does not refer to an existing remote
+      # @raise [Git::FailedError] when git exits with a non-zero status
       #
       def remove_remote(name)
         Git::Commands::Remote::Remove.new(@execution_context).call(name)
@@ -463,6 +468,24 @@ module Git
         Private.config_list(@execution_context).each_with_object({}) do |(key, value), hsh|
           hsh[key.delete_prefix(prefix)] = value if key.start_with?(prefix)
         end
+      end
+
+      # Returns a {Git::Remote} object for the named remote
+      #
+      # @example Get the default 'origin' remote
+      #   repo.remote  #=> #<Git::Remote 'origin'>
+      #
+      # @example Get a named remote
+      #   repo.remote('upstream')  #=> #<Git::Remote 'upstream'>
+      #
+      # @param name [String] the remote name (defaults to `'origin'`)
+      #
+      # @return [Git::Remote] the remote object
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def remote(name = 'origin')
+        Git::Remote.new(self, name)
       end
 
       # Helpers private to the `RemoteOperations` topic module
@@ -558,7 +581,7 @@ module Git
         # in this first call. Tags are pushed in a separate call when
         # {push_tags_separately?} is true.
         #
-        # @param execution_context [Git::ExecutionContext::Repository]
+        # @param execution_context [Git::ExecutionContext::Repository] the repository execution context
         # @param remote [String, nil] remote name or URL
         # @param branch [String, nil] branch or refspec
         # @param opts [Hash] push options (`:tags` key will be stripped)
@@ -590,7 +613,7 @@ module Git
 
         # Issue the tags push (second push when `:tags` is requested without `:mirror`)
         #
-        # @param execution_context [Git::ExecutionContext::Repository]
+        # @param execution_context [Git::ExecutionContext::Repository] the repository execution context
         # @param remote [String, nil] remote name or URL
         # @param opts [Hash] push options (`:tags` key included to emit `--tags`)
         #

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -61,9 +61,9 @@ such as `Branch`, `Diff`, `Log`, `Object`, `Remote`, `Status`, `Worktree`, etc.
 
 ### Next Task
 
-**Phase 3 — Iteration 7: `Git::Branch` + `Git::Remote`**
+**Phase 3 — Iteration 8: `Git::Branches`**
 
-Iter 1 (`Git::Stash` B2 + `Git::Stashes` B3) is ✅ complete ([PR #1306](https://github.com/ruby-git/ruby-git/pull/1306)). Iter 2 (`Git::DiffPathStatus` B1) is ✅ complete. Iter 3 (`Git::Object::*`) is ✅ complete. Iter 4 (`Git::Log` A+B) is ✅ complete ([PR #1327](https://github.com/ruby-git/ruby-git/pull/1327)). Iter 5 (`Git::Diff` + `Git::DiffStats` A+B) is ✅ complete (`feat/migrate-diff-to-repository`). Iter 6 (`Git::Status` A+B) is ✅ complete (`feat/migrate-status-to-repository` + `feat/iter6b-delegate-ls-files-config`). Proceed to iter 7.
+Iter 1 (`Git::Stash` B2 + `Git::Stashes` B3) is ✅ complete ([PR #1306](https://github.com/ruby-git/ruby-git/pull/1306)). Iter 2 (`Git::DiffPathStatus` B1) is ✅ complete. Iter 3 (`Git::Object::*`) is ✅ complete. Iter 4 (`Git::Log` A+B) is ✅ complete ([PR #1327](https://github.com/ruby-git/ruby-git/pull/1327)). Iter 5 (`Git::Diff` + `Git::DiffStats` A+B) is ✅ complete (`feat/migrate-diff-to-repository`). Iter 6 (`Git::Status` A+B) is ✅ complete (`feat/migrate-status-to-repository` + `feat/iter6b-delegate-ls-files-config`). Iter 7 (`Git::Branch` + `Git::Remote` A+B) is ✅ complete (`agents/migrate-git-branch-remote-polymorphism`). Proceed to iter 8.
 
 The full scope is still migrating all domain objects
 (`Git::Stash`, `Git::Stashes`, `Git::DiffPathStatus`, `Git::Object::*`,
@@ -115,8 +115,8 @@ After all 9 domain-object iterations, **verify facade coverage**: every public `
 | `Git::Diff` | ✅ Complete | iter 5 |
 | `Git::DiffStats` | ✅ Complete | iter 5 |
 | `Git::Status` | ✅ Complete | iter 6 |
-| `Git::Branch` | ⏳ Not started | iter 7 |
-| `Git::Remote` | ⏳ Not started | iter 7 |
+| `Git::Branch` | ✅ Complete | iter 7 |
+| `Git::Remote` | ✅ Complete | iter 7 |
 | `Git::Branches` | ⏳ Not started | iter 8 |
 | `Git::Worktree` | ⏳ Not started | iter 9 |
 | `Git::Worktrees` | ⏳ Not started | iter 9 |

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -294,7 +294,7 @@ RSpec.describe Git::Repository::Branching, :integration do
     context 'when the branch does not exist' do
       it 'raises Git::Error' do
         expect { described_instance.branch_delete('nonexistent-branch') }
-          .to raise_error(Git::Error)
+          .to raise_error(Git::Error, /nonexistent-branch/)
       end
     end
 
@@ -432,6 +432,24 @@ RSpec.describe Git::Repository::Branching, :integration do
     it 'returns a Git::CommandLineResult' do
       result = described_instance.update_ref('feature', repo.revparse('HEAD'))
       expect(result).to be_a(Git::CommandLineResult)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #branch (factory)
+  # ---------------------------------------------------------------------------
+
+  describe '#branch' do
+    it 'returns a Git::Branch for the given name' do
+      result = described_instance.branch('main')
+      expect(result).to be_a(Git::Branch)
+      expect(result.full).to eq('main')
+    end
+
+    it 'defaults to the current branch when no name is given' do
+      result = described_instance.branch
+      expect(result).to be_a(Git::Branch)
+      expect(result.full).to eq(described_instance.current_branch)
     end
   end
 end

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -36,21 +36,20 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       expect(result).to be_a(String)
     end
 
-    it 'succeeds when fetching from a valid remote' do
-      expect { described_instance.fetch('origin') }.not_to raise_error
-    end
-
     it 'uses "origin" as the default remote' do
-      expect { described_instance.fetch }.not_to raise_error
+      result = described_instance.fetch
+      expect(result).to be_a(String)
     end
 
     it 'raises Git::FailedError when the remote does not exist' do
-      expect { described_instance.fetch('nonexistent-remote') }.to raise_error(Git::FailedError)
+      expect { described_instance.fetch('nonexistent-remote') }
+        .to raise_error(Git::FailedError, /nonexistent-remote/)
     end
 
     context 'when opts is passed as the first argument (Hash-only form)' do
-      it 'does not raise when fetching without an explicit remote' do
-        expect { described_instance.fetch(prune: true) }.not_to raise_error
+      it 'returns a String when fetching without an explicit remote' do
+        result = described_instance.fetch(prune: true)
+        expect(result).to be_a(String)
       end
     end
 
@@ -72,13 +71,9 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       expect(result).to be_a(String)
     end
 
-    it 'succeeds when pushing to a valid remote' do
-      expect { described_instance.push('origin', 'main') }.not_to raise_error
-    end
-
     it 'raises Git::FailedError when the remote does not exist' do
       expect { described_instance.push('nonexistent-remote', 'main') }
-        .to raise_error(Git::FailedError)
+        .to raise_error(Git::FailedError, /nonexistent-remote/)
     end
 
     context 'when branch is specified without a remote' do
@@ -117,17 +112,14 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       expect(result).to be_a(String)
     end
 
-    it 'succeeds when the local branch is already up to date' do
-      expect { described_instance.pull('origin', 'main') }.not_to raise_error
-    end
-
     it 'raises ArgumentError when a branch is given without a remote' do
       expect { described_instance.pull(nil, 'main') }
         .to raise_error(ArgumentError, /You must specify a remote if a branch is specified/)
     end
 
     it 'raises Git::FailedError when the remote does not exist' do
-      expect { described_instance.pull('nonexistent-remote', 'main') }.to raise_error(Git::FailedError)
+      expect { described_instance.pull('nonexistent-remote', 'main') }
+        .to raise_error(Git::FailedError, /nonexistent-remote/)
     end
 
     it 'raises ArgumentError before calling git when an unknown option is given' do
@@ -205,7 +197,7 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
 
     it 'raises Git::FailedError when the remote does not exist' do
       expect { described_instance.remove_remote('nonexistent') }
-        .to raise_error(Git::FailedError)
+        .to raise_error(Git::FailedError, /nonexistent/)
     end
   end
 
@@ -230,6 +222,29 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
 
     it 'returns an empty hash for an unknown remote name' do
       expect(described_instance.config_remote('nonexistent-remote')).to eq({})
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #remote (factory)
+  # ---------------------------------------------------------------------------
+
+  describe '#remote' do
+    it 'returns a Git::Remote for the named remote' do
+      result = described_instance.remote('origin')
+      expect(result).to be_a(Git::Remote)
+      expect(result.name).to eq('origin')
+    end
+
+    it 'defaults to "origin" when no name is given' do
+      result = described_instance.remote
+      expect(result).to be_a(Git::Remote)
+      expect(result.name).to eq('origin')
+    end
+
+    it 'populates url from the remote configuration' do
+      result = described_instance.remote('origin')
+      expect(result.url).to eq(bare_dir)
     end
   end
 end

--- a/spec/unit/git/branch_spec.rb
+++ b/spec/unit/git/branch_spec.rb
@@ -3,11 +3,17 @@
 require 'spec_helper'
 
 RSpec.describe Git::Branch do
-  let(:lib) { instance_double(Git::Lib) }
-  let(:base) { instance_double(Git::Base, lib: lib) }
+  # Git::Branch accepts either Git::Repository (new form) or Git::Base (legacy) as base.
+  # These specs cover the Git::Repository path; the Git::Base path is exercised by the
+  # legacy integration tests in tests/units/test_branch.rb.
+
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:base) { Git::Repository.new(execution_context: execution_context) }
 
   describe '#initialize' do
     context 'with a BranchInfo object for a local branch' do
+      subject(:branch) { described_class.new(base, branch_info) }
+
       let(:branch_info) do
         Git::BranchInfo.new(
           refname: 'feature/my-feature',
@@ -18,8 +24,6 @@ RSpec.describe Git::Branch do
           upstream: nil
         )
       end
-
-      subject(:branch) { described_class.new(base, branch_info) }
 
       it 'sets the full refname' do
         expect(branch.full).to eq('feature/my-feature')
@@ -35,6 +39,8 @@ RSpec.describe Git::Branch do
     end
 
     context 'with a BranchInfo object for a remote branch' do
+      subject(:branch) { described_class.new(base, branch_info) }
+
       let(:branch_info) do
         Git::BranchInfo.new(
           refname: 'remotes/origin/main',
@@ -48,10 +54,8 @@ RSpec.describe Git::Branch do
 
       let(:remote_config) { { 'url' => 'https://github.com/test/repo.git' } }
 
-      subject(:branch) { described_class.new(base, branch_info) }
-
       before do
-        allow(lib).to receive(:config_remote).with('origin').and_return(remote_config)
+        allow(base).to receive(:config_remote).with('origin').and_return(remote_config)
       end
 
       it 'sets the full refname' do
@@ -69,12 +73,12 @@ RSpec.describe Git::Branch do
     end
 
     context 'with a String (legacy path)' do
-      let(:remote_config) { { 'url' => 'https://github.com/test/repo.git' } }
-
       subject(:branch) { described_class.new(base, 'remotes/origin/develop') }
 
+      let(:remote_config) { { 'url' => 'https://github.com/test/repo.git' } }
+
       before do
-        allow(lib).to receive(:config_remote).with('origin').and_return(remote_config)
+        allow(base).to receive(:config_remote).with('origin').and_return(remote_config)
       end
 
       it 'sets the full refname' do
@@ -91,7 +95,7 @@ RSpec.describe Git::Branch do
       end
     end
 
-    context 'equivalence between BranchInfo and String initialization' do
+    context 'when initialized from either BranchInfo or String with the same refname' do
       let(:refname) { 'remotes/upstream/feature/test' }
       let(:remote_config) { { 'url' => 'https://github.com/test/repo.git' } }
 
@@ -110,7 +114,7 @@ RSpec.describe Git::Branch do
       let(:branch_from_string) { described_class.new(base, refname) }
 
       before do
-        allow(lib).to receive(:config_remote).with('upstream').and_return(remote_config)
+        allow(base).to receive(:config_remote).with('upstream').and_return(remote_config)
       end
 
       it 'produces equivalent full refname' do
@@ -122,17 +126,15 @@ RSpec.describe Git::Branch do
       end
 
       it 'produces equivalent remote name' do
-        if branch_from_info.remote
-          expect(branch_from_info.remote.name).to eq(branch_from_string.remote.name)
-        else
-          expect(branch_from_string.remote).to be_nil
-        end
+        expect(branch_from_info.remote.name).to eq(branch_from_string.remote.name)
       end
     end
   end
 
   describe '#delete' do
     context 'with a local branch' do
+      subject(:delete_branch) { described_class.new(base, branch_info).delete }
+
       let(:branch_info) do
         Git::BranchInfo.new(
           refname: 'feature',
@@ -144,16 +146,16 @@ RSpec.describe Git::Branch do
         )
       end
 
-      subject(:delete_branch) { described_class.new(base, branch_info).delete }
-
       it 'deletes the local branch by short name' do
-        expect(lib).to receive(:branch_delete).with('feature').and_return('Deleted branch feature.')
+        expect(base).to receive(:branch_delete).with('feature').and_return('Deleted branch feature.')
 
         expect(delete_branch).to eq('Deleted branch feature.')
       end
     end
 
     context 'with a remote-tracking branch' do
+      subject(:delete_branch) { described_class.new(base, branch_info).delete }
+
       let(:branch_info) do
         Git::BranchInfo.new(
           refname: 'remotes/origin/feature',
@@ -167,19 +169,364 @@ RSpec.describe Git::Branch do
 
       let(:remote_config) { { 'url' => 'https://github.com/test/repo.git' } }
 
-      subject(:delete_branch) { described_class.new(base, branch_info).delete }
-
       before do
-        allow(lib).to receive(:config_remote).with('origin').and_return(remote_config)
+        allow(base).to receive(:config_remote).with('origin').and_return(remote_config)
       end
 
       it 'deletes the remote-tracking ref instead of a local branch with the same short name' do
-        expect(lib).to receive(:branch_delete)
+        expect(base).to receive(:branch_delete)
           .with('origin/feature', remotes: true)
           .and_return('Deleted remote-tracking branch origin/feature.')
 
         expect(delete_branch).to eq('Deleted remote-tracking branch origin/feature.')
       end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #current
+  # ---------------------------------------------------------------------------
+
+  describe '#current' do
+    let(:branch_info) do
+      Git::BranchInfo.new(
+        refname: 'feature',
+        target_oid: nil,
+        current: false,
+        worktree: false,
+        symref: nil,
+        upstream: nil
+      )
+    end
+
+    context 'when base is a Git::Repository and name matches current branch' do
+      subject(:branch) { described_class.new(base, branch_info) }
+
+      before { allow(base).to receive(:current_branch).and_return('feature') }
+
+      it 'returns true' do
+        expect(branch.current).to be true
+      end
+    end
+
+    context 'when base is a Git::Repository and name does not match current branch' do
+      subject(:branch) { described_class.new(base, branch_info) }
+
+      before { allow(base).to receive(:current_branch).and_return('main') }
+
+      it 'returns false' do
+        expect(branch.current).to be false
+      end
+    end
+
+    context 'when base is a Git::Base instance' do
+      subject(:branch) { described_class.new(base_like, branch_info) }
+
+      let(:facade_repo) { instance_double(Git::Repository) }
+      # Plain object with is_a?(Git::Base) returning true — simulates the legacy
+      # Git::Base path without requiring a real Git repository on disk.
+      let(:base_like) do
+        repo = facade_repo
+        Object.new.tap do |obj|
+          obj.define_singleton_method(:facade_repository) { repo }
+          obj.define_singleton_method(:is_a?) { |klass| klass == Git::Base || super(klass) }
+        end
+      end
+
+      it 'delegates current_branch through facade_repository' do
+        expect(facade_repo).to receive(:current_branch).and_return('feature')
+        expect(branch.current).to be true
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #contains?
+  # ---------------------------------------------------------------------------
+
+  describe '#contains?' do
+    subject(:branch) { described_class.new(base, branch_info) }
+
+    let(:branch_info) do
+      Git::BranchInfo.new(
+        refname: 'feature',
+        target_oid: nil,
+        current: false,
+        worktree: false,
+        symref: nil,
+        upstream: nil
+      )
+    end
+
+    context 'when the branch contains the commit' do
+      before { allow(base).to receive(:branch_contains).with('abc123', 'feature').and_return(['abc123']) }
+
+      it 'returns true' do
+        expect(branch.contains?('abc123')).to be true
+      end
+    end
+
+    context 'when the branch does not contain the commit' do
+      before { allow(base).to receive(:branch_contains).with('abc123', 'feature').and_return([]) }
+
+      it 'returns false' do
+        expect(branch.contains?('abc123')).to be false
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #update_ref
+  # ---------------------------------------------------------------------------
+
+  describe '#update_ref' do
+    context 'with a local branch' do
+      subject(:update) { described_class.new(base, branch_info).update_ref('newcommit') }
+
+      let(:branch_info) do
+        Git::BranchInfo.new(
+          refname: 'feature',
+          target_oid: nil,
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      it 'calls update_ref with the short branch name and commit' do
+        expect(base).to receive(:update_ref).with('feature', 'newcommit').and_return(command_result(''))
+        update
+      end
+    end
+
+    context 'with a remote-tracking branch' do
+      subject(:update) { described_class.new(base, branch_info).update_ref('newcommit') }
+
+      let(:remote_config) { { 'url' => 'https://github.com/test/repo.git' } }
+      let(:branch_info) do
+        Git::BranchInfo.new(
+          refname: 'remotes/origin/feature',
+          target_oid: nil,
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      before do
+        allow(base).to receive(:config_remote).with('origin').and_return(remote_config)
+      end
+
+      it 'calls update_ref with the remotes/<remote>/<name> path' do
+        expect(base).to receive(:update_ref).with('remotes/origin/feature', 'newcommit').and_return(command_result(''))
+        update
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #create
+  # ---------------------------------------------------------------------------
+
+  describe '#create' do
+    subject(:branch) { described_class.new(base, branch_info) }
+
+    let(:branch_info) do
+      Git::BranchInfo.new(
+        refname: 'new-feature',
+        target_oid: nil,
+        current: false,
+        worktree: false,
+        symref: nil,
+        upstream: nil
+      )
+    end
+
+    context 'when branch_new succeeds' do
+      it 'calls branch_new on the repository' do
+        expect(base).to receive(:branch_new).with('new-feature').and_return(command_result(''))
+        branch.create
+      end
+    end
+
+    context 'when branch_new raises a StandardError' do
+      before do
+        allow(base).to receive(:branch_new).with('new-feature').and_raise(StandardError, 'branch already exists')
+      end
+
+      it 'silently rescues and returns nil' do
+        expect(branch.create).to be_nil
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #gcommit
+  # ---------------------------------------------------------------------------
+
+  describe '#gcommit' do
+    subject(:branch) { described_class.new(base, branch_info) }
+
+    let(:branch_info) do
+      Git::BranchInfo.new(
+        refname: 'feature',
+        target_oid: 'abc123',
+        current: false,
+        worktree: false,
+        symref: nil,
+        upstream: nil
+      )
+    end
+
+    let(:gcommit_obj) { instance_double(Git::Object::Commit) }
+
+    it 'delegates to base.gcommit with the full refname' do
+      allow(base).to receive(:gcommit).with('feature').and_return(gcommit_obj)
+      expect(branch.gcommit).to be(gcommit_obj)
+    end
+
+    it 'memoizes the result' do
+      expect(base).to receive(:gcommit).with('feature').once.and_return(gcommit_obj)
+      branch.gcommit
+      branch.gcommit
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #archive
+  # ---------------------------------------------------------------------------
+
+  describe '#archive' do
+    subject(:branch) { described_class.new(base, branch_info) }
+
+    let(:branch_info) do
+      Git::BranchInfo.new(
+        refname: 'feature',
+        target_oid: nil,
+        current: false,
+        worktree: false,
+        symref: nil,
+        upstream: nil
+      )
+    end
+
+    it 'delegates to base.archive with full refname, file path, and options' do
+      expect(base).to receive(:archive).with('feature', 'out.tar', { format: 'tar' }).and_return('out.tar')
+      branch.archive('out.tar', format: 'tar')
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #checkout
+  # ---------------------------------------------------------------------------
+
+  describe '#checkout' do
+    subject(:branch) { described_class.new(base, branch_info) }
+
+    let(:branch_info) do
+      Git::BranchInfo.new(
+        refname: 'feature',
+        target_oid: nil,
+        current: false,
+        worktree: false,
+        symref: nil,
+        upstream: nil
+      )
+    end
+
+    it 'calls check_if_create then checks out the full refname' do
+      allow(base).to receive(:branch_new).with('feature').and_return(command_result(''))
+      expect(base).to receive(:checkout).with('feature').and_return('')
+      branch.checkout
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #in_branch
+  # ---------------------------------------------------------------------------
+
+  describe '#in_branch' do
+    subject(:branch) { described_class.new(base, branch_info) }
+
+    let(:branch_info) do
+      Git::BranchInfo.new(
+        refname: 'feature',
+        target_oid: nil,
+        current: false,
+        worktree: false,
+        symref: nil,
+        upstream: nil
+      )
+    end
+
+    before do
+      allow(base).to receive(:current_branch).and_return('main')
+      allow(base).to receive(:branch_new).with('feature').and_return(command_result(''))
+      allow(base).to receive(:checkout).and_return('')
+    end
+
+    context 'when block returns truthy' do
+      it 'commits all changes and restores the original branch' do
+        allow(base).to receive(:commit_all).with('my message').and_return(command_result(''))
+        expect(base).to receive(:checkout).with('main').and_return('')
+        branch.in_branch('my message') { true }
+      end
+    end
+
+    context 'when block returns falsy' do
+      it 'hard-resets and restores the original branch' do
+        allow(base).to receive(:reset).with(nil, hard: true).and_return(command_result(''))
+        expect(base).to receive(:checkout).with('main').and_return('')
+        branch.in_branch { false }
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #to_a
+  # ---------------------------------------------------------------------------
+
+  describe '#to_a' do
+    subject(:branch) { described_class.new(base, branch_info) }
+
+    let(:branch_info) do
+      Git::BranchInfo.new(
+        refname: 'feature',
+        target_oid: nil,
+        current: false,
+        worktree: false,
+        symref: nil,
+        upstream: nil
+      )
+    end
+
+    it 'returns a single-element array with the full refname' do
+      expect(branch.to_a).to eq(['feature'])
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #to_s
+  # ---------------------------------------------------------------------------
+
+  describe '#to_s' do
+    subject(:branch) { described_class.new(base, branch_info) }
+
+    let(:branch_info) do
+      Git::BranchInfo.new(
+        refname: 'feature',
+        target_oid: nil,
+        current: false,
+        worktree: false,
+        symref: nil,
+        upstream: nil
+      )
+    end
+
+    it 'returns the full refname as a string' do
+      expect(branch.to_s).to eq('feature')
     end
   end
 end

--- a/spec/unit/git/remote_spec.rb
+++ b/spec/unit/git/remote_spec.rb
@@ -1,0 +1,177 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/remote'
+
+RSpec.describe Git::Remote do
+  # Git::Remote accepts either Git::Repository (new form) or Git::Base (legacy) as base.
+  # These specs cover both the Git::Repository path and the Git::Base duck-type path
+  # for the remote_repository bridge method.
+
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:base) { Git::Repository.new(execution_context: execution_context) }
+  let(:remote_config) do
+    { 'url' => 'https://github.com/test/repo.git', 'fetch' => '+refs/heads/*:refs/remotes/origin/*' }
+  end
+
+  before do
+    allow(base).to receive(:config_remote).with('origin').and_return(remote_config)
+  end
+
+  let(:described_instance) { described_class.new(base, 'origin') }
+
+  # ---------------------------------------------------------------------------
+  # #initialize
+  # ---------------------------------------------------------------------------
+
+  describe '#initialize' do
+    context 'when base is a Git::Repository' do
+      subject(:remote) { described_instance }
+
+      it 'sets the name' do
+        expect(remote.name).to eq('origin')
+      end
+
+      it 'sets the url from config' do
+        expect(remote.url).to eq('https://github.com/test/repo.git')
+      end
+
+      it 'sets fetch_opts from config' do
+        expect(remote.fetch_opts).to eq('+refs/heads/*:refs/remotes/origin/*')
+      end
+
+      it 'calls config_remote on the repository' do
+        expect(base).to receive(:config_remote).with('origin').and_return(remote_config)
+        remote
+      end
+    end
+
+    context 'when base is a Git::Base instance' do
+      subject(:remote) { described_class.new(base_like, 'origin') }
+
+      let(:facade_repo) { instance_double(Git::Repository) }
+      # Plain object with is_a?(Git::Base) returning true — simulates the legacy
+      # Git::Base path without requiring a real Git repository on disk.
+      let(:base_like) do
+        repo = facade_repo
+        Object.new.tap do |obj|
+          obj.define_singleton_method(:facade_repository) { repo }
+          obj.define_singleton_method(:is_a?) { |klass| klass == Git::Base || super(klass) }
+        end
+      end
+
+      before do
+        allow(facade_repo).to receive(:config_remote).with('origin').and_return(remote_config)
+      end
+
+      it 'delegates config_remote through facade_repository' do
+        expect(facade_repo).to receive(:config_remote).with('origin').and_return(remote_config)
+        remote
+      end
+
+      it 'sets the name' do
+        expect(remote.name).to eq('origin')
+      end
+
+      it 'sets the url from config' do
+        expect(remote.url).to eq('https://github.com/test/repo.git')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #remove
+  # ---------------------------------------------------------------------------
+
+  describe '#remove' do
+    subject(:result) { described_instance.remove }
+
+    let(:remove_result) { command_result('') }
+
+    it 'delegates to remote_repository.remove_remote with the remote name' do
+      expect(base).to receive(:remove_remote).with('origin').and_return(remove_result)
+      result
+    end
+
+    it 'returns the result of remove_remote' do
+      allow(base).to receive(:remove_remote).with('origin').and_return(remove_result)
+      expect(result).to be(remove_result)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #fetch
+  # ---------------------------------------------------------------------------
+
+  describe '#fetch' do
+    subject(:result) { described_instance.fetch }
+
+    it 'delegates to base.fetch with the remote name' do
+      expect(base).to receive(:fetch).with('origin', {}).and_return('')
+      result
+    end
+
+    it 'forwards options to base.fetch' do
+      expect(base).to receive(:fetch).with('origin', { depth: 1 }).and_return('')
+      described_instance.fetch(depth: 1)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #merge
+  # ---------------------------------------------------------------------------
+
+  describe '#merge' do
+    context 'when branch is specified explicitly' do
+      it 'merges the remote-tracking branch into the given branch' do
+        expect(base).to receive(:merge).with('origin/main').and_return('')
+        described_instance.merge('main')
+      end
+    end
+
+    context 'when branch defaults to current_branch' do
+      before { allow(base).to receive(:current_branch).and_return('develop') }
+
+      it 'merges the remote-tracking branch for the current branch' do
+        expect(base).to receive(:merge).with('origin/develop').and_return('')
+        described_instance.merge
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #branch
+  # ---------------------------------------------------------------------------
+
+  describe '#branch' do
+    context 'when branch is specified explicitly' do
+      it 'returns a Git::Branch for <remote>/<branch>' do
+        result = described_instance.branch('main')
+        expect(result).to be_a(Git::Branch)
+        expect(result.full).to eq('origin/main')
+      end
+    end
+
+    context 'when branch defaults to current_branch' do
+      before { allow(base).to receive(:current_branch).and_return('develop') }
+
+      it 'returns a Git::Branch for <remote>/<current_branch>' do
+        result = described_instance.branch
+        expect(result).to be_a(Git::Branch)
+        expect(result.full).to eq('origin/develop')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #to_s
+  # ---------------------------------------------------------------------------
+
+  describe '#to_s' do
+    subject(:result) { described_instance.to_s }
+
+    it 'returns the remote name' do
+      expect(result).to eq('origin')
+    end
+  end
+end

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -164,11 +164,7 @@ RSpec.describe Git::Repository::Branching do
 
       it 'does not call the command' do
         expect(checkout_branch_command).not_to receive(:call)
-        begin
-          result
-        rescue ArgumentError
-          # expected
-        end
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
       end
     end
   end
@@ -793,6 +789,54 @@ RSpec.describe Git::Repository::Branching do
         expect(update_ref_command)
           .to receive(:call).with('refs/remotes/origin/main', 'abc1234').and_return(update_ref_result)
         result
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #branch
+  # ---------------------------------------------------------------------------
+
+  describe '#branch' do
+    let(:show_current_command) { instance_double(Git::Commands::Branch::ShowCurrent) }
+
+    before do
+      allow(Git::Commands::Branch::ShowCurrent)
+        .to receive(:new).with(execution_context).and_return(show_current_command)
+    end
+
+    context 'with an explicit branch name' do
+      subject(:result) { described_instance.branch('feature') }
+
+      it 'returns a Git::Branch for the given name' do
+        expect(result).to be_a(Git::Branch)
+      end
+
+      it 'sets the full refname to the given branch name' do
+        expect(result.full).to eq('feature')
+      end
+
+      it 'sets the short name to the given branch name' do
+        expect(result.name).to eq('feature')
+      end
+
+      it 'has no remote' do
+        expect(result.remote).to be_nil
+      end
+    end
+
+    context 'when no name is given (defaults to current_branch)' do
+      subject(:result) { described_instance.branch }
+
+      let(:show_current_result) { command_result("main\n") }
+
+      before do
+        allow(show_current_command).to receive(:call).and_return(show_current_result)
+      end
+
+      it 'returns a Git::Branch for the current branch name' do
+        expect(result).to be_a(Git::Branch)
+        expect(result.full).to eq('main')
       end
     end
   end

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -606,7 +606,7 @@ RSpec.describe Git::Repository::RemoteOperations do
       end
 
       it 'returns Git::Remote' do
-        expect(Git::Remote).to receive(:new).with(base_object, 'upstream').and_return(remote_object)
+        expect(Git::Remote).to receive(:new).with(described_instance, 'upstream').and_return(remote_object)
         expect(result).to eq(remote_object)
       end
     end
@@ -688,6 +688,8 @@ RSpec.describe Git::Repository::RemoteOperations do
   # ---------------------------------------------------------------------------
 
   describe '#remove_remote' do
+    subject(:result) { described_instance.remove_remote('upstream') }
+
     let(:remove_command) { instance_double(Git::Commands::Remote::Remove) }
     let(:remove_result) { command_result('') }
 
@@ -695,8 +697,6 @@ RSpec.describe Git::Repository::RemoteOperations do
       allow(Git::Commands::Remote::Remove)
         .to receive(:new).with(execution_context).and_return(remove_command)
     end
-
-    subject(:result) { described_instance.remove_remote('upstream') }
 
     it 'delegates to Git::Commands::Remote::Remove.new with the execution_context' do
       expect(Git::Commands::Remote::Remove)
@@ -781,6 +781,48 @@ RSpec.describe Git::Repository::RemoteOperations do
       it 'defaults the value to an empty string' do
         result = described_instance.config_remote('origin')
         expect(result['novalue']).to eq('')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #remote
+  # ---------------------------------------------------------------------------
+
+  describe '#remote' do
+    let(:config_list_command) { instance_double(Git::Commands::ConfigOptionSyntax::List) }
+    let(:config_stdout) do
+      "remote.origin.url=https://github.com/user/repo.git\n" \
+        "remote.origin.fetch=+refs/heads/*:refs/remotes/origin/*\n"
+    end
+
+    before do
+      allow(Git::Commands::ConfigOptionSyntax::List)
+        .to receive(:new).with(execution_context).and_return(config_list_command)
+      allow(config_list_command).to receive(:call).and_return(command_result(config_stdout))
+    end
+
+    context 'with an explicit remote name' do
+      subject(:result) { described_instance.remote('upstream') }
+
+      it 'returns a Git::Remote for the given name' do
+        expect(result).to be_a(Git::Remote)
+      end
+
+      it 'sets the name attribute to the given remote name' do
+        expect(result.name).to eq('upstream')
+      end
+    end
+
+    context 'when no name is given (defaults to origin)' do
+      subject(:result) { described_instance.remote }
+
+      it 'returns a Git::Remote named origin' do
+        expect(result.name).to eq('origin')
+      end
+
+      it 'populates the url from config' do
+        expect(result.url).to eq('https://github.com/user/repo.git')
       end
     end
   end


### PR DESCRIPTION
Migrate the polymorphism of `Git::Branch` and `Git::Remote` to the repository facade, enhancing the architecture. Update the implementation plan to reflect this migration.