### PR TITLE
feat(repository): add Git::Repository::WorktreeOperations facade module

### DIFF
--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -12,6 +12,7 @@ require 'git/repository/remote_operations'
 require 'git/repository/staging'
 require 'git/repository/stashing'
 require 'git/repository/status_operations'
+require 'git/repository/worktree_operations'
 
 module Git
   # The main public interface for interacting with a Git repository
@@ -50,6 +51,7 @@ module Git
     include Git::Repository::Staging
     include Git::Repository::Stashing
     include Git::Repository::StatusOperations
+    include Git::Repository::WorktreeOperations
 
     # @return [Git::ExecutionContext::Repository] the execution context used to run
     #   git commands for this repository

--- a/lib/git/repository/worktree_operations.rb
+++ b/lib/git/repository/worktree_operations.rb
@@ -1,0 +1,113 @@
+# frozen_string_literal: true
+
+require 'git/commands/worktree'
+
+module Git
+  class Repository
+    # Facade methods for worktree operations
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module WorktreeOperations
+      # Returns all worktrees as an array of directory and SHA pairs
+      #
+      # Lists all worktrees attached to the repository, including the main
+      # worktree and all linked worktrees. The output is parsed from
+      # `git worktree list --porcelain`.
+      #
+      # @example List all worktrees
+      #   repo.worktrees_all
+      #   #=> [["/path/to/main", "4bef5ab..."], ["/tmp/worktree-1", "b8c6320..."]]
+      #
+      # @return [Array<Array(String, String)>] array of `[directory, sha]` pairs
+      #
+      #   `directory` is the worktree path reported by git (absolute or relative,
+      #   depending on repository configuration); `sha` is the full SHA of the
+      #   checked-out HEAD commit
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      def worktrees_all
+        worktree_entries = []
+        current_directory = ''
+        command_output = Git::Commands::Worktree::List.new(@execution_context).call(porcelain: true).stdout
+
+        command_output.each_line(chomp: true) do |line|
+          key, value = line.split(' ', 2)
+          current_directory = value if key == 'worktree'
+          worktree_entries << [current_directory, value] if key == 'HEAD'
+        end
+
+        worktree_entries
+      end
+
+      # Create a new linked worktree at the given directory
+      #
+      # @example Create a worktree at a path (auto-creates a branch)
+      #   repo.worktree_add('/tmp/feature')
+      #
+      # @example Create a worktree and check out an existing commitish
+      #   repo.worktree_add('/tmp/hotfix', 'main')
+      #
+      # @param dir [String] filesystem path for the new worktree
+      #
+      # @param commitish [String, nil] branch, tag, or commit to check out
+      #
+      #   When `nil`, git creates a new branch named after the final path component
+      #
+      # @return [String] the output from the git worktree add command
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      def worktree_add(dir, commitish = nil)
+        args = [dir]
+        args << commitish unless commitish.nil?
+
+        Git::Commands::Worktree::Add.new(@execution_context).call(*args).stdout
+      end
+
+      # Remove a linked worktree
+      #
+      # @example Remove a worktree
+      #   repo.worktree_remove('/tmp/feature')
+      #
+      # @param dir [String] filesystem path of the worktree to remove
+      #
+      # @return [String] the output from the git worktree remove command
+      #   (typically empty)
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      def worktree_remove(dir)
+        Git::Commands::Worktree::Remove.new(@execution_context).call(dir).stdout
+      end
+
+      # Prune stale worktree administrative files
+      #
+      # Removes stale administrative files from `$GIT_DIR/worktrees`. A
+      # worktree becomes stale when its directory no longer exists on disk.
+      #
+      # @example Prune stale worktrees
+      #   repo.worktree_prune
+      #
+      # @return [String] the output from the git worktree prune command
+      #   (typically empty)
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      def worktree_prune
+        Git::Commands::Worktree::Prune.new(@execution_context).call.stdout
+      end
+    end
+  end
+end

