### PR TITLE
feat(repository): add compatibility aliases remove and revparse

### DIFF
--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -252,6 +252,8 @@ module Git
         Git::Commands::RevParse.new(@execution_context).call(objectish, '--', revs_only: true).stdout
       end
 
+      alias revparse rev_parse
+
       # Returns the SHA of a named tag
       #
       # Returns an empty string when the tag does not exist.

--- a/lib/git/repository/staging.rb
+++ b/lib/git/repository/staging.rb
@@ -157,6 +157,8 @@ module Git
         Git::Commands::Rm.new(@execution_context).call(*Array(path), **opts).stdout
       end
 
+      alias remove rm
+
       # Option keys accepted by {#clean}
       #
       # The deprecated `:ff` and `:force_force` keys are handled by

--- a/redesign/c1c2_audit.md
+++ b/redesign/c1c2_audit.md
@@ -29,12 +29,12 @@ surfaced.
 | Bucket | ✅ | ⬜ | ❌ | ⚠️ | 🔍 | Total |
 |--------|----|----|----|----|-----|-------|
 | 1 — Path/accessors | 4 | 0 | 0 | 0 | 0 | 4 |
-| 2 — Compatibility aliases & wrappers | 1 | 6 | 0 | 1 | 0 | 8 |
+| 2 — Compatibility aliases & wrappers | 3 | 4 | 0 | 1 | 0 | 8 |
 | 3 — Low-level public methods | 0 | 6 | 0 | 0 | 1 | 7 |
 | 4 — Factory & domain-object returns | 12 | 0 | 0 | 0 | 0 | 12 |
 | 5 — Keyword-arg signature review | 3 | 0 | 0 | 5 | 1 | 9 |
 | 6 — `Git::Lib` orphaned public methods | — | — | — | — | — | **⚠️ see §7** |
-| **Grand total (Buckets 1–5)** | **20** | **12** | **0** | **6** | **2** | **40** |
+| **Grand total (Buckets 1–5)** | **22** | **10** | **0** | **6** | **2** | **40** |
 
 > ⚠️ **Bucket 6 contains more than 40 genuine orphaned public methods**
 > (see §7 for the full count breakdown). Per the audit instructions, this
@@ -58,9 +58,9 @@ Sorted by bucket, then alphabetically within bucket.
 | `is_branch?` | 2 | ⬜ | Deprecated in 4.x; migrate deprecated stub to `Git::Repository::Branching` pointing to `branch?` |
 | `is_local_branch?` | 2 | ⬜ | Deprecated in 4.x; migrate deprecated stub to `Git::Repository::Branching` pointing to `local_branch?` |
 | `is_remote_branch?` | 2 | ⬜ | Deprecated in 4.x; migrate deprecated stub to `Git::Repository::Branching` pointing to `remote_branch?` |
-| `remove` | 2 | ⬜ | Alias for `rm`; add alias to `Git::Repository::Staging` |
+| `remove` | 2 | ✅ | `alias remove rm` added to `Git::Repository::Staging` |
 | `reset_hard` | 2 | ⬜ | Deprecated wrapper; migrate to `Git::Repository::Staging` with `@deprecated` tag pointing to `reset(commitish, hard: true)` |
-| `revparse` | 2 | ⬜ | Alias for `rev_parse`; add alias to `Git::Repository::ObjectOperations` |
+| `revparse` | 2 | ✅ | `alias revparse rev_parse` added to `Git::Repository::ObjectOperations` |
 | `apply` | 3 | ⬜ | New facade in `Git::Repository::Staging` (or new `Patching` module); `Git::Commands::Apply` ✅ |
 | `apply_mail` | 3 | ⬜ | Same module as `apply`; `Git::Commands::Am` ✅ |
 | `describe` | 3 | ⬜ | New facade in `Git::Repository::Inspecting`; `Git::Commands::Describe` ✅ |

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -395,6 +395,12 @@ RSpec.describe Git::Repository::ObjectOperations do
     end
   end
 
+  describe '#revparse' do
+    it 'is an alias for #rev_parse' do
+      expect(described_instance.method(:revparse)).to eq(described_instance.method(:rev_parse))
+    end
+  end
+
   describe '#tag_sha' do
     let(:show_ref_list_command) { instance_double(Git::Commands::ShowRef::List) }
     let(:git_dir) { '/fake/.git' }

--- a/spec/unit/git/repository/staging_spec.rb
+++ b/spec/unit/git/repository/staging_spec.rb
@@ -228,6 +228,12 @@ RSpec.describe Git::Repository::Staging do
     end
   end
 
+  describe '#remove' do
+    it 'is an alias for #rm' do
+      expect(described_instance.method(:remove)).to eq(described_instance.method(:rm))
+    end
+  end
+
   describe '#clean' do
     subject(:result) { described_instance.clean }
 


### PR DESCRIPTION
## Summary

Adds two 4.x public API compatibility aliases to `Git::Repository` as the first micro-step of the Bucket 2 migration identified in the C1c-2 audit (`redesign/c1c2_audit.md §3`).

| Alias | Module | Delegates to |
|-------|--------|--------------|
| `remove` | `Git::Repository::Staging` | `rm` |
| `revparse` | `Git::Repository::ObjectOperations` | `rev_parse` |

Both are plain `alias` statements — no deprecation warning, no changed behavior. They ensure callers using these names will not receive `NoMethodError` when `Git.open` eventually returns `Git::Repository` instead of `Git::Base`.

## Changes

- `lib/git/repository/staging.rb` — `alias remove rm` after `#rm`
- `lib/git/repository/object_operations.rb` — `alias revparse rev_parse` after `#rev_parse`
- `spec/unit/git/repository/staging_spec.rb` — unit test asserting `#remove` is an alias for `#rm`
- `spec/unit/git/repository/object_operations_spec.rb` — unit test asserting `#revparse` is an alias for `#rev_parse`
- `redesign/c1c2_audit.md` — `remove` and `revparse` rows updated ⬜ → ✅; Bucket 2 and Grand Total counts updated

## Testing

```
bundle exec rake default:parallel  # all tests and linters pass
```

## PR Checklist

- [x] All tests pass (`bundle exec rake default:parallel`)
- [x] Unit tests added for both aliases (method-identity assertions)
- [x] Audit document updated (status rows + summary counts)
- [x] No CHANGELOG edit (auto-generated from commits)
