### PR TITLE
refactor(base): delegate Git::Base#worktree and #worktrees to facade_repository (iter 9 PR5)

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -951,15 +951,32 @@ module Git
       Git::Branches.new(self)
     end
 
-    # returns a Git::Worktree object for dir, commitish
+    # Returns a {Git::Worktree} object for the given path and optional commitish
+    #
+    # @example Create a worktree object for an existing path
+    #   worktree = repo.worktree('/path/to/worktree')
+    #
+    # @param dir [String] filesystem path of the worktree
+    #
+    # @param commitish [String, nil] branch, tag, or commit to check out
+    #
+    # @return [Git::Worktree] worktree object for the given path
+    #
     def worktree(dir, commitish = nil)
-      Git::Worktree.new(self, dir, commitish)
+      facade_repository.worktree(dir, commitish)
     end
 
-    # returns a Git::worktrees object of all the Git::Worktrees
-    # objects for this repo
+    # Returns a {Git::Worktrees} collection of all worktrees in the repository
+    #
+    # @example List paths for all worktrees
+    #   repo.worktrees.each { |wt| puts wt.dir }
+    #
+    # @return [Git::Worktrees] all linked and main worktrees
+    #
+    # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
     def worktrees
-      Git::Worktrees.new(self)
+      facade_repository.worktrees
     end
 
     # @return [Git::Object::Commit] a commit object

--- a/lib/git/commands/worktree/add.rb
+++ b/lib/git/commands/worktree/add.rb
@@ -19,7 +19,7 @@ module Git
       # @example Add a detached-HEAD worktree locked at creation
       #   Git::Commands::Worktree::Add.new(execution_context).call('/tmp/exp', detach: true, lock: true)
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
@@ -70,44 +70,59 @@ module Git
         #
         #       Alias: :f
         #
-        #     @option options [String] :b (nil) create a new branch with this name and check it out
+        #     @option options [String] :b (nil) create a new branch with this name
+        #       and check it out
         #
-        #     @option options [String] :B (nil) create or reset a branch with this name and check it out
+        #     @option options [String] :B (nil) create or reset a branch with this
+        #       name and check it out
         #
-        #     @option options [Boolean, nil] :detach (nil) check out in detached-HEAD state
+        #     @option options [Boolean, nil] :detach (nil) check out in
+        #       detached-HEAD state
         #
         #       Alias: :d
         #
-        #     @option options [Boolean, nil] :checkout (nil) control whether the working tree
-        #       is checked out after creation (`--checkout`)
+        #     @option options [Boolean, nil] :checkout (nil) control whether the working
+        #       tree is checked out after creation (`--checkout`)
         #
-        #     @option options [Boolean, nil] :no_checkout (nil) suppress the initial checkout
-        #       after worktree creation (`--no-checkout`)
+        #     @option options [Boolean, nil] :no_checkout (nil) suppress the initial
+        #       checkout after worktree creation (`--no-checkout`)
         #
-        #     @option options [Boolean, nil] :guess_remote (nil) base new branch on a matching
-        #       remote-tracking branch when no `commit_ish` is given (`--guess-remote`)
+        #     @option options [Boolean, nil] :guess_remote (nil) base new branch on a
+        #       matching remote-tracking branch (`--guess-remote`)
         #
-        #     @option options [Boolean, nil] :no_guess_remote (nil) disable guess-remote behavior (`--no-guess-remote`)
+        #       Applied when no `commit_ish` argument is provided.
         #
-        #     @option options [Boolean, nil] :relative_paths (nil) link worktrees using relative paths,
-        #       overriding the `worktree.useRelativePaths` config option (`--relative-paths`)
+        #     @option options [Boolean, nil] :no_guess_remote (nil) disable guess-remote
+        #       behavior (`--no-guess-remote`)
         #
-        #     @option options [Boolean, nil] :no_relative_paths (nil) use absolute paths for worktree links,
-        #       overriding the `worktree.useRelativePaths` config option (`--no-relative-paths`)
+        #     @option options [Boolean, nil] :relative_paths (nil) link worktrees using
+        #       relative paths (`--relative-paths`)
         #
-        #     @option options [Boolean, nil] :track (nil) mark the upstream branch for tracking (`--track`)
+        #       Overrides the `worktree.useRelativePaths` config option.
         #
-        #     @option options [Boolean, nil] :no_track (nil) do not mark the upstream branch for tracking (`--no-track`)
+        #     @option options [Boolean, nil] :no_relative_paths (nil) use absolute paths
+        #       for worktree links (`--no-relative-paths`)
         #
-        #     @option options [Boolean, nil] :lock (nil) lock the worktree immediately after creation
+        #       Overrides the `worktree.useRelativePaths` config option.
         #
-        #     @option options [Boolean, nil] :orphan (nil) create an empty worktree associated with a new unborn branch
+        #     @option options [Boolean, nil] :track (nil) mark the upstream branch for
+        #       tracking (`--track`)
+        #
+        #     @option options [Boolean, nil] :no_track (nil) do not mark the upstream
+        #       branch for tracking (`--no-track`)
+        #
+        #     @option options [Boolean, nil] :lock (nil) lock the worktree immediately
+        #       after creation
+        #
+        #     @option options [Boolean, nil] :orphan (nil) create an empty worktree
+        #       associated with a new unborn branch
         #
         #     @option options [Boolean, nil] :quiet (nil) suppress informational messages
         #
         #       Alias: :q
         #
-        #     @option options [String] :reason (nil) explanation for why the worktree is locked
+        #     @option options [String] :reason (nil) explanation for why the worktree
+        #       is locked
         #
         #       Only meaningful when used with `:lock`.
         #
@@ -116,6 +131,8 @@ module Git
         #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
+        #
+        #     @api public
       end
     end
   end

