### PR TITLE
feat(staging): add deprecated reset_hard wrapper to Git::Repository::Staging

### DIFF
--- a/lib/git/repository/staging.rb
+++ b/lib/git/repository/staging.rb
@@ -90,6 +90,35 @@ module Git
         Git::Commands::Reset.new(@execution_context).call(commitish, **).stdout
       end
 
+      # Reset the current HEAD to a specified state with `--hard`
+      #
+      # @deprecated Use {#reset} with `hard: true` instead.
+      #
+      #   @example Hard reset to HEAD
+      #     repo.reset_hard
+      #
+      #   @example Hard reset to a specific commit
+      #     repo.reset_hard('HEAD~1')
+      #
+      # @param commitish [String, nil] the commit or tree-ish to reset to;
+      #   defaults to HEAD when `nil`
+      #
+      # @param opts [Hash] options passed through to {#reset}
+      #
+      # @return [String] git's stdout from the reset
+      #
+      # @raise [ArgumentError] when unsupported options are provided
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def reset_hard(commitish = nil, opts = {})
+        Git::Deprecation.warn(
+          'Git::Repository::Staging#reset_hard is deprecated and will be removed in a future version. ' \
+          'Use #reset(commitish, hard: true) instead.'
+        )
+        reset(commitish, **opts, hard: true)
+      end
+
       # Option keys accepted by {#rm}
       RM_ALLOWED_OPTS = %i[
         force f dry_run n r cached ignore_unmatch sparse quiet q

--- a/redesign/c1c2_audit.md
+++ b/redesign/c1c2_audit.md
@@ -29,12 +29,12 @@ surfaced.
 | Bucket | ✅ | ⬜ | ❌ | ⚠️ | 🔍 | Total |
 |--------|----|----|----|----|-----|-------|
 | 1 — Path/accessors | 4 | 0 | 0 | 0 | 0 | 4 |
-| 2 — Compatibility aliases & wrappers | 3 | 4 | 0 | 1 | 0 | 8 |
+| 2 — Compatibility aliases & wrappers | 4 | 3 | 0 | 1 | 0 | 8 |
 | 3 — Low-level public methods | 0 | 6 | 0 | 0 | 1 | 7 |
 | 4 — Factory & domain-object returns | 12 | 0 | 0 | 0 | 0 | 12 |
 | 5 — Keyword-arg signature review | 3 | 0 | 0 | 5 | 1 | 9 |
 | 6 — `Git::Lib` orphaned public methods | — | — | — | — | — | **⚠️ see §7** |
-| **Grand total (Buckets 1–5)** | **22** | **10** | **0** | **6** | **2** | **40** |
+| **Grand total (Buckets 1–5)** | **23** | **9** | **0** | **6** | **2** | **40** |
 
 > ⚠️ **Bucket 6 contains more than 40 genuine orphaned public methods**
 > (see §7 for the full count breakdown). Per the audit instructions, this
@@ -59,7 +59,7 @@ Sorted by bucket, then alphabetically within bucket.
 | `is_local_branch?` | 2 | ⬜ | Deprecated in 4.x; migrate deprecated stub to `Git::Repository::Branching` pointing to `local_branch?` |
 | `is_remote_branch?` | 2 | ⬜ | Deprecated in 4.x; migrate deprecated stub to `Git::Repository::Branching` pointing to `remote_branch?` |
 | `remove` | 2 | ✅ | `alias remove rm` added to `Git::Repository::Staging` |
-| `reset_hard` | 2 | ⬜ | Deprecated wrapper; migrate to `Git::Repository::Staging` with `@deprecated` tag pointing to `reset(commitish, hard: true)` |
+| `reset_hard` | 2 | ✅ | `Git::Repository::Staging#reset_hard` — deprecated wrapper delegating to `reset(commitish, hard: true)` |
 | `revparse` | 2 | ✅ | `alias revparse rev_parse` added to `Git::Repository::ObjectOperations` |
 | `apply` | 3 | ⬜ | New facade in `Git::Repository::Staging` (or new `Patching` module); `Git::Commands::Apply` ✅ |
 | `apply_mail` | 3 | ⬜ | Same module as `apply`; `Git::Commands::Am` ✅ |

--- a/spec/unit/git/repository/staging_spec.rb
+++ b/spec/unit/git/repository/staging_spec.rb
@@ -421,6 +421,47 @@ RSpec.describe Git::Repository::Staging do
     end
   end
 
+  describe '#reset_hard' do
+    subject(:result) { described_instance.reset_hard }
+
+    let(:reset_command) { instance_double(Git::Commands::Reset) }
+    let(:reset_result) { command_result('reset output') }
+
+    before do
+      allow(Git::Commands::Reset).to receive(:new).with(execution_context).and_return(reset_command)
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning' do
+      allow(reset_command).to receive(:call).and_return(reset_result)
+      expect(Git::Deprecation).to receive(:warn).with(/reset_hard is deprecated/)
+      result
+    end
+
+    it 'delegates to reset with hard: true' do
+      expect(reset_command).to receive(:call).with(nil, hard: true).and_return(reset_result)
+      result
+    end
+
+    context 'with a commitish' do
+      subject(:result) { described_instance.reset_hard('HEAD~1') }
+
+      it 'passes the commitish to reset' do
+        expect(reset_command).to receive(:call).with('HEAD~1', hard: true).and_return(reset_result)
+        result
+      end
+    end
+
+    context 'when hard: false is passed in opts' do
+      subject(:result) { described_instance.reset_hard(nil, hard: false) }
+
+      it 'enforces hard: true regardless of opts' do
+        expect(reset_command).to receive(:call).with(nil, hard: true).and_return(reset_result)
+        result
+      end
+    end
+  end
+
   describe '#ignored_files' do
     subject(:result) { described_instance.ignored_files }
 


### PR DESCRIPTION
# Description

Micro PR 2b (Bucket 2 migration): add a deprecated `reset_hard` wrapper method to
`Git::Repository::Staging`.

`Git::Base#reset_hard` was a non-deprecated public method in 4.x. In v5 it carries a
`Git::Deprecation.warn` on `Git::Base`, but `Git::Repository::Staging` had no
`reset_hard` at all — so when `Git.open` switches to return `Git::Repository`, callers
would get `NoMethodError` instead of the expected deprecation warning.

**Changes:**
- Add `Git::Repository::Staging#reset_hard(commitish = nil, opts = {})` with a full
  `@deprecated` YARD tag pointing callers to `#reset` with `hard: true`
- The method emits `Git::Deprecation.warn` and delegates to
  `reset(commitish, **opts, hard: true)`
- Unit tests cover deprecation warning emission and delegation to `#reset`
- Update `redesign/c1c2_audit.md`: `reset_hard` row ⬜ → ✅, Bucket 2 counts updated

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
