### PR TITLE
feat: add Git::Repository::RemoteOperations#ls_remote facade

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -78,6 +78,7 @@ notes for the final migration target.
 | `g.lib.unmerged` | `g.unmerged` |
 | `g.lib.change_head_branch(name)` | `g.change_head_branch(name)` |
 | `g.lib.branch_current` | `g.current_branch` |
+| `g.lib.ls_remote(location, opts)` | `g.ls_remote(location, opts)` |
 
 #### Methods with no replacement
 

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -606,6 +606,23 @@ module Git
       facade_repository.remotes
     end
 
+    # List references available in a remote repository
+    #
+    # @param location [String, nil] the remote name or URL to query; defaults to
+    #   `'.'` (the local repository) when nil
+    #
+    # @param opts [Hash] options forwarded to {Git::Repository::RemoteOperations#ls_remote}
+    #
+    # @return [Hash{String => Hash}] see {Git::Repository::RemoteOperations#ls_remote}
+    #
+    # @raise [ArgumentError] if unsupported options are provided
+    #
+    # @raise [Git::FailedError] if git exits outside the allowed range (exit code > 2)
+    #
+    def ls_remote(location = nil, opts = {})
+      facade_repository.ls_remote(location, opts)
+    end
+
     # sets the url for a remote
     # url can be a git url or a Git::Base object if it's a local reference
     #

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -578,7 +578,7 @@ module Git
       # @api private
       #
       LS_REMOTE_ALLOWED_OPTS = %i[
-        branches b heads h tags t refs upload_pack quiet q exit_code get_url sort symref server_option o timeout
+        branches b heads h tags t refs upload_pack quiet q exit_code sort server_option o timeout
       ].freeze
       private_constant :LS_REMOTE_ALLOWED_OPTS
 
@@ -623,9 +623,6 @@ module Git
       #
       # @option opts [Boolean, nil] :refs (nil) exclude peeled tags and pseudorefs
       #   like `HEAD` from the output
-      #
-      # @option opts [Boolean, nil] :symref (nil) show the underlying ref pointed to
-      #   by symbolic refs
       #
       # @option opts [Numeric] :timeout (nil) execution timeout in seconds
       #

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -2,6 +2,7 @@
 
 require 'git/commands/config_option_syntax'
 require 'git/commands/fetch'
+require 'git/commands/ls_remote'
 require 'git/commands/pull'
 require 'git/commands/push'
 require 'git/commands/remote'
@@ -570,12 +571,132 @@ module Git
         result.stdout.split("\n").map { |name| Git::Remote.new(self, name) }
       end
 
+      # Option keys accepted by {#ls_remote}
+      #
+      # @return [Array<Symbol>]
+      #
+      # @api private
+      #
+      LS_REMOTE_ALLOWED_OPTS = %i[
+        branches b heads h tags t refs upload_pack quiet q exit_code get_url sort symref server_option o timeout
+      ].freeze
+      private_constant :LS_REMOTE_ALLOWED_OPTS
+
+      # List references available in a remote repository
+      #
+      # Queries a remote for its available refs and returns a structured Hash
+      # mapping ref types to name/sha pairs. The remote is contacted but no local
+      # objects are created or updated.
+      #
+      # @example List all refs from the local repository
+      #   repo.ls_remote
+      #   # => {"head"=>{ref: "HEAD", sha: "abc123"},
+      #   #     "branches"=>{"main"=>{ref: "refs", sha: "abc123"}}}
+      #
+      # @note The `:ref` value in each pair is only the **first path segment** of the
+      #   full git ref (e.g. `"refs"` for `refs/heads/main`), not the complete ref
+      #   path. This matches the behavior of 4.x. See
+      #   [issue 1416](https://github.com/ruby-git/ruby-git/issues/1416) for the
+      #   planned fix.
+      #
+      # @example List all refs from a named remote
+      #   repo.ls_remote('origin')
+      #   # => {"head"=>..., "branches"=>..., "tags"=>...}
+      #
+      # @example List only tags from a named remote
+      #   repo.ls_remote('origin', tags: true)
+      #   # => {"tags"=>{"v1.0"=>{ref: "refs", sha: "def456"}}}
+      #
+      # @param location [String, nil] the remote name or URL to query; defaults to
+      #   `'.'` (the local repository) when nil
+      #
+      # @param opts [Hash] options for the ls-remote command
+      #
+      # @option opts [Boolean, nil] :branches (nil) limit output to refs under
+      #   `refs/heads/`; alias: `:b`
+      #
+      # @option opts [Boolean, nil] :heads (nil) limit output to refs under
+      #   `refs/heads/`; kept for backward compatibility; alias: `:h`
+      #
+      # @option opts [Boolean, nil] :tags (nil) limit output to refs under
+      #   `refs/tags/`; alias: `:t`
+      #
+      # @option opts [Boolean, nil] :refs (nil) exclude peeled tags and pseudorefs
+      #   like `HEAD` from the output
+      #
+      # @option opts [Boolean, nil] :symref (nil) show the underlying ref pointed to
+      #   by symbolic refs
+      #
+      # @option opts [Numeric] :timeout (nil) execution timeout in seconds
+      #
+      # @return [Hash{String => Hash}] a Hash keyed by ref type (e.g. `"head"`,
+      #   `"branches"`, `"tags"`; other git namespace segments may appear for
+      #   non-standard refs); for named refs the value is a Hash keyed by ref name
+      #   mapping to `{ ref: String, sha: String }`; for the `"head"` entry the value
+      #   is `{ ref: String, sha: String }` directly
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits outside the allowed range (exit code > 2)
+      #
+      def ls_remote(location = nil, opts = {})
+        SharedPrivate.assert_valid_opts!(LS_REMOTE_ALLOWED_OPTS, **opts)
+        repository = location || '.'
+        output_lines = Git::Commands::LsRemote.new(@execution_context).call(repository, **opts).stdout.split("\n")
+        Private.parse_ls_remote_output(output_lines)
+      end
+
       # Helpers private to the `RemoteOperations` topic module
       #
       # @api private
       #
       module Private
         module_function
