### PR TITLE
refactor: delegate Git::Base domain-object factories to facade_repository

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -929,21 +929,13 @@ module Git
 
     # @return [Git::Branch] an object for branch_name
     def branch(branch_name = current_branch)
-      branch_info = Git::BranchInfo.new(
-        refname: branch_name,
-        target_oid: nil,
-        current: false,
-        worktree: false,
-        symref: nil,
-        upstream: nil
-      )
-      Git::Branch.new(self, branch_info)
+      facade_repository.branch(branch_name)
     end
 
     # @return [Git::Branches] a collection of all the branches in the repository.
     #   Each branch is represented as a {Git::Branch}.
     def branches
-      Git::Branches.new(self)
+      facade_repository.branches
     end
 
     # Returns a {Git::Worktree} object for the given path and optional commitish
@@ -986,17 +978,17 @@ module Git
 
     # @return [Git::Object] a Git object
     def gblob(objectish)
-      Git::Object.new(self, objectish, 'blob')
+      facade_repository.gblob(objectish)
     end
 
     # @return [Git::Object] a Git object
     def gcommit(objectish)
-      Git::Object.new(self, objectish, 'commit')
+      facade_repository.gcommit(objectish)
     end
 
     # @return [Git::Object] a Git object
     def gtree(objectish)
-      Git::Object.new(self, objectish, 'tree')
+      facade_repository.gtree(objectish)
     end
 
     # @return [Git::Log] a log with the specified number of commits
@@ -1023,12 +1015,12 @@ module Git
     #
     # @return [Git::Object] an instance of the appropriate type of Git::Object
     def object(objectish)
-      Git::Object.new(self, objectish)
+      facade_repository.object(objectish)
     end
 
     # @return [Git::Remote] a remote of the specified name
     def remote(remote_name = 'origin')
-      Git::Remote.new(self, remote_name)
+      facade_repository.remote(remote_name)
     end
 
     # @return [Git::Status] a status object
@@ -1038,7 +1030,7 @@ module Git
 
     # @return [Git::Object::Tag] a tag object
     def tag(tag_name)
