### PR TITLE
feat(tags): add tags, add_tag, and delete_tag facade methods (Step A3)

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -643,9 +643,9 @@ module Git
       facade_repository.remove_remote(name)
     end
 
-    # returns an array of all Git::Tag objects for this repository
+    # returns an array of all Git::Object::Tag objects for this repository
     def tags
-      lib.tags.map { |r| tag(r) }
+      facade_repository.tags
     end
 
     # Create a new git tag
@@ -660,20 +660,22 @@ module Git
     #   See [git-tag](https://git-scm.com/docs/git-tag) for more details.
     # @option options [Boolean, nil] :annotate (nil) make an unsigned, annotated tag object
     # @option options [Boolean, nil] :a (nil) an alias for the `:annotate` option
-    # @option options [Boolean, nil] :d (nil) delete existing tag with the given names
+    # @option options [Boolean, nil] :d (nil) delete existing tag with the given name —
+    #   deprecated; use {#delete_tag} instead (alias: `:delete`)
+    # @option options [Boolean, nil] :delete (nil) delete existing tag with the given name —
+    #   deprecated; use {#delete_tag} instead (alias: `:d`)
     # @option options [Boolean, nil] :f (nil) replace an existing tag with the given name (instead of failing)
     # @option options [String] :message Use the given tag message
     # @option options [String] :m An alias for the `:message` option
     # @option options [Boolean, nil] :s (nil) make a GPG-signed tag
     #
     def add_tag(name, *options)
-      lib.tag(name, *options)
-      tag(name)
+      facade_repository.add_tag(name, *options)
     end
 
     # deletes a tag
     def delete_tag(name)
-      lib.tag(name, { d: true })
+      facade_repository.delete_tag(name)
     end
 
     # Creates an archive of the given tree-ish and writes it to a file

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -9,9 +9,13 @@ require 'git/commands/ls_tree'
 require 'git/commands/name_rev'
 require 'git/commands/rev_parse'
 require 'git/commands/show_ref/list'
+require 'git/commands/tag/create'
+require 'git/commands/tag/delete'
+require 'git/commands/tag/list'
 require 'git/parsers/cat_file'
 require 'git/parsers/grep'
 require 'git/parsers/ls_tree'
+require 'git/parsers/tag'
 require 'git/repository/shared_private'
 require 'git/escaped_path'
 require 'tempfile'
@@ -25,7 +29,7 @@ module Git
     #
     # @api public
     #
-    module ObjectOperations
+    module ObjectOperations # rubocop:disable Metrics/ModuleLength
       # Returns the raw content of a git object, or streams it into a tempfile
       #
       # Without a block, the full content is buffered in memory and returned as a
@@ -679,12 +683,231 @@ module Git
         Git::Object.new(self, objectish)
       end
 