+
+        # Parse `git ls-remote` stdout lines into a structured Hash
+        #
+        # @param lines [Array<String>] the individual stdout lines
+        #
+        # @return [Hash{String => Hash}] ref types to name/value maps
+        #
+        # @api private
+        #
+        def parse_ls_remote_output(lines)
+          lines.each_with_object(Hash.new { |h, k| h[k] = {} }) do |line, hsh|
+            type, name, value = parse_ls_remote_line(line)
+            if name
+              hsh[type][name] = value
+            else
+              hsh[type].update(value)
+            end
+          end
+        end
+
+        # Parse a single `git ls-remote` output line
+        #
+        # Each line is tab-separated: `<sha>\t<ref>`. The ref is split on `/` to
+        # determine the type and name: `HEAD` has no slashes (type `"head"`),
+        # `refs/heads/<name>` maps to type `"branches"`, and `refs/tags/<name>`
+        # maps to type `"tags"`.
+        #
+        # @param line [String] a single line from ls-remote stdout
+        #
+        # @return [Array(String, String|nil, Hash)] `[type, name, value]` where
+        #   `value` is `{ ref: String, sha: String }`
+        #
+        # @api private
+        #
+        def parse_ls_remote_line(line)
+          sha, info = line.split("\t", 2)
+          ref, type, name = info.split('/', 3)
+
+          type ||= 'head'
+          type = 'branches' if type == 'heads'
+
+          value = { ref: ref, sha: sha }
+
+          [type, name, value]
+        end
 
         # Resolve the (remote, opts) pair for {#fetch}, supporting the hash-only form
         #

--- a/redesign/c1c2_audit.md
+++ b/redesign/c1c2_audit.md
@@ -406,7 +406,7 @@ These require a new facade method before a base.rb delegator can be added.
 | `global_config_set(name, value)` | Sets a global config value. | 🔍 human decision |
 | `git_version` | Returns `Git::Version` for the current binary. Useful for tooling that conditionally enables features. Not a repository concern; `Git.git_version` is the canonical API. | ✅ delegator added to `Git::Base` — delegates to `Git.git_version` |
 | `list_files(ref_dir)` | Lists files under `.git/refs/{ref_dir}`. Internal ref-filesystem access. No plausible clean public use. | ❌ remove — internal plumbing; direct callers should migrate to `Git::Repository` ref-inspection methods |
-| `ls_remote(location = nil, opts = {})` | Lists remote refs. Clearly useful externally. | ⬜ promote — new facade in `Git::Repository::RemoteOperations`; `Git::Commands::LsRemote` ✅ exists; moderate effort |
+| `ls_remote(location = nil, opts = {})` | Lists remote refs. Clearly useful externally. | ✅ promoted — facade in `Git::Repository::RemoteOperations` + `Git::Base` delegator added (PR 5f) |
 | `mv(source, destination, options = {})` | Wraps `git mv`. Externally useful. | ⬜ promote — new facade in `Git::Repository::Staging`; `Git::Commands::Mv` ✅ exists; trivial effort |
 | `parse_config(file)` | Parses a config file from path. | 🔍 human decision — expose or fold into `config()` with `:file` option? |
 | `stash_list` | Returns a formatted string `"stash@{0}: ...\n..."` — distinct from `stashes_all` which returns structured data. | 🔍 human decision — promote for backward compat, or deprecate in favor of `stashes_all`? |
