### PR TITLE
feat: add Git::Repository::Configuring#global_config facade and deprecated aliases

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -231,6 +231,22 @@ module Git
       facade_repository.config(name, value, options)
     end
 
+    def global_config(name = nil, value = nil)
+      facade_repository.global_config(name, value)
+    end
+
+    def global_config_get(name)
+      facade_repository.global_config_get(name)
+    end
+
+    def global_config_list
+      facade_repository.global_config_list
+    end
+
+    def global_config_set(name, value)
+      facade_repository.global_config_set(name, value)
+    end
+
     # Returns a reference to the working directory
     #
     # @example

--- a/lib/git/repository/configuring.rb
+++ b/lib/git/repository/configuring.rb
@@ -7,8 +7,11 @@ module Git
   class Repository
     # Facade methods for reading and writing git configuration
     #
-    # Provides the {#config} method, which dispatches to read a single entry,
-    # list all entries, or write a value depending on the arguments supplied.
+    # Provides the {#config} and {#global_config} methods, which dispatch to read a
+    # single entry, list all entries, or write a value depending on the arguments
+    # supplied. {#config} uses git's default config scope (reads from the full
+    # resolution chain; set operations write to the repository's `.git/config`);
+    # {#global_config} targets the git global config scope (`git config --global`).
     #
     # Included by {Git::Repository}.
     #
@@ -81,6 +84,89 @@ module Git
         end
       end
 
+      # Read or write a global git configuration entry
+      #
+      # Dispatches to one of three modes depending on the arguments supplied,
+      # targeting the git global config scope (`git config --global`):
+      #
+      # * **List** — `global_config()` returns all global config entries as a `Hash`.
+      # * **Get** — `global_config(name)` returns the value for a single key as a `String`.
+      # * **Set** — `global_config(name, value)` writes a value and returns the raw
+      #   command result.
+      #
+      # @overload global_config
+      #
+      #   @example List all global config entries
+      #     repo.global_config #=> { "user.name" => "Alice", "core.autocrlf" => "false" }
+      #
+      #   @return [Hash{String => String}] all global config entries, keyed by their
+      #     full dotted key names (e.g. `"user.name"`)
+      #
+      #   @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @overload global_config(name)
+      #
+      #   @example Read the global committer name
+      #     repo.global_config('user.name') #=> "Alice"
+      #
+      #   @param name [String] the dotted config key to look up (e.g. `"user.name"`)
+      #
+      #   @return [String] the value of the global config entry
+      #
+      #   @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @overload global_config(name, value)
+      #
+      #   @example Set the global committer name
+      #     repo.global_config('user.name', 'Alice')
+      #
+      #   @param name [String] the dotted config key to write (e.g. `"user.name"`)
+      #
+      #   @param value [#to_s] the value to assign; any object is accepted and
+      #     converted to a String via `#to_s` before being passed to git
+      #
+      #   @return [Git::CommandLineResult] the raw result of
+      #     `git config --global <name> <value>`
+      #
+      #   @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def global_config(name = nil, value = nil)
+        if !name.nil? && !value.nil?
+          Private.global_config_set(@execution_context, name, value)
+        elsif !name.nil?
+          Private.global_config_get(@execution_context, name)
+        else
+          Private.global_config_list(@execution_context)
+        end
+      end
+
+      # @deprecated Use {#global_config} instead.
+      def global_config_get(name)
+        Git::Deprecation.warn(
+          'Git::Repository#global_config_get is deprecated and will be removed in a future version. ' \
+          'Use global_config(name) instead.'
+        )
+        global_config(name)
+      end
+
+      # @deprecated Use {#global_config} instead.
+      def global_config_list
+        Git::Deprecation.warn(
+          'Git::Repository#global_config_list is deprecated and will be removed in a future version. ' \
+          'Use global_config instead.'
+        )
+        global_config
+      end
+
+      # @deprecated Use {#global_config} instead.
+      def global_config_set(name, value)
+        Git::Deprecation.warn(
+          'Git::Repository#global_config_set is deprecated and will be removed in a future version. ' \
+          'Use global_config(name, value) instead.'
+        )
+        global_config(name, value)
+      end
+
       # Private helpers local to {Git::Repository::Configuring}
       #
       # @api private