+      # Returns all tags in the repository as tag objects
+      #
+      # Runs `git tag --list` with a machine-readable format, parses the output,
+      # and returns a {Git::Object::Tag} for each tag name.
+      #
+      # @example List the names of all tags
+      #   repo.tags.map(&:name) #=> ["v1.0.0", "v2.0.0"]
+      #
+      # @example No tags exist
+      #   repo.tags #=> []
+      #
+      # @return [Array<Git::Object::Tag>] one tag object per tag in the
+      #   repository; empty when there are none
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def tags
+        result = Git::Commands::Tag::List.new(@execution_context).call(format: Git::Parsers::Tag::FORMAT_STRING)
+        Git::Parsers::Tag.parse_list(result.stdout).map { |info| tag(info.name) }
+      end
+
+      # Option keys accepted by {#add_tag}
+      ADD_TAG_ALLOWED_OPTS = %i[
+        annotate a sign s no_sign local_user u force f message m file F
+        edit e no_edit trailer cleanup create_reflog
+      ].freeze
+      private_constant :ADD_TAG_ALLOWED_OPTS
+
+      # Create a new tag
+      #
+      # @overload add_tag(name, options = {})
+      #
+      #   @example Create a lightweight tag on HEAD
+      #     repo.add_tag('v1.0.0')
+      #
+      #   @example Create an annotated tag on HEAD
+      #     repo.add_tag('v1.0.0', annotate: true, message: 'Release 1.0.0')
+      #
+      #   @example Replace an existing tag on HEAD
+      #     repo.add_tag('v1.0.0', force: true)
+      #
+      #   @param name [String] the name of the tag to create
+      #
+      #   @param options [Hash] options for creating the tag
+      #
+      #   @option options [Boolean, nil] :annotate (nil) make an unsigned,
+      #     annotated tag object; requires `:message` or `:file` (alias: `:a`)
+      #
+      #   @option options [Boolean, nil] :a (nil) alias for `:annotate`
+      #
+      #   @option options [Boolean, nil] :sign (nil) make a GPG-signed tag;
+      #     requires `:message` or `:file` (alias: `:s`)
+      #
+      #   @option options [Boolean, nil] :s (nil) alias for `:sign`
+      #
+      #   @option options [Boolean, nil] :no_sign (nil) override `tag.gpgSign`
+      #     config to disable signing
+      #
+      #   @option options [String] :local_user (nil) make a signed tag using the
+      #     given key (alias: `:u`)
+      #
+      #   @option options [String] :u (nil) alias for `:local_user`
+      #
+      #   @option options [Boolean, nil] :force (nil) replace an existing tag with
+      #     the given name instead of failing (alias: `:f`)
+      #
+      #   @option options [Boolean, nil] :f (nil) alias for `:force`
+      #
+      #   @option options [String] :message (nil) use the given message as the tag
+      #     message (alias: `:m`)
+      #
+      #   @option options [String] :m (nil) alias for `:message`
+      #
+      #   @option options [String] :file (nil) take the tag message from the given
+      #     file; use `-` to read from standard input (alias: `:F`)
+      #
+      #   @option options [String] :F (nil) alias for `:file`
+      #
+      #   @option options [Boolean, nil] :edit (nil) open an editor to further edit
+      #     the tag message (alias: `:e`)
+      #
+      #   @option options [Boolean, nil] :e (nil) alias for `:edit`
+      #
+      #   @option options [Boolean, nil] :no_edit (nil) suppress the editor
+      #
+      #   @option options [Hash, Array<Array>] :trailer (nil) add trailers to the
+      #     tag message
+      #
+      #   @option options [String] :cleanup (nil) set how the tag message is
+      #     cleaned up; one of `verbatim`, `whitespace`, or `strip`
+      #
+      #   @option options [Boolean, nil] :create_reflog (nil) create a reflog for
+      #     the tag
+      #
+      #   @return [Git::Object::Tag] the newly created tag
+      #
+      # @overload add_tag(name, target, options = {})
+      #
+      #   @example Create a lightweight tag on a specific commit
+      #     repo.add_tag('v1.0.0', 'abc123')
+      #
+      #   @example Create an annotated tag on a specific commit
+      #     repo.add_tag('v1.0.0', 'abc123', annotate: true, message: 'Release 1.0.0')
+      #
+      #   @param name [String] the name of the tag to create
+      #
+      #   @param target [String] the object to tag (commit SHA, branch name, etc.)
+      #
+      #   @param options [Hash] options for creating the tag (same keys as the
+      #     first overload)
+      #
+      #   @return [Git::Object::Tag] the newly created tag
+      #
+      # @overload add_tag(name, delete: true)
+      #
+      #   @deprecated Use {#delete_tag} instead.
+      #
+      #   @example Delete a tag (deprecated)
+      #     repo.add_tag('v1.0.0', d: true)
+      #
+      #   @param name [String] the name of the tag to delete
+      #
+      #   @option options [Boolean, nil] :d (nil) delete the named tag
+      #     (alias: `:delete`); deprecated — use {#delete_tag} instead
+      #
+      #   @option options [Boolean, nil] :delete (nil) delete the named tag
+      #     (alias: `:d`); deprecated — use {#delete_tag} instead
+      #
+      #   @return [String] git's stdout from the delete
+      #
+      #   @raise [ArgumentError] if a target is also provided
+      #
+      #   @raise [ArgumentError] if options other than `:d`/`:delete` are also
+      #     provided
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [ArgumentError] if an annotated or signed tag is requested without
+      #   a message
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def add_tag(name, *options)
+        opts = options.last.is_a?(Hash) ? options.pop : {}
+        target = options.first
+
+        return Private.add_tag_delete_deprecated(self, name, target, opts) if opts[:d] || opts[:delete]
+
+        opts = opts.except(:d, :delete)
+        SharedPrivate.assert_valid_opts!(ADD_TAG_ALLOWED_OPTS, **opts)
+        Private.validate_tag_options!(opts)
+        Git::Commands::Tag::Create.new(@execution_context).call(name, target, **opts)
+        tag(name)
+      end
+
+      # Delete a tag
+      #
+      # @example Delete a tag
+      #   repo.delete_tag('v1.0.0')
+      #
+      # @param name [String] the name of the tag to delete
+      #
+      # @return [String] git's stdout from the delete
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def delete_tag(name)
+        result = Git::Commands::Tag::Delete.new(@execution_context).call(name)
+        raise Git::FailedError, result if result.status.exitstatus.positive?
+
+        result.stdout
+      end
+
       # Private helpers
       #
       # @api private
       #
       module Private
         module_function
