### PR TITLE
feat(branching): add deprecated is_branch?/is_local_branch?/is_remote_branch? stubs to Git::Repository::Branching

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -296,6 +296,7 @@ module Git
       facade_repository.local_branch?(branch)
     end
 
+    # @deprecated Use {#local_branch?} instead.
     def is_local_branch?(branch) # rubocop:disable Naming/PredicatePrefix
       Git::Deprecation.warn(
         'Git::Base#is_local_branch? is deprecated and will be removed in a future version. ' \
@@ -309,6 +310,7 @@ module Git
       facade_repository.remote_branch?(branch)
     end
 
+    # @deprecated Use {#remote_branch?} instead.
     def is_remote_branch?(branch) # rubocop:disable Naming/PredicatePrefix
       Git::Deprecation.warn(
         'Git::Base#is_remote_branch? is deprecated and will be removed in a future version. ' \
@@ -322,6 +324,7 @@ module Git
       facade_repository.branch?(branch)
     end
 
+    # @deprecated Use {#branch?} instead.
     def is_branch?(branch) # rubocop:disable Naming/PredicatePrefix
       Git::Deprecation.warn(
         'Git::Base#is_branch? is deprecated and will be removed in a future version. ' \

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -24,7 +24,7 @@ module Git
     #
     # @api public
     #
-    module Branching
+    module Branching # rubocop:disable Metrics/ModuleLength
       # Option keys accepted by {#checkout}
       #
       CHECKOUT_ALLOWED_OPTS = %i[force f new_branch b start_point].freeze
@@ -213,6 +213,65 @@ module Git
       #
       def branch?(branch)
         local_branch?(branch) || remote_branch?(branch)
+      end
+
+      # @deprecated Use {#local_branch?} instead.
+      #
+      # @example
+      #   repo.is_local_branch?('main')  # => true
+      #
+      # @param branch [String] the local branch name to look up
+      #
+      # @return [Boolean] `true` if the branch exists locally, `false` otherwise
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def is_local_branch?(branch) # rubocop:disable Naming/PredicatePrefix
+        Git::Deprecation.warn(
+          'Git::Repository#is_local_branch? is deprecated and will be removed in a future version. ' \
+          'Use Git::Repository#local_branch? instead.'
+        )
+        local_branch?(branch)
+      end
+
+      # @deprecated Use {#remote_branch?} instead.
+      #
+      # @example
+      #   repo.is_remote_branch?('master')  # => true
+      #
+      # @param branch [String] the short branch name to look up across all remotes
+      #
+      # @return [Boolean] `true` if a remote-tracking branch with that short name
+      #   exists, `false` otherwise
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def is_remote_branch?(branch) # rubocop:disable Naming/PredicatePrefix
+        Git::Deprecation.warn(
+          'Git::Repository#is_remote_branch? is deprecated and will be removed in a future version. ' \
+          'Use Git::Repository#remote_branch? instead.'
+        )
+        remote_branch?(branch)
+      end
+
+      # @deprecated Use {#branch?} instead.
+      #
+      # @example
+      #   repo.is_branch?('main')  # => true
+      #
+      # @param branch [String] the branch name to look up
+      #
+      # @return [Boolean] `true` if the branch exists locally or remotely,
+      #   `false` otherwise
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def is_branch?(branch) # rubocop:disable Naming/PredicatePrefix
+        Git::Deprecation.warn(
+          'Git::Repository#is_branch? is deprecated and will be removed in a future version. ' \
+          'Use Git::Repository#branch? instead.'
+        )
+        branch?(branch)
       end
 
       # Option keys accepted by {#branch_new}

--- a/redesign/c1c2_audit.md
+++ b/redesign/c1c2_audit.md
@@ -29,12 +29,12 @@ surfaced.
 | Bucket | ✅ | ⬜ | ❌ | ⚠️ | 🔍 | Total |
 |--------|----|----|----|----|-----|-------|
 | 1 — Path/accessors | 4 | 0 | 0 | 0 | 0 | 4 |
-| 2 — Compatibility aliases & wrappers | 4 | 3 | 0 | 1 | 0 | 8 |
+| 2 — Compatibility aliases & wrappers | 7 | 0 | 0 | 1 | 0 | 8 |
 | 3 — Low-level public methods | 0 | 6 | 0 | 0 | 1 | 7 |
 | 4 — Factory & domain-object returns | 12 | 0 | 0 | 0 | 0 | 12 |
 | 5 — Keyword-arg signature review | 3 | 0 | 0 | 5 | 1 | 9 |
 | 6 — `Git::Lib` orphaned public methods | — | — | — | — | — | **⚠️ see §7** |
-| **Grand total (Buckets 1–5)** | **23** | **9** | **0** | **6** | **2** | **40** |
+| **Grand total (Buckets 1–5)** | **26** | **6** | **0** | **6** | **2** | **40** |
 
 > ⚠️ **Bucket 6 contains more than 40 genuine orphaned public methods**
 > (see §7 for the full count breakdown). Per the audit instructions, this
@@ -55,9 +55,9 @@ Sorted by bucket, then alphabetically within bucket.
 | `repo_size` | 1 | ✅ | `Git::Repository#repo_size` (repository.rb:131) |
 | `checkout` | 2 | ⚠️ | `Branching#checkout(branch = nil, options = {})` diverges from 4.x `(*, **)` — legacy-contract violation; corrected signature is `(*args, **kwargs)` (see §5) |
 | `diff_name_status` | 2 | ✅ | `alias diff_name_status diff_path_status` already present in `Git::Repository::Diffing` (diffing.rb:382) |
-| `is_branch?` | 2 | ⬜ | Deprecated in 4.x; migrate deprecated stub to `Git::Repository::Branching` pointing to `branch?` |
-| `is_local_branch?` | 2 | ⬜ | Deprecated in 4.x; migrate deprecated stub to `Git::Repository::Branching` pointing to `local_branch?` |
-| `is_remote_branch?` | 2 | ⬜ | Deprecated in 4.x; migrate deprecated stub to `Git::Repository::Branching` pointing to `remote_branch?` |
+| `is_branch?` | 2 | ✅ | Deprecated stub added to `Git::Repository::Branching` delegating to `branch?` |
+| `is_local_branch?` | 2 | ✅ | Deprecated stub added to `Git::Repository::Branching` delegating to `local_branch?` |
+| `is_remote_branch?` | 2 | ✅ | Deprecated stub added to `Git::Repository::Branching` delegating to `remote_branch?` |
 | `remove` | 2 | ✅ | `alias remove rm` added to `Git::Repository::Staging` |
 | `reset_hard` | 2 | ✅ | `Git::Repository::Staging#reset_hard` — deprecated wrapper delegating to `reset(commitish, hard: true)` |
 | `revparse` | 2 | ✅ | `alias revparse rev_parse` added to `Git::Repository::ObjectOperations` |

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -855,4 +855,154 @@ RSpec.describe Git::Repository::Branching do
       expect(result).to eq(branches_collection)
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #is_local_branch? (deprecated)
+  # ---------------------------------------------------------------------------
+
+  describe '#is_local_branch?' do
+    subject(:result) { described_instance.is_local_branch?('main') }
+
+    let(:list_command) { instance_double(Git::Commands::Branch::List) }
+
+    before do
+      allow(Git::Commands::Branch::List)
+        .to receive(:new).with(execution_context).and_return(list_command)
+      allow(list_command)
+        .to receive(:call).with('main', format: '%(refname:short)').and_return(command_result("main\n"))
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning mentioning is_local_branch? and local_branch?' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#is_local_branch? is deprecated and will be removed in a future version. ' \
+        'Use Git::Repository#local_branch? instead.'
+      )
+      result
+    end
+
+    it 'returns true when the branch exists locally' do
+      expect(result).to be(true)
+    end
+
+    context 'when the branch does not exist locally' do
+      subject(:result) { described_instance.is_local_branch?('no-such-branch') }
+
+      before do
+        allow(list_command)
+          .to receive(:call).with('no-such-branch', format: '%(refname:short)').and_return(command_result(''))
+      end
+
+      it 'returns false' do
+        expect(result).to be(false)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #is_remote_branch? (deprecated)
+  # ---------------------------------------------------------------------------
+
+  describe '#is_remote_branch?' do
+    subject(:result) { described_instance.is_remote_branch?('master') }
+
+    let(:list_command) { instance_double(Git::Commands::Branch::List) }
+
+    before do
+      allow(Git::Commands::Branch::List)
+        .to receive(:new).with(execution_context).and_return(list_command)
+      allow(list_command)
+        .to receive(:call).with('*/master', remotes: true, format: '%(refname:lstrip=3)')
+        .and_return(command_result("master\n"))
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning mentioning is_remote_branch? and remote_branch?' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#is_remote_branch? is deprecated and will be removed in a future version. ' \
+        'Use Git::Repository#remote_branch? instead.'
+      )
+      result
+    end
+
+    it 'returns true when the remote tracking branch exists' do
+      expect(result).to be(true)
+    end
+
+    context 'when the branch does not exist remotely' do
+      subject(:result) { described_instance.is_remote_branch?('no-such-branch') }
+
+      before do
+        allow(list_command)
+          .to receive(:call).with('*/no-such-branch', remotes: true, format: '%(refname:lstrip=3)')
+          .and_return(command_result(''))
+      end
+
+      it 'returns false' do
+        expect(result).to be(false)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #is_branch? (deprecated)
+  # ---------------------------------------------------------------------------
+
+  describe '#is_branch?' do
+    subject(:result) { described_instance.is_branch?('main') }
+
+    let(:list_command) { instance_double(Git::Commands::Branch::List) }
+
+    before do
+      allow(Git::Commands::Branch::List)
+        .to receive(:new).with(execution_context).and_return(list_command)
+      allow(list_command)
+        .to receive(:call).with('main', format: '%(refname:short)').and_return(command_result("main\n"))
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning mentioning is_branch? and branch?' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#is_branch? is deprecated and will be removed in a future version. ' \
+        'Use Git::Repository#branch? instead.'
+      )
+      result
+    end
+
+    it 'returns true when the branch exists locally' do
+      expect(result).to be(true)
+    end
+
+    context 'when the branch exists only remotely' do
+      subject(:result) { described_instance.is_branch?('develop') }
+
+      before do
+        allow(list_command)
+          .to receive(:call).with('develop', format: '%(refname:short)').and_return(command_result(''))
+        allow(list_command)
+          .to receive(:call).with('*/develop', remotes: true, format: '%(refname:lstrip=3)')
+          .and_return(command_result("develop\n"))
+      end
+
+      it 'returns true' do
+        expect(result).to be(true)
+      end
+    end
+
+    context 'when the branch does not exist locally or remotely' do
+      subject(:result) { described_instance.is_branch?('nonexistent') }
+
+      before do
+        allow(list_command)
+          .to receive(:call).with('nonexistent', format: '%(refname:short)').and_return(command_result(''))
+        allow(list_command)
+          .to receive(:call).with('*/nonexistent', remotes: true, format: '%(refname:lstrip=3)')
+          .and_return(command_result(''))
+      end
+
+      it 'returns false' do
+        expect(result).to be(false)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository.