--- a/spec/integration/git/repository/worktree_operations_spec.rb
+++ b/spec/integration/git/repository/worktree_operations_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require 'securerandom'
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/worktree_operations'
+require 'git/execution_context/repository'
+
+# worktree_add, worktree_remove, and worktree_prune are one-line delegators with no
+# facade-owned post-processing. Their end-to-end coverage comes from the command
+# integration tests (spec/integration/git/commands/worktree/).
+#
+# worktrees_all parses porcelain output inline inside the facade. This integration
+# test verifies that the parsing logic works correctly against actual git output.
+
+RSpec.describe Git::Repository::WorktreeOperations, :integration do
+  include_context 'in an empty repository'
+
+  let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#worktrees_all' do
+    context 'when only the main worktree exists' do
+      it 'returns one entry for the main worktree' do
+        result = described_instance.worktrees_all
+        expect(result.length).to eq(1)
+      end
+
+      it 'returns the main worktree directory as the first element' do
+        result = described_instance.worktrees_all
+        expect(result.first.first).to eq(File.realpath(repo_dir))
+      end
+
+      it 'returns a full 40-character SHA as the second element' do
+        result = described_instance.worktrees_all
+        expect(result.first.last).to match(/\A[0-9a-f]{40}\z/)
+      end
+    end
+
+    context 'when a linked worktree has been added' do
+      let(:worktree_path) { File.join(repo_dir, '..', "worktree-#{SecureRandom.hex(4)}") }
+
+      before do
+        Git::Commands::Worktree::Add.new(execution_context).call(worktree_path)
+      end
+
+      after do
+        Git::Commands::Worktree::Remove.new(execution_context).call(worktree_path, force: true)
+        Git::Commands::Worktree::Prune.new(execution_context).call
+      end
+
+      it 'returns two entries' do
+        result = described_instance.worktrees_all
+        expect(result.length).to eq(2)
+      end
+
+      it 'includes the main worktree directory' do
+        result = described_instance.worktrees_all
+        directories = result.map(&:first)
+        expect(directories).to include(File.realpath(repo_dir))
+      end
+
+      it 'includes the linked worktree directory' do
+        result = described_instance.worktrees_all
+        directories = result.map(&:first)
+        expect(directories).to include(File.realpath(worktree_path))
+      end
+
+      it 'returns a valid 40-character SHA for each entry' do
+        shas = described_instance.worktrees_all.map(&:last)
+        expect(shas).to all(match(/\A[0-9a-f]{40}\z/))
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository/worktree_operations_spec.rb
+++ b/spec/unit/git/repository/worktree_operations_spec.rb
@@ -1,0 +1,222 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/worktree_operations'
+
+# Integration-level coverage for facade methods in Git::Repository::WorktreeOperations:
+#   worktree_add, worktree_remove, and worktree_prune are one-line delegators to
+#   single Git::Commands::Worktree::* classes with no post-processing. Their
+#   end-to-end coverage comes from the command integration tests:
+#     spec/integration/git/commands/worktree/add_spec.rb    (worktree_add)
+#     spec/integration/git/commands/worktree/remove_spec.rb (worktree_remove)
+#     spec/integration/git/commands/worktree/prune_spec.rb  (worktree_prune)
+#   worktrees_all does facade-owned inline parsing of porcelain output; its
+#   integration test is in spec/integration/git/repository/worktree_operations_spec.rb.
+
+RSpec.describe Git::Repository::WorktreeOperations do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  describe '#worktrees_all' do
+    let(:list_command) { instance_double(Git::Commands::Worktree::List) }
+    let(:list_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Worktree::List).to receive(:new).with(execution_context).and_return(list_command)
+      allow(list_command).to receive(:call).with(porcelain: true).and_return(list_result)
+    end
+
+    it 'constructs Git::Commands::Worktree::List with the execution context' do
+      expect(Git::Commands::Worktree::List).to receive(:new).with(execution_context).and_return(list_command)
+      described_instance.worktrees_all
+    end
+
+    it 'calls #call with porcelain: true' do
+      expect(list_command).to receive(:call).with(porcelain: true).and_return(list_result)
+      described_instance.worktrees_all
+    end
+
+    context 'when the output is empty (no worktrees reported)' do
+      it 'returns an empty array' do
+        expect(described_instance.worktrees_all).to eq([])
+      end
+    end
+
+    context 'when there is one worktree' do
+      let(:list_result) do
+        command_result(
+          "worktree /path/to/main\n" \
+          "HEAD 4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a\n" \
+          "branch refs/heads/main\n"
+        )
+      end
+
+      it 'returns a single [directory, sha] pair' do
+        expect(described_instance.worktrees_all).to eq(
+          [['/path/to/main', '4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a']]
+        )
+      end
+    end
+
+    context 'when there are multiple worktrees' do
+      let(:list_result) do
+        command_result(
+          "worktree /path/to/main\n" \
+          "HEAD 4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a\n" \
+          "branch refs/heads/main\n" \
+          "\n" \
+          "worktree /tmp/worktree-1\n" \
+          "HEAD b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1\n" \
+          "detached\n"
+        )
+      end
+
+      it 'returns a [directory, sha] pair for each worktree' do
+        expect(described_instance.worktrees_all).to eq(
+          [
+            ['/path/to/main', '4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a'],
+            ['/tmp/worktree-1', 'b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1']
+          ]
+        )
+      end
+    end
+
+    context 'when a worktree path contains spaces' do
+      let(:list_result) do
+        command_result(
+          "worktree /path/to/main\n" \
+          "HEAD 4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a\n" \
+          "branch refs/heads/main\n" \
+          "\n" \
+          "worktree /tmp/worktree with spaces\n" \
+          "HEAD b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1\n" \
+          "detached\n"
+        )
+      end
+
+      it 'preserves the full directory path when parsing worktree entries' do
+        expect(described_instance.worktrees_all).to eq(
+          [
+            ['/path/to/main', '4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a'],
+            ['/tmp/worktree with spaces', 'b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1']
+          ]
+        )
+      end
+    end
+
+    context 'when git output uses CRLF line endings' do
+      let(:list_result) do
+        command_result(
+          "worktree /path/to/main\r\n" \
+          "HEAD 4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a\r\n" \
+          "branch refs/heads/main\r\n" \
+          "\r\n" \
+          "worktree /tmp/worktree with spaces\r\n" \
+          "HEAD b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1\r\n" \
+          "detached\r\n"
+        )
+      end
+
+      it 'parses entries without carriage returns in directory or sha values' do
+        expect(described_instance.worktrees_all).to eq(
+          [
+            ['/path/to/main', '4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a'],
+            ['/tmp/worktree with spaces', 'b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1']
+          ]
+        )
+      end
+    end
+  end
+
+  describe '#worktree_add' do
+    let(:add_command) { instance_double(Git::Commands::Worktree::Add) }
+    let(:add_result) { command_result("Preparing worktree (new branch 'feature')\n") }
+
+    before do
+      allow(Git::Commands::Worktree::Add).to receive(:new).with(execution_context).and_return(add_command)
+    end
+
+    it 'constructs Git::Commands::Worktree::Add with the execution context' do
+      expect(Git::Commands::Worktree::Add).to receive(:new).with(execution_context).and_return(add_command)
+      allow(add_command).to receive(:call).and_return(add_result)
+      described_instance.worktree_add('/tmp/feature')
+    end
+
+    context 'when no commitish is given (nil)' do
+      it 'calls #call with only the directory' do
+        expect(add_command).to receive(:call).with('/tmp/feature').and_return(add_result)
+        described_instance.worktree_add('/tmp/feature')
+      end
+
+      it 'returns the stdout string' do
+        allow(add_command).to receive(:call).with('/tmp/feature').and_return(add_result)
+        expect(described_instance.worktree_add('/tmp/feature')).to eq("Preparing worktree (new branch 'feature')\n")
+      end
+    end
+
+    context 'when a commitish is given' do
+      it 'calls #call with the directory and the commitish' do
+        expect(add_command).to receive(:call).with('/tmp/feature', 'main').and_return(add_result)
+        described_instance.worktree_add('/tmp/feature', 'main')
+      end
+
+      it 'returns the stdout string' do
+        allow(add_command).to receive(:call).with('/tmp/feature', 'main').and_return(add_result)
+        result = described_instance.worktree_add('/tmp/feature', 'main')
+        expect(result).to eq("Preparing worktree (new branch 'feature')\n")
+      end
+    end
+  end
+
+  describe '#worktree_remove' do
+    let(:remove_command) { instance_double(Git::Commands::Worktree::Remove) }
+    let(:remove_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Worktree::Remove).to receive(:new).with(execution_context).and_return(remove_command)
+    end
+
+    it 'constructs Git::Commands::Worktree::Remove with the execution context' do
+      expect(Git::Commands::Worktree::Remove).to receive(:new).with(execution_context).and_return(remove_command)
+      allow(remove_command).to receive(:call).with('/tmp/feature').and_return(remove_result)
+      described_instance.worktree_remove('/tmp/feature')
+    end
+
+    it 'calls #call with the directory' do
+      expect(remove_command).to receive(:call).with('/tmp/feature').and_return(remove_result)
+      described_instance.worktree_remove('/tmp/feature')
+    end
+
+    it 'returns the stdout string' do
+      allow(remove_command).to receive(:call).with('/tmp/feature').and_return(remove_result)
+      expect(described_instance.worktree_remove('/tmp/feature')).to eq('')
+    end
+  end
+
+  describe '#worktree_prune' do
+    let(:prune_command) { instance_double(Git::Commands::Worktree::Prune) }
+    let(:prune_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Worktree::Prune).to receive(:new).with(execution_context).and_return(prune_command)
+    end
+
+    it 'constructs Git::Commands::Worktree::Prune with the execution context' do
+      expect(Git::Commands::Worktree::Prune).to receive(:new).with(execution_context).and_return(prune_command)
+      allow(prune_command).to receive(:call).with(no_args).and_return(prune_result)
+      described_instance.worktree_prune
+    end
+
+    it 'calls #call with no arguments' do
+      expect(prune_command).to receive(:call).with(no_args).and_return(prune_result)
+      described_instance.worktree_prune
+    end
+
+    it 'returns the stdout string' do
+      allow(prune_command).to receive(:call).and_return(prune_result)
+      expect(described_instance.worktree_prune).to eq('')
+    end
+  end
+end


