### PR TITLE
feat(staging): add Git::Repository::Staging#mv facade and Git::Base delegator

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -440,6 +440,11 @@ module Git
       lib.reset(commitish, opts)
     end
 
+    # @return [String] git's stdout from the mv command
+    def mv(source, destination, options = {})
+      facade_repository.mv(source, destination, options)
+    end
+
     # cleans the working directory
     #
     # options:

--- a/lib/git/repository/staging.rb
+++ b/lib/git/repository/staging.rb
@@ -5,6 +5,7 @@ require 'git/commands/am/apply'
 require 'git/commands/apply'
 require 'git/commands/clean'
 require 'git/commands/ls_files'
+require 'git/commands/mv'
 require 'git/commands/read_tree'
 require 'git/commands/reset'
 require 'git/commands/rm'
@@ -13,8 +14,8 @@ require 'git/repository/shared_private'
 
 module Git
   class Repository
-    # Facade methods for staging-area operations: adding, resetting, removing, and
-    # cleaning files
+    # Facade methods for staging-area operations: adding, resetting, moving,
+    # removing, and cleaning files
     #
     # Included by {Git::Repository}.
     #
@@ -270,6 +271,55 @@ module Git
       end
 
       alias remove rm
+
+      # Option keys accepted by {#mv}
+      MV_ALLOWED_OPTS = %i[force f dry_run n k].freeze
+      private_constant :MV_ALLOWED_OPTS
+
+      # Move or rename a file, directory, or symlink in the working tree
+      #
+      # Updates the index after successful completion, but the change must still
+      # be committed.
+      #
+      # @example Move a single file
+      #   repo.mv('old.rb', 'new.rb')
+      #
+      # @example Move multiple files to a directory
+      #   repo.mv(['file1.rb', 'file2.rb'], 'destination_dir/')
+      #
+      # @example Force overwrite if destination exists
+      #   repo.mv('source.rb', 'dest.rb', force: true)
+      #
+      # @param source [String, Array<String>] one or more source file(s),
+      #   directory(ies), or symlink(s) to move (relative to the worktree root)
+      #
+      # @param destination [String] the destination file or directory
+      #
+      # @param options [Hash] options for the mv command
+      #
+      # @option options [Boolean, nil] :force (nil) force renaming or moving even
+      #   if the destination exists (alias: `:f`)
+      #
+      # @option options [Boolean, nil] :f (nil) alias for `:force`
+      #
+      # @option options [Boolean, nil] :dry_run (nil) do not actually move any
+      #   files; only show what would happen (alias: `:n`)
+      #
+      # @option options [Boolean, nil] :n (nil) alias for `:dry_run`
+      #
+      # @option options [Boolean, nil] :k (nil) skip move or rename actions which
+      #   would lead to an error
+      #
+      # @return [String] git's stdout from the mv command
+      #
+      # @raise [ArgumentError] when unsupported options are provided
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def mv(source, destination, options = {})
+        SharedPrivate.assert_valid_opts!(MV_ALLOWED_OPTS, **options)
+        Git::Commands::Mv.new(@execution_context).call(*Array(source), destination, verbose: true, **options).stdout
+      end
 
       # Option keys accepted by {#clean}
       #

--- a/spec/integration/git/repository/staging_spec.rb
+++ b/spec/integration/git/repository/staging_spec.rb
@@ -19,6 +19,13 @@ require 'git/execution_context/repository'
 #   spec/integration/git/commands/reset_spec.rb
 #   spec/integration/git/commands/rm_spec.rb
 #   spec/integration/git/commands/clean_spec.rb
+#
+# #mv is also a single-command delegator and is covered by:
+#   spec/integration/git/commands/mv_spec.rb
+# Unlike the methods above, #mv adds two input pre-processing behaviors beyond
+# option whitelisting: Array source normalization (*Array(source)) and injecting
+# verbose: true. These are pure-Ruby transforms with no git involvement; the unit
+# specs cover them fully and real git adds no additional signal.
 
 RSpec.describe Git::Repository::Staging, :integration do
   include_context 'in an empty repository'

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -386,4 +386,13 @@ RSpec.describe Git::Base do
       expect(result).to be(tag_double)
     end
   end
+
+  describe '#mv' do
+    include_context 'with a stubbed facade_repository'
+
+    it 'delegates to facade_repository.mv' do
+      expect(facade_repository).to receive(:mv).with('old.rb', 'new.rb', {}).and_return('')
+      expect(described_instance.mv('old.rb', 'new.rb')).to eq('')
+    end
+  end
 end

--- a/spec/unit/git/repository/staging_spec.rb
+++ b/spec/unit/git/repository/staging_spec.rb
@@ -242,6 +242,94 @@ RSpec.describe Git::Repository::Staging do
     end
   end
 
