### PR TITLE
feat: add Git::Repository::Merging#unmerged facade

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -578,6 +578,10 @@ module Git
       facade_repository.each_conflict(&)
     end
 
+    def unmerged
+      facade_repository.unmerged
+    end
+
     # Pulls the given branch from the given remote into the current branch
     #
     # @param remote [String] the remote repository to pull from

--- a/lib/git/repository/merging.rb
+++ b/lib/git/repository/merging.rb
@@ -145,6 +145,24 @@ module Git
         result.stdout.lines.map(&:strip).reject(&:empty?)
       end
 
+      # Return the paths of files with unresolved merge conflicts
+      #
+      # @example List conflicting files after a failed merge
+      #   paths = repo.unmerged
+      #   # => ["config/settings.rb", "lib/git/base.rb"]
+      #   paths.each { |path| puts "Conflict in #{path}" }
+      #
+      # @return [Array<String>] repository-relative paths of files with unresolved
+      #   merge conflicts; empty array when the working tree has no conflicts
+      #
+      # @raise [Git::FailedError] if git exits outside the allowed range (exit code > 2)
+      #
+      # @see #each_conflict
+      #
+      def unmerged
+        Private.unmerged_paths(@execution_context)
+      end
+
       # Iterate over files with merge conflicts, yielding conflict details for each
       #
       # For each unmerged file, the staged content for both sides of the conflict
@@ -163,7 +181,8 @@ module Git
       #
       # @return [Array<String>] the list of unmerged file paths
       #
-      # @raise [Git::FailedError] when `git diff --cached` exits with a non-zero status
+      # @raise [Git::FailedError] when `git diff --cached` exits outside the
+      #   allowed range (exit code > 2)
       #
       # @yield [file, your_version, their_version] passes conflict details for
       #   each unmerged file

--- a/redesign/c1c2_audit.md
+++ b/redesign/c1c2_audit.md
@@ -410,7 +410,7 @@ These require a new facade method before a base.rb delegator can be added.
 | `mv(source, destination, options = {})` | Wraps `git mv`. Externally useful. | ⬜ promote — new facade in `Git::Repository::Staging`; `Git::Commands::Mv` ✅ exists; trivial effort |
 | `parse_config(file)` | Parses a config file from path. | 🔍 human decision — expose or fold into `config()` with `:file` option? |
 | `stash_list` | Returns a formatted string `"stash@{0}: ...\n..."` — distinct from `stashes_all` which returns structured data. | 🔍 human decision — promote for backward compat, or deprecate in favor of `stashes_all`? |
-| `unmerged` | Returns paths with unresolved merge conflicts. Already partially covered by `each_conflict` (yields paths to temporary files for staged content). Pure path list is useful. | 🔍 human decision — promote `unmerged` as a simpler alternative to `each_conflict`? |
+| `unmerged` | Returns paths with unresolved merge conflicts. Already partially covered by `each_conflict` (yields paths to temporary files for staged content). Pure path list is useful. | ✅ promoted — public method in `Git::Repository::Merging` + `Git::Base` delegator added (PR 5h-6) |
 | `current_branch_state` | Returns a `HeadState` value object with `:state` (`:active`/`:unborn`/`:detached`) and `:name`. Richer than `current_branch`. Legacy `Git::Lib` implementation used a mutable `Struct`; promoted facade uses an immutable `Data` object. | ✅ promoted — `HeadState` Data object defined in `Git::Repository::Branching`; facade in `Git::Repository::Branching` + `Git::Base` delegator added (PR 5g) |
 
 ### 7.4 Internal Plumbing — Mark as ❌ Remove

--- a/redesign/c1c2_bucket6_lib_orphans.md
+++ b/redesign/c1c2_bucket6_lib_orphans.md
@@ -490,6 +490,8 @@ Use `unmerged` as the promoted name to preserve backward compatibility.
 
 **Decision:** Accepted. Promote `unmerged` as a public method on `Git::Repository::Merging` by surfacing `Private.unmerged_paths`. Add `Git::Base` delegator.
 
+**Status:** ✅ Implemented — `Git::Repository::Merging#unmerged` added; `Git::Base#unmerged` delegator added.
+
 ## 4. Pre-resolved questions
 
 The following questions were raised during initial drafting and are now

--- a/spec/integration/git/repository/merging_spec.rb
+++ b/spec/integration/git/repository/merging_spec.rb
@@ -293,6 +293,52 @@ RSpec.describe Git::Repository::Merging, :integration do
   end
 
   # ---------------------------------------------------------------------------
