### PR TITLE
feat(repository): add worktree and worktrees factory methods to WorktreeOperations

### DIFF
--- a/lib/git/repository/worktree_operations.rb
+++ b/lib/git/repository/worktree_operations.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 require 'git/commands/worktree'
+require 'git/worktree'
+require 'git/worktrees'
 
 module Git
   class Repository
@@ -107,6 +109,51 @@ module Git
       #
       def worktree_prune
         Git::Commands::Worktree::Prune.new(@execution_context).call.stdout
+      end
+
+      # Return a {Git::Worktree} object for the given directory and optional commitish
+      #
+      # This is a factory method — it constructs the domain object but does not
+      # immediately execute any git commands.
+      #
+      # @example Get a worktree object for a new path
+      #   wt = repo.worktree('/tmp/feature')
+      #
+      # @example Get a worktree object for a specific branch or commit
+      #   wt = repo.worktree('/tmp/hotfix', 'main')
+      #
+      # @param dir [String] filesystem path for the worktree
+      #
+      # @param commitish [String, nil] branch, tag, or commit to associate with
+      #   the worktree; `nil` means no commitish is specified
+      #
+      # @return [Git::Worktree] a worktree domain object for the given path
+      #
+      def worktree(dir, commitish = nil)
+        Git::Worktree.new(self, dir, commitish)
+      end
+
+      # Return a {Git::Worktrees} collection of all worktrees (main and linked)
+      #
+      # The collection is populated eagerly when this method is called (git runs
+      # at construction time). It is enumerable and supports indexed access by
+      # worktree path.
+      #
+      # @example Iterate over all worktrees
+      #   repo.worktrees.each { |wt| puts wt.dir }
+      #
+      # @example Count worktrees
+      #   repo.worktrees.size
+      #
+      # @example Access a specific worktree by path
+      #   repo.worktrees['/tmp/feature']
+      #
+      # @return [Git::Worktrees] an enumerable collection of all worktrees
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def worktrees
+        Git::Worktrees.new(self)
       end
     end
   end

--- a/spec/unit/git/repository/worktree_operations_spec.rb
+++ b/spec/unit/git/repository/worktree_operations_spec.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'fileutils'
 require 'spec_helper'
 require 'git/repository'
 require 'git/repository/worktree_operations'
@@ -136,11 +135,11 @@ RSpec.describe Git::Repository::WorktreeOperations do
 
     before do
       allow(Git::Commands::Worktree::Add).to receive(:new).with(execution_context).and_return(add_command)
+      allow(add_command).to receive(:call).and_return(add_result)
     end
 
     it 'constructs Git::Commands::Worktree::Add with the execution context' do
       expect(Git::Commands::Worktree::Add).to receive(:new).with(execution_context).and_return(add_command)
-      allow(add_command).to receive(:call).and_return(add_result)
       described_instance.worktree_add('/tmp/feature')
     end
 
@@ -151,7 +150,6 @@ RSpec.describe Git::Repository::WorktreeOperations do
       end
 
       it 'returns the stdout string' do
-        allow(add_command).to receive(:call).with('/tmp/feature').and_return(add_result)
         expect(described_instance.worktree_add('/tmp/feature')).to eq("Preparing worktree (new branch 'feature')\n")
       end
     end
@@ -163,9 +161,8 @@ RSpec.describe Git::Repository::WorktreeOperations do
       end
 
       it 'returns the stdout string' do
-        allow(add_command).to receive(:call).with('/tmp/feature', 'main').and_return(add_result)
-        result = described_instance.worktree_add('/tmp/feature', 'main')
-        expect(result).to eq("Preparing worktree (new branch 'feature')\n")
+        expect(described_instance.worktree_add('/tmp/feature',
+                                               'main')).to eq("Preparing worktree (new branch 'feature')\n")
       end
     end
   end
@@ -176,11 +173,11 @@ RSpec.describe Git::Repository::WorktreeOperations do
 
     before do
       allow(Git::Commands::Worktree::Remove).to receive(:new).with(execution_context).and_return(remove_command)
