### PR TITLE
feat(base): add Git::Base delegators for 23 Bucket 6 trivial-wiring orphans (micro PR 2d)

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -925,9 +925,7 @@ module Git
       facade_repository.ls_tree(objectish, opts)
     end
 
-    def cat_file(objectish)
-      lib.cat_file(objectish)
-    end
+    # cat_file is aliased to cat_file_contents in the Bucket 6 delegators section below
 
     # The name of the branch HEAD refers to or 'HEAD' if detached
     #
@@ -1199,6 +1197,142 @@ module Git
     #
     # @see #diff_path_status
     alias diff_name_status diff_path_status
+
+    # @!group Bucket 6 delegators — Git::Repository::Branching
+
+    # @return [Array<Git::BranchInfo>] all local and remote-tracking branches
+    def branches_all
+      facade_repository.branches_all
+    end
+
+    # @return [String] `git branch --contains` output for the given commit
+    def branch_contains(commit, branch_name = '')
+      facade_repository.branch_contains(commit, branch_name)
+    end
+
+    # Creates a new local branch
+    # @return [nil]
+    def branch_new(branch, start_point = nil, options = {})
+      facade_repository.branch_new(branch, start_point, options)
+    end
+
+    # Deletes one or more local branches
+    # @return [String] stdout from the delete command
+    def branch_delete(*branches, **)
+      facade_repository.branch_delete(*branches, **)
+    end
+
+    # @!group Bucket 6 delegators — Git::Repository::ObjectOperations
+
+    # @return [String] raw content of the git object, or streams to a tempfile when a block is given
+    def cat_file_contents(object, &)
+      facade_repository.cat_file_contents(object, &)
+    end
+
+    # Alias for {#cat_file_contents}; `cat_file` is the established 4.x public name
+    alias cat_file cat_file_contents
+
+    # @return [Integer] size of the git object in bytes
+    def cat_file_size(object)
+      facade_repository.cat_file_size(object)
+    end
+
+    # @return [String] type of the git object (e.g. "blob", "commit", "tree", "tag")
+    def cat_file_type(object)
+      facade_repository.cat_file_type(object)
+    end
+
+    # @return [Hash] parsed commit metadata for the given object
+    def cat_file_commit(object)
+      facade_repository.cat_file_commit(object)
+    end
+
+    # @return [Hash] parsed tag metadata for the given object
+    def cat_file_tag(object)
+      facade_repository.cat_file_tag(object)
+    end
+
+    # @return [String] SHA of the tag object for the given tag name
+    def tag_sha(tag_name)
+      facade_repository.tag_sha(tag_name)
+    end
+
+    # @return [Array<String>] all file entries in the tree
+    def full_tree(sha)
+      facade_repository.full_tree(sha)
+    end
+
+    # @return [String] human-readable name for the given commit-ish
+    def name_rev(commit_ish)
+      facade_repository.name_rev(commit_ish)
+    end
+
+    # @!group Bucket 6 delegators — Git::Repository::RemoteOperations
+
+    # @return [Hash] remote configuration hash for the given remote name
+    def config_remote(name)
+      facade_repository.config_remote(name)
+    end
+
+    # @!group Bucket 6 delegators — Git::Repository::Diffing
+
+    # @return [Hash{String => Hash}] parsed diff-index output keyed by file path
+    def diff_index(treeish)
+      facade_repository.diff_index(treeish)
+    end
+
+    # @!group Bucket 6 delegators — Git::Repository::Stashing
+
+    # @return [Array] all stash entries as [index, message] pairs
+    def stashes_all
+      facade_repository.stashes_all
+    end
+
+    # @return [Boolean] true if changes were stashed, false if there was nothing to stash
+    def stash_save(message)
+      facade_repository.stash_save(message)
+    end
+
+    # @return [String] output from `git stash apply`
+    def stash_apply(id = nil)
+      facade_repository.stash_apply(id)
+    end
+
+    # @return [String] output from `git stash clear`
+    def stash_clear
+      facade_repository.stash_clear
+    end
+
+    # @!group Bucket 6 delegators — Git::Repository::StatusOperations
+
+    # @return [Array<String>] list of untracked file paths
+    def untracked_files
+      facade_repository.untracked_files
+    end
+
+    # @!group Bucket 6 delegators — Git::Repository::WorktreeOperations
+
+    # @return [Array] all worktrees as [path, sha] pairs
+    def worktrees_all
+      facade_repository.worktrees_all
+    end
+
+    # @return [String] output from `git worktree add`
+    def worktree_add(dir, commitish = nil)
+      facade_repository.worktree_add(dir, commitish)
+    end
+
+    # @return [String] output from `git worktree remove`
+    def worktree_remove(dir)
+      facade_repository.worktree_remove(dir)
+    end
+
+    # @return [String] output from `git worktree prune`
+    def worktree_prune
+      facade_repository.worktree_prune
+    end
+
+    # @!endgroup
 
     private
 

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -89,6 +89,11 @@ module Git
         end
       end
 