+
+        # Validate that a message is present when an annotated or signed tag is
+        # requested
+        #
+        # @param opts [Hash] the tag-creation options
+        #
+        # @return [void]
+        #
+        # @raise [ArgumentError] when an annotated or signed tag is requested
+        #   without a `:message`/`:m`/`:file`/`:F` value
+        #
+        def validate_tag_options!(opts)
+          needs_message = %i[a annotate s sign u local_user].any? { |k| opts[k] }
+          has_message = opts[:m] || opts[:message] || opts[:F] || opts[:file]
+
+          return unless needs_message && !has_message
+
+          raise ArgumentError, 'Cannot create an annotated or signed tag without a message.'
+        end
+
+        # Handle the deprecated :d/:delete option on add_tag
+        #
+        # Issues a deprecation warning and delegates to delete_tag. Raises
+        # ArgumentError if a target or incompatible options are also supplied.
+        #
+        # @param facade [ObjectOperations] the calling facade instance
+        # @param name [String] tag name
+        # @param target [String, nil] target argument (must be nil)
+        # @param opts [Hash] options hash (must contain only :d/:delete)
+        #
+        # @return [String] stdout from delete_tag
+        #
+        # @api private
+        #
+        def add_tag_delete_deprecated(facade, name, target, opts)
+          Git::Deprecation.warn(
+            'Passing :d or :delete to add_tag is deprecated and will be ' \
+            'removed in a future version. Use delete_tag instead.'
+          )
+          raise ArgumentError, 'Cannot pass a target when using the :d/:delete option.' if target
+
+          extra = opts.keys - %i[d delete]
+          raise ArgumentError, "Cannot combine :d/:delete with other options: #{extra.join(', ')}" unless extra.empty?
+
+          facade.delete_tag(name)
+        end
 
         def show_ref_tag_sha(execution_context, tag_name)
           ref = "refs/tags/#{tag_name}"

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -53,7 +53,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | `Git::Repository::RemoteOperations` | `lib/git/repository/remote_operations.rb` | ✅ | `fetch`, `pull`, `push`, `add_remote`, `remove_remote`, `config_remote`, `remotes`, `set_remote_url`, `remote_set_branches` |
 | `Git::Repository::Stashing` | `lib/git/repository/stashing.rb` | ✅ | `stash_save`, `stash_apply`, `stash_clear`, `stashes_all` |
 | `Git::Repository::Diffing` | `lib/git/repository/diffing.rb` | ✅ | `diff_path_status`, `diff_name_status`, `diff_full` |
