### PR TITLE
feat(base): add Git::Base#git_version delegator

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -69,6 +69,7 @@ notes for the final migration target.
 | `g.lib.config_get(name)` | `g.config(name)` |
 | `g.lib.config_list` | `g.config` |
 | `g.lib.config_set(name, value)` | `g.config(name, value)` |
+| `g.lib.git_version` | `g.git_version` |
 | `g.lib.global_config_get(name)` | `g.global_config(name)` |
 | `g.lib.global_config_list` | `g.global_config` |
 | `g.lib.global_config_set(name, value)` | `g.global_config(name, value)` |

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -371,6 +371,23 @@ module Git
     # @api private
     attr_reader :binary_path
 
+    # Returns the version of the git binary in use
+    #
+    # @example
+    #   g.git_version #=> #<Git::Version:... @version="2.42.0">
+    #
+    # @return [Git::Version] the parsed version of the git binary
+    #
+    # @see Git.git_version
+    #
+    def git_version
+      if binary_path == :use_global_config
+        Git.git_version
+      else
+        Git.git_version(binary_path)
+      end
+    end
+
     # Run a grep for 'string' on the HEAD of the git repository
     #
     # @example Limit grep's scope by calling grep() from a specific object:

--- a/redesign/c1c2_audit.md
+++ b/redesign/c1c2_audit.md
@@ -404,7 +404,7 @@ These require a new facade method before a base.rb delegator can be added.
 | `global_config_get(name)` | Gets a global config value. | 🔍 human decision |
 | `global_config_list` | Returns the full global config hash. | 🔍 human decision |
 | `global_config_set(name, value)` | Sets a global config value. | 🔍 human decision |
-| `git_version` | Returns `Git::Version` for the current binary. Useful for tooling that conditionally enables features. | ⬜ promote — add to a suitable module (e.g., `Git::Repository::Inspecting` or a new `VersionHelpers` module); moderate effort |
+| `git_version` | Returns `Git::Version` for the current binary. Useful for tooling that conditionally enables features. Not a repository concern; `Git.git_version` is the canonical API. | ✅ delegator added to `Git::Base` — delegates to `Git.git_version` |
 | `list_files(ref_dir)` | Lists files under `.git/refs/{ref_dir}`. Internal ref-filesystem access. No plausible clean public use. | ❌ remove — internal plumbing; direct callers should migrate to `Git::Repository` ref-inspection methods |
 | `ls_remote(location = nil, opts = {})` | Lists remote refs. Clearly useful externally. | ⬜ promote — new facade in `Git::Repository::RemoteOperations`; `Git::Commands::LsRemote` ✅ exists; moderate effort |
 | `mv(source, destination, options = {})` | Wraps `git mv`. Externally useful. | ⬜ promote — new facade in `Git::Repository::Staging`; `Git::Commands::Mv` ✅ exists; trivial effort |
@@ -439,7 +439,7 @@ upgrade notes as "unsupported; remove any `g.lib.X` calls."
 | Status | Count |
 |--------|-------|
 | ✅ promote (repo already had it, `Git::Base` delegator added — PR 2d; or alias added) | 24 |
-| ⬜ promote (new facade work required) | 4 |
+| ⬜ promote (new facade work required) | 3 |
 | ❌ remove (internal plumbing) | 12 |
 | 🔍 human decision | 16 |
 | **Total orphaned methods** | **56** |
@@ -481,7 +481,7 @@ upgrade notes as "unsupported; remove any `g.lib.X` calls."
 - Create a new `Git::Repository::Maintenance` module for `repack` and `gc`.
 - Add `Git::Base` delegators for all six methods.
 - Resolve `cat_file` per the human decision in §6.
-- Add facade methods for `mv`, `ls_remote`, `git_version`, `current_branch_state`
+- Add facade methods for `mv`, `ls_remote`, `current_branch_state`
   from Bucket 6 §7.3 (new facade work needed).
 
 **Dependency:** PR 3 is independent of PR 2 but should be merged after PR 2

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -395,4 +395,22 @@ RSpec.describe Git::Base do
       expect(described_instance.mv('old.rb', 'new.rb')).to eq('')
     end
   end
+
+  describe '#git_version' do
+    context 'when binary_path is :use_global_config (default)' do
+      it 'calls Git.git_version with no arguments' do
+        version = instance_double(Git::Version)
+        expect(Git).to receive(:git_version).with(no_args).and_return(version)
+        expect(described_class.new.git_version).to be(version)
+      end
+    end
+
+    context 'when binary_path is an explicit path' do
+      it 'forwards binary_path to Git.git_version' do
+        version = instance_double(Git::Version)
+        expect(Git).to receive(:git_version).with('/usr/local/bin/git').and_return(version)
+        expect(described_class.new(binary_path: '/usr/local/bin/git').git_version).to be(version)
+      end
+    end
+  end
 end


### PR DESCRIPTION
# Description

Adds `Git::Base#git_version` as a thin delegator to `Git.git_version`,
giving callers who hold a `Git::Base` instance a supported path (`g.git_version`)
while the module-level `Git.git_version` remains the canonical API.

`git_version` is **not** a repository-level concern — it answers "what version of
git is installed?", not "what does this repo contain?" — so it lives directly on
`Git::Base` rather than in any `Git::Repository::*` module.

## Changes

- **`lib/git/base.rb`** — add `#git_version` delegator near `#binary_path`
- **`spec/unit/git/base_spec.rb`** — unit test verifying the delegation
- **`UPGRADING.md`** — add `g.lib.git_version` → `Git.git_version` migration row
- **`redesign/c1c2_audit.md`** — update §7.3 row status, §7.5 count, §8 PR 5 scope

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
