### PR TITLE
refactor(config): move global config singleton ownership to Git::Config (Step C1b)

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -87,12 +87,33 @@ module Git
     end
   end
 
+  # Configures the gem by yielding {Git::Config.instance} to the block
+  #
+  # @example Set the global git binary path
+  #   Git.configure { |c| c.binary_path = '/usr/local/bin/git' }
+  #
+  # @yield [config] yields the singleton config object
+  #
+  # @yieldparam config [Git::Config] the singleton config object
+  #
+  # @yieldreturn [void]
+  #
+  # @return [void]
+  #
   def self.configure
-    yield Base.config
+    yield Git::Config.instance
+    nil
   end
 
+  # Returns the process-wide {Git::Config} singleton
+  #
+  # @example Read the configured binary path
+  #   Git.config.binary_path  #=> "git"
+  #
+  # @return [Git::Config] the singleton config object
+  #
   def self.config
-    Base.config
+    Git::Config.instance
   end
 
   def global_config(name = nil, value = nil)
@@ -368,7 +389,7 @@ module Git
   #   - If a non-empty string, uses that value for this instance.
   #
   # @option options [String, :use_global_config] :binary_path path to the git
-  #   binary; defaults to `Git::Base.config.binary_path` when not specified.
+  #   binary; defaults to `Git::Config.instance.binary_path` when not specified.
   #   Raises `ArgumentError` if set to `nil`.
   #
   # @option options [Logger] :log A logger to use for Git operations.  Git
@@ -396,8 +417,9 @@ module Git
     require_relative 'git/commands/init'
 
     options = options.dup