-| `Git::Repository::ObjectOperations` | `lib/git/repository/object_operations.rb` | ✅ | `rev_parse`, `tree_depth`, `ls_tree`, `grep`, `archive` |
+| `Git::Repository::ObjectOperations` | `lib/git/repository/object_operations.rb` | ✅ | `rev_parse`, `tree_depth`, `ls_tree`, `grep`, `archive`, `tags`, `add_tag`, `delete_tag` |
 | `Git::Repository::Logging` | `lib/git/repository/logging.rb` | ✅ | `log`, `full_log_commits` |
 | `Git::Repository::StatusOperations` | `lib/git/repository/status_operations.rb` | ✅ | `ls_files`, `no_commits?` (renamed from `Git::Lib#empty?`), `untracked_files`, `status`; `Git::Base#ls_files` delegates to facade |
 | `Git::Repository::Configuring` | `lib/git/repository/configuring.rb` | ✅ | `config`; `Git::Base#config` delegates to facade |
@@ -155,7 +155,7 @@ Files touched: `lib/git/repository/staging.rb`, `spec/unit/git/repository/stagin
 
 Files touched: `lib/git/repository/remote_operations.rb`, `spec/unit/git/repository/remote_operations_spec.rb`, `lib/git/base.rb`
 
-**Step A3 — Extend `Git::Repository::ObjectOperations`: `tags`, `add_tag`, `delete_tag`** ⬜
+**Step A3 — Extend `Git::Repository::ObjectOperations`: `tags`, `add_tag`, `delete_tag`** ✅
 
 | `Git::Base` method | Facade to add |
 | --- | --- |
@@ -489,7 +489,7 @@ classified as a v5-only PR with upgrade-note coverage before it lands.
 | --- | --- | --- | --- | --- |
 | A1 | ✅ | Add `rm`, `clean`, `ignored_files` facade coverage | 4.x-compatible | `Git::Base` public methods keep the same signatures, return values, and deprecation behavior. |
 | A2 | ⬜ | Add `remotes`, `set_remote_url`, `remote_set_branches` facade coverage | 4.x-compatible | `Git::Base` remote methods keep the same return objects and validation behavior. |
-| A3 | ⬜ | Add `tags`, `add_tag`, `delete_tag` facade coverage | 4.x-compatible | Tag list/create/delete return contracts match 4.x behavior. |
+| A3 | ✅ | Add `tags`, `add_tag`, `delete_tag` facade coverage | 4.x-compatible | Tag list/create/delete return contracts match 4.x behavior. |
 | A4 | ⬜ | Add `Inspecting#show` and `#fsck` | 4.x-compatible | `Git::Base#show` and `#fsck` remain behavior-compatible and delegate internally. |
 | B | ⬜ | Redirect `Git::Base` domain-object factories | 4.x-compatible | Method signatures and return types stay the same; only the internal provider changes to `Git::Repository`. Split into object/tag factories and branch/remote factories if the PR grows. |
 | C1a-1 | ⬜ | Add `Git::Repository.open`/`.bare`, path state, and `dir`/`repo`/`index`/`repo_size` | 4.x-compatible additive | `Git.open`/`.bare` still return `Git::Base`; new repository factories are additive until C1d. |

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -731,4 +731,90 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
   # integration tests above. Unit tests in
   # spec/unit/git/repository/object_operations_spec.rb verify the delegation
   # contract and argument forwarding.
