### PR TITLE
fix(repository): align 6 facade signatures with 4.x legacy contracts

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -424,7 +424,7 @@ module Git
 
     # resets the working directory to the provided commitish
     def reset(commitish = nil, opts = {})
-      facade_repository.reset(commitish, **opts)
+      facade_repository.reset(commitish, opts)
     end
 
     # resets the working directory to the commitish with '--hard'
@@ -489,19 +489,19 @@ module Git
     #   :author
     #
     def commit(message, opts = {})
-      facade_repository.commit(message, **opts)
+      facade_repository.commit(message, opts)
     end
 
     # commits all pending changes in the index file to the git repository,
     # but automatically adds all modified files without having to explicitly
     # calling @git.add() on them.
     def commit_all(message, opts = {})
-      facade_repository.commit_all(message, **opts)
+      facade_repository.commit_all(message, opts)
     end
 
     # checks out a branch as the new git working directory
-    def checkout(*, **)
-      facade_repository.checkout(*, **)
+    def checkout(branch = nil, opts = {})
+      facade_repository.checkout(branch, opts)
     end
 
     # checks out an old version of a file
@@ -820,7 +820,7 @@ module Git
     end
 
     def write_and_commit_tree(opts = {})
-      Git::Object::Commit.new(self, facade_repository.write_and_commit_tree(**opts))
+      Git::Object::Commit.new(self, facade_repository.write_and_commit_tree(opts))
     end
 
     def update_ref(branch, commit)
@@ -978,7 +978,7 @@ module Git
 
     # @return [Git::Object::Commit] a commit object
     def commit_tree(tree = nil, opts = {})
-      Git::Object::Commit.new(self, facade_repository.commit_tree(tree, **opts))
+      Git::Object::Commit.new(self, facade_repository.commit_tree(tree, opts))
     end
 
     # @return [Git::Diff] a Git::Diff object

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -89,22 +89,22 @@ module Git
       # @param branch [String, nil] the branch to check out; defaults to nil
       #   (i.e. restore HEAD state)
       #
-      # @param options [Hash] options for the checkout command
+      # @param opts [Hash] options for the checkout command
       #
-      # @option options [Boolean, nil] :force (nil) discard local changes when
+      # @option opts [Boolean, nil] :force (nil) discard local changes when
       #   switching branches
       #
-      # @option options [Boolean, String, nil] :new_branch (nil) when `true`,
+      # @option opts [Boolean, String, nil] :new_branch (nil) when `true`,
       #   creates a new branch named `branch` from `:start_point`
       #
       #   When a `String`, creates a new branch with that name, using `branch`
       #   as the start point.
       #
-      # @option options [Boolean, String, nil] :b (nil) alias for `:new_branch`
+      # @option opts [Boolean, String, nil] :b (nil) alias for `:new_branch`
       #
-      # @option options [Boolean, nil] :f (nil) alias for `:force`
+      # @option opts [Boolean, nil] :f (nil) alias for `:force`
       #
-      # @option options [String, nil] :start_point (nil) the commit or branch to
+      # @option opts [String, nil] :start_point (nil) the commit or branch to
       #   start the new branch from; used together with `new_branch: true`
       #
       # @return [String] git's stdout from the checkout
@@ -113,15 +113,15 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
-      def checkout(branch = nil, options = {})
-        if branch.is_a?(Hash) && options.empty?
-          options = branch
+      def checkout(branch = nil, opts = {})
+        if branch.is_a?(Hash) && opts.empty?
+          opts = branch
           branch = nil
         end
 
-        SharedPrivate.assert_valid_opts!(CHECKOUT_ALLOWED_OPTS, **options)
+        SharedPrivate.assert_valid_opts!(CHECKOUT_ALLOWED_OPTS, **opts)
 
-        target, translated_opts = Private.translate_checkout_opts(branch, options)
+        target, translated_opts = Private.translate_checkout_opts(branch, opts)
         Git::Commands::Checkout::Branch.new(@execution_context).call(target, **translated_opts).stdout
       end
 
@@ -215,9 +215,9 @@ module Git
         local_branch?(branch) || remote_branch?(branch)
       end
 
-      # @deprecated Use {#local_branch?} instead.
+      # Checks whether the named branch exists locally
       #
