### PR TITLE
feat(remote): add remotes, set_remote_url, remote_set_branches to facade

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -592,7 +592,7 @@ module Git
 
     # returns an array of Git:Remote objects
     def remotes
-      lib.remotes.map { |r| Git::Remote.new(self, r) }
+      facade_repository.remotes
     end
 
     # sets the url for a remote
@@ -601,9 +601,7 @@ module Git
     #  @git.set_remote_url('scotts_git', 'git://repo.or.cz/rubygit.git')
     #
     def set_remote_url(name, url)
-      url = url.repo.to_s if url.is_a?(Git::Base)
-      lib.remote_set_url(name, url)
-      Git::Remote.new(self, name)
+      facade_repository.set_remote_url(name, url)
     end
 
     # Configures which branches are fetched for a remote
@@ -635,12 +633,7 @@ module Git
     # the underlying git command fails
     #
     def remote_set_branches(name, *branches, add: false)
-      branch_list = branches.flatten
-      raise ArgumentError, 'branches are required' if branch_list.empty?
-
-      lib.remote_set_branches(name, branch_list, add: add)
-
-      nil
+      facade_repository.remote_set_branches(name, *branches, add: add)
     end
 
     # removes a remote from this repository

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -441,6 +441,72 @@ module Git
         Git::Commands::Remote::Remove.new(@execution_context).call(name)
       end
 
+      # Sets the URL for an existing remote
+      #
+      # Replaces the fetch URL configured for the remote named `name`.
+      #
+      # @example Set the URL for a remote
+      #   repo.set_remote_url('origin', 'https://github.com/user/repo.git')
+      #
+      # @example Set the URL from a local repository reference
+      #   source = Git.open('/path/to/source')
+      #   repo.set_remote_url('origin', source)
+      #
+      # @param name [String] the name of the remote to update
+      #
+      # @param url [String, Git::Base] the new URL for the remote
+      #
+      #   A {Git::Base} instance is accepted for local references and converted
+      #   to `url.repo.to_s`.
+      #
+      # @return [Git::Remote] the updated remote
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero status
+      #
+      def set_remote_url(name, url)
+        url = url.repo.to_s if url.is_a?(Git::Base)
+        Git::Commands::Remote::SetUrl.new(@execution_context).call(name, url)
+
+        Git::Remote.new(self, name)
+      end
+
+      # Configures which branches are fetched for a remote
+      #
+      # Uses `git remote set-branches` to set or append fetch refspecs. When the
+      # `add:` option is `false`, the `--add` flag is not passed to the git
+      # command and the tracked branch list is replaced.
+      #
+      # @example Replace fetched branches with a single glob pattern
+      #   repo.remote_set_branches('origin', 'feature/*')
+      #
+      # @example Append a glob pattern to existing fetched branches
+      #   repo.remote_set_branches('origin', 'release/*', add: true)
+      #
+      # @example Configure multiple explicit branches
+      #   repo.remote_set_branches('origin', 'main', 'development', 'hotfix')
+      #
+      # @param name [String] the remote name (for example, `"origin"`)
+      #
+      # @param branches [Array<String>] branch names or globs (for example, `'*'`)
+      #
+      # @param add [Boolean] when `true`, append to existing refspecs instead of
+      #   replacing them
+      #
+      # @return [nil]
+      #
+      # @raise [ArgumentError] when no branches are provided
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero status
+      #
+      def remote_set_branches(name, *branches, add: false)
+        branch_list = branches.flatten
+        raise ArgumentError, 'branches are required' if branch_list.empty?
+
+        Git::Commands::Remote::SetBranches.new(@execution_context).call(name, *branch_list, add: add)
+
+        nil
+      end
+
       # Return the git configuration entries for a named remote
       #
       # Reads `git config --list` and returns all entries whose keys begin with
@@ -486,6 +552,22 @@ module Git
       #
       def remote(name = 'origin')
         Git::Remote.new(self, name)
