### PR TITLE
feat(repository): add Git::Repository::Inspecting facade (show, fsck)

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -761,7 +761,7 @@ module Git
     #
     # rubocop:disable Style/ArgumentsForwarding
     def fsck(*objects, **opts)
-      lib.fsck(*objects, **opts)
+      facade_repository.fsck(*objects, **opts)
     end
     # rubocop:enable Style/ArgumentsForwarding
 
@@ -781,7 +781,7 @@ module Git
     # @param [String|NilClass] path the path of the file to be shown
     # @return [String] the object information
     def show(objectish = nil, path = nil)
-      lib.show(objectish, path)
+      facade_repository.show(objectish, path)
     end
 
     ## LOWER LEVEL INDEX OPERATIONS ##

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -5,6 +5,7 @@ require 'git/repository/branching'
 require 'git/repository/committing'
 require 'git/repository/configuring'
 require 'git/repository/diffing'
+require 'git/repository/inspecting'
 require 'git/repository/logging'
 require 'git/repository/merging'
 require 'git/repository/object_operations'
@@ -44,6 +45,7 @@ module Git
     include Git::Repository::Committing
     include Git::Repository::Configuring
     include Git::Repository::Diffing
+    include Git::Repository::Inspecting
     include Git::Repository::Logging
     include Git::Repository::Merging
     include Git::Repository::ObjectOperations

--- a/lib/git/repository/inspecting.rb
+++ b/lib/git/repository/inspecting.rb
@@ -1,0 +1,153 @@
+# frozen_string_literal: true
+
+require 'git/commands/fsck'
+require 'git/commands/show'
+require 'git/parsers/fsck'
+require 'git/repository/shared_private'
+
+module Git
+  class Repository
+    # Facade methods for read-only repository inspection operations
+    #
+    # These methods report on the contents and integrity of the repository.
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module Inspecting
+      # Show a single git object (a commit, tag, tree, or blob)
+      #
+      # @example Show the HEAD commit
+      #   repo.show
+      #
+      # @example Show a specific commit
+      #   repo.show('HEAD~1')
+      #
+      # @example Show the contents of a file at a revision
+      #   repo.show('HEAD', 'README.md')
+      #
+      # @param objectish [String, nil] the object to show; a ref, SHA, or
+      #   `objectish:path` expression
+      #
+      #   Defaults to `HEAD` when `nil`.
+      #
+      # @param path [String, nil] the file whose contents to show at `objectish`,
+      #   when given
+      #
+      #   Combined with `objectish` as `objectish:path`. When `objectish` is `nil`
+      #   and `path` is given, `HEAD` is used as the objectish, so
+      #   `show(nil, 'README.md')` resolves to `HEAD:README.md`.
+      #
+      # @return [String] git's stdout from the show, with trailing newlines
+      #   preserved
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def show(objectish = nil, path = nil)
+        object = path ? "#{objectish || 'HEAD'}:#{path}" : objectish
+        Git::Commands::Show.new(@execution_context).call(*[object].compact).stdout
+      end
+
+      # Option keys accepted by {#fsck}
+      #
+      # `:progress`/`:no_progress` are intentionally excluded: progress output is
+      # always suppressed (see {#fsck}), so callers may not toggle it.
+      FSCK_ALLOWED_OPTS = %i[
+        tags root unreachable cache no_reflogs
+        full no_full strict verbose lost_found dangling no_dangling
+        connectivity_only name_objects no_name_objects references no_references
+      ].freeze
+      private_constant :FSCK_ALLOWED_OPTS
+
+      # Verify the connectivity and validity of the objects in the database
+      #
+      # Runs `git fsck` and returns the categorized objects it flags. Progress
+      # output is always suppressed (`--no-progress`) so that stdout contains only
+      # the machine-parsable findings.
+      #
+      # @overload fsck(*objects, **options)
+      #
+      #   @example Check repository integrity
+      #     result = repo.fsck
+      #     result.dangling.each { |obj| puts "#{obj.type}: #{obj.oid}" }
+      #
+      #   @example Check if the repository is clean
+      #     repo.fsck.empty? #=> true
+      #
+      #   @example List root commits
+      #     repo.fsck(root: true).root.each { |obj| puts obj.oid }
+      #
+      #   @example Check specific objects
+      #     repo.fsck('abc1234', 'def5678')
+      #
+      #   @param objects [Array<String>] specific objects to treat as heads for the
+      #     unreachability trace
+      #
+      #     When none are given, git fsck defaults to the index file, all refs, and
+      #     all reflogs.
+      #
+      #   @param options [Hash] options for the fsck command
+      #
+      #   @option options [Boolean, nil] :tags (nil) report tags
+      #
+      #   @option options [Boolean, nil] :root (nil) report root nodes
+      #
+      #   @option options [Boolean, nil] :unreachable (nil) print objects that exist
+      #     but are not reachable from any reference node
+      #
+      #   @option options [Boolean, nil] :cache (nil) consider objects recorded in the
+      #     index as head nodes for reachability
+      #
+      #   @option options [Boolean, nil] :no_reflogs (nil) do not consider commits
+      #     referenced only by reflogs to be reachable
+      #
+      #   @option options [Boolean, nil] :full (nil) also check alternate object
+      #     pools and packed archives, not just the local store
+      #
+      #   @option options [Boolean, nil] :no_full (nil) skip alternate object pools and
+      #     packed archives
+      #
+      #   @option options [Boolean, nil] :strict (nil) enable stricter checking
+      #
+      #   @option options [Boolean, nil] :verbose (nil) be chatty
+      #
+      #   @option options [Boolean, nil] :lost_found (nil) write dangling objects
+      #     into `.git/lost-found`
+      #
+      #     This modifies the repository by creating files.
+      #
+      #   @option options [Boolean, nil] :dangling (nil) print dangling objects
+      #
+      #   @option options [Boolean, nil] :no_dangling (nil) suppress dangling object
+      #     reporting
+      #
+      #   @option options [Boolean, nil] :connectivity_only (nil) check only
+      #     connectivity; faster but does not validate blob content
+      #
+      #   @option options [Boolean, nil] :name_objects (nil) show the name of each
+      #     reachable object alongside its identifier
+      #
+      #   @option options [Boolean, nil] :no_name_objects (nil) suppress object name
+      #     display
+      #
+      #   @option options [Boolean, nil] :references (nil) check reference database
+      #     consistency
+      #
+      #   @option options [Boolean, nil] :no_references (nil) skip reference checking
+      #
+      #   @return [Git::FsckResult] the objects flagged by fsck, categorized by status
+      #
+      #   @raise [ArgumentError] when unsupported options are provided
+      #
+      #   @raise [Git::FailedError] when git exits outside the allowed range (exit
+      #     code > 7)
+      #
+      def fsck(*objects, **)
+        SharedPrivate.assert_valid_opts!(FSCK_ALLOWED_OPTS, **)
+        result = Git::Commands::Fsck.new(@execution_context).call(*objects, **, no_progress: true)
+        Git::Parsers::Fsck.parse(result.stdout)
+      end
+    end
+  end
+end

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -38,9 +38,9 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | ----- | ------ | ----------- | :--------------: | :--------------: |
 | Phase 1 | ✅ Complete | Foundation and scaffolding | 5% | 100% |
 | Phase 2 | ✅ Complete | Migrating commands (all checklist items done) | 40% | 100% |