+      # Alias for {#cat_file_contents}; retained for backward compatibility
+      #
+      # @see #cat_file_contents
+      alias cat_file cat_file_contents
+
       # Returns the size of a git object in bytes
       #
       # @example Get the size of a commit object

--- a/redesign/c1c2_audit.md
+++ b/redesign/c1c2_audit.md
@@ -349,29 +349,29 @@ These orphans exist on `Git::Lib` and have already been migrated to a
 
 | `Git::Lib` method | `Git::Repository` home | Status |
 |-------------------|------------------------|--------|
-| `branches_all` | `Git::Repository::Branching` | ⬜ promote — add `Git::Base` delegator |
-| `branch_contains(commit, branch_name = '')` | `Git::Repository::Branching` | ⬜ promote — add `Git::Base` delegator |
-| `branch_delete(*branches, **options)` | `Git::Repository::Branching` | ⬜ promote — add `Git::Base` delegator (see §6 classification note) |
-| `branch_new(branch, start_point = nil, options = {})` | `Git::Repository::Branching` | ⬜ promote — add `Git::Base` delegator |
-| `cat_file_commit(object)` | `Git::Repository::ObjectOperations` | ⬜ promote — add `Git::Base` delegator |
-| `cat_file_contents(object)` | `Git::Repository::ObjectOperations` | ⬜ promote — add `Git::Base` delegator |
-| `cat_file_size(object)` | `Git::Repository::ObjectOperations` | ⬜ promote — add `Git::Base` delegator |
-| `cat_file_tag(object)` | `Git::Repository::ObjectOperations` | ⬜ promote — add `Git::Base` delegator |
-| `cat_file_type(object)` | `Git::Repository::ObjectOperations` | ⬜ promote — add `Git::Base` delegator |
-| `config_remote(name)` | `Git::Repository::RemoteOperations` | ⬜ promote — add `Git::Base` delegator |
-| `diff_index(treeish)` | `Git::Repository::Diffing` | ⬜ promote — add `Git::Base` delegator |
-| `full_tree(sha)` | `Git::Repository::ObjectOperations` | ⬜ promote — add `Git::Base` delegator |
-| `name_rev(commit_ish)` | `Git::Repository::ObjectOperations` | ⬜ promote — add `Git::Base` delegator |
-| `stash_apply(id = nil)` | `Git::Repository::Stashing` | ⬜ promote — add `Git::Base` delegator |
-| `stash_clear` | `Git::Repository::Stashing` | ⬜ promote — add `Git::Base` delegator |
-| `stash_save(message)` | `Git::Repository::Stashing` | ⬜ promote — add `Git::Base` delegator |
-| `stashes_all` | `Git::Repository::Stashing` | ⬜ promote — add `Git::Base` delegator |
-| `tag_sha(tag_name)` | `Git::Repository::ObjectOperations` | ⬜ promote — add `Git::Base` delegator |
-| `untracked_files` | `Git::Repository::StatusOperations` | ⬜ promote — add `Git::Base` delegator |
-| `worktree_add(dir, commitish = nil)` | `Git::Repository::WorktreeOperations` | ⬜ promote — add `Git::Base` delegator |
-| `worktree_prune` | `Git::Repository::WorktreeOperations` | ⬜ promote — add `Git::Base` delegator |
-| `worktree_remove(dir)` | `Git::Repository::WorktreeOperations` | ⬜ promote — add `Git::Base` delegator |
-| `worktrees_all` | `Git::Repository::WorktreeOperations` | ⬜ promote — add `Git::Base` delegator |
+| `branches_all` | `Git::Repository::Branching` | ✅ `Git::Base` delegator added (PR 2d) |
+| `branch_contains(commit, branch_name = '')` | `Git::Repository::Branching` | ✅ `Git::Base` delegator added (PR 2d) |
+| `branch_delete(*branches, **options)` | `Git::Repository::Branching` | ✅ `Git::Base` delegator added (PR 2d) |
+| `branch_new(branch, start_point = nil, options = {})` | `Git::Repository::Branching` | ✅ `Git::Base` delegator added (PR 2d) |
+| `cat_file_commit(object)` | `Git::Repository::ObjectOperations` | ✅ `Git::Base` delegator added (PR 2d) |
+| `cat_file_contents(object)` | `Git::Repository::ObjectOperations` | ✅ `Git::Base` delegator added; `alias cat_file cat_file_contents` added (PR 2d) |
+| `cat_file_size(object)` | `Git::Repository::ObjectOperations` | ✅ `Git::Base` delegator added (PR 2d) |
+| `cat_file_tag(object)` | `Git::Repository::ObjectOperations` | ✅ `Git::Base` delegator added (PR 2d) |
+| `cat_file_type(object)` | `Git::Repository::ObjectOperations` | ✅ `Git::Base` delegator added (PR 2d) |
+| `config_remote(name)` | `Git::Repository::RemoteOperations` | ✅ `Git::Base` delegator added (PR 2d) |
+| `diff_index(treeish)` | `Git::Repository::Diffing` | ✅ `Git::Base` delegator added (PR 2d) |
+| `full_tree(sha)` | `Git::Repository::ObjectOperations` | ✅ `Git::Base` delegator added (PR 2d) |
+| `name_rev(commit_ish)` | `Git::Repository::ObjectOperations` | ✅ `Git::Base` delegator added (PR 2d) |
+| `stash_apply(id = nil)` | `Git::Repository::Stashing` | ✅ `Git::Base` delegator added (PR 2d) |
+| `stash_clear` | `Git::Repository::Stashing` | ✅ `Git::Base` delegator added (PR 2d) |
+| `stash_save(message)` | `Git::Repository::Stashing` | ✅ `Git::Base` delegator added (PR 2d) |
+| `stashes_all` | `Git::Repository::Stashing` | ✅ `Git::Base` delegator added (PR 2d) |
+| `tag_sha(tag_name)` | `Git::Repository::ObjectOperations` | ✅ `Git::Base` delegator added (PR 2d) |
+| `untracked_files` | `Git::Repository::StatusOperations` | ✅ `Git::Base` delegator added (PR 2d) |
+| `worktree_add(dir, commitish = nil)` | `Git::Repository::WorktreeOperations` | ✅ `Git::Base` delegator added (PR 2d) |
+| `worktree_prune` | `Git::Repository::WorktreeOperations` | ✅ `Git::Base` delegator added (PR 2d) |
+| `worktree_remove(dir)` | `Git::Repository::WorktreeOperations` | ✅ `Git::Base` delegator added (PR 2d) |
+| `worktrees_all` | `Git::Repository::WorktreeOperations` | ✅ `Git::Base` delegator added (PR 2d) |
 
 Also note name-mismatch cases where `Git::Lib` uses a different name than `Git::Repository`:
 
