### PR TITLE
test(branches): add unit and integration coverage for Git::Branches (Iteration 8 PR3)

### DIFF
--- a/lib/git/branches.rb
+++ b/lib/git/branches.rb
@@ -132,13 +132,15 @@ module Git
       out
     end
 
+    private
+
     # Resolves the {Git::Repository} for this collection of branches
     #
     # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
     # The `is_a?(Git::Base)` guard will be removed when {Git::Base} is deleted
     # in Phase 4.
     #
-    # @return [Git::Repository]
+    # @return [Git::Repository] the repository used to enumerate branches
     #
     # @api private
     #
@@ -147,11 +149,11 @@ module Git
     end
 
     # Indexes all supported lookup keys for a branch without mutating
-    # the canonical @branches collection used by enumeration.
+    # the canonical `@branches` collection used by enumeration
     #
-    # @param branch [Git::Branch]
+    # @param branch [Git::Branch] the branch to index
     #
-    # @param refname [String]
+    # @param refname [String] the full refname key to use for primary lookup
     #
     # @return [void]
     #

--- a/spec/integration/git/branches_spec.rb
+++ b/spec/integration/git/branches_spec.rb
@@ -15,11 +15,13 @@ RSpec.describe Git::Branches, :integration do
   # Git::Base constructor path: Git::Base#branches passes self (a Git::Base)
   # ---------------------------------------------------------------------------
 
-  describe 'via Git::Base#branches (Git::Base passed to constructor)' do
+  context 'when initialized via Git::Base (Git::Base passed to constructor)' do
     let(:branches) { repo.branches }
 
-    it 'returns a Git::Branches instance' do
-      expect(branches).to be_a(Git::Branches)
+    describe '#initialize' do
+      it 'returns a Git::Branches instance' do
+        expect(branches).to be_a(Git::Branches)
+      end
     end
 
     describe '#local' do
@@ -76,7 +78,7 @@ RSpec.describe Git::Branches, :integration do
 
     describe '#each' do
       it 'yields Git::Branch objects for every branch' do
-        yielded = branches.map { |b| b }
+        yielded = branches.to_a
         expect(yielded).to all(be_a(Git::Branch))
         expect(yielded.map(&:full)).to include('main')
       end
@@ -117,6 +119,20 @@ RSpec.describe Git::Branches, :integration do
         end
       end
     end
+
+    describe '#to_s' do
+      it 'marks the current branch with "* "' do
+        expect(branches.to_s).to include('* main')
+      end
+
+      context 'with a non-current local branch' do
+        before { repo.branch('feature').create }
+
+        it 'prefixes non-current branches with two spaces' do
+          expect(branches.to_s).to include('  feature')
+        end
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------
@@ -124,21 +140,27 @@ RSpec.describe Git::Branches, :integration do
   # (a Git::Repository) to Git::Branches.new
   # ---------------------------------------------------------------------------
 
-  describe 'via Git::Repository#branches (Git::Repository passed to constructor)' do
+  context 'when initialized via Git::Repository (Git::Repository passed to constructor)' do
     let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
     let(:repository) { Git::Repository.new(execution_context: execution_context) }
     let(:branches) { repository.branches }
 
-    it 'returns a Git::Branches instance' do
-      expect(branches).to be_a(Git::Branches)
+    describe '#initialize' do
+      it 'returns a Git::Branches instance' do
+        expect(branches).to be_a(Git::Branches)
+      end
     end
 
-    it 'includes the current local branch' do
-      expect(branches.local.map(&:full)).to include('main')
+    describe '#local' do
+      it 'includes the current local branch' do
+        expect(branches.local.map(&:full)).to include('main')
+      end
     end
 
-    it 'returns the same number of branches as the Git::Base path' do
-      expect(branches.size).to eq(repo.branches.size)
+    describe '#size' do
+      it 'returns the same number of branches as the Git::Base path' do
+        expect(branches.size).to eq(repo.branches.size)
+      end
     end
   end
 end

--- a/spec/unit/git/branches_spec.rb
+++ b/spec/unit/git/branches_spec.rb
@@ -53,10 +53,6 @@ RSpec.describe Git::Branches do
         expect(Git::Branch).to receive(:new).with(base, remote_info).and_return(remote_branch)
         described_class.new(base)
       end
-
-      it 'returns an instance of Git::Branches' do
-        expect(described_class.new(base)).to be_a(described_class)
-      end
     end
 
     context 'when passed a Git::Base' do
@@ -79,10 +75,6 @@ RSpec.describe Git::Branches do
         expect(Git::Branch).to receive(:new).with(base, local_info).and_return(local_branch)
         described_class.new(base)
       end
-
-      it 'returns an instance of Git::Branches' do
-        expect(described_class.new(base)).to be_a(described_class)
-      end
     end
   end
 
@@ -90,12 +82,13 @@ RSpec.describe Git::Branches do
   # Collection helpers: a Git::Branches with two known branches
   # ---------------------------------------------------------------------------
 
+  let(:branch_infos) { [local_info, remote_info] }
   let(:repo_base) { instance_double(Git::Repository) }
   let(:collection) { described_class.new(repo_base) }
 
   before do
     allow(repo_base).to receive(:is_a?).with(Git::Base).and_return(false)
-    allow(repo_base).to receive(:branches_all).and_return([local_info, remote_info])
+    allow(repo_base).to receive(:branches_all).and_return(branch_infos)
     allow(Git::Branch).to receive(:new).with(repo_base, local_info).and_return(local_branch)
     allow(Git::Branch).to receive(:new).with(repo_base, remote_info).and_return(remote_branch)
   end