-| Phase 3 | ⏳ In Progress | Refactoring public interface — see [Facade Modules Completed](#facade-modules-completed) and [Facade coverage checklist](#facade-coverage-checklist) | 45% | 40% |
+| Phase 3 | ⏳ In Progress | Refactoring public interface — see [Facade Modules Completed](#facade-modules-completed) and [Facade coverage checklist](#facade-coverage-checklist) | 45% | 45% |
 | Phase 4 | 🔲 Not Started | Final cleanup and release | 10% | 0% |
-| **TOTAL** | -- | -- | **100%** | **63%** |
+| **TOTAL** | -- | -- | **100%** | **65%** |
 
 ### Facade Modules Completed
 
@@ -53,6 +53,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | `Git::Repository::RemoteOperations` | `lib/git/repository/remote_operations.rb` | ✅ | `fetch`, `pull`, `push`, `add_remote`, `remove_remote`, `config_remote`, `remotes`, `set_remote_url`, `remote_set_branches` |
 | `Git::Repository::Stashing` | `lib/git/repository/stashing.rb` | ✅ | `stash_save`, `stash_apply`, `stash_clear`, `stashes_all` |
 | `Git::Repository::Diffing` | `lib/git/repository/diffing.rb` | ✅ | `diff_path_status`, `diff_name_status`, `diff_full` |
+| `Git::Repository::Inspecting` | `lib/git/repository/inspecting.rb` | ✅ | `show`, `fsck` |
 | `Git::Repository::ObjectOperations` | `lib/git/repository/object_operations.rb` | ✅ | `rev_parse`, `tree_depth`, `ls_tree`, `grep`, `archive`, `tags`, `add_tag`, `delete_tag` |
 | `Git::Repository::Logging` | `lib/git/repository/logging.rb` | ✅ | `log`, `full_log_commits` |
 | `Git::Repository::StatusOperations` | `lib/git/repository/status_operations.rb` | ✅ | `ls_files`, `no_commits?` (renamed from `Git::Lib#empty?`), `untracked_files`, `status`; `Git::Base#ls_files` delegates to facade |
@@ -165,7 +166,7 @@ Files touched: `lib/git/repository/remote_operations.rb`, `spec/unit/git/reposit
 
 Files touched: `lib/git/repository/object_operations.rb`, `spec/unit/git/repository/object_operations_spec.rb`, `lib/git/base.rb`
 
-**Step A4 — New `Git::Repository::Inspecting` module: `show`, `fsck`** ⬜
+**Step A4 — New `Git::Repository::Inspecting` module: `show`, `fsck`** ✅
 
 These are read-only repository inspection operations that don't fit an existing topic module.
 
@@ -488,9 +489,9 @@ classified as a v5-only PR with upgrade-note coverage before it lands.
 | Step | GitHub PR | Scope | Release lane | Backward-compatibility rule |
 | --- | --- | --- | --- | --- |
 | A1 | ✅ | Add `rm`, `clean`, `ignored_files` facade coverage | 4.x-compatible | `Git::Base` public methods keep the same signatures, return values, and deprecation behavior. |
-| A2 | ⬜ | Add `remotes`, `set_remote_url`, `remote_set_branches` facade coverage | 4.x-compatible | `Git::Base` remote methods keep the same return objects and validation behavior. |
+| A2 | ✅ | Add `remotes`, `set_remote_url`, `remote_set_branches` facade coverage | 4.x-compatible | `Git::Base` remote methods keep the same return objects and validation behavior. |
 | A3 | ✅ | Add `tags`, `add_tag`, `delete_tag` facade coverage | 4.x-compatible | Tag list/create/delete return contracts match 4.x behavior. |
-| A4 | ⬜ | Add `Inspecting#show` and `#fsck` | 4.x-compatible | `Git::Base#show` and `#fsck` remain behavior-compatible and delegate internally. |
+| A4 | ✅ | Add `Inspecting#show` and `#fsck` | 4.x-compatible | `Git::Base#show` and `#fsck` remain behavior-compatible and delegate internally. |
 | B | ⬜ | Redirect `Git::Base` domain-object factories | 4.x-compatible | Method signatures and return types stay the same; only the internal provider changes to `Git::Repository`. Split into object/tag factories and branch/remote factories if the PR grows. |
 | C1a-1 | ⬜ | Add `Git::Repository.open`/`.bare`, path state, and `dir`/`repo`/`index`/`repo_size` | 4.x-compatible additive | `Git.open`/`.bare` still return `Git::Base`; new repository factories are additive until C1d. |
 | C1a-2 | ⬜ | Add `Git::Repository.clone`/`.init` | 4.x-compatible additive | `Git.clone`/`.init` still return `Git::Base`; clone/init behavior is duplicated behind new factories without changing public entry points. |
@@ -536,9 +537,9 @@ done only when its code, focused specs, and delegation/cleanup checks are all tr
 | Step | Status |
 | --- | --- |
 | A1: `Staging` — `rm`, `clean`, `ignored_files` | ✅ |
-| A2: `RemoteOperations` — `remotes`, `set_remote_url`, `remote_set_branches` | ⬜ |
-| A3: `ObjectOperations` — `tags`, `add_tag`, `delete_tag` | ⬜ |
-| A4: new `Inspecting` — `show`, `fsck` | ⬜ |
+| A2: `RemoteOperations` — `remotes`, `set_remote_url`, `remote_set_branches` | ✅ |
+| A3: `ObjectOperations` — `tags`, `add_tag`, `delete_tag` | ✅ |
+| A4: new `Inspecting` — `show`, `fsck` | ✅ |
 | B (C0): `Git::Base` factory delegation wiring | ⬜ |
 | C1a-1: `Git::Repository.open`/`.bare`, path state (`dir`, `repo`, `index`, `repo_size`) | ⬜ |
 | C1a-2: `Git::Repository.clone`/`.init` (no `Git::Lib` dependency) | ⬜ |

--- a/spec/integration/git/repository/inspecting_spec.rb
+++ b/spec/integration/git/repository/inspecting_spec.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/inspecting'
+require 'git/execution_context/repository'
+
+# Integration tests for Git::Repository::Inspecting.
+#
+# Both facade methods are exercised end-to-end here because each performs
+# facade-owned processing that benefits from a real git invocation:
+#   * #show joins objectish and path into an `objectish:path` expression before
+#     calling git, so a real blob read proves the pre-processing produces a
+#     valid object specifier.
+#   * #fsck parses real `git fsck` stdout into a Git::FsckResult, so a real
+#     invocation proves the parsing handles actual output.
+
+RSpec.describe Git::Repository::Inspecting, :integration do
+  include_context 'in an empty repository'
+
+  let(:execution_context) { Git::ExecutionContext::Repository.from_base(repo) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  describe '#show' do
+    before do
+      write_file('README.md', "hello world\n")
+      repo.add(all: true)
+      repo.commit('Initial commit')
+    end
+
+    context 'with an objectish and a path' do
+      it 'shows the contents of the file at that revision' do
+        expect(described_instance.show('HEAD', 'README.md')).to eq("hello world\n")
+      end
+    end
+  end
+
+  describe '#fsck' do
+    before do
+      write_file('README.md', "hello world\n")
+      repo.add(all: true)
+      repo.commit('Initial commit')
+    end
+
+    it 'returns a Git::FsckResult' do
+      expect(described_instance.fsck).to be_a(Git::FsckResult)
+    end
+
+    context 'when the repository is healthy' do
+      it 'reports no issues' do
+        expect(described_instance.fsck).to be_empty
+      end
+    end
+
+    context 'when a dangling object exists' do
+      before do
+        write_file('orphan.txt', "orphan content\n")
+        Dir.chdir(repo_dir) { execution_context.command_capturing('hash-object', '-w', 'orphan.txt') }
+      end
+
+      it 'reports the dangling object' do
+        expect(described_instance.fsck.dangling).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository/inspecting_spec.rb
+++ b/spec/unit/git/repository/inspecting_spec.rb
@@ -1,0 +1,150 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/inspecting'
+
+# Integration-level coverage for Git::Repository::Inspecting#show is provided by
+# the underlying command integration tests (spec/integration/git/commands/show_spec.rb),
+# but #show performs facade-owned argument pre-processing (objectish/path joining)
+# and #fsck performs facade-owned output parsing, so end-to-end behavior is also
+# covered by spec/integration/git/repository/inspecting_spec.rb.
+
+RSpec.describe Git::Repository::Inspecting do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  describe '#show' do
+    subject(:result) { described_instance.show }
+
+    let(:show_command) { instance_double(Git::Commands::Show) }
+    let(:show_result) { command_result("commit content\n") }
+
+    before do
+      allow(Git::Commands::Show).to receive(:new).with(execution_context).and_return(show_command)
+    end
+
+    context 'with no arguments' do
+      it 'delegates to Git::Commands::Show#call with no object arguments' do
+        expect(show_command).to receive(:call).with(no_args).and_return(show_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(show_command).to receive(:call).with(no_args).and_return(show_result)
+        expect(result).to eq("commit content\n")
+      end
+    end
+
+    context 'with an objectish' do
+      subject(:result) { described_instance.show('HEAD~1') }
+
+      it 'delegates to Git::Commands::Show#call with the objectish' do
+        expect(show_command).to receive(:call).with('HEAD~1').and_return(show_result)
+        result
+      end
+    end
+
+    context 'with an objectish and a path' do
+      subject(:result) { described_instance.show('HEAD', 'README.md') }
+
+      it 'joins the objectish and path with a colon' do
+        expect(show_command).to receive(:call).with('HEAD:README.md').and_return(show_result)
+        result
+      end
+    end
+
+    context 'with only a path' do
+      subject(:result) { described_instance.show(nil, 'README.md') }
+
+      it 'defaults objectish to HEAD and joins with a colon' do
+        expect(show_command).to receive(:call).with('HEAD:README.md').and_return(show_result)
+        result
+      end
+    end
+  end
+
+  describe '#fsck' do
+    subject(:result) { described_instance.fsck }
+
+    let(:fsck_command) { instance_double(Git::Commands::Fsck) }
+    let(:fsck_result) { command_result("dangling commit #{'a' * 40}\n") }
+    let(:parsed_result) { instance_double(Git::FsckResult) }
+
+    before do
+      allow(Git::Commands::Fsck).to receive(:new).with(execution_context).and_return(fsck_command)
+      allow(Git::Parsers::Fsck).to receive(:parse).and_return(parsed_result)
+    end
+
+    context 'with no arguments' do
+      it 'delegates to Git::Commands::Fsck#call forcing no_progress' do
+        expect(fsck_command).to receive(:call).with(no_progress: true).and_return(fsck_result)
+        result
+      end
+
+      it 'parses the command stdout via Git::Parsers::Fsck' do
+        allow(fsck_command).to receive(:call).and_return(fsck_result)
+        expect(Git::Parsers::Fsck).to receive(:parse).with("dangling commit #{'a' * 40}\n")
+        result
+      end
+
+      it 'returns the parsed FsckResult' do
+        allow(fsck_command).to receive(:call).and_return(fsck_result)
+        expect(result).to be(parsed_result)
+      end
+    end
+
+    context 'with specific objects' do
+      subject(:result) { described_instance.fsck('abc1234', 'def5678') }
+
+      it 'forwards the objects to Git::Commands::Fsck#call' do
+        expect(fsck_command).to(
+          receive(:call).with('abc1234', 'def5678', no_progress: true).and_return(fsck_result)
+        )
+        result
+      end
+    end
+
+    context 'with options' do
+      subject(:result) { described_instance.fsck(strict: true, unreachable: true) }
+
+      it 'forwards the options to Git::Commands::Fsck#call' do
+        expect(fsck_command).to(
+          receive(:call).with(no_progress: true, strict: true, unreachable: true).and_return(fsck_result)
+        )
+        result
+      end
+    end
+
+    context 'with an unknown option' do
+      subject(:result) { described_instance.fsck(bogus: true) }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+
+      it 'does not call Git::Commands::Fsck' do
+        expect(fsck_command).not_to receive(:call)
+        begin
+          result
+        rescue ArgumentError
+          # expected
+        end
+      end
+    end
+
+    context 'when a caller tries to toggle progress' do
+      it 'rejects :progress so suppression cannot be overridden' do
+        expect { described_instance.fsck(progress: true) }.to(
+          raise_error(ArgumentError, /Unknown options: progress/)
+        )
+      end
+
+      it 'rejects :no_progress so suppression cannot be overridden' do
+        expect { described_instance.fsck(no_progress: false) }.to(
+          raise_error(ArgumentError, /Unknown options: no_progress/)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
# Description

Implements **Step A4** of the architectural redesign (Workstream A — fill facade
coverage gaps): a new `Git::Repository::Inspecting` topic module providing the
read-only repository inspection facade methods `#show` and `#fsck`, with
`Git::Base#show` and `Git::Base#fsck` redirected to delegate to the facade.

## What changed

- **New module `Git::Repository::Inspecting`** (`lib/git/repository/inspecting.rb`),
  required and `include`d by `Git::Repository`.
  - `#show(objectish = nil, path = nil)` → `Git::Commands::Show`. Joins `objectish`
    and `path` into an `objectish:path` specifier (compacting `nil`s) and returns
    git's stdout as a `String` with trailing newlines preserved.
  - `#fsck(*objects, **options)` → `Git::Commands::Fsck` + `Git::Parsers::Fsck`.
    Forces `--no-progress`, whitelists forwarded options against `FSCK_ALLOWED_OPTS`,
    and returns a `Git::FsckResult`.
- **`Git::Base#show` and `Git::Base#fsck`** now delegate to `facade_repository`
  instead of `lib`, preserving their existing signatures, return values, and
  behavior.
- **Redesign tracker** (`redesign/3_architecture_implementation.md`) updated to mark
  Step A4 complete and list the new facade module.

## Why

`Git::Base` still called `lib.*` directly for these inspection methods with no
`Git::Repository` counterpart. This step closes that gap so the facade owns the
argument pre-processing (`show`'s `objectish:path` join) and output assembly
(`fsck`'s parser wiring), per the redesign's facade responsibilities.

## Design notes

- **Backward compatible (legacy-contract).** `Git::Base#show`/`#fsck` keep their
  exact call shapes and return types; only the internal provider changed.
- **Option whitelisting.** `#fsck` validates forwarded options against
  `FSCK_ALLOWED_OPTS`, which matches the documented `@option` set and the underlying
  `Git::Commands::Fsck` argument surface (including negatable forms).

## Test coverage

- **Unit tests** (`spec/unit/git/repository/inspecting_spec.rb`): delegation
  contracts, both `#show` `objectish`/`path` pre-processing arms, `#fsck` default /
  explicit objects / options / forced `no_progress` / parser wiring / unknown-option
  rejection.
- **Integration tests** (`spec/integration/git/repository/inspecting_spec.rb`): real
  git — `#show` blob read via the `objectish:path` join, and `#fsck` parsing real
  output into a `Git::FsckResult` (healthy repo and a dangling object).
- **Coverage:** 100% line and 100% branch for `lib/git/repository/inspecting.rb`.
- `bundle exec rake default` passes locally (RSpec + Test::Unit suites, RuboCop,
  YARD).

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