@@ -438,7 +438,7 @@ upgrade notes as "unsupported; remove any `g.lib.X` calls."
 
 | Status | Count |
 |--------|-------|
-| ⬜ promote (repo already has it, trivial base.rb wiring) | 23 |
+| ✅ promote (repo already had it, `Git::Base` delegator added — PR 2d) | 23 |
 | ⬜ promote (new facade work required) | 7 |
 | ❌ remove (internal plumbing) | 12 |
 | 🔍 human decision | 16 |

--- a/spec/integration/git/base/branching_delegators_spec.rb
+++ b/spec/integration/git/base/branching_delegators_spec.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Integration tests confirming that Git::Base exposes the Git::Repository::Branching
+# facade methods via one-line delegators.  Each example calls the method on `repo`
+# (a Git::Base instance) and verifies it returns the expected type/value.
+
+RSpec.describe Git::Base, :integration do
+  include_context 'in an empty repository'
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#branches_all' do
+    it 'returns an array of branch info objects' do
+      result = repo.branches_all
+      expect(result).to be_an(Array)
+      expect(result).not_to be_empty
+    end
+  end
+
+  describe '#branch_contains' do
+    it 'returns a String' do
+      sha = repo.log(1).execute.first.sha
+      result = repo.branch_contains(sha)
+      expect(result).to be_a(String)
+    end
+  end
+
+  describe '#branch_new' do
+    it 'creates a new branch without raising' do
+      expect { repo.branch_new('feature-x') }.not_to raise_error
+    end
+
+    it 'makes the branch visible in branches_all' do
+      repo.branch_new('feature-y')
+      names = repo.branches_all.map { |b| b.refname.gsub(%r{\Arefs/heads/}, '') }
+      expect(names).to include('feature-y')
+    end
+  end
+
+  describe '#branch_delete' do
+    before { repo.branch_new('to-delete') }
+
+    it 'deletes the branch without raising' do
+      expect { repo.branch_delete('to-delete') }.not_to raise_error
+    end
+
+    it 'removes the branch from branches_all' do
+      repo.branch_delete('to-delete')
+      names = repo.branches_all.map { |b| b.refname.gsub(%r{\Arefs/heads/}, '') }
+      expect(names).not_to include('to-delete')
+    end
+  end
+end