+      end
+
+      # Returns all configured remotes as {Git::Remote} objects
+      #
+      # @example List all remotes
+      #   repo.remotes  #=> [#<Git::Remote 'origin'>, #<Git::Remote 'upstream'>]
+      #
+      # @return [Array<Git::Remote>] one {Git::Remote} for each configured remote
+      #
+      #   Returns an empty array when no remotes are configured.
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def remotes
+        result = Git::Commands::Remote::List.new(@execution_context).call
+        result.stdout.split("\n").map { |name| Git::Remote.new(self, name) }
       end
 
       # Helpers private to the `RemoteOperations` topic module

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -492,7 +492,7 @@ module Git
       # @param add [Boolean] when `true`, append to existing refspecs instead of
       #   replacing them
       #
-      # @return [nil]
+      # @return [void]
       #
       # @raise [ArgumentError] when no branches are provided
       #

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -50,7 +50,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | `Git::Repository::Committing` | `lib/git/repository/committing.rb` | ✅ | `commit`, `commit_all`, `write_tree`; `commit_tree` and `write_and_commit_tree` wrap the SHA result in `Git::Object::Commit.new(self, ...)` |
 | `Git::Repository::Branching` | `lib/git/repository/branching.rb` | ✅ | `checkout`, `checkout_file`, `checkout_index`, `current_branch`, `local_branch?`, `remote_branch?`, `branch?`, `branch_delete`, `branch_new`, `branch_contains`, `branches_all`, `update_ref` |
 | `Git::Repository::Merging` | `lib/git/repository/merging.rb` | ✅ | `merge`, `revert`, `each_conflict`; `merge_base` wraps the returned SHA strings in `Git::Object::Commit.new(self, ...)` instances |
-| `Git::Repository::RemoteOperations` | `lib/git/repository/remote_operations.rb` | ✅ | `fetch`, `pull`, `push`, `add_remote`, `remove_remote`, `config_remote` |
+| `Git::Repository::RemoteOperations` | `lib/git/repository/remote_operations.rb` | ✅ | `fetch`, `pull`, `push`, `add_remote`, `remove_remote`, `config_remote`, `remotes`, `set_remote_url`, `remote_set_branches` |
 | `Git::Repository::Stashing` | `lib/git/repository/stashing.rb` | ✅ | `stash_save`, `stash_apply`, `stash_clear`, `stashes_all` |
 | `Git::Repository::Diffing` | `lib/git/repository/diffing.rb` | ✅ | `diff_path_status`, `diff_name_status`, `diff_full` |
 | `Git::Repository::ObjectOperations` | `lib/git/repository/object_operations.rb` | ✅ | `rev_parse`, `tree_depth`, `ls_tree`, `grep`, `archive` |
@@ -145,7 +145,7 @@ updates `Git::Base` to delegate.
 
 Files touched: `lib/git/repository/staging.rb`, `spec/unit/git/repository/staging_spec.rb`, `lib/git/base.rb`
 
-**Step A2 — Extend `Git::Repository::RemoteOperations`: `remotes`, `set_remote_url`, `remote_set_branches`** ⬜
+**Step A2 — Extend `Git::Repository::RemoteOperations`: `remotes`, `set_remote_url`, `remote_set_branches`** ✅
 
 | `Git::Base` method | Facade to add |
 | --- | --- |

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -293,11 +293,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       expect(result).to be_a(Git::Remote)
       expect(result.name).to eq('origin')
     end
-
-    it 'raises Git::FailedError when the remote does not exist' do
-      expect { described_instance.set_remote_url('nonexistent', other_dir) }
-        .to raise_error(Git::FailedError)
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -319,16 +314,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       described_instance.remote_set_branches('origin', 'develop', add: true)
       fetch_values = execution_context.command_capturing('config', '--get-all', 'remote.origin.fetch').stdout
       expect(fetch_values).to include('main').and include('develop')
