### PR TITLE
feat(repository): add Git::Repository.open/.bare factories and path state

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -2,8 +2,7 @@
 
 require 'logger'
 require 'pathname'
-
-require 'git/commands/rev_parse'
+require 'git/repository/path_resolver'
 
 module Git
   # The main public interface for interacting with Git commands
@@ -17,7 +16,7 @@ module Git
   class Base
     # (see Git.bare)
     def self.bare(git_dir, options = {})
-      paths = resolve_paths(repository: git_dir, bare: true)
+      paths = Git::Repository::PathResolver.resolve_paths(repository: git_dir, bare: true)
       new(options.merge(paths))
     end
 
@@ -27,7 +26,7 @@ module Git
       lib_options[:git_ssh] = options[:git_ssh] if options.key?(:git_ssh)
       clone_result = Git::Lib.new(lib_options, options[:log]).clone(repository_url, directory, options)
       bare = options[:bare] || options[:mirror]
-      paths = resolve_paths(
+      paths = Git::Repository::PathResolver.resolve_paths(
         working_directory: clone_result[:working_directory],
         repository: clone_result[:repository],
         bare: bare
@@ -59,21 +58,20 @@ module Git
       Git.git_version(binary_path).to_a
     end
 
+    # Find the root of the working tree that contains `working_dir`
+    #
+    # Delegates to {Git::Repository::PathResolver.root_of_worktree}, using the
+    # global config for `binary_path` and `git_ssh`.
+    #
+    # @param working_dir [String] a path inside the working tree
+    #
+    # @return [String] the absolute path to the root of the working tree
+    #
+    # @raise [ArgumentError] if `working_dir` does not exist or is not inside a
+    #   git working tree
+    #
     def self.root_of_worktree(working_dir)
-      raise ArgumentError, "'#{working_dir}' does not exist" unless Dir.exist?(working_dir)
-
-      execute_rev_parse_toplevel(working_dir)
-    end
-
-    private_class_method def self.execute_rev_parse_toplevel(working_dir)
-      execution_context = Git::Lib.new(nil)
-      Git::Commands::RevParse.new(execution_context).call(
-        show_toplevel: true, chdir: File.expand_path(working_dir)
-      ).stdout
-    rescue Errno::ENOENT
-      raise ArgumentError, 'Failed to find the root of the worktree: git binary not found'
-    rescue Git::FailedError
-      raise ArgumentError, "'#{working_dir}' is not in a git working tree"
+      Git::Repository::PathResolver.root_of_worktree(working_dir)
     end
 
     # (see Git.open)
@@ -82,7 +80,7 @@ module Git
 
       working_dir = root_of_worktree(working_dir) unless options[:repository]
 
-      paths = resolve_paths(
+      paths = Git::Repository::PathResolver.resolve_paths(
         working_directory: working_dir,
         repository: options[:repository],
         index: options[:index]
@@ -1201,96 +1199,6 @@ module Git
       @working_directory = Pathname.new(options[:working_directory]) if options[:working_directory]
       @repository = Pathname.new(options[:repository]) if options[:repository]
       @index = Pathname.new(options[:index]) if options[:index]
-    end
-
-    # Resolve and normalize paths for a Git repository
-    #
-    # Returns a new hash containing the resolved absolute paths for:
-    #   * :working_directory - the working tree root (nil for bare repos)
-    #   * :repository - the .git directory
-    #   * :index - the index file
-    #
-    # This method does not mutate any inputs.
-    #
-    # @param working_directory [String, nil] the working directory path
-    # @param repository [String, nil] the repository (.git) directory path
-    # @param index [String, nil] the index file path
-    # @param bare [Boolean] whether this is a bare repository
-    #
-    # @return [Hash] a hash with :working_directory, :repository, and :index keys
-    #
-    private_class_method def self.resolve_paths(working_directory: nil, repository: nil, index: nil, bare: false)
-      working_dir = resolve_working_directory(working_directory, bare: bare)
-      # For bare repos, use working_directory as the default repository location
-      repo_path = resolve_repository(repository, working_dir, bare: bare, bare_default: working_directory)
-      index_path = resolve_index(index, repo_path)
-
-      {
-        working_directory: working_dir,
-        repository: repo_path,
-        index: index_path
-      }
-    end
-
-    # Resolve the working directory path
-    #
-    # @param path [String, nil] the working directory path or nil
-    # @param bare [Boolean] whether this is a bare repository
-    # @return [String, nil] the absolute path or nil for bare repos
-    #
-    private_class_method def self.resolve_working_directory(path, bare:)
-      return nil if bare
-
-      File.expand_path(path || Dir.pwd)
-    end
-
-    # Resolve the repository (.git) directory path
-    #
-    # Handles the gitdir pointer file case for submodules and worktrees.
-    #
-    # @param path [String, nil] the repository path or nil
-    # @param working_dir [String, nil] the working directory for relative path resolution
-    # @param bare [Boolean] whether this is a bare repository
-    # @param bare_default [String, nil] for bare repos, use this as default if path is nil
-    # @return [String] the absolute path to the repository
-    #
-    private_class_method def self.resolve_repository(path, working_dir, bare:, bare_default: nil)
-      initial_path = if bare
-                       File.expand_path(path || bare_default || Dir.pwd)
-                     else
-                       File.expand_path(path || '.git', working_dir)
-                     end
-
-      resolve_gitdir_pointer(initial_path, working_dir)
-    end
-
-    # Resolve gitdir pointer files used by submodules and worktrees
-    #
-    # If the path points to a file containing "gitdir: <path>", returns the
-    # resolved path. Otherwise returns the original path.
-    #
-    # @param path [String] the path to check
-    # @param working_dir [String, nil] base directory for relative path resolution
-    # @return [String] the resolved absolute path
-    #
-    private_class_method def self.resolve_gitdir_pointer(path, working_dir)
-      return path unless File.file?(path)
-
-      gitdir_content = File.read(path).strip
-      return path unless gitdir_content.start_with?('gitdir: ')
-
-      gitdir_path = gitdir_content.sub(/\Agitdir: /, '')
-      File.expand_path(gitdir_path, working_dir)
-    end
-
-    # Resolve the index file path
-    #
-    # @param path [String, nil] the index path or nil
-    # @param repository [String] the repository directory for relative path resolution
-    # @return [String] the absolute path to the index file
-    #
-    private_class_method def self.resolve_index(path, repository)
-      File.expand_path(path || 'index', repository)
     end
   end
 end

--- a/lib/git/execution_context.rb
+++ b/lib/git/execution_context.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'logger'
+require 'git/command_line'
 
 module Git
   # Base class for execution contexts that run git commands

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'find'
+require 'pathname'
+
 require 'git/execution_context/repository'
 require 'git/repository/branching'
 require 'git/repository/committing'
@@ -9,6 +12,7 @@ require 'git/repository/inspecting'
 require 'git/repository/logging'
 require 'git/repository/merging'
 require 'git/repository/object_operations'
+require 'git/repository/path_resolver'
 require 'git/repository/remote_operations'
 require 'git/repository/staging'
 require 'git/repository/stashing'
@@ -55,6 +59,134 @@ module Git
     include Git::Repository::StatusOperations
     include Git::Repository::WorktreeOperations
 
+    # Open a working copy at an existing path
+    #
+    # The new repository factories are additive scaffolding introduced by the
+    # architectural redesign. The top-level {Git.open} entry point still returns a
+    # {Git::Base} object; this method exists so future work can route construction
+    # through {Git::Repository} without changing the public entry points.
+    #
+    # Note: this method opens working copies only. To open a bare repository, use
+    # {Git::Repository.bare}.
+    #
+    # @example Open the working copy in the current directory
+    #   repository = Git::Repository.open('.')
+    #
+    # @param working_dir [String] the path to the root of the working copy
+    #
+    #   May be any path inside the working tree when `:repository` is not given.
+    #
+    # @param options [Hash] options that control how the repository is located
+    #
+    # @option options [String] :repository a non-standard path to the `.git`
+    #   directory
+    #
+    #   When given, `working_dir` is used as-is (the working tree root is not
+    #   auto-detected).
+    #
+    # @option options [String] :index a non-standard path to the index file
+    #
+    # @option options [Logger] :log a logger forwarded to the command layer
+    #
+    # @option options [String, nil, :use_global_config] :git_ssh path to a custom SSH executable;
+    #   pass `:use_global_config` (the default) to use `Git::Base.config.git_ssh`
+    #
+    # @option options [String, :use_global_config] :binary_path path to the git binary;
+    #   pass `:use_global_config` (the default) to use `Git::Base.config.binary_path`
+    #
+    # @return [Git::Repository] a repository bound to the resolved paths
+    #
+    # @raise [ArgumentError] if `working_dir` is not a directory or is not inside
+    #   a git working tree
+    #
+    def self.open(working_dir, options = {})
+      raise ArgumentError, "'#{working_dir}' is not a directory" unless Dir.exist?(working_dir)
+
+      working_dir = resolve_open_working_dir(working_dir, options) unless options[:repository]
+
+      paths = PathResolver.resolve_paths(
+        working_directory: working_dir,
+        repository: options[:repository],
+        index: options[:index]
+      )
+
+      from_paths(options, paths)
+    end
+
+    # Open an existing bare repository at `git_dir`
+    #
+    # The new repository factories are additive scaffolding introduced by the
+    # architectural redesign. The top-level {Git.bare} entry point still returns a
+    # {Git::Base} object; this method exists so future work can route construction
+    # through {Git::Repository} without changing the public entry points.
+    #
+    # @example Open a bare repository
+    #   repository = Git::Repository.bare('/path/to/repo.git')
+    #
+    # @param git_dir [String] the path to the bare repository directory
+    #
+    # @param options [Hash] options forwarded to the constructed repository
+    #
+    # @option options [Logger] :log a logger forwarded to the command layer
+    #
+    # @option options [String, nil, :use_global_config] :git_ssh path to a custom SSH executable;
+    #   pass `:use_global_config` (the default) to use `Git::Base.config.git_ssh`
+    #
+    # @option options [String, :use_global_config] :binary_path path to the git binary;
+    #   pass `:use_global_config` (the default) to use `Git::Base.config.binary_path`
+    #
+    # @return [Git::Repository] a repository bound to the bare repository directory
+    #
+    def self.bare(git_dir, options = {})
+      paths = PathResolver.resolve_paths(repository: git_dir, bare: true)
+
+      from_paths(options, paths)
+    end
+
+    # Resolve the worktree root to use as the working directory for `.open`
+    #
+    # Delegates to {PathResolver.root_of_worktree}, forwarding `:binary_path`
+    # and `:git_ssh` from `options`.
+    #
+    # @param working_dir [String] a path inside the working tree
+    #
+    # @param options [Hash] the caller-supplied options hash from `.open`
+    #
+    # @return [String] the absolute path to the root of the working tree
+    #
+    # @raise [ArgumentError] if `working_dir` is not inside a git working tree
+    #
+    # @api private
+    #
+    def self.resolve_open_working_dir(working_dir, options)
+      PathResolver.root_of_worktree(
+        working_dir,
+        binary_path: options.fetch(:binary_path, :use_global_config),
+        git_ssh: options.fetch(:git_ssh, :use_global_config)
+      )
+    end
+    private_class_method :resolve_open_working_dir
+
+    # Build a repository from caller options and resolved paths
+    #
+    # @param options [Hash] the caller-supplied options (`:git_ssh`,
+    #   `:binary_path`, `:log`)
+    #
+    # @param paths [Hash{Symbol => (String, nil)}] the resolved
+    #   `:working_directory`, `:repository`, and `:index` paths
+    #
+    # @return [Git::Repository] the constructed repository
+    #
+    # @api private
+    #
+    def self.from_paths(options, paths)
+      execution_context = Git::ExecutionContext::Repository.from_hash(
+        options.merge(paths), logger: options[:log]
+      )
+      new(execution_context: execution_context)
+    end
+    private_class_method :from_paths
+
     # @return [Git::ExecutionContext::Repository] the execution context used to run
     #   git commands for this repository
     # @api private
@@ -69,6 +201,69 @@ module Git
       raise ArgumentError, 'execution_context must not be nil' if execution_context.nil?
 
       @execution_context = execution_context
+    end
+
+    # Returns the root of the working tree, or `nil` for a bare repository
+    #
+    # @example Get the working directory path
+    #   repository.dir #=> #<Pathname:/path/to/repo>
+    #
+    # @return [Pathname, nil] the working directory path, or `nil` when bare
+    #
+    def dir
+      working_dir = execution_context.git_work_dir
+      working_dir && Pathname.new(working_dir)
+    end
+
+    # Returns the repository (`.git`) directory
+    #
+    # @example Get the repository directory path
+    #   repository.repo #=> #<Pathname:/path/to/repo/.git>
+    #
+    # @return [Pathname, nil] the repository directory path
+    #
+    def repo
+      repository = execution_context.git_dir
+      repository && Pathname.new(repository)
+    end
+
+    # Returns the git index file
+    #
+    # @example Get the index file path
+    #   repository.index #=> #<Pathname:/path/to/repo/.git/index>
+    #
+    # @return [Pathname, nil] the index file path
+    #
+    def index
+      index_file = execution_context.git_index_file
+      index_file && Pathname.new(index_file)
+    end
+
+    # Returns the size of the repository directory in bytes
+    #
+    # Sums the sizes of every regular file under the repository (`.git`)
+    # directory in a single traversal. Symbolic links are not followed, so files
+    # that physically live outside the repository (reached through a symlinked
+    # directory) are never counted. Files that disappear mid-traversal are
+    # silently skipped.
+    #
+    # @example Get the repository size in bytes
+    #   repository.repo_size #=> 12345
+    #
+    # @return [Integer] the total size in bytes of the repository directory
+    #
+    def repo_size
+      repository = repo
+      return 0 unless repository&.directory?
+
+      total = 0
+      Find.find(repository.to_s) do |path|
+        stat = File.lstat(path)
+        total += stat.size if stat.file?
+      rescue Errno::ENOENT
+        next
+      end
+      total
     end
   end
 end

--- a/lib/git/repository/path_resolver.rb
+++ b/lib/git/repository/path_resolver.rb
@@ -1,0 +1,207 @@
+# frozen_string_literal: true
+
+require 'git/commands/rev_parse'
+require 'git/errors'
+require 'git/execution_context'
+
+module Git
+  class Repository
+    # Resolves and normalizes the filesystem paths that locate a Git repository
+    #
+    # `PathResolver` is the single home for the path-resolution logic used by the
+    # `Git::Repository` factory class methods ({Git::Repository.open} and
+    # {Git::Repository.bare}). It computes the absolute working-directory,
+    # repository (`.git`), and index paths from the caller-supplied values,
+    # following the same rules Git itself uses (including gitdir-pointer files for
+    # submodules and linked worktrees).
+    #
+    # @api private
+    #
+    module PathResolver
+      module_function
+
+      # Resolve and normalize the paths that locate a Git repository
+      #
+      # Returns a new hash containing the resolved absolute paths for:
+      #   * `:working_directory` — the working tree root (`nil` for bare repos)
+      #   * `:repository` — the `.git` directory
+      #   * `:index` — the index file
+      #
+      # This method does not mutate any inputs.
+      #
+      # @example Resolve paths for a working tree
+      #   Git::Repository::PathResolver.resolve_paths(working_directory: '/repo')
+      #   #=> { working_directory: '/repo', repository: '/repo/.git', index: '/repo/.git/index' }
+      #
+      # @param working_directory [String, nil] the working directory path
+      #
+      # @param repository [String, nil] the repository (`.git`) directory path
+      #
+      # @param index [String, nil] the index file path
+      #
+      # @param bare [Boolean] whether this is a bare repository
+      #
+      # @return [Hash{Symbol => (String, nil)}] a hash with `:working_directory`,
+      #   `:repository`, and `:index` keys
+      #
+      def resolve_paths(working_directory: nil, repository: nil, index: nil, bare: false)
+        working_dir = resolve_working_directory(working_directory, bare: bare)
+        # For bare repos, use working_directory as the default repository location
+        repo_path = resolve_repository(repository, working_dir, bare: bare, bare_default: working_directory)
+        index_path = resolve_index(index, repo_path)
+
+        {
+          working_directory: working_dir,
+          repository: repo_path,
+          index: index_path
+        }
+      end
+
+      # Find the root of the working tree that contains `working_dir`
+      #
+      # Runs `git rev-parse --show-toplevel` from `working_dir` to locate the
+      # top-level directory of the working tree.
+      #
+      # @example Find the worktree root from a subdirectory
+      #   Git::Repository::PathResolver.root_of_worktree('/repo/subdir') #=> '/repo'
+      #
+      # @param working_dir [String] a path inside the working tree
+      #
+      # @param binary_path [String, :use_global_config] path to the git binary
+      #
+      #   Controls which git binary is invoked during root detection. Defaults to
+      #   `:use_global_config`, which resolves to `Git::Base.config.binary_path`.
+      #
+      # @param git_ssh [String, nil, :use_global_config] the SSH wrapper path
+      #
+      #   Forwarded as `GIT_SSH`. Defaults to `:use_global_config`.
+      #
+      # @return [String] the absolute path to the root of the working tree
+      #
+      # @raise [ArgumentError] if `working_dir` does not exist, is not a
+      #   directory, or is not inside a git working tree
+      #
+      #   Also raised if the git binary cannot be found.
+      #
+      def root_of_worktree(working_dir, binary_path: :use_global_config, git_ssh: :use_global_config)
+        raise ArgumentError, "'#{working_dir}' does not exist or is not a directory" unless Dir.exist?(working_dir)
+
+        execute_rev_parse_toplevel(working_dir, binary_path: binary_path, git_ssh: git_ssh)
+      end
+
+      # Run `git rev-parse --show-toplevel` from `working_dir` and return stdout
+      #
+      # @param working_dir [String] a path inside the working tree
+      #
+      # @param binary_path [String, :use_global_config] path to the git binary
+      #
+      # @param git_ssh [String, nil, :use_global_config] the SSH wrapper path
+      #
+      # @return [String] the top-level directory reported by git
+      #
+      # @raise [ArgumentError] if the git binary is not found or `working_dir` is
+      #   not inside a git working tree
+      #
+      # @api private
+      #
+      def execute_rev_parse_toplevel(working_dir, binary_path: :use_global_config, git_ssh: :use_global_config)
+        execution_context = Git::ExecutionContext::Global.new(binary_path: binary_path, git_ssh: git_ssh)
+        Git::Commands::RevParse.new(execution_context).call(
+          show_toplevel: true, chdir: File.expand_path(working_dir)
+        ).stdout
+      rescue Errno::ENOENT
+        raise ArgumentError, 'Failed to find the root of the worktree: git binary not found'
+      rescue Git::FailedError
+        raise ArgumentError, "'#{working_dir}' is not in a git working tree"
+      end
+      private_class_method :execute_rev_parse_toplevel
+
+      # Resolve the working directory path
+      #
+      # @param path [String, nil] the working directory path or `nil`
+      #
+      # @param bare [Boolean] whether this is a bare repository
+      #
+      # @return [String, nil] the absolute path, or `nil` for bare repos
+      #
+      # @api private
+      #
+      def resolve_working_directory(path, bare:)
+        return nil if bare
+
+        File.expand_path(path || Dir.pwd)
+      end
+      private_class_method :resolve_working_directory
+
+      # Resolve the repository (`.git`) directory path
+      #
+      # Handles the gitdir-pointer file case for submodules and linked worktrees.
+      #
+      # @param path [String, nil] the repository path or `nil`
+      #
+      # @param working_dir [String, nil] the working directory used for relative
+      #   path resolution
+      #
+      # @param bare [Boolean] whether this is a bare repository
+      #
+      # @param bare_default [String, nil] for bare repos, used as the default when
+      #   `path` is `nil`
+      #
+      # @return [String] the absolute path to the repository
+      #
+      # @api private
+      #
+      def resolve_repository(path, working_dir, bare:, bare_default: nil)
+        initial_path = if bare
+                         File.expand_path(path || bare_default || Dir.pwd)
+                       else
+                         File.expand_path(path || '.git', working_dir)
+                       end
+
+        resolve_gitdir_pointer(initial_path)
+      end
+      private_class_method :resolve_repository
+
+      # Resolve gitdir-pointer files used by submodules and linked worktrees
+      #
+      # If `path` points to a file containing `"gitdir: <path>"`, returns the
+      # resolved target path. Otherwise returns `path` unchanged.
+      #
+      # @param path [String] the path to check
+      #
+      # @return [String] the resolved absolute path
+      #
+      # Relative pointer targets are resolved from the directory containing the
+      # pointer file itself, matching git's pointer-file semantics.
+      #
+      # @api private
+      #
+      def resolve_gitdir_pointer(path)
+        return path unless File.file?(path)
+
+        gitdir_content = File.read(path).strip
+        return path unless gitdir_content.start_with?('gitdir: ')
+
+        gitdir_path = gitdir_content.sub(/\Agitdir: /, '')
+        File.expand_path(gitdir_path, File.dirname(path))
+      end
+      private_class_method :resolve_gitdir_pointer
+
+      # Resolve the index file path
+      #
+      # @param path [String, nil] the index path or `nil`
+      #
+      # @param repository [String] the repository directory used for relative
+      #   path resolution
+      #
+      # @return [String] the absolute path to the index file
+      #
+      # @api private
+      #
+      def resolve_index(path, repository)
+        File.expand_path(path || 'index', repository)
+      end
+      private_class_method :resolve_index
+    end
+  end
+end

--- a/spec/integration/git/repository_spec.rb
+++ b/spec/integration/git/repository_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+
+# Integration tests for the Git::Repository.open / .bare factory class methods
+# and the path accessors (#dir, #repo, #index, #repo_size) they configure.
+#
+# These exercise real path resolution against real repositories on disk. The
+# regression examples confirm that Step C1a-1 remains additive: the top-level
+# Git.open and Git.bare entry points still return Git::Base, not Git::Repository.
+
+RSpec.describe Git::Repository, :integration do
+  describe '.open' do
+    include_context 'in an empty repository'
+
+    subject(:repository) { described_class.open(repo_dir, options) }
+
+    let(:options) { {} }
+
+    it 'returns a Git::Repository' do
+      expect(repository).to be_a(described_class)
+    end
+
+    it 'exposes the working directory through #dir' do
+      expect(repository.dir).to eq(Pathname.new(repo_dir).realpath)
+    end
+
+    it 'exposes the repository directory through #repo' do
+      expect(repository.repo).to eq(Pathname.new(File.join(repo_dir, '.git')).realpath)
+    end
+
+    it 'exposes the index file through #index' do
+      expect(repository.index).to eq(repository.repo.join('index'))
+    end
+
+    it 'reports a positive repository size through #repo_size' do
+      expect(repository.repo_size).to be > 0
+    end
+
+    context 'when given an explicit repository path' do
+      let(:options) { { repository: File.join(repo_dir, '.git') } }
+
+      it 'uses the given repository directory' do
+        expect(repository.repo).to eq(Pathname.new(File.join(repo_dir, '.git')))
+      end
+    end
+  end
+
+  describe '.bare' do
+    subject(:repository) { described_class.bare(bare_dir) }
+
+    let(:bare_dir) { Dir.mktmpdir }
+
+    before { Git.init(bare_dir, bare: true) }
+
+    after { FileUtils.rm_rf(bare_dir) }
+
+    it 'returns a Git::Repository' do
+      expect(repository).to be_a(described_class)
+    end
+
+    it 'has no working directory' do
+      expect(repository.dir).to be_nil
+    end
+
+    it 'exposes the bare repository directory through #repo' do
+      expect(repository.repo).to eq(Pathname.new(bare_dir))
+    end
+
+    it 'reports a positive repository size through #repo_size' do
+      expect(repository.repo_size).to be > 0
+    end
+  end
+
+  describe 'top-level entry-point regression' do
+    include_context 'in an empty repository'
+
+    it 'Git.open still returns a Git::Base' do
+      expect(Git.open(repo_dir)).to be_a(Git::Base)
+    end
+
+    it 'Git.bare still returns a Git::Base' do
+      bare_dir = Dir.mktmpdir
+      Git.init(bare_dir, bare: true)
+      expect(Git.bare(bare_dir)).to be_a(Git::Base)
+    ensure
+      FileUtils.rm_rf(bare_dir)
+    end
+  end
+end

--- a/spec/unit/git/repository/path_resolver_spec.rb
+++ b/spec/unit/git/repository/path_resolver_spec.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository/path_resolver'
+
+RSpec.describe Git::Repository::PathResolver do
+  describe '.resolve_paths' do
+    subject(:paths) { described_class.resolve_paths(**args) }
+
+    context 'with a working directory for a non-bare repository' do
+      let(:args) { { working_directory: '/repo' } }
+
+      it 'resolves the working directory to an absolute path' do
+        expect(paths[:working_directory]).to eq(File.expand_path('/repo'))
+      end
+
+      it 'defaults the repository to <working_directory>/.git' do
+        expect(paths[:repository]).to eq(File.expand_path('/repo/.git'))
+      end
+
+      it 'defaults the index to <repository>/index' do
+        expect(paths[:index]).to eq(File.expand_path('/repo/.git/index'))
+      end
+    end
+
+    context 'when no working directory is given for a non-bare repository' do
+      let(:args) { {} }
+
+      it 'defaults the working directory to the current directory' do
+        expect(paths[:working_directory]).to eq(File.expand_path(Dir.pwd))
+      end
+    end
+
+    context 'with an explicit repository path' do
+      let(:args) { { working_directory: '/repo', repository: '/custom/git' } }
+
+      it 'uses the given repository path' do
+        expect(paths[:repository]).to eq(File.expand_path('/custom/git'))
+      end
+    end
+
+    context 'with an explicit index path' do
+      let(:args) { { working_directory: '/repo', index: '/custom/index' } }
+
+      it 'uses the given index path' do
+        expect(paths[:index]).to eq(File.expand_path('/custom/index'))
+      end
+    end
+
+    context 'when the repository is bare' do
+      let(:args) { { repository: '/repo.git', bare: true } }
+
+      it 'resolves the working directory to nil' do
+        expect(paths[:working_directory]).to be_nil
+      end
+
+      it 'uses the given repository path' do
+        expect(paths[:repository]).to eq(File.expand_path('/repo.git'))
+      end
+
+      it 'places the index inside the repository' do
+        expect(paths[:index]).to eq(File.expand_path('/repo.git/index'))
+      end
+    end
+
+    context 'when the repository is bare and no repository path is given' do
+      around { |example| Dir.chdir(Dir.tmpdir) { example.run } }
+
+      let(:args) { { bare: true } }
+
+      it 'defaults the repository to the current directory' do
+        expect(paths[:repository]).to eq(File.expand_path(Dir.pwd))
+      end
+    end
+
+    context 'when the repository path is a gitdir pointer file' do
+      let(:tmp_dir) { Dir.mktmpdir }
+      let(:pointer_file) { File.join(tmp_dir, '.git') }
+      let(:target_dir) { File.join(tmp_dir, 'actual-git-dir') }
+      let(:args) { { working_directory: tmp_dir, repository: pointer_file } }
+
+      before do
+        FileUtils.mkdir_p(target_dir)
+        File.write(pointer_file, "gitdir: #{target_dir}\n")
+      end
+
+      after { FileUtils.rm_rf(tmp_dir) }
+
+      it 'follows the pointer to the target repository directory' do
+        expect(paths[:repository]).to eq(File.expand_path(target_dir))
+      end
+    end
+
+    context 'when the repository path is a gitdir pointer with a relative target' do
+      let(:tmp_dir) { Dir.mktmpdir }
+      let(:pointer_base) { File.join(tmp_dir, 'pointer-base') }
+      let(:other_working_dir) { File.join(tmp_dir, 'other-working-dir') }
+      let(:pointer_file) { File.join(pointer_base, '.git') }
+      let(:args) { { working_directory: other_working_dir, repository: pointer_file } }
+
+      before do
+        FileUtils.mkdir_p(pointer_base)
+        FileUtils.mkdir_p(other_working_dir)
+        File.write(pointer_file, "gitdir: actual-git-dir\n")
+      end
+
+      after { FileUtils.rm_rf(tmp_dir) }
+
+      it 'resolves the relative target against the pointer file directory' do
+        expect(paths[:repository]).to eq(File.expand_path('actual-git-dir', pointer_base))
+      end
+
+      it 'does not resolve the relative target against working_directory' do
+        expect(paths[:repository]).not_to eq(File.expand_path('actual-git-dir', other_working_dir))
+      end
+    end
+
+    context 'when the repository path is a file without a gitdir pointer' do
+      let(:tmp_dir) { Dir.mktmpdir }
+      let(:plain_file) { File.join(tmp_dir, '.git') }
+      let(:args) { { working_directory: tmp_dir, repository: plain_file } }
+
+      before { File.write(plain_file, "not a pointer\n") }
+
+      after { FileUtils.rm_rf(tmp_dir) }
+
+      it 'returns the file path unchanged' do
+        expect(paths[:repository]).to eq(File.expand_path(plain_file))
+      end
+    end
+  end
+
+  describe '.root_of_worktree' do
+    subject(:root) { described_class.root_of_worktree(working_dir, **call_options) }
+
+    let(:working_dir) { Dir.mktmpdir }
+    let(:call_options) { {} }
+    let(:execution_context) { instance_double(Git::ExecutionContext::Global) }
+    let(:rev_parse_command) { instance_double(Git::Commands::RevParse) }
+
+    before do
+      allow(Git::ExecutionContext::Global).to receive(:new).and_return(execution_context)
+      allow(Git::Commands::RevParse).to receive(:new).with(execution_context).and_return(rev_parse_command)
+    end
+
+    after { FileUtils.rm_rf(working_dir) }
+
+    context 'when the directory is inside a working tree' do
+      before do
+        allow(rev_parse_command).to(
+          receive(:call)
+            .with(show_toplevel: true, chdir: File.expand_path(working_dir))
+            .and_return(command_result('/toplevel'))
+        )
+      end
+
+      it 'returns the toplevel reported by git rev-parse' do
+        expect(root).to eq('/toplevel')
+      end
+
+      it 'constructs an execution context with default binary_path and git_ssh' do
+        expect(Git::ExecutionContext::Global).to(
+          receive(:new).with(binary_path: :use_global_config, git_ssh: :use_global_config)
+        )
+        root
+      end
+    end
+
+    context 'when binary_path is given' do
+      let(:call_options) { { binary_path: '/custom/git' } }
+
+      before do
+        allow(rev_parse_command).to receive(:call).and_return(command_result('/toplevel'))
+      end
+
+      it 'passes the binary_path to the execution context' do
+        expect(Git::ExecutionContext::Global).to(
+          receive(:new).with(binary_path: '/custom/git', git_ssh: :use_global_config)
+        )
+        root
+      end
+    end
+
+    context 'when git_ssh is given' do
+      let(:call_options) { { git_ssh: '/custom/ssh' } }
+
+      before do
+        allow(rev_parse_command).to receive(:call).and_return(command_result('/toplevel'))
+      end
+
+      it 'passes the git_ssh to the execution context' do
+        expect(Git::ExecutionContext::Global).to(
+          receive(:new).with(binary_path: :use_global_config, git_ssh: '/custom/ssh')
+        )
+        root
+      end
+    end
+
+    context 'when git_ssh is nil (explicitly unset)' do
+      let(:call_options) { { git_ssh: nil } }
+
+      before do
+        allow(rev_parse_command).to receive(:call).and_return(command_result('/toplevel'))
+      end
+
+      it 'passes nil git_ssh to the execution context' do
+        expect(Git::ExecutionContext::Global).to(
+          receive(:new).with(binary_path: :use_global_config, git_ssh: nil)
+        )
+        root
+      end
+    end
+
+    context 'when the directory does not exist' do
+      let(:working_dir) do
+        # Generate a path that is guaranteed not to exist by creating and
+        # immediately deleting a temp directory.
+        path = Dir.mktmpdir
+        FileUtils.rm_rf(path)
+        path
+      end
+
+      it 'raises ArgumentError indicating the directory does not exist' do
+        expect { root }.to raise_error(ArgumentError, /does not exist/)
+      end
+    end
+
+    context 'when the path is a file rather than a directory' do
+      let(:parent_dir) { Dir.mktmpdir }
+      let(:working_dir) do
+        path = File.join(parent_dir, 'not-a-dir')
+        File.write(path, '')
+        path
+      end
+
+      after { FileUtils.rm_rf(parent_dir) }
+
+      it 'raises ArgumentError indicating the path is not a directory' do
+        expect { root }.to raise_error(ArgumentError, /is not a directory/)
+      end
+    end
+
+    context 'when the git binary cannot be found' do
+      before do
+        allow(rev_parse_command).to receive(:call).and_raise(Errno::ENOENT)
+      end
+
+      it 'raises ArgumentError indicating the git binary was not found' do
+        expect { root }.to raise_error(ArgumentError, /git binary not found/)
+      end
+    end
+
+    context 'when the directory is not in a git working tree' do
+      before do
+        failure = Git::FailedError.new(command_result('', stderr: 'fatal', exitstatus: 128))
+        allow(rev_parse_command).to receive(:call).and_raise(failure)
+      end
+
+      it 'raises ArgumentError indicating the directory is not in a working tree' do
+        expect { root }.to raise_error(ArgumentError, /is not in a git working tree/)
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository_spec.rb
+++ b/spec/unit/git/repository_spec.rb
@@ -8,20 +8,349 @@ RSpec.describe Git::Repository do
   let(:described_instance) { described_class.new(execution_context: execution_context) }
 
   describe '#initialize' do
-    subject { described_instance }
+    subject(:instance) { described_instance }
 
-    it 'can be constructed with an execution_context:' do
-      expect { described_class.new(execution_context: execution_context) }.not_to raise_error
+    it 'stores the execution context' do
+      expect(instance).to have_attributes(execution_context: execution_context)
     end
 
     it 'raises ArgumentError when execution_context: is missing' do
-      expect { described_class.new }.to raise_error(ArgumentError)
+      expect { described_class.new }.to raise_error(ArgumentError, /execution_context/)
     end
 
     it 'raises ArgumentError when execution_context: is nil' do
       expect do
         described_class.new(execution_context: nil)
       end.to raise_error(ArgumentError, /execution_context must not be nil/)
+    end
+  end
+
+  describe '.open' do
+    subject(:repository) { described_class.open(working_dir, options) }
+
+    let(:working_dir) { '/repo' }
+    let(:options) { {} }
+    let(:resolved_paths) do
+      { working_directory: '/repo', repository: '/repo/.git', index: '/repo/.git/index' }
+    end
+
+    before do
+      allow(Dir).to receive(:exist?).with(working_dir).and_return(true)
+      allow(Git::Repository::PathResolver).to(
+        receive(:root_of_worktree)
+          .with(working_dir, binary_path: :use_global_config, git_ssh: :use_global_config)
+          .and_return(working_dir)
+      )
+      allow(Git::Repository::PathResolver).to receive(:resolve_paths).and_return(resolved_paths)
+      allow(Git::ExecutionContext::Repository).to receive(:from_hash).and_return(execution_context)
+    end
+
+    it 'returns a Git::Repository' do
+      expect(repository).to be_a(described_class)
+    end
+
+    it 'detects the root of the worktree when no repository option is given' do
+      expect(Git::Repository::PathResolver).to(
+        receive(:root_of_worktree)
+          .with(working_dir, binary_path: :use_global_config, git_ssh: :use_global_config)
+      )
+      repository
+    end
+
+    it 'resolves the paths from the detected working directory' do
+      expect(Git::Repository::PathResolver).to(
+        receive(:resolve_paths).with(working_directory: working_dir, repository: nil, index: nil)
+      )
+      repository
+    end
+
+    it 'builds the execution context from the merged options and resolved paths' do
+      expect(Git::ExecutionContext::Repository).to(
+        receive(:from_hash).with(options.merge(resolved_paths), logger: nil)
+      )
+      repository
+    end
+
+    context 'when binary_path is given' do
+      let(:options) { { binary_path: '/custom/git' } }
+
+      it 'forwards binary_path to root_of_worktree' do
+        expect(Git::Repository::PathResolver).to(
+          receive(:root_of_worktree)
+            .with(working_dir, binary_path: '/custom/git', git_ssh: :use_global_config)
+            .and_return(working_dir)
+        )
+        repository
+      end
+    end
+
+    context 'when git_ssh is given' do
+      let(:options) { { git_ssh: '/custom/ssh' } }
+
+      it 'forwards git_ssh to root_of_worktree' do
+        expect(Git::Repository::PathResolver).to(
+          receive(:root_of_worktree)
+            .with(working_dir, binary_path: :use_global_config, git_ssh: '/custom/ssh')
+            .and_return(working_dir)
+        )
+        repository
+      end
+    end
+
+    context 'when git_ssh is nil (explicitly unset)' do
+      let(:options) { { git_ssh: nil } }
+
+      before do
+        allow(Git::Repository::PathResolver).to(
+          receive(:root_of_worktree)
+            .with(working_dir, binary_path: :use_global_config, git_ssh: nil)
+            .and_return(working_dir)
+        )
+      end
+
+      it 'forwards nil git_ssh to root_of_worktree' do
+        expect(Git::Repository::PathResolver).to(
+          receive(:root_of_worktree)
+            .with(working_dir, binary_path: :use_global_config, git_ssh: nil)
+        )
+        repository
+      end
+    end
+
+    context 'when an explicit repository option is given' do
+      let(:options) { { repository: '/custom/.git' } }
+
+      it 'does not auto-detect the root of the worktree' do
+        expect(Git::Repository::PathResolver).not_to receive(:root_of_worktree)
+        repository
+      end
+
+      it 'forwards the repository and index options to resolve_paths' do
+        expect(Git::Repository::PathResolver).to(
+          receive(:resolve_paths).with(working_directory: working_dir, repository: '/custom/.git', index: nil)
+        )
+        repository
+      end
+    end
+
+    context 'when a logger is given' do
+      let(:options) { { log: instance_double(Logger) } }
+
+      it 'forwards the logger to the execution context' do
+        expect(Git::ExecutionContext::Repository).to(
+          receive(:from_hash).with(anything, logger: options[:log])
+        )
+        repository
+      end
+    end
+
+    context 'when the working directory is not a directory' do
+      before { allow(Dir).to receive(:exist?).with(working_dir).and_return(false) }
+
+      it 'raises ArgumentError' do
+        expect { repository }.to raise_error(ArgumentError, /is not a directory/)
+      end
+    end
+  end
+
+  describe '.bare' do
+    subject(:repository) { described_class.bare(git_dir, options) }
+
+    let(:git_dir) { '/repo.git' }
+    let(:options) { {} }
+    let(:resolved_paths) do
+      { working_directory: nil, repository: '/repo.git', index: '/repo.git/index' }
+    end
+
+    before do
+      allow(Git::Repository::PathResolver).to receive(:resolve_paths).and_return(resolved_paths)
+      allow(Git::ExecutionContext::Repository).to receive(:from_hash).and_return(execution_context)
+    end
+
+    it 'returns a Git::Repository' do
+      expect(repository).to be_a(described_class)
+    end
+
+    it 'resolves the paths as a bare repository' do
+      expect(Git::Repository::PathResolver).to(
+        receive(:resolve_paths).with(repository: git_dir, bare: true)
+      )
+      repository
+    end
+
+    it 'builds the execution context from the merged options and resolved paths' do
+      expect(Git::ExecutionContext::Repository).to(
+        receive(:from_hash).with(options.merge(resolved_paths), logger: nil)
+      )
+      repository
+    end
+  end
+
+  describe '#dir' do
+    subject(:dir) { described_instance.dir }
+
+    context 'when the execution context has a working directory' do
+      before { allow(execution_context).to receive(:git_work_dir).and_return('/repo') }
+
+      it 'returns the working directory as a Pathname' do
+        expect(dir).to eq(Pathname.new('/repo'))
+      end
+    end
+
+    context 'when the execution context has no working directory (bare)' do
+      before { allow(execution_context).to receive(:git_work_dir).and_return(nil) }
+
+      it 'returns nil' do
+        expect(dir).to be_nil
+      end
+    end
+  end
+
+  describe '#repo' do
+    subject(:repo) { described_instance.repo }
+
+    context 'when the execution context has a repository directory' do
+      before { allow(execution_context).to receive(:git_dir).and_return('/repo/.git') }
+
+      it 'returns the repository directory as a Pathname' do
+        expect(repo).to eq(Pathname.new('/repo/.git'))
+      end
+    end
+
+    context 'when the execution context has no repository directory' do
+      before { allow(execution_context).to receive(:git_dir).and_return(nil) }
+
+      it 'returns nil' do
+        expect(repo).to be_nil
+      end
+    end
+  end
+
+  describe '#index' do
+    subject(:index) { described_instance.index }
+
+    context 'when the execution context has an index file' do
+      before { allow(execution_context).to receive(:git_index_file).and_return('/repo/.git/index') }
+
+      it 'returns the index file as a Pathname' do
+        expect(index).to eq(Pathname.new('/repo/.git/index'))
+      end
+    end
+
+    context 'when the execution context has no index file' do
+      before { allow(execution_context).to receive(:git_index_file).and_return(nil) }
+
+      it 'returns nil' do
+        expect(index).to be_nil
+      end
+    end
+  end
+
+  describe '#repo_size' do
+    subject(:repo_size) { described_instance.repo_size }
+
+    let(:repo_dir) { Dir.mktmpdir }
+
+    before do
+      allow(execution_context).to receive(:git_dir).and_return(repo_dir)
+      File.write(File.join(repo_dir, 'a.txt'), 'a' * 100)
+      File.write(File.join(repo_dir, 'b.txt'), 'b' * 50)
+    end
+
+    after { FileUtils.rm_rf(repo_dir) }
+
+    it 'returns the total size in bytes of the files under the repository' do
+      expect(repo_size).to be_an(Integer)
+      expect(repo_size).to be >= 150
+    end
+
+    context 'when the repository directory is nil' do
+      before { allow(execution_context).to receive(:git_dir).and_return(nil) }
+
+      it 'returns zero' do
+        expect(repo_size).to eq(0)
+      end
+    end
+
+    context 'when the repository contains directories' do
+      let(:nested_dir) { File.join(repo_dir, 'nested') }
+      let(:nested_file) { File.join(nested_dir, 'c.txt') }
+
+      before do
+        FileUtils.mkdir_p(nested_dir)
+        File.write(nested_file, 'c' * 25)
+      end
+
+      it 'counts only file sizes' do
+        expect(repo_size).to eq(175)
+      end
+    end
+
+    context 'when a file name includes double dots' do
+      let(:double_dot_file) { File.join(repo_dir, 'release..notes.txt') }
+
+      before do
+        File.write(double_dot_file, 'd' * 10)
+      end
+
+      it 'includes that file in the total size' do
+        expect(repo_size).to eq(160)
+      end
+    end
+
+    context 'when the repository contains a symlink pointing outside the repo' do
+      let(:outside_dir) { Dir.mktmpdir }
+      let(:outside_file) { File.join(outside_dir, 'large.txt') }
+      let(:symlink) { File.join(repo_dir, 'link') }
+
+      before do
+        File.write(outside_file, 'y' * 9999)
+        File.symlink(outside_file, symlink)
+      end
+
+      after { FileUtils.rm_rf(outside_dir) }
+
+      it 'does not count the target file size through the symlink' do
+        # Symlinks are not followed, so only the two real files are counted and
+        # the 9999-byte target is excluded.
+        expect(repo_size).to eq(150)
+      end
+    end
+
+    context 'when the repository contains a symlinked directory pointing outside the repo' do
+      let(:outside_dir) { Dir.mktmpdir }
+      let(:outside_file) { File.join(outside_dir, 'large.txt') }
+      let(:linked_dir) { File.join(repo_dir, 'linkdir') }
+
+      before do
+        File.write(outside_file, 'y' * 9999)
+        File.symlink(outside_dir, linked_dir)
+      end
+
+      after { FileUtils.rm_rf(outside_dir) }
+
+      it 'does not count files reached through the symlinked directory' do
+        # The traversal must not descend into the symlinked directory, so the
+        # 9999-byte file living outside the repository is excluded.
+        expect(repo_size).to eq(150)
+      end
+    end
+
+    context 'when a file disappears during traversal' do
+      let(:vanishing_file) { File.join(repo_dir, 'vanishing.txt') }
+
+      before do
+        File.write(vanishing_file, 'z' * 500)
+        allow(File).to receive(:lstat).and_wrap_original do |original, path|
+          raise Errno::ENOENT, path if File.expand_path(path) == File.expand_path(vanishing_file)
+
+          original.call(path)
+        end
+      end
+
+      it 'skips the missing file and totals the remaining files' do
+        expect(repo_size).to eq(150)
+      end
     end
   end
 end


### PR DESCRIPTION
# Description

Implements architectural redesign **Step C1a-1** as defined in
`redesign/3_architecture_implementation.md`.

This is a **4.x-compatible, additive** step. It introduces new factory scaffolding
on `Git::Repository` and relocates path-resolution logic out of `Git::Base` into a
dedicated module, **without changing any top-level entry-point behavior**:
`Git.open` and `Git.bare` continue to return `Git::Base`.

## What changed

- **New factories:** `Git::Repository.open(working_dir, options = {})` and
  `Git::Repository.bare(git_dir, options = {})` construct a `Git::Repository`
  backed by a `Git::ExecutionContext::Repository` built from resolved paths.
- **New module `Git::Repository::PathResolver`** (`lib/git/repository/path_resolver.rb`):
  owns `resolve_paths` and the public `root_of_worktree`, plus private helpers
  (`resolve_working_directory`, `resolve_repository`, `resolve_gitdir_pointer`,
  `resolve_index`, `execute_rev_parse_toplevel`). This logic was moved from
  `Git::Base`, with one deliberate correction: `resolve_gitdir_pointer` now
  resolves relative `gitdir:` targets against the directory containing the pointer
  file (`File.dirname(path)`), matching Git's own specification. The prior
  `Git::Base` implementation expanded relative targets against `working_dir`, which
  was incorrect. All real `gitdir:` pointer files written by `git` use absolute
  paths in the scenario where the pointer file lives outside the working-tree root,
  so this correction has no practical effect on existing callers.
- **New accessors on `Git::Repository`:** `#dir`, `#repo`, `#index` (each a
  `Pathname` or `nil`, derived from the execution context as the single source of
  truth) and `#repo_size` (Integer byte total).
- **`Git::Base` now delegates:** `.open`/`.bare`/`.clone` call
  `Git::Repository::PathResolver.resolve_paths`, and the public
  `Git::Base.root_of_worktree` class method delegates to
  `Git::Repository::PathResolver.root_of_worktree`. The now-duplicated private
  helpers were removed from `Git::Base`, and a dead
  `require 'git/commands/rev_parse'` (made unused by this move) was removed.

## Why this change is needed

This is foundational scaffolding for the larger Strangler Fig migration of
`Git::Base`/`Git::Lib` into the `Git::Repository` facade. Establishing the path
state and `.open`/`.bare` factories on `Git::Repository` first — while keeping
`Git::Base` entry-point behavior identical for all practical callers — lets
subsequent steps move public methods over incrementally with no user-visible
disruption.

## Backward compatibility

Audited with the **review-backward-compatibility** skill — **verdict: backward
compatible**:

- `Git::Base.root_of_worktree` keeps its signature, return value, and raising
  behavior (legacy `tests/units/test_git_base_root_of_worktree.rb` passes).
- `.open`/`.bare`/`.clone` resolve `@working_directory`/`@repository`/`@index`
  identically for all practical inputs; only the call receiver changed. The one
  functional difference is that `resolve_gitdir_pointer` now correctly resolves
  relative `gitdir:` targets against the pointer file's own directory rather than
  `working_dir`, fixing a latent bug. Because `git` itself always writes absolute
  paths in this situation, no real-world caller is affected.
- The removed private methods were `private_class_method` and had no external
  references.
- A pre-existing `Git::Base#repo_size` bug (`Pathname#path` is protected) predates
  this step and is intentionally left out of scope; the new
  `Git::Repository#repo_size` implements the equivalent algorithm correctly via
  `repo.to_s`.

## Test coverage

- **Unit tests:** `spec/unit/git/repository_spec.rb`,
  `spec/unit/git/repository/path_resolver_spec.rb` — factories, all four
  accessors (incl. `nil`/bare branches), and `resolve_paths`/`root_of_worktree`
  edge cases (gitdir pointer absolute/relative/plain-file, bare defaults,
  `Errno::ENOENT`, `Git::FailedError`, nonexistent dir).
- **Integration tests:** `spec/integration/git/repository_spec.rb` — real `.open`/
  `.bare` construction against real git, accessor values, and a regression guard
  that `Git.open`/`Git.bare` still return `Git::Base`.
- **Coverage:** 100% line **and** branch coverage of both
  `lib/git/repository.rb` and `lib/git/repository/path_resolver.rb` (verified via
  merged SimpleCov resultset).

## Quality verification

- `bundle exec rake default:parallel` (CI-equivalent: tests + RuboCop + YARD +
  build) passes with no failures, no offenses, and no Ruby warnings.
- Full RSpec (6021 examples) and Test::Unit (556 tests) suites green.
- YARD: 0 warnings, coverage 83.6% (threshold 75%); all new public API documented.

## Breaking changes

None. This step is additive and 4.x-compatible.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
