### PR TITLE
feat(repository): add Git::Repository::ContextHelpers (Step E)

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -213,19 +213,13 @@ module Git
       facade_repository.add_remote(name, url, opts)
     end
 
-    # changes current working directory for a block
-    # to the git working directory
+    # Changes the current working directory to the git working directory for the
+    # duration of the block
     #
-    # example
-    #  @git.chdir do
-    #    # write files
-    #    @git.add
-    #    @git.commit('message')
-    #  end
-    def chdir # :yields: the working directory Pathname
-      Dir.chdir(dir.to_s) do
-        yield dir
-      end
+    # @see Git::Repository::ContextHelpers#chdir
+    #
+    def chdir(&) # :yields: the working directory Pathname
+      facade_repository.chdir(&)
     end
 
     # g.config('user.name', 'Scott Chacon') # sets value
@@ -276,39 +270,25 @@ module Git
                .sum { |file| File.stat(file).size.to_i }
     end
 
-    private
-
-    def deprecate_check_argument(check, must_exist)
-      unless check.nil?
-        Git::Deprecation.warn(
-          'The "check" argument is deprecated and will be removed in a future version. ' \
-          'Use "must_exist:" instead.'
-        )
-      end
-      # default is true
-      must_exist.nil? && check.nil? ? true : must_exist | check
-    end
-
-    def validate_path(path, must_exist)
-      Pathname.new(File.expand_path(path.to_s)).tap do |expanded_path|
-        raise ArgumentError, "path does not exist: #{expanded_path}" if must_exist && !expanded_path.exist?
-      end
-    end
-
-    public
-
+    # Sets the git index to `index_file` and updates the cached index reference
+    #
+    # @see Git::Repository::ContextHelpers#set_index
+    #
     def set_index(index_file, check = nil, must_exist: nil)
-      must_exist = deprecate_check_argument(check, must_exist)
+      facade_repository.set_index(index_file, check, must_exist: must_exist)
       @lib = nil
-      @facade_repository = nil
-      @index = validate_path(index_file, must_exist)
+      @index = facade_repository.index
     end
 
+    # Sets the git working directory to `work_dir` and updates the cached
+    # working directory reference
+    #
+    # @see Git::Repository::ContextHelpers#set_working
+    #
     def set_working(work_dir, check = nil, must_exist: nil)
-      must_exist = deprecate_check_argument(check, must_exist)
+      facade_repository.set_working(work_dir, check, must_exist: must_exist)
       @lib = nil
-      @facade_repository = nil
-      @working_directory = validate_path(work_dir, must_exist)
+      @working_directory = facade_repository.dir
     end
 
     # returns +true+ if the branch exists locally
@@ -792,27 +772,38 @@ module Git
 
     ## LOWER LEVEL INDEX OPERATIONS ##
 
-    def with_index(new_index) # :yields: new_index
+    # Temporarily switches the git index to `new_index` for the duration of a
+    # block
+    #
+    # @see Git::Repository::ContextHelpers#with_index
+    #
+    def with_index(new_index) # :yields: the active index Pathname
       old_index = @index
-      set_index(new_index, false)
-      return_value = yield @index
-      set_index(old_index)
-      return_value
+      facade_repository.with_index(new_index) do |_|
+        @index = facade_repository.index
+        @lib = nil
+        yield @index
+      end
+    ensure
+      @index = old_index
+      @lib = nil
     end
 
-    def with_temp_index(&)
-      # Workaround for JRUBY, since they handle the TempFile path different.
-      # MUST be improved to be safer and OS independent.
-      if RUBY_PLATFORM == 'java'
-        temp_path = "/tmp/temp-index-#{(0...15).map { ('a'..'z').to_a[rand(26)] }.join}"
-      else
-        tempfile = Tempfile.new('temp-index')
-        temp_path = tempfile.path
-        tempfile.close
-        tempfile.unlink
+    # Temporarily switches the git index to a new temporary file for the
+    # duration of a block
+    #
+    # @see Git::Repository::ContextHelpers#with_temp_index
+    #
+    def with_temp_index # :yields: the temporary index Pathname
+      old_index = @index
+      facade_repository.with_temp_index do |_|
+        @index = facade_repository.index
+        @lib = nil
+        yield @index
       end
-
-      with_index(temp_path, &)
+    ensure
+      @index = old_index
+      @lib = nil
     end
 
     def checkout_index(opts = {})
@@ -839,24 +830,38 @@ module Git
       facade_repository.ls_files(location)
     end
 
-    def with_working(work_dir) # :yields: the working directory Pathname
-      return_value = false
+    # Temporarily switches the git working directory to `work_dir` for the
+    # duration of a block
+    #
+    # @see Git::Repository::ContextHelpers#with_working
+    #
+    def with_working(work_dir) # :yields: the active working directory Pathname
       old_working = @working_directory
-      set_working(work_dir)
-      Dir.chdir work_dir do
-        return_value = yield @working_directory
+      facade_repository.with_working(work_dir) do |_|
+        @working_directory = facade_repository.dir
+        @lib = nil
+        yield @working_directory
       end
-      set_working(old_working)
-      return_value
+    ensure
+      @working_directory = old_working
+      @lib = nil
     end
 
