### PR TITLE
feat(object-operations): add 6 legacy aliases to ObjectOperations (PR 2e)

### DIFF
--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -94,6 +94,13 @@ module Git
       # @see #cat_file_contents
       alias cat_file cat_file_contents
 
+      # Alias for {#cat_file_contents}
+      #
+      # @deprecated Use {#cat_file_contents} instead
+      #
+      # @see #cat_file_contents
+      alias object_contents cat_file_contents
+
       # Returns the size of a git object in bytes
       #
       # @example Get the size of a commit object
@@ -117,6 +124,13 @@ module Git
 
         Git::Commands::CatFile::Raw.new(@execution_context).call(object, s: true).stdout.chomp.to_i
       end
+
+      # Alias for {#cat_file_size}
+      #
+      # @deprecated Use {#cat_file_size} instead
+      #
+      # @see #cat_file_size
+      alias object_size cat_file_size
 
       # Returns the type of a git object
       #
@@ -142,6 +156,13 @@ module Git
 
         Git::Commands::CatFile::Raw.new(@execution_context).call(object, t: true).stdout.chomp
       end
+
+      # Alias for {#cat_file_type}
+      #
+      # @deprecated Use {#cat_file_type} instead
+      #
+      # @see #cat_file_type
+      alias object_type cat_file_type
 
       # Returns parsed commit data for the given git object
       #
@@ -178,6 +199,13 @@ module Git
         result = Git::Commands::CatFile::Raw.new(@execution_context).call('commit', object)
         Git::Parsers::CatFile.parse_commit(result.stdout.split("\n"), object)
       end
+
+      # Alias for {#cat_file_commit}
+      #
+      # @deprecated Use {#cat_file_commit} instead
+      #
+      # @see #cat_file_commit
+      alias commit_data cat_file_commit
 
       # Returns parsed tag data for the given annotated tag object
       #
@@ -227,6 +255,13 @@ module Git
         tdata = Git::Commands::CatFile::Raw.new(@execution_context).call('tag', object).stdout.split("\n")
         Git::Parsers::CatFile.parse_tag(tdata, object)
       end
+
+      # Alias for {#cat_file_tag}
+      #
+      # @deprecated Use {#cat_file_tag} instead
+      #
+      # @see #cat_file_tag
+      alias tag_data cat_file_tag
 
       # Resolve a revision specifier to its full object ID
       #
@@ -359,6 +394,13 @@ module Git
 
         Git::Commands::NameRev.new(@execution_context).call(commit_ish).stdout.split[1]
       end
+
+      # Alias for {#name_rev}
+      #
+      # @deprecated Use {#name_rev} instead
+      #
+      # @see #name_rev
+      alias namerev name_rev
 
       # Option keys accepted by {#ls_tree}
       LS_TREE_ALLOWED_OPTS = %i[recursive path].freeze

--- a/redesign/c1c2_audit.md
+++ b/redesign/c1c2_audit.md
@@ -382,12 +382,12 @@ Also note name-mismatch cases where `Git::Lib` uses a different name than `Git::
 | `remote_add(name, url, opts)` | `Git::Repository::RemoteOperations#add_remote` | 🔍 name mismatch; `add_remote` is already on `Git::Base` — `remote_add` is the lib name; mark as internal |
 | `remote_remove(name)` | `Git::Repository::RemoteOperations#remove_remote` | 🔍 name mismatch; `remove_remote` is already on `Git::Base` |
 | `remote_set_url(name, url, opts)` | `Git::Repository::RemoteOperations#set_remote_url` | 🔍 name mismatch; `set_remote_url` is already on `Git::Base` |
-| `namerev` (alias for `name_rev`) | `Git::Repository::ObjectOperations#name_rev` | ⬜ add `alias namerev name_rev` to `ObjectOperations` |
-| `object_contents` (alias for `cat_file_contents`) | `Git::Repository::ObjectOperations#cat_file_contents` | ⬜ add alias to `ObjectOperations` |
-| `object_type` (alias for `cat_file_type`) | `Git::Repository::ObjectOperations#cat_file_type` | ⬜ add alias to `ObjectOperations` |
-| `object_size` (alias for `cat_file_size`) | `Git::Repository::ObjectOperations#cat_file_size` | ⬜ add alias to `ObjectOperations` |
-| `commit_data` (alias for `cat_file_commit`) | `Git::Repository::ObjectOperations#cat_file_commit` | ⬜ add alias to `ObjectOperations` |
-| `tag_data` (alias for `cat_file_tag`) | `Git::Repository::ObjectOperations#cat_file_tag` | ⬜ add alias to `ObjectOperations` |
+| `namerev` (alias for `name_rev`) | `Git::Repository::ObjectOperations#name_rev` | ✅ `alias namerev name_rev` added (PR 2e) |
+| `object_contents` (alias for `cat_file_contents`) | `Git::Repository::ObjectOperations#cat_file_contents` | ✅ `alias object_contents cat_file_contents` added (PR 2e) |
+| `object_type` (alias for `cat_file_type`) | `Git::Repository::ObjectOperations#cat_file_type` | ✅ `alias object_type cat_file_type` added (PR 2e) |
+| `object_size` (alias for `cat_file_size`) | `Git::Repository::ObjectOperations#cat_file_size` | ✅ `alias object_size cat_file_size` added (PR 2e) |
+| `commit_data` (alias for `cat_file_commit`) | `Git::Repository::ObjectOperations#cat_file_commit` | ✅ `alias commit_data cat_file_commit` added (PR 2e) |
+| `tag_data` (alias for `cat_file_tag`) | `Git::Repository::ObjectOperations#cat_file_tag` | ✅ `alias tag_data cat_file_tag` added (PR 2e) |
 | `revparse` (alias for `rev_parse`) | (covered in Bucket 2) | ✅ covered |
 
 ### 7.3 Methods NOT Yet in `Git::Repository` (new facade work required)

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -106,6 +106,13 @@ RSpec.describe Git::Repository::ObjectOperations do
     end
   end
 
