### PR TITLE
feat: add deprecated empty? wrapper on Git::Repository::StatusOperations

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1402,6 +1402,23 @@ module Git
 
     # @!group Bucket 6 delegators — Git::Repository::StatusOperations
 
+    # @return [Boolean] `true` when the repository has no commits, `false` otherwise
+    def no_commits?
+      facade_repository.no_commits?
+    end
+
+    # @deprecated Use {#no_commits?} instead.
+    #
+    # @return [Boolean] `true` when the repository has no commits, `false` otherwise
+    #
+    def empty?
+      Git::Deprecation.warn(
+        'Git::Base#empty? is deprecated and will be removed in a future version. ' \
+        'Use Git::Base#no_commits? instead.'
+      )
+      no_commits?
+    end
+
     # @return [Array<String>] list of untracked file paths
     def untracked_files
       facade_repository.untracked_files

--- a/lib/git/repository/status_operations.rb
+++ b/lib/git/repository/status_operations.rb
@@ -43,6 +43,27 @@ module Git
         true
       end
 
+      # Returns `true` if the repository has no commits yet
+      #
+      # @example Check whether a repository is empty
+      #   repo.empty? #=> true   # freshly initialized, no commits yet
+      #   repo.empty? #=> false  # at least one commit exists
+      #
+      # @return [Boolean] `true` when the repository has no commits, `false` otherwise
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status other
+      #   than when the repository has no commits
+      #
+      # @deprecated Use {#no_commits?} instead
+      #
+      def empty?
+        Git::Deprecation.warn(
+          'Git::Repository#empty? is deprecated and will be removed in a future version. ' \
+          'Use Git::Repository#no_commits? instead.'
+        )
+        no_commits?
+      end
+
       # List all files in the working tree that are not tracked by git
       #
       # Runs `git ls-files --others --exclude-standard` from the working tree

--- a/spec/unit/git/repository/status_operations_spec.rb
+++ b/spec/unit/git/repository/status_operations_spec.rb
@@ -145,6 +145,30 @@ RSpec.describe Git::Repository::StatusOperations do
     end
   end
 
+  describe '#empty?' do
+    subject(:result) { described_instance.empty? }
+
+    before do
+      allow(described_instance).to receive(:no_commits?).and_return(true)
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning matching /empty\? is deprecated/' do
+      expect(Git::Deprecation).to receive(:warn).with(/empty\? is deprecated/)
+      result
+    end
+
+    it 'delegates to no_commits?' do
+      expect(described_instance).to receive(:no_commits?).and_return(true)
+      result
+    end
+
+    it 'returns the return value of no_commits?' do
+      allow(described_instance).to receive(:no_commits?).and_return(false)
+      expect(result).to be(false)
+    end
+  end
+
   describe '#untracked_files' do
     subject(:result) { described_instance.untracked_files }
 


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository.

# Description

Part of Phase C1c-2 of the v5 architectural redesign (`redesign/c1c2_audit.md` §7.2).

`Git::Base` historically had an `empty?` method. In v5 the canonical name is
`no_commits?` on `Git::Repository::StatusOperations`. This PR keeps `empty?` as a
deprecated wrapper that:

1. Emits `Git::Deprecation.warn` with a clear migration message.
2. Delegates to `no_commits?` and returns its value unchanged.

**Changes:**

- `lib/git/repository/status_operations.rb` — add `empty?` deprecated wrapper
  after `no_commits?`, with full YARD docs (`@return`, `@deprecated`, `@example`).
- `lib/git/base.rb` — add the previously-missing `no_commits?` delegator and a
  deprecated `empty?` wrapper, both under the Bucket 6 StatusOperations group.
- `spec/unit/git/repository/status_operations_spec.rb` — add `describe '#empty?'`
  covering: deprecation warning (regex match), delegation to `no_commits?`, and
  return-value passthrough.

No production logic changes; no existing tests modified.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