@@ -147,6 +233,58 @@ module Git
             key, value = line.split('=', 2)
             hsh[key] = value || ''
           end
+        end
+
+        # Retrieve a global config value by key name
+        #
+        # @param execution_context [Git::ExecutionContext] the execution context
+        #
+        # @param name [String] the dotted config key to look up (e.g. `"user.name"`)
+        #
+        # @return [String] the value of the global config entry
+        #
+        # @raise [Git::FailedError] if git exits with a non-zero exit status
+        #
+        def global_config_get(execution_context, name)
+          result = Git::Commands::ConfigOptionSyntax::Get.new(execution_context).call(name, global: true)
+          raise Git::FailedError, result if result.status.exitstatus != 0
+
+          result.stdout
+        end
+
+        # Retrieve all global config entries as a hash
+        #
+        # @param execution_context [Git::ExecutionContext] the execution context
+        #
+        # @return [Hash{String => String}] all global config entries, keyed by their full
+        #   dotted key names (e.g. `"user.name"`)
+        #
+        # @raise [Git::FailedError] if git exits with a non-zero exit status
+        #
+        def global_config_list(execution_context)
+          lines = Git::Commands::ConfigOptionSyntax::List.new(execution_context).call(global: true).stdout.split("\n")
+          lines.each_with_object({}) do |line, hsh|
+            key, value = line.split('=', 2)
+            hsh[key] = value || ''
+          end
+        end
+
+        # Set a global config value by key name
+        #
+        # @param execution_context [Git::ExecutionContext] the execution context
+        #
+        # @param name [String] the dotted config key to write (e.g. `"user.name"`)
+        #
+        # @param value [#to_s] the value to assign; any object is accepted and
+        #   converted to a String via `#to_s` before being passed to git
+        #
+        # @return [Git::CommandLineResult] the raw result of
+        #   `git config --global <name> <value>`
+        #
+        # @raise [Git::FailedError] if git exits with a non-zero exit status
+        #
+        def global_config_set(execution_context, name, value)
+          Git::Commands::ConfigOptionSyntax::Set.new(execution_context).call(name, value, global: true)
         end
       end
 

--- a/redesign/c1c2_audit.md
+++ b/redesign/c1c2_audit.md
@@ -401,9 +401,9 @@ These require a new facade method before a base.rb delegator can be added.
 | `config_get(name)` | Returns a single config value. Used by tooling. Part of the existing `config()` facade which reads/writes. | 🔍 human decision — expose as `config_get` or fold into `config(name)`? |
 | `config_list` | Returns full config hash. Used by tooling. | 🔍 human decision — expose separately or fold into `config()`? |
 | `config_set(name, value, options)` | Sets a config value. | 🔍 human decision — expose separately or fold into `config(name, value)`? |
-| `global_config_get(name)` | Gets a global config value. | 🔍 human decision |
-| `global_config_list` | Returns the full global config hash. | 🔍 human decision |
-| `global_config_set(name, value)` | Sets a global config value. | 🔍 human decision |
+| `global_config_get(name)` | Gets a global config value. | ✅ promoted — `global_config` facade + deprecated aliases in `Git::Repository::Configuring` + `Git::Base` delegators added (PR 5h-3) |
+| `global_config_list` | Returns the full global config hash. | ✅ promoted — `global_config` facade + deprecated aliases in `Git::Repository::Configuring` + `Git::Base` delegators added (PR 5h-3) |
+| `global_config_set(name, value)` | Sets a global config value. | ✅ promoted — `global_config` facade + deprecated aliases in `Git::Repository::Configuring` + `Git::Base` delegators added (PR 5h-3) |
 | `git_version` | Returns `Git::Version` for the current binary. Useful for tooling that conditionally enables features. Not a repository concern; `Git.git_version` is the canonical API. | ✅ delegator added to `Git::Base` — delegates to `Git.git_version` |
 | `list_files(ref_dir)` | Lists files under `.git/refs/{ref_dir}`. Internal ref-filesystem access. No plausible clean public use. | ❌ remove — internal plumbing; direct callers should migrate to `Git::Repository` ref-inspection methods |
 | `ls_remote(location = nil, opts = {})` | Lists remote refs. Clearly useful externally. | ✅ promoted — facade in `Git::Repository::RemoteOperations` + `Git::Base` delegator added (PR 5f) |
