### PR TITLE
chore: release v5.0.0.beta.1

### DIFF
--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -9,9 +9,7 @@
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,
-      "prerelease": true,
-      "versioning-strategy": "prerelease",
-      "prerelease-type": "beta",
+      "prerelease": false,
       "include-component-in-tag": false,
       "pull-request-title-pattern": "chore: release v${version}",
       "changelog-sections": [

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?log
   - [Ruby Version Support Policy](#ruby-version-support-policy)
   - [Git Version Support Policy](#git-version-support-policy)
 - [📢 Project Announcements 📢](#-project-announcements-)
+  - [2026-06-04: v5.0.0.beta.1 Released](#2026-06-04-v500beta1-released)
   - [2026-01-07: AI Policy Introduced](#2026-01-07-ai-policy-introduced)
   - [2025-07-09: Architectural Redesign](#2025-07-09-architectural-redesign)
   - [2025-07-07: We Now Use RuboCop](#2025-07-07-we-now-use-rubocop)
@@ -648,6 +649,17 @@ impractical. Such changes will be clearly documented in the CHANGELOG and releas
 notes.
 
 ## 📢 Project Announcements 📢
+
+### 2026-06-04: v5.0.0.beta.1 Released
+
+The architectural redesign is approximately **65% complete** and we have published
+[`git 5.0.0.beta.1`](https://rubygems.org/gems/git/versions/5.0.0.beta.1) as our
+first pre-release.
+
+The intent is full backward compatibility with 4.x, but given the size and scope of
+the redesign, some incompatibilities may exist. Please give the latest beta a try and
+[open an issue](https://github.com/ruby-git/ruby-git/issues) if you hit anything
+unexpected — your feedback helps us ship a solid 5.0.0.
 
 ### 2026-01-07: AI Policy Introduced
 

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -4,7 +4,7 @@ module Git
   # The current gem version
   #
   # @return [String] the current gem version
-  VERSION = '4.1.2'
+  VERSION = '5.0.0.beta.1'
 
   # Represents a git version with major, minor, and patch components
   #


### PR DESCRIPTION
## Release v5.0.0.beta.1

This is the first pre-release of the upcoming v5.0.0 major release.

### Changes

- `lib/git/version.rb`: bump `VERSION` to `5.0.0.beta.1`
- `.release-please-config.json`: remove `prerelease` versioning strategy so release-please tracks changes toward the final `5.0.0` release
- `README.md`: add project announcement for the beta release

### Notes

This pre-release is managed manually — it is intentionally outside the release-please automation so that release-please continues to accumulate commits toward the final `5.0.0` release. The `.release-please-manifest.json` is **not** updated by this PR.