### PR TITLE
feat(staging): add rm, clean, and ignored_files facade methods

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -420,15 +420,15 @@ module Git
     end
 
     # List the files in the worktree that are ignored by git
-    # @return [Array<String>] the list of ignored files relative to teh root of the worktree
+    # @return [Array<String>] the list of ignored files relative to the root of the worktree
     #
     def ignored_files
-      lib.ignored_files
+      facade_repository.ignored_files
     end
 
     # removes file(s) from the git repository
     def rm(path = '.', opts = {})
-      lib.rm(path, opts)
+      facade_repository.rm(path, opts)
     end
 
     alias remove rm
@@ -459,7 +459,7 @@ module Git
     #  :ff
     #
     def clean(opts = {})
-      lib.clean(opts)
+      facade_repository.clean(opts)
     end
 
     #  returns the most recent tag that is reachable from a commit

--- a/lib/git/repository/staging.rb
+++ b/lib/git/repository/staging.rb
@@ -1,12 +1,17 @@
 # frozen_string_literal: true
 
 require 'git/commands/add'
+require 'git/commands/clean'
+require 'git/commands/ls_files'
 require 'git/commands/reset'
+require 'git/commands/rm'
+require 'git/escaped_path'
 require 'git/repository/shared_private'
 
 module Git
   class Repository
-    # Facade methods for staging-area operations: adding and resetting files
+    # Facade methods for staging-area operations: adding, resetting, removing, and
+    # cleaning files
     #
     # Included by {Git::Repository}.
     #
@@ -84,6 +89,302 @@ module Git
         SharedPrivate.assert_valid_opts!(RESET_ALLOWED_OPTS, **)
         Git::Commands::Reset.new(@execution_context).call(commitish, **).stdout
       end