+
+  describe '#tags' do
+    context 'when the repository has no tags' do
+      it 'returns an empty array' do
+        expect(described_instance.tags).to eq([])
+      end
+    end
+
+    context 'when the repository has tags' do
+      before do
+        described_instance.add_tag('v1.0.0')
+        described_instance.add_tag('v2.0.0', annotate: true, message: 'Release 2.0.0')
+      end
+
+      it 'returns a Git::Object::Tag for every tag' do
+        expect(described_instance.tags).to all(be_a(Git::Object::Tag))
+      end
+
+      it 'returns every tag name' do
+        expect(described_instance.tags.map(&:name)).to contain_exactly('v1.0.0', 'v2.0.0')
+      end
+    end
+  end
+
+  describe '#add_tag' do
+    context 'with no target and no options' do
+      it 'creates a lightweight tag on HEAD' do
+        tag = described_instance.add_tag('v1.0.0')
+        expect(tag).to be_a(Git::Object::Tag)
+        expect(tag.name).to eq('v1.0.0')
+        expect(tag.annotated?).to be(false)
+      end
+    end
+
+    context 'with a target commit' do
+      it 'creates the tag pointing at the given commit' do
+        head_sha = described_instance.rev_parse('HEAD')
+        tag = described_instance.add_tag('v1.0.0', head_sha)
+        expect(tag.objectish).to eq(head_sha)
+      end
+    end
+
+    context 'with annotate and a message' do
+      it 'creates an annotated tag carrying the message' do
+        tag = described_instance.add_tag('v1.0.0', annotate: true, message: 'Release 1.0.0')
+        expect(tag.annotated?).to be(true)
+        expect(tag.message).to eq('Release 1.0.0')
+      end
+    end
+
+    # Facade-owned validation (annotated/signed without a message, unsupported
+    # options) and command error wrapping (tagging an existing name without
+    # :force) are pure-Ruby or command concerns with no added end-to-end signal;
+    # they are covered by the unit spec and command integration specs.
+    context 'when the tag already exists' do
+      before { described_instance.add_tag('v1.0.0') }
+
+      it 'replaces the existing tag when force is given' do
+        replaced = described_instance.add_tag('v1.0.0', force: true, annotate: true, message: 'replaced')
+        expect(replaced.annotated?).to be(true)
+        expect(replaced.message).to eq('replaced')
+      end
+    end
+  end
+
+  describe '#delete_tag' do
+    context 'when the tag exists' do
+      before { described_instance.add_tag('v1.0.0') }
+
+      it 'removes the tag' do
+        described_instance.delete_tag('v1.0.0')
+        expect(described_instance.tags.map(&:name)).not_to include('v1.0.0')
+      end
+
+      it 'returns git stdout confirming the deletion' do
+        expect(described_instance.delete_tag('v1.0.0')).to match(/Deleted tag 'v1.0.0'/)
+      end
+    end
+
+    context 'when the tag does not exist' do
+      it 'raises Git::FailedError naming the failed delete command' do
+        expect { described_instance.delete_tag('does-not-exist') }
+          .to raise_error(Git::FailedError, /does-not-exist/)
+      end
+    end
+  end
 end

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -1210,4 +1210,265 @@ RSpec.describe Git::Repository::ObjectOperations do
       expect(result).to be(commit_object)
     end
   end
