### PR TITLE
feat: add Git::Repository::Branching#change_head_branch facade

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1271,6 +1271,15 @@ module Git
       facade_repository.branch_delete(*branches, **)
     end
 
+    # Writes the HEAD symbolic ref to point at the given branch
+    #
+    # @param branch_name [String] the branch name to point HEAD at
+    #
+    # @return [void]
+    def change_head_branch(branch_name)
+      facade_repository.change_head_branch(branch_name)
+    end
+
     # @!group Bucket 6 delegators — Git::Repository::ObjectOperations
 
     # @return [String] raw content of the git object, or streams to a tempfile when a block is given

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -13,6 +13,7 @@ require 'git/commands/checkout/files'
 require 'git/commands/checkout_index'
 require 'git/commands/rev_parse'
 require 'git/commands/update_ref/update'
+require 'git/commands/symbolic_ref/update'
 require 'git/parsers/branch'
 require 'git/repository/shared_private'
 
@@ -414,6 +415,39 @@ module Git
         raise Git::Error, result.stderr.strip unless result.status.success?
 
         result.stdout.strip
+      end
+
+      # Writes the HEAD symbolic ref to point at the given branch
+      #
+      # Sets `HEAD` to `refs/heads/<branch_name>` via `git symbolic-ref`. This is
+      # equivalent to running `git symbolic-ref HEAD refs/heads/<branch_name>` on
+      # the command line and is the mechanism git uses internally for branch
+      # renaming and orphan-branch checkout.
+      #
+      # @example Change HEAD to point to an existing branch
+      #   repo.change_head_branch('main')
+      #
+      # @example Initialize a repository with a custom default branch name (unborn-branch pattern)
+      #   repo = Git.init('/path/to/repo')
+      #   repo.change_head_branch('my-branch')
+      #   # HEAD now points at refs/heads/my-branch before any commits exist
+      #
+      # @note Pointing HEAD at a branch that does not yet exist places the
+      #   repository in unborn-branch state. This is intentional for repository
+      #   initialization workflows — for example, setting a custom default branch
+      #   name before any commits land — but is unexpected if done by mistake.
+      #   The repository will appear to have no commits until the first commit is
+      #   made on the new branch.
+      #
+      # @param branch_name [String] the branch name to point HEAD at
+      #
+      # @return [void]
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def change_head_branch(branch_name)
+        Git::Commands::SymbolicRef::Update.new(@execution_context).call('HEAD', "refs/heads/#{branch_name}")
+        nil
       end
 
       # Returns the `git branch --list --contains` stdout for a given commit

--- a/redesign/c1c2_audit.md
+++ b/redesign/c1c2_audit.md
@@ -397,7 +397,7 @@ These require a new facade method before a base.rb delegator can be added.
 
 | `Git::Lib` method | Assessment | Recommended status |
 |-------------------|------------|--------------------|
-| `change_head_branch(branch_name)` | Low-level `git symbolic-ref HEAD refs/heads/<name>`; used internally for branch renaming and orphan checkout. Plausible external use by tooling. | 🔍 human decision — promote to `Git::Repository::Branching` or mark as internal? |
+| `change_head_branch(branch_name)` | Low-level `git symbolic-ref HEAD refs/heads/<name>`; used internally for branch renaming and orphan checkout. Plausible external use by tooling. | ✅ promoted — facade in `Git::Repository::Branching` + `Git::Base` delegator added (PR 5h-1) |
 | `config_get(name)` | Returns a single config value. Used by tooling. Part of the existing `config()` facade which reads/writes. | 🔍 human decision — expose as `config_get` or fold into `config(name)`? |
 | `config_list` | Returns full config hash. Used by tooling. | 🔍 human decision — expose separately or fold into `config()`? |
 | `config_set(name, value, options)` | Sets a config value. | 🔍 human decision — expose separately or fold into `config(name, value)`? |
@@ -438,10 +438,10 @@ upgrade notes as "unsupported; remove any `g.lib.X` calls."
 
 | Status | Count |
 |--------|-------|
-| ✅ promote (repo already had it, `Git::Base` delegator added — PR 2d; or alias added) | 24 |
+| ✅ promote (repo already had it, `Git::Base` delegator added — PR 2d; or alias added) | 25 |
 | ⬜ promote (new facade work required) | 1 |
 | ❌ remove (internal plumbing) | 12 |
-| 🔍 human decision | 16 |
+| 🔍 human decision | 15 |
 | **Total orphaned methods** | **56** |
 
 > **Recommendation:** The 24 "trivial wiring" promotions can be handled in PR 5a

--- a/redesign/c1c2_bucket6_lib_orphans.md
+++ b/redesign/c1c2_bucket6_lib_orphans.md
@@ -123,6 +123,8 @@ clear documentation explaining unborn-branch semantics.
 
 **Decision:** Accepted. Promote `change_head_branch(branch_name)` to `Git::Repository::Branching` with a `Git::Base` delegator. No guard. Document unborn-branch semantics in YARD.
 
+**Status:** ✅ Implemented — facade in `Git::Repository::Branching` + `Git::Base` delegator added (PR 5h-1).
+
 ---
 
 ### 3.2 `config_get(name)`, `config_list`, and `config_set(name, value, options = {})`

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -309,6 +309,38 @@ RSpec.describe Git::Repository::Branching, :integration do
   end
 
   # ---------------------------------------------------------------------------
