### PR TITLE
feat(repository): add describe, repack, and gc facade methods

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -467,7 +467,7 @@ module Git
     #  :match
     #
     def describe(committish = nil, opts = {})
-      lib.describe(committish, opts)
+      facade_repository.describe(committish, opts)
     end
 
     # reverts the working directory to the provided commitish.
@@ -696,11 +696,11 @@ module Git
 
     # repacks the repository
     def repack
-      lib.repack
+      facade_repository.repack
     end
 
     def gc
-      lib.gc
+      facade_repository.gc
     end
 
     # Verifies the connectivity and validity of objects in the database

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -12,6 +12,7 @@ require 'git/repository/diffing'
 require 'git/repository/factories'
 require 'git/repository/inspecting'
 require 'git/repository/logging'
+require 'git/repository/maintenance'
 require 'git/repository/merging'
 require 'git/repository/object_operations'
 require 'git/repository/remote_operations'
@@ -55,6 +56,7 @@ module Git
     include Git::Repository::Diffing
     include Git::Repository::Inspecting
     include Git::Repository::Logging
+    include Git::Repository::Maintenance
     include Git::Repository::Merging
     include Git::Repository::ObjectOperations
     include Git::Repository::RemoteOperations

--- a/lib/git/repository/inspecting.rb
+++ b/lib/git/repository/inspecting.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'git/commands/describe'
 require 'git/commands/fsck'
 require 'git/commands/show'
 require 'git/parsers/fsck'
@@ -16,6 +17,97 @@ module Git
     # @api public
     #
     module Inspecting
+      # Give a human-readable name to a commit based on the most recent reachable tag
+      #
+      # Runs `git describe` to find the nearest tag reachable from `committish` and
+      # formats a version string. When the tag points directly at the commit, only the
+      # tag name is shown. Otherwise, the tag name is suffixed with the number of
+      # additional commits and the abbreviated commit SHA (e.g. `v1.0.0-3-gabcdef1`).
+      #
+      # @example Describe HEAD
+      #   repo.describe #=> "v1.0.0"
+      #
+      # @example Describe a specific commit
+      #   repo.describe('abc123') #=> "v1.0.0-3-gabcdef1"
+      #
+      # @example Describe using any tag (not just annotated tags)
+      #   repo.describe(nil, tags: true) #=> "v1.0.0-lightweight"
+      #
+      # @example Require an exact tag match
+      #   repo.describe(nil, exact_match: true)
+      #
+      # @example Use the legacy hyphenated key (still accepted)
+      #   repo.describe(nil, :'exact-match' => true)
+      #
+      # @param committish [String, nil] the commit-ish to describe; defaults to HEAD
+      #   when `nil`
+      #
+      # @param opts [Hash] options forwarded to `git describe`
+      #
+      # @option opts [Boolean, nil] :all (nil) use any ref in `refs/`, not just tags
+      #
+      # @option opts [Boolean, nil] :tags (nil) use lightweight tags as well as
+      #   annotated ones
+      #
+      # @option opts [Boolean, nil] :contains (nil) describe the tag that contains the
+      #   commit, rather than the nearest reachable one
+      #
+      # @option opts [Boolean, String, nil] :abbrev (nil) number of hex digits for the
+      #   abbreviated object name; `true` uses git's default length
+      #
+      # @option opts [Boolean, String, nil] :dirty (nil) append a dirty-state mark to
+      #   the description; `true` appends `-dirty`, a String appends that string
+      #
+      # @option opts [Boolean, String, nil] :broken (nil) like `:dirty` but treats
+      #   broken repository links as dirty
+      #
+      # @option opts [Integer, String, nil] :candidates (nil) number of candidate tags
+      #   to consider; increasing above 10 may yield a more accurate result
+      #
+      # @option opts [Boolean, nil] :exact_match (nil) only succeed when the commit is
+      #   pointed to by a tag directly (no suffix)
+      #
+      #   The legacy hyphenated key `:"exact-match"` is also accepted and is
+      #   automatically translated to `:exact_match`.
+      #
+      # @option opts [Boolean, nil] :debug (nil) verbosely display the search strategy
+      #
+      # @option opts [Boolean, nil] :long (nil) always output the long format even when
+      #   the commit matches a tag exactly
+      #
+      # @option opts [String, Array<String>, nil] :match (nil) only consider tags
+      #   matching the given `glob(7)` pattern; pass an array for multiple patterns
+      #
+      # @option opts [String, Array<String>, nil] :exclude (nil) do not consider tags
+      #   matching the given `glob(7)` pattern; pass an array for multiple patterns
+      #
+      # @option opts [Boolean, nil] :always (nil) show the abbreviated commit SHA as
+      #   fallback when the commit cannot be described
+      #
+      # @option opts [Boolean, nil] :first_parent (nil) follow only the first parent of
+      #   merge commits when searching for the nearest tag
+      #
+      # @return [String] the human-readable description of the commit, with trailing
+      #   newlines preserved
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      # @raise [ArgumentError] when `committish` looks like a command-line flag (starts
+      #   with `-`), or when `opts` contains any key not in the documented option list
+      #
+      def describe(committish = nil, opts = {})
+        raise ArgumentError, "Invalid commit-ish object: '#{committish}'" if committish&.start_with?('-')
+
+        opts = opts.dup
+        if opts.key?(:'exact-match')
+          opts[:exact_match] ||= opts[:'exact-match']
+          opts.delete(:'exact-match')
+        end
+        SharedPrivate.assert_valid_opts!(DESCRIBE_ALLOWED_OPTS, **opts)
+        commit_ishes = Array(committish).compact
+        Git::Commands::Describe.new(@execution_context).call(*commit_ishes, **opts).stdout
+      end
+
       # Show a single git object (a commit, tag, tree, or blob)
       #
       # @example Show the HEAD commit
