### PR TITLE
docs(lib): add @api private YARD tags to 12 internal plumbing methods

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -459,6 +459,7 @@ module Git
 
     alias commit_data cat_file_commit
 
+    # @api private
     def process_commit_data(data, sha)
       # process_commit_headers consumes the header lines from the `data` array,
       # leaving only the message lines behind.
@@ -490,6 +491,7 @@ module Git
     #
     # @raise [NoMethodError] if `data` contains non-string entries
     #
+    # @api private
     def each_cat_file_header(data)
       while (match = CAT_FILE_HEADER_LINE.match(data.shift))
         key = match[:key]
@@ -548,11 +550,13 @@ module Git
 
     alias tag_data cat_file_tag
 
+    # @api private
     def cat_file_object_meta(object)
       stdout = Git::Commands::CatFile::Batch.new(self).call(object, batch_check: true).stdout
       parse_cat_file_meta(stdout, object)
     end
 
+    # @api private
     def parse_cat_file_meta(output, object)
       line = output.to_s.lines.first.to_s.chomp
 
@@ -824,6 +828,7 @@ module Git
     # @raise [ArgumentError] if any of the parameters are a string starting with a hyphen
     # @return [void]
     #
+    # @api private
     def assert_args_are_not_options(arg_name, *args)
       invalid_args = args.select { |arg| arg&.start_with?('-') }
       return unless invalid_args.any?
@@ -842,6 +847,7 @@ module Git
     # @return [Array<String>, nil] normalized array of path strings, or nil if empty/nil input
     # @raise [ArgumentError] if any path is not a String or Pathname
     #
+    # @api private
     def normalize_pathspecs(pathspecs, arg_name)
       return nil unless pathspecs
 
@@ -860,6 +866,7 @@ module Git
     # @param arg_name [String] name of the argument for error messages
     # @raise [ArgumentError] if any path is not a String or Pathname
     #
+    # @api private
     def validate_pathspec_types(pathspecs, arg_name)
       return if pathspecs.all? { |path| path.is_a?(String) || path.is_a?(Pathname) }
 
@@ -884,6 +891,7 @@ module Git
     #
     # @return [String, Pathname, Array<String, Pathname>, nil] the resolved path limiter
     #
+    # @api private
     def handle_deprecated_path_option(opts)
       if opts.key?(:path_limiter)
         opts[:path_limiter]
@@ -903,6 +911,7 @@ module Git
     #
     # @raise [ArgumentError] if unknown keys are present
     #
+    # @api private
     def assert_valid_opts(opts, allowed)
       unknown = opts.keys - allowed
       raise ArgumentError, "Unknown options: #{unknown.join(', ')}" if unknown.any?
@@ -1118,6 +1127,7 @@ module Git
       parse_config_list Git::Commands::ConfigOptionSyntax::List.new(self).call(global: true).stdout.split("\n")
     end
 
+    # @api private
     def parse_config_list(lines)
       hsh = {}
       lines.each do |line|
@@ -2111,6 +2121,7 @@ module Git
     #   contain the result of the command including the exit status, stdout, and
     #   stderr.
     #
+    # @api private
     def command_capturing(*, **options_hash)
       options_hash = COMMAND_CAPTURING_ARG_DEFAULTS.merge(options_hash)
       options_hash[:timeout] ||= Git.config.timeout
@@ -2185,6 +2196,7 @@ module Git
     #
     # @see #command_line_streaming
     #
+    # @api private
     def command_streaming(*, **options_hash)
       options_hash = COMMAND_STREAMING_ARG_DEFAULTS.merge(options_hash)
       options_hash[:timeout] ||= Git.config.timeout


### PR DESCRIPTION
## Summary

Adds `# @api private` YARD tags to 12 internal plumbing methods in `Git::Lib`
identified in §7.4 of `redesign/c1c2_audit.md` as "Internal Plumbing — Mark as
❌ Remove".

These methods are technically public (defined before the `private` keyword in
`lib/git/lib.rb`) but are clearly internal helpers with no plausible external
use. Tagging them `@api private` signals to YARD, tooling, and callers that
these methods are unsupported and will be removed in v5.

## Methods annotated

| Method | Reason |
|--------|--------|
| `process_commit_data` | Parsing helper (used by `cat_file_commit`) |
| `each_cat_file_header` | Parsing helper |
| `cat_file_object_meta` | Internal batch cat-file helper |
| `parse_cat_file_meta` | Parsing helper |
| `assert_args_are_not_options` | Input validation helper |
| `normalize_pathspecs` | Input normalization helper |
| `validate_pathspec_types` | Input validation helper |
| `handle_deprecated_path_option` | Deprecation handling helper |
| `assert_valid_opts` | Option validation helper |
| `parse_config_list` | Internal config parsing helper |
| `command_capturing` | Low-level command execution infrastructure |
| `command_streaming` | Low-level command execution infrastructure |

## Changes

- `lib/git/lib.rb` — 12 `# @api private` comment lines added (one per method,
  immediately above each `def` line). No code changes of any kind.

## Verification

- `bundle exec rake yard` passes: 83.9% coverage (threshold 75%), 0 errors,
  88 doc-example tests pass.

## Type of change

- [x] Documentation only (no production code changes, no tests needed)

## Checklist

- [x] `bundle exec rake yard` passes with no new warnings or errors
- [x] No production code was changed
- [x] Follows §7.4 of `redesign/c1c2_audit.md`