@@ -438,14 +438,14 @@ upgrade notes as "unsupported; remove any `g.lib.X` calls."
 
 | Status | Count |
 |--------|-------|
-| ✅ promote (repo already had it, `Git::Base` delegator added — PR 2d; or alias added) | 26 |
+| ✅ promote (repo already had it, `Git::Base` delegator added — PR 2d; or alias added) | 29 |
 | ⬜ promote (new facade work required) | 1 |
 | ❌ remove (internal plumbing) | 12 |
-| 🔍 human decision | 14 |
+| 🔍 human decision | 11 |
 | **Total orphaned methods** | **56** |
 
 > **Recommendation:** The 24 "trivial wiring" promotions can be handled in PR 5a
-> as a batch. The 4 "new facade" promotions and 16 human-decision items should be
+> as a batch. The 1 "new facade" promotion and 11 human-decision items should be
 > addressed in a companion document (`redesign/c1c2_bucket6_lib_orphans.md`)
 > before PR 5b begins.
 

--- a/redesign/c1c2_bucket6_lib_orphans.md
+++ b/redesign/c1c2_bucket6_lib_orphans.md
@@ -326,6 +326,8 @@ These can be removed in v6 after a full deprecation cycle.
 
 **Decision:** Accepted. Add `global_config(name = nil, value = nil)` to `Git::Repository::Configuring` with three-way dispatch (list/get/set). Add deprecated forwarding methods `global_config_get`, `global_config_list`, `global_config_set` with `Git::Deprecation.warn` calls. Add `Git::Base` delegators for all four. Remove deprecated aliases in v6.
 
+**Implemented in PR 5h-3.** `global_config` facade added to `Git::Repository::Configuring` with three-way dispatch; private helpers `global_config_get/list/set` in the `Private` module; deprecated forwarding methods on the public API; `Git::Base` delegators for all four methods.
+
 ---
 
 ### 3.4 `parse_config(file)`

--- a/spec/integration/git/repository/configuring_spec.rb
+++ b/spec/integration/git/repository/configuring_spec.rb
@@ -45,4 +45,41 @@ RSpec.describe Git::Repository::Configuring, :integration do
       end
     end
   end
+
+  describe '#global_config' do
+    around do |example|
+      with_isolated_global_config { example.run }
+    end
+
+    context 'when called with no arguments' do
+      before do
+        described_instance.global_config('user.name', 'GlobalUser')
+        described_instance.global_config('user.email', 'global@example.com')
+      end
+
+      it 'returns a Hash containing the written global config entries' do
+        result = described_instance.global_config
+        expect(result).to be_a(Hash)
+        expect(result).to include('user.name' => 'GlobalUser', 'user.email' => 'global@example.com')
+      end
+    end
+
+    context 'when called with a name' do
+      before { described_instance.global_config('user.name', 'GlobalUser') }
+
+      it 'returns the String value for the named key from global config' do
+        expect(described_instance.global_config('user.name')).to eq('GlobalUser')
+      end
+    end
+
+    def with_isolated_global_config
+      global_config = File.join(repo_dir, 'global.config')
+      FileUtils.touch(global_config)
+      saved = ENV.fetch('GIT_CONFIG_GLOBAL', nil)
+      ENV['GIT_CONFIG_GLOBAL'] = global_config
+      yield
+    ensure
+      saved.nil? ? ENV.delete('GIT_CONFIG_GLOBAL') : ENV['GIT_CONFIG_GLOBAL'] = saved
+    end
+  end
 end

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -460,4 +460,42 @@ RSpec.describe Git::Base do
       expect(described_instance.stash_list).to eq('stash@{0}: WIP')
     end
   end
