### PR TITLE
feat: extend config() with :file option for reads; add deprecated parse_config wrapper

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -259,6 +259,15 @@ module Git
       facade_repository.config_set(name, value, opts)
     end
 
+    # @deprecated Use {#config} with the `:file` option instead.
+    def parse_config(file)
+      Git::Deprecation.warn(
+        'Git::Base#parse_config is deprecated and will be removed in a future version. ' \
+        'Use config(file: <path>) instead.'
+      )
+      config(file: file)
+    end
+
     # Returns a reference to the working directory
     #
     # @example

--- a/lib/git/repository/configuring.rb
+++ b/lib/git/repository/configuring.rb
@@ -22,6 +22,10 @@ module Git
       CONFIG_SET_ALLOWED_OPTS = %i[file].freeze
       private_constant :CONFIG_SET_ALLOWED_OPTS
 
+      # Option keys accepted by {#config} when reading a single value or listing
+      CONFIG_READ_ALLOWED_OPTS = %i[file].freeze
+      private_constant :CONFIG_READ_ALLOWED_OPTS
+
       # Read or write a git configuration entry
       #
       # Dispatches to one of three modes depending on the arguments supplied:
@@ -31,23 +35,44 @@ module Git
       # * **Set** — `config(name, value)` writes a value and returns the raw
       #   command result.
       #
-      # @overload config
+      # @overload config(options = {})
       #
       #   @example List all config entries
       #     repo.config #=> { "user.name" => "Alice", "core.bare" => "false" }
       #
+      #   @example List all entries from a custom config file
+      #     repo.config(file: '/path/to/.gitconfig')
+      #     #=> { "user.name" => "Alice", "core.bare" => "false" }
+      #
+      #   @param options [Hash] options for the list operation
+      #
+      #   @option options [String, nil] :file (nil) path to a custom config file
+      #     to read from instead of the default resolution chain
+      #
       #   @return [Hash{String => String}] all visible config entries, keyed by
       #     their full dotted key names (e.g. `"user.name"`)
       #
-      # @overload config(name)
+      #   @raise [ArgumentError] if unsupported options are provided
+      #
+      # @overload config(name, options = {})
       #
       #   @example Read the committer name from config
       #     repo.config('user.name') #=> "Alice"
       #
+      #   @example Read a value from a custom config file
+      #     repo.config('user.name', file: '/path/to/.gitconfig') #=> "Alice"
+      #
       #   @param name [String] the dotted config key to look up (e.g.
       #     `"user.name"`)
       #
+      #   @param options [Hash] options for the get operation
+      #
+      #   @option options [String, nil] :file (nil) path to a custom config file
+      #     to read from instead of the default resolution chain
+      #
       #   @return [String] the value of the config entry
+      #
+      #   @raise [ArgumentError] if unsupported options are provided
       #
       # @overload config(name, value, options = {})
       #
@@ -62,8 +87,10 @@ module Git
       #
       #   @param value [#to_s] the value to assign; must not be `nil` (a `nil`
       #     value is treated as "no value" and routes to the get overload).
-      #     Any non-nil object is converted to a String via `#to_s` before
-      #     being passed to git
+      #     Must not be a `Hash` (a Hash is treated as the `options` argument;
+      #     call `value.to_s` explicitly before passing if a stringified Hash
+      #     is genuinely needed). Any other non-nil object is converted to a
+      #     String via `#to_s` before being passed to git
       #
       #   @param options [Hash] options for the set operation
       #
@@ -78,12 +105,14 @@ module Git
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
       def config(name = nil, value = nil, options = {})
+        name, value, options = Private.normalize_config_args(name, value, options)
+
         if !name.nil? && !value.nil?
           Private.config_set(@execution_context, name, value, **options)
         elsif name
-          Private.config_get(@execution_context, name)
+          Private.config_get(@execution_context, name, **options)
         else
-          Private.config_list(@execution_context)
+          Private.config_list(@execution_context, **options)
         end
       end
 
@@ -250,12 +279,68 @@ module Git
         config(name, value, opts)
       end
 