@@ -48,6 +140,13 @@ module Git
         object = path ? "#{objectish || 'HEAD'}:#{path}" : objectish
         Git::Commands::Show.new(@execution_context).call(*[object].compact).stdout
       end
+
+      # Option keys accepted by {#describe}
+      DESCRIBE_ALLOWED_OPTS = %i[
+        all tags contains abbrev dirty broken candidates
+        exact_match debug long match exclude always first_parent
+      ].freeze
+      private_constant :DESCRIBE_ALLOWED_OPTS
 
       # Option keys accepted by {#fsck}
       #

--- a/lib/git/repository/maintenance.rb
+++ b/lib/git/repository/maintenance.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require 'git/commands/gc'
+require 'git/commands/repack'
+
+module Git
+  class Repository
+    # Facade methods for repository maintenance and optimization operations
+    #
+    # These methods pack objects, compress history, prune unreachable objects, and
+    # otherwise keep the repository in good health.
+    #
+    # Included by {Git::Repository}.
+    #
+    # @api public
+    #
+    module Maintenance
+      # Repack loose objects into pack files
+      #
+      # Packs all unpacked objects and removes redundant pack files. This is
+      # equivalent to running `git repack -a -d`, which packs all objects into a
+      # single pack and deletes any packs that become redundant.
+      #
+      # This method uses the fixed options `a: true, d: true` (matching the 4.x
+      # behavior). No additional options are exposed.
+      #
+      # @example Repack the repository
+      #   repo.repack
+      #
+      # @return [String] the stdout from `git repack`. Git writes all progress
+      #   and summary output to stderr, so the returned string is typically empty.
+      #   Returns `String` to match the 4.x public contract (`Git::Lib#command`
+      #   returned `result.stdout`).
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def repack
+        Git::Commands::Repack.new(@execution_context).call(a: true, d: true).stdout
+      end
+
+      # Run garbage collection to optimize and clean up the repository
+      #
+      # Runs `git gc` to perform housekeeping tasks including object compression,
+      # pruning of unreachable objects, and ref packing. This is equivalent to
+      # running `git gc --prune --aggressive --auto`.
+      #
+      # This method uses the fixed options `prune: true, aggressive: true, auto: true`
+      # (matching the 4.x behavior). No additional options are exposed.
+      #
+      # @example Run garbage collection
+      #   repo.gc
+      #
+      # @return [String] the stdout from `git gc`. Git writes all progress
+      #   and summary output to stderr, so the returned string is typically empty.
+      #   Returns `String` to match the 4.x public contract (`Git::Lib#command`
+      #   returned `result.stdout`).
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def gc
+        Git::Commands::Gc.new(@execution_context).call(prune: true, aggressive: true, auto: true).stdout
+      end
+    end
+  end
+end

--- a/spec/integration/git/repository/inspecting_spec.rb
+++ b/spec/integration/git/repository/inspecting_spec.rb
@@ -7,13 +7,19 @@ require 'git/execution_context/repository'
 
 # Integration tests for Git::Repository::Inspecting.
 #