+
+  describe '#global_config' do
+    include_context 'with a stubbed facade_repository'
+
+    it 'delegates to facade_repository.global_config with name and value' do
+      expect(facade_repository).to receive(:global_config).with('user.name', 'Alice').and_return(nil)
+      described_instance.global_config('user.name', 'Alice')
+    end
+  end
+
+  describe '#global_config_get' do
+    include_context 'with a stubbed facade_repository'
+
+    it 'delegates to facade_repository.global_config_get with name' do
+      expect(facade_repository).to receive(:global_config_get).with('user.name').and_return('Alice')
+      expect(described_instance.global_config_get('user.name')).to eq('Alice')
+    end
+  end
+
+  describe '#global_config_list' do
+    include_context 'with a stubbed facade_repository'
+
+    it 'delegates to facade_repository.global_config_list' do
+      result = { 'user.name' => 'Alice' }
+      expect(facade_repository).to receive(:global_config_list).and_return(result)
+      expect(described_instance.global_config_list).to eq(result)
+    end
+  end
+
+  describe '#global_config_set' do
+    include_context 'with a stubbed facade_repository'
+
+    it 'delegates to facade_repository.global_config_set with name and value' do
+      set_result = instance_double(Git::CommandLineResult)
+      expect(facade_repository).to receive(:global_config_set).with('user.name', 'Alice').and_return(set_result)
+      expect(described_instance.global_config_set('user.name', 'Alice')).to be(set_result)
+    end
+  end
 end

--- a/spec/unit/git/repository/configuring_spec.rb
+++ b/spec/unit/git/repository/configuring_spec.rb
@@ -135,4 +135,186 @@ RSpec.describe Git::Repository::Configuring do
       end
     end
   end