--- a/lib/git/commands/worktree/list.rb
+++ b/lib/git/commands/worktree/list.rb
@@ -10,9 +10,9 @@ module Git
       # @example List all worktrees in porcelain format
       #   Git::Commands::Worktree::List.new(execution_context).call(porcelain: true)
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
       #
-      # @see Git::Commands::Worktree
+      # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
       #
@@ -36,22 +36,27 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, nil] :porcelain (nil) produce machine-readable output
+        #     @option options [Boolean, nil] :porcelain (nil) produce machine-readable
+        #       output
         #
-        #     @option options [Boolean, nil] :z (nil) NUL-terminate lines (use with `:porcelain`)
+        #     @option options [Boolean, nil] :z (nil) terminate output lines with NUL
+        #       bytes (use with `:porcelain`)
         #
-        #     @option options [Boolean, nil] :verbose (nil) output additional information about worktrees
+        #     @option options [Boolean, nil] :verbose (nil) output additional information
+        #       about worktrees
         #
         #       Alias: :v
         #
-        #     @option options [String] :expire (nil) annotate missing worktrees as prunable if older than
-        #       this time expression
+        #     @option options [String] :expire (nil) annotate missing worktrees as
+        #       prunable if older than this time expression
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree list`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
+        #
+        #     @api public
       end
     end
   end

--- a/lib/git/commands/worktree/lock.rb
+++ b/lib/git/commands/worktree/lock.rb
@@ -13,7 +13,7 @@ module Git
       # @example Lock with a reason message
       #   Git::Commands::Worktree::Lock.new(execution_context).call('/tmp/feature', reason: 'on NFS share')
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
@@ -36,17 +36,21 @@ module Git
         #
         #     Lock a worktree to prevent it from being pruned
         #
-        #     @param worktree [String] path or unique suffix identifying the worktree to lock
+        #     @param worktree [String] path or unique suffix identifying the
+        #       worktree to lock
         #
         #     @param options [Hash] command options
         #
-        #     @option options [String] :reason (nil) human-readable explanation stored alongside the lock
+        #     @option options [String] :reason (nil) human-readable explanation stored
+        #       alongside the lock
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree lock`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
+        #
+        #     @api public
       end
     end
   end

--- a/lib/git/commands/worktree/move.rb
+++ b/lib/git/commands/worktree/move.rb
@@ -13,7 +13,7 @@ module Git
       # @example Force-move a locked worktree
       #   Git::Commands::Worktree::Move.new(execution_context).call('/tmp/feat', '/tmp/feat2', force: true)
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
@@ -37,13 +37,15 @@ module Git
         #
         #     Move a linked worktree to a new filesystem location
         #
-        #     @param worktree [String] path or unique suffix identifying the worktree to move
+        #     @param worktree [String] path or unique suffix identifying the
+        #       worktree to move
         #
         #     @param new_path [String] destination path for the worktree
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, Integer, nil] :force (nil) allow moving a locked worktree
+        #     @option options [Boolean, Integer, nil] :force (nil) allow moving a
+        #       locked worktree
         #
         #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit
         #       `--force --force`, which also handles locked or missing destinations.
@@ -55,6 +57,8 @@ module Git
         #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
+        #
+        #     @api public
       end
     end
   end

--- a/lib/git/commands/worktree/prune.rb
+++ b/lib/git/commands/worktree/prune.rb
@@ -16,7 +16,7 @@ module Git
       # @example Prune entries older than 2 weeks
       #   Git::Commands::Worktree::Prune.new(execution_context).call(expire: '2.weeks.ago')
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
@@ -58,6 +58,8 @@ module Git
         #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
+        #
+        #     @api public
       end
     end
   end

--- a/lib/git/commands/worktree/remove.rb
+++ b/lib/git/commands/worktree/remove.rb
@@ -13,7 +13,7 @@ module Git
       # @example Force-remove an unclean worktree
       #   Git::Commands::Worktree::Remove.new(execution_context).call('/tmp/feature', force: true)
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
@@ -36,15 +36,16 @@ module Git
         #
         #     Remove a linked worktree
         #
-        #     @param worktree [String] path or unique suffix identifying the worktree to remove
+        #     @param worktree [String] path or unique suffix identifying the
+        #       worktree to remove
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, Integer, nil] :force (nil) remove even if the worktree has
-        #       uncommitted changes
+        #     @option options [Boolean, Integer, nil] :force (nil) remove even if the
+        #       worktree has uncommitted changes
         #
-        #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit `--force --force`,
-        #       which also removes locked worktrees.
+        #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit
+        #       `--force --force`, which also removes locked worktrees.
         #
         #       Alias: :f
         #
@@ -53,6 +54,8 @@ module Git
         #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
+        #
+        #     @api public
       end
     end
   end

--- a/lib/git/commands/worktree/repair.rb
+++ b/lib/git/commands/worktree/repair.rb
@@ -16,7 +16,7 @@ module Git
       # @example Repair specific moved worktrees
       #   Git::Commands::Worktree::Repair.new(execution_context).call('/tmp/moved1', '/tmp/moved2')
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
@@ -48,13 +48,16 @@ module Git
         #
         #     @param options [Hash] command options
         #
-        #     @option options [Boolean, nil] :relative_paths (nil) link worktrees using relative paths,
-        #       overriding the `worktree.useRelativePaths` config option (`--relative-paths`)
+        #     @option options [Boolean, nil] :relative_paths (nil) link worktrees using
+        #       relative paths (`--relative-paths`)
         #
-        #     @option options [Boolean, nil] :no_relative_paths (nil) use absolute paths for worktree links,
-        #       overriding the `worktree.useRelativePaths` config option (`--no-relative-paths`)
+        #       Overrides the `worktree.useRelativePaths` config option.
         #