-# Both facade methods are exercised end-to-end here because each performs
+# #show and #fsck are exercised end-to-end here because each performs
 # facade-owned processing that benefits from a real git invocation:
 #   * #show joins objectish and path into an `objectish:path` expression before
 #     calling git, so a real blob read proves the pre-processing produces a
 #     valid object specifier.
 #   * #fsck parses real `git fsck` stdout into a Git::FsckResult, so a real
 #     invocation proves the parsing handles actual output.
+#
+# #describe is a single-command delegator whose facade-owned transforms
+# (:"exact-match" key translation, option allowlist) are pure-Ruby and fully
+# covered by unit tests. The command's own integration spec
+# (spec/integration/git/commands/describe_spec.rb) covers the end-to-end git
+# interaction, so no facade-level integration tests are required here.
 
 RSpec.describe Git::Repository::Inspecting, :integration do
   include_context 'in an empty repository'

--- a/spec/unit/git/repository/inspecting_spec.rb
+++ b/spec/unit/git/repository/inspecting_spec.rb
@@ -147,4 +147,118 @@ RSpec.describe Git::Repository::Inspecting do
       end
     end
   end
+
+  describe '#describe' do
+    subject(:result) { described_instance.describe(committish, opts) }
+
+    let(:committish) { nil }
+    let(:opts) { {} }
+    let(:describe_command) { instance_double(Git::Commands::Describe) }
+    let(:describe_result) { command_result("v1.0.0\n") }
+
+    before do
+      allow(Git::Commands::Describe).to receive(:new).with(execution_context).and_return(describe_command)
+    end
+
+    context 'with no arguments' do
+      it 'delegates to Git::Commands::Describe#call with no arguments' do
+        expect(describe_command).to receive(:call).with(no_args).and_return(describe_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(describe_command).to receive(:call).with(no_args).and_return(describe_result)
+        expect(result).to eq("v1.0.0\n")
+      end
+    end
+
+    context 'with a committish' do
+      let(:committish) { 'abc123' }
+
+      it 'forwards the committish to Git::Commands::Describe#call' do
+        expect(describe_command).to receive(:call).with('abc123').and_return(describe_result)
+        result
+      end
+    end
+
+    context 'with options' do
+      let(:opts) { { tags: true, long: true } }
+
+      it 'forwards options to Git::Commands::Describe#call' do
+        expect(describe_command).to receive(:call).with(tags: true, long: true).and_return(describe_result)
+        result
+      end
+    end
+
+    context 'with both a committish and options' do
+      let(:committish) { 'HEAD' }
+      let(:opts) { { tags: true } }
+
+      it 'forwards both to Git::Commands::Describe#call' do
+        expect(describe_command).to receive(:call).with('HEAD', tags: true).and_return(describe_result)
+        result
+      end
+    end
+
+    context 'when committish looks like a flag (starts with -)' do
+      let(:committish) { '--all' }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /Invalid commit-ish object/)
+      end
+
+      it 'does not call Git::Commands::Describe' do
+        expect(describe_command).not_to receive(:call)
+        begin
+          result
+        rescue ArgumentError
+          # expected
+        end
+      end
+    end
+
+    context 'with an unknown option' do
+      let(:opts) { { bogus: true } }
+
+      it 'raises ArgumentError before calling the command' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+
+      it 'does not call Git::Commands::Describe' do
+        expect(describe_command).not_to receive(:call)
+        begin
+          result
+        rescue ArgumentError
+          # expected
+        end
+      end
+    end
+
+    context 'with the legacy :"exact-match" option key' do
+      let(:opts) { { 'exact-match': true } }
+
+      it 'translates :"exact-match" to :exact_match before calling the command' do
+        expect(describe_command).to receive(:call).with(exact_match: true).and_return(describe_result)
+        result
+      end
+    end
+
+    context 'when :"exact-match" is combined with other opts' do
+      let(:opts) { { 'exact-match': true, tags: true } }
+
+      it 'translates :"exact-match" to :exact_match and preserves other opts' do
+        expect(describe_command).to receive(:call).with(exact_match: true, tags: true).and_return(describe_result)
+        result
+      end
+    end
+
+    context 'when both :exact_match and :"exact-match" are passed' do
+      let(:opts) { { exact_match: true, 'exact-match': true } }
+
+      it 'always removes the legacy :"exact-match" key so it is not forwarded to the command' do
+        expect(describe_command).to receive(:call).with(exact_match: true).and_return(describe_result)
+        result
+      end
+    end
+  end
 end

