### PR TITLE
feat: rename facade methods to {noun}_{verb} convention; keep old names as deprecated aliases

### DIFF
--- a/.github/skills/extract-facade-from-base-lib/SKILL.md
+++ b/.github/skills/extract-facade-from-base-lib/SKILL.md
@@ -425,15 +425,13 @@ end
 
 ```ruby
 # lib/git/base.rb
-def add_remote(name, url, opts = {})
-  repository.add_remote(name, url, opts)
+def remote_add(name, url, opts = {})
+  facade_repository.remote_add(name, url, opts)
 end
 ```
 
-(The exact accessor — `repository`, `@repository`, `self.repository` — depends
-on how `Git::Base` and `Git::Lib` hold their reference to the new
-`Git::Repository` instance during the migration window. Match the existing
-pattern used by other migrated methods.)
+(Use `facade_repository` to access the `Git::Repository` facade instance — this
+is the accessor used by all migrated methods in `Git::Base`.)
 
 After delegation is in place, verify:
 

--- a/README.md
+++ b/README.md
@@ -416,8 +416,8 @@ repo.merge([branch1, branch2])
 
 repo.merge_base('branch1', 'branch2')
 
-r = repo.add_remote(name, uri)  # Git::Remote
-r = repo.add_remote(name, Git::Base)  # Git::Remote
+r = repo.remote_add(name, uri)  # Git::Remote
+r = repo.remote_add(name, other_repo)  # Git::Remote (other_repo is a Git::Base instance)
 
 repo.remotes  # array of Git::Remotes
 repo.remote(name).fetch
@@ -437,12 +437,12 @@ repo.fetch('origin', {:'update-head-ok' => true})
 repo.pull
 repo.pull(Git::Repo, Git::Branch) # fetch and a merge
 
-repo.add_tag('tag_name') # returns Git::Tag
-repo.add_tag('tag_name', 'object_reference')
-repo.add_tag('tag_name', 'object_reference', {:options => 'here'})
-repo.add_tag('tag_name', {:options => 'here'})
+repo.tag_add('tag_name') # returns Git::Object::Tag
+repo.tag_add('tag_name', 'object_reference')
+repo.tag_add('tag_name', 'object_reference', {:options => 'here'})
+repo.tag_add('tag_name', {:options => 'here'})
 
-repo.delete_tag('tag_name')
+repo.tag_delete('tag_name')
 
 repo.repack
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -130,5 +130,10 @@ are removed in v6.0.0.
 | `g.global_config_set(name, value)` | `g.global_config(name, value)` |
 | `g.parse_config(file)` | `g.config(file: file)` |
 | `g.stash_list` | `g.stashes_all` |
+| `g.add_remote(name, url, opts)` | `g.remote_add(name, url, opts)` |
+| `g.remove_remote(name)` | `g.remote_remove(name)` |
+| `g.set_remote_url(name, url)` | `g.remote_set_url(name, url)` |
+| `g.add_tag(name, ...)` | `g.tag_add(name, ...)` |
+| `g.delete_tag(name)` | `g.tag_delete(name)` |
 
 ---

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -202,15 +202,24 @@ module Git
     # adds a new remote to this repository
     # url can be a git url or a Git::Base object if it's a local reference
     #
-    #  @git.add_remote('scotts_git', 'git://repo.or.cz/rubygit.git')
+    #  @git.remote_add('scotts_git', 'git://repo.or.cz/rubygit.git')
     #  @git.fetch('scotts_git')
     #  @git.merge('scotts_git/master')
     #
     # Options:
     #   :fetch => true
     #   :track => <branch_name>
+    def remote_add(name, url, opts = {})
+      facade_repository.remote_add(name, url, opts)
+    end
+
+    # @deprecated Use {#remote_add} instead.
     def add_remote(name, url, opts = {})
-      facade_repository.add_remote(name, url, opts)
+      Git::Deprecation.warn(
+        'Git::Base#add_remote is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Base#remote_add instead.'
+      )
+      remote_add(name, url, opts)
     end
 
     # Changes the current working directory to the git working directory for the
@@ -676,10 +685,19 @@ module Git
     # sets the url for a remote
     # url can be a git url or a Git::Base object if it's a local reference
     #
-    #  @git.set_remote_url('scotts_git', 'git://repo.or.cz/rubygit.git')
+    #  @git.remote_set_url('scotts_git', 'git://repo.or.cz/rubygit.git')
     #
+    def remote_set_url(name, url)
+      facade_repository.remote_set_url(name, url)
+    end
+
+    # @deprecated Use {#remote_set_url} instead.
     def set_remote_url(name, url)
-      facade_repository.set_remote_url(name, url)
+      Git::Deprecation.warn(
+        'Git::Base#set_remote_url is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Base#remote_set_url instead.'
+      )
+      remote_set_url(name, url)
     end
 
     # Configures which branches are fetched for a remote
@@ -716,9 +734,18 @@ module Git
 
     # removes a remote from this repository
     #
-    # @git.remove_remote('scott_git')
+    # @git.remote_remove('scott_git')
+    def remote_remove(name)
+      facade_repository.remote_remove(name)
+    end
+
+    # @deprecated Use {#remote_remove} instead.
     def remove_remote(name)
-      facade_repository.remove_remote(name)
+      Git::Deprecation.warn(
+        'Git::Base#remove_remote is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Base#remote_remove instead.'
+      )
+      remote_remove(name)
     end
 
     # returns an array of all Git::Object::Tag objects for this repository
@@ -729,9 +756,9 @@ module Git
     # Create a new git tag
     #
     # @example
-    #   repo.add_tag('tag_name', object_reference)
-    #   repo.add_tag('tag_name', object_reference, {:options => 'here'})
-    #   repo.add_tag('tag_name', {:options => 'here'})
+    #   repo.tag_add('tag_name', object_reference)
+    #   repo.tag_add('tag_name', object_reference, {:options => 'here'})
+    #   repo.tag_add('tag_name', {:options => 'here'})
     #
     # @param [String] name The name of the tag to add
     # @param [Hash] options Options to pass to `git tag`.
@@ -739,21 +766,39 @@ module Git
     # @option options [Boolean, nil] :annotate (nil) make an unsigned, annotated tag object
     # @option options [Boolean, nil] :a (nil) an alias for the `:annotate` option
     # @option options [Boolean, nil] :d (nil) delete existing tag with the given name —
-    #   deprecated; use {#delete_tag} instead (alias: `:delete`)
+    #   deprecated; use {#tag_delete} instead (alias: `:delete`)
     # @option options [Boolean, nil] :delete (nil) delete existing tag with the given name —
-    #   deprecated; use {#delete_tag} instead (alias: `:d`)
+    #   deprecated; use {#tag_delete} instead (alias: `:d`)
     # @option options [Boolean, nil] :f (nil) replace an existing tag with the given name (instead of failing)
     # @option options [String] :message Use the given tag message
     # @option options [String] :m An alias for the `:message` option
     # @option options [Boolean, nil] :s (nil) make a GPG-signed tag
     #
+    def tag_add(name, *options)
+      facade_repository.tag_add(name, *options)
+    end
+
+    # @deprecated Use {#tag_add} instead.
     def add_tag(name, *options)
-      facade_repository.add_tag(name, *options)
+      Git::Deprecation.warn(
+        'Git::Base#add_tag is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Base#tag_add instead.'
+      )
+      tag_add(name, *options)
     end
 
     # deletes a tag
+    def tag_delete(name)
+      facade_repository.tag_delete(name)
+    end
+
+    # @deprecated Use {#tag_delete} instead.
     def delete_tag(name)
-      facade_repository.delete_tag(name)
+      Git::Deprecation.warn(
+        'Git::Base#delete_tag is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Base#tag_delete instead.'
+      )
+      tag_delete(name)
     end
 
     # Creates an archive of the given tree-ish and writes it to a file

--- a/lib/git/remote.rb
+++ b/lib/git/remote.rb
@@ -119,7 +119,7 @@ module Git
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
     def remove
-      remote_repository.remove_remote(@name)
+      remote_repository.remote_remove(@name)
     end
 
     # Returns the name of this remote as a string

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -754,11 +754,11 @@ module Git
       end
 
       # Option keys accepted by {#tag_add}