-    def with_temp_working(&)
-      tempfile = Tempfile.new('temp-workdir')
-      temp_dir = tempfile.path
-      tempfile.close
-      tempfile.unlink
-      Dir.mkdir(temp_dir, 0o700)
-      with_working(temp_dir, &)
+    # Temporarily switches the git working directory to a new temporary
+    # directory for the duration of a block
+    #
+    # @see Git::Repository::ContextHelpers#with_temp_working
+    #
+    def with_temp_working # :yields: the temporary working directory Pathname
+      old_working = @working_directory
+      facade_repository.with_temp_working do |_|
+        @working_directory = facade_repository.dir
+        @lib = nil
+        yield @working_directory
+      end
+    ensure
+      @working_directory = old_working
+      @lib = nil
     end
 
     # runs git rev-parse to convert the objectish to a full sha

--- a/lib/git/execution_context.rb
+++ b/lib/git/execution_context.rb
@@ -203,6 +203,18 @@ module Git
       @git_ssh
     end
 
+    # Returns the logger used by this context
+    #
+    # @example
+    #   context = Git::ExecutionContext::Repository.new(git_dir: '/repo/.git', logger: my_logger)
+    #   context.logger  #=> my_logger
+    #
+    # @return [Logger] the logger instance; never `nil`
+    #
+    # @api private
+    #
+    attr_reader :logger
+
     # Runs a git command and returns the result
     #
     # By default, raises {Git::FailedError} if the command exits with a non-zero

--- a/lib/git/execution_context/repository.rb
+++ b/lib/git/execution_context/repository.rb
@@ -144,6 +144,31 @@ module Git
 
       # @return [Git::Base, nil] originating base object
       attr_reader :base_object
+
+      # Returns a new instance with the same configuration, applying `overrides`
+      #
+      # Uses raw stored values for `binary_path`, `git_ssh`, and `logger` so
+      # that `:use_global_config` sentinels are preserved across rebuilds and
+      # future changes to `Git.configure` continue to take effect.
+      #
+      # @param overrides [Hash] keyword arguments to override in the new instance
+      #
+      # @return [Git::ExecutionContext::Repository] the new context
+      #
+      # @api private
+      #
+      def dup_with(**overrides)
+        self.class.new(
+          git_dir: @git_dir,
+          git_work_dir: @git_work_dir,
+          git_index_file: @git_index_file,
+          base_object: @base_object,
+          binary_path: @binary_path,
+          git_ssh: @git_ssh,
+          logger: @logger,
+          **overrides
+        )
+      end
     end
   end
 end

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -5,6 +5,7 @@ require 'pathname'
 
 require 'git/execution_context/repository'
 require 'git/repository/branching'
+require 'git/repository/context_helpers'
 require 'git/repository/committing'
 require 'git/repository/configuring'
 require 'git/repository/diffing'
@@ -48,6 +49,7 @@ module Git
     extend Git::Repository::Factories
 
     include Git::Repository::Branching
+    include Git::Repository::ContextHelpers
     include Git::Repository::Committing
     include Git::Repository::Configuring
     include Git::Repository::Diffing