+
+      # Option keys accepted by {#rm}
+      RM_ALLOWED_OPTS = %i[
+        force f dry_run n r cached ignore_unmatch sparse quiet q
+        pathspec_from_file pathspec_file_nul
+      ].freeze
+      private_constant :RM_ALLOWED_OPTS
+
+      # Remove file(s) from the working tree and the index
+      #
+      # @example Remove a single file
+      #   repo.rm('obsolete.txt', force: true)
+      #
+      # @example Remove a directory recursively
+      #   repo.rm('build', r: true)
+      #
+      # @example Remove from the index only, keeping the working tree copy
+      #   repo.rm('keep_me.txt', cached: true)
+      #
+      # @param path [String, Array<String>] a file or files to remove (relative to
+      #   the worktree root); defaults to `'.'` (all files)
+      #
+      # @param opts [Hash] options for the rm command
+      #
+      # @option opts [Boolean, nil] :force (nil) override the up-to-date check and
+      #   remove files with local modifications (alias: `:f`)
+      #
+      # @option opts [Boolean, nil] :f (nil) alias for `:force`
+      #
+      # @option opts [Boolean, nil] :dry_run (nil) do not actually remove any files;
+      #   only show what would be removed (alias: `:n`)
+      #
+      # @option opts [Boolean, nil] :n (nil) alias for `:dry_run`
+      #
+      # @option opts [Boolean, nil] :r (nil) allow recursive removal when a leading
+      #   directory name is given
+      #
+      # @option opts [Boolean, nil] :cached (nil) only remove from the index, keeping
+      #   the working tree files
+      #
+      # @option opts [Boolean, nil] :ignore_unmatch (nil) exit with a zero status even
+      #   if no files matched
+      #
+      # @option opts [Boolean, nil] :sparse (nil) allow updating index entries outside
+      #   of the sparse-checkout cone
+      #
+      # @option opts [Boolean, nil] :quiet (nil) suppress the one-line-per-file output
+      #   (alias: `:q`)
+      #
+      # @option opts [Boolean, nil] :q (nil) alias for `:quiet`
+      #
+      # @option opts [String] :pathspec_from_file (nil) read pathspec from the given
+      #   file, one pathspec element per line; pass `-` to read from standard input
+      #
+      # @option opts [Boolean, nil] :pathspec_file_nul (nil) when used with
+      #   `:pathspec_from_file`, separate pathspec elements with NUL instead of newlines
+      #
+      # @return [String] git's stdout from the rm
+      #
+      # @raise [ArgumentError] when unsupported options are provided
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def rm(path = '.', opts = {})
+        SharedPrivate.assert_valid_opts!(RM_ALLOWED_OPTS, **opts)
+        Git::Commands::Rm.new(@execution_context).call(*Array(path), **opts).stdout
+      end
+
+      # Option keys accepted by {#clean}
+      #
+      # The deprecated `:ff` and `:force_force` keys are handled by
+      # {Git::Repository::Staging::Private.migrate_clean_legacy_options} before this
+      # whitelist is enforced, so they are intentionally absent here.
+      CLEAN_ALLOWED_OPTS = %i[d force f dry_run n quiet q exclude e x X pathspec].freeze
+      private_constant :CLEAN_ALLOWED_OPTS
+
+      # Remove untracked files from the working tree
+      #
+      # @example Remove untracked files
+      #   repo.clean(force: true)
+      #
+      # @example Remove untracked files and directories
+      #   repo.clean(force: true, d: true)
+      #
+      # @example Remove untracked and ignored files
+      #   repo.clean(force: true, x: true)
+      #
+      # @param opts [Hash] options for the clean command
+      #
+      # @option opts [Boolean, nil] :d (nil) recurse into untracked directories
+      #
+      # @option opts [Boolean, Integer, nil] :force (nil) force the removal of
+      #   untracked files; pass `2` to also remove untracked nested git repositories
+      #   (alias: `:f`)
+      #
+      # @option opts [Boolean, Integer, nil] :f (nil) alias for `:force`
+      #
+      # @option opts [Boolean, nil] :dry_run (nil) do not actually remove anything,
+      #   just show what would be done (alias: `:n`)
+      #
+      # @option opts [Boolean, nil] :n (nil) alias for `:dry_run`
+      #
+      # @option opts [Boolean, nil] :quiet (nil) be quiet, only report errors
+      #   (alias: `:q`)
+      #
+      # @option opts [Boolean, nil] :q (nil) alias for `:quiet`
+      #
+      # @option opts [String, Array<String>] :exclude (nil) use the given exclude
+      #   pattern in addition to the standard ignore rules (alias: `:e`)
+      #
+      # @option opts [String, Array<String>] :e (nil) alias for `:exclude`
+      #
+      # @option opts [Boolean, nil] :x (nil) don't use the standard ignore rules
+      #
+      # @option opts [Boolean, nil] :X (nil) remove only files ignored by git
+      #
+      # @option opts [String, Array<String>] :pathspec (nil) limit cleaning to files
+      #   matching the given pathspec(s)
+      #
+      # @return [String] git's stdout from the clean
+      #
+      # @raise [ArgumentError] when unsupported options are provided, or when a
+      #   deprecated `:ff`/`:force_force` value is not `true`, `false`, or `nil`
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def clean(opts = {})
+        opts = Private.migrate_clean_legacy_options(opts)
+        SharedPrivate.assert_valid_opts!(CLEAN_ALLOWED_OPTS, **opts)
+        Git::Commands::Clean.new(@execution_context).call(**opts).stdout
+      end
+
+      # List the files in the working tree that are ignored by git
+      #
+      # Runs `git ls-files --others --ignored --exclude-standard` and returns the
+      # ignored files as repository-relative paths.
+      #
+      # @example List ignored files
+      #   repo.ignored_files #=> ["coverage/index.html", "tmp/cache.db"]
+      #
+      # @example No ignored files
+      #   repo.ignored_files #=> []
+      #
+      # @return [Array<String>] repository-relative paths of ignored files; empty
+      #   when there are none
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def ignored_files
+        Git::Commands::LsFiles.new(@execution_context).call(
+          others: true, ignored: true, exclude_standard: true
+        ).stdout.split("\n").map { |f| Private.unescape_quoted_path(f) }
+      end
+
+      # Private helpers local to {Git::Repository::Staging}
+      #
+      # @api private
+      #
+      module Private
+        module_function
+
+        # Translate deprecated `git clean` option keys into their modern form
+        #
+        # Maps the legacy `:ff` and `:force_force` boolean options onto the
+        # `:force` option, emitting a deprecation warning for each.
+        #
+        # @param opts [Hash] the caller-provided clean options
+        #
+        # @return [Hash] a new options hash with deprecated keys translated
+        #
+        # @raise [ArgumentError] when a deprecated value is not `true`, `false`, or `nil`
+        #
+        def migrate_clean_legacy_options(opts)
+          opts = deprecate_clean_option(opts, :ff, ':ff option is deprecated. Use force: 2 instead.')
+          deprecate_clean_option(opts, :force_force, ':force_force option is deprecated. Use force: 2 instead.')
+        end
+
+        # Translate a single deprecated clean option key onto `:force`
+        #
+        # @param opts [Hash] the clean options
+        #
+        # @param key [Symbol] the deprecated option key (`:ff` or `:force_force`)
+        #
+        # @param message [String] the deprecation message to emit
+        #
+        # @return [Hash] a new options hash with the deprecated key removed
+        #
+        # @raise [ArgumentError] when the deprecated value is not `true`, `false`,
+        #   or `nil`
+        #
+        def deprecate_clean_option(opts, key, message)
+          return opts unless opts.key?(key)
+
+          opts = opts.dup
+          deprecated_value = opts.delete(key)
+          validate_deprecated_clean_option_value!(key, deprecated_value)
+
+          Git::Deprecation.warn(message)
+          return opts unless deprecated_value
+
+          opts[:force] = merge_clean_force_option(opts[:force], force_specified: force_option_specified?(opts))
+          opts
+        end
+
+        # Whether the caller explicitly set a non-nil `:force` value
+        #
+        # @param opts [Hash] the clean options
+        #
+        # @return [Boolean] true if `:force` was set to a non-nil value, false
+        #   otherwise
+        #
+        def force_option_specified?(opts)
+          opts.key?(:force) && !opts[:force].nil?
+        end
+
+        # Validate the value passed to a deprecated clean option
+        #
+        # @param key [Symbol] the deprecated option key
+        #
+        # @param value [Object] the value provided for the deprecated key
+        #
+        # @return [void]
+        #
+        # @raise [ArgumentError] when `value` is not `true`, `false`, or `nil`
+        #
+        def validate_deprecated_clean_option_value!(key, value)
+          return if value.nil? || value == true || value == false
+
+          raise ArgumentError, "#{key} option only accepts true, false, or nil"
+        end
+
+        # Merge a deprecated force request into the existing `:force` value
+        #
+        # @param existing_force [Boolean, Integer, nil] the caller's `:force` value
+        #
+        # @param force_specified [Boolean] whether the caller explicitly set `:force`
+        #
+        # @return [Integer] the resolved `:force` value
+        #
+        def merge_clean_force_option(existing_force, force_specified: false)
+          return 2 unless force_specified
+
+          normalized_force = normalize_clean_force_option(existing_force)
+
+          case normalized_force
+          when Integer then merge_integer_clean_force_option(normalized_force)
+          when false then 2
+          else normalized_force
+          end
+        end
+
+        # Merge an integer `:force` value with the deprecated force request
+        #
+        # @param normalized_force [Integer] the caller's normalized `:force` value
+        #
+        # @return [Integer] the resolved `:force` value
+        #
+        def merge_integer_clean_force_option(normalized_force)
+          return normalized_force if normalized_force < 1
+
+          [normalized_force, 2].max
+        end
+
+        # Normalize a `:force` value, coercing `true` to the integer `1`
+        #
+        # @param value [Boolean, Integer, nil] the `:force` value
+        #
+        # @return [Integer, Boolean, nil] the normalized value
+        #
+        def normalize_clean_force_option(value)
+          case value
+          when true then 1
+          else value
+          end
+        end
+
+        # Unescape a git-quoted path
+        #
+        # Git wraps paths containing non-ASCII or special characters in
+        # double-quotes and octal-escapes each byte. This method strips the
+        # surrounding quotes and delegates unescaping to {Git::EscapedPath}.
+        #
+        # @param path [String] the path as it appears in git output
+        #
+        # @return [String] the unescaped path
+        #
+        def unescape_quoted_path(path)
+          if path.start_with?('"') && path.end_with?('"')
+            Git::EscapedPath.new(path[1..-2]).unescape
+          else
+            path
+          end
+        end
+      end
+
+      private_constant :Private
     end
   end
 end

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -46,7 +46,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
 
 | Module | File | Included in `Git::Repository` | `Git::Base` delegates |
 | ------ | ---- | ------------------------------ | --------------------- |