+      # Read all entries from an arbitrary git-format config file
+      #
+      # @example Read all entries from a custom config file
+      #   repo.parse_config('/path/to/.gitconfig')
+      #   #=> { "user.name" => "Alice", "core.bare" => "false" }
+      #
+      # @param file [String] path to the git-format config file to read
+      #
+      # @return [Hash{String => String}] all config entries in the file, keyed by
+      #   their full dotted key names (e.g. `"user.name"`)
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @deprecated Use {#config} with the `:file` option instead
+      #
+      def parse_config(file)
+        Git::Deprecation.warn(
+          'Git::Repository#parse_config is deprecated and will be removed in a future version. ' \
+          'Use config(file: <path>) instead.'
+        )
+        config(file: file)
+      end
+
       # Private helpers local to {Git::Repository::Configuring}
       #
       # @api private
       #
       module Private
         module_function
+
+        # Normalize `config()` positional arguments
+        #
+        # In Ruby 3.x, calling `config(file: '/path')` passes the hash as the
+        # first positional argument. This helper re-maps those patterns so that
+        # `name`, `value`, and `options` are always in their canonical positions.
+        #
+        # Raises `ArgumentError` for call shapes that are ambiguous or clearly
+        # wrong, such as passing extra positional arguments after an options Hash.
+        #
+        # @param name [String, Hash, nil] the raw first argument to {#config}
+        #
+        # @param value [Object, Hash, nil] the raw second argument to {#config}
+        #
+        # @param options [Hash] the raw third argument to {#config}
+        #
+        # @return [Array(String|nil, Object|nil, Hash)] normalized [name, value, options]
+        #
+        # @raise [ArgumentError] if extra positional arguments follow an options Hash
+        #
+        def normalize_config_args(name, value, options)
+          if name.is_a?(Hash)
+            raise ArgumentError, 'unexpected positional arguments after options hash' if !value.nil? || !options.empty?
+
+            [nil, nil, name]
+          elsif value.is_a?(Hash)
+            raise ArgumentError, 'unexpected third argument when second argument is options hash' unless options.empty?
+
+            [name, nil, value]
+          else
+            [name, value, options]
+          end
+        end
 
         # Set a config value by key name
         #
@@ -290,12 +375,20 @@ module Git
         #
         # @param name [String] the dotted config key to look up (e.g. `"user.name"`)
         #
+        # @param options [Hash] keyword options
+        #
+        # @option options [String, nil] :file (nil) path to a custom config file to read from
+        #
         # @return [String] the value of the config entry
+        #
+        # @raise [ArgumentError] if unsupported options are provided
         #
         # @raise [Git::FailedError] if git exits with a non-zero exit status
         #
-        def config_get(execution_context, name)
-          result = Git::Commands::ConfigOptionSyntax::Get.new(execution_context).call(name)
+        def config_get(execution_context, name, **options)
+          SharedPrivate.assert_valid_opts!(CONFIG_READ_ALLOWED_OPTS, **options)
+          opts = options[:file] ? { file: options[:file] } : {}
+          result = Git::Commands::ConfigOptionSyntax::Get.new(execution_context).call(name, **opts)
           raise Git::FailedError, result if result.status.exitstatus != 0
 
           result.stdout
@@ -305,13 +398,21 @@ module Git
         #
         # @param execution_context [Git::ExecutionContext] the execution context
         #
+        # @param options [Hash] keyword options
+        #
+        # @option options [String, nil] :file (nil) path to a custom config file to read from
+        #
         # @return [Hash{String => String}] all config entries, keyed by their full
         #   dotted key names (e.g. `"user.name"`)
         #
+        # @raise [ArgumentError] if unsupported options are provided
+        #
         # @raise [Git::FailedError] if git exits with a non-zero exit status
         #
-        def config_list(execution_context)
-          lines = Git::Commands::ConfigOptionSyntax::List.new(execution_context).call.stdout.split("\n")
+        def config_list(execution_context, **options)
+          SharedPrivate.assert_valid_opts!(CONFIG_READ_ALLOWED_OPTS, **options)
+          opts = options[:file] ? { file: options[:file] } : {}
+          lines = Git::Commands::ConfigOptionSyntax::List.new(execution_context).call(**opts).stdout.split("\n")
           lines.each_with_object({}) do |line, hsh|
             key, value = line.split('=', 2)
             hsh[key] = value || ''

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -526,6 +526,29 @@ RSpec.describe Git::Base do
     end
   end
 
+  describe '#parse_config' do
+    subject(:result) { described_instance.parse_config('/path/to/config') }
+
+    include_context 'with a stubbed facade_repository'
+
+    let(:expected_hash) { { 'user.name' => 'Alice' } }
+
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+      allow(described_instance).to receive(:config).with(file: '/path/to/config').and_return(expected_hash)
+    end
+
+    it 'emits a deprecation warning matching /parse_config is deprecated/' do
+      expect(Git::Deprecation).to receive(:warn).with(/parse_config is deprecated/)
+      result
+    end
+
+    it 'calls config with file: argument forwarded and returns its return value' do
+      expect(described_instance).to receive(:config).with(file: '/path/to/config').and_return(expected_hash)
+      expect(result).to eq(expected_hash)
+    end
+  end
+
   describe '#global_config_get' do
     include_context 'with a stubbed facade_repository'
 

--- a/spec/unit/git/repository/configuring_spec.rb
+++ b/spec/unit/git/repository/configuring_spec.rb
@@ -56,6 +56,14 @@ RSpec.describe Git::Repository::Configuring do
           expect(result).to eq({})
         end
       end
+
+      context 'with an unknown option' do
+        subject(:result) { described_instance.config(bogus: true) }
+
+        it 'raises ArgumentError' do
+          expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+        end
+      end
     end
 
     context 'when called with a name only' do
@@ -85,6 +93,14 @@ RSpec.describe Git::Repository::Configuring do
         it 'raises Git::FailedError' do
           allow(get_command).to receive(:call).with('user.name').and_return(get_result)
           expect { result }.to raise_error(Git::FailedError, /git/)
+        end
+      end
+
+      context 'with an unknown option' do
+        subject(:result) { described_instance.config('user.name', bogus: true) }
+
+        it 'raises ArgumentError' do
+          expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
         end
       end
     end
@@ -140,6 +156,68 @@ RSpec.describe Git::Repository::Configuring do
         it 'routes to the set path, not the get path' do
           expect(set_command).to receive(:call).with('core.bare', false).and_return(set_result)
           result
+        end
+      end
+    end
+
+    context 'when called with no arguments and file: option' do
+      subject(:result) { described_instance.config(file: '/path/to/config') }
+
+      let(:list_command) { instance_double(Git::Commands::ConfigOptionSyntax::List) }
+      let(:list_result) { command_result("user.name=Alice\ncore.bare=false") }
+
+      before do
+        allow(Git::Commands::ConfigOptionSyntax::List)
+          .to receive(:new).with(execution_context).and_return(list_command)
+      end
+
+      it 'delegates to Git::Commands::ConfigOptionSyntax::List#call with file: option' do
+        expect(list_command).to receive(:call).with(file: '/path/to/config').and_return(list_result)
+        result
+      end
+
+      it 'returns a Hash of config entries from the file' do
+        allow(list_command).to receive(:call).with(file: '/path/to/config').and_return(list_result)
+        expect(result).to eq({ 'user.name' => 'Alice', 'core.bare' => 'false' })
+      end
+    end
+
+    context 'when called with a name only and file: option' do
+      subject(:result) { described_instance.config('user.name', file: '/path/to/config') }
+
+      let(:get_command) { instance_double(Git::Commands::ConfigOptionSyntax::Get) }
+      let(:get_result) { command_result('Alice') }
+
+      before do
+        allow(Git::Commands::ConfigOptionSyntax::Get)
+          .to receive(:new).with(execution_context).and_return(get_command)
+      end
+
+      it 'delegates to Git::Commands::ConfigOptionSyntax::Get#call with name and file: option' do
+        expect(get_command).to receive(:call).with('user.name', file: '/path/to/config').and_return(get_result)
+        result
+      end
+
+      it 'returns the config value as a String' do
+        allow(get_command).to receive(:call).with('user.name', file: '/path/to/config').and_return(get_result)
+        expect(result).to eq('Alice')
+      end
+    end
+
+    context 'when called with ambiguous positional arguments' do
+      context 'when options Hash is first argument and extra positional args are present' do
+        subject(:result) { described_instance.config({ file: '/path' }, 'extra') }
+
+        it 'raises ArgumentError' do
+          expect { result }.to raise_error(ArgumentError, /unexpected/)
+        end
+      end
+
+      context 'when second argument is a Hash and third argument is non-empty' do
+        subject(:result) { described_instance.config('user.name', { file: '/path' }, { bogus: true }) }
+
+        it 'raises ArgumentError' do
+          expect { result }.to raise_error(ArgumentError, /unexpected/)
         end
       end
     end
@@ -407,6 +485,27 @@ RSpec.describe Git::Repository::Configuring do
         expect(set_command).to receive(:call).with('core.bare', false).and_return(set_result)
         result
       end
+    end
+  end
+
+  describe '#parse_config' do
+    subject(:result) { described_instance.parse_config('/path/to/config') }
+
+    let(:expected_hash) { { 'user.name' => 'Alice' } }
+
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+      allow(described_instance).to receive(:config).with(file: '/path/to/config').and_return(expected_hash)
+    end
+
+    it 'emits a deprecation warning matching /parse_config is deprecated/' do
+      expect(Git::Deprecation).to receive(:warn).with(/parse_config is deprecated/)
+      result
+    end
+
+    it 'calls config with file: argument forwarded and returns its return value' do
+      expect(described_instance).to receive(:config).with(file: '/path/to/config').and_return(expected_hash)
+      expect(result).to eq(expected_hash)
     end
   end
 end


### PR DESCRIPTION
# Description

Extends `Git::Repository::Configuring#config()` (and `Git::Base#config()`) to
accept a `:file` option in the **get** and **list** overloads, matching the
existing `:file` support already present in the **set** overload.

Also adds a deprecated `parse_config(file)` method to both `Git::Repository::Configuring`
and `Git::Base` that forwards to `config(file: path)`, providing a migration bridge
from `Git::Lib#parse_config`.

This is the final item in Phase C1c-2 (`redesign/c1c2_bucket6_lib_orphans.md` §3.4).

## What changed

### `lib/git/repository/configuring.rb`

- `Private.normalize_config_args` — new private helper that fixes a Ruby 3.x
  positional-hash edge case: calling `config(file: '/path')` passes the hash as
  the first positional argument; this helper normalises the three patterns back to
  canonical `[name, value, options]`.
- `config()` — delegates normalization, then passes `file: options[:file]` to the
  get and list dispatch branches.
- `Private.config_get` — now accepts `file:` keyword and forwards it to
  `ConfigOptionSyntax::Get#call`.
- `Private.config_list` — now accepts `file:` keyword and forwards it to
  `ConfigOptionSyntax::List#call`.
- `parse_config(file)` — new deprecated facade method; emits a `Git::Deprecation`
  warning and calls `config(file: file)`.
- YARD updated: `config()` list and get overloads now document `@param options`
  and `@option :file`; `parse_config` documented with `@example`, `@param`,
  `@return`, `@raise`, and `@deprecated` in correct tag order.

### `lib/git/base.rb`

- `parse_config(file)` — new deprecated wrapper; emits deprecation warning, calls
  the local `config` delegator (not `facade_repository` directly).

### `spec/unit/git/repository/configuring_spec.rb`

- Two new `context` blocks inside `describe '#config'`:
  - `'when called with no arguments and file: option'`
  - `'when called with a name only and file: option'`
- New `describe '#parse_config'` block covering the deprecation warning and
  delegation to `config(file:)`.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).