### PR TITLE
docs: update c1c2 audit documents to reflect completed work

### DIFF
--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -305,7 +305,7 @@ Files touched: `.github/skills/extract-facade-from-base-lib/SKILL.md`,
 
 Tracked as [Issue #1369](https://github.com/ruby-git/ruby-git/issues/1369).
 
-**Step C1c-2 — End-of-Phase-3 public-API parity audit and remediation sweep** ⬜
+**Step C1c-2 — End-of-Phase-3 public-API parity audit and remediation sweep** ✅
 
 Compare every public `Git::Base` method against `Git::Repository`; fix mismatches
 or explicitly record each as a documented v5 breaking change. No unclassified

--- a/redesign/c1c2_audit.md
+++ b/redesign/c1c2_audit.md
@@ -470,10 +470,10 @@ upgrade notes as "unsupported; remove any `g.lib.X` calls."
 | 🔍 human decision | 0 |
 | **Total orphaned methods** | **48** |
 
-> **Recommendation:** The 24 "trivial wiring" promotions can be handled in PR 5a
-> as a batch. The 1 "new facade" promotion and 11 human-decision items should be
-> addressed in a companion document (`redesign/c1c2_bucket6_lib_orphans.md`)
-> before PR 5b begins.
+> ✅ **All promotions complete.** All 36 promotable methods (§7.2 trivial wiring
+> + name-mismatch cases, §7.3 new-facade methods) have been merged (PR
+> 2d/2e/3/5f/5g/5h series). The 12 internal plumbing methods are annotated
+> `@api private` (§7.4). No further action required for Bucket 6.
 
 ---
 

--- a/redesign/c1c2_bucket6_lib_orphans.md
+++ b/redesign/c1c2_bucket6_lib_orphans.md
@@ -620,6 +620,7 @@ Complete items 1–4 below, then open PR 5h to implement the decisions.
       before PR 5h merges. *(No items landed in this bucket — all decisions
       were "promote" or "deprecated forwarding alias". `UPGRADING.md` created
       with all entries pre-populated.)*
-- [ ] Once all decisions are recorded, open PR 5h targeting `main` to
+- [x] Once all decisions are recorded, open PR 5h targeting `main` to
       implement the promotions, add the deprecated aliases with runtime
       warnings, add the upgrade notes to `UPGRADING.md`, and close this document's action items.
+      *(All PR 5h-1 through 5h-6 implementations merged; `UPGRADING.md` populated.)*


### PR DESCRIPTION
# Description

Audits `redesign/c1c2_audit.md` and `redesign/c1c2_bucket6_lib_orphans.md` against the current state of `main` and updates both documents to reflect all completed work. Also marks Step C1c-2 as ✅ complete in the implementation plan.

## Changes

**`redesign/c1c2_audit.md`**
- §7.5: Replace stale forward-looking "Recommendation" blockquote (referenced obsolete PR 5a labels and pre-completion counts) with a completion note citing the actual merged PR series (2d/2e/3/5f/5g/5h) and confirmed final counts (36 ✅ promoted, 12 ❌ internal plumbing)

**`redesign/c1c2_bucket6_lib_orphans.md`**
- §5 Next Steps: Check off the last unchecked action item (open PR 5h) — all PR 5h-1 through 5h-6 implementations are confirmed merged and `UPGRADING.md` is populated

**`redesign/3_architecture_implementation.md`**
- Mark Step C1c-2 as ✅ complete (was ⬜)

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed. *(documentation-only change; no tests needed)*
- [x] Documentation updated where applicable (README and/or YARD). *(these are the doc changes)*