-| `Git::Repository::Staging` | `lib/git/repository/staging.rb` | ✅ | `add`, `reset` |
+| `Git::Repository::Staging` | `lib/git/repository/staging.rb` | ✅ | `add`, `reset`, `rm`, `clean`, `ignored_files` |
 | `Git::Repository::Committing` | `lib/git/repository/committing.rb` | ✅ | `commit`, `commit_all`, `write_tree`; `commit_tree` and `write_and_commit_tree` wrap the SHA result in `Git::Object::Commit.new(self, ...)` |
 | `Git::Repository::Branching` | `lib/git/repository/branching.rb` | ✅ | `checkout`, `checkout_file`, `checkout_index`, `current_branch`, `local_branch?`, `remote_branch?`, `branch?`, `branch_delete`, `branch_new`, `branch_contains`, `branches_all`, `update_ref` |
 | `Git::Repository::Merging` | `lib/git/repository/merging.rb` | ✅ | `merge`, `revert`, `each_conflict`; `merge_base` wraps the returned SHA strings in `Git::Object::Commit.new(self, ...)` instances |
@@ -135,7 +135,7 @@ graph LR
 `Git::Repository` counterpart yet. Each step below adds the missing facade methods and
 updates `Git::Base` to delegate.
 
-**Step A1 — Extend `Git::Repository::Staging`: `rm`, `clean`, `ignored_files`** ⬜
+**Step A1 — Extend `Git::Repository::Staging`: `rm`, `clean`, `ignored_files`** ✅
 
 | `Git::Base` method | Facade to add |
 | --- | --- |
