### PR TITLE
feat(staging): add apply, apply_mail, and read_tree facade methods

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -755,13 +755,11 @@ module Git
     # rubocop:enable Style/ArgumentsForwarding
 
     def apply(file)
-      return unless File.exist?(file)
-
-      lib.apply(file)
+      facade_repository.apply(file)
     end
 
     def apply_mail(file)
-      lib.apply_mail(file) if File.exist?(file)
+      facade_repository.apply_mail(file)
     end
 
     # Shows objects
@@ -814,7 +812,7 @@ module Git
     end
 
     def read_tree(treeish, opts = {})
-      lib.read_tree(treeish, opts)
+      facade_repository.read_tree(treeish, opts)
     end
 
     def write_tree

--- a/lib/git/repository/staging.rb
+++ b/lib/git/repository/staging.rb
@@ -1,8 +1,11 @@
 # frozen_string_literal: true
 
 require 'git/commands/add'
+require 'git/commands/am/apply'
+require 'git/commands/apply'
 require 'git/commands/clean'
 require 'git/commands/ls_files'
+require 'git/commands/read_tree'
 require 'git/commands/reset'
 require 'git/commands/rm'
 require 'git/escaped_path'
@@ -119,6 +122,88 @@ module Git
         reset(commitish, **opts, hard: true)
       end
 
