### PR TITLE
feat: add branch_current delegator to Git::Base

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1220,6 +1220,12 @@ module Git
       facade_repository.branch_delete(*branches, **)
     end
 
+    # @return [String] the current branch name, or `'HEAD'` when in detached
+    #   HEAD state
+    def branch_current
+      facade_repository.current_branch
+    end
+
     # @!group Bucket 6 delegators — Git::Repository::ObjectOperations
 
     # @return [String] raw content of the git object, or streams to a tempfile when a block is given

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -367,6 +367,15 @@ RSpec.describe Git::Base do
     end
   end
 
+  describe '#branch_current' do
+    include_context 'with a stubbed facade_repository'
+
+    it 'delegates to facade_repository.current_branch' do
+      expect(facade_repository).to receive(:current_branch).and_return('main')
+      expect(described_instance.branch_current).to eq('main')
+    end
+  end
+
   describe '#tag' do
     include_context 'with a stubbed facade_repository'
 


### PR DESCRIPTION
## Summary

Adds `Git::Base#branch_current` as a Bucket 6 delegator (§7.3 of the C1c-2 audit) that forwards to `facade_repository.current_branch`.

Returns the current branch name, or `'HEAD'` when in detached HEAD state — equivalent behavior to `Git::Lib#branch_current`.

## Changes

- **`lib/git/base.rb`** — new `#branch_current` delegator in the Bucket 6 Branching section, delegating to `facade_repository.current_branch`
- **`spec/unit/git/base_spec.rb`** — one unit test verifying the delegation

No new facade method is needed; `Git::Repository::Branching#current_branch` already provides the equivalent behaviour and is fully integration-tested.

## Checklist

- [x] Follows existing Bucket 6 delegator style (`def` + `facade_repository.method`)
- [x] Unit test added matching existing `described_instance` / `facade_repository` conventions
- [x] No integration test needed (already covered in `spec/integration/git/repository/branching_spec.rb`)
- [x] `bundle exec rake default:parallel` passes