+
+  describe '#tags' do
+    subject(:result) { described_instance.tags }
+
+    let(:list_command) { instance_double(Git::Commands::Tag::List) }
+    let(:command_result) { instance_double(Git::CommandLineResult, stdout: 'raw-stdout') }
+    let(:tag_first) { instance_double(Git::Object::Tag) }
+    let(:tag_second) { instance_double(Git::Object::Tag) }
+
+    before do
+      allow(Git::Commands::Tag::List).to receive(:new).with(execution_context).and_return(list_command)
+      allow(list_command).to receive(:call).and_return(command_result)
+      allow(Git::Parsers::Tag).to receive(:parse_list).with('raw-stdout').and_return(
+        [instance_double(Git::TagInfo, name: 'v1.0.0'), instance_double(Git::TagInfo, name: 'v2.0.0')]
+      )
+      allow(described_instance).to receive(:tag).with('v1.0.0').and_return(tag_first)
+      allow(described_instance).to receive(:tag).with('v2.0.0').and_return(tag_second)
+    end
+
+    it 'constructs Git::Commands::Tag::List with the execution context' do
+      expect(Git::Commands::Tag::List).to receive(:new).with(execution_context).and_return(list_command)
+      result
+    end
+
+    it 'requests the parser format string from the list command' do
+      expect(list_command).to receive(:call).with(format: Git::Parsers::Tag::FORMAT_STRING).and_return(command_result)
+      result
+    end
+
+    it 'parses the command stdout with Git::Parsers::Tag' do
+      expect(Git::Parsers::Tag).to receive(:parse_list).with('raw-stdout').and_return([])
+      result
+    end
+
+    it 'returns one Git::Object::Tag per parsed tag name' do
+      expect(result).to eq([tag_first, tag_second])
+    end
+
+    context 'when there are no tags' do
+      before do
+        allow(Git::Parsers::Tag).to receive(:parse_list).with('raw-stdout').and_return([])
+      end
+
+      it 'returns an empty array' do
+        expect(result).to eq([])
+      end
+    end
+  end
+
+  describe '#add_tag' do
+    let(:create_command) { instance_double(Git::Commands::Tag::Create) }
+    let(:command_result) { instance_double(Git::CommandLineResult) }
+    let(:tag_object) { instance_double(Git::Object::Tag) }
+
+    before do
+      allow(Git::Commands::Tag::Create).to receive(:new).with(execution_context).and_return(create_command)
+      allow(create_command).to receive(:call).and_return(command_result)
+      allow(described_instance).to receive(:tag).with('v1.0.0').and_return(tag_object)
+    end
+
+    it 'constructs Git::Commands::Tag::Create with the execution context' do
+      expect(Git::Commands::Tag::Create).to receive(:new).with(execution_context).and_return(create_command)
+      described_instance.add_tag('v1.0.0')
+    end
+
+    it 'returns the Git::Object::Tag for the created tag' do
+      expect(described_instance.add_tag('v1.0.0')).to be(tag_object)
+    end
+
+    context 'with no target and no options' do
+      it 'calls the create command with a nil commit and no options' do
+        expect(create_command).to receive(:call).with('v1.0.0', nil).and_return(command_result)
+        described_instance.add_tag('v1.0.0')
+      end
+    end
+
+    context 'with a target commit' do
+      it 'forwards the target as the commit operand' do
+        expect(create_command).to receive(:call).with('v1.0.0', 'abc123').and_return(command_result)
+        described_instance.add_tag('v1.0.0', 'abc123')
+      end
+    end
+
+    context 'with an options hash only' do
+      it 'forwards the options and a nil commit' do
+        expect(create_command).to receive(:call)
+          .with('v1.0.0', nil, annotate: true, message: 'hi').and_return(command_result)
+        described_instance.add_tag('v1.0.0', annotate: true, message: 'hi')
+      end
+    end
+
+    context 'with both a target and an options hash' do
+      it 'forwards the target and options' do
+        expect(create_command).to receive(:call)
+          .with('v1.0.0', 'abc123', force: true).and_return(command_result)
+        described_instance.add_tag('v1.0.0', 'abc123', force: true)
+      end
+    end
+
+    context 'with a positional options hash (legacy call shape)' do
+      it 'accepts the trailing hash as options' do
+        expect(create_command).to receive(:call)
+          .with('v1.0.0', nil, force: true).and_return(command_result)
+        described_instance.add_tag('v1.0.0', { force: true })
+      end
+    end
+
+    context 'when an unknown option is provided' do
+      it 'raises ArgumentError without calling git' do
+        expect(Git::Commands::Tag::Create).not_to receive(:new)
+        expect { described_instance.add_tag('v1.0.0', bogus: true) }
+          .to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+
+    context 'when an annotated tag is requested without a message' do
+      it 'raises ArgumentError without calling git' do
+        expect(Git::Commands::Tag::Create).not_to receive(:new)
+        expect { described_instance.add_tag('v1.0.0', annotate: true) }
+          .to raise_error(ArgumentError, 'Cannot create an annotated or signed tag without a message.')
+      end
+    end
+
+    context 'when a signed tag is requested without a message' do
+      it 'raises ArgumentError without calling git' do
+        expect(Git::Commands::Tag::Create).not_to receive(:new)
+        expect { described_instance.add_tag('v1.0.0', s: true) }
+          .to raise_error(ArgumentError, 'Cannot create an annotated or signed tag without a message.')
+      end
+    end
+
+    context 'when an annotated tag is requested with a message' do
+      it 'creates the tag and returns it' do
+        expect(described_instance.add_tag('v1.0.0', annotate: true, message: 'release')).to be(tag_object)
+      end
+    end
+
+    context 'when an annotated tag is requested with a :file option' do
+      it 'does not raise and creates the tag' do
+        expect(described_instance.add_tag('v1.0.0', annotate: true, file: 'msg.txt')).to be(tag_object)
+      end
+    end
+
+    context 'when an annotated tag is requested with the :F alias' do
+      it 'does not raise and creates the tag' do
+        expect(described_instance.add_tag('v1.0.0', annotate: true, F: 'msg.txt')).to be(tag_object)
+      end
+    end
+
+    context 'when a signed tag is requested with a :file option' do
+      it 'does not raise and creates the tag' do
+        expect(described_instance.add_tag('v1.0.0', sign: true, file: 'msg.txt')).to be(tag_object)
+      end
+    end
+
+    context 'when a signed tag is requested with the :F alias' do
+      it 'does not raise and creates the tag' do
+        expect(described_instance.add_tag('v1.0.0', sign: true, F: 'msg.txt')).to be(tag_object)
+      end
+    end
+
+    context 'when the deprecated :d option is given' do
+      let(:delete_stdout) { "Deleted tag 'v1.0.0' (was abc123)\n" }
+
+      before do
+        allow(described_instance).to receive(:delete_tag).with('v1.0.0').and_return(delete_stdout)
+        allow(Git::Deprecation).to receive(:warn)
+      end
+
+      it 'issues a deprecation warning' do
+        expect(Git::Deprecation).to receive(:warn).with(/deprecated/)
+        described_instance.add_tag('v1.0.0', d: true)
+      end
+
+      it 'delegates to delete_tag and returns its stdout' do
+        expect(described_instance).to receive(:delete_tag).with('v1.0.0').and_return(delete_stdout)
+        expect(described_instance.add_tag('v1.0.0', d: true)).to eq(delete_stdout)
+      end
+
+      it 'does not call Git::Commands::Tag::Create' do
+        expect(Git::Commands::Tag::Create).not_to receive(:new)
+        described_instance.add_tag('v1.0.0', d: true)
+      end
+
+      it 'also accepts the :delete alias' do
+        expect(described_instance).to receive(:delete_tag).with('v1.0.0').and_return(delete_stdout)
+        described_instance.add_tag('v1.0.0', delete: true)
+      end
+
+      it 'raises ArgumentError when a target is also given' do
+        expect { described_instance.add_tag('v1.0.0', 'abc123', d: true) }
+          .to raise_error(ArgumentError, /target/)
+      end
+
+      it 'raises ArgumentError when other options are also given' do
+        expect { described_instance.add_tag('v1.0.0', d: true, force: true) }
+          .to raise_error(ArgumentError, /force/)
+      end
+    end
+
+    context 'when :d is given as false' do
+      it 'treats it as omitted and creates the tag normally' do
+        expect(described_instance.add_tag('v1.0.0', d: false)).to be(tag_object)
+      end
+    end
+
+    context 'when :delete is given as false' do
+      it 'treats it as omitted and creates the tag normally' do
+        expect(described_instance.add_tag('v1.0.0', delete: false)).to be(tag_object)
+      end
+    end
+
+    context 'when :d is given as nil' do
+      it 'treats it as omitted and creates the tag normally' do
+        expect(described_instance.add_tag('v1.0.0', d: nil)).to be(tag_object)
+      end
+    end
+  end
+
+  describe '#delete_tag' do
+    subject(:result) { described_instance.delete_tag('v1.0.0') }
+
+    let(:delete_command) { instance_double(Git::Commands::Tag::Delete) }
+    let(:status) { instance_double(Process::Status, exitstatus: 0) }
+    let(:command_result) do
+      instance_double(
+        Git::CommandLineResult,
+        stdout: "Deleted tag 'v1.0.0' (was abc123)\n", stderr: '', status: status,
+        git_cmd: %w[git tag --delete v1.0.0]
+      )
+    end
+
+    before do
+      allow(Git::Commands::Tag::Delete).to receive(:new).with(execution_context).and_return(delete_command)
+      allow(delete_command).to receive(:call).with('v1.0.0').and_return(command_result)
+    end
+
+    it 'constructs Git::Commands::Tag::Delete with the execution context' do
+      expect(Git::Commands::Tag::Delete).to receive(:new).with(execution_context).and_return(delete_command)
+      result
+    end
+
+    it 'calls the delete command with the tag name' do
+      expect(delete_command).to receive(:call).with('v1.0.0').and_return(command_result)
+      result
+    end
+
+    it 'returns the command stdout' do
+      expect(result).to eq("Deleted tag 'v1.0.0' (was abc123)\n")
+    end
+
+    context 'when the tag does not exist (exit status 1)' do
+      let(:status) { instance_double(Process::Status, exitstatus: 1) }
+
+      it 'raises Git::FailedError carrying the failed command result' do
+        expect { result }.to raise_error(Git::FailedError, /--delete/) do |error|
+          expect(error.result).to be(command_result)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Description

