### PR TITLE
feat: add deprecated Git::Repository::Stashing#stash_list facade

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1350,6 +1350,13 @@ module Git
       facade_repository.stashes_all
     end
 
+    # @deprecated Use {#stashes_all} instead.
+    #
+    # @return [String] stash entries formatted as `"stash@{n}: <full message>"`, one per line
+    def stash_list
+      facade_repository.stash_list
+    end
+
     # @return [Boolean] true if changes were stashed, false if there was nothing to stash
     def stash_save(message)
       facade_repository.stash_save(message)

--- a/lib/git/repository/stashing.rb
+++ b/lib/git/repository/stashing.rb
@@ -40,6 +40,33 @@ module Git
         end
       end
 
+      # Returns stash entries as a formatted string matching `git stash list` output
+      #
+      # @deprecated Use {#stashes_all} instead.
+      #
+      # @example List stashes as a formatted string
+      #   repo.stash_list #=> "stash@{0}: On main: WIP\nstash@{1}: On feature: Fix bug"
+      #
+      # @return [String] newline-joined `"stash@{n}: <full message>"` entries, or an
+      #   empty string when there are no stashes; the format matches `git stash list`
+      #   output
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see #stashes_all
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stash_list
+        Git::Deprecation.warn(
+          'Git::Repository#stash_list is deprecated and will be removed in a future version. ' \
+          'Use Git::Repository#stashes_all instead.'
+        )
+        result = Git::Commands::Stash::List.new(@execution_context).call
+        stashes = Git::Parsers::Stash.parse_list(result.stdout)
+        stashes.map { |info| "#{info.name}: #{info.message}" }.join("\n")
+      end
+
       # Save the current working directory and index state to a new stash
       #
       # @param message [String] the stash message

--- a/redesign/c1c2_audit.md
+++ b/redesign/c1c2_audit.md
@@ -409,7 +409,7 @@ These require a new facade method before a base.rb delegator can be added.
 | `ls_remote(location = nil, opts = {})` | Lists remote refs. Clearly useful externally. | ✅ promoted — facade in `Git::Repository::RemoteOperations` + `Git::Base` delegator added (PR 5f) |
 | `mv(source, destination, options = {})` | Wraps `git mv`. Externally useful. | ⬜ promote — new facade in `Git::Repository::Staging`; `Git::Commands::Mv` ✅ exists; trivial effort |
 | `parse_config(file)` | Parses a config file from path. | 🔍 human decision — expose or fold into `config()` with `:file` option? |
-| `stash_list` | Returns a formatted string `"stash@{0}: ...\n..."` — distinct from `stashes_all` which returns structured data. | 🔍 human decision — promote for backward compat, or deprecate in favor of `stashes_all`? |
+| `stash_list` | Returns a formatted string `"stash@{0}: ...\n..."` — distinct from `stashes_all` which returns structured data. | ✅ promoted as deprecated method — `Git::Repository::Stashing#stash_list` + `Git::Base` delegator added (PR 5h-5); remove in v6 |
 | `unmerged` | Returns paths with unresolved merge conflicts. Already partially covered by `each_conflict` (yields paths to temporary files for staged content). Pure path list is useful. | ✅ promoted — public method in `Git::Repository::Merging` + `Git::Base` delegator added (PR 5h-6) |
 | `current_branch_state` | Returns a `HeadState` value object with `:state` (`:active`/`:unborn`/`:detached`) and `:name`. Richer than `current_branch`. Legacy `Git::Lib` implementation used a mutable `Struct`; promoted facade uses an immutable `Data` object. | ✅ promoted — `HeadState` Data object defined in `Git::Repository::Branching`; facade in `Git::Repository::Branching` + `Git::Base` delegator added (PR 5g) |
 
@@ -438,10 +438,10 @@ upgrade notes as "unsupported; remove any `g.lib.X` calls."
 
 | Status | Count |
 |--------|-------|
-| ✅ promote (repo already had it, `Git::Base` delegator added — PR 2d; or alias added) | 25 |
+| ✅ promote (repo already had it, `Git::Base` delegator added — PR 2d; or alias added) | 26 |
 | ⬜ promote (new facade work required) | 1 |
 | ❌ remove (internal plumbing) | 12 |