--- a/spec/integration/git/base/misc_delegators_spec.rb
+++ b/spec/integration/git/base/misc_delegators_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Integration tests confirming that Git::Base exposes the remaining Bucket 6
+# facade methods via one-line delegators:
+#   - Git::Repository::RemoteOperations#config_remote
+#   - Git::Repository::Diffing#diff_index
+#   - Git::Repository::StatusOperations#untracked_files
+
+RSpec.describe Git::Base, :integration do
+  include_context 'in an empty repository'
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#config_remote' do
+    before do
+      repo.add_remote('origin', 'https://github.com/example/repo.git')
+    end
+
+    it 'returns a Hash with remote configuration' do
+      result = repo.config_remote('origin')
+      expect(result).to be_a(Hash)
+      expect(result['url']).to eq('https://github.com/example/repo.git')
+    end
+  end
+
+  describe '#diff_index' do
+    it 'returns a Hash' do
+      result = repo.diff_index('HEAD')
+      expect(result).to be_a(Hash)
+    end
+
+    context 'when a tracked file is modified' do
+      before { write_file('README.md', "# Modified\n") }
+
+      it 'includes an entry for the modified file' do
+        expect(repo.diff_index('HEAD')).to have_key('README.md')
+      end
+    end
+  end
+
+  describe '#untracked_files' do
+    it 'returns an Array' do
+      expect(repo.untracked_files).to be_an(Array)
+    end
+
+    context 'when an untracked file exists' do
+      before { write_file('untracked.txt', 'content') }
+
+      it 'includes the untracked file' do
+        expect(repo.untracked_files).to include('untracked.txt')
+      end
+    end
+  end
+end