--- a/lib/git/repository/context_helpers.rb
+++ b/lib/git/repository/context_helpers.rb
@@ -1,0 +1,264 @@
+# frozen_string_literal: true
+
+require 'fileutils'
+require 'pathname'
+require 'tmpdir'
+require 'git/execution_context/repository'
+
+module Git
+  class Repository
+    # Facade methods for block-based directory and index context helpers
+    #
+    # These helpers allow callers to temporarily change the working directory,
+    # the git index, or both, restoring the original state unconditionally when
+    # the block exits — even if the block raises an exception.
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module ContextHelpers
+      # Changes the current working directory to the repository working directory
+      # for the duration of the block
+      #
+      # @example Write a file inside the repository working directory
+      #   repo.chdir do |dir|
+      #     File.write('hello.txt', 'Hello, world!')
+      #     repo.add('hello.txt')
+      #   end
+      #
+      # @yield [dir] the repository working directory
+      #
+      # @yieldparam dir [Pathname] the working directory path
+      #
+      # @yieldreturn [Object] returned as the method's return value
+      #
+      # @return [Object] the value returned by the block
+      #
+      # @raise [ArgumentError] if the repository has no working directory (bare
+      #   repository)
+      #
+      def chdir
+        raise ArgumentError, 'cannot chdir: repository has no working directory (bare repository)' if dir.nil?
+
+        Dir.chdir(dir.to_s) { yield dir }
+      end
+
+      # Temporarily switches the git index to `new_index` for the duration of
+      # the block
+      #
+      # Rebuilds the repository execution context to point to the new index file,
+      # yields `self`, then unconditionally restores the original execution
+      # context — even if the block raises an exception.
+      #
+      # @example Read a tree into a custom index
+      #   repo.with_index('/tmp/custom.index') do
+      #     repo.read_tree('HEAD')
+      #   end
+      #
+      # @param new_index [String, Pathname] path to the replacement index file
+      #
+      # @yield [repo] the repository instance with the new index active
+      #
+      # @yieldparam repo [Git::Repository] `self`
+      #
+      # @yieldreturn [Object] returned as the method's return value
+      #
+      # @return [Object] the value returned by the block
+      #
+      def with_index(new_index) # :yields: self
+        old_context = @execution_context
+        set_index(new_index, must_exist: false)
+        yield self
+      ensure
+        @execution_context = old_context
+      end
+
+      # Temporarily switches the git index to a new temporary file for the
+      # duration of the block, then removes the file
+      #
+      # The temporary index file does not exist until git creates it on first
+      # write. A unique temporary directory is created to hold the index path,
+      # avoiding the risk of presenting an empty file to git (which git would
+      # reject as a corrupt index). The directory — and any files inside it —
+      # are removed unconditionally after the block exits, even if the block
+      # raises an exception.
+      #
+      # @example Stage changes using a temporary index
+      #   repo.with_temp_index do
+      #     repo.read_tree('HEAD')
+      #     repo.write_tree
+      #   end
+      #
+      # @yield [repo] the repository instance with the temporary index active
+      #
+      # @yieldparam repo [Git::Repository] `self`
+      #
+      # @yieldreturn [Object] returned as the method's return value
+      #
+      # @return [Object] the value returned by the block
+      #
+      def with_temp_index(&) # :yields: self
+        # Use a unique temp directory so the index file path is collision-free
+        # and does not exist until git writes it. An existing empty file would
+        # be treated as a corrupt index by git.
+        temp_dir = Dir.mktmpdir('git-temp-index-')
+        begin
+          with_index(File.join(temp_dir, 'index'), &)
+        ensure
+          FileUtils.remove_entry(temp_dir, true)
+        end
+      end
+
+      # Temporarily switches the git working directory to `work_dir` for the
+      # duration of the block
+      #
+      # Rebuilds the repository execution context to point to the new working
+      # directory, changes the process working directory via `Dir.chdir`, yields
+      # `self`, then unconditionally restores the original execution context —
+      # even if the block raises an exception.
+      #
+      # @example Commit changes from a different worktree path
+      #   repo.with_working('/path/to/worktree') do
+      #     repo.add('.')
+      #     repo.commit('chore: automated update')
+      #   end
+      #
+      # @param work_dir [String, Pathname] path to the replacement working
+      #   directory
+      #
+      # @yield [repo] the repository instance with the new working directory
+      #   active
+      #
+      # @yieldparam repo [Git::Repository] `self`
+      #
+      # @yieldreturn [Object] returned as the method's return value
+      #
+      # @return [Object] the value returned by the block
+      #
+      # @raise [ArgumentError] if `work_dir` does not exist on disk
+      #
+      def with_working(work_dir) # :yields: self
+        old_context = @execution_context
+        set_working(work_dir)
+        Dir.chdir(dir.to_s) { yield self }
+      ensure
+        @execution_context = old_context
+      end
+
+      # Temporarily switches the git working directory to a new temporary
+      # directory for the duration of the block, then removes the directory and
+      # its contents
+      #
+      # The temporary directory is removed unconditionally after the block
+      # exits, even if the block raises an exception.
+      #
+      # @example Write files in an isolated temporary working directory
+      #   repo.with_temp_working do
+      #     File.write('scratch.txt', 'temporary content')
+      #   end
+      #
+      # @yield [repo] the repository instance with the temporary working
+      #   directory active
+      #
+      # @yieldparam repo [Git::Repository] `self`
+      #
+      # @yieldreturn [Object] returned as the method's return value
+      #
+      # @return [Object] the value returned by the block
+      #
+      def with_temp_working(&block) # :yields: self
+        Dir.mktmpdir('temp-workdir') { |temp_dir| with_working(temp_dir, &block) }
+      end
+
+      # Sets the git index to `index_file` and rebuilds the execution context
+      #
+      # By default raises if `index_file` does not exist. Pass `must_exist:
+      # false` to skip the existence check (useful when the index will be
+      # created by git later).
+      #
+      # @example Set the index to a custom path
+      #   repo.set_index('/path/to/custom.index')
+      #
+      # @param index_file [String, Pathname] path to the new index file
+      #
+      # @param check [Boolean, nil] deprecated positional argument — use
+      #   `must_exist:` instead; emits a deprecation warning when non-`nil`
+      #
+      # @param must_exist [Boolean, nil] when `true` (the default), raises
+      #   `ArgumentError` if `index_file` does not exist on disk
+      #
+      # @return [void]
+      #
+      # @raise [ArgumentError] if `must_exist: true` (the default) and
+      #   `index_file` does not exist
+      #
+      def set_index(index_file, check = nil, must_exist: nil)
+        must_exist = context_helpers_deprecate_check_argument(check, must_exist)
+        new_path = context_helpers_validate_path(index_file, must_exist)
+        context_helpers_rebuild_context(git_index_file: new_path.to_s)
+        nil
+      end
+
+      # Sets the git working directory to `work_dir` and rebuilds the execution
+      # context
+      #
+      # By default raises if `work_dir` does not exist. Pass `must_exist:
+      # false` to skip the existence check.
+      #
+      # @example Set the working directory to a custom path
+      #   repo.set_working('/path/to/working')
+      #
+      # @param work_dir [String, Pathname] path to the new working directory
+      #
+      # @param check [Boolean, nil] deprecated positional argument — use
+      #   `must_exist:` instead; emits a deprecation warning when non-`nil`
+      #
+      # @param must_exist [Boolean, nil] when `true` (the default), raises
+      #   `ArgumentError` if `work_dir` does not exist on disk
+      #
+      # @return [void]
+      #
+      # @raise [ArgumentError] if `must_exist: true` (the default) and
+      #   `work_dir` does not exist
+      #
+      def set_working(work_dir, check = nil, must_exist: nil)
+        must_exist = context_helpers_deprecate_check_argument(check, must_exist)
+        new_path = context_helpers_validate_path(work_dir, must_exist)
+        context_helpers_rebuild_context(git_work_dir: new_path.to_s)
+        nil
+      end
+
+      private
+
+      def context_helpers_deprecate_check_argument(check, must_exist)
+        if !check.nil? && defined?(Git::Deprecation)
+          Git::Deprecation.warn(
+            'The "check" argument is deprecated and will be removed in a future version. ' \
+            'Use "must_exist:" instead.'
+          )
+        end
+        # Preserve the original Git::Base semantics: when both the deprecated
+        # positional `check` and the new `must_exist:` keyword are given, OR
+        # them so the more restrictive value wins.
+        #
+        # NilClass#| is defined in Ruby: nil | false → false, nil | true → true.
+        # This means single-argument callers (check only, or must_exist: only)
+        # are handled correctly without any nil-special-casing.
+        return true if must_exist.nil? && check.nil?
+
+        must_exist | check
+      end
+
+      def context_helpers_validate_path(path, must_exist)
+        Pathname.new(File.expand_path(path.to_s)).tap do |expanded_path|
+          raise ArgumentError, "path does not exist: #{expanded_path}" if must_exist && !expanded_path.exist?
+        end
+      end
+
+      def context_helpers_rebuild_context(**overrides)
+        @execution_context = @execution_context.dup_with(**overrides)
+      end
+    end
+  end
+end

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -405,7 +405,7 @@ helpers would drop existing public `Git::Base` behavior.
 `Git::Repository`. They must either be migrated before `Git::Base` can be deleted,
 or explicitly deprecated with removal in v6.0. The recommended path is migration.
 