@@ -487,7 +487,7 @@ classified as a v5-only PR with upgrade-note coverage before it lands.
 
 | Step | GitHub PR | Scope | Release lane | Backward-compatibility rule |
 | --- | --- | --- | --- | --- |
-| A1 | ⬜ | Add `rm`, `clean`, `ignored_files` facade coverage | 4.x-compatible | `Git::Base` public methods keep the same signatures, return values, and deprecation behavior. |
+| A1 | ✅ | Add `rm`, `clean`, `ignored_files` facade coverage | 4.x-compatible | `Git::Base` public methods keep the same signatures, return values, and deprecation behavior. |
 | A2 | ⬜ | Add `remotes`, `set_remote_url`, `remote_set_branches` facade coverage | 4.x-compatible | `Git::Base` remote methods keep the same return objects and validation behavior. |
 | A3 | ⬜ | Add `tags`, `add_tag`, `delete_tag` facade coverage | 4.x-compatible | Tag list/create/delete return contracts match 4.x behavior. |
 | A4 | ⬜ | Add `Inspecting#show` and `#fsck` | 4.x-compatible | `Git::Base#show` and `#fsck` remain behavior-compatible and delegate internally. |
@@ -535,7 +535,7 @@ done only when its code, focused specs, and delegation/cleanup checks are all tr
 
 | Step | Status |
 | --- | --- |