# Description

Micro PR 2c — Bucket 2 migration: add deprecated stub methods
`is_branch?`, `is_local_branch?`, and `is_remote_branch?` to
`Git::Repository::Branching`.

## Why

All three were non-deprecated public methods in 4.x. They carry
`Git::Deprecation.warn` on `Git::Base` in v5, but `Git::Repository::Branching`
had none of them. When `Git.open` switches to return `Git::Repository`, callers
would get `NoMethodError` instead of the helpful deprecation warning.

## What changed

**`lib/git/repository/branching.rb`**
- Added `is_local_branch?(branch)` — emits `Git::Deprecation.warn`, delegates to `local_branch?`
- Added `is_remote_branch?(branch)` — emits `Git::Deprecation.warn`, delegates to `remote_branch?`
- Added `is_branch?(branch)` — emits `Git::Deprecation.warn`, delegates to `branch?`
- Each method has a `# rubocop:disable Naming/PredicatePrefix` annotation and a full YARD `@deprecated` tag
- Added `# rubocop:disable Metrics/ModuleLength` on the module declaration (module exceeded 100 lines; matches existing pattern in `ObjectOperations` and `Factories`)

**`lib/git/base.rb`**
- Added missing `@deprecated` YARD tags to the three corresponding `Git::Base` methods (deprecation warn was already present; only the YARD tag was absent)

**`redesign/c1c2_audit.md`**
- §2 table: `is_branch?`, `is_local_branch?`, `is_remote_branch?` changed ⬜ → ✅
- §1 summary: Bucket 2 ✅ 4 → 7, ⬜ 3 → 0; Grand total ✅ 23 → 26, ⬜ 9 → 6

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