+  describe '#object_contents' do
+    it 'is an alias for #cat_file_contents' do
+      expect(described_class.instance_method(:object_contents))
+        .to eq(described_class.instance_method(:cat_file_contents))
+    end
+  end
+
   describe '#cat_file_size' do
     let(:raw_command) { instance_double(Git::Commands::CatFile::Raw) }
 
@@ -167,6 +174,12 @@ RSpec.describe Git::Repository::ObjectOperations do
         allow(raw_command).to receive(:call).with(nil, s: true).and_return(command_result("0\n"))
         expect { described_instance.cat_file_size(nil) }.not_to raise_error
       end
+    end
+  end
+
+  describe '#object_size' do
+    it 'is an alias for #cat_file_size' do
+      expect(described_class.instance_method(:object_size)).to eq(described_class.instance_method(:cat_file_size))
     end
   end
 
@@ -234,6 +247,12 @@ RSpec.describe Git::Repository::ObjectOperations do
     end
   end
 
+  describe '#object_type' do
+    it 'is an alias for #cat_file_type' do
+      expect(described_class.instance_method(:object_type)).to eq(described_class.instance_method(:cat_file_type))
+    end
+  end
+
   describe '#cat_file_commit' do
     let(:raw_command) { instance_double(Git::Commands::CatFile::Raw) }
 
@@ -279,6 +298,12 @@ RSpec.describe Git::Repository::ObjectOperations do
         allow(Git::Parsers::CatFile).to receive(:parse_commit).and_return(parsed_commit)
         expect(result).to eq(parsed_commit)
       end
+    end
+  end
+
+  describe '#commit_data' do
+    it 'is an alias for #cat_file_commit' do
+      expect(described_class.instance_method(:commit_data)).to eq(described_class.instance_method(:cat_file_commit))
     end
   end
 
@@ -342,6 +367,12 @@ RSpec.describe Git::Repository::ObjectOperations do
         allow(Git::Parsers::CatFile).to receive(:parse_tag).and_return({})
         expect { described_instance.cat_file_tag(nil) }.not_to raise_error
       end
+    end
+  end
+
+  describe '#tag_data' do
+    it 'is an alias for #cat_file_tag' do
+      expect(described_class.instance_method(:tag_data)).to eq(described_class.instance_method(:cat_file_tag))
     end
   end
 
@@ -667,6 +698,12 @@ RSpec.describe Git::Repository::ObjectOperations do
         allow(name_rev_command).to receive(:call).with(nil).and_return(command_result("undefined\n"))
         expect { described_instance.name_rev(nil) }.not_to raise_error
       end
+    end
+  end
+
+  describe '#namerev' do
+    it 'is an alias for #name_rev' do
+      expect(described_class.instance_method(:namerev)).to eq(described_class.instance_method(:name_rev))
     end
   end
 


### PR DESCRIPTION
# Description

Micro PR 2e — Bucket 6 name-mismatch remediation.

Adds six legacy aliases to `Git::Repository::ObjectOperations` so callers that
currently reach these methods via `repo.lib.namerev` (etc.) can call them
directly on the repository facade once `Git::Lib` is retired in Phase 4.

| Alias | Canonical method |
|-------|-----------------|
| `namerev` | `name_rev` |
| `object_contents` | `cat_file_contents` |
| `object_type` | `cat_file_type` |
| `object_size` | `cat_file_size` |
| `commit_data` | `cat_file_commit` |
| `tag_data` | `cat_file_tag` |

Each alias is placed immediately after its canonical method in
`lib/git/repository/object_operations.rb` and annotated with a YARD
`@deprecated` tag directing callers to prefer the canonical name.

`Git::Base` already has delegators for all six canonical methods (added in
PR 2d); no new delegators are needed.

Also updates the §7.2 name-mismatch table in `redesign/c1c2_audit.md`,
marking all six rows from ⬜ to ✅.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