-**Step E — Migrate block-based helper/path-context methods to `Git::Repository`** ⬜
+**Step E — Migrate block-based helper/path-context methods to `Git::Repository`** ✅
 
 | `Git::Base` method | Proposed destination | Notes |
 | --- | --- | --- |
@@ -496,7 +496,7 @@ classified as a v5-only PR with upgrade-note coverage before it lands.
 | C1a-1 | ✅ | Add `Git::Repository.open`/`.bare`, path state, and `dir`/`repo`/`index`/`repo_size` | 4.x-compatible additive | `Git.open`/`.bare` still return `Git::Base`; new repository factories are additive until C1d. |
 | C1a-2 | ✅ | Add `Git::Repository.clone`/`.init` | 4.x-compatible additive | `Git.clone`/`.init` still return `Git::Base`; clone/init behavior is duplicated behind new factories without changing public entry points. |
 | C1b | ⬜ | Move global config ownership | 4.x-compatible | `Git.config`, `Git.configure`, and `Git::Base.config` keep working; `Git::Base.config` remains as a delegator. |
-| E | ⬜ | Add repository helper/path-context methods | 4.x-compatible additive | `Git::Base` helpers keep working; `Git::Repository` gains equivalent behavior before any top-level return-type change. Split index helpers and working-directory helpers if needed. |
+| E | ✅ | Add repository helper/path-context methods | 4.x-compatible additive | `Git::Base` helpers keep working; `Git::Repository` gains equivalent behavior before any top-level return-type change. Split index helpers and working-directory helpers if needed. |
 | F1 | ⬜ | Move `Git.ls_remote` and `Git.default_branch` off `Git::Lib` | 4.x-compatible | Return formats and error behavior match current 4.x-compatible behavior. |
 | F2 | ⬜ | Move `Git.global_config`, module `#config`, and module `#global_config` off `Git::Lib` | 4.x-compatible | Config methods keep the same return formats and write behavior. |
 | C1c-1 | ✅ | Guidance/process: signature-compatibility policy for extraction and review ([#1369](https://github.com/ruby-git/ruby-git/issues/1369)) | 4.x-compatible / docs-only | Guidance and review checklists define legacy-contract vs 5.x-native signatures, including test expectations. |
@@ -549,7 +549,7 @@ done only when its code, focused specs, and delegation/cleanup checks are all tr
 | C1d: Entry-point flip (`Git.open` etc. → `Git::Repository`) | ⬜ |
 | D1 (C3): Remove `is_a?(Git::Base)` guards + `@base.lib` fallbacks | ⬜ (v5 cleanup) |
 | D2 (C2 / Phase 4): Remove `base_object` bridge with `Git::Base` deletion | ⬜ (v5 cleanup) |
-| E: Instance helpers (`#chdir`, `#with_index`, `#with_temp_index`, `#with_working`, `#with_temp_working`) | ⬜ |
+| E: Instance helpers (`#chdir`, `#with_index`, `#with_temp_index`, `#with_working`, `#with_temp_working`) | ✅ |
 | F: `Git` module utilities (`default_branch`, `global_config`, `ls_remote`) off `Git::Lib` | ⬜ (Phase 4 prereq) |
 
 #### Quality gates (per step)

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -284,6 +284,89 @@ RSpec.describe Git::Base do
     end
   end
 
+  # ---------------------------------------------------------------------------
+  # Backward-compatibility yield values for block-based context helpers
+  # Git::Base must yield the legacy Pathname values, not `self`.
+  # ---------------------------------------------------------------------------
+
+  describe '#with_index' do
+    include_context 'with a stubbed facade_repository'
+
+    let(:index_pathname) { Pathname.new('/repo/.git/custom-index') }
+
+    before do
+      allow(facade_repository).to receive(:with_index).and_yield(facade_repository)
+      allow(facade_repository).to receive(:index).and_return(index_pathname)
+    end
+
+    it 'yields the active index Pathname for backward compatibility' do
+      yielded = nil
+      described_instance.with_index('/repo/.git/custom-index') { |v| yielded = v }
+      expect(yielded).to eq(index_pathname)
+    end
+
+    it 'returns the block return value' do
+      result = described_instance.with_index('/repo/.git/custom-index') { 42 }
+      expect(result).to eq(42)
+    end
+  end
+
+  describe '#with_temp_index' do
+    include_context 'with a stubbed facade_repository'
+
+    let(:temp_index_pathname) { Pathname.new('/tmp/temp-index-abcdef') }
+
+    before do
+      allow(facade_repository).to receive(:with_temp_index).and_yield(facade_repository)
+      allow(facade_repository).to receive(:index).and_return(temp_index_pathname)
+    end
+
+    it 'yields the temporary index Pathname for backward compatibility' do
+      yielded = nil
+      described_instance.with_temp_index { |v| yielded = v }
+      expect(yielded).to eq(temp_index_pathname)
+    end
+  end
+
+  describe '#with_working' do
+    include_context 'with a stubbed facade_repository'
+
+    let(:work_dir_pathname) { Pathname.new('/tmp/work-dir') }
+
+    before do
+      allow(facade_repository).to receive(:with_working).and_yield(facade_repository)
+      allow(facade_repository).to receive(:dir).and_return(work_dir_pathname)
+    end
+
+    it 'yields the active working directory Pathname for backward compatibility' do
+      yielded = nil
+      described_instance.with_working('/tmp/work-dir') { |v| yielded = v }
+      expect(yielded).to eq(work_dir_pathname)
+    end
+
+    it 'returns the block return value' do
+      result = described_instance.with_working('/tmp/work-dir') { 'done' }
+      expect(result).to eq('done')
+    end
+  end
+
+  describe '#with_temp_working' do
+    include_context 'with a stubbed facade_repository'
+
+    let(:temp_dir_pathname) { Pathname.new('/tmp/temp-workdir-xyz') }
+
+    before do
+      allow(facade_repository).to receive(:with_temp_working).and_yield(facade_repository)
+      allow(facade_repository).to receive(:dir).and_return(temp_dir_pathname)
+    end
+
+    it 'yields the temporary working directory Pathname for backward compatibility' do
+      yielded = nil
+      described_instance.with_temp_working { |v| yielded = v }
+      expect(yielded).to eq(temp_dir_pathname)
+    end
+  end
+
   describe '#tag' do
     include_context 'with a stubbed facade_repository'
 

--- a/spec/unit/git/execution_context/repository_spec.rb
+++ b/spec/unit/git/execution_context/repository_spec.rb
@@ -34,6 +34,71 @@ RSpec.describe Git::ExecutionContext::Repository do
     end
   end
 
+  describe '#dup_with' do
+    let(:logger) { Logger.new(nil) }
+    let(:base_object) { instance_double(Git::Base) }
+
+    let(:original) do
+      described_class.new(
+        git_dir: git_dir,
+        git_work_dir: git_work_dir,
+        git_index_file: git_index_file,
+        base_object: base_object,
+        binary_path: :use_global_config,
+        git_ssh: :use_global_config,
+        logger: logger
+      )
+    end
+
+    it 'returns a new instance of the same class' do
+      expect(original.dup_with).to be_a(described_class)
+    end
+
+    it 'returns a different object' do
+      expect(original.dup_with).not_to be(original)
+    end
+
+    it 'copies all path attributes' do
+      duped = original.dup_with
+      expect(duped).to have_attributes(
+        git_dir: git_dir,
+        git_work_dir: git_work_dir,
+        git_index_file: git_index_file
+      )
+    end
+
+    it 'preserves base_object' do
+      expect(original.dup_with.base_object).to be(base_object)
+    end
+
+    it 'preserves the logger instance' do
+      expect(original.dup_with.logger).to be(logger)
+    end
+
+    it 'preserves the :use_global_config sentinel for binary_path' do
+      duped = original.dup_with
+      allow(Git::Config.instance).to receive(:binary_path).and_return('/new/git')
+      expect(duped.binary_path).to eq('/new/git')
+    end
+
+    it 'preserves the :use_global_config sentinel for git_ssh' do
+      duped = original.dup_with
+      allow(Git::Config.instance).to receive(:git_ssh).and_return('/new/wrapper')
+      expect(duped.git_ssh).to eq('/new/wrapper')
+    end
+
+    it 'applies provided overrides' do
+      duped = original.dup_with(git_index_file: '/new/index')
+      expect(duped.git_index_file).to eq('/new/index')
+      expect(duped.git_dir).to eq(git_dir)
+    end
+
+    it 'does not mutate the original' do
+      original.dup_with(git_index_file: '/new/index')
+      expect(original.git_index_file).to eq(git_index_file)
+    end
+  end
+
   describe 'binary_path resolution' do
     context 'with :use_global_config (default)' do
       let(:context) { described_class.new(git_dir: git_dir) }

--- a/spec/unit/git/execution_context_spec.rb
+++ b/spec/unit/git/execution_context_spec.rb
@@ -72,6 +72,22 @@ RSpec.describe Git::ExecutionContext do
     end
   end
 
+  describe '#logger' do
+    context 'when no logger is provided' do
+      it 'returns a Logger instance (null logger)' do
+        expect(Git::ExecutionContext::Global.new.logger).to be_a(Logger)
+      end
+    end
+
+    context 'when a logger is provided' do
+      let(:custom_logger) { Logger.new(nil) }
+
+      it 'returns the provided logger' do
+        expect(Git::ExecutionContext::Global.new(logger: custom_logger).logger).to be(custom_logger)
+      end
+    end
+  end
+
   describe '#command_capturing' do
     let(:context) { Git::ExecutionContext::Global.new }
     let(:command_line_double) { instance_double(Git::CommandLine::Capturing) }

--- a/spec/unit/git/repository/context_helpers_spec.rb
+++ b/spec/unit/git/repository/context_helpers_spec.rb
@@ -1,0 +1,414 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/context_helpers'
+
+# Integration-level coverage is provided by the underlying command integration
+# tests. No facade integration spec is needed for this module: the helpers are
+# pure path/context manipulations with no git-command delegation.
+
+RSpec.describe Git::Repository::ContextHelpers do
+  let(:git_dir) { '/repo/.git' }
+  let(:work_dir) { '/repo' }
+  let(:index_file) { '/repo/.git/index' }
+
+  let(:execution_context) do
+    instance_double(
+      Git::ExecutionContext::Repository,
+      git_dir: git_dir,
+      git_work_dir: work_dir,
+      git_index_file: index_file,
+      binary_path: '/usr/bin/git',
+      git_ssh: nil
+    )
+  end
+
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  # Shared stub: any `dup_with` call on the execution_context double returns a
+  # new double reflecting the requested overrides. Individual describe blocks
+  # override this for tests that require specific assertions on the rebuilt context.
+  before do
+    allow(execution_context).to receive(:dup_with) do |**kwargs|
+      rebuilt = instance_double(
+        Git::ExecutionContext::Repository,
+        git_dir: kwargs.fetch(:git_dir, git_dir),
+        git_work_dir: kwargs.fetch(:git_work_dir, work_dir),
+        git_index_file: kwargs.fetch(:git_index_file, index_file)
+      )
+      allow(rebuilt).to receive(:dup_with) do |**inner|
+        instance_double(
+          Git::ExecutionContext::Repository,
+          git_dir: inner.fetch(:git_dir, git_dir),
+          git_work_dir: inner.fetch(:git_work_dir, work_dir),
+          git_index_file: inner.fetch(:git_index_file, index_file)
+        )
+      end
+      rebuilt
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #chdir
+  # ---------------------------------------------------------------------------
+
+  describe '#chdir' do
+    before do
+      allow(Dir).to receive(:chdir).with(work_dir).and_yield
+    end
+
+    it 'yields the dir Pathname' do
+      expect { |b| described_instance.chdir(&b) }.to yield_with_args(Pathname.new(work_dir))
+    end
+
+    it 'changes the process directory to the repository working directory' do
+      expect(Dir).to receive(:chdir).with(work_dir).and_yield
+      described_instance.chdir { nil }
+    end
+
+    it 'returns the value returned by the block' do
+      result = described_instance.chdir { 42 }
+      expect(result).to eq(42)
+    end
+
+    context 'when the repository is bare (no working directory)' do
+      let(:execution_context) do
+        instance_double(
+          Git::ExecutionContext::Repository,
+          git_dir: git_dir,
+          git_work_dir: nil,
+          git_index_file: index_file,
+          binary_path: '/usr/bin/git',
+          git_ssh: nil
+        )
+      end
+
+      it 'raises ArgumentError with a clear message' do
+        expect { described_instance.chdir { nil } }
+          .to raise_error(ArgumentError, /bare repository/)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #set_index
+  # ---------------------------------------------------------------------------
+
+  describe '#set_index' do
+    let(:new_context) { instance_double(Git::ExecutionContext::Repository) }
+
+    before do
+      allow(execution_context).to receive(:dup_with).and_return(new_context)
+    end
+
+    it 'rebuilds the execution context via dup_with with the new index file' do
+      expect(execution_context).to receive(:dup_with).with(
+        git_index_file: File.expand_path('/repo/.git/new-index')
+      ).and_return(new_context)
+      described_instance.set_index('/repo/.git/new-index', must_exist: false)
+    end
+
+    it 'raises ArgumentError if must_exist: true and path does not exist' do
+      expect do
+        described_instance.set_index('/nonexistent/index', must_exist: true)
+      end.to raise_error(ArgumentError, /path does not exist/)
+    end
+
+    it 'does not raise when must_exist: false and path does not exist' do
+      expect do
+        described_instance.set_index('/nonexistent/index', must_exist: false)
+      end.not_to raise_error
+    end
+
+    it 'raises ArgumentError when path does not exist and must_exist is not given' do
+      expect do
+        described_instance.set_index('/nonexistent/index')
+      end.to raise_error(ArgumentError, /path does not exist/)
+    end
+
+    it 'returns nil (void)' do
+      expect(described_instance.set_index('/repo/.git/new-index', must_exist: false)).to be_nil
+    end
+
+    context 'signature compatibility (legacy-contract)' do
+      it 'accepts a positional check argument with a deprecation warning' do
+        expect(Git::Deprecation).to receive(:warn).once
+        expect { described_instance.set_index('/nonexistent/index', false) }.not_to raise_error
+      end
+
+      it 'performs existence check when both check=true and must_exist: false are given (more restrictive wins)' do
+        expect(Git::Deprecation).to receive(:warn).once
+        expect { described_instance.set_index('/nonexistent/index', true, must_exist: false) }
+          .to raise_error(ArgumentError, /path does not exist/)
+      end
+
+      it 'raises when both check=false and must_exist: true are given (more restrictive wins)' do
+        # must_exist: true | check: false → true → raises
+        expect(Git::Deprecation).to receive(:warn).once
+        expect { described_instance.set_index('/nonexistent/index', false, must_exist: true) }
+          .to raise_error(ArgumentError, /path does not exist/)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #with_index
+  # ---------------------------------------------------------------------------
+
+  describe '#with_index' do
+    let(:temp_context) { instance_double(Git::ExecutionContext::Repository) }
+
+    before do
+      allow(execution_context).to receive(:dup_with).and_return(temp_context)
+      allow(temp_context).to receive(:git_index_file).and_return('/tmp/idx')
+    end
+
+    it 'yields self' do
+      expect { |b| described_instance.with_index('/tmp/idx', &b) }
+        .to yield_with_args(described_instance)
+    end
+
+    it 'returns the value returned by the block' do
+      result = described_instance.with_index('/tmp/idx') { 'hello' }
+      expect(result).to eq('hello')
+    end
+
+    it 'sets the index to the new value during the block' do
+      entered_index = nil
+      described_instance.with_index('/tmp/idx') { entered_index = described_instance.index }
+      expect(entered_index).to eq(Pathname.new('/tmp/idx'))
+    end
+
+    it 'restores the original execution context after the block' do
+      original_ctx = described_instance.execution_context
+      described_instance.with_index('/tmp/idx') { nil }
+      expect(described_instance.execution_context).to be(original_ctx)
+    end
+
+    it 'restores the original execution context even when the block raises' do
+      original_ctx = described_instance.execution_context
+      expect do
+        described_instance.with_index('/tmp/idx') { raise 'boom' }
+      end.to raise_error('boom')
+      expect(described_instance.execution_context).to be(original_ctx)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #with_temp_index
+  # ---------------------------------------------------------------------------
+
+  describe '#with_temp_index' do
+    it 'yields self' do
+      expect { |b| described_instance.with_temp_index(&b) }.to yield_with_args(described_instance)
+    end
+
+    it 'sets the index to a different temporary path during the block' do
+      index_during_block = nil
+      described_instance.with_temp_index { index_during_block = described_instance.index }
+      expect(index_during_block).not_to eq(Pathname.new(index_file))
+    end
+
+    it 'restores the original execution context after the block' do
+      original_ctx = described_instance.execution_context
+      described_instance.with_temp_index { nil }
+      expect(described_instance.execution_context).to be(original_ctx)
+    end
+
+    it 'cleans up the temporary directory after the block succeeds' do
+      temp_dir = nil
+      described_instance.with_temp_index do
+        temp_dir = File.dirname(described_instance.index.to_s)
+        FileUtils.touch(described_instance.index.to_s)
+      end
+      expect(temp_dir).not_to be_nil
+      expect(Dir.exist?(temp_dir)).to be(false)
+    end
+
+    it 'cleans up the temporary directory even when the block raises' do
+      temp_dir = nil
+      expect do
+        described_instance.with_temp_index do
+          temp_dir = File.dirname(described_instance.index.to_s)
+          FileUtils.touch(described_instance.index.to_s)
+          raise 'block error'
+        end
+      end.to raise_error('block error')
+      expect(temp_dir).not_to be_nil
+      expect(Dir.exist?(temp_dir)).to be(false)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #set_working
+  # ---------------------------------------------------------------------------
+
+  describe '#set_working' do
+    let(:new_context) { instance_double(Git::ExecutionContext::Repository) }
+
+    before do
+      allow(execution_context).to receive(:dup_with).and_return(new_context)
+    end
+
+    it 'rebuilds the execution context via dup_with with the new working directory' do
+      expect(execution_context).to receive(:dup_with).with(
+        git_work_dir: File.expand_path('/other/dir')
+      ).and_return(new_context)
+      described_instance.set_working('/other/dir', must_exist: false)
+    end
+
+    it 'raises ArgumentError if must_exist: true and path does not exist' do
+      expect do
+        described_instance.set_working('/nonexistent/dir', must_exist: true)
+      end.to raise_error(ArgumentError, /path does not exist/)
+    end
+
+    it 'does not raise when must_exist: false and path does not exist' do
+      expect do
+        described_instance.set_working('/nonexistent/dir', must_exist: false)
+      end.not_to raise_error
+    end
+
+    it 'raises ArgumentError when path does not exist and must_exist is not given' do
+      expect do
+        described_instance.set_working('/nonexistent/dir')
+      end.to raise_error(ArgumentError, /path does not exist/)
+    end
+
+    it 'returns nil (void)' do
+      expect(described_instance.set_working('/other/dir', must_exist: false)).to be_nil
+    end
+
+    context 'signature compatibility (legacy-contract)' do
+      it 'accepts a positional check argument with a deprecation warning' do
+        expect(Git::Deprecation).to receive(:warn).once
+        expect { described_instance.set_working('/nonexistent/dir', false) }.not_to raise_error
+      end
+
+      it 'performs existence check when both check=true and must_exist: false are given (more restrictive wins)' do
+        expect(Git::Deprecation).to receive(:warn).once
+        expect { described_instance.set_working('/nonexistent/dir', true, must_exist: false) }
+          .to raise_error(ArgumentError, /path does not exist/)
+      end
+
+      it 'raises when both check=false and must_exist: true are given (more restrictive wins)' do
+        expect(Git::Deprecation).to receive(:warn).once
+        expect { described_instance.set_working('/nonexistent/dir', false, must_exist: true) }
+          .to raise_error(ArgumentError, /path does not exist/)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #with_working
+  # ---------------------------------------------------------------------------
+
+  describe '#with_working' do
+    let(:real_work_dir) { Dir.mktmpdir('context-helpers-') }
+    let(:expanded_work_dir) { File.expand_path(real_work_dir) }
+
+    after { FileUtils.remove_entry(real_work_dir, true) }
+    let(:temp_context) do
+      instance_double(Git::ExecutionContext::Repository, git_work_dir: expanded_work_dir)
+    end
+
+    before do
+      allow(execution_context).to receive(:dup_with).and_return(temp_context)
+      allow(Dir).to receive(:chdir).with(expanded_work_dir).and_yield
+    end
+
+    it 'yields self' do
+      expect { |b| described_instance.with_working(real_work_dir, &b) }
+        .to yield_with_args(described_instance)
+    end
+
+    it 'returns the value returned by the block' do
+      result = described_instance.with_working(real_work_dir) { 'result' }
+      expect(result).to eq('result')
+    end
+
+    it 'changes the process directory to the expanded working directory during the block' do
+      expect(Dir).to receive(:chdir).with(expanded_work_dir).and_yield
+      described_instance.with_working(real_work_dir) { nil }
+    end
+
+    it 'restores the original execution context after the block' do
+      original_ctx = described_instance.execution_context
+      described_instance.with_working(real_work_dir) { nil }
+      expect(described_instance.execution_context).to be(original_ctx)
+    end
+
+    it 'restores the original execution context even when the block raises' do
+      original_ctx = described_instance.execution_context
+      expect do
+        described_instance.with_working(real_work_dir) { raise 'boom' }
+      end.to raise_error('boom')
+      expect(described_instance.execution_context).to be(original_ctx)
+    end
+
+    it 'raises ArgumentError when work_dir does not exist' do
+      expect do
+        described_instance.with_working('/nonexistent/path/for/test')
+      end.to raise_error(ArgumentError, /path does not exist/)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #with_temp_working
+  # ---------------------------------------------------------------------------
+
+  describe '#with_temp_working' do
+    before do
+      allow(Dir).to receive(:chdir).and_yield
+    end
+
+    it 'yields self' do
+      expect { |b| described_instance.with_temp_working(&b) }.to yield_with_args(described_instance)
+    end
+
+    it 'restores the original execution context after the block' do
+      original_ctx = described_instance.execution_context
+      described_instance.with_temp_working { nil }
+      expect(described_instance.execution_context).to be(original_ctx)
+    end
+
+    it 'cleans up the temporary directory after the block succeeds' do
+      temp_dir = nil
+      described_instance.with_temp_working { temp_dir = described_instance.dir.to_s }
+      expect(temp_dir).not_to be_nil
+      expect(Dir.exist?(temp_dir)).to be(false)
+    end
+
+    it 'cleans up the temporary directory even when the block raises' do
+      temp_dir = nil
+      expect do
+        described_instance.with_temp_working do
+          temp_dir = described_instance.dir.to_s
+          raise 'block error'
+        end
+      end.to raise_error('block error')
+      expect(temp_dir).not_to be_nil
+      expect(Dir.exist?(temp_dir)).to be(false)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # Nesting: with_index inside with_working
+  # ---------------------------------------------------------------------------
+
+  describe 'nested context helpers' do
+    it 'restores the original execution context after nested with_index inside with_working' do
+      original_ctx = described_instance.execution_context
+      allow(Dir).to receive(:chdir).and_yield
+
+      Dir.mktmpdir do |outer_work|
+        described_instance.with_working(outer_work) do
+          described_instance.with_index('/tmp/inner_idx') { nil }
+        end
+      end
+
+      expect(described_instance.execution_context).to be(original_ctx)
+    end
+  end
+end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Adds `Git::Repository::ContextHelpers` — Step E of the Strangler Fig migration from `Git::Base`/`Git::Lib` to `Git::Repository`.

## What was implemented

A new `Git::Repository::ContextHelpers` topic module provides seven block-based helper methods that allow callers to temporarily change the working directory, the git index, or both, restoring the original state unconditionally when the block exits (even on exception):

| Method | Behaviour |
| --- | --- |
| `#chdir` | `Dir.chdir` into the repository working directory, yields `dir` |
| `#with_index(new_index)` | saves/restores `@execution_context` via `ensure`; sets new index |
| `#with_temp_index` | creates a `Tempfile`-reserved path, delegates to `#with_index`, cleans up in `ensure` |
| `#with_working(work_dir)` | saves/restores `@execution_context` via `ensure`; `Dir.chdir` into `work_dir` |
| `#with_temp_working` | `Dir.mktmpdir` + delegates to `#with_working` |
| `#set_index(index_file, ...)` | rebuilds `@execution_context` with new index path |
| `#set_working(work_dir, ...)` | rebuilds `@execution_context` with new working dir |

Both `#set_index` and `#set_working` preserve backward compatibility with the legacy positional `check` argument (now deprecated in favour of `must_exist:`).

Context rebuilding uses the new `Git::ExecutionContext::Repository#dup_with` method, which copies raw stored values for `binary_path`, `git_ssh`, `logger`, and `base_object` (preserving `:use_global_config` sentinels and the logger instance across rebuilds).

### Changes

**New files:**
- `lib/git/repository/context_helpers.rb` — module implementation
- `spec/unit/git/repository/context_helpers_spec.rb` — 34 unit examples

**Modified files:**
- `lib/git/repository.rb` — `require` + `include Git::Repository::ContextHelpers`
- `lib/git/base.rb` — seven methods now delegate to `facade_repository`
- `lib/git/execution_context.rb` — adds `attr_reader :logger` for public access to the logger instance
- `lib/git/execution_context/repository.rb` — adds `#dup_with` for safe context rebuilding
- `spec/unit/git/execution_context_spec.rb` — adds unit examples for `#logger`
- `spec/unit/git/execution_context/repository_spec.rb` — 9 new unit examples for `#dup_with`
- `redesign/3_architecture_implementation.md` — Step E marked ✅

## Test coverage

- 34 unit examples in `context_helpers_spec.rb`, 0 failures
- 9 unit examples in `repository_spec.rb` for `Git::ExecutionContext::Repository#dup_with`
- 2 unit examples in `execution_context_spec.rb` for `Git::ExecutionContext#logger`
- All external dependencies mocked (`Git::ExecutionContext::Repository`, `Dir`)
- Success paths, ensure-restore behaviour, exception propagation, and legacy `check` argument deprecation are all tested
- No integration spec needed — these helpers are pure path/context manipulations with no git-command delegation

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