-        #       Also causes repair to update linking files if there is an absolute/relative
+        #     @option options [Boolean, nil] :no_relative_paths (nil) use absolute paths
+        #       for worktree links (`--no-relative-paths`)
+        #
+        #       Overrides the `worktree.useRelativePaths` config option. Also causes
+        #       repair to update linking files if there is an absolute/relative
         #       mismatch, even if the links are already correct.
         #
         #     @return [Git::CommandLineResult] the result of calling `git worktree repair`
@@ -62,6 +65,10 @@ module Git
         #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
+        #
+        #     @raise [Git::VersionError] if git version is below 2.29.0
+        #
+        #     @api public
       end
     end
   end

--- a/lib/git/commands/worktree/unlock.rb
+++ b/lib/git/commands/worktree/unlock.rb
@@ -10,7 +10,7 @@ module Git
       # @example Unlock a worktree
       #   Git::Commands::Worktree::Unlock.new(execution_context).call('/tmp/feature')
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.53.0
+      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #
@@ -38,6 +38,8 @@ module Git
         #     @return [Git::CommandLineResult] the result of calling `git worktree unlock`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
+        #
+        #     @api public
       end
     end
   end

--- a/lib/git/repository/worktree_operations.rb
+++ b/lib/git/repository/worktree_operations.rb
@@ -16,8 +16,7 @@ module Git
       # Returns all worktrees as an array of directory and SHA pairs
       #
       # Lists all worktrees attached to the repository, including the main
-      # worktree and all linked worktrees. The output is parsed from
-      # `git worktree list --porcelain`.
+      # worktree and all linked worktrees.
       #
       # @example List all worktrees
       #   repo.worktrees_all

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -45,6 +45,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | `Git::Repository::Logging` | `lib/git/repository/logging.rb` | ✅ | `log`, `full_log_commits` |
 | `Git::Repository::StatusOperations` | `lib/git/repository/status_operations.rb` | ✅ | `ls_files`, `no_commits?` (renamed from `Git::Lib#empty?`), `untracked_files`, `status`; `Git::Base#ls_files` delegates to facade |
 | `Git::Repository::Configuring` | `lib/git/repository/configuring.rb` | ✅ | `config`; `Git::Base#config` delegates to facade |
+| `Git::Repository::WorktreeOperations` | `lib/git/repository/worktree_operations.rb` | ✅ | `worktrees_all`, `worktree_add`, `worktree_remove`, `worktree_prune`, `worktree`, `worktrees` |
 
 #### Facade module naming convention
 
@@ -61,9 +62,9 @@ such as `Branch`, `Diff`, `Log`, `Object`, `Remote`, `Status`, `Worktree`, etc.
 
 ### Next Task
 
-**Phase 3 — Iteration 9: `Git::Worktree` + `Git::Worktrees`**
+**Phase 3 — Verify Facade Coverage (all 9 domain-object iterations complete)**
 