+  # #unmerged
+  # ---------------------------------------------------------------------------
+
+  describe '#unmerged' do
+    context 'when there are no conflicts' do
+      it 'returns an empty Array' do
+        expect(described_instance.unmerged).to eq([])
+      end
+    end
+
+    context 'when there is a conflict' do
+      before do
+        repo.lib.branch_new('branch_ours')
+        repo.lib.checkout('branch_ours')
+        write_file('example.txt', "1\n2\n3\n")
+        repo.add('example.txt')
+        repo.commit('ours: add example.txt')
+
+        repo.lib.checkout('main')
+        repo.lib.branch_new('branch_theirs')
+        repo.lib.checkout('branch_theirs')
+        write_file('example.txt', "1\n4\n3\n")
+        repo.add('example.txt')
+        repo.commit('theirs: add example.txt')
+
+        repo.lib.checkout('main')
+        repo.merge('branch_ours')
+
+        begin
+          repo.merge('branch_theirs')
+        rescue Git::FailedError
+          # expected conflict
+        end
+      end
+
+      it 'returns an Array' do
+        expect(described_instance.unmerged).to be_an(Array)
+      end
+
+      it 'returns the conflicting file path(s)' do
+        expect(described_instance.unmerged).to include('example.txt')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # #each_conflict
   # ---------------------------------------------------------------------------
 

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -442,4 +442,13 @@ RSpec.describe Git::Base do
       expect(described_instance.ls_remote).to eq(result_hash)
     end
   end
+
+  describe '#unmerged' do
+    include_context 'with a stubbed facade_repository'
+
+    it 'delegates to facade_repository.unmerged' do
+      expect(facade_repository).to receive(:unmerged).and_return(['file.rb'])
+      expect(described_instance.unmerged).to eq(['file.rb'])
+    end
+  end
 end

--- a/spec/unit/git/repository/merging_spec.rb
+++ b/spec/unit/git/repository/merging_spec.rb
@@ -361,6 +361,46 @@ RSpec.describe Git::Repository::Merging do
   end
 
   # ---------------------------------------------------------------------------
+  # #unmerged
+  # ---------------------------------------------------------------------------
+
+  describe '#unmerged' do
+    let(:diff_command) { instance_double(Git::Commands::Diff) }
+
+    before do
+      allow(Git::Commands::Diff).to receive(:new).with(execution_context).and_return(diff_command)
+    end
+
+    context 'when there are no conflicts' do
+      before do
+        allow(diff_command).to receive(:call).with(cached: true).and_return(command_result(''))
+      end
+
+      it 'returns an empty Array' do
+        expect(described_instance.unmerged).to eq([])
+      end
+    end
+
+    context 'when there are conflicts' do
+      let(:diff_stdout) { "* Unmerged path file.rb\n* Unmerged path other.rb\n" }
+
+      before do
+        allow(diff_command).to receive(:call).with(cached: true).and_return(command_result(diff_stdout))
+      end
+
+      it 'returns an Array of the conflicting file paths' do
+        expect(described_instance.unmerged).to eq(%w[file.rb other.rb])
+      end
+    end
+
+    it 'delegates to Git::Commands::Diff.new with the execution_context' do
+      allow(diff_command).to receive(:call).with(cached: true).and_return(command_result(''))
+      expect(Git::Commands::Diff).to receive(:new).with(execution_context).and_return(diff_command)
+      described_instance.unmerged
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # #each_conflict
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository.

# Description

Promotes `Git::Repository::Merging::Private.unmerged_paths` as a new public
method `Git::Repository::Merging#unmerged`, and adds a `Git::Base#unmerged`
delegator so callers can use `repo.unmerged` directly.

## Why

`each_conflict` already calls `Private.unmerged_paths` internally to get the
list of conflicting files, then yields those paths (plus temporary staged-content
files) to a block. Callers who only need the path list had no clean public API —
they had to call `each_conflict` with a block that discarded the temp-file
arguments. This promotes the private helper as a one-liner with no new commands
or parsers required.

Decision trail: `redesign/c1c2_bucket6_lib_orphans.md` §3.6 (accepted Option A).

## Changes

- `lib/git/repository/merging.rb` — add `#unmerged` immediately before
  `#each_conflict` (they are conceptually paired); delegates to
  `Private.unmerged_paths(@execution_context)` with full YARD docs including
  `@see #each_conflict`
- `lib/git/base.rb` — add `#unmerged` delegator near `#each_conflict`
- `spec/unit/git/repository/merging_spec.rb` — three unit tests using the same
  `Git::Commands::Diff` stub pattern as the existing `#each_conflict` unit tests
- `spec/unit/git/base_spec.rb` — one delegator unit test
- `spec/integration/git/repository/merging_spec.rb` — integration tests for
  the no-conflicts and conflicts-present cases (reusing the conflict-setup
  scenario from `#each_conflict`)
- `redesign/c1c2_audit.md` — §7.3 row updated to ✅; §7.5 counts updated
- `redesign/c1c2_bucket6_lib_orphans.md` — §3.6 marked as implemented
- `UPGRADING.md` — already contained the `g.lib.unmerged` → `g.unmerged` row

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