-    end
-
-    it 'raises ArgumentError when no branches are given' do
-      expect { described_instance.remote_set_branches('origin') }
-        .to raise_error(ArgumentError, /branches are required/)
-    end
-
-    it 'raises Git::FailedError when the remote does not exist' do
-      expect { described_instance.remote_set_branches('nonexistent', 'main') }
-        .to raise_error(Git::FailedError)
     end
   end
 end

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -247,4 +247,88 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       expect(result.url).to eq(bare_dir)
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #remotes
+  # ---------------------------------------------------------------------------
+
+  describe '#remotes' do
+    it 'returns an Array of Git::Remote objects' do
+      result = described_instance.remotes
+      expect(result).to all(be_a(Git::Remote))
+    end
+
+    it 'includes each configured remote by name' do
+      described_instance.add_remote('upstream', bare_dir)
+      expect(described_instance.remotes.map(&:name)).to contain_exactly('origin', 'upstream')
+    end
+
+    context 'when the repository has no remotes' do
+      before { described_instance.remove_remote('origin') }
+
+      it 'returns an empty array' do
+        expect(described_instance.remotes).to eq([])
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #set_remote_url
+  # ---------------------------------------------------------------------------
+
+  describe '#set_remote_url' do
+    let(:other_dir) { Dir.mktmpdir('other_repo') }
+
+    after { FileUtils.rm_rf(other_dir) }
+
+    before { Git.init(other_dir, bare: true) }
+
+    it 'updates the fetch URL for the named remote' do
+      described_instance.set_remote_url('origin', other_dir)
+      expect(described_instance.config_remote('origin')['url']).to eq(other_dir)
+    end
+
+    it 'returns a Git::Remote for the updated remote' do
+      result = described_instance.set_remote_url('origin', other_dir)
+      expect(result).to be_a(Git::Remote)
+      expect(result.name).to eq('origin')
+    end
+
+    it 'raises Git::FailedError when the remote does not exist' do
+      expect { described_instance.set_remote_url('nonexistent', other_dir) }
+        .to raise_error(Git::FailedError)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #remote_set_branches
+  # ---------------------------------------------------------------------------
+
+  describe '#remote_set_branches' do
+    it 'returns nil' do
+      expect(described_instance.remote_set_branches('origin', 'main')).to be_nil
+    end
+
+    it 'replaces the tracked branches for the remote' do
+      described_instance.remote_set_branches('origin', 'main')
+      expect(described_instance.config_remote('origin')['fetch']).to include('main')
+    end
+
+    it 'appends tracked branches when add: true' do
+      described_instance.remote_set_branches('origin', 'main')
+      described_instance.remote_set_branches('origin', 'develop', add: true)
+      fetch_values = execution_context.command_capturing('config', '--get-all', 'remote.origin.fetch').stdout
+      expect(fetch_values).to include('main').and include('develop')
+    end
+
+    it 'raises ArgumentError when no branches are given' do
+      expect { described_instance.remote_set_branches('origin') }
+        .to raise_error(ArgumentError, /branches are required/)
+    end
+
+    it 'raises Git::FailedError when the remote does not exist' do
+      expect { described_instance.remote_set_branches('nonexistent', 'main') }
+        .to raise_error(Git::FailedError)
+    end
+  end
 end

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -813,16 +813,178 @@ RSpec.describe Git::Repository::RemoteOperations do
         expect(result.name).to eq('upstream')
       end
     end
+  end
 
-    context 'when no name is given (defaults to origin)' do
-      subject(:result) { described_instance.remote }
+  # ---------------------------------------------------------------------------
+  # #set_remote_url
+  # ---------------------------------------------------------------------------
 
-      it 'returns a Git::Remote named origin' do
-        expect(result.name).to eq('origin')
+  describe '#set_remote_url' do
+    let(:set_url_command) { instance_double(Git::Commands::Remote::SetUrl) }
+    let(:set_url_result) { command_result('') }
+    let(:remote_object) { instance_double(Git::Remote) }
+
+    before do
+      allow(Git::Commands::Remote::SetUrl)
+        .to receive(:new).with(execution_context).and_return(set_url_command)
+      allow(set_url_command).to receive(:call).and_return(set_url_result)
+      allow(Git::Remote).to receive(:new).and_return(remote_object)
+    end
+
+    context 'with a string url' do
+      subject(:result) { described_instance.set_remote_url('origin', 'https://example.com/repo.git') }
+
+      it 'delegates to Git::Commands::Remote::SetUrl.new with the execution_context' do
+        expect(Git::Commands::Remote::SetUrl)
+          .to receive(:new).with(execution_context).and_return(set_url_command)
+        result
       end
 