Implements **Step A3** of the architectural redesign
(`redesign/3_architecture_implementation.md`): extend
`Git::Repository::ObjectOperations` with the `tags`, `add_tag`, and `delete_tag`
facade methods, and delegate the matching `Git::Base` methods to them.

This fills three of the Workstream A facade-coverage gaps so that `Git::Base` no
longer calls `lib.tags` / `lib.tag` directly for these operations.

## What changed

| `Git::Base` method | Facade added | Underlying |
| --- | --- | --- |
| `tags` | `ObjectOperations#tags` | `Commands::Tag::List` + `Parsers::Tag`; returns `Array<Git::Object::Tag>` |
| `add_tag(name, *options)` | `ObjectOperations#add_tag` | `Commands::Tag::Create`; `validate_tag_options!` moves into the facade |
| `delete_tag(name)` | `ObjectOperations#delete_tag` | `Commands::Tag::Delete` |

- All three are classified **legacy-contract** and preserve their exact 4.x
  signatures.
- `add_tag` whitelists forwarded options via `ADD_TAG_ALLOWED_OPTS` +
  `SharedPrivate.assert_valid_opts!`, and the annotated/signed-without-message
  validation (`validate_tag_options!`) now lives in the facade's `Private`
  module.
- `delete_tag` raises `Git::FailedError` when git exits with a positive status
  (e.g. the tag does not exist), matching the prior `Git::Lib` behavior.