-    options[:repository] = options.delete(:separate_git_dir) \
-      if options.key?(:separate_git_dir) && options[:repository].nil?
+    if options.key?(:separate_git_dir) && options[:repository].nil?
+      options[:repository] = options.delete(:separate_git_dir)
+    end
     init_opts = options.slice(:bare, :initial_branch)
     init_opts[:separate_git_dir] = options[:repository] if options.key?(:repository)
     context = Git::ExecutionContext::Global.new(
@@ -493,8 +515,14 @@ module Git
 
   # Return the version of a git binary as a {Git::Version}
   #
+  # @example Default binary
+  #   Git.git_version #=> #<Git::Version 2.42.0>
+  #
+  # @example Explicit binary path
+  #   Git.git_version('/opt/homebrew/bin/git') #=> #<Git::Version 2.42.0>
+  #
   # @param binary_path [String, nil] path to the git binary; defaults to
-  #   `Git::Base.config.binary_path`
+  #   `Git::Config.instance.binary_path`
   #
   # @return [Git::Version] the parsed git version
   #
@@ -504,14 +532,8 @@ module Git
   #
   # @raise [Git::Error] if the binary is not found or fails to launch
   #
-  # @example Default binary
-  #   Git.git_version #=> #<Git::Version 2.42.0>
-  #
-  # @example Explicit binary path
-  #   Git.git_version('/opt/homebrew/bin/git') #=> #<Git::Version 2.42.0>
-  #
   def self.git_version(binary_path = nil)
-    path = binary_path || Git::Base.config.binary_path
+    path = binary_path || Git::Config.instance.binary_path
     Git::Lib.cached_git_version(path) { run_git_version(path) }
   end
 
@@ -524,16 +546,23 @@ module Git
 
   # Return the version of the git binary
   #
-  # @example
-  #  Git.binary_version # => [2, 46, 0]
+  # @example Basic usage
+  #   Git.binary_version  # => [2, 46, 0]
+  #
+  # @param binary_path [String, nil] path to the git binary; defaults to
+  #   `Git::Config.instance.binary_path`
   #
   # @return [Array<Integer>] the version of the git binary
   #
-  # @deprecated Use {Git.git_version} instead, which returns a {Git::Version} (not an Array).
-  #   For the legacy array shape, call: `Git.git_version.to_a`.
-  #   The optional binary_path argument is preserved: `Git.git_version(binary_path)`.
+  # @deprecated Use {Git.git_version} instead, which returns a
+  #   {Git::Version} (not an Array)
   #
-  def self.binary_version(binary_path = Git::Base.config.binary_path)
+  #   For the legacy array shape, call: `Git.git_version.to_a`.
+  #   The optional binary_path argument is preserved:
+  #   `Git.git_version(binary_path)`.
+  #
+  def self.binary_version(binary_path = nil)
+    binary_path ||= Git::Config.instance.binary_path
     Git::Deprecation.warn(
       'Git.binary_version is deprecated and will be removed in 6.0. ' \
       'Use Git.git_version instead, which returns a Git::Version ' \

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -39,11 +39,19 @@ module Git
       Git::Lib.new(nil, options[:log]).repository_default_branch(repository)
     end
 
-    # Returns (and initialize if needed) a Git::Config instance
+    # Returns the process-wide {Git::Config} singleton
     #
-    # @return [Git::Config] the current config instance.
+    # Delegates to {Git::Config.instance} so that all call sites that relied on
+    # `Git::Base.config` continue to work while {Git::Base} remains in the tree.
+    # No config state is owned here.
+    #
+    # @example Read the configured binary path
+    #   Git::Base.config.binary_path  #=> "git"
+    #
+    # @return [Git::Config] the global config singleton
+    #
     def self.config
-      @config ||= Config.new
+      Git::Config.instance
     end
 
     # @deprecated Use {Git.git_version} instead, which returns a {Git::Version} (not an Array).
@@ -116,24 +124,24 @@ module Git
     # @option options [String, nil] :git_ssh Path to a custom SSH executable or script
     #
     #   Controls how SSH is configured for this {Git::Base} instance:
-    #   - If this option is not provided, the global Git::Base.config.git_ssh setting is used.
+    #   - If this option is not provided, the global `Git::Config.instance.git_ssh` setting is used.
     #   - If this option is explicitly set to nil, SSH is disabled for this instance.
     #   - If this option is a non-empty String, that value is used as the SSH command for
-    #     this instance, overriding the global Git::Base.config.git_ssh setting.
+    #     this instance, overriding the global `Git::Config.instance.git_ssh` setting.
     #
     # @option options [String, :use_global_config] :binary_path Path to the git binary
     #
     #   Controls which git binary is used for commands routed through
     #   {Git::ExecutionContext} (i.e., commands already migrated to
     #   +Git::Commands::*+ classes). Commands still delegating through +Git::Lib+
-    #   continue to use the global `Git::Base.config.binary_path` setting.
+    #   continue to use the global `Git::Config.instance.binary_path` setting.
     #
     #   This limitation will be resolved when the architectural migration to
     #   +Git::Repository+ is complete.
     #
-    #   - If this option is not provided, the global Git::Base.config.binary_path setting is used.
+    #   - If this option is not provided, the global `Git::Config.instance.binary_path` setting is used.
     #   - If this option is a String, that value is used as the git binary path for
-    #     migrated commands, overriding the global Git::Base.config.binary_path setting.
+    #     migrated commands, overriding the global `Git::Config.instance.binary_path` setting.
     #   - Passing `nil` raises ArgumentError — there is no "unset the binary" semantic.
     #
     # @return [Git::Base] an object that can execute git commands on a working copy or

--- a/lib/git/config.rb
+++ b/lib/git/config.rb
@@ -3,6 +3,26 @@
 module Git
   # The global configuration for this gem
   class Config
+    # Returns the process-wide singleton {Git::Config} instance
+    #
+    # All calls to {Git.configure}, {Git.config}, and the {Git::ExecutionContext}
+    # classes resolve global configuration through this method. Owning the
+    # singleton here (rather than on {Git::Base}) means these call sites are
+    # independent of `Git::Base` and will continue to work when `Git::Base` is
+    # removed in a future version.
+    #
+    # @example Read the configured binary path
+    #   Git::Config.instance.binary_path  #=> "git"
+    #
+    # @example Mutate the singleton (same as Git.configure { |c| ... })
+    #   Git::Config.instance.binary_path = '/usr/local/bin/git'
+    #
+    # @return [Git::Config] the singleton config object
+    #
+    def self.instance
+      @instance ||= new
+    end
+
     attr_writer :binary_path, :git_ssh, :timeout
 
     def initialize

--- a/lib/git/execution_context.rb
+++ b/lib/git/execution_context.rb
@@ -88,20 +88,22 @@ module Git
     #
     # @param binary_path [String, :use_global_config] path to the git binary
     #
-    #   Give `:use_global_config` (the default) to use `Git::Base.config.binary_path`.
+    #   Give `:use_global_config` (the default) to use `Git::Config.instance.binary_path`.
     #
     #   Passing `nil` raises `ArgumentError` — there is no "unset the
     #   binary" semantic.
     #
     # @param git_ssh [String, nil, :use_global_config] the SSH wrapper path
     #
-    #   Give `nil` to unset `GIT_SSH`, or `:use_global_config` (default) to use `Git::Base.config.git_ssh`.
+    #   Give `nil` to unset `GIT_SSH`, or `:use_global_config` (default)
+    #   to use `Git::Config.instance.git_ssh`.
     #
     # @param logger [Logger, nil] the logger to use in the CommandLine layer
     #
     #   Give `nil` to use a null logger (`Logger.new(nil)`).
     #
-    # @raise [NotImplementedError] if called directly on {Git::ExecutionContext} rather than a subclass
+    # @raise [NotImplementedError] if called directly on {Git::ExecutionContext}
+    #   rather than a subclass
     #
     # @raise [ArgumentError] if `binary_path` is `nil`
     #
@@ -156,11 +158,12 @@ module Git
 
     # Returns the resolved git binary path for this context
     #
-    # `:use_global_config` is resolved to `Git::Base.config.binary_path` each time a
-    # command method is called, so runtime changes to `Git::Base.config.binary_path`
+    # `:use_global_config` is resolved to `Git::Config.instance.binary_path` each time a
+    # command method is called, so runtime changes to
+    # `Git.configure { |c| c.binary_path = ... }`
     # are reflected per command invocation.
     #
-    # @example With the default sentinel (resolves from Git::Base.config at call-time)
+    # @example With the default sentinel (resolves from Git::Config.instance at call-time)
     #   context = Git::ExecutionContext::Global.new
     #   context.binary_path  #=> "git"
     #
@@ -171,19 +174,20 @@ module Git
     # @return [String] the resolved git binary path
     #
     def binary_path
-      return Git::Base.config.binary_path if @binary_path == :use_global_config
+      return Git::Config.instance.binary_path if @binary_path == :use_global_config
 
       @binary_path
     end
 
     # Returns the resolved `GIT_SSH` wrapper path for this context
     #
-    # `:use_global_config` is resolved to `Git::Base.config.git_ssh` each time a
-    # command method is called, so runtime changes to `Git::Base.config.git_ssh`
+    # `:use_global_config` is resolved to `Git::Config.instance.git_ssh` each time a
+    # command method is called, so runtime changes to
+    # `Git.configure { |c| c.git_ssh = ... }`
     # are reflected per command invocation. `nil` means the variable will be
     # explicitly unset.
     #
-    # @example With the default sentinel (resolves from Git::Base.config at call-time)
+    # @example With the default sentinel (resolves from Git::Config.instance at call-time)
     #   context = Git::ExecutionContext::Global.new
     #   context.git_ssh  #=> nil
     #
@@ -194,7 +198,7 @@ module Git
     # @return [String, nil] the resolved `GIT_SSH` wrapper path, or `nil` to unset
     #
     def git_ssh
-      return Git::Base.config.git_ssh if @git_ssh == :use_global_config
+      return Git::Config.instance.git_ssh if @git_ssh == :use_global_config
 
       @git_ssh
     end
@@ -453,9 +457,9 @@ module Git
     # Creates a {Git::CommandLine::Capturing} instance for the current invocation.
     #
     # A new instance is created per call so that {#binary_path} — resolved from
-    # `Git::Base.config` when set to `:use_global_config` — and {#env_overrides}
+    # `Git::Config.instance` when set to `:use_global_config` — and {#env_overrides}
     # — including {#git_ssh} resolution for `:use_global_config` — reflect the
-    # state of `Git::Base.config` at the time of each command invocation.
+    # state of {Git::Config.instance} at the time of each command invocation.
     #
     # @return [Git::CommandLine::Capturing] the capturing command line instance
     #
@@ -466,9 +470,9 @@ module Git
     # Creates a {Git::CommandLine::Streaming} instance for the current invocation.
     #
     # A new instance is created per call so that {#binary_path} — resolved from
-    # `Git::Base.config` when set to `:use_global_config` — and {#env_overrides}
+    # `Git::Config.instance` when set to `:use_global_config` — and {#env_overrides}
     # — including {#git_ssh} resolution for `:use_global_config` — reflect the
-    # state of `Git::Base.config` at the time of each command invocation.
+    # state of {Git::Config.instance} at the time of each command invocation.
     #
     # @return [Git::CommandLine::Streaming] the streaming command line instance
     #

--- a/lib/git/execution_context/global.rb
+++ b/lib/git/execution_context/global.rb
@@ -33,14 +33,16 @@ module Git
       #
       # @param binary_path [String, :use_global_config] path to the git binary
       #
-      #   Give `:use_global_config` (the default) to use `Git::Base.config.binary_path`.
+      #   Give `:use_global_config` (the default) to use
+      #   `Git::Config.instance.binary_path`.
       #
       #   Passing `nil` raises `ArgumentError` — there is no "unset the
       #   binary" semantic.
       #
       # @param git_ssh [String, nil, :use_global_config] the SSH wrapper path
       #
-      #   Give `nil` to unset `GIT_SSH`, or `:use_global_config` (default) to use `Git::Base.config.git_ssh`.
+      #   Give `nil` to unset `GIT_SSH`, or `:use_global_config` (default)
+      #   to use `Git::Config.instance.git_ssh`.
       #
       # @param logger [Logger, nil] the logger to use in the CommandLine layer
       #

--- a/lib/git/execution_context/repository.rb
+++ b/lib/git/execution_context/repository.rb
@@ -100,14 +100,16 @@ module Git
       #
       # @param binary_path [String, :use_global_config] path to the git binary
       #
-      #   Give `:use_global_config` (the default) to use `Git::Base.config.binary_path`.
+      #   Give `:use_global_config` (the default) to use
+      #   `Git::Config.instance.binary_path`.
       #
       #   Passing `nil` raises `ArgumentError` — there is no "unset the
       #   binary" semantic.
       #
       # @param git_ssh [String, nil, :use_global_config] the SSH wrapper path
       #
-      #   Give `nil` to unset `GIT_SSH`, or `:use_global_config` (default) to use `Git::Base.config.git_ssh`.
+      #   Give `nil` to unset `GIT_SSH`, or `:use_global_config` (default)
+      #   to use `Git::Config.instance.git_ssh`.
       #
       # @param logger [Logger, nil] the logger to use in the CommandLine layer
       #

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -259,7 +259,7 @@ Workstream F.
 
 Files touched: `lib/git/repository.rb`, `lib/git/base.rb`, `lib/git.rb`
 
-**Step C1b — Move global config singleton ownership off `Git::Base`**
+**Step C1b — Move global config singleton ownership off `Git::Base`** ✅
 
 `Git.configure` and `Git.config` both delegate to `Base.config`, which returns the
 `Git::Base`-owned `Git::Config` singleton. When `Git::Base` is deleted, these break.

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -12,6 +12,12 @@ RSpec.describe Git::Base do
     end
   end
 
+  describe '.config' do
+    it 'returns Git::Config.instance (delegator for backward compatibility)' do
+      expect(described_class.config).to be(Git::Config.instance)
+    end
+  end
+
   describe '#binary_path' do
     context 'when not specified' do
       subject(:base) { described_class.new }

--- a/spec/unit/git/config_spec.rb
+++ b/spec/unit/git/config_spec.rb
@@ -1,0 +1,194 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::Config do
+  let(:described_instance) { described_class.new }
+
+  describe '.instance' do
+    it 'returns a Git::Config instance' do
+      expect(described_class.instance).to be_a(described_class)
+    end
+
+    it 'returns the same object on repeated calls (singleton)' do
+      expect(described_class.instance).to be(described_class.instance)
+    end
+  end
+
+  describe '#initialize' do
+    subject(:instance) { described_instance }
+
+    # Clear env vars that the readers fall through to, so defaults are deterministic
+    around do |example|
+      saved_path    = ENV.delete('GIT_PATH')
+      saved_ssh     = ENV.delete('GIT_SSH')
+      saved_timeout = ENV.delete('GIT_TIMEOUT')
+      example.run
+    ensure
+      ENV['GIT_PATH']    = saved_path    if saved_path
+      ENV['GIT_SSH']     = saved_ssh     if saved_ssh
+      ENV['GIT_TIMEOUT'] = saved_timeout if saved_timeout
+    end
+
+    it 'initializes all attributes to nil, producing hardcoded reader defaults' do
+      expect(instance).to have_attributes(
+        binary_path: 'git',
+        git_ssh: nil,
+        timeout: nil
+      )
+    end
+  end
+
+  describe '#binary_path' do
+    subject(:result) { described_instance.binary_path }
+
+    context 'when the binary_path attribute has been set' do
+      before { described_instance.binary_path = '/explicit/git' }
+
+      it 'returns the set value' do
+        expect(result).to eq('/explicit/git')
+      end
+    end
+
+    context 'when the binary_path attribute is nil but GIT_PATH env is set' do
+      around do |example|
+        ENV['GIT_PATH'] = '/env/git/dir'
+        example.run
+      ensure
+        ENV.delete('GIT_PATH')
+      end
+
+      it 'returns File.join(GIT_PATH, "git")' do
+        expect(result).to eq(File.join('/env/git/dir', 'git'))
+      end
+    end
+
+    context 'when neither the binary_path attribute nor GIT_PATH env is set' do
+      around do |example|
+        saved = ENV.delete('GIT_PATH')
+        example.run
+      ensure
+        ENV['GIT_PATH'] = saved if saved
+      end
+
+      it 'returns "git"' do
+        expect(result).to eq('git')
+      end
+    end
+  end
+
+  describe '#git_ssh' do
+    subject(:result) { described_instance.git_ssh }
+
+    context 'when the git_ssh attribute has been set' do
+      before { described_instance.git_ssh = '/explicit/ssh' }
+
+      it 'returns the set value' do
+        expect(result).to eq('/explicit/ssh')
+      end
+    end
+
+    context 'when the git_ssh attribute is nil but GIT_SSH env is set' do
+      around do |example|
+        ENV['GIT_SSH'] = '/env/ssh'
+        example.run
+      ensure
+        ENV.delete('GIT_SSH')
+      end
+
+      it 'returns the GIT_SSH env value' do
+        expect(result).to eq('/env/ssh')
+      end
+    end
+
+    context 'when neither the git_ssh attribute nor GIT_SSH env is set' do
+      around do |example|
+        saved = ENV.delete('GIT_SSH')
+        example.run
+      ensure
+        ENV['GIT_SSH'] = saved if saved
+      end
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe '#timeout' do
+    subject(:result) { described_instance.timeout }
+
+    context 'when the timeout attribute has been set' do
+      before { described_instance.timeout = 30 }
+
+      it 'returns the set value' do
+        expect(result).to eq(30)
+      end
+    end
+
+    context 'when the timeout attribute is nil but GIT_TIMEOUT env is set' do
+      around do |example|
+        ENV['GIT_TIMEOUT'] = '60'
+        example.run
+      ensure
+        ENV.delete('GIT_TIMEOUT')
+      end
+
+      it 'returns the GIT_TIMEOUT env value as an integer' do
+        expect(result).to eq(60)
+      end
+    end
+
+    context 'when neither the timeout attribute nor GIT_TIMEOUT env is set' do
+      around do |example|
+        saved = ENV.delete('GIT_TIMEOUT')
+        example.run
+      ensure
+        ENV['GIT_TIMEOUT'] = saved if saved
+      end
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  # End-to-end: runtime changes to Git.configure are honored by ExecutionContext subclasses
+  describe 'end-to-end runtime change propagation' do
+    around do |example|
+      # Capture the raw instance variables (not the resolved reader values) so
+      # that nil is preserved as-is. Using the reader would convert a nil ivar
+      # into "git" or an ENV value, causing state to leak into later examples.
+      saved_binary_path = Git::Config.instance.instance_variable_get(:@binary_path)
+      saved_git_ssh     = Git::Config.instance.instance_variable_get(:@git_ssh)
+      example.run
+    ensure
+      Git::Config.instance.binary_path = saved_binary_path
+      Git::Config.instance.git_ssh     = saved_git_ssh
+    end
+
+    it 'Git::ExecutionContext::Global picks up a runtime binary_path change via Git.configure' do
+      Git.configure { |c| c.binary_path = '/custom/git' }
+      context = Git::ExecutionContext::Global.new
+      expect(context.binary_path).to eq('/custom/git')
+    end
+
+    it 'Git::ExecutionContext::Global picks up a runtime git_ssh change via Git.configure' do
+      Git.configure { |c| c.git_ssh = '/custom/ssh' }
+      context = Git::ExecutionContext::Global.new
+      expect(context.git_ssh).to eq('/custom/ssh')
+    end
+
+    it 'Git::ExecutionContext::Repository picks up a runtime binary_path change via Git.configure' do
+      Git.configure { |c| c.binary_path = '/custom/git2' }
+      context = Git::ExecutionContext::Repository.new(git_dir: '/repo/.git')
+      expect(context.binary_path).to eq('/custom/git2')
+    end
+
+    it 'Git::ExecutionContext::Repository picks up a runtime git_ssh change via Git.configure' do
+      Git.configure { |c| c.git_ssh = '/custom/ssh2' }
+      context = Git::ExecutionContext::Repository.new(git_dir: '/repo/.git')
+      expect(context.git_ssh).to eq('/custom/ssh2')
+    end
+  end
+end

--- a/spec/unit/git/execution_context/global_spec.rb
+++ b/spec/unit/git/execution_context/global_spec.rb
@@ -11,27 +11,22 @@ RSpec.describe Git::ExecutionContext::Global do
   end
 
   describe '#initialize' do
-    it 'can be created with no arguments' do
-      expect { described_class.new }.not_to raise_error
-    end
-
-    it 'accepts an optional logger' do
-      logger = double('logger')
-      expect { described_class.new(logger: logger) }.not_to raise_error
-    end
-
-    it 'accepts an optional git_ssh path' do
-      expect { described_class.new(git_ssh: '/usr/bin/ssh') }.not_to raise_error
-    end
-
-    it 'accepts an optional binary_path' do
-      expect { described_class.new(binary_path: '/usr/local/bin/git') }.not_to raise_error
+    it 'exposes default attribute values using Git::Config.instance' do
+      allow(Git::Config.instance).to receive(:binary_path).and_return('git')
+      allow(Git::Config.instance).to receive(:git_ssh).and_return(nil)
+      expect(described_class.new).to have_attributes(
+        binary_path: 'git',
+        git_ssh: nil,
+        git_dir: nil,
+        git_work_dir: nil,
+        git_index_file: nil
+      )
     end
   end
 
   describe 'binary_path resolution' do
-    it 'delegates to Git::Base.config by default' do
-      allow(Git::Base).to receive_message_chain(:config, :binary_path).and_return('/global/git')
+    it 'delegates to Git::Config.instance by default' do
+      allow(Git::Config.instance).to receive(:binary_path).and_return('/global/git')
       expect(described_class.new.binary_path).to eq('/global/git')
     end
 
@@ -61,8 +56,8 @@ RSpec.describe Git::ExecutionContext::Global do
   end
 
   describe 'git_ssh resolution' do
-    it 'delegates to Git::Base.config by default' do
-      allow(Git::Base).to receive_message_chain(:config, :git_ssh).and_return('/global/ssh')
+    it 'delegates to Git::Config.instance by default' do
+      allow(Git::Config.instance).to receive(:git_ssh).and_return('/global/ssh')
       expect(described_class.new.git_ssh).to eq('/global/ssh')
     end
 
@@ -75,55 +70,6 @@ RSpec.describe Git::ExecutionContext::Global do
     end
   end
 
-  describe 'env_overrides (via #send)' do
-    let(:context) { described_class.new(git_ssh: nil) }
-
-    it 'explicitly unsets GIT_DIR' do
-      expect(context.send(:env_overrides)['GIT_DIR']).to be_nil
-    end
-
-    it 'explicitly unsets GIT_WORK_TREE' do
-      expect(context.send(:env_overrides)['GIT_WORK_TREE']).to be_nil
-    end
-
-    it 'explicitly unsets GIT_INDEX_FILE' do
-      expect(context.send(:env_overrides)['GIT_INDEX_FILE']).to be_nil
-    end
-
-    it 'explicitly unsets GIT_SSH when git_ssh is nil' do
-      expect(context.send(:env_overrides)['GIT_SSH']).to be_nil
-    end
-
-    it 'sets GIT_EDITOR to "true" (no-op editor)' do
-      expect(context.send(:env_overrides)['GIT_EDITOR']).to eq('true')
-    end
-
-    it 'sets LC_ALL to "en_US.UTF-8"' do
-      expect(context.send(:env_overrides)['LC_ALL']).to eq('en_US.UTF-8')
-    end
-
-    it 'merges caller-supplied additional overrides' do
-      env = context.send(:env_overrides, 'MY_VAR' => 'val')
-      expect(env['MY_VAR']).to eq('val')
-    end
-  end
-
-  describe 'global_opts (via #send)' do
-    let(:context) { described_class.new }
-
-    it 'does not include --git-dir' do
-      expect(context.send(:global_opts).grep(/\A--git-dir/)).to be_empty
-    end
-
-    it 'does not include --work-tree' do
-      expect(context.send(:global_opts).grep(/\A--work-tree/)).to be_empty
-    end
-
-    it 'includes the static global opts' do
-      expect(context.send(:global_opts)).to include('-c', 'core.quotePath=true')
-    end
-  end
-
   describe '#command_capturing' do
     let(:context) { described_class.new }
     let(:command_line_double) { instance_double(Git::CommandLine::Capturing) }
@@ -131,7 +77,7 @@ RSpec.describe Git::ExecutionContext::Global do
 
     before do
       allow(context).to receive(:command_line_capturing).and_return(command_line_double)
-      allow(Git::Base).to receive_message_chain(:config, :timeout).and_return(nil)
+      allow(Git::Config.instance).to receive(:timeout).and_return(nil)
     end
 
     it 'delegates to command_line_capturing.run' do
@@ -139,6 +85,42 @@ RSpec.describe Git::ExecutionContext::Global do
         .with('version', hash_including(raise_on_failure: true, normalize: true))
         .and_return(result)
       context.command_capturing('version')
+    end
+
+    context 'when building the CommandLine instance (env and global opts)' do
+      before do
+        allow(context).to receive(:command_line_capturing).and_call_original
+        allow(Git::CommandLine::Capturing).to receive(:new).and_return(command_line_double)
+        allow(command_line_double).to receive(:run).and_return(result)
+      end
+
+      it 'passes GIT_EDITOR=true and LC_ALL=en_US.UTF-8 in the env hash' do
+        context.command_capturing('version')
+        expect(Git::CommandLine::Capturing).to have_received(:new).with(
+          hash_including('GIT_EDITOR' => 'true', 'LC_ALL' => 'en_US.UTF-8'),
+          anything, anything, anything
+        )
+      end
+
+      it 'does not include --git-dir in global opts (no repository scope)' do
+        context.command_capturing('version')
+        expect(Git::CommandLine::Capturing).to have_received(:new).with(
+          anything,
+          anything,
+          satisfy { |opts| opts.none? { |o| o.start_with?('--git-dir') } },
+          anything
+        )
+      end
+
+      it 'includes the static global opts' do
+        context.command_capturing('version')
+        expect(Git::CommandLine::Capturing).to have_received(:new).with(
+          anything,
+          anything,
+          include('-c', 'core.quotePath=true'),
+          anything
+        )
+      end
     end
   end
 
@@ -150,7 +132,7 @@ RSpec.describe Git::ExecutionContext::Global do
 
     before do
       allow(context).to receive(:command_line_streaming).and_return(command_line_double)
-      allow(Git::Base).to receive_message_chain(:config, :timeout).and_return(nil)
+      allow(Git::Config.instance).to receive(:timeout).and_return(nil)
     end
 
     it 'delegates to command_line_streaming.run' do

--- a/spec/unit/git/execution_context/repository_spec.rb
+++ b/spec/unit/git/execution_context/repository_spec.rb
@@ -16,22 +16,21 @@ RSpec.describe Git::ExecutionContext::Repository do
   end
 
   describe '#initialize' do
-    it 'accepts git_dir as a keyword argument' do
-      expect { described_class.new(git_dir: git_dir) }.not_to raise_error
-    end
-
-    it 'accepts all repository path options' do
-      expect do
-        described_class.new(
-          git_dir: git_dir,
-          git_work_dir: git_work_dir,
-          git_index_file: git_index_file,
-          base_object: nil,
-          git_ssh: '/usr/bin/ssh',
-          binary_path: '/usr/local/bin/git',
-          logger: nil
-        )
-      end.not_to raise_error
+    it 'stores all provided keyword arguments as attributes' do
+      instance = described_class.new(
+        git_dir: git_dir,
+        git_work_dir: git_work_dir,
+        git_index_file: git_index_file,
+        git_ssh: '/usr/bin/ssh',
+        binary_path: '/usr/local/bin/git'
+      )
+      expect(instance).to have_attributes(
+        git_dir: git_dir,
+        git_work_dir: git_work_dir,
+        git_index_file: git_index_file,
+        git_ssh: '/usr/bin/ssh',
+        binary_path: '/usr/local/bin/git'
+      )
     end
   end
 
@@ -39,8 +38,8 @@ RSpec.describe Git::ExecutionContext::Repository do
     context 'with :use_global_config (default)' do
       let(:context) { described_class.new(git_dir: git_dir) }
 
-      it 'delegates to Git::Base.config.binary_path' do
-        allow(Git::Base).to receive_message_chain(:config, :binary_path).and_return('/global/git')
+      it 'delegates to Git::Config.instance.binary_path' do
+        allow(Git::Config.instance).to receive(:binary_path).and_return('/global/git')
         expect(context.binary_path).to eq('/global/git')
       end
     end
@@ -76,86 +75,6 @@ RSpec.describe Git::ExecutionContext::Repository do
     end
   end
 
-  describe 'env_overrides (via #send)' do
-    let(:context) do
-      described_class.new(
-        git_dir: git_dir,
-        git_work_dir: git_work_dir,
-        git_index_file: git_index_file
-      )
-    end
-
-    before do
-      allow(Git::Base).to receive_message_chain(:config, :git_ssh).and_return(nil)
-    end
-
-    it 'sets GIT_DIR to git_dir' do
-      expect(context.send(:env_overrides)['GIT_DIR']).to eq(git_dir)
-    end
-
-    it 'sets GIT_WORK_TREE to git_work_dir' do
-      expect(context.send(:env_overrides)['GIT_WORK_TREE']).to eq(git_work_dir)
-    end
-
-    it 'sets GIT_INDEX_FILE to git_index_file' do
-      expect(context.send(:env_overrides)['GIT_INDEX_FILE']).to eq(git_index_file)
-    end
-
-    it 'sets GIT_EDITOR to "true" (no-op editor)' do
-      expect(context.send(:env_overrides)['GIT_EDITOR']).to eq('true')
-    end
-
-    it 'sets LC_ALL to "en_US.UTF-8"' do
-      expect(context.send(:env_overrides)['LC_ALL']).to eq('en_US.UTF-8')
-    end
-
-    it 'merges caller-supplied additional overrides' do
-      env = context.send(:env_overrides, 'GIT_TRACE' => '1')
-      expect(env['GIT_TRACE']).to eq('1')
-    end
-
-    it 'allows unsetting an env var by passing nil' do
-      env = context.send(:env_overrides, 'GIT_INDEX_FILE' => nil)
-      expect(env['GIT_INDEX_FILE']).to be_nil
-    end
-  end
-
-  describe 'global_opts (via #send)' do
-    context 'with git_dir and git_work_dir set' do
-      let(:context) do
-        described_class.new(git_dir: git_dir, git_work_dir: git_work_dir)
-      end
-
-      it 'includes --git-dir=<path>' do
-        expect(context.send(:global_opts)).to include("--git-dir=#{git_dir}")
-      end
-
-      it 'includes --work-tree=<path>' do
-        expect(context.send(:global_opts)).to include("--work-tree=#{git_work_dir}")
-      end
-
-      it 'includes the static global opts' do
-        expect(context.send(:global_opts)).to include('-c', 'core.quotePath=true')
-      end
-    end
-
-    context 'without git_work_dir' do
-      let(:context) { described_class.new(git_dir: git_dir) }
-
-      it 'does not include --work-tree' do
-        expect(context.send(:global_opts).grep(/\A--work-tree/)).to be_empty
-      end
-    end
-
-    context 'without git_dir' do
-      let(:context) { described_class.new(git_dir: nil) }
-
-      it 'does not include --git-dir' do
-        expect(context.send(:global_opts).grep(/\A--git-dir/)).to be_empty
-      end
-    end
-  end
-
   describe 'git_ssh resolution' do
     context 'with a literal git_ssh path' do
       let(:context) { described_class.new(git_dir: git_dir, git_ssh: '/usr/bin/ssh') }
@@ -168,8 +87,8 @@ RSpec.describe Git::ExecutionContext::Repository do
     context 'with :use_global_config (default)' do
       let(:context) { described_class.new(git_dir: git_dir) }
 
-      it 'delegates to Git::Base.config.git_ssh' do
-        allow(Git::Base).to receive_message_chain(:config, :git_ssh).and_return('/configured/ssh')
+      it 'delegates to Git::Config.instance.git_ssh' do
+        allow(Git::Config.instance).to receive(:git_ssh).and_return('/configured/ssh')
         expect(context.git_ssh).to eq('/configured/ssh')
       end
     end
@@ -184,13 +103,13 @@ RSpec.describe Git::ExecutionContext::Repository do
   end
 
   describe '.from_base' do
-    let(:repo_double) { double('repo', to_s: git_dir) }
-    let(:index_double) { double('index', to_s: git_index_file) }
-    let(:dir_double) { double('dir', to_s: git_work_dir) }
+    let(:repo_double) { instance_double(Pathname, to_s: git_dir) }
+    let(:index_double) { instance_double(Pathname, to_s: git_index_file) }
+    let(:dir_double) { instance_double(Pathname, to_s: git_work_dir) }
     let(:base) do
-      double('Git::Base',
-             repo: repo_double, index: index_double, dir: dir_double,
-             git_ssh: nil, binary_path: :use_global_config)
+      instance_double(Git::Base,
+                      repo: repo_double, index: index_double, dir: dir_double,
+                      git_ssh: nil, binary_path: :use_global_config)
     end
 
     subject(:context) { described_class.from_base(base) }
@@ -217,9 +136,9 @@ RSpec.describe Git::ExecutionContext::Repository do
 
     context 'when base.binary_path is an explicit path' do
       let(:base) do
-        double('Git::Base',
-               repo: repo_double, index: index_double, dir: dir_double,
-               git_ssh: nil, binary_path: '/custom/git')
+        instance_double(Git::Base,
+                        repo: repo_double, index: index_double, dir: dir_double,
+                        git_ssh: nil, binary_path: '/custom/git')
       end
 
       it 'forwards binary_path to the context' do
@@ -228,8 +147,8 @@ RSpec.describe Git::ExecutionContext::Repository do
     end
 
     context 'when base.binary_path is :use_global_config (default)' do
-      it 'delegates binary_path resolution to Git::Base.config' do
-        allow(Git::Base).to receive_message_chain(:config, :binary_path).and_return('/global/git')
+      it 'delegates binary_path resolution to Git::Config.instance' do
+        allow(Git::Config.instance).to receive(:binary_path).and_return('/global/git')
         expect(context.binary_path).to eq('/global/git')
       end
     end
@@ -279,7 +198,7 @@ RSpec.describe Git::ExecutionContext::Repository do
     end
 
     it 'defaults git_ssh to :use_global_config when :git_ssh is absent' do
-      allow(Git::Base).to receive_message_chain(:config, :git_ssh).and_return('/global/ssh')
+      allow(Git::Config.instance).to receive(:git_ssh).and_return('/global/ssh')
       expect(context.git_ssh).to eq('/global/ssh')
     end
 
@@ -289,7 +208,7 @@ RSpec.describe Git::ExecutionContext::Repository do
     end
 
     it 'defaults binary_path to :use_global_config when :binary_path is absent' do
-      allow(Git::Base).to receive_message_chain(:config, :binary_path).and_return('/global/git')
+      allow(Git::Config.instance).to receive(:binary_path).and_return('/global/git')
       expect(context.binary_path).to eq('/global/git')
     end
 
@@ -306,7 +225,7 @@ RSpec.describe Git::ExecutionContext::Repository do
 
     before do
       allow(context).to receive(:command_line_capturing).and_return(command_line_double)
-      allow(Git::Base).to receive_message_chain(:config, :timeout).and_return(nil)
+      allow(Git::Config.instance).to receive(:timeout).and_return(nil)
     end
 
     it 'delegates to command_line_capturing.run' do
@@ -324,7 +243,7 @@ RSpec.describe Git::ExecutionContext::Repository do
     end
 
     it 'applies the global timeout when no timeout is specified' do
-      allow(Git::Base).to receive_message_chain(:config, :timeout).and_return(30)
+      allow(Git::Config.instance).to receive(:timeout).and_return(30)
       expect(command_line_double).to receive(:run)
         .with('status', hash_including(timeout: 30))
         .and_return(result)
@@ -334,6 +253,50 @@ RSpec.describe Git::ExecutionContext::Repository do
     it 'raises ArgumentError for unknown options' do
       expect { context.command_capturing('version', unknown_opt: true) }
         .to raise_error(ArgumentError, /Unknown options: unknown_opt/)
+    end
+
+    context 'when building the CommandLine instance (env and global opts)' do
+      before do
+        allow(context).to receive(:command_line_capturing).and_call_original
+        allow(Git::CommandLine::Capturing).to receive(:new).and_return(command_line_double)
+        allow(command_line_double).to receive(:run).and_return(result)
+      end
+
+      it 'passes GIT_DIR and GIT_WORK_TREE in the env hash' do
+        context.command_capturing('version')
+        expect(Git::CommandLine::Capturing).to have_received(:new).with(
+          hash_including('GIT_DIR' => git_dir, 'GIT_WORK_TREE' => git_work_dir),
+          anything, anything, anything
+        )
+      end
+
+      it 'passes GIT_EDITOR=true and LC_ALL=en_US.UTF-8 in the env hash' do
+        context.command_capturing('version')
+        expect(Git::CommandLine::Capturing).to have_received(:new).with(
+          hash_including('GIT_EDITOR' => 'true', 'LC_ALL' => 'en_US.UTF-8'),
+          anything, anything, anything
+        )
+      end
+
+      it 'includes --git-dir and --work-tree in global opts' do
+        context.command_capturing('version')
+        expect(Git::CommandLine::Capturing).to have_received(:new).with(
+          anything,
+          anything,
+          include("--git-dir=#{git_dir}", "--work-tree=#{git_work_dir}"),
+          anything
+        )
+      end
+
+      it 'includes the static global opts' do
+        context.command_capturing('version')
+        expect(Git::CommandLine::Capturing).to have_received(:new).with(
+          anything,
+          anything,
+          include('-c', 'core.quotePath=true'),
+          anything
+        )
+      end
     end
   end
 
@@ -345,7 +308,7 @@ RSpec.describe Git::ExecutionContext::Repository do
 
     before do
       allow(context).to receive(:command_line_streaming).and_return(command_line_double)
-      allow(Git::Base).to receive_message_chain(:config, :timeout).and_return(nil)
+      allow(Git::Config.instance).to receive(:timeout).and_return(nil)
     end
 
     it 'delegates to command_line_streaming.run' do

--- a/spec/unit/git/execution_context_config_spec.rb
+++ b/spec/unit/git/execution_context_config_spec.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# These specs verify that ExecutionContext resolves config through Git::Config.instance
+# (not Git::Base.config) — Step C1b of the architectural redesign.
+#
+RSpec.describe Git::ExecutionContext do
+  describe '#binary_path' do
+    context 'when using global config (default, no explicit binary_path)' do
+      let(:context) { Git::ExecutionContext::Global.new }
+
+      it 'reads from Git::Config.instance (not Git::Base.config)' do
+        allow(Git::Config.instance).to receive(:binary_path).and_return('/from/config/instance/git')
+        expect(Git::Base).not_to receive(:config)
+        expect(context.binary_path).to eq('/from/config/instance/git')
+      end
+    end
+  end
+
+  describe '#git_ssh' do
+    context 'when using global config (default, no explicit git_ssh)' do
+      let(:context) { Git::ExecutionContext::Global.new }
+
+      it 'reads from Git::Config.instance (not Git::Base.config)' do
+        allow(Git::Config.instance).to receive(:git_ssh).and_return('/from/config/instance/ssh')
+        expect(Git::Base).not_to receive(:config)
+        expect(context.git_ssh).to eq('/from/config/instance/ssh')
+      end
+    end
+  end
+end

--- a/spec/unit/git/execution_context_spec.rb
+++ b/spec/unit/git/execution_context_spec.rb
@@ -3,111 +3,72 @@
 require 'spec_helper'
 
 RSpec.describe Git::ExecutionContext do
-  describe '.new' do
+  describe '#initialize' do
     it 'raises NotImplementedError when instantiated directly' do
       expect { described_class.new }
         .to raise_error(NotImplementedError, /abstract base class/)
     end
   end
 
-  describe 'constants' do
-    it 'defines COMMAND_CAPTURING_ARG_DEFAULTS' do
-      expect(described_class::COMMAND_CAPTURING_ARG_DEFAULTS).to be_a(Hash)
-      expect(described_class::COMMAND_CAPTURING_ARG_DEFAULTS).to include(:normalize, :chomp, :raise_on_failure)
-    end
-
-    it 'defines COMMAND_STREAMING_ARG_DEFAULTS' do
-      expect(described_class::COMMAND_STREAMING_ARG_DEFAULTS).to be_a(Hash)
-      expect(described_class::COMMAND_STREAMING_ARG_DEFAULTS).to include(:raise_on_failure)
-    end
-
-    it 'defines STATIC_GLOBAL_OPTS' do
-      expect(described_class::STATIC_GLOBAL_OPTS).to be_a(Array)
-      expect(described_class::STATIC_GLOBAL_OPTS).to include('-c', 'core.quotePath=true')
+  describe '#git_dir' do
+    it 'returns nil for a Global context' do
+      expect(Git::ExecutionContext::Global.new.git_dir).to be_nil
     end
   end
 
-  describe 'accessor defaults' do
-    let(:context) { Git::ExecutionContext::Global.new }
-
-    it 'returns nil for git_dir' do
-      expect(context.git_dir).to be_nil
-    end
-
-    it 'returns nil for git_work_dir' do
-      expect(context.git_work_dir).to be_nil
-    end
-
-    it 'returns nil for git_index_file' do
-      expect(context.git_index_file).to be_nil
-    end
-
-    it 'delegates git_ssh to Git::Base.config by default' do
-      allow(Git::Base).to receive_message_chain(:config, :git_ssh).and_return('/configured/ssh')
-      expect(context.git_ssh).to eq('/configured/ssh')
-    end
-
-    it 'returns nil for git_ssh when explicitly passed nil' do
-      expect(Git::ExecutionContext::Global.new(git_ssh: nil).git_ssh).to be_nil
-    end
-
-    it 'returns a literal git_ssh path when provided' do
-      expect(Git::ExecutionContext::Global.new(git_ssh: '/usr/bin/ssh').git_ssh).to eq('/usr/bin/ssh')
-    end
-
-    it 'delegates binary_path to Git::Base.config by default' do
-      allow(Git::Base).to receive_message_chain(:config, :binary_path).and_return('/configured/git')
-      expect(context.binary_path).to eq('/configured/git')
-    end
-
-    it 'returns an explicit binary_path when provided' do
-      expect(Git::ExecutionContext::Global.new(binary_path: '/usr/local/bin/git').binary_path).to(
-        eq('/usr/local/bin/git')
-      )
-    end
-
-    it 'raises ArgumentError when explicitly passed nil' do
-      expect { Git::ExecutionContext::Global.new(binary_path: nil) }.to raise_error(ArgumentError, /binary_path/)
+  describe '#git_work_dir' do
+    it 'returns nil for a Global context' do
+      expect(Git::ExecutionContext::Global.new.git_work_dir).to be_nil
     end
   end
 
-  describe 'env_overrides (via #send)' do
-    let(:context) { Git::ExecutionContext::Global.new(git_ssh: nil) }
-
-    it 'returns GIT_DIR as nil by default' do
-      expect(context.send(:env_overrides)['GIT_DIR']).to be_nil
-    end
-
-    it 'returns GIT_WORK_TREE as nil by default' do
-      expect(context.send(:env_overrides)['GIT_WORK_TREE']).to be_nil
-    end
-
-    it 'returns GIT_INDEX_FILE as nil by default' do
-      expect(context.send(:env_overrides)['GIT_INDEX_FILE']).to be_nil
-    end
-
-    it 'returns GIT_SSH as nil when git_ssh is nil' do
-      expect(context.send(:env_overrides)['GIT_SSH']).to be_nil
-    end
-
-    it 'sets GIT_EDITOR to "true"' do
-      expect(context.send(:env_overrides)['GIT_EDITOR']).to eq('true')
-    end
-
-    it 'sets LC_ALL to "en_US.UTF-8"' do
-      expect(context.send(:env_overrides)['LC_ALL']).to eq('en_US.UTF-8')
-    end
-
-    it 'merges caller-supplied additional overrides' do
-      env = context.send(:env_overrides, 'GIT_TRACE' => '1')
-      expect(env['GIT_TRACE']).to eq('1')
+  describe '#git_index_file' do
+    it 'returns nil for a Global context' do
+      expect(Git::ExecutionContext::Global.new.git_index_file).to be_nil
     end
   end
 
-  describe 'global_opts (via #send)' do
-    it 'includes only static opts when git_dir and git_work_dir are nil' do
-      context = Git::ExecutionContext::Global.new
-      expect(context.send(:global_opts)).to eq(described_class::STATIC_GLOBAL_OPTS)
+  describe '#git_ssh' do
+    context 'when using global config (default)' do
+      it 'delegates to Git::Config.instance' do
+        allow(Git::Config.instance).to receive(:git_ssh).and_return('/configured/ssh')
+        expect(Git::ExecutionContext::Global.new.git_ssh).to eq('/configured/ssh')
+      end
+    end
+
+    context 'when nil is passed explicitly' do
+      it 'returns nil' do
+        expect(Git::ExecutionContext::Global.new(git_ssh: nil).git_ssh).to be_nil
+      end
+    end
+
+    context 'when a literal path is provided' do
+      it 'returns the provided path' do
+        expect(Git::ExecutionContext::Global.new(git_ssh: '/usr/bin/ssh').git_ssh).to eq('/usr/bin/ssh')
+      end
+    end
+  end
+
+  describe '#binary_path' do
+    context 'when using global config (default)' do
+      it 'delegates to Git::Config.instance' do
+        allow(Git::Config.instance).to receive(:binary_path).and_return('/configured/git')
+        expect(Git::ExecutionContext::Global.new.binary_path).to eq('/configured/git')
+      end
+    end
+
+    context 'when an explicit path is provided' do
+      it 'returns the provided path' do
+        expect(Git::ExecutionContext::Global.new(binary_path: '/usr/local/bin/git').binary_path).to(
+          eq('/usr/local/bin/git')
+        )
+      end
+    end
+
+    context 'when nil is passed explicitly' do
+      it 'raises ArgumentError' do
+        expect { Git::ExecutionContext::Global.new(binary_path: nil) }.to raise_error(ArgumentError, /binary_path/)
+      end
     end
   end
 
@@ -118,7 +79,7 @@ RSpec.describe Git::ExecutionContext do
 
     before do
       allow(context).to receive(:command_line_capturing).and_return(command_line_double)
-      allow(Git::Base).to receive_message_chain(:config, :timeout).and_return(nil)
+      allow(Git::Config.instance).to receive(:timeout).and_return(nil)
     end
 
     it 'delegates to command_line_capturing.run with defaults' do
@@ -132,6 +93,40 @@ RSpec.describe Git::ExecutionContext do
       expect { context.command_capturing('version', bogus: true) }
         .to raise_error(ArgumentError, /Unknown options: bogus/)
     end
+
+    context 'when building the CommandLine instance (env and global opts)' do
+      before do
+        allow(context).to receive(:command_line_capturing).and_call_original
+        allow(Git::CommandLine::Capturing).to receive(:new).and_return(command_line_double)
+        allow(command_line_double).to receive(:run).and_return(result)
+      end
+
+      it 'passes GIT_EDITOR=true and LC_ALL=en_US.UTF-8 in the env hash' do
+        context.command_capturing('version')
+        expect(Git::CommandLine::Capturing).to have_received(:new).with(
+          hash_including('GIT_EDITOR' => 'true', 'LC_ALL' => 'en_US.UTF-8'),
+          anything, anything, anything
+        )
+      end
+
+      it 'passes the resolved binary_path as the second argument' do
+        allow(Git::Config.instance).to receive(:binary_path).and_return('configured-git')
+        context.command_capturing('version')
+        expect(Git::CommandLine::Capturing).to have_received(:new).with(
+          anything, 'configured-git', anything, anything
+        )
+      end
+
+      it 'includes the static global opts and excludes --git-dir for a Global context' do
+        context.command_capturing('version')
+        expect(Git::CommandLine::Capturing).to have_received(:new).with(
+          anything,
+          anything,
+          satisfy { |opts| opts.include?('-c') && opts.none? { |o| o.start_with?('--git-dir') } },
+          anything
+        )
+      end
+    end
   end
 
   describe '#command_streaming' do
@@ -141,7 +136,7 @@ RSpec.describe Git::ExecutionContext do
 
     before do
       allow(context).to receive(:command_line_streaming).and_return(command_line_double)
-      allow(Git::Base).to receive_message_chain(:config, :timeout).and_return(nil)
+      allow(Git::Config.instance).to receive(:timeout).and_return(nil)
     end
 
     it 'delegates to command_line_streaming.run' do
@@ -154,6 +149,25 @@ RSpec.describe Git::ExecutionContext do
     it 'raises ArgumentError for unknown option keys' do
       expect { context.command_streaming('cat-file', bogus: true) }
         .to raise_error(ArgumentError, /Unknown options: bogus/)
+    end
+
+    context 'when building the CommandLine instance (env and resolved binary_path)' do
+      before do
+        allow(context).to receive(:command_line_streaming).and_call_original
+        allow(Git::CommandLine::Streaming).to receive(:new).and_return(command_line_double)
+        allow(command_line_double).to receive(:run).and_return(result)
+      end
+
+      it 'creates a Git::CommandLine::Streaming with env overrides and resolved binary_path' do
+        context.command_streaming('version')
+
+        expect(Git::CommandLine::Streaming).to have_received(:new).with(
+          hash_including('GIT_EDITOR' => 'true', 'LC_ALL' => 'en_US.UTF-8'),
+          context.binary_path,
+          anything,
+          anything
+        )
+      end
     end
   end
 
@@ -180,7 +194,7 @@ RSpec.describe Git::ExecutionContext do
     it 'raises Git::UnexpectedResultError when the output cannot be parsed' do
       allow(version_command_double).to receive(:call).and_return(command_result('not a version string'))
       expect { context.git_version }
-        .to raise_error(Git::UnexpectedResultError)
+        .to raise_error(Git::UnexpectedResultError, /Invalid version/)
     end
   end
 end

--- a/spec/unit/git/git_configure_spec.rb
+++ b/spec/unit/git/git_configure_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# These specs verify that Git.configure, Git.config, Git.git_version, and
+# Git.binary_version resolve global config through Git::Config.instance and NOT
+# through Git::Base.config (Step C1b of the architectural redesign).
+#
+RSpec.describe Git do
+  describe '.config' do
+    it 'returns Git::Config.instance' do
+      expect(described_class.config).to be(Git::Config.instance)
+    end
+
+    it 'does NOT route through Git::Base.config' do
+      expect(Git::Base).not_to receive(:config)
+      described_class.config
+    end
+  end
+
+  describe '.configure' do
+    it 'yields Git::Config.instance' do
+      expect { |b| described_class.configure(&b) }.to yield_with_args(Git::Config.instance)
+    end
+
+    it 'returns nil (void semantics)' do
+      expect(described_class.configure { |_c| 'ignored' }).to be_nil
+    end
+
+    it 'does NOT route through Git::Base.config' do
+      expect(Git::Base).not_to receive(:config)
+      described_class.configure { |_c| nil }
+    end
+  end
+
+  describe '.git_version default binary path' do
+    before { Git::Lib.clear_git_version_cache }
+
+    it 'uses Git::Config.instance.binary_path (not Git::Base.config) when no arg given' do
+      expected_path = Git::Config.instance.binary_path
+      allow(Git::Lib).to receive(:cached_git_version).and_return(Git::Version.new(2, 42, 0))
+      expect(Git::Base).not_to receive(:config)
+      described_class.git_version
+      expect(Git::Lib).to have_received(:cached_git_version).with(expected_path)
+    end
+  end
+
+  describe '.binary_version' do
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+      allow(Git).to receive(:git_version).and_return(Git::Version.new(2, 42, 0))
+    end
+
+    it 'does NOT route through Git::Base.config for the default binary path' do
+      expect(Git::Base).not_to receive(:config)
+      described_class.binary_version
+    end
+  end
+end

--- a/spec/unit/git/git_version_spec.rb
+++ b/spec/unit/git/git_version_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 RSpec.describe Git do
   describe '.git_version' do
-    let(:binary_path) { Git::Base.config.binary_path }
+    let(:binary_path) { Git::Config.instance.binary_path }
     let(:context) { instance_double(Git::ExecutionContext::Global) }
     let(:version_cmd) { instance_double(Git::Commands::Version) }
 
@@ -77,7 +77,7 @@ RSpec.describe Git do
       end
 
       it 'raises Git::Error with Errno::ENOENT as cause' do
-        expect { described_class.git_version }.to raise_error(Git::Error) do |error|
+        expect { described_class.git_version }.to raise_error(Git::Error, /No such file or directory/) do |error|
           expect(error.cause).to be_a(Errno::ENOENT)
         end
       end
@@ -95,7 +95,7 @@ RSpec.describe Git do
       end
 
       it 'raises Git::Error with Errno::EACCES as cause' do
-        expect { described_class.git_version }.to raise_error(Git::Error) do |error|
+        expect { described_class.git_version }.to raise_error(Git::Error, /Permission denied/) do |error|
           expect(error.cause).to be_a(Errno::EACCES)
         end
       end
@@ -108,8 +108,8 @@ RSpec.describe Git do
         )
       end
 
-      it 'raises Git::FailedError' do
-        expect { described_class.git_version }.to raise_error(Git::FailedError)
+      it 'raises Git::FailedError with the stderr in the message' do
+        expect { described_class.git_version }.to raise_error(Git::FailedError, /command not found/)
       end
     end
 
@@ -118,8 +118,8 @@ RSpec.describe Git do
         allow(version_cmd).to receive(:call).and_return(command_result('not a version string'))
       end
 
-      it 'raises Git::UnexpectedResultError' do
-        expect { described_class.git_version }.to raise_error(Git::UnexpectedResultError)
+      it 'raises Git::UnexpectedResultError with an invalid version message' do
+        expect { described_class.git_version }.to raise_error(Git::UnexpectedResultError, /Invalid version/)
       end
     end
   end
@@ -149,6 +149,18 @@ RSpec.describe Git do
 
     it 'still returns an Array of integers' do
       expect(described_class.binary_version).to eq([2, 42, 0])
+    end
+
+    context 'when called with an explicit binary_path' do
+      it 'passes the explicit binary_path to git_version' do
+        described_class.binary_version('/explicit/git')
+
+        expect(Git).to have_received(:git_version).with('/explicit/git')
+      end
+
+      it 'still returns an Array of integers' do
+        expect(described_class.binary_version('/explicit/git')).to eq([2, 42, 0])
+      end
     end
   end
 end


### PR DESCRIPTION
1. Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Implements Step C1b of the architectural redesign: move global `Git::Config` singleton ownership off `Git::Base` so that `Git.configure`, `Git.config`, `Git.git_version`, `Git.binary_version`, and all `Git::ExecutionContext` subclasses resolve global configuration without routing through `Git::Base`.

## Changes

### `lib/git/config.rb`
- Add `Git::Config.instance` class-level singleton accessor (`@instance ||= new`)
- This is the canonical home for the global config object going forward

### `lib/git.rb`
- `Git.configure` now yields `Git::Config.instance` directly
- `Git.config` now returns `Git::Config.instance` directly
- `Git.git_version` body updated: uses `Git::Config.instance.binary_path` (no longer routes through `Git::Base.config`)
- `Git.binary_version` signature updated: default arg changed from `Git::Base.config.binary_path` to `nil`; body resolves from `Git::Config.instance`
- Added full YARD documentation for `Git.configure` and `Git.config`

### `lib/git/base.rb`
- `Git::Base.config` changed from owning `@config ||= Config.new` to delegating `Git::Config.instance`
- This preserves full backward compatibility — all existing callers of `Git::Base.config` continue to work identically

### `lib/git/execution_context.rb`
- `#binary_path` updated: uses `Git::Config.instance.binary_path`
- `#git_ssh` updated: uses `Git::Config.instance.git_ssh`
- YARD docs updated throughout

### `lib/git/execution_context/global.rb` and `lib/git/execution_context/repository.rb`
- YARD param docs updated to reflect that global config is now owned by `Git::Config.instance`

### Specs
- `spec/unit/git/config_spec.rb` (new): full coverage of `Git::Config.instance` contract, instance methods with ENV fallback branches, end-to-end runtime propagation tests, `Git::Base.config` delegation
- `spec/unit/git/git_configure_spec.rb` (new): verifies `Git.configure`, `Git.config`, `Git.git_version`, `Git.binary_version` use `Git::Config.instance` not `Git::Base.config`
- `spec/unit/git/execution_context_config_spec.rb` (new): verifies `ExecutionContext#binary_path` and `#git_ssh` resolve via `Git::Config.instance`
- `spec/unit/git/execution_context_spec.rb`, `global_spec.rb`, `repository_spec.rb`: updated stubs from `Git::Base.config` chain to `Git::Config.instance`; removed private-method testing; improved doubles

### Architecture doc
- `redesign/3_architecture_implementation.md`: Step C1b marked ✅

## Backward Compatibility

All existing public call shapes are preserved:
- `Git.configure { |c| ... }` — ✅ call shape unchanged. Note: the return value is now explicitly `nil` (void semantics), whereas previously `yield config` incidentally returned the block's return value. This was never documented, designed, or tested as a public API contract, so this is a clarification rather than a breaking change.
- `Git.config` — ✅ same object as before (was already `Git::Base.config`, which is now `Git::Config.instance`)
- `Git::Base.config` — ✅ still works; now a delegator to `Git::Config.instance`
- `Git.git_version` / `Git.binary_version` — ✅ identical outputs

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
