### PR TITLE
refactor: centralize execution-context option defaulting

### DIFF
--- a/lib/git/execution_context/global.rb
+++ b/lib/git/execution_context/global.rb
@@ -20,39 +20,12 @@ module Git
     # @example Create a context targeting a specific binary
     #   context = Git::ExecutionContext::Global.new(binary_path: '/usr/local/bin/git2')
     #
+    # @see Git::ExecutionContext#initialize for constructor parameters and
+    #   their semantics
+    #
     # @api private
     #
     class Global < ExecutionContext
-      # Creates a new global execution context
-      #
-      # @example Create with default settings
-      #   Git::ExecutionContext::Global.new
-      #
-      # @example Create with an explicit binary path
-      #   Git::ExecutionContext::Global.new(binary_path: '/usr/local/bin/git2')
-      #
-      # @param binary_path [String, :use_global_config] path to the git binary
-      #
-      #   Give `:use_global_config` (the default) to use
-      #   `Git::Config.instance.binary_path`.
-      #
-      #   Passing `nil` raises `ArgumentError` — there is no "unset the
-      #   binary" semantic.
-      #
-      # @param git_ssh [String, nil, :use_global_config] the SSH wrapper path
-      #
-      #   Give `nil` to unset `GIT_SSH`, or `:use_global_config` (default)
-      #   to use `Git::Config.instance.git_ssh`.
-      #
-      # @param logger [Logger, nil] the logger to use in the CommandLine layer
-      #
-      #   Give `nil` to use a null logger (`Logger.new(nil)`).
-      #
-      # @raise [ArgumentError] if `binary_path` is `nil`
-      #
-      def initialize(binary_path: :use_global_config, git_ssh: :use_global_config, logger: nil)
-        super
-      end
     end
   end
 end

--- a/lib/git/execution_context/repository.rb
+++ b/lib/git/execution_context/repository.rb
@@ -79,8 +79,8 @@ module Git
           git_dir: base_hash[:repository],
           git_index_file: base_hash[:index],
           git_work_dir: base_hash[:working_directory],
-          git_ssh: base_hash.key?(:git_ssh) ? base_hash[:git_ssh] : :use_global_config,
-          binary_path: base_hash.key?(:binary_path) ? base_hash[:binary_path] : :use_global_config,
+          git_ssh: base_hash.fetch(:git_ssh, :use_global_config),
+          binary_path: base_hash.fetch(:binary_path, :use_global_config),
           logger: logger
         )
       end

--- a/lib/git/repository/factories.rb
+++ b/lib/git/repository/factories.rb
@@ -411,6 +411,28 @@ module Git
         }
       end
 
+      # Build the `:binary_path` and `:git_ssh` execution-context defaults
+      #
+      # Reads the values from the caller-supplied options, falling back to the
+      # `:use_global_config` sentinel for any the caller did not provide so the
+      # value is resolved from `Git::Config.instance` at call time.
+      #
+      # @param options [Hash] the caller-supplied options hash
+      #
+      # @return [Hash] context defaults with two keys: `:binary_path`
+      #   (`String` or `:use_global_config` — `nil` is not valid and raises
+      #   `ArgumentError` in {Git::ExecutionContext#initialize}) and `:git_ssh`
+      #   (`String`, `nil`, or `:use_global_config`)
+      #
+      # @api private
+      #
+      def context_defaults(options)
+        {
+          binary_path: options.fetch(:binary_path, :use_global_config),
+          git_ssh: options.fetch(:git_ssh, :use_global_config)
+        }
+      end
+
       # Resolve the worktree root to use as the working directory for {.open}
       #
       # @param working_dir [String] a path inside the working tree
@@ -424,11 +446,7 @@ module Git
       # @api private
       #
       def resolve_open_working_dir(working_dir, options)
-        PathResolver.root_of_worktree(
-          working_dir,
-          binary_path: options.fetch(:binary_path, :use_global_config),
-          git_ssh: options.fetch(:git_ssh, :use_global_config)
-        )
+        PathResolver.root_of_worktree(working_dir, **context_defaults(options))
       end
 
       # Build a repository from caller options and resolved paths
@@ -536,15 +554,10 @@ module Git
       # @api private
       #
       def run_init_command(directory, options)
-        git_ssh = options.fetch(:git_ssh, :use_global_config)
-        binary_path = options.fetch(:binary_path, :use_global_config)
-
         init_opts = options.slice(:bare, :initial_branch)
         init_opts[:separate_git_dir] = options[:repository] if options.key?(:repository)
 
-        context = Git::ExecutionContext::Global.new(
-          binary_path: binary_path, git_ssh: git_ssh, logger: options[:log]
-        )
+        context = Git::ExecutionContext::Global.new(**context_defaults(options), logger: options[:log])
         Git::Commands::Init.new(context).call(directory, **init_opts)
       end
 


### PR DESCRIPTION
## Summary

Centralizes how the `Git::Repository` factories build the `:binary_path` and
`:git_ssh` execution-context defaults, and removes a redundant no-op
initializer. This is a behavior-preserving refactor — no public API or runtime
behavior changes.

## Changes

- **Add `Factories#context_defaults` helper** — builds the `:binary_path` /
  `:git_ssh` execution-context defaults (falling back to the
  `:use_global_config` sentinel) in one place, applied at the `.open`
  (`resolve_open_working_dir`) and `.init` (`run_init_command`) boundaries.
- **Simplify `ExecutionContext::Repository.from_hash`** — replaces verbose
  `key? ? value : default` ternaries with `Hash#fetch`.
- **Remove the no-op `ExecutionContext::Global#initialize`** — it duplicated the
  base initializer's signature and behavior exactly, so `Global` now inherits
  the documented base initializer.

## Notes

- The `:use_global_config` sentinel contract and deferred (call-time) resolution
  are preserved, so runtime `Git.configure` changes continue to take effect.
- `extract_clone_context_options!` was intentionally left unchanged: its result
  is forwarded positionally into `Global.new`, so omitting keys there would risk
  forwarding `nil` (which has distinct "unset" / "raise" semantics) rather than
  the sentinel.

## Verification

- `bundle exec rake default` passes: full RSpec suite, RuboCop (clean), YARD
  coverage (84%), and YARD example tests all green.
- Behavior of changed methods is fully covered by existing specs
  (`ExecutionContext::Repository.from_hash` defaulting branches and the
  `.open` / `.init` factory call-shape assertions).