-      it 'populates the url from config' do
-        expect(result.url).to eq('https://github.com/user/repo.git')
+      it 'calls SetUrl#call with the name and url' do
+        expect(set_url_command)
+          .to receive(:call).with('origin', 'https://example.com/repo.git').and_return(set_url_result)
+        result
+      end
+
+      it 'returns the Git::Remote for the updated name' do
+        expect(Git::Remote).to receive(:new).with(described_instance, 'origin').and_return(remote_object)
+        expect(result).to eq(remote_object)
+      end
+    end
+
+    context 'with url as a Git::Base' do
+      let(:url_base) do
+        Object.new.tap do |obj|
+          def obj.repo
+            Pathname.new('/tmp/source.git')
+          end
+
+          def obj.is_a?(klass)
+            klass == Git::Base || super
+          end
+        end
+      end
+
+      subject(:result) { described_instance.set_remote_url('origin', url_base) }
+
+      it 'normalizes the url to repo.to_s before calling the command' do
+        expect(set_url_command)
+          .to receive(:call).with('origin', '/tmp/source.git').and_return(set_url_result)
+        result
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #remote_set_branches
+  # ---------------------------------------------------------------------------
+
+  describe '#remote_set_branches' do
+    let(:set_branches_command) { instance_double(Git::Commands::Remote::SetBranches) }
+    let(:set_branches_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Remote::SetBranches)
+        .to receive(:new).with(execution_context).and_return(set_branches_command)
+      allow(set_branches_command).to receive(:call).and_return(set_branches_result)
+    end
+
+    context 'with a single branch' do
+      subject(:result) { described_instance.remote_set_branches('origin', 'main') }
+
+      it 'delegates to Git::Commands::Remote::SetBranches.new with the execution_context' do
+        expect(Git::Commands::Remote::SetBranches)
+          .to receive(:new).with(execution_context).and_return(set_branches_command)
+        result
+      end
+
+      it 'calls SetBranches#call with the name, branch, and add: false' do
+        expect(set_branches_command)
+          .to receive(:call).with('origin', 'main', add: false).and_return(set_branches_result)
+        result
+      end
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+
+    context 'with multiple branches' do
+      subject(:result) { described_instance.remote_set_branches('origin', 'main', 'develop') }
+
+      it 'forwards each branch to the command' do
+        expect(set_branches_command)
+          .to receive(:call).with('origin', 'main', 'develop', add: false).and_return(set_branches_result)
+        result
+      end
+    end
+
+    context 'with a nested array of branches' do
+      subject(:result) { described_instance.remote_set_branches('origin', %w[main develop]) }
+
+      it 'flattens the branches before calling the command' do
+        expect(set_branches_command)
+          .to receive(:call).with('origin', 'main', 'develop', add: false).and_return(set_branches_result)
+        result
+      end
+    end
+
+    context 'with add: true' do
+      subject(:result) { described_instance.remote_set_branches('origin', 'release/*', add: true) }
+
+      it 'forwards add: true to the command' do
+        expect(set_branches_command)
+          .to receive(:call).with('origin', 'release/*', add: true).and_return(set_branches_result)
+        result
+      end
+    end
+
+    context 'with no branches' do
+      it 'raises ArgumentError before calling the command' do
+        expect(set_branches_command).not_to receive(:call)
+        expect { described_instance.remote_set_branches('origin') }
+          .to raise_error(ArgumentError, /branches are required/)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #remotes
+  # ---------------------------------------------------------------------------
+
+  describe '#remotes' do
+    let(:list_command) { instance_double(Git::Commands::Remote::List) }
+
+    before do
+      allow(Git::Commands::Remote::List)
+        .to receive(:new).with(execution_context).and_return(list_command)
+      allow(list_command).to receive(:call).and_return(command_result("origin\nupstream\n"))
+      allow(Git::Remote).to receive(:new) { |_base, name| instance_double(Git::Remote, name: name) }
+    end
+
+    it 'delegates to Git::Commands::Remote::List.new with the execution_context' do
+      expect(Git::Commands::Remote::List)
+        .to receive(:new).with(execution_context).and_return(list_command)
+      described_instance.remotes
+    end
+
+    it 'returns a Git::Remote for each configured remote' do
+      expect(described_instance.remotes.map(&:name)).to eq(%w[origin upstream])
+    end
+
+    it 'builds each Git::Remote with the repository and remote name' do
+      expect(Git::Remote).to receive(:new).with(described_instance, 'origin')
+      expect(Git::Remote).to receive(:new).with(described_instance, 'upstream')
+      described_instance.remotes
+    end
+
+    context 'when no remotes are configured' do
+      before do
+        allow(list_command).to receive(:call).and_return(command_result(''))
+      end
+
+      it 'returns an empty array' do
+        expect(described_instance.remotes).to eq([])
       end
     end
   end