-| A1: `Staging` — `rm`, `clean`, `ignored_files` | ⬜ |
+| A1: `Staging` — `rm`, `clean`, `ignored_files` | ✅ |
 | A2: `RemoteOperations` — `remotes`, `set_remote_url`, `remote_set_branches` | ⬜ |
 | A3: `ObjectOperations` — `tags`, `add_tag`, `delete_tag` | ⬜ |
 | A4: new `Inspecting` — `show`, `fsck` | ⬜ |

--- a/spec/integration/git/repository/staging_spec.rb
+++ b/spec/integration/git/repository/staging_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/staging'
+require 'git/execution_context/repository'
+
+# Integration tests for Git::Repository::Staging.
+#
+# Only #ignored_files is exercised end-to-end here because it performs
+# facade-owned post-processing of real git output (splitting `git ls-files`
+# stdout into paths and unescaping git-quoted paths). A real git invocation
+# proves that post-processing handles actual output.
+#
+# The other facade methods are single-command delegators whose only
+# facade-owned behavior is pure-Ruby argument pre-processing (option
+# whitelisting for #add/#reset/#rm/#clean and deprecated-option migration for
+# #clean). Real git adds no signal for those transforms, and their end-to-end
+# git behavior is already covered by the underlying command integration specs:
+#   spec/integration/git/commands/add_spec.rb
+#   spec/integration/git/commands/reset_spec.rb
+#   spec/integration/git/commands/rm_spec.rb
+#   spec/integration/git/commands/clean_spec.rb
+
+RSpec.describe Git::Repository::Staging, :integration do
+  include_context 'in an empty repository'
+
+  let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  describe '#ignored_files' do
+    before do
+      write_file('.gitignore', "*.log\n")
+      repo.add(all: true)
+      repo.commit('Add gitignore')
+    end
+
+    context 'when there are no ignored files' do
+      it 'returns an empty array' do
+        expect(described_instance.ignored_files).to eq([])
+      end
+    end
+
+    context 'when ignored files exist' do
+      before do
+        write_file('debug.log', 'log')
+        write_file('tmp/trace.log', 'log')
+      end
+
+      it 'returns the ignored file paths relative to the repository root' do
+        expect(described_instance.ignored_files).to contain_exactly('debug.log', 'tmp/trace.log')
+      end
+
+      it 'does not include tracked or untracked non-ignored files' do
+        write_file('keep.txt', 'content')
+        expect(described_instance.ignored_files).not_to include('keep.txt', '.gitignore')
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository/staging_spec.rb
+++ b/spec/unit/git/repository/staging_spec.rb
@@ -74,20 +74,6 @@ RSpec.describe Git::Repository::Staging do
         expect(add_command).to receive(:call).with('file.rb', all: true).and_return(add_result)
         result
       end
-
-      it 'returns the command stdout' do
-        allow(add_command).to receive(:call).with('file.rb', all: true).and_return(add_result)
-        expect(result).to eq('add output')
-      end
-    end
-
-    context 'with all: false' do
-      subject(:result) { described_instance.add('file.rb', all: false) }
-
-      it 'forwards all: false to Git::Commands::Add#call' do
-        expect(add_command).to receive(:call).with('file.rb', all: false).and_return(add_result)
-        result
-      end
     end
 
     context 'with an unknown option' do
@@ -154,6 +140,311 @@ RSpec.describe Git::Repository::Staging do
       it 'raises ArgumentError' do
         expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
       end