@@ -439,7 +439,7 @@ upgrade notes as "unsupported; remove any `g.lib.X` calls."
 | Status | Count |
 |--------|-------|
 | ✅ promote (repo already had it, `Git::Base` delegator added — PR 2d; or alias added) | 24 |
-| ⬜ promote (new facade work required) | 3 |
+| ⬜ promote (new facade work required) | 2 |
 | ❌ remove (internal plumbing) | 12 |
 | 🔍 human decision | 16 |
 | **Total orphaned methods** | **56** |

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -316,4 +316,33 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       expect(fetch_values).to include('main').and include('develop')
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #ls_remote
+  # ---------------------------------------------------------------------------
+
+  describe '#ls_remote' do
+    it 'returns a Hash' do
+      result = described_instance.ls_remote('origin')
+      expect(result).to be_a(Hash)
+    end
+
+    it 'contains a "branches" key with at least one entry for the pushed branch' do
+      result = described_instance.ls_remote('origin')
+      expect(result).to have_key('branches')
+      expect(result['branches']).not_to be_empty
+    end
+
+    it 'contains a "head" key' do
+      result = described_instance.ls_remote('origin')
+      expect(result).to have_key('head')
+    end
+
+    context 'with tags: true' do
+      it 'returns a Hash without raising' do
+        result = described_instance.ls_remote('origin', tags: true)
+        expect(result).to be_a(Hash)
+      end
+    end
+  end
 end

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -413,4 +413,14 @@ RSpec.describe Git::Base do
       end
     end
   end
+
+  describe '#ls_remote' do
+    include_context 'with a stubbed facade_repository'
+
+    it 'delegates to facade_repository.ls_remote' do
+      result_hash = { 'head' => { ref: 'HEAD', sha: 'abc123' } }
+      expect(facade_repository).to receive(:ls_remote).with(nil, {}).and_return(result_hash)
+      expect(described_instance.ls_remote).to eq(result_hash)
+    end
+  end
 end

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -1111,5 +1111,23 @@ RSpec.describe Git::Repository::RemoteOperations do
         expect { described_instance.ls_remote }.not_to raise_error
       end
     end
+
+    # --- Option safety (parser-incompatible options rejected) ----------------
+
+    context 'with :get_url option' do
+      it 'raises ArgumentError before calling the command' do
+        expect(ls_remote_command).not_to receive(:call)
+        expect { described_instance.ls_remote('origin', get_url: true) }
+          .to raise_error(ArgumentError, /get_url/)
+      end
+    end
+
+    context 'with :symref option' do
+      it 'raises ArgumentError before calling the command' do
+        expect(ls_remote_command).not_to receive(:call)
+        expect { described_instance.ls_remote('origin', symref: true) }
+          .to raise_error(ArgumentError, /symref/)
+      end
+    end
   end
 end

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -988,4 +988,128 @@ RSpec.describe Git::Repository::RemoteOperations do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #ls_remote
+  # ---------------------------------------------------------------------------
+
+  describe '#ls_remote' do
+    let(:ls_remote_command) { instance_double(Git::Commands::LsRemote) }
+    let(:ls_remote_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::LsRemote)
+        .to receive(:new).with(execution_context).and_return(ls_remote_command)
+    end
+
+    # --- Default invocation (nil location → '.') ----------------------------
+
+    context 'with no arguments (nil location)' do
+      subject(:result) { described_instance.ls_remote }
+
+      before do
+        allow(ls_remote_command).to receive(:call).and_return(ls_remote_result)
+      end
+
+      it 'delegates to Git::Commands::LsRemote.new with the execution_context' do
+        expect(Git::Commands::LsRemote).to receive(:new).with(execution_context).and_return(ls_remote_command)
+        result
+      end
+
+      it "passes '.' as the repository when location is nil" do
+        expect(ls_remote_command).to receive(:call).with('.').and_return(ls_remote_result)
+        result
+      end
+
+      it 'returns a Hash' do
+        expect(result).to be_a(Hash)
+      end
+    end
+
+    # --- Explicit location ---------------------------------------------------
+
+    context 'with an explicit location string' do
+      subject(:result) { described_instance.ls_remote('origin') }
+
+      it 'passes the location as the repository argument' do
+        expect(ls_remote_command)
+          .to receive(:call).with('origin').and_return(ls_remote_result)
+        result
+      end
+    end
+
+    # --- Opts forwarded ------------------------------------------------------
+
+    context 'with tags: true option' do
+      subject(:result) { described_instance.ls_remote('origin', tags: true) }
+
+      before do
+        allow(ls_remote_command).to receive(:call).and_return(ls_remote_result)
+      end
+
+      it 'forwards opts as keyword arguments to the command' do
+        expect(ls_remote_command)
+          .to receive(:call).with('origin', tags: true).and_return(ls_remote_result)
+        result
+      end
+    end
+
+    context 'with heads: true option' do
+      subject(:result) { described_instance.ls_remote('origin', heads: true) }
+
+      it 'forwards :heads to the command' do
+        expect(ls_remote_command)
+          .to receive(:call).with('origin', heads: true).and_return(ls_remote_result)
+        result
+      end
+    end
+
+    # --- Return value (parsed hash structure) --------------------------------
+
+    context 'with representative two-line output' do
+      let(:stdout) do
+        "abc123\tHEAD\n" \
+          "abc123\trefs/heads/main\n"
+      end
+
+      before do
+        allow(ls_remote_command).to receive(:call).and_return(command_result(stdout))
+      end
+
+      subject(:result) { described_instance.ls_remote }
+
+      it 'returns a Hash with a "head" key' do
+        expect(result).to have_key('head')
+      end
+
+      it 'returns a Hash with a "branches" key' do
+        expect(result).to have_key('branches')
+      end
+
+      it 'parses the HEAD entry with ref and sha merged into the type hash' do
+        head = result['head']
+        expect(head).to eq({ ref: 'HEAD', sha: 'abc123' })
+      end
+
+      it 'parses the branch entry keyed by branch name' do
+        branches = result['branches']
+        expect(branches).to have_key('main')
+        expect(branches['main'][:sha]).to eq('abc123')
+      end
+    end
+
+    # --- Signature compatibility (legacy-contract) ---------------------------
+
+    context 'signature compatibility' do
+      it 'accepts the positional hash call shape (legacy-contract)' do
+        allow(ls_remote_command).to receive(:call).and_return(ls_remote_result)
+        expect { described_instance.ls_remote('origin', tags: true) }.not_to raise_error
+      end
+
+      it 'accepts no arguments' do
+        allow(ls_remote_command).to receive(:call).and_return(ls_remote_result)
+        expect { described_instance.ls_remote }.not_to raise_error
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Promotes `Git::Lib#ls_remote` to a proper facade method on
`Git::Repository::RemoteOperations` and wires a `Git::Base#ls_remote` delegator
so callers can use `g.ls_remote` instead of `g.lib.ls_remote`.