@@ -110,10 +103,6 @@ RSpec.describe Git::Branches do
     it 'returns only non-remote branches' do
       expect(result).to eq([local_branch])
     end
-
-    it 'excludes remote-tracking branches' do
-      expect(result).not_to include(remote_branch)
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -126,10 +115,6 @@ RSpec.describe Git::Branches do
     it 'returns only remote-tracking branches' do
       expect(result).to eq([remote_branch])
     end
-
-    it 'excludes local branches' do
-      expect(result).not_to include(local_branch)
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -137,21 +122,17 @@ RSpec.describe Git::Branches do
   # ---------------------------------------------------------------------------
 
   describe '#size' do
+    subject(:result) { collection.size }
+
     it 'returns the total number of branches' do
-      expect(collection.size).to eq(2)
+      expect(result).to eq(2)
     end
 
     context 'when the branch list is empty' do
-      let(:empty_base) { instance_double(Git::Repository) }
-      let(:empty_collection) { described_class.new(empty_base) }
-
-      before do
-        allow(empty_base).to receive(:is_a?).with(Git::Base).and_return(false)
-        allow(empty_base).to receive(:branches_all).and_return([])
-      end
+      let(:branch_infos) { [] }
 
       it 'returns 0' do
-        expect(empty_collection.size).to eq(0)
+        expect(result).to eq(0)
       end
     end
   end
@@ -161,13 +142,14 @@ RSpec.describe Git::Branches do
   # ---------------------------------------------------------------------------
 
   describe '#each' do
+    subject(:result) { collection.each }
+
     it 'yields every branch in the collection' do
-      yielded = collection.map { |b| b }
-      expect(yielded).to contain_exactly(local_branch, remote_branch)
+      expect(result.to_a).to contain_exactly(local_branch, remote_branch)
     end
 
     it 'returns an Enumerator when called without a block' do
-      expect(collection.each).to be_an(Enumerator)
+      expect(result).to be_an(Enumerator)
     end
   end
 
@@ -176,43 +158,55 @@ RSpec.describe Git::Branches do
   # ---------------------------------------------------------------------------
 
   describe '#[]' do
+    subject(:result) { collection[branch_name] }
+
+    let(:branch_name) { 'main' }
+
     context 'with the exact refname of a local branch' do
       it 'returns the matching branch' do
-        expect(collection['main']).to eq(local_branch)
+        expect(result).to eq(local_branch)
       end
     end
 
     context 'with the full refname of a remote-tracking branch' do
+      let(:branch_name) { 'remotes/origin/main' }
+
       it 'returns the matching remote branch' do
-        expect(collection['remotes/origin/main']).to eq(remote_branch)
+        expect(result).to eq(remote_branch)
       end
     end
 
     context 'with the short form of a remote-tracking branch (omitting "remotes/")' do
+      let(:branch_name) { 'origin/main' }
+
       it 'returns the remote branch' do
-        expect(collection['origin/main']).to eq(remote_branch)
+        expect(result).to eq(remote_branch)
       end
 
       it 'does not change the collection size' do
-        expect { collection['origin/main'] }.not_to change(collection, :size)
+        expect { result }.not_to change(collection, :size)
       end
 
       it 'does not duplicate branches in enumeration' do
-        collection['origin/main']
+        result
 
         expect(collection.map(&:full)).to contain_exactly('main', 'remotes/origin/main')
       end
     end
 
     context 'with an unknown branch name' do
+      let(:branch_name) { 'nonexistent' }
+
       it 'returns nil' do
-        expect(collection['nonexistent']).to be_nil
+        expect(result).to be_nil
       end
     end
 
     context 'with a non-String argument' do
+      let(:branch_name) { :main }
+
       it 'coerces to string via to_s and returns the matching branch' do
-        expect(collection[:main]).to eq(local_branch)
+        expect(result).to eq(local_branch)
       end
     end
   end
@@ -223,11 +217,6 @@ RSpec.describe Git::Branches do
 
   describe '#to_s' do
     subject(:result) { collection.to_s }
-
-    it 'includes each branch name' do
-      expect(result).to include('main')
-      expect(result).to include('remotes/origin/main')
-    end
 
     it 'marks the current branch with "* "' do
       expect(result).to include('* main')


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository.

# Description

Iteration 8 PR3 — B-work unit hardening for `Git::Branches`.

Adds dedicated unit and integration test coverage for `Git::Branches` with 100% line and branch coverage, covering all public methods (`local`, `remote`, `[]`, `each`, `size`, `to_s`) across both constructor forms (`Git::Base` and `Git::Repository`).

Also includes minor improvements to `lib/git/branches.rb` discovered during the review:
- Declared private methods (`branch_repository`, `index_branch_lookup`) explicitly with the `private` keyword
- Improved YARD `@return` and `@param` descriptions for those private methods

## Changes

- `lib/git/branches.rb` — add `private` keyword; improve YARD descriptions for private methods
- `spec/unit/git/branches_spec.rb` — full unit coverage with `let`/`subject` patterns; both constructor paths tested
- `spec/integration/git/branches_spec.rb` — integration coverage including `#to_s` tests for current/non-current branch marking

## Depends on

- [PR2 (#1357)](https://github.com/ruby-git/ruby-git/pull/1357) — ✅ already merged

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed.
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).