-      ADD_TAG_ALLOWED_OPTS = %i[
+      TAG_ADD_ALLOWED_OPTS = %i[
         annotate a sign s no_sign local_user u force f message m file F
         edit e no_edit trailer cleanup create_reflog
       ].freeze
-      private_constant :ADD_TAG_ALLOWED_OPTS
+      private_constant :TAG_ADD_ALLOWED_OPTS
 
       # Create a new tag
       #
@@ -883,7 +883,7 @@ module Git
         return Private.tag_add_delete_deprecated(self, name, target, opts) if opts[:d] || opts[:delete]
 
         opts = opts.except(:d, :delete)
-        SharedPrivate.assert_valid_opts!(ADD_TAG_ALLOWED_OPTS, **opts)
+        SharedPrivate.assert_valid_opts!(TAG_ADD_ALLOWED_OPTS, **opts)
         Private.validate_tag_options!(opts)
         Git::Commands::Tag::Create.new(@execution_context).call(name, target, **opts)
         tag(name)

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -845,7 +845,7 @@ module Git
       #
       #   @return [Git::Object::Tag] the newly created tag
       #
-      # @overload tag_add(name, options = { d: true })
+      # @overload tag_add(name, delete_options)
       #
       #   @deprecated Use {#tag_delete} instead.
       #
@@ -854,13 +854,9 @@ module Git
       #
       #   @param name [String] the name of the tag to delete
       #
-      #   @param options [Hash] deletion options (only `:d` / `:delete` accepted)
-      #
-      #   @option options [Boolean, nil] :d (nil) delete the named tag
-      #     (alias: `:delete`); deprecated — use {#tag_delete} instead
-      #
-      #   @option options [Boolean, nil] :delete (nil) delete the named tag
-      #     (alias: `:d`); deprecated — use {#tag_delete} instead
+      #   @param delete_options [{ d: true }, { delete: true }] deletion options;
+      #     only `:d` or `:delete` (set to `true`) is accepted — no other keys
+      #     and no `target` argument may be combined with this form
       #
       #   @return [String] git's stdout from the delete
       #
@@ -876,16 +872,16 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
-      def tag_add(name, *options)
-        opts = options.last.is_a?(Hash) ? options.pop : {}
-        target = options.first
+      def tag_add(name, *args)
+        options = args.last.is_a?(Hash) ? args.pop : {}
+        target = args.first
 
-        return Private.tag_add_delete_deprecated(self, name, target, opts) if opts[:d] || opts[:delete]
+        return Private.tag_add_delete_deprecated(self, name, target, options) if options[:d] || options[:delete]
 
-        opts = opts.except(:d, :delete)
-        SharedPrivate.assert_valid_opts!(TAG_ADD_ALLOWED_OPTS, **opts)
-        Private.validate_tag_options!(opts)
-        Git::Commands::Tag::Create.new(@execution_context).call(name, target, **opts)
+        options = options.except(:d, :delete)
+        SharedPrivate.assert_valid_opts!(TAG_ADD_ALLOWED_OPTS, **options)
+        Private.validate_tag_options!(options)
+        Git::Commands::Tag::Create.new(@execution_context).call(name, target, **options)
         tag(name)
       end
 

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -753,7 +753,7 @@ module Git
         Git::Parsers::Tag.parse_list(result.stdout).map { |info| tag(info.name) }
       end
 
-      # Option keys accepted by {#add_tag}
+      # Option keys accepted by {#tag_add}
       ADD_TAG_ALLOWED_OPTS = %i[
         annotate a sign s no_sign local_user u force f message m file F
         edit e no_edit trailer cleanup create_reflog
@@ -762,16 +762,16 @@ module Git
 
       # Create a new tag
       #
-      # @overload add_tag(name, options = {})
+      # @overload tag_add(name, options = {})
       #
       #   @example Create a lightweight tag on HEAD
-      #     repo.add_tag('v1.0.0')
+      #     repo.tag_add('v1.0.0')
       #
       #   @example Create an annotated tag on HEAD
-      #     repo.add_tag('v1.0.0', annotate: true, message: 'Release 1.0.0')
+      #     repo.tag_add('v1.0.0', annotate: true, message: 'Release 1.0.0')
       #
       #   @example Replace an existing tag on HEAD
-      #     repo.add_tag('v1.0.0', force: true)
+      #     repo.tag_add('v1.0.0', force: true)
       #
       #   @param name [String] the name of the tag to create
       #
@@ -828,13 +828,13 @@ module Git
       #
       #   @return [Git::Object::Tag] the newly created tag
       #
-      # @overload add_tag(name, target, options = {})
+      # @overload tag_add(name, target, options = {})
       #
       #   @example Create a lightweight tag on a specific commit
-      #     repo.add_tag('v1.0.0', 'abc123')
+      #     repo.tag_add('v1.0.0', 'abc123')
       #
       #   @example Create an annotated tag on a specific commit
-      #     repo.add_tag('v1.0.0', 'abc123', annotate: true, message: 'Release 1.0.0')
+      #     repo.tag_add('v1.0.0', 'abc123', annotate: true, message: 'Release 1.0.0')
       #
       #   @param name [String] the name of the tag to create
       #
@@ -845,20 +845,22 @@ module Git
       #
       #   @return [Git::Object::Tag] the newly created tag
       #
-      # @overload add_tag(name, delete: true)
+      # @overload tag_add(name, options = { d: true })
       #
-      #   @deprecated Use {#delete_tag} instead.
+      #   @deprecated Use {#tag_delete} instead.
       #
       #   @example Delete a tag (deprecated)
-      #     repo.add_tag('v1.0.0', d: true)
+      #     repo.tag_add('v1.0.0', d: true)
       #
       #   @param name [String] the name of the tag to delete
       #
+      #   @param options [Hash] deletion options (only `:d` / `:delete` accepted)
+      #
       #   @option options [Boolean, nil] :d (nil) delete the named tag
-      #     (alias: `:delete`); deprecated — use {#delete_tag} instead
+      #     (alias: `:delete`); deprecated — use {#tag_delete} instead
       #
       #   @option options [Boolean, nil] :delete (nil) delete the named tag
-      #     (alias: `:d`); deprecated — use {#delete_tag} instead
+      #     (alias: `:d`); deprecated — use {#tag_delete} instead
       #
       #   @return [String] git's stdout from the delete
       #
@@ -874,11 +876,11 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
-      def add_tag(name, *options)
+      def tag_add(name, *options)
         opts = options.last.is_a?(Hash) ? options.pop : {}
         target = options.first
 
-        return Private.add_tag_delete_deprecated(self, name, target, opts) if opts[:d] || opts[:delete]
+        return Private.tag_add_delete_deprecated(self, name, target, opts) if opts[:d] || opts[:delete]
 
         opts = opts.except(:d, :delete)
         SharedPrivate.assert_valid_opts!(ADD_TAG_ALLOWED_OPTS, **opts)
@@ -887,10 +889,60 @@ module Git
         tag(name)
       end
 
+      # @deprecated Use {#tag_add} instead.
+      #
+      # @overload add_tag(name, options = {})
+      #
+      #   @param name [String] the name of the tag to create
+      #
+      #   @param options [Hash] options for creating the tag
+      #
+      #   @return [Git::Object::Tag] the newly created tag
+      #
+      # @overload add_tag(name, target, options = {})
+      #
+      #   @param name [String] the name of the tag to create
+      #
+      #   @param target [String] the object to tag (commit SHA, branch name, etc.)
+      #
+      #   @param options [Hash] options for creating the tag
+      #
+      #   @return [Git::Object::Tag] the newly created tag
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [ArgumentError] if an annotated or signed tag is requested without
+      #   a message
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def add_tag(name, *options)
+        Git::Deprecation.warn(
+          'Git::Repository#add_tag is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#tag_add instead.'
+        )
+        tag_add(name, *options)
+      end
+
       # Delete a tag
       #
       # @example Delete a tag
-      #   repo.delete_tag('v1.0.0')
+      #   repo.tag_delete('v1.0.0')
+      #
+      # @param name [String] the name of the tag to delete
+      #
+      # @return [String] git's stdout from the delete
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def tag_delete(name)
+        result = Git::Commands::Tag::Delete.new(@execution_context).call(name)
+        raise Git::FailedError, result if result.status.exitstatus.positive?
+
+        result.stdout
+      end
+
+      # @deprecated Use {#tag_delete} instead.
       #
       # @param name [String] the name of the tag to delete
       #
@@ -899,10 +951,11 @@ module Git
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
       def delete_tag(name)
-        result = Git::Commands::Tag::Delete.new(@execution_context).call(name)
-        raise Git::FailedError, result if result.status.exitstatus.positive?
-
-        result.stdout
+        Git::Deprecation.warn(
+          'Git::Repository#delete_tag is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#tag_delete instead.'
+        )
+        tag_delete(name)
       end
 
       # Private helpers
@@ -931,9 +984,9 @@ module Git
           raise ArgumentError, 'Cannot create an annotated or signed tag without a message.'
         end
 
-        # Handle the deprecated :d/:delete option on add_tag
+        # Handle the deprecated :d/:delete option on tag_add
         #
-        # Issues a deprecation warning and delegates to delete_tag. Raises
+        # Issues a deprecation warning and delegates to tag_delete. Raises
         # ArgumentError if a target or incompatible options are also supplied.
         #
         # @param facade [ObjectOperations] the calling facade instance
@@ -941,21 +994,21 @@ module Git
         # @param target [String, nil] target argument (must be nil)
         # @param opts [Hash] options hash (must contain only :d/:delete)
         #
-        # @return [String] stdout from delete_tag
+        # @return [String] stdout from tag_delete
         #
         # @api private
         #
-        def add_tag_delete_deprecated(facade, name, target, opts)
+        def tag_add_delete_deprecated(facade, name, target, opts)
           Git::Deprecation.warn(
-            'Passing :d or :delete to add_tag is deprecated and will be ' \
-            'removed in a future version. Use delete_tag instead.'
+            'Passing :d or :delete to tag_add is deprecated and will be removed in v6.0.0. ' \
+            'Use tag_delete instead.'
           )
           raise ArgumentError, 'Cannot pass a target when using the :d/:delete option.' if target
 
           extra = opts.keys - %i[d delete]
           raise ArgumentError, "Cannot combine :d/:delete with other options: #{extra.join(', ')}" unless extra.empty?
 
-          facade.delete_tag(name)
+          facade.tag_delete(name)
         end
 
         def show_ref_tag_sha(execution_context, tag_name)

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -374,8 +374,8 @@ module Git
       # Option keys accepted by {#remote_add}
       #
       # Derived from the 4.x `REMOTE_ADD_OPTION_MAP` in `Git::Lib`.
-      ADD_REMOTE_ALLOWED_OPTS = %i[fetch track].freeze
-      private_constant :ADD_REMOTE_ALLOWED_OPTS
+      REMOTE_ADD_ALLOWED_OPTS = %i[fetch track].freeze
+      private_constant :REMOTE_ADD_ALLOWED_OPTS
 
       # Register a new remote in the local repository
       #
@@ -418,7 +418,7 @@ module Git
       def remote_add(name, url, opts = {})
         url = url.repo.to_s if url.is_a?(Git::Base)
         opts = Private.normalize_add_remote_keys(opts)
-        SharedPrivate.assert_valid_opts!(ADD_REMOTE_ALLOWED_OPTS, **opts)
+        SharedPrivate.assert_valid_opts!(REMOTE_ADD_ALLOWED_OPTS, **opts)
         Git::Commands::Remote::Add.new(@execution_context).call(name, url, **opts)
 
         Git::Remote.new(self, name)

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -18,7 +18,7 @@ module Git
     #
     # @api public
     #
-    module RemoteOperations
+    module RemoteOperations # rubocop:disable Metrics/ModuleLength
       # Key normalizations for {#fetch} options
       #
       # Maps dash-style option keys (which the 4.x `Git::Lib#fetch` accepted)
@@ -371,7 +371,7 @@ module Git
         Private.push_tags(@execution_context, remote, opts).stdout
       end
 
-      # Option keys accepted by {#add_remote}
+      # Option keys accepted by {#remote_add}
       #
       # Derived from the 4.x `REMOTE_ADD_OPTION_MAP` in `Git::Lib`.
       ADD_REMOTE_ALLOWED_OPTS = %i[fetch track].freeze
@@ -383,13 +383,48 @@ module Git
       # configures which branches are tracked.
       #
       # @example Add a remote
-      #   repo.add_remote('upstream', 'https://github.com/user/repo.git')
+      #   repo.remote_add('upstream', 'https://github.com/user/repo.git')
       #
       # @example Add a remote and fetch immediately
-      #   repo.add_remote('upstream', 'https://github.com/user/repo.git', fetch: true)
+      #   repo.remote_add('upstream', 'https://github.com/user/repo.git', fetch: true)
       #
       # @example Add a remote tracking a specific branch
-      #   repo.add_remote('upstream', 'https://github.com/user/repo.git', track: 'main')
+      #   repo.remote_add('upstream', 'https://github.com/user/repo.git', track: 'main')
+      #
+      # @param name [String] the name for the new remote
+      #
+      # @param url [String, Git::Base] the URL of the remote repository
+      #
+      #   A {Git::Base} instance is accepted for local references and converted
+      #   to `url.repo.to_s`.
+      #
+      # @param opts [Hash] options for adding the remote
+      #
+      # @option opts [Boolean, nil] :fetch (nil) fetch from the remote immediately
+      #   after adding it (`-f`)
+      #
+      #   The deprecated alias `:with_fetch` is accepted and normalized
+      #   automatically.
+      #
+      # @option opts [String, nil] :track (nil) track only the given branch during
+      #   fetch (`-t`)
+      #
+      # @return [Git::Remote] the newly added remote
+      #
+      # @raise [ArgumentError] when unsupported option keys are provided
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero status
+      #
+      def remote_add(name, url, opts = {})
+        url = url.repo.to_s if url.is_a?(Git::Base)
+        opts = Private.normalize_add_remote_keys(opts)
+        SharedPrivate.assert_valid_opts!(ADD_REMOTE_ALLOWED_OPTS, **opts)
+        Git::Commands::Remote::Add.new(@execution_context).call(name, url, **opts)
+
+        Git::Remote.new(self, name)
+      end
+
+      # @deprecated Use {#remote_add} instead.
       #
       # @param name [String] the name for the new remote
       #
@@ -416,12 +451,11 @@ module Git
       # @raise [Git::FailedError] when git exits with a non-zero status
       #
       def add_remote(name, url, opts = {})
-        url = url.repo.to_s if url.is_a?(Git::Base)
-        opts = Private.normalize_add_remote_keys(opts)
-        SharedPrivate.assert_valid_opts!(ADD_REMOTE_ALLOWED_OPTS, **opts)
-        Git::Commands::Remote::Add.new(@execution_context).call(name, url, **opts)
-
-        Git::Remote.new(self, name)
+        Git::Deprecation.warn(
+          'Git::Repository#add_remote is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#remote_add instead.'
+        )
+        remote_add(name, url, opts)
       end
 
       # Removes a remote from this repository
@@ -430,7 +464,19 @@ module Git
       # tracking references, and remote-tracking branches.
       #
       # @example Remove a remote named 'upstream'
-      #   repo.remove_remote('upstream')
+      #   repo.remote_remove('upstream')
+      #
+      # @param name [String] the name of the remote to remove
+      #
+      # @return [Git::CommandLineResult] the result of calling `git remote remove`
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero status
+      #
+      def remote_remove(name)
+        Git::Commands::Remote::Remove.new(@execution_context).call(name)
+      end
+
+      # @deprecated Use {#remote_remove} instead.
       #
       # @param name [String] the name of the remote to remove
       #
@@ -439,7 +485,11 @@ module Git
       # @raise [Git::FailedError] when git exits with a non-zero status
       #
       def remove_remote(name)
-        Git::Commands::Remote::Remove.new(@execution_context).call(name)
+        Git::Deprecation.warn(
+          'Git::Repository#remove_remote is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#remote_remove instead.'
+        )
+        remote_remove(name)
       end
 
       # Sets the URL for an existing remote
@@ -447,11 +497,31 @@ module Git
       # Replaces the fetch URL configured for the remote named `name`.
       #
       # @example Set the URL for a remote
-      #   repo.set_remote_url('origin', 'https://github.com/user/repo.git')
+      #   repo.remote_set_url('origin', 'https://github.com/user/repo.git')
       #
       # @example Set the URL from a local repository reference
       #   source = Git.open('/path/to/source')
-      #   repo.set_remote_url('origin', source)
+      #   repo.remote_set_url('origin', source)
+      #
+      # @param name [String] the name of the remote to update
+      #
+      # @param url [String, Git::Base] the new URL for the remote
+      #
+      #   A {Git::Base} instance is accepted for local references and converted
+      #   to `url.repo.to_s`.
+      #
+      # @return [Git::Remote] the updated remote
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero status
+      #
+      def remote_set_url(name, url)
+        url = url.repo.to_s if url.is_a?(Git::Base)
+        Git::Commands::Remote::SetUrl.new(@execution_context).call(name, url)
+
+        Git::Remote.new(self, name)
+      end
+
+      # @deprecated Use {#remote_set_url} instead.
       #
       # @param name [String] the name of the remote to update
       #
@@ -465,10 +535,11 @@ module Git
       # @raise [Git::FailedError] when git exits with a non-zero status
       #
       def set_remote_url(name, url)
-        url = url.repo.to_s if url.is_a?(Git::Base)
-        Git::Commands::Remote::SetUrl.new(@execution_context).call(name, url)
-
-        Git::Remote.new(self, name)
+        Git::Deprecation.warn(
+          'Git::Repository#set_remote_url is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#remote_set_url instead.'
+        )
+        remote_set_url(name, url)
       end
 
       # Configures which branches are fetched for a remote
@@ -825,7 +896,7 @@ module Git
           Git::Commands::Push.new(execution_context).call(*[remote].compact, **opts)
         end
 
-        # Normalize deprecated {#add_remote} option keys to their canonical equivalents
+        # Normalize deprecated option keys for {#remote_add} to their canonical equivalents
         #
         # Renames the deprecated `:with_fetch` key to `:fetch`, removing it from
         # the copy. When both keys are present, `:with_fetch` takes precedence.

--- a/spec/integration/git/base/misc_delegators_spec.rb
+++ b/spec/integration/git/base/misc_delegators_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Base, :integration do
 
   describe '#config_remote' do
     before do
-      repo.add_remote('origin', 'https://github.com/example/repo.git')
+      repo.remote_add('origin', 'https://github.com/example/repo.git')
     end
 
     it 'returns a Hash with remote configuration' do

--- a/spec/integration/git/base/object_operations_delegators_spec.rb
+++ b/spec/integration/git/base/object_operations_delegators_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Git::Base, :integration do
   end
 
   describe '#cat_file_tag' do
-    before { repo.add_tag('v1.0.0', annotate: true, message: 'release') }
+    before { repo.tag_add('v1.0.0', annotate: true, message: 'release') }
 
     it 'returns a hash with tag metadata' do
       result = repo.cat_file_tag('v1.0.0')
@@ -66,7 +66,7 @@ RSpec.describe Git::Base, :integration do
   end
 
   describe '#tag_sha' do
-    before { repo.add_tag('v1.0.0') }
+    before { repo.tag_add('v1.0.0') }
 
     it 'returns a non-empty SHA string' do
       expect(repo.tag_sha('v1.0.0').chomp).to match(/\A[0-9a-f]{40}\z/)

--- a/spec/integration/git/branch_spec.rb
+++ b/spec/integration/git/branch_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Git::Branch, :integration do
     repo.commit('Initial commit')
 
     Git.init(bare_dir, bare: true)
-    repo.add_remote('origin', bare_dir)
+    repo.remote_add('origin', bare_dir)
     repo.branch('feature').create
     repo.push('origin', 'feature')
   end

--- a/spec/integration/git/branches_spec.rb
+++ b/spec/integration/git/branches_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe Git::Branches, :integration do
 
         before do
           Git.init(bare_dir, bare: true)
-          repo.add_remote('origin', bare_dir)
+          repo.remote_add('origin', bare_dir)
           repo.push('origin', 'main')
         end
 
@@ -96,7 +96,7 @@ RSpec.describe Git::Branches, :integration do
 
         before do
           Git.init(bare_dir, bare: true)
-          repo.add_remote('origin', bare_dir)
+          repo.remote_add('origin', bare_dir)
           repo.push('origin', 'main')
         end
 

--- a/spec/integration/git/commands/branch/set_upstream_spec.rb
+++ b/spec/integration/git/commands/branch/set_upstream_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Git::Commands::Branch::SetUpstream, :integration do
       repo.commit('Initial commit')
 
       Git.init(bare_dir, bare: true)
-      repo.add_remote('origin', bare_dir)
+      repo.remote_add('origin', bare_dir)
       repo.push('origin', 'main')
     end
 

--- a/spec/integration/git/commands/branch/unset_upstream_spec.rb
+++ b/spec/integration/git/commands/branch/unset_upstream_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Git::Commands::Branch::UnsetUpstream, :integration do
       repo.commit('Initial commit')
 
       Git.init(bare_dir, bare: true)
-      repo.add_remote('origin', bare_dir)
+      repo.remote_add('origin', bare_dir)
       repo.push('origin', 'main')
       execution_context.command_capturing('branch', '--set-upstream-to=origin/main', 'main')
     end

--- a/spec/integration/git/commands/describe_spec.rb
+++ b/spec/integration/git/commands/describe_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Git::Commands::Describe, :integration do
     write_file('file.txt', 'content')
     repo.add('file.txt')
     repo.commit('Initial commit')
-    repo.add_tag('v1.0.0')
+    repo.tag_add('v1.0.0')
   end
 
   describe '#call' do

--- a/spec/integration/git/commands/diff_spec.rb
+++ b/spec/integration/git/commands/diff_spec.rb
@@ -59,13 +59,13 @@ RSpec.describe Git::Commands::Diff, :integration do
         File.write(File.join(@check_repo_dir, 'file.txt'), "clean content\n")
         check_repo.add('file.txt')
         check_repo.commit('Initial commit')
-        check_repo.add_tag('check_clean')
+        check_repo.tag_add('check_clean')
 
         # Commit that introduces trailing whitespace
         File.write(File.join(@check_repo_dir, 'file.txt'), "trailing whitespace   \n")
         check_repo.add('file.txt')
         check_repo.commit('Add trailing whitespace')
-        check_repo.add_tag('check_dirty')
+        check_repo.tag_add('check_dirty')
 
         @check_command = described_class.new(check_repo.lib)
       end

--- a/spec/integration/git/commands/fetch_spec.rb
+++ b/spec/integration/git/commands/fetch_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Git::Commands::Fetch, :integration do
       repo.commit('Initial commit')
 
       Git.init(bare_dir, bare: true)
-      repo.add_remote('origin', bare_dir)
+      repo.remote_add('origin', bare_dir)
       repo.push('origin', 'main')
     end
 

--- a/spec/integration/git/commands/ls_remote_spec.rb
+++ b/spec/integration/git/commands/ls_remote_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Git::Commands::LsRemote, :integration do
     repo.commit('Initial commit')
 
     Git.init(bare_dir, bare: true, initial_branch: 'main')
-    repo.add_remote('origin', bare_dir)
+    repo.remote_add('origin', bare_dir)
     repo.push('origin', 'main')
   end
 

--- a/spec/integration/git/commands/name_rev_spec.rb
+++ b/spec/integration/git/commands/name_rev_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Git::Commands::NameRev, :integration do
       end
 
       it 'resolves using only tags when :tags is given' do
-        repo.add_tag('v1.0')
+        repo.tag_add('v1.0')
 
         result = command.call('HEAD', tags: true)
 

--- a/spec/integration/git/commands/pull_spec.rb
+++ b/spec/integration/git/commands/pull_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Git::Commands::Pull, :integration do
       repo.commit('Initial commit')
 
       Git.init(bare_dir, bare: true, initial_branch: 'main')
-      repo.add_remote('origin', bare_dir)
+      repo.remote_add('origin', bare_dir)
       repo.push('origin', 'main')
 
       # Create a second clone, add a commit, and push to the bare remote

--- a/spec/integration/git/commands/push_spec.rb
+++ b/spec/integration/git/commands/push_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Git::Commands::Push, :integration do
       repo.commit('Initial commit')
 
       Git.init(bare_dir, bare: true)
-      repo.add_remote('origin', bare_dir)
+      repo.remote_add('origin', bare_dir)
     end
 
     context 'when the command succeeds' do

--- a/spec/integration/git/commands/remote/get_url_spec.rb
+++ b/spec/integration/git/commands/remote/get_url_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Git::Commands::Remote::GetUrl, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       it 'returns the remote url' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
 
         result = command.call('origin')
 

--- a/spec/integration/git/commands/remote/list_spec.rb
+++ b/spec/integration/git/commands/remote/list_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Git::Commands::Remote::List, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       it 'lists configured remotes' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
 
         result = command.call
 

--- a/spec/integration/git/commands/remote/prune_spec.rb
+++ b/spec/integration/git/commands/remote/prune_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Git::Commands::Remote::Prune, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       it 'supports dry-run pruning for a configured remote' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
 
         result = command.call('origin', dry_run: true)
 
@@ -34,7 +34,7 @@ RSpec.describe Git::Commands::Remote::Prune, :integration do
       end
 
       it 'prunes stale tracking refs for a configured remote' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
         repo.fetch('origin')
 
         result = command.call('origin')

--- a/spec/integration/git/commands/remote/remove_spec.rb
+++ b/spec/integration/git/commands/remote/remove_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Git::Commands::Remote::Remove, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       it 'removes a configured remote' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
 
         result = command.call('origin')
 

--- a/spec/integration/git/commands/remote/rename_spec.rb
+++ b/spec/integration/git/commands/remote/rename_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Git::Commands::Remote::Rename, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       it 'renames a configured remote' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
 
         result = command.call('origin', 'upstream')
 

--- a/spec/integration/git/commands/remote/set_branches_spec.rb
+++ b/spec/integration/git/commands/remote/set_branches_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Git::Commands::Remote::SetBranches, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       it 'returns a CommandLineResult when setting fetch branches' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
 
         result = command.call('origin', 'feature/*')
 
@@ -31,7 +31,7 @@ RSpec.describe Git::Commands::Remote::SetBranches, :integration do
       end
 
       it 'returns a CommandLineResult with :add option' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
         command.call('origin', 'main')
 
         result = command.call('origin', 'release/*', add: true)

--- a/spec/integration/git/commands/remote/set_head_spec.rb
+++ b/spec/integration/git/commands/remote/set_head_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Git::Commands::Remote::SetHead, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       it 'sets the remote HEAD to an explicit branch' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
         repo.fetch('origin')
 
         result = command.call('origin', initial_branch)
@@ -35,7 +35,7 @@ RSpec.describe Git::Commands::Remote::SetHead, :integration do
       end
 
       it 'auto-detects the remote HEAD with :auto' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
         repo.fetch('origin')
 
         result = command.call('origin', auto: true)
@@ -44,7 +44,7 @@ RSpec.describe Git::Commands::Remote::SetHead, :integration do
       end
 
       it 'deletes the remote HEAD when :delete is given' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
         repo.fetch('origin')
         command.call('origin', initial_branch)
 

--- a/spec/integration/git/commands/remote/set_url_add_spec.rb
+++ b/spec/integration/git/commands/remote/set_url_add_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Git::Commands::Remote::SetUrlAdd, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       it 'adds an additional fetch url' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
 
         result = command.call('origin', extra_repo.dir.to_s)
 
@@ -39,7 +39,7 @@ RSpec.describe Git::Commands::Remote::SetUrlAdd, :integration do
       end
 
       it 'adds a push url when :push is given' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
 
         result = command.call('origin', extra_repo.dir.to_s, push: true)
 

--- a/spec/integration/git/commands/remote/set_url_delete_spec.rb
+++ b/spec/integration/git/commands/remote/set_url_delete_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Git::Commands::Remote::SetUrlDelete, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       it 'deletes matching fetch urls' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
         execution_context.command_capturing('remote', 'set-url', '--add', 'origin', extra_repo.dir.to_s,
                                             raise_on_failure: false)
 
@@ -41,7 +41,7 @@ RSpec.describe Git::Commands::Remote::SetUrlDelete, :integration do
       end
 
       it 'deletes a push url when :push is given' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
         execution_context.command_capturing('remote', 'set-url', '--add', '--push', 'origin', extra_repo.dir.to_s,
                                             raise_on_failure: false)
 

--- a/spec/integration/git/commands/remote/set_url_spec.rb
+++ b/spec/integration/git/commands/remote/set_url_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Git::Commands::Remote::SetUrl, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       it 'replaces the configured remote url' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
 
         result = command.call('origin', replacement_repo.dir.to_s)
 
@@ -40,7 +40,7 @@ RSpec.describe Git::Commands::Remote::SetUrl, :integration do
       end
 
       it 'returns a CommandLineResult with :push option' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
 
         result = command.call('origin', replacement_repo.dir.to_s, push: true)
 

--- a/spec/integration/git/commands/remote/show_spec.rb
+++ b/spec/integration/git/commands/remote/show_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Git::Commands::Remote::Show, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       it 'shows information about the remote' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
 
         result = command.call('origin', n: true)
 

--- a/spec/integration/git/commands/remote/update_spec.rb
+++ b/spec/integration/git/commands/remote/update_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Git::Commands::Remote::Update, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       it 'fetches updates for the named remote' do
-        repo.add_remote('origin', remote_repo.dir.to_s)
+        repo.remote_add('origin', remote_repo.dir.to_s)
 
         result = command.call('origin')
 

--- a/spec/integration/git/commands/show_ref/list_spec.rb
+++ b/spec/integration/git/commands/show_ref/list_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Git::Commands::ShowRef::List, :integration do
     write_file('file.txt', "content\n")
     repo.add('.')
     repo.commit('Initial commit')
-    repo.add_tag('v1.0')
+    repo.tag_add('v1.0')
   end
 
   describe '#call' do
@@ -61,7 +61,7 @@ RSpec.describe Git::Commands::ShowRef::List, :integration do
       end
 
       it 'returns exit status 0 with the :dereference option' do
-        repo.add_tag('v1.0-annotated', annotate: true, message: 'annotation')
+        repo.tag_add('v1.0-annotated', annotate: true, message: 'annotation')
 
         result = command.call(dereference: true)
 

--- a/spec/integration/git/commands/tag/delete_spec.rb
+++ b/spec/integration/git/commands/tag/delete_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::Tag::Delete, :integration do
       write_file('file.txt', 'content')
       repo.add('file.txt')
       repo.commit('Initial commit')
-      repo.add_tag('v1.0.0')
+      repo.tag_add('v1.0.0')
     end
 
     context 'when the command succeeds' do
@@ -31,7 +31,7 @@ RSpec.describe Git::Commands::Tag::Delete, :integration do
       end
 
       it 'returns exit code 1 for partial failure' do
-        repo.add_tag('v2.0.0')
+        repo.tag_add('v2.0.0')
 
         result = command.call('v1.0.0', 'nonexistent', 'v2.0.0')
 

--- a/spec/integration/git/commands/tag/list_spec.rb
+++ b/spec/integration/git/commands/tag/list_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Commands::Tag::List, :integration do
         write_file('file.txt', 'content')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.add_tag('v1.0.0')
+        repo.tag_add('v1.0.0')
 
         result = command.call
 

--- a/spec/integration/git/commands/tag/verify_spec.rb
+++ b/spec/integration/git/commands/tag/verify_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Git::Commands::Tag::Verify, :integration do
 
       it 'verifies a signed tag successfully' do
         # This would need:
-        # repo.add_tag('v3.0.0', sign: true, message: 'Signed release')
+        # repo.tag_add('v3.0.0', sign: true, message: 'Signed release')
         # result = command.call('v3.0.0')
         # expect(result.stdout).to include('Good signature')
       end
@@ -33,13 +33,13 @@ RSpec.describe Git::Commands::Tag::Verify, :integration do
 
     describe 'when the command fails' do
       it 'raises FailedError for an unsigned lightweight tag' do
-        repo.add_tag('v1.0.0')
+        repo.tag_add('v1.0.0')
 
         expect { command.call('v1.0.0') }.to raise_error(Git::FailedError)
       end
 
       it 'raises FailedError for an unsigned annotated tag' do
-        repo.add_tag('v2.0.0', annotate: true, message: 'Release version 2.0.0')
+        repo.tag_add('v2.0.0', annotate: true, message: 'Release version 2.0.0')
 
         expect { command.call('v2.0.0') }.to raise_error(Git::FailedError)
       end
@@ -49,14 +49,14 @@ RSpec.describe Git::Commands::Tag::Verify, :integration do
       end
 
       it 'raises FailedError when any tag is unsigned' do
-        repo.add_tag('v1.0.0')
-        repo.add_tag('v2.0.0', annotate: true, message: 'Release 2.0')
+        repo.tag_add('v1.0.0')
+        repo.tag_add('v2.0.0', annotate: true, message: 'Release 2.0')
 
         expect { command.call('v1.0.0', 'v2.0.0') }.to raise_error(Git::FailedError)
       end
 
       it 'raises FailedError with format option on unsigned tag' do
-        repo.add_tag('v1.0.0')
+        repo.tag_add('v1.0.0')
 
         # Format option is still passed through even when verification fails
         expect { command.call('v1.0.0', format: '%(refname:short)') }.to raise_error(Git::FailedError)

--- a/spec/integration/git/parsers/branch_spec.rb
+++ b/spec/integration/git/parsers/branch_spec.rb
@@ -152,7 +152,7 @@ RSpec.describe Git::Parsers::Branch, :integration do
         repo.commit('Initial commit')
 
         Git.init(bare_dir, bare: true)
-        repo.add_remote('origin', bare_dir)
+        repo.remote_add('origin', bare_dir)
         repo.push('origin', 'main')
         repo.lib.command_capturing('branch', '-u', 'origin/main', 'main')
       end
@@ -175,7 +175,7 @@ RSpec.describe Git::Parsers::Branch, :integration do
         write_file('file.txt')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.add_tag('v1.0.0')
+        repo.tag_add('v1.0.0')
         write_file('file2.txt')
         repo.add('file2.txt')
         repo.commit('Second commit')

--- a/spec/integration/git/parsers/fsck_spec.rb
+++ b/spec/integration/git/parsers/fsck_spec.rb
@@ -108,7 +108,7 @@ git commit --allow-empty -m "Another root" >/dev/null 2>&1`
         write_file('file.txt', 'content')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.add_tag('v1.0.0', annotate: true, message: 'Version 1.0.0')
+        repo.tag_add('v1.0.0', annotate: true, message: 'Version 1.0.0')
       end
 
       it 'reports tagged objects' do
@@ -177,7 +177,7 @@ git commit --allow-empty -m "Another root" >/dev/null 2>&1`
         write_file('file.txt', 'content')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.add_tag('v1.0.0', annotate: true, message: 'Version 1.0.0')
+        repo.tag_add('v1.0.0', annotate: true, message: 'Version 1.0.0')
       end
 
       it 'matches TAGGED_PATTERN for tagged lines' do

--- a/spec/integration/git/parsers/tag_spec.rb
+++ b/spec/integration/git/parsers/tag_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Git::Parsers::Tag, :integration do
         write_file('file.txt', 'content')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.add_tag('v1.0.0')
+        repo.tag_add('v1.0.0')
       end
 
       it 'returns tag with populated metadata' do
@@ -74,7 +74,7 @@ RSpec.describe Git::Parsers::Tag, :integration do
         write_file('file.txt', 'content')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.add_tag('v2.0.0', annotate: true, message: 'Release version 2.0.0')
+        repo.tag_add('v2.0.0', annotate: true, message: 'Release version 2.0.0')
       end
 
       it 'returns tag with populated metadata' do
@@ -113,8 +113,8 @@ RSpec.describe Git::Parsers::Tag, :integration do
         write_file('file.txt', 'content')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.add_tag('v1.0.0', annotate: true, message: multiline_message)
-        repo.add_tag('v1.1.0', annotate: true, message: 'Simple message')
+        repo.tag_add('v1.0.0', annotate: true, message: multiline_message)
+        repo.tag_add('v1.1.0', annotate: true, message: 'Simple message')
       end
 
       it 'captures full multi-line message' do
@@ -146,17 +146,17 @@ RSpec.describe Git::Parsers::Tag, :integration do
         write_file('file1.txt', 'content1')
         repo.add('file1.txt')
         repo.commit('First commit')
-        repo.add_tag('v1.0.0')
+        repo.tag_add('v1.0.0')
 
         write_file('file2.txt', 'content2')
         repo.add('file2.txt')
         repo.commit('Second commit')
-        repo.add_tag('v1.1.0', annotate: true, message: 'Version 1.1.0')
+        repo.tag_add('v1.1.0', annotate: true, message: 'Version 1.1.0')
 
         write_file('file3.txt', 'content3')
         repo.add('file3.txt')
         repo.commit('Third commit')
-        repo.add_tag('v2.0.0')
+        repo.tag_add('v2.0.0')
       end
 
       it 'returns all tags' do
@@ -184,8 +184,8 @@ RSpec.describe Git::Parsers::Tag, :integration do
         write_file('file.txt', 'content')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.add_tag('release/v1.0')
-        repo.add_tag('feature-branch-tag')
+        repo.tag_add('release/v1.0')
+        repo.tag_add('feature-branch-tag')
       end
 
       it 'handles tags with slashes' do
@@ -218,7 +218,7 @@ RSpec.describe Git::Parsers::Tag, :integration do
       write_file('file.txt', 'content')
       repo.add('file.txt')
       repo.commit('Initial commit')
-      repo.add_tag('v1.0.0', annotate: true, message: 'Release v1.0.0')
+      repo.tag_add('v1.0.0', annotate: true, message: 'Release v1.0.0')
     end
 
     it 'uses unit separator (0x1F) as field delimiter' do

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -128,7 +128,7 @@ RSpec.describe Git::Repository::Branching, :integration do
 
       before do
         Git.init(bare_dir, bare: true)
-        repo.add_remote('origin', bare_dir)
+        repo.remote_add('origin', bare_dir)
         repo.push('origin', 'main')
       end
 
@@ -162,7 +162,7 @@ RSpec.describe Git::Repository::Branching, :integration do
 
       before do
         Git.init(bare_dir, bare: true)
-        repo.add_remote('origin', bare_dir)
+        repo.remote_add('origin', bare_dir)
         repo.push('origin', 'main')
         # Push a second branch to the remote, then delete it locally so it only
         # exists as a remote-tracking branch
@@ -183,7 +183,7 @@ RSpec.describe Git::Repository::Branching, :integration do
 
       before do
         Git.init(bare_dir, bare: true)
-        repo.add_remote('origin', bare_dir)
+        repo.remote_add('origin', bare_dir)
         repo.push('origin', 'main')
       end
 
@@ -411,7 +411,7 @@ RSpec.describe Git::Repository::Branching, :integration do
 
       before do
         Git.init(bare_dir, bare: true)
-        repo.add_remote('origin', bare_dir)
+        repo.remote_add('origin', bare_dir)
         repo.push('origin', 'main')
       end
 

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -187,7 +187,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
   describe '#cat_file_tag' do
     before do
-      repo.add_tag('v1.0', annotate: true, message: 'Release v1.0')
+      repo.tag_add('v1.0', annotate: true, message: 'Release v1.0')
     end
 
     context 'with a valid annotated tag' do
@@ -238,7 +238,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
     context 'with an annotated tag whose message is empty' do
       before do
-        repo.add_tag('v2.0', annotate: true, message: '')
+        repo.tag_add('v2.0', annotate: true, message: '')
       end
 
       it 'returns a Hash without raising NoMethodError' do
@@ -290,7 +290,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
   describe '#tag_sha' do
     context 'when the tag exists' do
       before do
-        repo.add_tag('v1.0')
+        repo.tag_add('v1.0')
       end
 
       it 'returns the SHA of the tagged commit as a String' do
@@ -741,8 +741,8 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
     context 'when the repository has tags' do
       before do
-        described_instance.add_tag('v1.0.0')
-        described_instance.add_tag('v2.0.0', annotate: true, message: 'Release 2.0.0')
+        described_instance.tag_add('v1.0.0')
+        described_instance.tag_add('v2.0.0', annotate: true, message: 'Release 2.0.0')
       end
 
       it 'returns a Git::Object::Tag for every tag' do
@@ -755,10 +755,10 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     end
   end
 
-  describe '#add_tag' do
+  describe '#tag_add' do
     context 'with no target and no options' do
       it 'creates a lightweight tag on HEAD' do
-        tag = described_instance.add_tag('v1.0.0')
+        tag = described_instance.tag_add('v1.0.0')
         expect(tag).to be_a(Git::Object::Tag)
         expect(tag.name).to eq('v1.0.0')
         expect(tag.annotated?).to be(false)
@@ -768,14 +768,14 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     context 'with a target commit' do
       it 'creates the tag pointing at the given commit' do
         head_sha = described_instance.rev_parse('HEAD')
-        tag = described_instance.add_tag('v1.0.0', head_sha)
+        tag = described_instance.tag_add('v1.0.0', head_sha)
         expect(tag.objectish).to eq(head_sha)
       end
     end
 
     context 'with annotate and a message' do
       it 'creates an annotated tag carrying the message' do
-        tag = described_instance.add_tag('v1.0.0', annotate: true, message: 'Release 1.0.0')
+        tag = described_instance.tag_add('v1.0.0', annotate: true, message: 'Release 1.0.0')
         expect(tag.annotated?).to be(true)
         expect(tag.message).to eq('Release 1.0.0')
       end
@@ -786,33 +786,33 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     # :force) are pure-Ruby or command concerns with no added end-to-end signal;
     # they are covered by the unit spec and command integration specs.
     context 'when the tag already exists' do
-      before { described_instance.add_tag('v1.0.0') }
+      before { described_instance.tag_add('v1.0.0') }
 
       it 'replaces the existing tag when force is given' do
-        replaced = described_instance.add_tag('v1.0.0', force: true, annotate: true, message: 'replaced')
+        replaced = described_instance.tag_add('v1.0.0', force: true, annotate: true, message: 'replaced')
         expect(replaced.annotated?).to be(true)
         expect(replaced.message).to eq('replaced')
       end
     end
   end
 
-  describe '#delete_tag' do
+  describe '#tag_delete' do
     context 'when the tag exists' do
-      before { described_instance.add_tag('v1.0.0') }
+      before { described_instance.tag_add('v1.0.0') }
 
       it 'removes the tag' do
-        described_instance.delete_tag('v1.0.0')
+        described_instance.tag_delete('v1.0.0')
         expect(described_instance.tags.map(&:name)).not_to include('v1.0.0')
       end
 
       it 'returns git stdout confirming the deletion' do
-        expect(described_instance.delete_tag('v1.0.0')).to match(/Deleted tag 'v1.0.0'/)
+        expect(described_instance.tag_delete('v1.0.0')).to match(/Deleted tag 'v1.0.0'/)
       end
     end
 
     context 'when the tag does not exist' do
       it 'raises Git::FailedError naming the failed delete command' do
-        expect { described_instance.delete_tag('does-not-exist') }
+        expect { described_instance.tag_delete('does-not-exist') }
           .to raise_error(Git::FailedError, /does-not-exist/)
       end
     end

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
     repo.commit('Initial commit')
 
     Git.init(bare_dir, bare: true)
-    repo.add_remote('origin', bare_dir)
+    repo.remote_add('origin', bare_dir)
     repo.push('origin', 'main')
   end
 
@@ -92,7 +92,7 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
 
     context 'with tags: true' do
       before do
-        repo.add_tag('v1.0')
+        repo.tag_add('v1.0')
       end
 
       it 'pushes refs and tags and returns a String' do
@@ -129,10 +129,10 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   end
 
   # ---------------------------------------------------------------------------
-  # #add_remote — basic invocations
+  # #remote_add — basic invocations
   # ---------------------------------------------------------------------------
 
-  describe '#add_remote' do
+  describe '#remote_add' do
     let(:remote_dir) { Dir.mktmpdir('remote_repo') }
 
     after do
@@ -144,59 +144,59 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
     end
 
     it 'returns Git::Remote' do
-      result = described_instance.add_remote('secondary', remote_dir)
+      result = described_instance.remote_add('secondary', remote_dir)
       expect(result).to be_a(Git::Remote)
       expect(result.name).to eq('secondary')
     end
 
     it 'registers the remote so it appears in the repository config' do
-      described_instance.add_remote('secondary', remote_dir)
+      described_instance.remote_add('secondary', remote_dir)
       expect(repo.remotes.map(&:name)).to include('secondary')
     end
 
     context 'with fetch: true' do
       it 'does not raise an error' do
-        expect { described_instance.add_remote('secondary', remote_dir, fetch: true) }.not_to raise_error
+        expect { described_instance.remote_add('secondary', remote_dir, fetch: true) }.not_to raise_error
       end
     end
 
     context 'with track: "main"' do
       it 'does not raise an error' do
-        expect { described_instance.add_remote('secondary', remote_dir, track: 'main') }.not_to raise_error
+        expect { described_instance.remote_add('secondary', remote_dir, track: 'main') }.not_to raise_error
       end
     end
 
     context 'with the deprecated :with_fetch alias' do
       it 'does not raise an error' do
-        expect { described_instance.add_remote('secondary', remote_dir, with_fetch: true) }.not_to raise_error
+        expect { described_instance.remote_add('secondary', remote_dir, with_fetch: true) }.not_to raise_error
       end
     end
 
     context 'with an unknown option key' do
       it 'raises ArgumentError before calling git' do
-        expect { described_instance.add_remote('secondary', remote_dir, unknown_key: true) }
+        expect { described_instance.remote_add('secondary', remote_dir, unknown_key: true) }
           .to raise_error(ArgumentError, /unknown_key/)
       end
     end
   end
 
   # ---------------------------------------------------------------------------
-  # #remove_remote
+  # #remote_remove
   # ---------------------------------------------------------------------------
 
-  describe '#remove_remote' do
+  describe '#remote_remove' do
     it 'removes the named remote' do
-      described_instance.remove_remote('origin')
+      described_instance.remote_remove('origin')
       expect(repo.remotes.map(&:name)).not_to include('origin')
     end
 
     it 'returns a Git::CommandLineResult' do
-      result = described_instance.remove_remote('origin')
+      result = described_instance.remote_remove('origin')
       expect(result).to be_a(Git::CommandLineResult)
     end
 
     it 'raises Git::FailedError when the remote does not exist' do
-      expect { described_instance.remove_remote('nonexistent') }
+      expect { described_instance.remote_remove('nonexistent') }
         .to raise_error(Git::FailedError, /nonexistent/)
     end
   end
@@ -259,12 +259,12 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
     end
 
     it 'includes each configured remote by name' do
-      described_instance.add_remote('upstream', bare_dir)
+      described_instance.remote_add('upstream', bare_dir)
       expect(described_instance.remotes.map(&:name)).to contain_exactly('origin', 'upstream')
     end
 
     context 'when the repository has no remotes' do
-      before { described_instance.remove_remote('origin') }
+      before { described_instance.remote_remove('origin') }
 
       it 'returns an empty array' do
         expect(described_instance.remotes).to eq([])
@@ -273,10 +273,10 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   end
 
   # ---------------------------------------------------------------------------
-  # #set_remote_url
+  # #remote_set_url
   # ---------------------------------------------------------------------------
 
-  describe '#set_remote_url' do
+  describe '#remote_set_url' do
     let(:other_dir) { Dir.mktmpdir('other_repo') }
 
     after { FileUtils.rm_rf(other_dir) }
@@ -284,12 +284,12 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
     before { Git.init(other_dir, bare: true) }
 
     it 'updates the fetch URL for the named remote' do
-      described_instance.set_remote_url('origin', other_dir)
+      described_instance.remote_set_url('origin', other_dir)
       expect(described_instance.config_remote('origin')['url']).to eq(other_dir)
     end
 
     it 'returns a Git::Remote for the updated remote' do
-      result = described_instance.set_remote_url('origin', other_dir)
+      result = described_instance.remote_set_url('origin', other_dir)
       expect(result).to be_a(Git::Remote)
       expect(result.name).to eq('origin')
     end

--- a/spec/support/contexts/diff_test_repository.rb
+++ b/spec/support/contexts/diff_test_repository.rb
@@ -22,13 +22,13 @@ module DiffTestRepositorySetup
     write_file('README.md', "# Project\n\nThis is a test project.\n")
     repo.add('README.md')
     repo.commit('Initial commit')
-    repo.add_tag('initial')
+    repo.tag_add('initial')
 
     # Modify file
     write_file('README.md', "# Project\n\nThis is a test project.\n\n## Installation\n\nRun `bundle install`.\n")
     repo.add('README.md')
     repo.commit('Add installation section')
-    repo.add_tag('after_modify')
+    repo.tag_add('after_modify')
   end
 
   def setup_file_operations
@@ -37,19 +37,19 @@ module DiffTestRepositorySetup
     write_file('docs.md', "# Documentation\n\nThis is a test project.\n\n## Installation\n\nRun `bundle install`.\n")
     repo.add(all: true)
     repo.commit('Rename README to docs')
-    repo.add_tag('after_rename')
+    repo.tag_add('after_rename')
 
     # Delete file
     FileUtils.rm(File.join(repo_dir, 'docs.md'))
     repo.add(all: true)
     repo.commit('Remove docs file')
-    repo.add_tag('after_delete')
+    repo.tag_add('after_delete')
 
     # Add new file
     write_file('lib/main.rb', "# frozen_string_literal: true\n\nmodule Main\n  VERSION = '1.0.0'\nend\n")
     repo.add('lib/main.rb')
     repo.commit('Add main library')
-    repo.add_tag('after_add')
+    repo.tag_add('after_add')
   end
 
   def setup_special_cases
@@ -57,7 +57,7 @@ module DiffTestRepositorySetup
     write_file('image.png', "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01")
     repo.add('image.png')
     repo.commit('Add binary image')
-    repo.add_tag('after_binary')
+    repo.tag_add('after_binary')
 
     # Change file mode (make executable) - skip on Windows where chmod isn't supported
     write_file('bin/run', "#!/usr/bin/env ruby\nputs 'Hello'\n")
@@ -68,26 +68,26 @@ module DiffTestRepositorySetup
       repo.add('bin/run')
       repo.commit('Make run script executable')
     end
-    repo.add_tag('after_mode_change')
+    repo.tag_add('after_mode_change')
 
     # Add file with spaces in path
     write_file('path with spaces/file name.txt', "Content in spaced path\n")
     repo.add(all: true)
     repo.commit('Add file with spaces')
-    repo.add_tag('after_spaces')
+    repo.tag_add('after_spaces')
 
     # Add file with UTF-8 characters (skull ☠ = U+2620)
     write_file('file☠skull.rb', "# frozen_string_literal: true\n\nmodule Skull\nend\n")
     repo.add(all: true)
     repo.commit('Add file with UTF-8 name')
-    repo.add_tag('after_utf8')
+    repo.tag_add('after_utf8')
 
     # Rename UTF-8 file
     FileUtils.mv(File.join(repo_dir, 'file☠skull.rb'), File.join(repo_dir, 'renamed☠skull.rb'))
     write_file('renamed☠skull.rb', "# frozen_string_literal: true\n\nmodule RenamedSkull\nend\n")
     repo.add(all: true)
     repo.commit('Rename UTF-8 file')
-    repo.add_tag('after_utf8_rename')
+    repo.tag_add('after_utf8_rename')
 
     # Add file with tab in name (git escapes as \t)
     setup_tab_filename
@@ -98,8 +98,8 @@ module DiffTestRepositorySetup
     write_file('CHANGELOG.md', "# Changelog\n\n## 1.1.0\n\n- Added helper\n")
     repo.add(all: true)
     repo.commit('Bump version and add helper')
-    repo.add_tag('after_multi')
-    repo.add_tag('main_tip')
+    repo.tag_add('after_multi')
+    repo.tag_add('main_tip')
   end
 
   def setup_tab_filename
@@ -111,7 +111,7 @@ module DiffTestRepositorySetup
       repo.add(all: true)
       repo.commit('Add file with tab in name')
     end
-    repo.add_tag('after_tab_filename')
+    repo.tag_add('after_tab_filename')
   end
 
   def setup_submodule
@@ -125,7 +125,7 @@ module DiffTestRepositorySetup
     sub_repo.commit('Initial submodule commit')
 
     # Add submodule to main repo
-    repo.add_tag('before_submodule')
+    repo.tag_add('before_submodule')
     submodule_path = File.join(repo_dir, 'vendor/submodule')
     Dir.chdir(repo_dir) do
       # Allow file:// protocol for local submodule (needed for newer git versions)
@@ -134,7 +134,7 @@ module DiffTestRepositorySetup
       system('git', 'submodule', 'add', submodule_source, 'vendor/submodule', out: File::NULL, err: File::NULL)
       system('git', 'commit', '-m', 'Add submodule', out: File::NULL, err: File::NULL)
     end
-    repo.add_tag('after_submodule')
+    repo.tag_add('after_submodule')
 
     # Update submodule to new commit (only if submodule was successfully added)
     if Dir.exist?(submodule_path)
@@ -149,7 +149,7 @@ module DiffTestRepositorySetup
         system('git', 'commit', '-m', 'Update submodule pointer', out: File::NULL, err: File::NULL)
       end
     end
-    repo.add_tag('after_submodule_update')
+    repo.tag_add('after_submodule_update')
   end
 
   def setup_feature_branch
@@ -160,7 +160,7 @@ module DiffTestRepositorySetup
     write_file('lib/feature.rb', "# frozen_string_literal: true\n\nmodule Feature\nend\n")
     repo.add('lib/feature.rb')
     repo.commit('Add feature module')
-    repo.add_tag('feature_tip')
+    repo.tag_add('feature_tip')
 
     # Return to main
     repo.checkout('main')

--- a/spec/unit/git/remote_spec.rb
+++ b/spec/unit/git/remote_spec.rb
@@ -88,13 +88,13 @@ RSpec.describe Git::Remote do
 
     let(:remove_result) { command_result('') }
 
-    it 'delegates to remote_repository.remove_remote with the remote name' do
-      expect(base).to receive(:remove_remote).with('origin').and_return(remove_result)
+    it 'delegates to remote_repository.remote_remove with the remote name' do
+      expect(base).to receive(:remote_remove).with('origin').and_return(remove_result)
       result
     end
 
-    it 'returns the result of remove_remote' do
-      allow(base).to receive(:remove_remote).with('origin').and_return(remove_result)
+    it 'returns the result of remote_remove' do
+      allow(base).to receive(:remote_remove).with('origin').and_return(remove_result)
       expect(result).to be(remove_result)
     end
   end

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -1302,7 +1302,7 @@ RSpec.describe Git::Repository::ObjectOperations do
     end
   end
 
-  describe '#add_tag' do
+  describe '#tag_add' do
     let(:create_command) { instance_double(Git::Commands::Tag::Create) }
     let(:command_result) { instance_double(Git::CommandLineResult) }
     let(:tag_object) { instance_double(Git::Object::Tag) }
@@ -1315,24 +1315,24 @@ RSpec.describe Git::Repository::ObjectOperations do
 
     it 'constructs Git::Commands::Tag::Create with the execution context' do
       expect(Git::Commands::Tag::Create).to receive(:new).with(execution_context).and_return(create_command)
-      described_instance.add_tag('v1.0.0')
+      described_instance.tag_add('v1.0.0')
     end
 
     it 'returns the Git::Object::Tag for the created tag' do
-      expect(described_instance.add_tag('v1.0.0')).to be(tag_object)
+      expect(described_instance.tag_add('v1.0.0')).to be(tag_object)
     end
 
     context 'with no target and no options' do
       it 'calls the create command with a nil commit and no options' do
         expect(create_command).to receive(:call).with('v1.0.0', nil).and_return(command_result)
-        described_instance.add_tag('v1.0.0')
+        described_instance.tag_add('v1.0.0')
       end
     end
 
     context 'with a target commit' do
       it 'forwards the target as the commit operand' do
         expect(create_command).to receive(:call).with('v1.0.0', 'abc123').and_return(command_result)
-        described_instance.add_tag('v1.0.0', 'abc123')
+        described_instance.tag_add('v1.0.0', 'abc123')
       end
     end
 
@@ -1340,7 +1340,7 @@ RSpec.describe Git::Repository::ObjectOperations do
       it 'forwards the options and a nil commit' do
         expect(create_command).to receive(:call)
           .with('v1.0.0', nil, annotate: true, message: 'hi').and_return(command_result)
-        described_instance.add_tag('v1.0.0', annotate: true, message: 'hi')
+        described_instance.tag_add('v1.0.0', annotate: true, message: 'hi')
       end
     end
 
@@ -1348,7 +1348,7 @@ RSpec.describe Git::Repository::ObjectOperations do
       it 'forwards the target and options' do
         expect(create_command).to receive(:call)
           .with('v1.0.0', 'abc123', force: true).and_return(command_result)
-        described_instance.add_tag('v1.0.0', 'abc123', force: true)
+        described_instance.tag_add('v1.0.0', 'abc123', force: true)
       end
     end
 
@@ -1356,14 +1356,14 @@ RSpec.describe Git::Repository::ObjectOperations do
       it 'accepts the trailing hash as options' do
         expect(create_command).to receive(:call)
           .with('v1.0.0', nil, force: true).and_return(command_result)
-        described_instance.add_tag('v1.0.0', { force: true })
+        described_instance.tag_add('v1.0.0', { force: true })
       end
     end
 
     context 'when an unknown option is provided' do
       it 'raises ArgumentError without calling git' do
         expect(Git::Commands::Tag::Create).not_to receive(:new)
-        expect { described_instance.add_tag('v1.0.0', bogus: true) }
+        expect { described_instance.tag_add('v1.0.0', bogus: true) }
           .to raise_error(ArgumentError, /Unknown options: bogus/)
       end
     end
@@ -1371,7 +1371,7 @@ RSpec.describe Git::Repository::ObjectOperations do
     context 'when an annotated tag is requested without a message' do
       it 'raises ArgumentError without calling git' do
         expect(Git::Commands::Tag::Create).not_to receive(:new)
-        expect { described_instance.add_tag('v1.0.0', annotate: true) }
+        expect { described_instance.tag_add('v1.0.0', annotate: true) }
           .to raise_error(ArgumentError, 'Cannot create an annotated or signed tag without a message.')
       end
     end
@@ -1379,38 +1379,38 @@ RSpec.describe Git::Repository::ObjectOperations do
     context 'when a signed tag is requested without a message' do
       it 'raises ArgumentError without calling git' do
         expect(Git::Commands::Tag::Create).not_to receive(:new)
-        expect { described_instance.add_tag('v1.0.0', s: true) }
+        expect { described_instance.tag_add('v1.0.0', s: true) }
           .to raise_error(ArgumentError, 'Cannot create an annotated or signed tag without a message.')
       end
     end
 
     context 'when an annotated tag is requested with a message' do
       it 'creates the tag and returns it' do
-        expect(described_instance.add_tag('v1.0.0', annotate: true, message: 'release')).to be(tag_object)
+        expect(described_instance.tag_add('v1.0.0', annotate: true, message: 'release')).to be(tag_object)
       end
     end
 
     context 'when an annotated tag is requested with a :file option' do
       it 'does not raise and creates the tag' do
-        expect(described_instance.add_tag('v1.0.0', annotate: true, file: 'msg.txt')).to be(tag_object)
+        expect(described_instance.tag_add('v1.0.0', annotate: true, file: 'msg.txt')).to be(tag_object)
       end
     end
 
     context 'when an annotated tag is requested with the :F alias' do
       it 'does not raise and creates the tag' do
-        expect(described_instance.add_tag('v1.0.0', annotate: true, F: 'msg.txt')).to be(tag_object)
+        expect(described_instance.tag_add('v1.0.0', annotate: true, F: 'msg.txt')).to be(tag_object)
       end
     end
 
     context 'when a signed tag is requested with a :file option' do
       it 'does not raise and creates the tag' do
-        expect(described_instance.add_tag('v1.0.0', sign: true, file: 'msg.txt')).to be(tag_object)
+        expect(described_instance.tag_add('v1.0.0', sign: true, file: 'msg.txt')).to be(tag_object)
       end
     end
 
     context 'when a signed tag is requested with the :F alias' do
       it 'does not raise and creates the tag' do
-        expect(described_instance.add_tag('v1.0.0', sign: true, F: 'msg.txt')).to be(tag_object)
+        expect(described_instance.tag_add('v1.0.0', sign: true, F: 'msg.txt')).to be(tag_object)
       end
     end
 
@@ -1418,62 +1418,88 @@ RSpec.describe Git::Repository::ObjectOperations do
       let(:delete_stdout) { "Deleted tag 'v1.0.0' (was abc123)\n" }
 
       before do
-        allow(described_instance).to receive(:delete_tag).with('v1.0.0').and_return(delete_stdout)
+        allow(described_instance).to receive(:tag_delete).with('v1.0.0').and_return(delete_stdout)
         allow(Git::Deprecation).to receive(:warn)
       end
 
       it 'issues a deprecation warning' do
         expect(Git::Deprecation).to receive(:warn).with(/deprecated/)
-        described_instance.add_tag('v1.0.0', d: true)
+        described_instance.tag_add('v1.0.0', d: true)
       end
 
-      it 'delegates to delete_tag and returns its stdout' do
-        expect(described_instance).to receive(:delete_tag).with('v1.0.0').and_return(delete_stdout)
-        expect(described_instance.add_tag('v1.0.0', d: true)).to eq(delete_stdout)
+      it 'delegates to tag_delete and returns its stdout' do
+        expect(described_instance).to receive(:tag_delete).with('v1.0.0').and_return(delete_stdout)
+        expect(described_instance.tag_add('v1.0.0', d: true)).to eq(delete_stdout)
       end
 
       it 'does not call Git::Commands::Tag::Create' do
         expect(Git::Commands::Tag::Create).not_to receive(:new)
-        described_instance.add_tag('v1.0.0', d: true)
+        described_instance.tag_add('v1.0.0', d: true)
       end
 
       it 'also accepts the :delete alias' do
-        expect(described_instance).to receive(:delete_tag).with('v1.0.0').and_return(delete_stdout)
-        described_instance.add_tag('v1.0.0', delete: true)
+        expect(described_instance).to receive(:tag_delete).with('v1.0.0').and_return(delete_stdout)
+        described_instance.tag_add('v1.0.0', delete: true)
       end
 
       it 'raises ArgumentError when a target is also given' do
-        expect { described_instance.add_tag('v1.0.0', 'abc123', d: true) }
+        expect { described_instance.tag_add('v1.0.0', 'abc123', d: true) }
           .to raise_error(ArgumentError, /target/)
       end
 
       it 'raises ArgumentError when other options are also given' do
-        expect { described_instance.add_tag('v1.0.0', d: true, force: true) }
+        expect { described_instance.tag_add('v1.0.0', d: true, force: true) }
           .to raise_error(ArgumentError, /force/)
       end
     end
 
     context 'when :d is given as false' do
       it 'treats it as omitted and creates the tag normally' do
-        expect(described_instance.add_tag('v1.0.0', d: false)).to be(tag_object)
+        expect(described_instance.tag_add('v1.0.0', d: false)).to be(tag_object)
       end
     end
 
     context 'when :delete is given as false' do
       it 'treats it as omitted and creates the tag normally' do
-        expect(described_instance.add_tag('v1.0.0', delete: false)).to be(tag_object)
+        expect(described_instance.tag_add('v1.0.0', delete: false)).to be(tag_object)
       end
     end
 
     context 'when :d is given as nil' do
       it 'treats it as omitted and creates the tag normally' do
-        expect(described_instance.add_tag('v1.0.0', d: nil)).to be(tag_object)
+        expect(described_instance.tag_add('v1.0.0', d: nil)).to be(tag_object)
       end
     end
   end
 
-  describe '#delete_tag' do
-    subject(:result) { described_instance.delete_tag('v1.0.0') }
+  # ---------------------------------------------------------------------------
+  # #add_tag (deprecated alias for #tag_add)
+  # ---------------------------------------------------------------------------
+
+  describe '#add_tag' do
+    let(:tag_object) { instance_double(Git::Object::Tag) }
+
+    before do
+      allow(described_instance).to receive(:tag_add).and_return(tag_object)
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning matching /add_tag is deprecated/' do
+      expect(Git::Deprecation).to receive(:warn).with(/add_tag is deprecated/)
+      described_instance.add_tag('v1.0.0')
+    end
+
+    it 'calls tag_add with all arguments forwarded and returns its return value' do
+      expect(described_instance)
+        .to receive(:tag_add).with('v1.0.0', 'abc123', { force: true })
+        .and_return(tag_object)
+      result = described_instance.add_tag('v1.0.0', 'abc123', force: true)
+      expect(result).to be(tag_object)
+    end
+  end
+
+  describe '#tag_delete' do
+    subject(:result) { described_instance.tag_delete('v1.0.0') }
 
     let(:delete_command) { instance_double(Git::Commands::Tag::Delete) }
     let(:status) { instance_double(Process::Status, exitstatus: 0) }
@@ -1512,6 +1538,32 @@ RSpec.describe Git::Repository::ObjectOperations do
           expect(error.result).to be(command_result)
         end
       end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #delete_tag (deprecated alias for #tag_delete)
+  # ---------------------------------------------------------------------------
+
+  describe '#delete_tag' do
+    let(:delete_stdout) { "Deleted tag 'v1.0.0' (was abc123)\n" }
+
+    before do
+      allow(described_instance).to receive(:tag_delete).and_return(delete_stdout)
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning matching /delete_tag is deprecated/' do
+      expect(Git::Deprecation).to receive(:warn).with(/delete_tag is deprecated/)
+      described_instance.delete_tag('v1.0.0')
+    end
+
+    it 'calls tag_delete with all arguments forwarded and returns its return value' do
+      expect(described_instance)
+        .to receive(:tag_delete).with('v1.0.0')
+        .and_return(delete_stdout)
+      result = described_instance.delete_tag('v1.0.0')
+      expect(result).to be(delete_stdout)
     end
   end
 end

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -574,10 +574,10 @@ RSpec.describe Git::Repository::RemoteOperations do
   end
 
   # ---------------------------------------------------------------------------
-  # #add_remote
+  # #remote_add
   # ---------------------------------------------------------------------------
 
-  describe '#add_remote' do
+  describe '#remote_add' do
     let(:add_remote_command) { instance_double(Git::Commands::Remote::Add) }
     let(:add_remote_result) { command_result('') }
     let(:remote_object) { instance_double(Git::Remote) }
@@ -592,7 +592,7 @@ RSpec.describe Git::Repository::RemoteOperations do
     # --- Default invocation --------------------------------------------------
 
     context 'with name and url only' do
-      subject(:result) { described_instance.add_remote('upstream', 'https://example.com/repo.git') }
+      subject(:result) { described_instance.remote_add('upstream', 'https://example.com/repo.git') }
 
       it 'delegates to Git::Commands::Remote::Add.new with the execution_context' do
         expect(Git::Commands::Remote::Add).to receive(:new).with(execution_context).and_return(add_remote_command)
@@ -624,7 +624,7 @@ RSpec.describe Git::Repository::RemoteOperations do
         end
       end
 
-      subject(:result) { described_instance.add_remote('upstream', url_base) }
+      subject(:result) { described_instance.remote_add('upstream', url_base) }
 
       it 'normalizes url to repo.to_s before calling the command' do
         expect(add_remote_command)
@@ -636,7 +636,7 @@ RSpec.describe Git::Repository::RemoteOperations do
     # --- :fetch option -------------------------------------------------------
 
     context 'with fetch: true' do
-      subject(:result) { described_instance.add_remote('upstream', 'https://example.com/repo.git', fetch: true) }
+      subject(:result) { described_instance.remote_add('upstream', 'https://example.com/repo.git', fetch: true) }
 
       it 'forwards :fetch to the command' do
         expect(add_remote_command)
@@ -649,7 +649,7 @@ RSpec.describe Git::Repository::RemoteOperations do
     # --- :track option -------------------------------------------------------
 
     context 'with track: "main"' do
-      subject(:result) { described_instance.add_remote('upstream', 'https://example.com/repo.git', track: 'main') }
+      subject(:result) { described_instance.remote_add('upstream', 'https://example.com/repo.git', track: 'main') }
 
       it 'forwards :track to the command' do
         expect(add_remote_command)
@@ -662,7 +662,7 @@ RSpec.describe Git::Repository::RemoteOperations do
     # --- :with_fetch alias (deprecated) --------------------------------------
 
     context 'with the deprecated :with_fetch alias' do
-      subject(:result) { described_instance.add_remote('upstream', 'https://example.com/repo.git', with_fetch: true) }
+      subject(:result) { described_instance.remote_add('upstream', 'https://example.com/repo.git', with_fetch: true) }
 
       it 'normalizes :with_fetch to :fetch before calling the command' do
         expect(add_remote_command)
@@ -677,18 +677,44 @@ RSpec.describe Git::Repository::RemoteOperations do
     context 'with an unknown option key' do
       it 'raises ArgumentError before calling the command' do
         expect(add_remote_command).not_to receive(:call)
-        expect { described_instance.add_remote('upstream', 'https://example.com/repo.git', unknown_opt: true) }
+        expect { described_instance.remote_add('upstream', 'https://example.com/repo.git', unknown_opt: true) }
           .to raise_error(ArgumentError, /unknown_opt/)
       end
     end
   end
 
   # ---------------------------------------------------------------------------
-  # #remove_remote
+  # #add_remote (deprecated alias for #remote_add)
   # ---------------------------------------------------------------------------
 
-  describe '#remove_remote' do
-    subject(:result) { described_instance.remove_remote('upstream') }
+  describe '#add_remote' do
+    let(:remote_object) { instance_double(Git::Remote) }
+
+    before do
+      allow(described_instance).to receive(:remote_add).and_return(remote_object)
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning matching /add_remote is deprecated/' do
+      expect(Git::Deprecation).to receive(:warn).with(/add_remote is deprecated/)
+      described_instance.add_remote('upstream', 'https://example.com/repo.git')
+    end
+
+    it 'calls remote_add with all arguments forwarded and returns its return value' do
+      expect(described_instance)
+        .to receive(:remote_add).with('upstream', 'https://example.com/repo.git', { fetch: true })
+        .and_return(remote_object)
+      result = described_instance.add_remote('upstream', 'https://example.com/repo.git', fetch: true)
+      expect(result).to be(remote_object)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #remote_remove
+  # ---------------------------------------------------------------------------
+
+  describe '#remote_remove' do
+    subject(:result) { described_instance.remote_remove('upstream') }
 
     let(:remove_command) { instance_double(Git::Commands::Remote::Remove) }
     let(:remove_result) { command_result('') }
@@ -696,12 +722,12 @@ RSpec.describe Git::Repository::RemoteOperations do
     before do
       allow(Git::Commands::Remote::Remove)
         .to receive(:new).with(execution_context).and_return(remove_command)
+      allow(remove_command).to receive(:call).and_return(remove_result)
     end
 
     it 'delegates to Git::Commands::Remote::Remove.new with the execution_context' do
       expect(Git::Commands::Remote::Remove)
         .to receive(:new).with(execution_context).and_return(remove_command)
-      allow(remove_command).to receive(:call).and_return(remove_result)
       result
     end
 
@@ -711,7 +737,32 @@ RSpec.describe Git::Repository::RemoteOperations do
     end
 
     it 'returns the Git::CommandLineResult' do
-      allow(remove_command).to receive(:call).and_return(remove_result)
+      expect(result).to be(remove_result)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #remove_remote (deprecated alias for #remote_remove)
+  # ---------------------------------------------------------------------------
+
+  describe '#remove_remote' do
+    let(:remove_result) { command_result('') }
+
+    before do
+      allow(described_instance).to receive(:remote_remove).and_return(remove_result)
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning matching /remove_remote is deprecated/' do
+      expect(Git::Deprecation).to receive(:warn).with(/remove_remote is deprecated/)
+      described_instance.remove_remote('upstream')
+    end
+
+    it 'calls remote_remove with all arguments forwarded and returns its return value' do
+      expect(described_instance)
+        .to receive(:remote_remove).with('upstream')
+        .and_return(remove_result)
+      result = described_instance.remove_remote('upstream')
       expect(result).to be(remove_result)
     end
   end
@@ -816,10 +867,10 @@ RSpec.describe Git::Repository::RemoteOperations do
   end
 
   # ---------------------------------------------------------------------------
-  # #set_remote_url
+  # #remote_set_url
   # ---------------------------------------------------------------------------
 
-  describe '#set_remote_url' do
+  describe '#remote_set_url' do
     let(:set_url_command) { instance_double(Git::Commands::Remote::SetUrl) }
     let(:set_url_result) { command_result('') }
     let(:remote_object) { instance_double(Git::Remote) }
@@ -832,7 +883,7 @@ RSpec.describe Git::Repository::RemoteOperations do
     end
 
     context 'with a string url' do
-      subject(:result) { described_instance.set_remote_url('origin', 'https://example.com/repo.git') }
+      subject(:result) { described_instance.remote_set_url('origin', 'https://example.com/repo.git') }
 
       it 'delegates to Git::Commands::Remote::SetUrl.new with the execution_context' do
         expect(Git::Commands::Remote::SetUrl)
@@ -865,13 +916,39 @@ RSpec.describe Git::Repository::RemoteOperations do
         end
       end
 
-      subject(:result) { described_instance.set_remote_url('origin', url_base) }
+      subject(:result) { described_instance.remote_set_url('origin', url_base) }
 
       it 'normalizes the url to repo.to_s before calling the command' do
         expect(set_url_command)
           .to receive(:call).with('origin', '/tmp/source.git').and_return(set_url_result)
         result
       end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #set_remote_url (deprecated alias for #remote_set_url)
+  # ---------------------------------------------------------------------------
+
+  describe '#set_remote_url' do
+    let(:remote_object) { instance_double(Git::Remote) }
+
+    before do
+      allow(described_instance).to receive(:remote_set_url).and_return(remote_object)
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning matching /set_remote_url is deprecated/' do
+      expect(Git::Deprecation).to receive(:warn).with(/set_remote_url is deprecated/)
+      described_instance.set_remote_url('origin', 'https://example.com/repo.git')
+    end
+
+    it 'calls remote_set_url with all arguments forwarded and returns its return value' do
+      expect(described_instance)
+        .to receive(:remote_set_url).with('origin', 'https://example.com/repo.git')
+        .and_return(remote_object)
+      result = described_instance.set_remote_url('origin', 'https://example.com/repo.git')
+      expect(result).to be(remote_object)
     end
   end
 

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -578,14 +578,14 @@ RSpec.describe Git::Repository::RemoteOperations do
   # ---------------------------------------------------------------------------
 
   describe '#remote_add' do
-    let(:add_remote_command) { instance_double(Git::Commands::Remote::Add) }
-    let(:add_remote_result) { command_result('') }
+    let(:remote_add_command) { instance_double(Git::Commands::Remote::Add) }
+    let(:remote_add_result) { command_result('') }
     let(:remote_object) { instance_double(Git::Remote) }
 
     before do
       allow(Git::Commands::Remote::Add)
-        .to receive(:new).with(execution_context).and_return(add_remote_command)
-      allow(add_remote_command).to receive(:call).and_return(add_remote_result)
+        .to receive(:new).with(execution_context).and_return(remote_add_command)
+      allow(remote_add_command).to receive(:call).and_return(remote_add_result)
       allow(Git::Remote).to receive(:new).and_return(remote_object)
     end
 
@@ -595,13 +595,13 @@ RSpec.describe Git::Repository::RemoteOperations do
       subject(:result) { described_instance.remote_add('upstream', 'https://example.com/repo.git') }
 
       it 'delegates to Git::Commands::Remote::Add.new with the execution_context' do
-        expect(Git::Commands::Remote::Add).to receive(:new).with(execution_context).and_return(add_remote_command)
+        expect(Git::Commands::Remote::Add).to receive(:new).with(execution_context).and_return(remote_add_command)
         result
       end
 
       it 'calls Add#call with name and url' do
-        expect(add_remote_command)
-          .to receive(:call).with('upstream', 'https://example.com/repo.git').and_return(add_remote_result)
+        expect(remote_add_command)
+          .to receive(:call).with('upstream', 'https://example.com/repo.git').and_return(remote_add_result)
         result
       end
 
@@ -627,8 +627,8 @@ RSpec.describe Git::Repository::RemoteOperations do
       subject(:result) { described_instance.remote_add('upstream', url_base) }
 
       it 'normalizes url to repo.to_s before calling the command' do
-        expect(add_remote_command)
-          .to receive(:call).with('upstream', '/tmp/source.git').and_return(add_remote_result)
+        expect(remote_add_command)
+          .to receive(:call).with('upstream', '/tmp/source.git').and_return(remote_add_result)
         result
       end
     end
@@ -639,9 +639,9 @@ RSpec.describe Git::Repository::RemoteOperations do
       subject(:result) { described_instance.remote_add('upstream', 'https://example.com/repo.git', fetch: true) }
 
       it 'forwards :fetch to the command' do
-        expect(add_remote_command)
+        expect(remote_add_command)
           .to receive(:call).with('upstream', 'https://example.com/repo.git', fetch: true)
-          .and_return(add_remote_result)
+          .and_return(remote_add_result)
         result
       end
     end
@@ -652,9 +652,9 @@ RSpec.describe Git::Repository::RemoteOperations do
       subject(:result) { described_instance.remote_add('upstream', 'https://example.com/repo.git', track: 'main') }
 
       it 'forwards :track to the command' do
-        expect(add_remote_command)
+        expect(remote_add_command)
           .to receive(:call).with('upstream', 'https://example.com/repo.git', track: 'main')
-          .and_return(add_remote_result)
+          .and_return(remote_add_result)
         result
       end
     end
@@ -665,9 +665,9 @@ RSpec.describe Git::Repository::RemoteOperations do
       subject(:result) { described_instance.remote_add('upstream', 'https://example.com/repo.git', with_fetch: true) }
 
       it 'normalizes :with_fetch to :fetch before calling the command' do
-        expect(add_remote_command)
+        expect(remote_add_command)
           .to receive(:call).with('upstream', 'https://example.com/repo.git', fetch: true)
-          .and_return(add_remote_result)
+          .and_return(remote_add_result)
         result
       end
     end
@@ -676,7 +676,7 @@ RSpec.describe Git::Repository::RemoteOperations do
 
     context 'with an unknown option key' do
       it 'raises ArgumentError before calling the command' do
-        expect(add_remote_command).not_to receive(:call)
+        expect(remote_add_command).not_to receive(:call)
         expect { described_instance.remote_add('upstream', 'https://example.com/repo.git', unknown_opt: true) }
           .to raise_error(ArgumentError, /unknown_opt/)
       end

--- a/tests/units/test_branch.rb
+++ b/tests/units/test_branch.rb
@@ -186,7 +186,7 @@ class TestBranch < Test::Unit::TestCase
       File.write('file1.txt', 'hello world')
       git.add('file1.txt')
       git.commit('Initial commit')
-      git.add_tag('v1.0.0')
+      git.tag_add('v1.0.0')
       File.write('file2.txt', 'hello world')
       git.add('file2.txt')
       git.commit('Second commit')

--- a/tests/units/test_fsck.rb
+++ b/tests/units/test_fsck.rb
@@ -312,7 +312,7 @@ class TestFsck < Test::Unit::TestCase
         git.commit('Initial commit')
 
         # Create an annotated tag
-        git.add_tag('v1.0.0', message: 'Version 1.0.0')
+        git.tag_add('v1.0.0', message: 'Version 1.0.0')
 
         result = git.fsck(tags: true)
 

--- a/tests/units/test_object_new.rb
+++ b/tests/units/test_object_new.rb
@@ -16,7 +16,7 @@ class ObjectNewTest < Test::Unit::TestCase
       File.write('file.txt', 'This is a test file.')
       @repo.add('file.txt')
       @repo.commit('Initial commit')
-      @repo.add_tag('v1.0', message: 'Version 1.0', annotate: true)
+      @repo.tag_add('v1.0', message: 'Version 1.0', annotate: true)
     end
 
     @commit = @repo.gcommit('HEAD')

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -8,19 +8,19 @@ class TestRemotes < Test::Unit::TestCase
       local = Git.clone(BARE_REPO_PATH, 'local')
       remote = Git.clone(BARE_REPO_PATH, 'remote')
 
-      local.add_remote('testremote', remote)
+      local.remote_add('testremote', remote)
 
       assert(!local.branches.map(&:full).include?('testremote/master'))
       assert(local.remotes.map(&:name).include?('testremote'))
 
-      local.add_remote('testremote2', remote, fetch: true)
+      local.remote_add('testremote2', remote, fetch: true)
 
       assert(local.branches.map(&:full).include?('remotes/testremote2/master'))
       assert(local.remotes.map(&:name).include?('testremote2'))
 
-      local.add_remote('testremote3', remote, track: 'master')
+      local.remote_add('testremote3', remote, track: 'master')
 
-      assert( # We actually a new branch ('test_track') on the remote and track that one intead.
+      assert( # We don't actually create a new branch ('test_track') on the remote and track that one instead.
         local.branches.map(&:full).include?('master')
       )
       assert(local.remotes.map(&:name).include?('testremote3'))
@@ -32,12 +32,12 @@ class TestRemotes < Test::Unit::TestCase
       local = Git.clone(BARE_REPO_PATH, 'local')
       remote = Git.clone(BARE_REPO_PATH, 'remote')
 
-      local.add_remote('testremote', remote)
-      local.remove_remote('testremote')
+      local.remote_add('testremote', remote)
+      local.remote_remove('testremote')
 
       assert(!local.remotes.map(&:name).include?('testremote'))
 
-      local.add_remote('testremote', remote)
+      local.remote_add('testremote', remote)
       local.remote('testremote').remove
 
       assert(!local.remotes.map(&:name).include?('testremote'))
@@ -50,8 +50,8 @@ class TestRemotes < Test::Unit::TestCase
       remote1 = Git.clone(BARE_REPO_PATH, 'remote1')
       remote2 = Git.clone(BARE_REPO_PATH, 'remote2')
 
-      local.add_remote('testremote', remote1)
-      local.set_remote_url('testremote', remote2)
+      local.remote_add('testremote', remote1)
+      local.remote_set_url('testremote', remote2)
 
       assert(local.remotes.map(&:name).include?('testremote'))
       assert(local.remote('testremote').url != remote1.repo.to_s)
@@ -164,7 +164,7 @@ class TestRemotes < Test::Unit::TestCase
       loc = Git.clone(BARE_REPO_PATH, 'local')
       rem = Git.clone(BARE_REPO_PATH, 'remote')
 
-      r = loc.add_remote('testrem', rem)
+      r = loc.remote_add('testrem', rem)
 
       Dir.chdir('remote') do
         new_file('test-file1', 'blahblahblah1')
@@ -199,7 +199,7 @@ class TestRemotes < Test::Unit::TestCase
       loc = Git.clone(BARE_REPO_PATH, 'local')
       rem = Git.clone(BARE_REPO_PATH, 'remote')
 
-      r = loc.add_remote('testrem', rem)
+      r = loc.remote_add('testrem', rem)
 
       Dir.chdir('remote') do
         rem.branch('testbranch').in_branch('tb commit') do
@@ -208,7 +208,7 @@ class TestRemotes < Test::Unit::TestCase
           true
         end
         rem.branch('testbranch').in_branch do
-          rem.add_tag('test-tag-in-deleted-branch')
+          rem.tag_add('test-tag-in-deleted-branch')
           false
         end
         rem.branch('testbranch').delete
@@ -270,7 +270,7 @@ class TestRemotes < Test::Unit::TestCase
     in_temp_dir do |_path|
       loc = Git.clone(BARE_REPO_PATH, 'local')
       rem = Git.clone(BARE_REPO_PATH, 'remote', config: 'receive.denyCurrentBranch=ignore')
-      loc.add_remote('testrem', rem)
+      loc.remote_add('testrem', rem)
 
       first_commit_sha = second_commit_sha = nil
 
@@ -305,13 +305,13 @@ class TestRemotes < Test::Unit::TestCase
       loc = Git.clone(BARE_REPO_PATH, 'local')
       rem = Git.clone(BARE_REPO_PATH, 'remote', config: 'receive.denyCurrentBranch=ignore')
 
-      loc.add_remote('testrem', rem)
+      loc.remote_add('testrem', rem)
 
       loc.chdir do
         new_file('test-file1', 'blahblahblah1')
         loc.add
         loc.commit('master commit')
-        loc.add_tag('test-tag')
+        loc.tag_add('test-tag')
 
         loc.branch('testbranch').in_branch('tb commit') do
           new_file('test-file3', 'blahblahblah3')

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -3,7 +3,7 @@
 require 'test_helper'
 
 class TestRemotes < Test::Unit::TestCase
-  def test_add_remote
+  def test_remote_add
     in_temp_dir do |_path|
       local = Git.clone(BARE_REPO_PATH, 'local')
       remote = Git.clone(BARE_REPO_PATH, 'remote')
@@ -20,14 +20,14 @@ class TestRemotes < Test::Unit::TestCase
 
       local.remote_add('testremote3', remote, track: 'master')
 
-      assert( # We don't actually create a new branch ('test_track') on the remote and track that one instead.
+      assert( # track: 'master' does not create a local tracking branch; 'master' already exists from the clone
         local.branches.map(&:full).include?('master')
       )
       assert(local.remotes.map(&:name).include?('testremote3'))
     end
   end
 
-  def test_remove_remote_remove
+  def test_remote_remove
     in_temp_dir do |_path|
       local = Git.clone(BARE_REPO_PATH, 'local')
       remote = Git.clone(BARE_REPO_PATH, 'remote')
@@ -44,7 +44,7 @@ class TestRemotes < Test::Unit::TestCase
     end
   end
 
-  def test_set_remote_url
+  def test_remote_set_url
     in_temp_dir do |_path|
       local = Git.clone(BARE_REPO_PATH, 'local')
       remote1 = Git.clone(BARE_REPO_PATH, 'remote1')

--- a/tests/units/test_tags.rb
+++ b/tests/units/test_tags.rb
@@ -17,42 +17,42 @@ class TestTags < Test::Unit::TestCase
       end
       assert_equal error.message, "Tag 'first' does not exist."
 
-      r1.add_tag('first')
+      r1.tag_add('first')
       r1.chdir do
         new_file('new_file', 'new content')
       end
       r1.add
       r1.commit('my commit')
-      r1.add_tag('second')
+      r1.tag_add('second')
 
       assert(r1.tags.any? { |t| t.name == 'first' })
 
-      r2.add_tag('third')
+      r2.tag_add('third')
 
       assert(r2.tags.any? { |t| t.name == 'third' })
       assert(r2.tags.none? { |t| t.name == 'second' })
 
       error = assert_raises ArgumentError do
-        r2.add_tag('fourth', { a: true })
+        r2.tag_add('fourth', { a: true })
       end
 
       assert(!error.message.to_s.empty?, 'Expected error message to be present')
 
-      r2.add_tag('fourth', { a: true, m: 'test message' })
+      r2.tag_add('fourth', { a: true, m: 'test message' })
 
       assert(r2.tags.any? { |t| t.name == 'fourth' })
 
-      r2.add_tag('fifth', r2.tags.detect { |t| t.name == 'third' }.objectish)
+      r2.tag_add('fifth', r2.tags.detect { |t| t.name == 'third' }.objectish)
 
       assert(r2.tags.detect { |t| t.name == 'third' }.objectish == r2.tags.detect { |t| t.name == 'fifth' }.objectish)
 
       assert_raise Git::FailedError do
-        r2.add_tag('third')
+        r2.tag_add('third')
       end
 
-      r2.add_tag('third', { f: true })
+      r2.tag_add('third', { f: true })
 
-      r2.delete_tag('third')
+      r2.tag_delete('third')
 
       error = assert_raise Git::UnexpectedResultError do
         r2.tag('third')
@@ -76,7 +76,7 @@ class TestTags < Test::Unit::TestCase
 
   def test_tag_message_not_prefixed_with_space
     in_bare_repo_clone do |repo|
-      repo.add_tag('donkey', annotate: true, message: 'hello')
+      repo.tag_add('donkey', annotate: true, message: 'hello')
       tag = repo.tag('donkey')
       assert_equal(tag.message, 'hello')
     end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Standardizes 5 `Git::Repository` facade methods to the project's `{noun}_{verb}` naming convention (e.g. `branch_new`, `stash_save`). The old `{verb}_{noun}` names remain available as deprecated aliases that emit a `Git::Deprecation.warn` message and will be removed in a future version.

This is PR 6 of the Phase C1c-2 redesign (see `redesign/c1c2_audit.md` §9).

## What changed

| Deprecated alias (old name) | New canonical name | Module |
|---|---|---|
| `add_remote` | `remote_add` | `Git::Repository::RemoteOperations` |
| `remove_remote` | `remote_remove` | `Git::Repository::RemoteOperations` |
| `set_remote_url` | `remote_set_url` | `Git::Repository::RemoteOperations` |
| `add_tag` | `tag_add` | `Git::Repository::ObjectOperations` |
| `delete_tag` | `tag_delete` | `Git::Repository::ObjectOperations` |

### Changes per file

- **`lib/git/repository/remote_operations.rb`** — renamed the 3 method bodies to canonical names; added deprecated forwarding aliases that emit `Git::Deprecation.warn`
- **`lib/git/repository/object_operations.rb`** — renamed `add_tag` → `tag_add` and `delete_tag` → `tag_delete`; updated internal `add_tag_delete_deprecated` helper to call `tag_delete`; added deprecated aliases
- **`lib/git/base.rb`** — replaced 5 one-liner delegators with canonical delegators plus deprecated wrapper methods (wrappers call the local delegator, not `facade_repository` directly)
- **`UPGRADING.md`** — added 5 new rows to the "Deprecated methods" table
- **`spec/unit/git/repository/remote_operations_spec.rb`** — renamed describe blocks to `#remote_add`, `#remote_remove`, `#remote_set_url`; added deprecated alias describe blocks; fixed a pre-existing RSpec MUST violation (inline `allow` stubs moved to `before` block)
- **`spec/unit/git/repository/object_operations_spec.rb`** — renamed describe blocks to `#tag_add`, `#tag_delete`; added deprecated alias describe blocks

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