+  # #change_head_branch
+  # ---------------------------------------------------------------------------
+  #
+  # change_head_branch is a single-command delegator. Integration tests verify
+  # both the unborn-branch initialization workflow (no prior commits) and the
+  # post-commit case (HEAD symbolic ref rewired to a new refs/heads/ entry).
+
+  describe '#change_head_branch' do
+    context 'with an unborn repository (no commits)' do
+      let(:unborn_repo_dir) { Dir.mktmpdir('unborn_repo') }
+      let(:unborn_repo) { Git.init(unborn_repo_dir) }
+      let(:unborn_execution_context) { Git::ExecutionContext::Repository.from_base(unborn_repo) }
+      let(:unborn_instance) { Git::Repository.new(execution_context: unborn_execution_context) }
+
+      after { FileUtils.rm_rf(unborn_repo_dir) }
+
+      it 'changes HEAD to point at the given branch name' do
+        unborn_instance.change_head_branch('my-branch')
+        expect(unborn_instance.current_branch).to eq('my-branch')
+      end
+    end
+
+    context 'with a repository that already has commits' do
+      it 'rewrites the HEAD symbolic ref to refs/heads/<branch_name>' do
+        described_instance.change_head_branch('other')
+        head_content = File.read(File.join(repo_dir, '.git', 'HEAD')).strip
+        expect(head_content).to eq('ref: refs/heads/other')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # #branch_contains
   # ---------------------------------------------------------------------------
   #

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -215,6 +215,15 @@ RSpec.describe Git::Base do
     end
   end
 
+  describe '#change_head_branch' do
+    include_context 'with a stubbed facade_repository'
+
+    it 'delegates to facade_repository.change_head_branch' do
+      expect(facade_repository).to receive(:change_head_branch).with('new-branch')
+      described_instance.change_head_branch('new-branch')
+    end
+  end
+
   describe '#gblob' do
     include_context 'with a stubbed facade_repository'
 

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -722,6 +722,52 @@ RSpec.describe Git::Repository::Branching do
   end
 
   # ---------------------------------------------------------------------------
+  # #change_head_branch
+  # ---------------------------------------------------------------------------
+
+  describe '#change_head_branch' do
+    let(:update_command) { instance_double(Git::Commands::SymbolicRef::Update) }
+    let(:update_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::SymbolicRef::Update)
+        .to receive(:new).with(execution_context).and_return(update_command)
+    end
+
+    context 'with a typical slash-separated branch name' do
+      subject(:result) { described_instance.change_head_branch('feature/my-branch') }
+
+      it 'constructs Git::Commands::SymbolicRef::Update with the execution context' do
+        expect(Git::Commands::SymbolicRef::Update)
+          .to receive(:new).with(execution_context).and_return(update_command)
+        allow(update_command).to receive(:call).and_return(update_result)
+        result
+      end
+
+      it "delegates to #call with 'HEAD' and 'refs/heads/feature/my-branch'" do
+        expect(update_command)
+          .to receive(:call).with('HEAD', 'refs/heads/feature/my-branch').and_return(update_result)
+        result
+      end
+
+      it 'returns nil' do
+        allow(update_command).to receive(:call).and_return(update_result)
+        expect(result).to be_nil
+      end
+    end
+
+    context 'with a simple branch name' do
+      subject(:result) { described_instance.change_head_branch('main') }
+
+      it "delegates to #call with 'HEAD' and 'refs/heads/main'" do
+        expect(update_command)
+          .to receive(:call).with('HEAD', 'refs/heads/main').and_return(update_result)
+        result
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # #branch_contains
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Promotes `Git::Lib#change_head_branch` to a public facade method as decided in
redesign/c1c2_bucket6_lib_orphans.md §3.1 (PR 5h-1).

## Description

Adds `Git::Repository::Branching#change_head_branch(branch_name)` and a
`Git::Base#change_head_branch` delegator so callers can point HEAD at an
arbitrary branch via the public API without going through `g.lib`.

The method writes the HEAD symbolic ref directly:

```
git symbolic-ref HEAD refs/heads/<branch_name>
```

**No existence guard** is added intentionally. The unborn-branch workflow —
pointing HEAD at a branch before any commits exist — is a first-class git
pattern used by repository initialization tooling (e.g., setting a custom
default branch name with `Git.init` before the first commit lands). A guard
would silently break that workflow. The `@note` in the YARD docs makes the
footgun explicit.

## Changes

| File | Change |
|------|--------|
| `lib/git/repository/branching.rb` | Add `#change_head_branch` with full YARD docs |
| `lib/git/base.rb` | Add `#change_head_branch` delegator (Bucket 6 section) |
| `spec/unit/git/repository/branching_spec.rb` | 3 unit examples |
| `spec/unit/git/base_spec.rb` | 1 delegator unit example |
| `spec/integration/git/repository/branching_spec.rb` | 2 integration examples (unborn repo + post-commit HEAD rewrite) |
| `redesign/c1c2_audit.md` | Mark `change_head_branch` as `✅ promoted` in §7.3; update §7.5 counts |
| `redesign/c1c2_bucket6_lib_orphans.md` | Mark §3.1 as implemented |

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