+
+  describe '#global_config' do
+    context 'when called with no arguments' do
+      subject(:result) { described_instance.global_config }
+
+      let(:list_command) { instance_double(Git::Commands::ConfigOptionSyntax::List) }
+      let(:list_result) { command_result("user.name=Alice\ncore.autocrlf=false") }
+
+      before do
+        allow(Git::Commands::ConfigOptionSyntax::List)
+          .to receive(:new).with(execution_context).and_return(list_command)
+      end
+
+      it 'delegates to Git::Commands::ConfigOptionSyntax::List#call with global: true' do
+        expect(list_command).to receive(:call).with(global: true).and_return(list_result)
+        result
+      end
+
+      it 'returns a Hash of global config entries keyed by dotted name' do
+        allow(list_command).to receive(:call).with(global: true).and_return(list_result)
+        expect(result).to eq({ 'user.name' => 'Alice', 'core.autocrlf' => 'false' })
+      end
+
+      context 'when stdout contains = characters in values' do
+        let(:list_result) { command_result('url.https://github.com/.insteadof=git://github.com/') }
+
+        it 'parses values correctly, treating only the first = as the delimiter' do
+          allow(list_command).to receive(:call).with(global: true).and_return(list_result)
+          expect(result).to eq({ 'url.https://github.com/.insteadof' => 'git://github.com/' })
+        end
+      end
+
+      context 'when a line has no = separator (valueless key)' do
+        let(:list_result) { command_result('core.bare') }
+
+        it 'returns an empty string value' do
+          allow(list_command).to receive(:call).with(global: true).and_return(list_result)
+          expect(result).to eq({ 'core.bare' => '' })
+        end
+      end
+
+      context 'when stdout is empty' do
+        let(:list_result) { command_result('') }
+
+        it 'returns an empty Hash' do
+          allow(list_command).to receive(:call).with(global: true).and_return(list_result)
+          expect(result).to eq({})
+        end
+      end
+    end
+
+    context 'when called with a name only' do
+      subject(:result) { described_instance.global_config('user.name') }
+
+      let(:get_command) { instance_double(Git::Commands::ConfigOptionSyntax::Get) }
+      let(:get_result) { command_result('Alice') }
+
+      before do
+        allow(Git::Commands::ConfigOptionSyntax::Get)
+          .to receive(:new).with(execution_context).and_return(get_command)
+      end
+
+      it 'delegates to Git::Commands::ConfigOptionSyntax::Get#call with name and global: true' do
+        expect(get_command).to receive(:call).with('user.name', global: true).and_return(get_result)
+        result
+      end
+
+      it 'returns the config value as a String' do
+        allow(get_command).to receive(:call).with('user.name', global: true).and_return(get_result)
+        expect(result).to eq('Alice')
+      end
+
+      context 'when the key is not found' do
+        let(:get_result) { command_result('', exitstatus: 1) }
+
+        it 'raises Git::FailedError' do
+          allow(get_command).to receive(:call).with('user.name', global: true).and_return(get_result)
+          expect { result }.to raise_error(Git::FailedError, /git/)
+        end
+      end
+    end
+
+    context 'when called with name and value' do
+      subject(:result) { described_instance.global_config('user.name', 'Alice') }
+
+      let(:set_command) { instance_double(Git::Commands::ConfigOptionSyntax::Set) }
+      let(:set_result) { command_result('') }
+
+      before do
+        allow(Git::Commands::ConfigOptionSyntax::Set)
+          .to receive(:new).with(execution_context).and_return(set_command)
+      end
+
+      it 'delegates to Git::Commands::ConfigOptionSyntax::Set#call with name, value, and global: true' do
+        expect(set_command).to receive(:call).with('user.name', 'Alice', global: true).and_return(set_result)
+        result
+      end
+
+      it 'returns the Git::CommandLineResult from the set command' do
+        allow(set_command).to receive(:call).with('user.name', 'Alice', global: true).and_return(set_result)
+        expect(result).to eq(set_result)
+      end
+
+      context 'when value is false (valid falsy config value)' do
+        subject(:result) { described_instance.global_config('core.bare', false) }
+
+        it 'routes to the set path, not the get path' do
+          expect(set_command).to receive(:call).with('core.bare', false, global: true).and_return(set_result)
+          result
+        end
+      end
+    end
+  end
+
+  describe '#global_config_get' do
+    subject(:result) { described_instance.global_config_get('user.name') }
+
+    let(:get_command) { instance_double(Git::Commands::ConfigOptionSyntax::Get) }
+    let(:get_result) { command_result('Alice') }
+
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+      allow(Git::Commands::ConfigOptionSyntax::Get)
+        .to receive(:new).with(execution_context).and_return(get_command)
+      allow(get_command).to receive(:call).with('user.name', global: true).and_return(get_result)
+    end
+
+    it 'emits a deprecation warning mentioning Git::Repository#global_config_get' do
+      expect(Git::Deprecation).to receive(:warn).with(/Git::Repository#global_config_get/)
+      result
+    end
+
+    it 'delegates to global_config(name) and returns the value' do
+      expect(result).to eq('Alice')
+    end
+  end
+
+  describe '#global_config_list' do
+    subject(:result) { described_instance.global_config_list }
+
+    let(:list_command) { instance_double(Git::Commands::ConfigOptionSyntax::List) }
+    let(:list_result) { command_result('user.name=Alice') }
+
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+      allow(Git::Commands::ConfigOptionSyntax::List)
+        .to receive(:new).with(execution_context).and_return(list_command)
+      allow(list_command).to receive(:call).with(global: true).and_return(list_result)
+    end
+
+    it 'emits a deprecation warning mentioning Git::Repository#global_config_list' do
+      expect(Git::Deprecation).to receive(:warn).with(/Git::Repository#global_config_list/)
+      result
+    end
+
+    it 'delegates to global_config and returns a Hash' do
+      expect(result).to eq({ 'user.name' => 'Alice' })
+    end
+  end
+
+  describe '#global_config_set' do
+    subject(:result) { described_instance.global_config_set('user.name', 'Bob') }
+
+    let(:set_command) { instance_double(Git::Commands::ConfigOptionSyntax::Set) }
+    let(:set_result) { command_result('') }
+
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+      allow(Git::Commands::ConfigOptionSyntax::Set)
+        .to receive(:new).with(execution_context).and_return(set_command)
+      allow(set_command).to receive(:call).with('user.name', 'Bob', global: true).and_return(set_result)
+    end
+
+    it 'emits a deprecation warning mentioning Git::Repository#global_config_set' do
+      expect(Git::Deprecation).to receive(:warn).with(/Git::Repository#global_config_set/)
+      result
+    end
+
+    it 'delegates to global_config(name, value) and returns the result' do
+      expect(result).to eq(set_result)
+    end
+  end
 end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository.

# Description

Implements the `Git::Repository::Configuring#global_config` facade and deprecated
backward-compatibility aliases as specified in `redesign/c1c2_bucket6_lib_orphans.md §3.3`
and the binding constraint in `§4.1` (no `:system`, no `:file` on `global_config`).

## What was changed

**`lib/git/repository/configuring.rb`**

- Added `global_config(name = nil, value = nil)` public facade method with three-way
  dispatch targeting the user's global config (`~/.gitconfig`):
  - No args → returns `Hash{String => String}` of all global config entries
  - One arg → returns `String` value for the named key
  - Two args → writes the value and returns `Git::CommandLineResult`
- Added three private helpers in the `Private` module:
  `global_config_get`, `global_config_list`, `global_config_set` — each passes
  `global: true` to the existing `ConfigOptionSyntax` command classes
- Added three deprecated forwarding methods `global_config_get(name)`,
  `global_config_list`, and `global_config_set(name, value)` that emit
  `Git::Deprecation.warn` and delegate to `global_config`
- Updated the module-level YARD summary to mention `global_config`
- Full three-`@overload` YARD docs on `global_config`

**`lib/git/base.rb`**

- Added `Git::Base` delegators for all four methods: `global_config`,
  `global_config_get`, `global_config_list`, `global_config_set`

**`redesign/c1c2_audit.md`**

- §7.3: Updated the three `global_config_*` rows from `🔍 human decision` to
  `✅ promoted — global_config facade + deprecated aliases in
  Git::Repository::Configuring + Git::Base delegators added (PR 5h-3)`
- §7.5: Decremented the `🔍 human decision` count from 16 to 13

**`redesign/c1c2_bucket6_lib_orphans.md`**

- §3.3: Marked as implemented in PR 5h-3

## Design decisions

- **Narrow signature** (`name = nil, value = nil` only): §4.1 is binding —
  no `:system` option, no `:file` option. Global mode and `--file` are mutually
  exclusive in git itself.
- **Deprecated aliases** delegate to `global_config`, not to `Private` helpers
  directly, so the delegation chain is clear and easy to trace.
- **UPGRADING.md** already contained the needed rows from a prior session; no
  changes were required.

## Test coverage

- **Unit tests** (`spec/unit/git/repository/configuring_spec.rb`):
  - 12 examples for `#global_config` (list/get/set paths, edge cases: `=` in values,
    valueless keys, empty stdout, key-not-found raises `Git::FailedError`)
  - 2 examples each for `#global_config_get`, `#global_config_list`,
    `#global_config_set` (deprecation warning emitted; delegation returns correct value)
- **Unit tests** (`spec/unit/git/base_spec.rb`):
  - 1 example each for the four `Git::Base` delegators (4 total)
- **Integration tests** (`spec/integration/git/repository/configuring_spec.rb`):
  - `global_config` (no args) returns a `Hash` with string keys and values
  - `global_config('user.name')` returns a non-empty `String`

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
