### PR TITLE
feat: add deprecated conflicts wrapper on Git::Repository::Merging

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -606,6 +606,15 @@ module Git
       facade_repository.each_conflict(&)
     end
 
+    # @deprecated Use {#each_conflict} instead.
+    def conflicts(&)
+      Git::Deprecation.warn(
+        'Git::Base#conflicts is deprecated and will be removed in a future version. ' \
+        'Use Git::Base#each_conflict instead.'
+      )
+      each_conflict(&)
+    end
+
     def unmerged
       facade_repository.unmerged
     end

--- a/lib/git/repository/merging.rb
+++ b/lib/git/repository/merging.rb
@@ -208,6 +208,49 @@ module Git
         end
       end
 
+      # Iterate over files with merge conflicts, yielding conflict details for each
+      #
+      # For each unmerged file, the staged content for both sides of the conflict
+      # (stage 2 "ours" and stage 3 "theirs") is written to temporary files whose
+      # paths are yielded alongside the file path. The temporary files are deleted
+      # automatically when the block returns.
+      #
+      # @example Inspect conflicting files
+      #   repo.conflicts do |file, your_version, their_version|
+      #     puts "Conflict in #{file}"
+      #     puts File.read(your_version)
+      #     puts File.read(their_version)
+      #   end
+      #
+      # @return [Array<String>] the list of unmerged file paths
+      #
+      # @raise [Git::FailedError] when `git diff --cached` exits outside the
+      #   allowed range (exit code > 2)
+      #
+      # @yield [file, your_version, their_version] passes conflict details for
+      #   each unmerged file
+      #
+      # @yieldparam file [String] path to the conflicting file, relative to the
+      #   working tree
+      #
+      # @yieldparam your_version [String] path to a temporary file containing the
+      #   stage-2 (ours) content for the conflicting file
+      #
+      # @yieldparam their_version [String] path to a temporary file containing the
+      #   stage-3 (theirs) content for the conflicting file
+      #
+      # @yieldreturn [void]
+      #
+      # @deprecated Use {#each_conflict} instead
+      #
+      def conflicts(&)
+        Git::Deprecation.warn(
+          'Git::Repository#conflicts is deprecated and will be removed in a future version. ' \
+          'Use Git::Repository#each_conflict instead.'
+        )
+        each_conflict(&)
+      end
+
       # Option keys accepted by {#revert}
       #
       # Derived from the 4.x option map for `Git::Lib#revert`.

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -452,6 +452,33 @@ RSpec.describe Git::Base do
     end
   end
 
+  describe '#conflicts' do
+    include_context 'with a stubbed facade_repository'
+
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning matching /conflicts is deprecated/' do
+      allow(described_instance).to receive(:each_conflict).and_return([])
+      expect(Git::Deprecation).to receive(:warn).with(/conflicts is deprecated/)
+      described_instance.conflicts
+    end
+
+    it 'delegates to each_conflict, forwarding the block, and returns its return value' do
+      expected_result = ['file.rb']
+      the_block = proc {}
+      captured_block = nil
+      expect(described_instance).to receive(:each_conflict) do |&b|
+        captured_block = b
+        expected_result
+      end
+      result = described_instance.conflicts(&the_block)
+      expect(captured_block).to be(the_block)
+      expect(result).to eq(expected_result)
+    end
+  end
+
   describe '#stash_list' do
     include_context 'with a stubbed facade_repository'
 

--- a/spec/unit/git/repository/merging_spec.rb
+++ b/spec/unit/git/repository/merging_spec.rb
@@ -535,6 +535,35 @@ RSpec.describe Git::Repository::Merging do
   end
 
   # ---------------------------------------------------------------------------
+  # #conflicts (deprecated)
+  # ---------------------------------------------------------------------------
+
+  describe '#conflicts' do
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning matching /conflicts is deprecated/' do
+      allow(described_instance).to receive(:each_conflict).and_return([])
+      expect(Git::Deprecation).to receive(:warn).with(/conflicts is deprecated/)
+      described_instance.conflicts
+    end
+
+    it 'delegates to each_conflict, forwarding the block, and returns its return value' do
+      expected_result = ['file.rb']
+      the_block = proc {}
+      captured_block = nil
+      expect(described_instance).to receive(:each_conflict) do |&b|
+        captured_block = b
+        expected_result
+      end
+      result = described_instance.conflicts(&the_block)
+      expect(captured_block).to be(the_block)
+      expect(result).to eq(expected_result)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # #revert
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# Description

Adds a deprecated `conflicts` wrapper method to `Git::Repository::Merging` (and a
corresponding `Git::Base#conflicts` wrapper) as part of Phase C1c-2 of the v5
architectural redesign.

The historical `Git::Base#conflicts` public API is preserved as a deprecated
forwarding method pointing to the canonical `each_conflict` on
`Git::Repository::Merging`. Both wrappers emit `Git::Deprecation.warn` and
delegate via the local `each_conflict` delegator.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