+      # Apply a patch file to the working tree
+      #
+      # Reads the unified diff in `file` and applies it to the working tree via
+      # `git apply`. If `file` does not exist, the method returns `nil` without
+      # calling git — preserving the 4.x `Git::Base#apply` no-op contract.
+      #
+      # @example Apply a patch to the working tree
+      #   repo.apply('fix.patch')
+      #
+      # @param file [String] path to the patch file to apply
+      #
+      # @return [String] git's stdout (usually empty on success)
+      #
+      # @return [nil] when `file` does not exist
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def apply(file)
+        return unless File.exist?(file)
+
+        Git::Commands::Apply.new(@execution_context).call(file, chdir: @execution_context.git_work_dir).stdout
+      end
+
+      # Apply a series of patches from a mailbox file to the current branch
+      #
+      # Reads the mbox-format file in `file` and applies the patches via
+      # `git am`. If `file` does not exist, the method returns `nil` without
+      # calling git — preserving the 4.x `Git::Base#apply_mail` no-op contract.
+      #
+      # @example Apply patches from a mailbox
+      #   repo.apply_mail('patches.mbox')
+      #
+      # @param file [String] path to the mbox patch file to apply
+      #
+      # @return [String] git's stdout (usually empty on success)
+      #
+      # @return [nil] when `file` does not exist
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def apply_mail(file)
+        return unless File.exist?(file)
+
+        Git::Commands::Am::Apply.new(@execution_context).call(file, chdir: @execution_context.git_work_dir).stdout
+      end
+
+      # Option keys accepted by {#read_tree}
+      READ_TREE_ALLOWED_OPTS = %i[prefix].freeze
+      private_constant :READ_TREE_ALLOWED_OPTS
+
+      # Read tree information into the index
+      #
+      # Reads the named tree object into the index. This is a low-level plumbing
+      # operation used to stage the contents of a tree without updating the
+      # working tree. Typically called before {#checkout_index} or as part of
+      # custom merge flows.
+      #
+      # @example Read HEAD into the index
+      #   repo.read_tree('HEAD')
+      #
+      # @example Read a tree under a prefix directory
+      #   repo.read_tree('HEAD', { prefix: 'subdir/' })
+      #
+      # @param treeish [String] the tree-ish to read into the index
+      #
+      # @param opts [Hash] options for the read-tree command
+      #
+      # @option opts [String] :prefix (nil) keep the current index contents and
+      #   read the named tree-ish under the directory at the given prefix
+      #   (`--prefix=<prefix>`)
+      #
+      # @return [String] git's stdout (usually empty on success)
+      #
+      # @raise [ArgumentError] when unsupported options are provided
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def read_tree(treeish, opts = {})
+        SharedPrivate.assert_valid_opts!(READ_TREE_ALLOWED_OPTS, **opts)
+        Git::Commands::ReadTree.new(@execution_context).call(treeish, **opts).stdout
+      end
+
       # Option keys accepted by {#rm}
       RM_ALLOWED_OPTS = %i[
         force f dry_run n r cached ignore_unmatch sparse quiet q
@@ -129,13 +214,13 @@ module Git
       # Remove file(s) from the working tree and the index
       #
       # @example Remove a single file
-      #   repo.rm('obsolete.txt', force: true)
+      #   repo.rm('obsolete.txt', { force: true })
       #
       # @example Remove a directory recursively
-      #   repo.rm('build', r: true)
+      #   repo.rm('build', { r: true })
       #
       # @example Remove from the index only, keeping the working tree copy
-      #   repo.rm('keep_me.txt', cached: true)
+      #   repo.rm('keep_me.txt', { cached: true })
       #
       # @param path [String, Array<String>] a file or files to remove (relative to
       #   the worktree root); defaults to `'.'` (all files)
@@ -199,13 +284,13 @@ module Git
       # Remove untracked files from the working tree
       #
       # @example Remove untracked files
-      #   repo.clean(force: true)
+      #   repo.clean({ force: true })
       #
       # @example Remove untracked files and directories
-      #   repo.clean(force: true, d: true)
+      #   repo.clean({ force: true, d: true })
       #
       # @example Remove untracked and ignored files
-      #   repo.clean(force: true, x: true)
+      #   repo.clean({ force: true, x: true })
       #
       # @param opts [Hash] options for the clean command
       #

--- a/spec/integration/git/repository/staging_spec.rb
+++ b/spec/integration/git/repository/staging_spec.rb
@@ -7,16 +7,14 @@ require 'git/execution_context/repository'
 
 # Integration tests for Git::Repository::Staging.
 #
-# Only #ignored_files is exercised end-to-end here because it performs
-# facade-owned post-processing of real git output (splitting `git ls-files`
-# stdout into paths and unescaping git-quoted paths). A real git invocation
-# proves that post-processing handles actual output.
+# #ignored_files, #apply, #apply_mail, and #read_tree are exercised end-to-end
+# because they each perform facade-owned logic beyond simple delegation:
+#   - #ignored_files post-processes git output (splitting + path unescaping)
+#   - #apply and #apply_mail guard on File.exist? before calling git
+#   - #read_tree owns option whitelisting and maps opts={} to command kwargs
 #
-# The other facade methods are single-command delegators whose only
-# facade-owned behavior is pure-Ruby argument pre-processing (option
-# whitelisting for #add/#reset/#rm/#clean and deprecated-option migration for
-# #clean). Real git adds no signal for those transforms, and their end-to-end
-# git behavior is already covered by the underlying command integration specs:
+# Single-command delegators whose only facade behavior is option whitelisting
+# (#add, #reset, #rm, #clean) are covered by underlying command integration specs:
 #   spec/integration/git/commands/add_spec.rb
 #   spec/integration/git/commands/reset_spec.rb
 #   spec/integration/git/commands/rm_spec.rb
@@ -54,6 +52,117 @@ RSpec.describe Git::Repository::Staging, :integration do
       it 'does not include tracked or untracked non-ignored files' do
         write_file('keep.txt', 'content')
         expect(described_instance.ignored_files).not_to include('keep.txt', '.gitignore')
+      end
+    end
+  end
+
+  describe '#apply' do
+    let(:patch_file) { File.join(repo_dir, 'changes.patch') }
+
+    before do
+      write_file('hello.txt', "hello\n")
+      repo.add(all: true)
+      repo.commit('Initial commit')
+      write_file('hello.txt', "hello world\n")
+      patch_content = execution_context.command_capturing('diff', 'HEAD', chomp: false, chdir: repo_dir).stdout
+      File.write(patch_file, patch_content)
+      write_file('hello.txt', "hello\n") # restore original content
+    end
+
+    context 'when the patch file exists' do
+      it 'applies the patch to the working tree' do
+        described_instance.apply(patch_file)
+        expect(read_file('hello.txt')).to eq("hello world\n")
+      end
+
+      it 'returns a String' do
+        expect(described_instance.apply(patch_file)).to be_a(String)
+      end
+    end
+
+    context 'when the patch file does not exist' do
+      it 'returns nil without raising' do
+        expect(described_instance.apply('/nonexistent/fix.patch')).to be_nil
+      end
+
+      it 'leaves the working tree unchanged' do
+        described_instance.apply('/nonexistent/fix.patch')
+        expect(read_file('hello.txt')).to eq("hello\n")
+      end
+    end
+  end
+
+  describe '#apply_mail' do
+    let(:mbox_file) { File.join(repo_dir, 'patch.mbox') }
+
+    before do
+      write_file('hello.txt', "hello\n")
+      repo.add(all: true)
+      repo.commit('Initial commit')
+      write_file('hello.txt', "hello world\n")
+      repo.add(all: true)
+      repo.commit('add world')
+      mbox_content = execution_context.command_capturing(
+        'format-patch', '-1', 'HEAD', '--stdout', chomp: false, chdir: repo_dir
+      ).stdout
+      File.write(mbox_file, mbox_content)
+      repo.reset('HEAD~1', hard: true)
+    end
+
+    context 'when the mbox file exists' do
+      it 'applies the patch to the current branch' do
+        described_instance.apply_mail(mbox_file)
+        expect(read_file('hello.txt')).to eq("hello world\n")
+      end
+
+      it 'returns a String' do
+        expect(described_instance.apply_mail(mbox_file)).to be_a(String)
+      end
+    end
+
+    context 'when the mbox file does not exist' do
+      it 'returns nil without raising' do
+        expect(described_instance.apply_mail('/nonexistent/patch.mbox')).to be_nil
+      end
+
+      it 'leaves the working tree unchanged' do
+        described_instance.apply_mail('/nonexistent/patch.mbox')
+        expect(read_file('hello.txt')).to eq("hello\n")
+      end
+    end
+  end
+
+  describe '#read_tree' do
+    before do
+      write_file('hello.txt', "hello\n")
+      repo.add(all: true)
+      repo.commit('Initial commit')
+    end
+
+    it 'reads the tree into the index without error' do
+      expect { described_instance.read_tree('HEAD') }.not_to raise_error
+    end
+
+    it 'returns a String' do
+      expect(described_instance.read_tree('HEAD')).to be_a(String)
+    end
+
+    context 'with prefix option' do
+      it 'reads the tree under the given prefix without error' do
+        expect { described_instance.read_tree('HEAD', { prefix: 'sub/' }) }.not_to raise_error
+      end
+    end
+
+    context 'with an unknown option' do
+      it 'raises ArgumentError before calling git' do
+        expect { described_instance.read_tree('HEAD', { bogus: true }) }
+          .to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+
+    context 'legacy positional hash signature' do
+      it 'accepts opts as a positional hash' do
+        expect { described_instance.read_tree('HEAD', { prefix: 'sub/' }) }.not_to raise_error
       end
     end
   end

--- a/spec/unit/git/repository/staging_spec.rb
+++ b/spec/unit/git/repository/staging_spec.rb
@@ -462,6 +462,169 @@ RSpec.describe Git::Repository::Staging do
     end
   end
 
+  describe '#apply' do
+    subject(:result) { described_instance.apply(patch_file) }
+
+    let(:apply_command) { instance_double(Git::Commands::Apply) }
+    let(:apply_result) { command_result('') }
+    let(:patch_file) { '/tmp/fix.patch' }
+    let(:work_dir) { '/path/to/work/tree' }
+
+    before do
+      allow(Git::Commands::Apply).to receive(:new).with(execution_context).and_return(apply_command)
+      allow(execution_context).to receive(:git_work_dir).and_return(work_dir)
+    end
+
+    context 'when the file exists' do
+      before do
+        allow(File).to receive(:exist?).with(patch_file).and_return(true)
+      end
+
+      it 'delegates to Git::Commands::Apply#call with the file and chdir' do
+        expect(apply_command).to receive(:call).with(patch_file, chdir: work_dir).and_return(apply_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(apply_command).to receive(:call).with(patch_file, chdir: work_dir).and_return(command_result('applied'))
+        expect(result).to eq('applied')
+      end
+    end
+
+    context 'when the file does not exist' do
+      before do
+        allow(File).to receive(:exist?).with(patch_file).and_return(false)
+      end
+
+      it 'returns nil without calling git' do
+        expect(apply_command).not_to receive(:call)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'signature compatibility' do
+      before do
+        allow(File).to receive(:exist?).with(patch_file).and_return(true)
+        allow(apply_command).to receive(:call).with(patch_file, chdir: work_dir).and_return(apply_result)
+      end
+
+      it 'accepts a positional file argument' do
+        expect(described_instance.apply(patch_file)).to eq('')
+      end
+    end
+  end
+
+  describe '#apply_mail' do
+    subject(:result) { described_instance.apply_mail(mbox_file) }
+
+    let(:am_apply_command) { instance_double(Git::Commands::Am::Apply) }
+    let(:am_apply_result) { command_result('') }
+    let(:mbox_file) { '/tmp/patches.mbox' }
+    let(:work_dir) { '/path/to/work/tree' }
+
+    before do
+      allow(Git::Commands::Am::Apply).to receive(:new).with(execution_context).and_return(am_apply_command)
+      allow(execution_context).to receive(:git_work_dir).and_return(work_dir)
+    end
+
+    context 'when the file exists' do
+      before do
+        allow(File).to receive(:exist?).with(mbox_file).and_return(true)
+      end
+
+      it 'delegates to Git::Commands::Am::Apply#call with the file and chdir' do
+        expect(am_apply_command).to receive(:call).with(mbox_file, chdir: work_dir).and_return(am_apply_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(am_apply_command).to receive(:call)
+          .with(mbox_file, chdir: work_dir).and_return(command_result('applied mail'))
+        expect(result).to eq('applied mail')
+      end
+    end
+
+    context 'when the file does not exist' do
+      before do
+        allow(File).to receive(:exist?).with(mbox_file).and_return(false)
+      end
+
+      it 'returns nil without calling git' do
+        expect(am_apply_command).not_to receive(:call)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'signature compatibility' do
+      before do
+        allow(File).to receive(:exist?).with(mbox_file).and_return(true)
+        allow(am_apply_command).to receive(:call).with(mbox_file, chdir: work_dir).and_return(am_apply_result)
+      end
+
+      it 'accepts a positional file argument' do
+        expect(described_instance.apply_mail(mbox_file)).to eq('')
+      end
+    end
+  end
+
+  describe '#read_tree' do
+    subject(:result) { described_instance.read_tree('HEAD') }
+
+    let(:read_tree_command) { instance_double(Git::Commands::ReadTree) }
+    let(:read_tree_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::ReadTree).to receive(:new).with(execution_context).and_return(read_tree_command)
+    end
+
+    context 'with a treeish and no options' do
+      it 'delegates to Git::Commands::ReadTree#call with the treeish' do
+        expect(read_tree_command).to receive(:call).with('HEAD').and_return(read_tree_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(read_tree_command).to receive(:call).with('HEAD').and_return(command_result('output'))
+        expect(result).to eq('output')
+      end
+    end
+
+    context 'with the prefix option' do
+      subject(:result) { described_instance.read_tree('HEAD', { prefix: 'sub/' }) }
+
+      it 'forwards the prefix option to Git::Commands::ReadTree#call' do
+        expect(read_tree_command).to receive(:call).with('HEAD', prefix: 'sub/').and_return(read_tree_result)
+        result
+      end
+    end
+
+    context 'with an unknown option' do
+      subject(:result) { described_instance.read_tree('HEAD', { bogus: true }) }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+
+      it 'does not call Git::Commands::ReadTree' do
+        expect(read_tree_command).not_to receive(:call)
+        begin
+          result
+        rescue ArgumentError
+          # expected
+        end
+      end
+    end
+
+    context 'signature compatibility' do
+      subject(:result) { described_instance.read_tree('HEAD', { prefix: 'sub/' }) }
+
+      it 'accepts the legacy positional options hash' do
+        expect(read_tree_command).to receive(:call).with('HEAD', prefix: 'sub/').and_return(read_tree_result)
+        result
+      end
+    end
+  end
+
   describe '#ignored_files' do
     subject(:result) { described_instance.ignored_files }
 


### PR DESCRIPTION
# Description

Implements three Bucket 3 `legacy-contract` facade methods on `Git::Repository::Staging`
as specified in `redesign/c1c2_audit.md` §3 (Migration Candidates):

| Method | Command class | Notes |
| --- | --- | --- |
| `#apply(file)` | `Git::Commands::Apply` | Guards `File.exist?`; passes `chdir:` (required by `git apply` outside the work tree) |
| `#apply_mail(file)` | `Git::Commands::Am::Apply` | Same guard + `chdir:` pattern |
| `#read_tree(treeish, opts = {})` | `Git::Commands::ReadTree` | Whitelists `:prefix` via `READ_TREE_ALLOWED_OPTS` |

`Git::Base` now delegates all three to `facade_repository` instead of going through `lib`.

### Key design decisions

- `apply` and `apply_mail` pass `chdir: @execution_context.git_work_dir` to their
  command classes. This mirrors `Git::Lib#apply` / `Git::Lib#apply_mail` and is required
  because `git apply` / `git am` do not honour `--work-tree` when run from outside the
  working tree directory.
- `read_tree` preserves the 4.x `opts = {}` positional hash signature (legacy-contract)
  and exposes only `:prefix` — the sole option that `Git::Lib#read_tree` ever forwarded.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