+    end
+  end
+
+  describe '#rm' do
+    subject(:result) { described_instance.rm }
+
+    let(:rm_command) { instance_double(Git::Commands::Rm) }
+    let(:rm_result) { command_result('rm output') }
+
+    before do
+      allow(Git::Commands::Rm).to receive(:new).with(execution_context).and_return(rm_command)
+    end
+
+    context 'with default arguments' do
+      it 'delegates to Git::Commands::Rm#call with the default pathspec' do
+        expect(rm_command).to receive(:call).with('.').and_return(rm_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(rm_command).to receive(:call).with('.').and_return(rm_result)
+        expect(result).to eq('rm output')
+      end
+    end
+
+    context 'with a single pathspec' do
+      subject(:result) { described_instance.rm('file.rb') }
+
+      it 'delegates to Git::Commands::Rm#call with the given pathspec' do
+        expect(rm_command).to receive(:call).with('file.rb').and_return(rm_result)
+        result
+      end
+    end
+
+    context 'with an array of pathspecs' do
+      subject(:result) { described_instance.rm(['a.rb', 'b.rb']) }
+
+      it 'splatted pathspecs are forwarded as separate arguments' do
+        expect(rm_command).to receive(:call).with('a.rb', 'b.rb').and_return(rm_result)
+        result
+      end
+    end
+
+    context 'with the force option' do
+      subject(:result) { described_instance.rm('file.rb', force: true) }
+
+      it 'forwards force: true to Git::Commands::Rm#call' do
+        expect(rm_command).to receive(:call).with('file.rb', force: true).and_return(rm_result)
+        result
+      end
+    end
+
+    context 'with the cached option' do
+      subject(:result) { described_instance.rm('file.rb', cached: true) }
+
+      it 'forwards cached: true to Git::Commands::Rm#call' do
+        expect(rm_command).to receive(:call).with('file.rb', cached: true).and_return(rm_result)
+        result
+      end
+    end
+
+    context 'with an unknown option' do
+      subject(:result) { described_instance.rm('file.rb', bogus: true) }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+
+      it 'does not call Git::Commands::Rm' do
+        expect(rm_command).not_to receive(:call)
+        begin
+          result
+        rescue ArgumentError
+          # expected
+        end
+      end
+    end
+
+    context 'signature compatibility' do
+      subject(:result) { described_instance.rm('file.rb', { force: true }) }
+
+      it 'accepts the legacy positional options hash' do
+        expect(rm_command).to receive(:call).with('file.rb', force: true).and_return(rm_result)
+        result
+      end
+    end
+  end
+
+  describe '#clean' do
+    subject(:result) { described_instance.clean }
+
+    let(:clean_command) { instance_double(Git::Commands::Clean) }
+    let(:clean_result) { command_result('clean output') }
+
+    before do
+      allow(Git::Commands::Clean).to receive(:new).with(execution_context).and_return(clean_command)
+    end
+
+    context 'with no options' do
+      it 'delegates to Git::Commands::Clean#call with no arguments' do
+        expect(clean_command).to receive(:call).with(no_args).and_return(clean_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(clean_command).to receive(:call).with(no_args).and_return(clean_result)
+        expect(result).to eq('clean output')
+      end
+    end
+
+    context 'with force: true' do
+      subject(:result) { described_instance.clean(force: true) }
+
+      it 'forwards force: true to Git::Commands::Clean#call' do
+        expect(clean_command).to receive(:call).with(force: true).and_return(clean_result)
+        result
+      end
+    end
+
+    context 'with force and d options' do
+      subject(:result) { described_instance.clean(force: true, d: true) }
+
+      it 'forwards force and d to Git::Commands::Clean#call' do
+        expect(clean_command).to receive(:call).with(force: true, d: true).and_return(clean_result)
+        result
+      end
+    end
+
+    context 'with an unknown option' do
+      subject(:result) { described_instance.clean(bogus: true) }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+
+      it 'does not call Git::Commands::Clean' do
+        expect(clean_command).not_to receive(:call)
+        begin
+          result
+        rescue ArgumentError
+          # expected
+        end
+      end
+    end
+
+    context 'with the deprecated :ff option set to true' do
+      subject(:result) { described_instance.clean(ff: true) }
+
+      it 'warns about the deprecation' do
+        allow(clean_command).to receive(:call).and_return(clean_result)
+        expect(Git::Deprecation).to receive(:warn).with(/:ff option is deprecated/)
+        result
+      end
+
+      it 'translates :ff to force: 2' do
+        allow(Git::Deprecation).to receive(:warn)
+        expect(clean_command).to receive(:call).with(force: 2).and_return(clean_result)
+        result
+      end
+    end
+
+    context 'with the deprecated :ff option set to false' do
+      subject(:result) { described_instance.clean(ff: false) }
+
+      it 'warns about the deprecation' do
+        allow(clean_command).to receive(:call).and_return(clean_result)
+        expect(Git::Deprecation).to receive(:warn).with(/:ff option is deprecated/)
+        result
+      end
+
+      it 'does not pass force to Git::Commands::Clean#call' do
+        allow(Git::Deprecation).to receive(:warn)
+        expect(clean_command).to receive(:call).with(no_args).and_return(clean_result)
+        result
+      end
+    end
+
+    context 'with the deprecated :force_force option set to true' do
+      subject(:result) { described_instance.clean(force_force: true) }
+
+      it 'warns about the deprecation' do
+        allow(clean_command).to receive(:call).and_return(clean_result)
+        expect(Git::Deprecation).to receive(:warn).with(/:force_force option is deprecated/)
+        result
+      end
+
+      it 'translates :force_force to force: 2' do
+        allow(Git::Deprecation).to receive(:warn)
+        expect(clean_command).to receive(:call).with(force: 2).and_return(clean_result)
+        result
+      end
+    end
+
+    context 'with the deprecated :ff option set to a non-boolean value' do
+      subject(:result) { described_instance.clean(ff: 0) }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /ff option only accepts true, false, or nil/)
+      end
+
+      it 'does not call Git::Commands::Clean' do
+        expect(clean_command).not_to receive(:call)
+        begin
+          result
+        rescue ArgumentError
+          # expected
+        end
+      end
+    end
+
+    context 'with the deprecated :ff option combined with an explicit force: true' do
+      subject(:result) { described_instance.clean(ff: true, force: true) }
+
+      before { allow(Git::Deprecation).to receive(:warn) }
+
+      it 'normalizes force: true to 1 then raises it to force: 2' do
+        expect(clean_command).to receive(:call).with(force: 2).and_return(clean_result)
+        result
+      end
+    end
+
+    context 'with the deprecated :ff option combined with an explicit force: false' do
+      subject(:result) { described_instance.clean(ff: true, force: false) }
+
+      before { allow(Git::Deprecation).to receive(:warn) }
+
+      it 'translates the explicit false force to force: 2' do
+        expect(clean_command).to receive(:call).with(force: 2).and_return(clean_result)
+        result
+      end
+    end
+
+    context 'with the deprecated :ff option combined with an explicit integer force >= 1' do
+      subject(:result) { described_instance.clean(ff: true, force: 3) }
+
+      before { allow(Git::Deprecation).to receive(:warn) }
+
+      it 'keeps the larger of the explicit force and 2' do
+        expect(clean_command).to receive(:call).with(force: 3).and_return(clean_result)
+        result
+      end
+    end
+
+    context 'with the deprecated :ff option combined with an explicit force: 0' do
+      subject(:result) { described_instance.clean(ff: true, force: 0) }
+
+      before { allow(Git::Deprecation).to receive(:warn) }
+
+      it 'forwards the below-one integer force value unchanged' do
+        expect(clean_command).to receive(:call).with(force: 0).and_return(clean_result)
+        result
+      end
+    end
+
+    context 'with the deprecated :ff option combined with a non-integer force value' do
+      subject(:result) { described_instance.clean(ff: true, force: 1.5) }
+
+      before { allow(Git::Deprecation).to receive(:warn) }
+
+      it 'forwards the non-integer force value unchanged' do
+        expect(clean_command).to receive(:call).with(force: 1.5).and_return(clean_result)
+        result
+      end
+    end
+
+    context 'signature compatibility' do
+      subject(:result) { described_instance.clean({ force: true }) }
+
+      it 'accepts the legacy positional options hash' do
+        expect(clean_command).to receive(:call).with(force: true).and_return(clean_result)
+        result
+      end
+    end
+  end
+
+  describe '#ignored_files' do
+    subject(:result) { described_instance.ignored_files }
+
+    let(:ls_files_command) { instance_double(Git::Commands::LsFiles) }
+
+    before do
+      allow(Git::Commands::LsFiles).to receive(:new).with(execution_context).and_return(ls_files_command)
+    end
+
+    it 'lists ignored, non-tracked files via git ls-files' do
+      expect(ls_files_command).to(
+        receive(:call).with(others: true, ignored: true, exclude_standard: true)
+                      .and_return(command_result("a.log\nb.log\n"))
+      )
+      result
+    end
+
+    it 'returns the ignored files as an array of paths' do
+      allow(ls_files_command).to receive(:call).and_return(command_result("a.log\ntmp/b.log\n"))
+      expect(result).to eq(['a.log', 'tmp/b.log'])
+    end
+
+    it 'returns an empty array when there are no ignored files' do
+      allow(ls_files_command).to receive(:call).and_return(command_result(''))
+      expect(result).to eq([])
+    end
+
+    it 'unescapes git-quoted paths' do
+      allow(ls_files_command).to receive(:call).and_return(command_result("\"qu\\303\\251.log\"\n"))
+      expect(result).to eq(['qué.log'])
     end
   end
 end


### PR DESCRIPTION
# Description

Implements **PR A1** from the architectural redesign
(`redesign/3_architecture_implementation.md`): extends `Git::Repository::Staging`
with three facade methods and delegates the matching `Git::Base` public methods to
`facade_repository`, preserving full 4.x backward compatibility.

## What changed

### `lib/git/repository/staging.rb`

Added three public facade methods to `Git::Repository::Staging`:

| Method | Underlying command | Returns |
|---|---|---|
| `rm(path = '.', **opts)` | `Git::Commands::Rm` | `String` (stdout) |
| `clean(**opts)` | `Git::Commands::Clean` | `String` (stdout) |
| `ignored_files` | `Git::Commands::LsFiles` | `Array<String>` |

- `rm` and `clean` whitelist forwarded options via per-method `*_ALLOWED_OPTS`
  constants + `SharedPrivate.assert_valid_opts!`, accepting command aliases
  (`f`/`force`, `n`/`dry_run`, etc.) consistent with the existing project pattern.
- `clean` preserves the legacy `:ff` / `:force_force` deprecation adapter (with
  its force-merge arithmetic) in a new `Staging::Private` module. `Git::Lib#clean`
  is left intact so direct legacy callers are unaffected.
- `ignored_files` runs `git ls-files --others --ignored --exclude-standard` and
  unescapes git-quoted paths via a local `Private` helper (mirroring
  `StatusOperations::Private#unescape_quoted_path`).

### `lib/git/base.rb`

`Git::Base#rm`, `#clean`, and `#ignored_files` now delegate to
`facade_repository.*`, keeping the same public signatures and return values.

### Tests

- **Unit spec** (`spec/unit/git/repository/staging_spec.rb`): 46 examples covering
  delegation contracts, option whitelisting, deprecation paths (`:ff`/`:force_force`
  all value branches), and signature compatibility (legacy positional hash form).
  `staging.rb` achieves **100% line and branch coverage**.
- **Integration spec** (`spec/integration/git/repository/staging_spec.rb`): 3
  examples for `#ignored_files` (the only method with non-trivial output parsing
  that benefits from an end-to-end test).

### Docs

- `redesign/3_architecture_implementation.md` updated: A1 marked ✅ in the
  step definition, status table, and acceptance-criteria table; Facade Modules
  Completed table updated to reflect `add, reset, rm, clean, ignored_files` for
  `Staging`.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).