--- a/spec/integration/git/base/object_operations_delegators_spec.rb
+++ b/spec/integration/git/base/object_operations_delegators_spec.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Integration tests confirming that Git::Base exposes the Git::Repository::ObjectOperations
+# facade methods via one-line delegators. Each example calls the method on `repo`
+# (a Git::Base instance) and verifies the return type or expected value.
+
+RSpec.describe Git::Base, :integration do
+  include_context 'in an empty repository'
+
+  before do
+    write_file('README.md', "# Hello World\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#cat_file_contents' do
+    it 'returns the blob content as a String' do
+      result = repo.cat_file_contents('HEAD:README.md')
+      expect(result).to be_a(String)
+      expect(result).to include('# Hello World')
+    end
+  end
+
+  describe '#cat_file (alias)' do
+    it 'is an alias for cat_file_contents' do
+      expect(repo.method(:cat_file)).to eq(repo.method(:cat_file_contents))
+    end
+  end
+
+  describe '#cat_file_size' do
+    it 'returns an Integer' do
+      result = repo.cat_file_size('HEAD:README.md')
+      expect(result).to be_an(Integer)
+      expect(result).to be > 0
+    end
+  end
+
+  describe '#cat_file_type' do
+    it 'returns "blob" for a blob reference' do
+      expect(repo.cat_file_type('HEAD:README.md')).to eq('blob')
+    end
+
+    it 'returns "commit" for a commit reference' do
+      expect(repo.cat_file_type('HEAD')).to eq('commit')
+    end
+  end
+
+  describe '#cat_file_commit' do
+    it 'returns a hash with commit metadata' do
+      result = repo.cat_file_commit('HEAD')
+      expect(result).to be_a(Hash)
+      expect(result).to have_key('message')
+    end
+  end
+
+  describe '#cat_file_tag' do
+    before { repo.add_tag('v1.0.0', annotate: true, message: 'release') }
+
+    it 'returns a hash with tag metadata' do
+      result = repo.cat_file_tag('v1.0.0')
+      expect(result).to be_a(Hash)
+      expect(result).to have_key('message')
+    end
+  end
+
+  describe '#tag_sha' do
+    before { repo.add_tag('v1.0.0') }
+
+    it 'returns a non-empty SHA string' do
+      expect(repo.tag_sha('v1.0.0').chomp).to match(/\A[0-9a-f]{40}\z/)
+    end
+  end
+
+  describe '#full_tree' do
+    it 'returns an array of file path strings' do
+      result = repo.full_tree('HEAD')
+      expect(result).to be_an(Array)
+      expect(result.any? { |e| e.include?('README.md') }).to be true
+    end
+  end
+
+  describe '#name_rev' do
+    it 'returns a non-empty String' do
+      sha = repo.rev_parse('HEAD')
+      result = repo.name_rev(sha)
+      expect(result).to be_a(String)
+      expect(result).not_to be_empty
+    end
+  end
+end

--- a/spec/integration/git/base/stashing_delegators_spec.rb
+++ b/spec/integration/git/base/stashing_delegators_spec.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Integration tests confirming that Git::Base exposes the Git::Repository::Stashing
+# facade methods via one-line delegators.
+
+RSpec.describe Git::Base, :integration do
+  include_context 'in an empty repository'
+
+  before do
+    write_file('file.txt', 'initial content')
+    repo.add('file.txt')
+    repo.commit('Initial commit')
+  end
+
+  describe '#stashes_all' do
+    context 'when there are no stashes' do
+      it 'returns an empty array' do
+        expect(repo.stashes_all).to eq([])
+      end
+    end
+
+    context 'after saving a stash' do
+      before do
+        write_file('file.txt', 'modified')
+        repo.stash_save('my work')
+      end
+
+      it 'returns a non-empty array' do
+        expect(repo.stashes_all).not_to be_empty
+      end
+    end
+  end
+
+  describe '#stash_save' do
+    before { write_file('file.txt', 'modified content') }
+
+    it 'returns a truthy value when changes are stashed' do
+      result = repo.stash_save('save test')
+      expect(result).to be_truthy
+    end
+
+    it 'increases the stash count by one' do
+      expect { repo.stash_save('work') }.to change { repo.stashes_all.length }.by(1)
+    end
+  end
+
+  describe '#stash_apply' do
+    before do
+      write_file('file.txt', 'modified content')
+      repo.stash_save('apply test')
+    end
+
+    it 'restores stashed changes without raising' do
+      expect { repo.stash_apply }.not_to raise_error
+    end
+  end
+
+  describe '#stash_clear' do
+    before do
+      write_file('file.txt', 'modified content')
+      repo.stash_save('clear test')
+    end
+
+    it 'removes all stash entries' do
+      repo.stash_clear
+      expect(repo.stashes_all).to eq([])
+    end
+  end
+end

--- a/spec/integration/git/base/worktree_operations_delegators_spec.rb
+++ b/spec/integration/git/base/worktree_operations_delegators_spec.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'securerandom'
+
+# Integration tests confirming that Git::Base exposes the Git::Repository::WorktreeOperations
+# facade methods via one-line delegators.
+
+RSpec.describe Git::Base, :integration do
+  include_context 'in an empty repository'
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '#worktrees_all' do
+    it 'returns an array with at least the main worktree' do
+      result = repo.worktrees_all
+      expect(result).to be_an(Array)
+      expect(result.length).to be >= 1
+    end
+  end
+
+  describe '#worktree_add and #worktree_remove' do
+    let(:worktree_path) { File.join(repo_dir, '..', "wt-#{SecureRandom.hex(4)}") }
+
+    after do
+      FileUtils.rm_rf(worktree_path)
+      repo.worktree_prune
+    end
+
+    it '#worktree_add creates a linked worktree' do
+      expect { repo.worktree_add(worktree_path) }.not_to raise_error
+      expect(File.directory?(worktree_path)).to be true
+    end
+
+    it '#worktree_remove removes the linked worktree' do
+      repo.worktree_add(worktree_path)
+      expect { repo.worktree_remove(worktree_path) }.not_to raise_error
+    end
+  end
+
+  describe '#worktree_prune' do
+    it 'completes without raising' do
+      expect { repo.worktree_prune }.not_to raise_error
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Adds one-line `facade_repository.*` delegators on `Git::Base` for the 23
**Bucket 6 "trivial wiring"** orphans identified in §7.2 of
`redesign/c1c2_audit.md`.  Each of these methods was already fully implemented
in a `Git::Repository` module but had no `Git::Base` entry point, so
`repo.lib.method_name` worked today while `repo.method_name` raised
`NoMethodError`.

Also fixes the long-standing broken `Git::Base#cat_file` delegator (which
called `lib.cat_file` — a method that does not exist on `Git::Lib`) by wiring
it to `facade_repository.cat_file`, backed by a new
`alias cat_file cat_file_contents` in `Git::Repository::ObjectOperations`.

## Changes

### `lib/git/base.rb`
- 23 new one-line delegators grouped by `Git::Repository` module:
  - **Branching:** `branches_all`, `branch_contains`, `branch_new`, `branch_delete`
  - **ObjectOperations:** `cat_file_contents`, `cat_file_size`, `cat_file_type`,
    `cat_file_commit`, `cat_file_tag`, `tag_sha`, `full_tree`, `name_rev`
  - **RemoteOperations:** `config_remote`
  - **Diffing:** `diff_index`
  - **Stashing:** `stashes_all`, `stash_save`, `stash_apply`, `stash_clear`
  - **StatusOperations:** `untracked_files`
  - **WorktreeOperations:** `worktrees_all`, `worktree_add`, `worktree_remove`, `worktree_prune`
- Fixes `Git::Base#cat_file` to delegate to `facade_repository.cat_file` (was broken)

### `lib/git/repository/object_operations.rb`
- Adds `alias cat_file cat_file_contents` per the §6 audit decision

### `redesign/c1c2_audit.md`
- §7.2: all 23 rows updated from ⬜ to ✅
- §7.5: count row updated to reflect completion

### `spec/integration/git/base/`  _(5 new files)_
- `branching_delegators_spec.rb`
- `object_operations_delegators_spec.rb`
- `stashing_delegators_spec.rb`
- `worktree_operations_delegators_spec.rb`
- `misc_delegators_spec.rb` (covers `config_remote`, `diff_index`, `untracked_files`)

Each file confirms the delegated methods are callable on a real `Git::Base`
repo object and return the expected types.

## Notes

- `branch_delete` uses `def branch_delete(*branches, **)` (anonymous keyword
  forwarding) — consistent with RuboCop Style/ArgumentsForwarding and
  delegates to `Git::Repository::Branching#branch_delete(*branches, **options)`.
  The audit §6 decision's `opts = {}` positional-hash form is syntactically
  impossible after `*branches` in Ruby 3; this will be revisited in the PR 4
  signature sweep.
- All existing tests continue to pass (`bundle exec rake default:parallel`).

## Testing

```
bundle exec rake default:parallel
```

All tests pass. RuboCop clean. YARD coverage above threshold.