### PR DESCRIPTION
## Description

Iteration 9, PR 1 (A-work core): extract the four worktree Pattern B methods
from `Git::Lib` into a new `Git::Repository::WorktreeOperations` facade module.

### Methods extracted

| Facade method | Source | Return type |
|---|---|---|
| `worktrees_all` | `Git::Lib#worktrees_all` | `Array<[String, String]>` — `[dir, sha]` pairs |
| `worktree_add(dir, commitish = nil)` | `Git::Lib#worktree_add` | `String` (stdout) |
| `worktree_remove(dir)` | `Git::Lib#worktree_remove` | `String` (stdout) |
| `worktree_prune` | `Git::Lib#worktree_prune` | `String` (stdout) |

All four are Pattern B (Lib-only, public-by-exposure). No `Git::Base` wrappers
exist for these methods and none are added (per plan). The `Git::Lib`
implementations remain in place during the migration window (Phase 4 deletion
will remove them).

### Parsing

`worktrees_all` parses `git worktree list --porcelain` output inline — no
separate parser class, matching the `stashes_all` pattern in `Stashing`.

### Files changed

- `lib/git/repository/worktree_operations.rb` — **new** facade module
- `lib/git/repository.rb` — add require/include for the new module
- `spec/unit/git/repository/worktree_operations_spec.rb` — **new** unit specs (16 examples)
- `spec/integration/git/repository/worktree_operations_spec.rb` — **new** integration specs for `worktrees_all` parsing (7 examples)

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