- `Git::Base#tags`, `#add_tag`, and `#delete_tag` now delegate to
  `facade_repository`.

## Why

Part of the Strangler Fig migration of `Git::Base`/`Git::Lib` into
`Git::Repository`. Step A3 is a prerequisite for Workstream B (redirecting
`Git::Base#tag` to the facade) and the C1 entry-point flip.

## Test coverage

- **Unit tests** (`spec/unit/git/repository/object_operations_spec.rb`): cover
  command/parser delegation, every `add_tag` call shape (target/opts present or
  absent, legacy positional hash), option whitelisting, both
  annotated/signed-without-message rejections, and `delete_tag` exit-status
  handling.
- **Integration tests**
  (`spec/integration/git/repository/object_operations_spec.rb`): real-git
  end-to-end coverage of listing, lightweight/annotated/targeted/force tag
  creation, and tag deletion.
- The four new code objects are at **100% line and branch coverage**.
- `bundle exec rake default` passes (RSpec, Test::Unit, RuboCop, YARD, build).

## Breaking changes

None. `Git::Base` public methods keep the same signatures, return values, and
error behavior.

## Checklist

- [x] I reviewed and applied the project's AI Policy.
- [x] I ran `bundle exec rake` locally on this branch and it passed.
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (YARD docs for the new facade
  methods; redesign tracker marked A3 complete).
