### PR TITLE
docs: revert branch_current delegator; mark as not needed in c1c2 audit

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1220,12 +1220,6 @@ module Git
       facade_repository.branch_delete(*branches, **)
     end
 
-    # @return [String] the current branch name, or `'HEAD'` when in detached
-    #   HEAD state
-    def branch_current
-      facade_repository.current_branch
-    end
-
     # @!group Bucket 6 delegators — Git::Repository::ObjectOperations
 
     # @return [String] raw content of the git object, or streams to a tempfile when a block is given

--- a/redesign/c1c2_audit.md
+++ b/redesign/c1c2_audit.md
@@ -389,6 +389,7 @@ Also note name-mismatch cases where `Git::Lib` uses a different name than `Git::
 | `commit_data` (alias for `cat_file_commit`) | `Git::Repository::ObjectOperations#cat_file_commit` | ✅ `alias commit_data cat_file_commit` added (PR 2e) |
 | `tag_data` (alias for `cat_file_tag`) | `Git::Repository::ObjectOperations#cat_file_tag` | ✅ `alias tag_data cat_file_tag` added (PR 2e) |
 | `revparse` (alias for `rev_parse`) | (covered in Bucket 2) | ✅ covered |
+| `branch_current` | Returns current branch name or 'HEAD' — equivalent to `Git::Repository::Branching#current_branch` (name mismatch). A `Git::Base` delegator was added and then reverted: `branch_current` was never a public v4 `Git::Base` method (only an internal `Git::Lib` method), so no backward-compatibility obligation exists. `Git::Lib` callers should migrate to `Git::Base#current_branch` (`g.current_branch`), which is already documented in UPGRADING.md. | ❌ no delegator needed — callers migrate to `g.current_branch` |
 
 ### 7.3 Methods NOT Yet in `Git::Repository` (new facade work required)
 
@@ -396,7 +397,6 @@ These require a new facade method before a base.rb delegator can be added.
 
 | `Git::Lib` method | Assessment | Recommended status |
 |-------------------|------------|--------------------|
-| `branch_current` | Returns current branch name or 'HEAD' — equivalent to `Git::Repository::Branching#current_branch`. No new facade needed; just add delegator to `Git::Base` pointing to `current_branch`. | ⬜ promote (trivial) |
 | `change_head_branch(branch_name)` | Low-level `git symbolic-ref HEAD refs/heads/<name>`; used internally for branch renaming and orphan checkout. Plausible external use by tooling. | 🔍 human decision — promote to `Git::Repository::Branching` or mark as internal? |
 | `config_get(name)` | Returns a single config value. Used by tooling. Part of the existing `config()` facade which reads/writes. | 🔍 human decision — expose as `config_get` or fold into `config(name)`? |
 | `config_list` | Returns full config hash. Used by tooling. | 🔍 human decision — expose separately or fold into `config()`? |
@@ -439,8 +439,9 @@ upgrade notes as "unsupported; remove any `g.lib.X` calls."
 | Status | Count |
 |--------|-------|
 | ✅ promote (repo already had it, `Git::Base` delegator added — PR 2d) | 23 |
-| ⬜ promote (new facade work required) | 7 |
+| ⬜ promote (new facade work required) | 6 |
 | ❌ remove (internal plumbing) | 12 |
+| ❌ no delegator needed (name-mismatch; `Git::Repository` equivalent exists) | 1 |
 | 🔍 human decision | 16 |
 | **Total orphaned methods** | **58** |
 

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -367,15 +367,6 @@ RSpec.describe Git::Base do
     end
   end
 
-  describe '#branch_current' do
-    include_context 'with a stubbed facade_repository'
-
-    it 'delegates to facade_repository.current_branch' do
-      expect(facade_repository).to receive(:current_branch).and_return('main')
-      expect(described_instance.branch_current).to eq('main')
-    end
-  end
-
   describe '#tag' do
     include_context 'with a stubbed facade_repository'
 


### PR DESCRIPTION
## Summary

Reverts the `Git::Base#branch_current` delegator added in #1408 and records the decision in `redesign/c1c2_audit.md`.

## Rationale

`Git::Lib#branch_current` was never a public `Git::Base` method in v4.x — it was purely internal to `Git::Lib`. There is no backward-compatibility obligation for a `Git::Base` delegator. `Git::Lib` callers should migrate directly to `Git::Repository#current_branch`.

## Changes

- **`lib/git/base.rb`** — removes the `#branch_current` delegator
- **`spec/unit/git/base_spec.rb`** — removes the corresponding unit test
- **`redesign/c1c2_audit.md` §7.3** — updates `branch_current` from `⬜ promote (trivial)` to `❌ no delegator needed` with rationale