-      Git::Object::Tag.new(self, tag_name)
+      facade_repository.tag(tag_name)
     end
 
     # Find as good common ancestors as possible for a merge

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -191,7 +191,7 @@ wiring with no new facade code needed. Ship as one PR (`feat/c0-delegate-base-fa
 
 ⚠️ Depends on A3 (`tags`/`add_tag`/`delete_tag`) before `tag` can be redirected.
 
-**Step B — Redirect `Git::Base` domain-object factories to `facade_repository`** ⬜
+**Step B — Redirect `Git::Base` domain-object factories to `facade_repository`** ✅
 
 | `Git::Base` method | Current | Replace with |
 | --- | --- | --- |
@@ -492,7 +492,7 @@ classified as a v5-only PR with upgrade-note coverage before it lands.
 | A2 | ✅ | Add `remotes`, `set_remote_url`, `remote_set_branches` facade coverage | 4.x-compatible | `Git::Base` remote methods keep the same return objects and validation behavior. |
 | A3 | ✅ | Add `tags`, `add_tag`, `delete_tag` facade coverage | 4.x-compatible | Tag list/create/delete return contracts match 4.x behavior. |
 | A4 | ✅ | Add `Inspecting#show` and `#fsck` | 4.x-compatible | `Git::Base#show` and `#fsck` remain behavior-compatible and delegate internally. |
-| B | ⬜ | Redirect `Git::Base` domain-object factories | 4.x-compatible | Method signatures and return types stay the same; only the internal provider changes to `Git::Repository`. Split into object/tag factories and branch/remote factories if the PR grows. |
+| B | ✅ | Redirect `Git::Base` domain-object factories | 4.x-compatible | Method signatures and return types stay the same; only the internal provider changes to `Git::Repository`. Split into object/tag factories and branch/remote factories if the PR grows. |
 | C1a-1 | ⬜ | Add `Git::Repository.open`/`.bare`, path state, and `dir`/`repo`/`index`/`repo_size` | 4.x-compatible additive | `Git.open`/`.bare` still return `Git::Base`; new repository factories are additive until C1d. |
 | C1a-2 | ⬜ | Add `Git::Repository.clone`/`.init` | 4.x-compatible additive | `Git.clone`/`.init` still return `Git::Base`; clone/init behavior is duplicated behind new factories without changing public entry points. |
 | C1b | ⬜ | Move global config ownership | 4.x-compatible | `Git.config`, `Git.configure`, and `Git::Base.config` keep working; `Git::Base.config` remains as a delegator. |
@@ -540,7 +540,7 @@ done only when its code, focused specs, and delegation/cleanup checks are all tr
 | A2: `RemoteOperations` — `remotes`, `set_remote_url`, `remote_set_branches` | ✅ |
 | A3: `ObjectOperations` — `tags`, `add_tag`, `delete_tag` | ✅ |
 | A4: new `Inspecting` — `show`, `fsck` | ✅ |
-| B (C0): `Git::Base` factory delegation wiring | ⬜ |
+| B (C0): `Git::Base` factory delegation wiring | ✅ |
 | C1a-1: `Git::Repository.open`/`.bare`, path state (`dir`, `repo`, `index`, `repo_size`) | ⬜ |
 | C1a-2: `Git::Repository.clone`/`.init` (no `Git::Lib` dependency) | ⬜ |
 | C1b: Global config ownership (`Base.config` → `Git::Config`) | ⬜ |

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -161,4 +161,134 @@ RSpec.describe Git::Base do
       expect(result).to be(worktrees_collection)
     end
   end
+
+  describe '#branch' do
+    include_context 'with a stubbed facade_repository'
+
+    subject(:result) { described_instance.branch(branch_name) }
+
+    let(:branch_name) { 'feature' }
+    let(:branch_double) { instance_double(Git::Branch) }
+
+    it 'delegates to facade_repository.branch and returns the facade result unchanged' do
+      expect(facade_repository).to receive(:branch).with(branch_name).and_return(branch_double)
+      expect(result).to be(branch_double)
+    end
+
+    context 'when called without a branch name' do
+      subject(:result) { described_instance.branch }
+
+      it 'delegates to facade_repository.branch with the current branch as the default' do
+        allow(described_instance).to receive(:current_branch).and_return('main')
+        expect(facade_repository).to receive(:branch).with('main').and_return(branch_double)
+        expect(result).to be(branch_double)
+      end
+    end
+  end
+
+  describe '#branches' do
+    include_context 'with a stubbed facade_repository'
+
+    subject(:result) { described_instance.branches }
+
+    let(:branches_collection) { instance_double(Git::Branches) }
+
+    it 'delegates to facade_repository.branches and returns the facade result unchanged' do
+      expect(facade_repository).to receive(:branches).and_return(branches_collection)
+      expect(result).to be(branches_collection)
+    end
+  end
+
+  describe '#gblob' do
+    include_context 'with a stubbed facade_repository'
+
+    subject(:result) { described_instance.gblob(objectish) }
+
+    let(:objectish) { 'HEAD:README.md' }
+    let(:object_double) { instance_double(Git::Object::Blob) }
+
+    it 'delegates to facade_repository.gblob and returns the facade result unchanged' do
+      expect(facade_repository).to receive(:gblob).with(objectish).and_return(object_double)
+      expect(result).to be(object_double)
+    end
+  end
+
+  describe '#gcommit' do
+    include_context 'with a stubbed facade_repository'
+
+    subject(:result) { described_instance.gcommit(objectish) }
+
+    let(:objectish) { 'HEAD' }
+    let(:object_double) { instance_double(Git::Object::Commit) }
+
+    it 'delegates to facade_repository.gcommit and returns the facade result unchanged' do
+      expect(facade_repository).to receive(:gcommit).with(objectish).and_return(object_double)
+      expect(result).to be(object_double)
+    end
+  end
+
+  describe '#gtree' do
+    include_context 'with a stubbed facade_repository'
+
+    subject(:result) { described_instance.gtree(objectish) }
+
+    let(:objectish) { 'HEAD^{tree}' }
+    let(:object_double) { instance_double(Git::Object::Tree) }
+
+    it 'delegates to facade_repository.gtree and returns the facade result unchanged' do
+      expect(facade_repository).to receive(:gtree).with(objectish).and_return(object_double)
+      expect(result).to be(object_double)
+    end
+  end
+
+  describe '#object' do
+    include_context 'with a stubbed facade_repository'
+
+    subject(:result) { described_instance.object(objectish) }
+
+    let(:objectish) { 'HEAD' }
+    let(:object_double) { instance_double(Git::Object::AbstractObject) }
+
+    it 'delegates to facade_repository.object and returns the facade result unchanged' do
+      expect(facade_repository).to receive(:object).with(objectish).and_return(object_double)
+      expect(result).to be(object_double)
+    end
+  end
+
+  describe '#remote' do
+    include_context 'with a stubbed facade_repository'
+
+    subject(:result) { described_instance.remote(remote_name) }
+
+    let(:remote_name) { 'upstream' }
+    let(:remote_double) { instance_double(Git::Remote) }
+
+    it 'delegates to facade_repository.remote and returns the facade result unchanged' do
+      expect(facade_repository).to receive(:remote).with(remote_name).and_return(remote_double)
+      expect(result).to be(remote_double)
+    end
+
+    context 'when called without a remote name' do
+      subject(:result) { described_instance.remote }
+
+      it "delegates to facade_repository.remote with 'origin' as the default" do
+        expect(facade_repository).to receive(:remote).with('origin').and_return(remote_double)
+        expect(result).to be(remote_double)
+      end
+    end
+  end
+
+  describe '#tag' do
+    include_context 'with a stubbed facade_repository'
+
+    subject(:result) { described_instance.tag(tag_name) }
+
+    let(:tag_name) { 'v1.0.0' }
+    let(:tag_double) { instance_double(Git::Object::Tag) }
+
+    it 'delegates to facade_repository.tag and returns the facade result unchanged' do
+      expect(facade_repository).to receive(:tag).with(tag_name).and_return(tag_double)
+      expect(result).to be(tag_double)
+    end
+  end
 end


### PR DESCRIPTION
# Description

Implements **Step B (Workstream B / C0)** of the architectural redesign
(`redesign/3_architecture_implementation.md`): pure delegation wiring that
redirects the `Git::Base` domain-object factory methods to the internal
`facade_repository` (`Git::Repository`) instead of constructing domain objects
directly with `self`.

All corresponding facade methods already exist on `Git::Repository`, so no new
facade code was needed. The returned domain object classes are unchanged; only
their provider becomes a `Git::Repository` rather than `Git::Base`.

## Methods redirected (`lib/git/base.rb`)

| Method | Now delegates to |
| --- | --- |
| `branch(branch_name = current_branch)` | `facade_repository.branch(branch_name)` |
| `branches` | `facade_repository.branches` |
| `gblob(objectish)` | `facade_repository.gblob(objectish)` |
| `gcommit(objectish)` | `facade_repository.gcommit(objectish)` |
| `gtree(objectish)` | `facade_repository.gtree(objectish)` |
| `object(objectish)` | `facade_repository.object(objectish)` |
| `remote(remote_name = 'origin')` | `facade_repository.remote(remote_name)` |
| `tag(tag_name)` | `facade_repository.tag(tag_name)` |

# Why this change is needed

This is a prerequisite for flipping the top-level entry points (`Git.open`,
`Git.clone`, etc.) to return `Git::Repository`. Routing the factories through
`facade_repository` removes direct `self`-as-provider construction from
`Git::Base` while preserving every public signature, default argument, and
return contract.

# Test coverage

- **Unit tests:** Added focused specs in `spec/unit/git/base_spec.rb` for all
  eight factories (22 examples total, 0 failures). Each proves: (a) the facade
  result is returned unchanged, (b) the delegation routes through
  `facade_repository` (a `Git::Repository`), and (c) legacy signatures and
  default arguments are preserved (dedicated no-arg contexts for `branch` and
  `remote`). 100% line and branch coverage of the changed methods.
- **Backward-compatibility audit:** Verified no signature, return-contract, or
  deprecation regressions. Confirmed the returned domain objects only invoke
  provider methods that exist on `Git::Repository`. Legacy Test::Unit suites
  (`test_branch`, `test_object`, `test_object_new`, `test_remotes`,
  `test_tags`) pass unchanged.
- `bundle exec rake default:parallel` passes (all tests + RuboCop + YARD +
  build).

# Breaking changes

None. Public method signatures, default arguments, and return types are
unchanged.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