### PR DESCRIPTION
# Description

Implements **Step A2** of the architectural redesign (Workstream A — fill facade
coverage gaps), as defined in `redesign/3_architecture_implementation.md`.

This extends `Git::Repository::RemoteOperations` with three facade methods that
previously called `Git::Lib` directly from `Git::Base`, and updates `Git::Base`
to delegate to the facade:

| `Git::Base` method | New facade method | Underlying command | Returns |
| --- | --- | --- | --- |
| `remotes` | `Git::Repository::RemoteOperations#remotes` | `Commands::Remote::List` | `Array<Git::Remote>` |
| `set_remote_url(name, url)` | `#set_remote_url` | `Commands::Remote::SetUrl` | `Git::Remote` |
| `remote_set_branches(name, *branches, add:)` | `#remote_set_branches` | `Commands::Remote::SetBranches` | `nil` |

## Why

`Git::Base` still reached into `Git::Lib` for these three remote operations. Moving
them into the `Git::Repository` facade is part of the Strangler Fig migration toward
making `Git::Repository` the public entry point in v5.0.0.

## Key design decisions

- **`remotes`** runs `git remote` via `Commands::Remote::List`, splits stdout into
  names, and maps each to `Git::Remote.new(self, name)`.
- **`set_remote_url`** coerces a local-repository `Git::Base` argument to
  `url.repo.to_s` in facade pre-processing (preserving the 4.x contract), delegates
  to `Commands::Remote::SetUrl`, and returns a `Git::Remote`.
- **`remote_set_branches`** flattens the branch list, raises `ArgumentError` when no
  branches are given, and delegates to `Commands::Remote::SetBranches`.
- All three are classified **legacy-contract**: their signatures match the existing
  `Git::Base` methods exactly so the public API is unchanged.

## Test coverage

- **Unit tests** (`spec/unit/git/repository/remote_operations_spec.rb`): delegation
  contracts, option/argument pre-processing, `Git::Base` url coercion, branch
  flattening, the empty-branches `ArgumentError` guard, and empty/non-empty remote
  lists. 100% line and branch coverage of the three new methods.
- **Integration tests** (`spec/integration/git/repository/remote_operations_spec.rb`):
  end-to-end behavior against real git — remote enumeration, URL updates reflected in
  config, and replace/append branch tracking.

## Verification

`bundle exec rake default` passes (RSpec + Test::Unit + RuboCop + YARD + build),
with no new Ruby warnings.

## Breaking changes

None. The public API of `Git::Base` is preserved; the methods now delegate to the
facade.

## Checklist

- [x] I reviewed and applied the project's AI Policy.
- [x] I ran `bundle exec rake` locally on this branch and it passed.
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (YARD docs + redesign tracker).