-| 🔍 human decision | 15 |
+| 🔍 human decision | 14 |
 | **Total orphaned methods** | **56** |
 
 > **Recommendation:** The 24 "trivial wiring" promotions can be handled in PR 5a

--- a/redesign/c1c2_bucket6_lib_orphans.md
+++ b/redesign/c1c2_bucket6_lib_orphans.md
@@ -447,6 +447,8 @@ Remove the method in v6 after a full deprecation cycle.
 
 **Decision:** Accepted. Add `stash_list` to `Git::Repository::Stashing` as a deprecated method with `Git::Deprecation.warn` pointing to `stashes_all`. Add `Git::Base` delegator. Remove in v6.
 
+**Status: ✅ Implemented** — `Git::Repository::Stashing#stash_list` + `Git::Base#stash_list` delegator added (PR 5h-5).
+
 ---
 
 ### 3.6 `unmerged`

--- a/spec/integration/git/repository/stashing_spec.rb
+++ b/spec/integration/git/repository/stashing_spec.rb
@@ -70,9 +70,37 @@ RSpec.describe Git::Repository::Stashing, :integration do
 
       it 'strips only the branch prefix and keeps the rest of the message' do
         result = described_instance.stashes_all
-        # Git stores: "On main: saving: work"; facade strips "On main:" → "saving: work"
+        # Git stores: "On main: saving: work"; facade strips "On main:" => "saving: work"
         expect(result.first.last).to eq('saving: work')
       end
+    end
+  end
+
+  describe '#stash_list' do
+    before do
+      write_file('file.txt', 'modified content')
+      repo.add('file.txt')
+      described_instance.stash_save('WIP')
+    end
+
+    it 'emits a deprecation warning' do
+      expect(Git::Deprecation).to receive(:warn).with(a_string_including('stash_list'))
+      described_instance.stash_list
+    end
+
+    it 'returns a String' do
+      allow(Git::Deprecation).to receive(:warn)
+      expect(described_instance.stash_list).to be_a(String)
+    end
+
+    it 'contains "stash@{0}"' do
+      allow(Git::Deprecation).to receive(:warn)
+      expect(described_instance.stash_list).to include('stash@{0}')
+    end
+
+    it 'contains the stash message' do
+      allow(Git::Deprecation).to receive(:warn)
+      expect(described_instance.stash_list).to include('WIP')
     end
   end
 end

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -451,4 +451,13 @@ RSpec.describe Git::Base do
       expect(described_instance.unmerged).to eq(['file.rb'])
     end
   end
+
+  describe '#stash_list' do
+    include_context 'with a stubbed facade_repository'
+
+    it 'delegates to facade_repository.stash_list' do
+      expect(facade_repository).to receive(:stash_list).and_return('stash@{0}: WIP')
+      expect(described_instance.stash_list).to eq('stash@{0}: WIP')
+    end
+  end
 end

--- a/spec/unit/git/repository/stashing_spec.rb
+++ b/spec/unit/git/repository/stashing_spec.rb
@@ -180,6 +180,61 @@ RSpec.describe Git::Repository::Stashing do
     end
   end
 
