### PR TITLE
test(worktrees): add integration spec for Git::Worktrees (iter 9 PR6)

### DIFF
--- a/lib/git/commands/worktree/add.rb
+++ b/lib/git/commands/worktree/add.rb
@@ -19,7 +19,8 @@ module Git
       # @example Add a detached-HEAD worktree locked at creation
       #   Git::Commands::Worktree::Add.new(execution_context).call('/tmp/exp', detach: true, lock: true)
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
+      # @note `arguments` block audited against
+      #   https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #

--- a/lib/git/commands/worktree/list.rb
+++ b/lib/git/commands/worktree/list.rb
@@ -10,7 +10,8 @@ module Git
       # @example List all worktrees in porcelain format
       #   Git::Commands::Worktree::List.new(execution_context).call(porcelain: true)
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
+      # @note `arguments` block audited against
+      #   https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #

--- a/lib/git/commands/worktree/lock.rb
+++ b/lib/git/commands/worktree/lock.rb
@@ -13,7 +13,8 @@ module Git
       # @example Lock with a reason message
       #   Git::Commands::Worktree::Lock.new(execution_context).call('/tmp/feature', reason: 'on NFS share')
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
+      # @note `arguments` block audited against
+      #   https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #

--- a/lib/git/commands/worktree/management_base.rb
+++ b/lib/git/commands/worktree/management_base.rb
@@ -40,6 +40,8 @@ module Git
         # @return [Hash] the environment variable overrides, always
         #   `{ 'GIT_INDEX_FILE' => nil }`
         #
+        # @api private
+        #
         def env
           { 'GIT_INDEX_FILE' => nil }
         end

--- a/lib/git/commands/worktree/move.rb
+++ b/lib/git/commands/worktree/move.rb
@@ -13,7 +13,8 @@ module Git
       # @example Force-move a locked worktree
       #   Git::Commands::Worktree::Move.new(execution_context).call('/tmp/feat', '/tmp/feat2', force: true)
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
+      # @note `arguments` block audited against
+      #   https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #

--- a/lib/git/commands/worktree/prune.rb
+++ b/lib/git/commands/worktree/prune.rb
@@ -16,7 +16,8 @@ module Git
       # @example Prune entries older than 2 weeks
       #   Git::Commands::Worktree::Prune.new(execution_context).call(expire: '2.weeks.ago')
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
+      # @note `arguments` block audited against
+      #   https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #

--- a/lib/git/commands/worktree/remove.rb
+++ b/lib/git/commands/worktree/remove.rb
@@ -13,7 +13,8 @@ module Git
       # @example Force-remove an unclean worktree
       #   Git::Commands::Worktree::Remove.new(execution_context).call('/tmp/feature', force: true)
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
+      # @note `arguments` block audited against
+      #   https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #

--- a/lib/git/commands/worktree/repair.rb
+++ b/lib/git/commands/worktree/repair.rb
@@ -16,7 +16,8 @@ module Git
       # @example Repair specific moved worktrees
       #   Git::Commands::Worktree::Repair.new(execution_context).call('/tmp/moved1', '/tmp/moved2')
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
+      # @note `arguments` block audited against
+      #   https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #

--- a/lib/git/commands/worktree/unlock.rb
+++ b/lib/git/commands/worktree/unlock.rb
@@ -10,7 +10,8 @@ module Git
       # @example Unlock a worktree
       #   Git::Commands::Worktree::Unlock.new(execution_context).call('/tmp/feature')
       #
-      # @note `arguments` block audited against https://git-scm.com/docs/git-worktree/2.54.0
+      # @note `arguments` block audited against
+      #   https://git-scm.com/docs/git-worktree/2.54.0
       #
       # @see Git::Commands::Worktree Git::Commands::Worktree for the full sub-command list
       #