-Iter 1 (`Git::Stash` B2 + `Git::Stashes` B3) is ✅ complete ([PR #1306](https://github.com/ruby-git/ruby-git/pull/1306)). Iter 2 (`Git::DiffPathStatus` B1) is ✅ complete. Iter 3 (`Git::Object::*`) is ✅ complete. Iter 4 (`Git::Log` A+B) is ✅ complete ([PR #1327](https://github.com/ruby-git/ruby-git/pull/1327)). Iter 5 (`Git::Diff` + `Git::DiffStats` A+B) is ✅ complete (`feat/migrate-diff-to-repository`). Iter 6 (`Git::Status` A+B) is ✅ complete (`feat/migrate-status-to-repository` + `feat/iter6b-delegate-ls-files-config`). Iter 7 (`Git::Branch` + `Git::Remote` A+B) is ✅ complete (`agents/migrate-git-branch-remote-polymorphism`). Iter 8 (`Git::Branches` A+B) is ✅ complete ([PR #1356](https://github.com/ruby-git/ruby-git/pull/1356), [PR #1357](https://github.com/ruby-git/ruby-git/pull/1357), [PR #1358](https://github.com/ruby-git/ruby-git/pull/1358), [PR #1359](https://github.com/ruby-git/ruby-git/pull/1359)). Proceed to iter 9.
+All 9 domain-object iterations are ✅ complete. Iter 1 (`Git::Stash` B2 + `Git::Stashes` B3) is ✅ complete ([PR #1306](https://github.com/ruby-git/ruby-git/pull/1306)). Iter 2 (`Git::DiffPathStatus` B1) is ✅ complete. Iter 3 (`Git::Object::*`) is ✅ complete. Iter 4 (`Git::Log` A+B) is ✅ complete ([PR #1327](https://github.com/ruby-git/ruby-git/pull/1327)). Iter 5 (`Git::Diff` + `Git::DiffStats` A+B) is ✅ complete (`feat/migrate-diff-to-repository`). Iter 6 (`Git::Status` A+B) is ✅ complete (`feat/migrate-status-to-repository` + `feat/iter6b-delegate-ls-files-config`). Iter 7 (`Git::Branch` + `Git::Remote` A+B) is ✅ complete (`agents/migrate-git-branch-remote-polymorphism`). Iter 8 (`Git::Branches` A+B) is ✅ complete ([PR #1356](https://github.com/ruby-git/ruby-git/pull/1356), [PR #1357](https://github.com/ruby-git/ruby-git/pull/1357), [PR #1358](https://github.com/ruby-git/ruby-git/pull/1358), [PR #1359](https://github.com/ruby-git/ruby-git/pull/1359)). Iter 9 (`Git::Worktree` + `Git::Worktrees` A+B) is ✅ complete (`agents/pr5-facade-module-improvements`).
 
 The full scope is still migrating all domain objects
 (`Git::Stash`, `Git::Stashes`, `Git::DiffPathStatus`, `Git::Object::*`,
@@ -87,7 +88,7 @@ Each iteration follows an interleaved A→B pattern (some iterations only need a
    polymorphism and replace `@base.lib.*` calls with facade calls (**Phase B** work).
 3. Open one PR per iteration.
 
-After all 9 domain-object iterations, **verify facade coverage**: every public `Git::Base` method must have a corresponding `Git::Repository` facade before the cleanup PR can run. Methods such as `clean`, `rm`, `tags`/`add_tag`, `fsck`, `show`, `remotes`, and remote URL/branch helpers are not covered by the 9 domain-object iterations and will need dedicated facade PRs first. Once coverage is complete, open a final **cleanup PR** (`feat/cleanup-base-object-bridge`): C0 — update `Git::Base` domain-object factory methods (`branch`, `branches`, `gcommit`/`gblob`/`gtree`, `log`, `diff`, `object`, `remote`, `status`, `tag`, etc.) to delegate to `facade_repository` rather than constructing domain objects directly with `self`; C1 — update top-level entry-point methods (`Git.open`, `Git.clone`, `Git.init`, `Git.bare`) to construct and return `Git::Repository` instead of `Git::Base`; C2 — remove `base_object` bridge from `Git::ExecutionContext::Repository`; C3 — remove `is_a?(Git::Base)` polymorphism guards.
+The next step is to **verify facade coverage**: audit every public `Git::Base` method to ensure it has a corresponding `Git::Repository` facade (or is intentionally excluded). Methods such as `clean`, `rm`, `tags`/`add_tag`, `fsck`, `show`, `remotes`, and remote URL/branch helpers are not yet covered and will need dedicated facade PRs. Once coverage is complete, open a final **cleanup PR** (`feat/cleanup-base-object-bridge`): C0 — update `Git::Base` domain-object factory methods (`branch`, `branches`, `gcommit`/`gblob`/`gtree`, `log`, `diff`, `object`, `remote`, `status`, `tag`, etc.) to delegate to `facade_repository` rather than constructing domain objects directly with `self`; C1 — update top-level entry-point methods (`Git.open`, `Git.clone`, `Git.init`, `Git.bare`) to construct and return `Git::Repository` instead of `Git::Base`; C2 — remove `base_object` bridge from `Git::ExecutionContext::Repository`; C3 — remove `is_a?(Git::Base)` polymorphism guards.
 
 #### Delivery iterations
 
@@ -119,7 +120,7 @@ After all 9 domain-object iterations, **verify facade coverage**: every public `
 | `Git::Remote` | ✅ Complete | iter 7 |
 | `Git::Branches` | ✅ Complete | iter 8 |
 | `Git::Worktree` | ✅ Complete | iter 9 |
-| `Git::Worktrees` | ⏳ Not started | iter 9 |
+| `Git::Worktrees` | ✅ Complete | iter 9 |
 
 > **Note**: Several internal/private nested classes also hold `@base` and must be migrated alongside their parent domain object in the same iteration:
 >
@@ -152,7 +153,7 @@ logic. The gem will be fully functional after this phase.*
 1. **Create New Directory Structure**
 
    - `lib/git/commands/` ✅
-   - `lib/git/repository/` ✅ — populated with 9 facade modules in Phase 3 (see [Facade Modules Completed](#facade-modules-completed))
+   - `lib/git/repository/` ✅ — populated with 12 facade modules in Phase 3 (see [Facade Modules Completed](#facade-modules-completed))
 
 2. **Eliminate Custom Path Classes**
 
@@ -174,7 +175,7 @@ logic. The gem will be fully functional after this phase.*
      - `Git::ExecutionContext::Global` subclass in `lib/git/execution_context/global.rb` ✅
 
    - `Git::Repository` in `lib/git/repository.rb` ✅
-     - Now includes 9 facade modules (see [Facade Modules Completed](#facade-modules-completed))
+     - Now includes 12 facade modules (see [Facade Modules Completed](#facade-modules-completed))
 
    - `Git::Commands::Arguments` DSL in `lib/git/commands/arguments.rb` ✅
      - Provides declarative argument definition for command classes
@@ -1067,7 +1068,7 @@ breaking the final ties to the old implementation.*
 
 2. **Implement the Facade** ⏳
 
-   `Git::Repository` now includes 5 facade modules (see
+   `Git::Repository` now includes 12 facade modules (see
    [Facade Modules Completed](#facade-modules-completed)). `Git::Base` wraps the
    corresponding methods via `facade_repository`. The domain-object migration
    iterations (iters 1–9) add further facade methods, but full `Git::Base`

--- a/spec/integration/git/repository/worktree_operations_spec.rb
+++ b/spec/integration/git/repository/worktree_operations_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-require 'securerandom'
 require 'spec_helper'
+require 'securerandom'
 require 'git/repository'
 require 'git/repository/worktree_operations'
 require 'git/execution_context/repository'
@@ -9,6 +9,10 @@ require 'git/execution_context/repository'
 # worktree_add, worktree_remove, and worktree_prune are one-line delegators with no
 # facade-owned post-processing. Their end-to-end coverage comes from the command
 # integration tests (spec/integration/git/commands/worktree/).
+#
+# worktree and worktrees are factory methods that construct domain objects
+# (Git::Worktree and Git::Worktrees) without running git commands directly; they
+# have no integration tests and are fully covered by the unit tests.
 #
 # worktrees_all parses porcelain output inline inside the facade. This integration
 # test verifies that the parsing logic works correctly against actual git output.

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -3,6 +3,15 @@
 require 'spec_helper'
 
 RSpec.describe Git::Base do
+  shared_context 'with a stubbed facade_repository' do
+    let(:described_instance) { described_class.new }
+    let(:facade_repository) { instance_double(Git::Repository) }
+
+    before do
+      allow(described_instance).to receive(:facade_repository).and_return(facade_repository)
+    end
+  end
+
   describe '#binary_path' do
     context 'when not specified' do
       subject(:base) { described_class.new }
@@ -28,16 +37,12 @@ RSpec.describe Git::Base do
   end
 
   describe '#full_log_commits' do
+    include_context 'with a stubbed facade_repository'
+
     subject(:result) { described_instance.full_log_commits(opts) }
 
-    let(:described_instance) { described_class.new }
     let(:opts) { { count: 3 } }
-    let(:facade_repository) { instance_double(Git::Repository) }
     let(:log_data) { [{ 'sha' => 'abc123' }] }
-
-    before do
-      allow(described_instance).to receive(:facade_repository).and_return(facade_repository)
-    end
 
     it 'delegates to facade_repository with opts and returns the facade result' do
       expect(facade_repository).to receive(:full_log_commits).with(opts).and_return(log_data)
@@ -46,15 +51,14 @@ RSpec.describe Git::Base do
   end
 
   describe '#log' do
+    include_context 'with a stubbed facade_repository'
+
     subject(:result) { described_instance.log(count) }
 
-    let(:described_instance) { described_class.new }
     let(:count) { 5 }
-    let(:facade_repository) { instance_double(Git::Repository) }
     let(:log_instance) { instance_double(Git::Log) }
 
     before do
-      allow(described_instance).to receive(:facade_repository).and_return(facade_repository)
       allow(facade_repository).to receive(:log).with(count).and_return(log_instance)
     end
 
@@ -78,18 +82,14 @@ RSpec.describe Git::Base do
   end
 
   describe '#diff_stats' do
+    include_context 'with a stubbed facade_repository'
+
     subject(:result) { described_instance.diff_stats(objectish, obj2, opts) }
 
-    let(:described_instance) { described_class.new }
     let(:objectish) { 'HEAD~1' }
     let(:obj2) { 'HEAD' }
     let(:opts) { { path_limiter: 'lib/' } }
-    let(:facade_repository) { instance_double(Git::Repository) }
     let(:diff_stats_result) { instance_double(Git::DiffStats) }
-
-    before do
-      allow(described_instance).to receive(:facade_repository).and_return(facade_repository)
-    end
 
     it 'delegates to facade_repository.diff_stats with all arguments' do
       expect(facade_repository).to receive(:diff_stats).with(objectish, obj2, opts).and_return(diff_stats_result)
@@ -98,17 +98,13 @@ RSpec.describe Git::Base do
   end
 
   describe '#diff' do
+    include_context 'with a stubbed facade_repository'
+
     subject(:result) { described_instance.diff(objectish, obj2) }
 
-    let(:described_instance) { described_class.new }
     let(:objectish) { 'HEAD~1' }
     let(:obj2) { 'HEAD' }
-    let(:facade_repository) { instance_double(Git::Repository) }
     let(:diff_result) { instance_double(Git::Diff) }
-
-    before do
-      allow(described_instance).to receive(:facade_repository).and_return(facade_repository)
-    end
 
     it 'delegates to facade_repository.diff with objectish and obj2' do
       expect(facade_repository).to receive(:diff).with(objectish, obj2).and_return(diff_result)
@@ -126,6 +122,43 @@ RSpec.describe Git::Base do
         expect(facade_repository).to receive(:diff).with('HEAD', nil).and_return(diff_result)
         result
       end
+    end
+  end
+
+  describe '#worktree' do
+    include_context 'with a stubbed facade_repository'
+
+    subject(:result) { described_instance.worktree(dir, commitish) }
+
+    let(:dir) { '/tmp/feature' }
+    let(:commitish) { 'main' }
+    let(:worktree_double) { instance_double(Git::Worktree) }
+
+    it 'delegates to facade_repository.worktree with dir and commitish' do
+      expect(facade_repository).to receive(:worktree).with(dir, commitish).and_return(worktree_double)
+      expect(result).to be(worktree_double)
+    end
+
+    context 'when called without a commitish' do
+      let(:commitish) { nil }
+
+      it 'delegates to facade_repository.worktree with nil as the commitish' do
+        expect(facade_repository).to receive(:worktree).with(dir, nil).and_return(worktree_double)
+        expect(result).to be(worktree_double)
+      end
+    end
+  end
+
+  describe '#worktrees' do
+    include_context 'with a stubbed facade_repository'
+
+    subject(:result) { described_instance.worktrees }
+
+    let(:worktrees_collection) { instance_double(Git::Worktrees) }
+
+    it 'delegates to facade_repository.worktrees' do
+      expect(facade_repository).to receive(:worktrees).and_return(worktrees_collection)
+      expect(result).to be(worktrees_collection)
     end
   end
 end

--- a/spec/unit/git/repository/worktree_operations_spec.rb
+++ b/spec/unit/git/repository/worktree_operations_spec.rb
@@ -11,6 +11,9 @@ require 'git/repository/worktree_operations'
 #     spec/integration/git/commands/worktree/add_spec.rb    (worktree_add)
 #     spec/integration/git/commands/worktree/remove_spec.rb (worktree_remove)
 #     spec/integration/git/commands/worktree/prune_spec.rb  (worktree_prune)
+#   worktree and worktrees are factory methods that construct domain objects
+#   (Git::Worktree and Git::Worktrees) without running git commands directly;
+#   their behavior is fully covered by the unit tests below.
 #   worktrees_all does facade-owned inline parsing of porcelain output; its
 #   integration test is in spec/integration/git/repository/worktree_operations_spec.rb.
 
@@ -19,6 +22,8 @@ RSpec.describe Git::Repository::WorktreeOperations do
   let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
 
   describe '#worktrees_all' do
+    subject(:result) { described_instance.worktrees_all }
+
     let(:list_command) { instance_double(Git::Commands::Worktree::List) }
     let(:list_result) { command_result('') }
 
@@ -39,7 +44,7 @@ RSpec.describe Git::Repository::WorktreeOperations do
 
     context 'when the output is empty (no worktrees reported)' do
       it 'returns an empty array' do
-        expect(described_instance.worktrees_all).to eq([])
+        expect(result).to eq([])
       end
     end
 
@@ -53,7 +58,7 @@ RSpec.describe Git::Repository::WorktreeOperations do
       end
 
       it 'returns a single [directory, sha] pair' do
-        expect(described_instance.worktrees_all).to eq(
+        expect(result).to eq(
           [['/path/to/main', '4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a']]
         )
       end
@@ -73,7 +78,7 @@ RSpec.describe Git::Repository::WorktreeOperations do
       end
 
       it 'returns a [directory, sha] pair for each worktree' do
-        expect(described_instance.worktrees_all).to eq(
+        expect(result).to eq(
           [
             ['/path/to/main', '4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a'],
             ['/tmp/worktree-1', 'b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1']
@@ -96,7 +101,7 @@ RSpec.describe Git::Repository::WorktreeOperations do
       end
 
       it 'preserves the full directory path when parsing worktree entries' do
-        expect(described_instance.worktrees_all).to eq(
+        expect(result).to eq(
           [
             ['/path/to/main', '4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a'],
             ['/tmp/worktree with spaces', 'b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1']
@@ -119,7 +124,7 @@ RSpec.describe Git::Repository::WorktreeOperations do
       end
 
       it 'parses entries without carriage returns in directory or sha values' do
-        expect(described_instance.worktrees_all).to eq(
+        expect(result).to eq(
           [
             ['/path/to/main', '4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a'],
             ['/tmp/worktree with spaces', 'b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1']
@@ -130,6 +135,10 @@ RSpec.describe Git::Repository::WorktreeOperations do
   end
 
   describe '#worktree_add' do
+    subject(:result) { described_instance.worktree_add(dir, commitish) }
+
+    let(:dir) { '/tmp/feature' }
+    let(:commitish) { nil }
     let(:add_command) { instance_double(Git::Commands::Worktree::Add) }
     let(:add_result) { command_result("Preparing worktree (new branch 'feature')\n") }
 
@@ -140,58 +149,64 @@ RSpec.describe Git::Repository::WorktreeOperations do
 
     it 'constructs Git::Commands::Worktree::Add with the execution context' do
       expect(Git::Commands::Worktree::Add).to receive(:new).with(execution_context).and_return(add_command)
-      described_instance.worktree_add('/tmp/feature')
+      described_instance.worktree_add(dir)
     end
 
     context 'when no commitish is given (nil)' do
       it 'calls #call with only the directory' do
-        expect(add_command).to receive(:call).with('/tmp/feature').and_return(add_result)
-        described_instance.worktree_add('/tmp/feature')
+        expect(add_command).to receive(:call).with(dir).and_return(add_result)
+        described_instance.worktree_add(dir)
       end
 
       it 'returns the stdout string' do
-        expect(described_instance.worktree_add('/tmp/feature')).to eq("Preparing worktree (new branch 'feature')\n")
+        expect(result).to eq("Preparing worktree (new branch 'feature')\n")
       end
     end
 
     context 'when a commitish is given' do
+      let(:commitish) { 'main' }
+
       it 'calls #call with the directory and the commitish' do
-        expect(add_command).to receive(:call).with('/tmp/feature', 'main').and_return(add_result)
-        described_instance.worktree_add('/tmp/feature', 'main')
+        expect(add_command).to receive(:call).with(dir, commitish).and_return(add_result)
+        described_instance.worktree_add(dir, commitish)
       end
 
       it 'returns the stdout string' do
-        expect(described_instance.worktree_add('/tmp/feature',
-                                               'main')).to eq("Preparing worktree (new branch 'feature')\n")
+        expect(result).to eq("Preparing worktree (new branch 'feature')\n")
       end
     end
   end
 
   describe '#worktree_remove' do
+    subject(:result) { described_instance.worktree_remove(dir) }
+
+    let(:dir) { '/tmp/feature' }
     let(:remove_command) { instance_double(Git::Commands::Worktree::Remove) }
     let(:remove_result) { command_result('') }
 
     before do
       allow(Git::Commands::Worktree::Remove).to receive(:new).with(execution_context).and_return(remove_command)
-      allow(remove_command).to receive(:call).with('/tmp/feature').and_return(remove_result)
+      allow(remove_command).to receive(:call).with(dir).and_return(remove_result)
     end
 
     it 'constructs Git::Commands::Worktree::Remove with the execution context' do
       expect(Git::Commands::Worktree::Remove).to receive(:new).with(execution_context).and_return(remove_command)
-      described_instance.worktree_remove('/tmp/feature')
+      described_instance.worktree_remove(dir)
     end
 
     it 'calls #call with the directory' do
-      expect(remove_command).to receive(:call).with('/tmp/feature').and_return(remove_result)
-      described_instance.worktree_remove('/tmp/feature')
+      expect(remove_command).to receive(:call).with(dir).and_return(remove_result)
+      described_instance.worktree_remove(dir)
     end
 
     it 'returns the stdout string' do
-      expect(described_instance.worktree_remove('/tmp/feature')).to eq('')
+      expect(result).to eq('')
     end
   end
 
   describe '#worktree_prune' do
+    subject(:result) { described_instance.worktree_prune }
+
     let(:prune_command) { instance_double(Git::Commands::Worktree::Prune) }
     let(:prune_result) { command_result('') }
 
@@ -211,28 +226,29 @@ RSpec.describe Git::Repository::WorktreeOperations do
     end
 
     it 'returns the stdout string' do
-      expect(described_instance.worktree_prune).to eq('')
+      expect(result).to eq('')
     end
   end
 
   describe '#worktree' do
+    subject(:result) { described_instance.worktree(dir, commitish) }
+
+    let(:dir) { '/tmp/feature' }
+    let(:commitish) { nil }
     let(:worktree_double) { instance_double(Git::Worktree) }
 
     context 'when called without a commitish' do
-      subject(:result) { described_instance.worktree('/tmp/feature') }
-
-      it 'constructs Git::Worktree with self, the directory, and nil commitish, and returns it' do
-        expect(Git::Worktree).to receive(:new).with(described_instance, '/tmp/feature', nil).and_return(worktree_double)
+      it 'returns a Git::Worktree for the directory with no commitish' do
+        expect(Git::Worktree).to receive(:new).with(described_instance, dir, nil).and_return(worktree_double)
         expect(result).to eq(worktree_double)
       end
     end
 
     context 'when called with a commitish' do
-      subject(:result) { described_instance.worktree('/tmp/feature', 'main') }
+      let(:commitish) { 'main' }
 
-      it 'constructs Git::Worktree with self, the directory, and the commitish, and returns it' do
-        expect(Git::Worktree).to receive(:new).with(described_instance, '/tmp/feature',
-                                                    'main').and_return(worktree_double)
+      it 'returns a Git::Worktree for the directory and commitish' do
+        expect(Git::Worktree).to receive(:new).with(described_instance, dir, commitish).and_return(worktree_double)
         expect(result).to eq(worktree_double)
       end
     end
@@ -243,7 +259,7 @@ RSpec.describe Git::Repository::WorktreeOperations do
 
     let(:worktrees_collection) { instance_double(Git::Worktrees) }
 
-    it 'constructs Git::Worktrees with self and returns the collection' do
+    it 'returns a Git::Worktrees collection for all worktrees' do
       expect(Git::Worktrees).to receive(:new).with(described_instance).and_return(worktrees_collection)
       expect(result).to eq(worktrees_collection)
     end

--- a/spec/unit/git/worktree_spec.rb
+++ b/spec/unit/git/worktree_spec.rb
@@ -20,19 +20,21 @@ RSpec.describe Git::Worktree do
   # ---------------------------------------------------------------------------
 
   describe '#initialize' do
-    context 'when gcommit is nil' do
-      subject(:instance) { described_class.new(base, dir) }
+    subject(:instance) { described_class.new(base, dir, gcommit) }
 
+    let(:gcommit) { nil }
+
+    context 'when gcommit is nil' do
       it 'sets both full and dir to the path' do
         expect(instance).to have_attributes(full: dir, dir: dir)
       end
     end
 
     context 'when gcommit is non-nil' do
-      subject(:instance) { described_class.new(base, dir, 'abc123') }
+      let(:gcommit) { 'abc123' }
 
       it 'sets full to "dir gcommit" and dir to the path' do
-        expect(instance).to have_attributes(full: "#{dir} abc123", dir: dir)
+        expect(instance).to have_attributes(full: "#{dir} #{gcommit}", dir: dir)
       end
     end
   end
@@ -42,9 +44,13 @@ RSpec.describe Git::Worktree do
   # ---------------------------------------------------------------------------
 
   describe '#gcommit' do
+    subject(:result) { wt.gcommit }
+
+    let(:gcommit) { nil }
+    let(:wt) { described_class.new(base, dir, gcommit) }
+
     context 'when no gcommit was given at construction (nil)' do
       let(:commit_object) { instance_double(Git::Object::Commit) }
-      let(:wt) { described_class.new(base, dir) }
 
       before do
         allow(base).to receive(:gcommit).with(dir).and_return(commit_object)
@@ -56,7 +62,7 @@ RSpec.describe Git::Worktree do
       end
 
       it 'returns the result from base.gcommit' do
-        expect(wt.gcommit).to eq(commit_object)
+        expect(result).to eq(commit_object)
       end
 
       it 'memoizes the result so base.gcommit is not called on subsequent calls' do
@@ -67,10 +73,10 @@ RSpec.describe Git::Worktree do
     end
 
     context 'when a gcommit was given at construction' do
-      let(:wt) { described_class.new(base, dir, 'abc123') }
+      let(:gcommit) { 'abc123' }
 
       it 'returns the pre-set gcommit' do
-        expect(wt.gcommit).to eq('abc123')
+        expect(result).to eq(gcommit)
       end
 
       it 'does not call base.gcommit' do
@@ -83,7 +89,6 @@ RSpec.describe Git::Worktree do
       let(:facade_repo) { instance_double(Git::Repository) }
       let(:base) { instance_double(Git::Base) }
       let(:commit_object) { instance_double(Git::Object::Commit) }
-      let(:wt) { described_class.new(base, dir) }
 
       before do
         allow(base).to receive(:is_a?).with(Git::Base).and_return(true)
@@ -97,7 +102,7 @@ RSpec.describe Git::Worktree do
       end
 
       it 'returns the result from facade_repository.gcommit' do
-        expect(wt.gcommit).to eq(commit_object)
+        expect(result).to eq(commit_object)
       end
     end
   end
@@ -107,10 +112,11 @@ RSpec.describe Git::Worktree do
   # ---------------------------------------------------------------------------
 
   describe '#add' do
+    let(:gcommit) { nil }
+    let(:wt) { described_class.new(base, dir, gcommit) }
+
     context 'when base is a Git::Repository (new form)' do
       context 'when gcommit is nil' do
-        let(:wt) { described_class.new(base, dir) }
-
         it 'calls worktree_add on base directly with dir and nil' do
           expect(base).to receive(:worktree_add).with(dir, nil).and_return('output')
           wt.add
@@ -118,10 +124,10 @@ RSpec.describe Git::Worktree do
       end
 
       context 'when gcommit is set' do
-        let(:wt) { described_class.new(base, dir, 'main') }
+        let(:gcommit) { 'main' }
 
         it 'calls worktree_add on base directly with dir and the gcommit' do
-          expect(base).to receive(:worktree_add).with(dir, 'main').and_return('output')
+          expect(base).to receive(:worktree_add).with(dir, gcommit).and_return('output')
           wt.add
         end
       end
@@ -137,8 +143,6 @@ RSpec.describe Git::Worktree do
       end
 
       context 'when gcommit is nil' do
-        let(:wt) { described_class.new(base, dir) }
-
         it 'resolves facade_repository and calls worktree_add on it with dir and nil' do
           expect(facade_repo).to receive(:worktree_add).with(dir, nil).and_return('output')
           wt.add
@@ -146,10 +150,10 @@ RSpec.describe Git::Worktree do
       end
 
       context 'when gcommit is set' do
-        let(:wt) { described_class.new(base, dir, 'main') }
+        let(:gcommit) { 'main' }
 
         it 'resolves facade_repository and calls worktree_add on it with dir and gcommit' do
-          expect(facade_repo).to receive(:worktree_add).with(dir, 'main').and_return('output')
+          expect(facade_repo).to receive(:worktree_add).with(dir, gcommit).and_return('output')
           wt.add
         end
       end
@@ -161,9 +165,9 @@ RSpec.describe Git::Worktree do
   # ---------------------------------------------------------------------------
 
   describe '#remove' do
-    context 'when base is a Git::Repository (new form)' do
-      let(:wt) { described_class.new(base, dir) }
+    let(:wt) { described_class.new(base, dir) }
 
+    context 'when base is a Git::Repository (new form)' do
       it 'calls worktree_remove on base directly with dir' do
         expect(base).to receive(:worktree_remove).with(dir).and_return('')
         wt.remove
@@ -173,7 +177,6 @@ RSpec.describe Git::Worktree do
     context 'when base is a Git::Base (legacy form)' do
       let(:facade_repo) { instance_double(Git::Repository) }
       let(:base) { instance_double(Git::Base) }
-      let(:wt) { described_class.new(base, dir) }
 
       before do
         allow(base).to receive(:is_a?).with(Git::Base).and_return(true)
@@ -205,7 +208,7 @@ RSpec.describe Git::Worktree do
       let(:gcommit) { 'abc123' }
 
       it 'returns an array containing the full descriptor with gcommit appended' do
-        expect(result).to eq(["#{dir} abc123"])
+        expect(result).to eq(["#{dir} #{gcommit}"])
       end
     end
   end
@@ -228,7 +231,7 @@ RSpec.describe Git::Worktree do
       let(:gcommit) { 'abc123' }
 
       it 'returns "dir gcommit" as the full descriptor' do
-        expect(result).to eq("#{dir} abc123")
+        expect(result).to eq("#{dir} #{gcommit}")
       end
     end
   end

--- a/spec/unit/git/worktrees_spec.rb
+++ b/spec/unit/git/worktrees_spec.rb
@@ -173,21 +173,20 @@ RSpec.describe Git::Worktrees do
   # ---------------------------------------------------------------------------
 
   describe '#prune' do
-    context 'when base is a Git::Repository (new form)' do
-      it 'calls worktree_prune on base directly' do
-        expect(repo_base).to receive(:worktree_prune).and_return('')
-        described_instance.prune
-      end
+    subject(:result) { described_instance.prune }
 
-      it 'returns the result from worktree_prune' do
-        allow(repo_base).to receive(:worktree_prune).and_return('pruned output')
-        expect(described_instance.prune).to eq('pruned output')
-      end
+    it 'calls worktree_prune on base directly' do
+      expect(repo_base).to receive(:worktree_prune).and_return('')
+      described_instance.prune
+    end
+
+    it 'returns the result from worktree_prune' do
+      allow(repo_base).to receive(:worktree_prune).and_return('pruned output')
+      expect(result).to eq('pruned output')
     end
 
     context 'when base is a Git::Base (legacy form)' do
-      subject(:collection) { described_class.new(base) }
-
+      let(:described_instance) { described_class.new(base) }
       let(:facade_repo) { instance_double(Git::Repository) }
       let(:base)        { instance_double(Git::Base) }
 
@@ -200,7 +199,7 @@ RSpec.describe Git::Worktrees do
 
       it 'resolves facade_repository and calls worktree_prune on it' do
         expect(facade_repo).to receive(:worktree_prune).and_return('')
-        collection.prune
+        result
       end
     end
   end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Iteration 9, PR 5 of 7 — Base delegation step.

Update the two `Git::Base` worktree methods to delegate through `facade_repository` instead of constructing domain objects directly, completing the architectural migration for worktree support.

## Changes

### Core refactoring (`lib/git/base.rb`)

- `Git::Base#worktree(dir, commitish = nil)` now calls `facade_repository.worktree(dir, commitish)` (was `Git::Worktree.new(self, dir, commitish)`)
- `Git::Base#worktrees` now calls `facade_repository.worktrees` (was `Git::Worktrees.new(self)`)
- Adds full YARD documentation (`@param`, `@return`, `@raise`, `@example`) to both methods

### Tests (`spec/unit/git/base_spec.rb`)

- Adds `describe '#worktree'` block covering both the default-nil and explicit-commitish delegation paths
- Adds `describe '#worktrees'` block covering the delegation path
- Refines worktree/worktrees unit and integration specs for convention compliance: named `subject`, extracted `let` variables, consistent `context` naming

### YARD documentation (`lib/git/commands/worktree/`, `lib/git/repository/worktree_operations.rb`)

- Audited all 8 `Git::Commands::Worktree::*` command files against git-worktree 2.54.0
- Updated `@note` audit version from 2.53.0 → 2.54.0 in all 8 command files
- Fixed `@option` SUMMARY_LIMIT violations (`add.rb`, `repair.rb`)
- Fixed uppercase-start `@option` description in `list.rb`
- Added `@raise [Git::VersionError]` to `repair.rb`

### Architecture tracker (`redesign/3_architecture_implementation.md`)

- Marks `Git::Worktrees` as ✅ Complete
- Adds `Git::Repository::WorktreeOperations` to the Facade Modules Completed table
- Updates facade module counts and advances the Next Task section

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