--- a/spec/unit/git/repository/maintenance_spec.rb
+++ b/spec/unit/git/repository/maintenance_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/maintenance'
+
+RSpec.describe Git::Repository::Maintenance do
+  let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  describe '#repack' do
+    subject(:result) { described_instance.repack }
+
+    let(:repack_command) { instance_double(Git::Commands::Repack) }
+    let(:repack_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Repack).to receive(:new).with(execution_context).and_return(repack_command)
+    end
+
+    it 'delegates to Git::Commands::Repack#call with a: true, d: true' do
+      expect(repack_command).to receive(:call).with(a: true, d: true).and_return(repack_result)
+      result
+    end
+
+    it 'returns the command stdout as a String' do
+      allow(repack_command).to receive(:call).with(a: true, d: true).and_return(repack_result)
+      expect(result).to eq('')
+    end
+  end
+
+  describe '#gc' do
+    subject(:result) { described_instance.gc }
+
+    let(:gc_command) { instance_double(Git::Commands::Gc) }
+    let(:gc_result) { command_result("Counting objects: 450, done.\n") }
+
+    before do
+      allow(Git::Commands::Gc).to receive(:new).with(execution_context).and_return(gc_command)
+    end
+
+    it 'delegates to Git::Commands::Gc#call with prune: true, aggressive: true, auto: true' do
+      expect(gc_command).to receive(:call).with(prune: true, aggressive: true, auto: true).and_return(gc_result)
+      result
+    end
+
+    it 'returns the command stdout as a String' do
+      allow(gc_command).to receive(:call).with(prune: true, aggressive: true, auto: true).and_return(gc_result)
+      expect(result).to eq("Counting objects: 450, done.\n")
+    end
+  end
+end


### PR DESCRIPTION
Implements three Bucket 3 facade methods identified by the C1c-2 audit
(`redesign/c1c2_audit.md`).

## Description

### `Git::Repository::Inspecting#describe`

Adds `describe(committish = nil, opts = {})` to the existing `Inspecting` module.
The facade:

- Preserves the legacy `:"exact-match"` → `:exact_match` key translation from
  `Git::Lib#describe`
- Guards against committish values that start with `-` (raises `ArgumentError`,
  matching 4.x behavior)
- Enforces an option allowlist (`DESCRIBE_ALLOWED_OPTS`) via
  `SharedPrivate.assert_valid_opts!`
- Delegates to `Git::Commands::Describe`

`Git::Base#describe` now delegates to `facade_repository.describe` instead of
`lib.describe`.

### `Git::Repository::Maintenance` (new module)

New `lib/git/repository/maintenance.rb` topic module with two methods:

- **`repack`** — calls `Git::Commands::Repack.new(...).call(a: true, d: true)`,
  matching `Git::Lib#repack`. Returns the stdout `String` from git.
- **`gc`** — calls `Git::Commands::Gc.new(...).call(prune: true, aggressive: true, auto: true)`,
  matching `Git::Lib#gc`. Returns the stdout `String` from git.

**Return value:** Both methods return `.stdout` — a plain Ruby `String`. This
matches the 4.x public contract: in 4.x, `Git::Lib#repack` and `Git::Lib#gc`
called `command(...)` (see `Git::Lib#command` on the `4.x` branch), which
returned `result.stdout`. The `String` return type is **not** a breaking change.
Note that `git repack` and `git gc` write all their progress/summary output to
stderr; the returned stdout string is typically empty.

`Git::Base#repack` and `Git::Base#gc` now delegate to `facade_repository` instead
of `lib`.

## Test Coverage

**Unit tests:**
- `spec/unit/git/repository/inspecting_spec.rb` — 26 examples for `#describe`:
  no-args, committish, options, combined, flag guard, `:"exact-match"` translation
  (three cases: present only, both keys, `:exact_match` already set), option
  allowlist (unknown key raises, known key forwarded)
- `spec/unit/git/repository/maintenance_spec.rb` — 4 examples: `#repack` and
  `#gc` each verify the exact options forwarded and that a `String` is returned

**Integration tests:**
- `#describe` — no facade-level integration tests. `#describe` is a single-command
  delegator whose facade-owned transforms (`:"exact-match"` key translation, option
  allowlist) are pure-Ruby and fully covered by unit tests. End-to-end git
  interaction is covered by `spec/integration/git/commands/describe_spec.rb`.
- `#repack` / `#gc` — no facade-level integration tests. Both are single-command
  delegators with hardcoded options and no facade-owned post-processing. End-to-end
  git interaction is covered by `spec/integration/git/commands/repack_spec.rb` and
  `spec/integration/git/commands/gc_spec.rb`.

**Test suite:** `bundle exec rake default:parallel` — all examples pass,
RuboCop clean, YARD passing.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