+      allow(remove_command).to receive(:call).with('/tmp/feature').and_return(remove_result)
     end
 
     it 'constructs Git::Commands::Worktree::Remove with the execution context' do
       expect(Git::Commands::Worktree::Remove).to receive(:new).with(execution_context).and_return(remove_command)
-      allow(remove_command).to receive(:call).with('/tmp/feature').and_return(remove_result)
       described_instance.worktree_remove('/tmp/feature')
     end
 
@@ -190,7 +187,6 @@ RSpec.describe Git::Repository::WorktreeOperations do
     end
 
     it 'returns the stdout string' do
-      allow(remove_command).to receive(:call).with('/tmp/feature').and_return(remove_result)
       expect(described_instance.worktree_remove('/tmp/feature')).to eq('')
     end
   end
@@ -201,11 +197,11 @@ RSpec.describe Git::Repository::WorktreeOperations do
 
     before do
       allow(Git::Commands::Worktree::Prune).to receive(:new).with(execution_context).and_return(prune_command)
+      allow(prune_command).to receive(:call).and_return(prune_result)
     end
 
     it 'constructs Git::Commands::Worktree::Prune with the execution context' do
       expect(Git::Commands::Worktree::Prune).to receive(:new).with(execution_context).and_return(prune_command)
-      allow(prune_command).to receive(:call).with(no_args).and_return(prune_result)
       described_instance.worktree_prune
     end
 
@@ -215,8 +211,41 @@ RSpec.describe Git::Repository::WorktreeOperations do
     end
 
     it 'returns the stdout string' do
-      allow(prune_command).to receive(:call).and_return(prune_result)
       expect(described_instance.worktree_prune).to eq('')
+    end
+  end
+
+  describe '#worktree' do
+    let(:worktree_double) { instance_double(Git::Worktree) }
+
+    context 'when called without a commitish' do
+      subject(:result) { described_instance.worktree('/tmp/feature') }
+
+      it 'constructs Git::Worktree with self, the directory, and nil commitish, and returns it' do
+        expect(Git::Worktree).to receive(:new).with(described_instance, '/tmp/feature', nil).and_return(worktree_double)
+        expect(result).to eq(worktree_double)
+      end
+    end
+
+    context 'when called with a commitish' do
+      subject(:result) { described_instance.worktree('/tmp/feature', 'main') }
+
+      it 'constructs Git::Worktree with self, the directory, and the commitish, and returns it' do
+        expect(Git::Worktree).to receive(:new).with(described_instance, '/tmp/feature',
+                                                    'main').and_return(worktree_double)
+        expect(result).to eq(worktree_double)
+      end
+    end
+  end
+
+  describe '#worktrees' do
+    subject(:result) { described_instance.worktrees }
+
+    let(:worktrees_collection) { instance_double(Git::Worktrees) }
+
+    it 'constructs Git::Worktrees with self and returns the collection' do
+      expect(Git::Worktrees).to receive(:new).with(described_instance).and_return(worktrees_collection)
+      expect(result).to eq(worktrees_collection)
     end
   end
 end


### PR DESCRIPTION
Adds the two factory methods for PR2 of the iteration 9 worktree facade migration. Depends on PR1 (`feat(repository): add Git::Repository::WorktreeOperations facade module`), which is already merged to `main`.

## Description

Extends `Git::Repository::WorktreeOperations` with factory methods 5 and 6 from the iteration 9 plan:

- **`#worktree(dir, commitish = nil)`** — constructs and returns a `Git::Worktree` domain object for the given path and optional commitish. This is a factory — it does not immediately execute any git commands.
- **`#worktrees`** — constructs and returns a `Git::Worktrees` collection of all linked worktrees.

Also adds the necessary `require` statements for `git/worktree` and `git/worktrees` to the facade module.

> **Note:** These factories are not end-to-end functional until PRs 3 and 4 apply constructor polymorphism to `Git::Worktree` and `Git::Worktrees` (both domain objects still call `@base.lib.*` internally). Unit tests stub the constructors to isolate from the domain objects per the established iteration 8 pattern.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