+  describe '#stash_list' do
+    let(:list_command) { instance_double(Git::Commands::Stash::List) }
+
+    before do
+      allow(Git::Commands::Stash::List).to receive(:new).with(execution_context).and_return(list_command)
+    end
+
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      allow(list_command).to receive(:call).with(no_args).and_return(command_result(''))
+      allow(Git::Parsers::Stash).to receive(:parse_list).with('').and_return([])
+      expect(Git::Deprecation).to receive(:warn).with(a_string_including('stash_list'))
+      described_instance.stash_list
+    end
+
+    context 'when there are stash entries' do
+      let(:list_result) { command_result('fixture') }
+      let(:stash_info_first) { instance_double(Git::StashInfo, name: 'stash@{0}', message: 'On main: WIP') }
+      let(:stash_info_second) { instance_double(Git::StashInfo, name: 'stash@{1}', message: 'On main: Fix bug') }
+      let(:stash_infos) { [stash_info_first, stash_info_second] }
+
+      before do
+        allow(Git::Deprecation).to receive(:warn)
+        allow(list_command).to receive(:call).with(no_args).and_return(list_result)
+        allow(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return(stash_infos)
+      end
+
+      it 'calls Git::Commands::Stash::List with the execution context' do
+        expect(Git::Commands::Stash::List).to receive(:new).with(execution_context).and_return(list_command)
+        allow(list_command).to receive(:call).and_return(list_result)
+        described_instance.stash_list
+      end
+
+      it 'passes the command stdout to Git::Parsers::Stash.parse_list' do
+        expect(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return(stash_infos)
+        described_instance.stash_list
+      end
+
+      it 'returns a newline-joined "stash@{n}: <full message>" string' do
+        expect(described_instance.stash_list).to eq("stash@{0}: On main: WIP\nstash@{1}: On main: Fix bug")
+      end
+    end
+
+    context 'when there are no stash entries' do
+      before do
+        allow(Git::Deprecation).to receive(:warn)
+        allow(list_command).to receive(:call).with(no_args).and_return(command_result(''))
+        allow(Git::Parsers::Stash).to receive(:parse_list).with('').and_return([])
+      end
+
+      it 'returns an empty string' do
+        expect(described_instance.stash_list).to eq('')
+      end
+    end
+  end
+
   describe '#stash_clear' do
     let(:clear_command) { instance_double(Git::Commands::Stash::Clear) }
     let(:clear_result) { command_result('') }


### PR DESCRIPTION
# Description

Implements the decision recorded in `redesign/c1c2_bucket6_lib_orphans.md` §3.5:
promote `Git::Lib#stash_list` as a **deprecated** facade method on
`Git::Repository::Stashing`, preserving backward compatibility for v4 callers
who depend on the `"stash@{n}: ..."` string format while directing them to
`stashes_all` as the migration target.

## What changed

- **`Git::Repository::Stashing#stash_list`** — new deprecated facade method that
  emits `Git::Deprecation.warn` and returns a newline-joined string of
  `"stash@{n}: <full message>"` entries (or an empty string when no stashes
  exist). The return format matches raw `git stash list` output, which is
  distinct from `stashes_all` (which returns structured `[index, message]` pairs
  with the branch prefix stripped and oldest-first ordering).

- **`Git::Base#stash_list`** — simple delegator to `facade_repository.stash_list`,
  placed near the other stash delegators (`stashes_all`, `stash_save`, etc.).

- **Audit trackers updated** — `redesign/c1c2_audit.md` §7.3 row updated to ✅,
  §7.5 human-decision count decremented from 16 to 15;
  `redesign/c1c2_bucket6_lib_orphans.md` §3.5 marked as implemented.

## Why this approach

`stash_list` must **not** delegate internally to `stashes_all`: the two methods
return different data — `stash_list` returns the full formatted string
`"stash@{n}: On main: WIP"`, while `stashes_all` returns `[0, "WIP"]` (index
renumbered, branch prefix stripped). Callers who depend on the `"stash@{n}: ..."`
format would silently get wrong data if the implementation delegated to
`stashes_all`. The implementation calls `Git::Commands::Stash::List` directly,
identical to the `Git::Lib` original.

## Test coverage

**Unit tests** (`spec/unit/git/repository/stashing_spec.rb`):
- Deprecation warning emitted via `Git::Deprecation.warn` (exact message includes `'stash_list'`)
- Correct `"stash@{n}: <full message>"` string format with two stash entries
- Command constructed with the injection execution context
- Parser called with command stdout
- Empty string returned when there are no stashes

**Unit test** (`spec/unit/git/base_spec.rb`):
- `Git::Base#stash_list` delegates to `facade_repository.stash_list`

**Integration tests** (`spec/integration/git/repository/stashing_spec.rb`):
- Deprecation warning emitted in a real git repo
- Return value is a `String`
- Contains `'stash@{0}'`
- Contains the stash message (`'WIP'`)

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