-      # @example
+      # @example Check whether main exists locally
       #   repo.is_local_branch?('main')  # => true
       #
       # @param branch [String] the local branch name to look up
@@ -225,6 +225,8 @@ module Git
       # @return [Boolean] `true` if the branch exists locally, `false` otherwise
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @deprecated use {#local_branch?} instead
       #
       def is_local_branch?(branch) # rubocop:disable Naming/PredicatePrefix
         Git::Deprecation.warn(
@@ -234,9 +236,9 @@ module Git
         local_branch?(branch)
       end
 
-      # @deprecated Use {#remote_branch?} instead.
+      # Checks whether the named branch exists as a remote-tracking branch
       #
-      # @example
+      # @example Check whether master exists on any remote
       #   repo.is_remote_branch?('master')  # => true
       #
       # @param branch [String] the short branch name to look up across all remotes
@@ -246,6 +248,8 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @deprecated use {#remote_branch?} instead
+      #
       def is_remote_branch?(branch) # rubocop:disable Naming/PredicatePrefix
         Git::Deprecation.warn(
           'Git::Repository#is_remote_branch? is deprecated and will be removed in a future version. ' \
@@ -254,9 +258,9 @@ module Git
         remote_branch?(branch)
       end
 
-      # @deprecated Use {#branch?} instead.
+      # Checks whether the named branch exists locally or as a remote-tracking branch
       #
-      # @example
+      # @example Check whether main exists anywhere
       #   repo.is_branch?('main')  # => true
       #
       # @param branch [String] the branch name to look up
@@ -265,6 +269,8 @@ module Git
       #   `false` otherwise
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @deprecated use {#branch?} instead
       #
       def is_branch?(branch) # rubocop:disable Naming/PredicatePrefix
         Git::Deprecation.warn(

--- a/lib/git/repository/committing.rb
+++ b/lib/git/repository/committing.rb
@@ -28,53 +28,52 @@ module Git
 
       # Record staged changes as a new commit
       #
-      # @overload commit(message = nil, **options)
+      # @example Commit with a message
+      #   repo.commit('Add README')
       #
-      #   @example Commit with a message
-      #     repo.commit('Add README')
+      # @example Amend the previous commit, reusing its message
+      #   repo.commit(nil, amend: true)
       #
-      #   @example Amend the previous commit, reusing its message
-      #     repo.commit(nil, amend: true)
+      # @example Stage all modified files and commit
+      #   repo.commit('Cleanup', all: true)
       #
-      #   @example Stage all modified files and commit
-      #     repo.commit('Cleanup', all: true)
+      # @param message [String, nil] the commit message; pass `nil` to omit
+      #   (e.g. when using `:amend` to reuse the previous message)
       #
-      #   @param message [String, nil] the commit message; pass `nil` to omit
-      #     (e.g. when using `:amend` to reuse the previous message)
+      # @param opts [Hash] options for the commit command
       #
-      #   @param options [Hash] options for the commit command
+      # @option opts [Boolean, nil] :all (nil) automatically stage modified and
+      #   deleted files before committing
       #
-      #   @option options [Boolean, nil] :all (nil) automatically stage modified and
-      #     deleted files before committing
+      # @option opts [Boolean, nil] :amend (nil) replace the tip of the current
+      #   branch with a new commit
       #
-      #   @option options [Boolean, nil] :amend (nil) replace the tip of the current
-      #     branch with a new commit
+      # @option opts [Boolean, nil] :allow_empty (nil) allow committing with no
+      #   changes
       #
-      #   @option options [Boolean, nil] :allow_empty (nil) allow committing with no
-      #     changes
+      # @option opts [Boolean, nil] :allow_empty_message (nil) allow committing
+      #   with an empty message
       #
-      #   @option options [Boolean, nil] :allow_empty_message (nil) allow committing
-      #     with an empty message
+      # @option opts [String] :author (nil) override the commit author in
+      #   `A U Thor <author@example.com>` format
       #
-      #   @option options [String] :author (nil) override the commit author in
-      #     `A U Thor <author@example.com>` format
+      # @option opts [String] :date (nil) override the author date
       #
-      #   @option options [String] :date (nil) override the author date
+      # @option opts [Boolean, nil] :gpg_sign (nil) GPG-sign the commit
       #
-      #   @option options [Boolean, nil] :gpg_sign (nil) GPG-sign the commit
+      # @option opts [Boolean, nil] :no_gpg_sign (nil) disable GPG signing
       #
-      #   @option options [Boolean, nil] :no_gpg_sign (nil) disable GPG signing
+      # @option opts [Boolean, nil] :no_verify (nil) bypass the pre-commit and
+      #   commit-msg hooks
       #
-      #   @option options [Boolean, nil] :no_verify (nil) bypass the pre-commit and
-      #     commit-msg hooks
+      # @return [String] git's stdout from the commit
       #
-      #   @return [String] git's stdout from the commit
+      # @raise [ArgumentError] when unsupported options are provided
       #
-      #   @raise [ArgumentError] when unsupported options are provided
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
-      #   @raise [Git::FailedError] when git exits with a non-zero exit status
-      #
-      def commit(message = nil, **opts)
+      def commit(message, opts = {})
+        opts = opts.dup
         if opts.key?(:add_all)
           Git::Deprecation.warn('The :add_all option for #commit is deprecated, use :all instead')
           opts[:all] = opts.delete(:add_all)
@@ -90,25 +89,23 @@ module Git
 
       # Commit all modified tracked files without explicitly staging them first
       #
-      # Equivalent to `commit(message, all: true, **options)`.
+      # Equivalent to calling {#commit} with `all: true` merged into `opts`.
       #
-      # @overload commit_all(message, **options)
+      # @example Commit all changes with a message
+      #   repo.commit_all('Update everything')
       #
-      #   @example Commit all changes with a message
-      #     repo.commit_all('Update everything')
+      # @param message [String] the commit message
       #
-      #   @param message [String] the commit message
+      # @param opts [Hash] additional options forwarded to {#commit}
       #
-      #   @param options [Hash] additional options forwarded to {#commit}
+      # @return [String] git's stdout from the commit
       #
-      #   @return [String] git's stdout from the commit
+      # @raise [ArgumentError] when unsupported options are provided
       #
-      #   @raise [ArgumentError] when unsupported options are provided
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
-      #   @raise [Git::FailedError] when git exits with a non-zero exit status
-      #
-      def commit_all(*, **)
-        commit(*, all: true, **)
+      def commit_all(message, opts = {})
+        commit(message, opts.merge(all: true))
       end
 
       # Create a commit object from a tree SHA without moving HEAD
@@ -116,37 +113,36 @@ module Git
       # Unlike {#commit}, this does not read the index; it directly wraps
       # `git commit-tree`.
       #
-      # @overload commit_tree(tree, **options)
+      # @example Commit a tree with a parent
+      #   repo.commit_tree('deadbeef', message: 'snapshot', parent: 'HEAD')
       #
-      #   @example Commit a tree with a parent
-      #     repo.commit_tree('deadbeef', message: 'snapshot', parent: 'HEAD')
+      # @param tree [String, nil] the tree SHA to commit; defaults to `nil`
       #
-      #   @param tree [String] the tree SHA to commit
+      # @param opts [Hash] options for the commit-tree command
       #
-      #   @param options [Hash] options for the commit-tree command
+      # @option opts [String] :m (nil) the commit message (short form)
       #
-      #   @option options [String] :m (nil) the commit message (short form)
+      # @option opts [String] :message (nil) the commit message (normalized
+      #   to `:m` before passing to the command)
       #
-      #   @option options [String] :message (nil) the commit message (normalized
-      #     to `:m` before passing to the command)
+      # @option opts [String, Array<String>] :p (nil) parent commit SHA(s)
       #
-      #   @option options [String, Array<String>] :p (nil) parent commit SHA(s)
+      # @option opts [String] :parent (nil) a single parent commit SHA
+      #   (normalized to `:p`)
       #
-      #   @option options [String] :parent (nil) a single parent commit SHA
-      #     (normalized to `:p`)
+      # @option opts [Array<String>] :parents (nil) multiple parent commit
+      #   SHAs (normalized to `:p`)
       #
-      #   @option options [Array<String>] :parents (nil) multiple parent commit
-      #     SHAs (normalized to `:p`)
+      # @return [String] the SHA of the newly created commit object
       #
-      #   @return [String] the SHA of the newly created commit object
+      # @raise [ArgumentError] when unsupported options are provided
       #
-      #   @raise [ArgumentError] when unsupported options are provided
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
-      #   @raise [Git::FailedError] when git exits with a non-zero exit status
-      #
-      def commit_tree(tree, **opts)
+      def commit_tree(tree = nil, opts = {}) # rubocop:disable Metrics/AbcSize
         SharedPrivate.assert_valid_opts!(COMMIT_TREE_ALLOWED_OPTS, **opts)
 
+        opts = opts.dup
         opts[:p] = opts.delete(:parents) if opts.key?(:parents)
         opts[:p] = opts.delete(:parent) if opts.key?(:parent)
         opts[:m] = opts.delete(:message) if opts.key?(:message)
@@ -172,19 +168,19 @@ module Git
       #
       # Combines {#write_tree} and {#commit_tree} in a single call.
       #
-      # @overload write_and_commit_tree(**options)
+      # @example Commit the current index as a snapshot
+      #   commit_sha = repo.write_and_commit_tree(message: 'snapshot')
       #
-      #   @example Commit the current index as a snapshot
-      #     commit_sha = repo.write_and_commit_tree(message: 'snapshot')
+      # @param opts [Hash] options forwarded to {#commit_tree}
       #
-      #   @param options [Hash] options forwarded to {#commit_tree}
+      # @return [String] the SHA of the newly created commit object
       #
-      #   @return [String] the SHA of the newly created commit object
+      # @raise [ArgumentError] when unsupported options are provided
       #
-      #   @raise [Git::FailedError] when git exits with a non-zero exit status
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
-      def write_and_commit_tree(**)
-        commit_tree(write_tree, **)
+      def write_and_commit_tree(opts = {})
+        commit_tree(write_tree, opts)
       end
     end
   end

--- a/lib/git/repository/staging.rb
+++ b/lib/git/repository/staging.rb
@@ -66,31 +66,29 @@ module Git
 
       # Reset the current HEAD to a specified state
       #
-      # @overload reset(commitish = nil, **options)
+      # @example Reset the index and working tree to HEAD
+      #   repo.reset
       #
-      #   @example Reset the index and working tree to HEAD
-      #     repo.reset
+      # @example Hard reset to a specific commit
+      #   repo.reset('HEAD~1', hard: true)
       #
-      #   @example Hard reset to a specific commit
-      #     repo.reset('HEAD~1', hard: true)
+      # @param commitish [String, nil] the commit or tree-ish to reset to;
+      #   defaults to HEAD when `nil`
       #
-      #   @param commitish [String, nil] the commit or tree-ish to reset to;
-      #     defaults to HEAD when `nil`
+      # @param opts [Hash] options for the reset command
       #
-      #   @param options [Hash] options for the reset command
+      # @option opts [Boolean, nil] :hard (nil) reset the index and working
+      #   tree; discards all tracked changes
       #
-      #   @option options [Boolean, nil] :hard (nil) reset the index and working
-      #     tree; discards all tracked changes
+      # @return [String] git's stdout from the reset
       #
-      #   @return [String] git's stdout from the reset
+      # @raise [ArgumentError] when unsupported options are provided
       #
-      #   @raise [ArgumentError] when unsupported options are provided
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
-      #   @raise [Git::FailedError] when git exits with a non-zero exit status
-      #
-      def reset(commitish = nil, **)
-        SharedPrivate.assert_valid_opts!(RESET_ALLOWED_OPTS, **)
-        Git::Commands::Reset.new(@execution_context).call(commitish, **).stdout
+      def reset(commitish = nil, opts = {})
+        SharedPrivate.assert_valid_opts!(RESET_ALLOWED_OPTS, **opts)
+        Git::Commands::Reset.new(@execution_context).call(commitish, **opts).stdout
       end
 
       # Reset the current HEAD to a specified state with `--hard`

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -155,6 +155,31 @@ RSpec.describe Git::Repository::Branching do
       end
     end
 
+    context 'with options passed as a bare Hash variable' do
+      let(:opts) { { force: true } }
+
+      subject(:result) { described_instance.checkout('main', opts) }
+
+      it 'does not raise ArgumentError' do
+        allow(checkout_branch_command)
+          .to receive(:call).with('main', force: true).and_return(checkout_branch_result)
+        expect { result }.not_to raise_error
+      end
+
+      it 'forwards the options to the command' do
+        expect(checkout_branch_command)
+          .to receive(:call).with('main', force: true).and_return(checkout_branch_result)
+        result
+      end
+    end
+
+    context 'with too many positional arguments' do
+      it 'raises ArgumentError' do
+        expect { described_instance.checkout('main', {}, :extra) }
+          .to raise_error(ArgumentError)
+      end
+    end
+
     context 'with an unknown option' do
       subject(:result) { described_instance.checkout('main', bogus: true) }
 

--- a/spec/unit/git/repository/committing_spec.rb
+++ b/spec/unit/git/repository/committing_spec.rb
@@ -57,8 +57,8 @@ RSpec.describe Git::Repository::Committing do
       end
     end
 
-    context 'with no message argument' do
-      subject(:result) { described_instance.commit(amend: true) }
+    context 'with nil message and amend option' do
+      subject(:result) { described_instance.commit(nil, amend: true) }
 
       it 'does not include :message in the call' do
         expect(commit_command).to receive(:call).with(no_edit: true, amend: true).and_return(commit_result)
@@ -189,6 +189,23 @@ RSpec.describe Git::Repository::Committing do
         end
       end
     end
+
+    context 'with a plain Hash variable (legacy-contract calling convention)' do
+      it 'does not raise ArgumentError when opts is a bare Hash variable' do
+        opts = { all: true }
+        allow(commit_command).to receive(:call).and_return(commit_result)
+        expect { described_instance.commit('msg', opts) }.not_to raise_error
+      end
+
+      it 'does not mutate the caller-provided Hash when :add_all is present' do
+        opts = { add_all: true }
+        original = opts.dup
+        allow(Git::Deprecation).to receive(:warn)
+        allow(commit_command).to receive(:call).and_return(commit_result)
+        described_instance.commit('msg', opts)
+        expect(opts).to eq(original)
+      end
+    end
   end
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -224,6 +241,14 @@ RSpec.describe Git::Repository::Committing do
         expect(commit_command).to receive(:call).with(no_edit: true, message: 'msg', all: true,
                                                       no_verify: true).and_return(commit_result)
         result
+      end
+    end
+
+    context 'with a plain Hash variable (legacy-contract calling convention)' do
+      it 'does not raise ArgumentError when opts is a bare Hash variable' do
+        opts = { no_verify: true }
+        allow(commit_command).to receive(:call).and_return(commit_result)
+        expect { described_instance.commit_all('msg', opts) }.not_to raise_error
       end
     end
   end
@@ -339,6 +364,22 @@ RSpec.describe Git::Repository::Committing do
         expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
       end
     end
+
+    context 'with a plain Hash variable (legacy-contract calling convention)' do
+      it 'does not raise ArgumentError when opts is a bare Hash variable' do
+        opts = { message: 'snapshot' }
+        allow(commit_tree_command).to receive(:call).and_return(commit_tree_result)
+        expect { described_instance.commit_tree('tree-sha', opts) }.not_to raise_error
+      end
+
+      it 'does not mutate the caller-provided Hash' do
+        opts = { message: 'snapshot', parent: 'HEAD' }
+        original = opts.dup
+        allow(commit_tree_command).to receive(:call).and_return(commit_tree_result)
+        described_instance.commit_tree('tree-sha', opts)
+        expect(opts).to eq(original)
+      end
+    end
   end
 
   # ─────────────────────────────────────────────────────────────────────────
@@ -410,6 +451,15 @@ RSpec.describe Git::Repository::Committing do
         expect(commit_tree_command).to receive(:call).with(tree_sha,
                                                            m: 'my commit').and_return(command_result(commit_sha))
         result
+      end
+    end
+
+    context 'with a plain Hash variable (legacy-contract calling convention)' do
+      it 'does not raise ArgumentError when opts is a bare Hash variable' do
+        opts = { message: 'snapshot' }
+        allow(write_tree_command).to receive(:call).and_return(command_result(tree_sha))
+        allow(commit_tree_command).to receive(:call).and_return(command_result(commit_sha))
+        expect { described_instance.write_and_commit_tree(opts) }.not_to raise_error
       end
     end
   end

--- a/spec/unit/git/repository/staging_spec.rb
+++ b/spec/unit/git/repository/staging_spec.rb
@@ -141,6 +141,14 @@ RSpec.describe Git::Repository::Staging do
         expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
       end
     end
+
+    context 'with a plain Hash variable (legacy-contract calling convention)' do
+      it 'does not raise ArgumentError when opts is a bare Hash variable' do
+        opts = { hard: true }
+        allow(reset_command).to receive(:call).and_return(reset_result)
+        expect { described_instance.reset('HEAD~1', opts) }.not_to raise_error
+      end
+    end
   end
 
   describe '#rm' do


### PR DESCRIPTION
## Summary

Implements the six ⚠️ signature fixes from §5 "Signature Gaps" of `redesign/c1c2_audit.md`.

All six are legacy-contract violations: facade signatures used `**opts` or anonymous `**` keyword-splat where the 4.x predecessors used a positional `opts = {}` hash — in Ruby 3+, passing a bare Hash variable as the last positional argument to a `**`-accepting method raises `ArgumentError`.

## Changes

### 1. `checkout` — `Git::Repository::Branching`

- **Before:** `def checkout(branch = nil, options = {})`
- **After:** `def checkout(branch = nil, opts = {})` (4.x signature restored)
- Identical to the 4.x contract; the `branch.is_a?(Hash)` guard handles the legacy hash-only calling convention.
- YARD docs converted from Form A (`@overload`) to Form B (direct `@param`/`@option`) since all parameters are named.
- `Git::Base#checkout` delegator changed from `(*, **)` to `(branch = nil, opts = {})` to match the consistent style of all other delegators.

### 2. `reset` — `Git::Repository::Staging`

- **Before:** `def reset(commitish = nil, **)`
- **After:** `def reset(commitish = nil, opts = {})`
- Body updated to pass `**opts` explicitly to `assert_valid_opts!` and `Commands::Reset`.
- `Git::Base#reset` delegator updated to pass `opts` positionally.
- YARD docs converted from Form A (`@overload`) to Form B (direct `@param`/`@option`).

### 3. `commit` — `Git::Repository::Committing`

- **Before:** `def commit(message = nil, **opts)`
- **After:** `def commit(message, opts = {})`
- Removes the default from `message` (required per 4.x contract; documented form for amend is `commit(nil, amend: true)`).
- Internal body continues to splat `opts` via `**opts`.
- `Git::Base#commit` delegator updated to pass `opts` positionally.

### 4. `commit_all` — `Git::Repository::Committing`

- **Before:** `def commit_all(*, **)`
- **After:** `def commit_all(message, opts = {})`
- Body: `commit(message, opts.merge(all: true))`.
- `Git::Base#commit_all` delegator updated to pass `opts` positionally.

### 5. `commit_tree` — `Git::Repository::Committing`

- **Before:** `def commit_tree(tree, **opts)`
- **After:** `def commit_tree(tree = nil, opts = {})`
- Adds default `nil` to `tree` to align with 4.x contract.
- Adds `opts = opts.dup` before key-normalization to avoid mutating the caller's Hash.
- Internal body splats `opts` via `**opts` when calling `Commands::CommitTree`.
- `Git::Base#commit_tree` delegator updated to pass `opts` positionally.

### 6. `write_and_commit_tree` — `Git::Repository::Committing`

- **Before:** `def write_and_commit_tree(**)`
- **After:** `def write_and_commit_tree(opts = {})`
- Body: `commit_tree(write_tree, opts)` (passes opts positionally).
- `Git::Base#write_and_commit_tree` delegator updated to pass `opts` positionally.

## Tests

- Added bare-Hash calling convention tests (`opts = {...}; method(arg, opts)`) for `reset`, `commit`, `commit_all`, `commit_tree`, and `write_and_commit_tree` — these fail before the fix and pass after.
- Added `checkout` bare-Hash test and arity test (passing extra positional args raises `ArgumentError`).
- Added `commit_tree` non-mutation test — confirms the caller's Hash is not modified.
- Updated the `commit(amend: true)` unit test context to `commit(nil, amend: true)` per the documented API.
- All 868 RSpec examples and 177 Test::Unit assertions pass; 684 files, no RuboCop offenses; no YARD warnings.

## Related

- `redesign/c1c2_audit.md` §5 "Signature Gaps"