--- a/spec/integration/git/worktrees_spec.rb
+++ b/spec/integration/git/worktrees_spec.rb
@@ -1,0 +1,148 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'securerandom'
+
+RSpec.describe Git::Worktrees, :integration do
+  include_context 'in an empty repository'
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  # ---------------------------------------------------------------------------
+  # Git::Base constructor path: Git::Base#worktrees passes self (a Git::Base)
+  # ---------------------------------------------------------------------------
+
+  context 'when initialized via Git::Base (Git::Base passed to constructor)' do
+    let(:worktrees) { repo.worktrees }
+
+    describe '#size' do
+      it 'returns 1 for a repository with only the main worktree' do
+        expect(worktrees.size).to eq(1)
+      end
+    end
+
+    describe '#each' do
+      it 'yields Git::Worktree objects' do
+        expect(worktrees.to_a).to all(be_a(Git::Worktree))
+      end
+
+      it 'includes the main worktree directory' do
+        expect(worktrees.map(&:dir)).to include(File.realpath(repo_dir))
+      end
+    end
+
+    describe '#[]' do
+      it 'finds the main worktree by its filesystem path' do
+        result = worktrees[File.realpath(repo_dir)]
+        expect(result).to be_a(Git::Worktree)
+        expect(result.dir).to eq(File.realpath(repo_dir))
+      end
+
+      it 'returns nil for a path that does not correspond to any worktree' do
+        expect(worktrees['/no/such/worktree/path']).to be_nil
+      end
+    end
+
+    describe '#to_s' do
+      it 'includes the main worktree path in the listing' do
+        expect(worktrees.to_s).to include(File.realpath(repo_dir))
+      end
+    end
+
+    context 'with a linked worktree' do
+      let(:linked_path) do
+        File.join(File.dirname(File.realpath(repo_dir)), "wt-#{SecureRandom.hex(4)}")
+      end
+
+      before do
+        repo.worktree(linked_path).add
+      end
+
+      after do
+        repo.worktree(linked_path).remove
+      ensure
+        FileUtils.rm_rf(linked_path)
+        repo.worktrees.prune
+      end
+
+      describe '#size' do
+        it 'returns 2 when a linked worktree has been added' do
+          expect(repo.worktrees.size).to eq(2)
+        end
+      end
+
+      describe '#each' do
+        it 'yields both the main and linked worktrees' do
+          dirs = repo.worktrees.map(&:dir)
+          expect(dirs).to include(File.realpath(repo_dir), linked_path)
+        end
+      end
+
+      describe '#[]' do
+        it 'finds the linked worktree by its filesystem path' do
+          result = repo.worktrees[linked_path]
+          expect(result).to be_a(Git::Worktree)
+          expect(result.dir).to eq(linked_path)
+        end
+      end
+    end
+
+    describe '#prune' do
+      let(:linked_path) do
+        File.join(File.dirname(File.realpath(repo_dir)), "wt-#{SecureRandom.hex(4)}")
+      end
+
+      before do
+        repo.worktree(linked_path).add
+      end
+
+      after do
+        FileUtils.rm_rf(linked_path)
+      end
+
+      it 'removes administrative files for worktrees whose directories no longer exist' do
+        expect(repo.worktrees.size).to eq(2)
+
+        # Simulate a stale worktree by deleting the directory without running
+        # git worktree remove
+        FileUtils.rm_rf(linked_path)
+
+        repo.worktrees.prune
+
+        # A freshly constructed collection must now contain only the main worktree
+        expect(repo.worktrees.size).to eq(1)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Git::Repository constructor path: Git::Repository#worktrees passes self
+  # (a Git::Repository) to Git::Worktrees.new
+  # ---------------------------------------------------------------------------
+
+  context 'when initialized via Git::Repository (Git::Repository passed to constructor)' do
+    let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
+    let(:repository) { Git::Repository.new(execution_context: execution_context) }
+    let(:worktrees) { repository.worktrees }
+
+    describe '#size' do
+      it 'returns 1 for a repository with only the main worktree' do
+        expect(worktrees.size).to eq(1)
+      end
+    end
+
+    describe '#each' do
+      it 'yields Git::Worktree objects' do
+        expect(worktrees.to_a).to all(be_a(Git::Worktree))
+      end
+
+      it 'includes the main worktree directory' do
+        expect(worktrees.map(&:dir)).to include(File.realpath(repo_dir))
+      end
+    end
+  end
+end

--- a/spec/unit/git/worktrees_spec.rb
+++ b/spec/unit/git/worktrees_spec.rb
@@ -175,13 +175,16 @@ RSpec.describe Git::Worktrees do
   describe '#prune' do
     subject(:result) { described_instance.prune }
 
+    before do
+      allow(repo_base).to receive(:worktree_prune).and_return('pruned output')
+    end
+
     it 'calls worktree_prune on base directly' do
-      expect(repo_base).to receive(:worktree_prune).and_return('')
+      expect(repo_base).to receive(:worktree_prune).and_return('pruned output')
       described_instance.prune
     end
 
     it 'returns the result from worktree_prune' do
-      allow(repo_base).to receive(:worktree_prune).and_return('pruned output')
       expect(result).to eq('pruned output')
     end
 


### PR DESCRIPTION
## Description

Adds the missing `spec/integration/git/worktrees_spec.rb` integration spec that was identified as incomplete in the iteration 9 plan (`feat/iter9-worktree-integration`). Also fixes minor YARD violations found during review.

### Commit 1 — test changes (`spec/`)

**`spec/integration/git/worktrees_spec.rb`** (new) — end-to-end integration tests for `Git::Worktrees` covering:

- **`Git::Base` constructor path** (`repo.worktrees` — the typical end-user path):
  - `#size` — 1 for main worktree only; 2 with a linked worktree present
  - `#each` — yields `Git::Worktree` objects; includes the main worktree directory
  - `#[]` — finds worktrees by filesystem path; returns `nil` for unknown paths
  - `#to_s` — includes the main worktree path
  - **Prune cycle** — adds a linked worktree, deletes its directory without `git worktree remove` (simulating a stale entry), calls `#prune`, then verifies the collection shrinks back to 1
- **`Git::Repository` constructor path** (`repository.worktrees` — the new facade path): `#size` and `#each`

**`spec/unit/git/worktrees_spec.rb`** (modified) — move `allow` stub from inside an `it` block into a `before` block (RSpec convention: stubs belong in setup, not assertions). Also fix `Style/RescueModifier` in the new integration spec.

### Commit 2 — YARD doc fixes (`lib/`)

**9 worktree command files** — split `@note` audit URLs onto continuation lines to comply with the 90-character line limit (lines were 92 chars). Add missing `@api private` tag to the documented private `env` method in `ManagementBase`.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed.
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