This is part of the C1c-2 audit work (§7.3 `ls_remote` row, PR 5f).
`Git::Commands::LsRemote` already existed; this PR adds only the facade layer.

## Changes

### Production code

- **`lib/git/repository/remote_operations.rb`**
  - Added `require 'git/commands/ls_remote'`
  - Added `LS_REMOTE_ALLOWED_OPTS` constant (placed immediately before the
    method, `private_constant` declared)
  - Added `#ls_remote(location = nil, opts = {})` public facade method
    (legacy-contract signature) after `#remotes`
  - Added two private helpers in the `Private` module:
    `parse_ls_remote_output` and `parse_ls_remote_line` (reproduced from
    `Git::Lib` — no dependency on `Git::Lib`)
- **`lib/git/base.rb`**
  - Added `#ls_remote(location = nil, opts = {})` delegator to
    `facade_repository.ls_remote`

### Tests

- **`spec/unit/git/repository/remote_operations_spec.rb`** — 14 new examples:
  nil location defaults to `'.'`, explicit location forwarded, opts (`tags:`,
  `heads:`) forwarded, return value structure verified against a two-line
  fixture, signature compatibility shapes accepted
- **`spec/unit/git/base_spec.rb`** — 1 new example: delegator contract
- **`spec/integration/git/repository/remote_operations_spec.rb`** — 4 new
  examples: returns Hash, has `"branches"` key with entry, has `"head"` key,
  `tags: true` option accepted without error

### Documentation & tracking

- **`UPGRADING.md`** — added `g.lib.ls_remote(location, opts)` →
  `g.ls_remote(location, opts)` migration row
- **`redesign/c1c2_audit.md`** — §7.3 `ls_remote` row marked ✅ promoted;
  §7.5 promote-count decremented from 3 to 2

## Test coverage

All 294 additions are exercised. `bundle exec rake default:parallel` passes
with 0 failures across unit (5429 examples) and integration (872 examples)
suites. RuboCop and YARD report no offenses.

## Checklist

- [x] Tests written (RED before GREEN)
- [x] All tests pass (`bundle exec rake default:parallel`)
- [x] RuboCop passes with no offenses
- [x] YARD docs complete (`bundle exec rake yard`)
- [x] No breaking changes (additive only)
- [x] `opts = {}` legacy-contract signature preserved
- [x] Private helpers reproduce `Git::Lib` parsing logic — no `Git::Lib` call
- [x] `LS_REMOTE_ALLOWED_OPTS` placed immediately before the method
- [x] `UPGRADING.md` updated
- [x] `redesign/c1c2_audit.md` updated