+  describe '#mv' do
+    subject(:result) { described_instance.mv(source, destination, options) }
+
+    let(:source) { 'old.rb' }
+    let(:destination) { 'new.rb' }
+    let(:options) { {} }
+    let(:mv_command) { instance_double(Git::Commands::Mv) }
+    let(:mv_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Mv).to receive(:new).with(execution_context).and_return(mv_command)
+    end
+
+    context 'with a single source file' do
+      it 'delegates to Git::Commands::Mv#call with source as a single-element argument' do
+        expect(mv_command).to receive(:call).with('old.rb', 'new.rb', verbose: true).and_return(mv_result)
+        result
+      end
+
+      it 'returns the command stdout' do
+        allow(mv_command).to receive(:call).with('old.rb', 'new.rb', verbose: true).and_return(mv_result)
+        expect(result).to eq('')
+      end
+    end
+
+    context 'with multiple source files' do
+      let(:source) { ['old1.rb', 'old2.rb'] }
+      let(:destination) { 'destination/' }
+
+      it 'splatted sources are forwarded as separate arguments' do
+        expect(mv_command).to receive(:call)
+          .with('old1.rb', 'old2.rb', 'destination/', verbose: true)
+          .and_return(mv_result)
+        result
+      end
+    end
+
+    context 'with the force option' do
+      let(:options) { { force: true } }
+
+      it 'forwards force: true to Git::Commands::Mv#call' do
+        expect(mv_command).to receive(:call)
+          .with('old.rb', 'new.rb', verbose: true, force: true)
+          .and_return(mv_result)
+        result
+      end
+    end
+
+    context 'with the dry_run option' do
+      let(:options) { { dry_run: true } }
+
+      it 'forwards dry_run: true to Git::Commands::Mv#call' do
+        expect(mv_command).to receive(:call)
+          .with('old.rb', 'new.rb', verbose: true, dry_run: true)
+          .and_return(mv_result)
+        result
+      end
+    end
+
+    context 'option whitelisting' do
+      context 'with an unknown option' do
+        let(:options) { { bogus: true } }
+
+        it 'raises ArgumentError' do
+          expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+        end
+
+        it 'does not instantiate Git::Commands::Mv' do
+          expect(Git::Commands::Mv).not_to receive(:new)
+          begin
+            result
+          rescue ArgumentError
+            # expected
+          end
+        end
+      end
+    end
+
+    context 'signature compatibility' do
+      it 'accepts a legacy positional options hash and forwards options to the command' do
+        expect(mv_command).to receive(:call)
+          .with('old.rb', 'new.rb', verbose: true, force: true)
+          .and_return(mv_result)
+        expect(described_instance.mv('old.rb', 'new.rb', { force: true })).to eq('')
+      end
+    end
+  end
+
   describe '#clean' do
     subject(:result) { described_instance.clean }
 


### PR DESCRIPTION
# Description

Promotes `Git::Lib#mv` to the facade layer as called for in the C1c-2 audit (`redesign/c1c2_audit.md` §7.3 — `mv` row, status ⬜ promote).

## Changes

### `lib/git/repository/staging.rb`
- Added `require 'git/commands/mv'`
- Added `MV_ALLOWED_OPTS` constant (`[:force, :f, :dry_run, :n, :k]`)
- Added `#mv(source, destination, options = {})` facade method with full YARD documentation (examples, `@param`, `@option`, `@return`, `@raise`)
- Delegates to `Git::Commands::Mv.new(@execution_context).call(*Array(source), destination, verbose: true, **options).stdout`
- Uses `SharedPrivate.assert_valid_opts!` for option whitelisting

### `lib/git/base.rb`
- Added `#mv(source, destination, options = {})` delegator that calls `facade_repository.mv(source, destination, options)` (positional hash — legacy contract)

### Tests
- **`spec/unit/git/repository/staging_spec.rb`** — `describe '#mv'` block covering: single source file, array of sources (splatted), option forwarding (`force:`, `dry_run:`), stdout return value, option whitelisting (unknown option raises `ArgumentError` without instantiating the command), and signature compatibility (legacy positional options hash)
- **`spec/unit/git/base_spec.rb`** — `describe '#mv'` block with one example verifying delegation to `facade_repository.mv`
- **`spec/integration/git/repository/staging_spec.rb`** — no `#mv` integration test added; the file's header comment explains the decision: `#mv`'s extra facade behaviors (Array source normalization, `verbose: true` injection) are pure-Ruby transforms with no git involvement, so unit tests are sufficient. Git-level behavior is covered by `spec/integration/git/commands/mv_spec.rb`.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).