### PR TITLE
Refactor tests to remove deprecated `repo.lib` calls

### DIFF
--- a/spec/integration/git/commands/apply_spec.rb
+++ b/spec/integration/git/commands/apply_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Git::Commands::Apply, :integration do
         repo.add('file.txt')
         repo.commit('Add line2')
 
-        patch_content = execution_context.diff_full('HEAD~1', 'HEAD')
+        patch_content = repo.diff_full('HEAD~1', 'HEAD')
         File.write(patch_file, "#{patch_content}\n")
 
         repo.reset('HEAD~1', hard: true)

--- a/spec/integration/git/commands/diff_spec.rb
+++ b/spec/integration/git/commands/diff_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Git::Commands::Diff, :integration do
         check_repo.commit('Add trailing whitespace')
         check_repo.tag_add('check_dirty')
 
-        @check_command = described_class.new(check_repo.lib)
+        @check_command = described_class.new(check_repo.execution_context)
       end
 
       after(:all) do

--- a/spec/integration/git/commands/log_spec.rb
+++ b/spec/integration/git/commands/log_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Git::Commands::Log, :integration do
 
       context 'with a revision range operand' do
         it 'returns a CommandLineResult for the given range' do
-          first_sha = repo.lib.rev_parse('HEAD~1')
+          first_sha = repo.rev_parse('HEAD~1')
           result = command.call("#{first_sha}..")
 
           expect(result).to be_a(Git::CommandLineResult)

--- a/spec/integration/git/commands/stash/apply_spec.rb
+++ b/spec/integration/git/commands/stash/apply_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::Stash::Apply, :integration do
     describe 'when the command succeeds' do
       before do
         write_file('file.txt', "modified content\n")
-        repo.lib.stash_save('WIP')
+        repo.stash_save('WIP')
       end
 
       it 'returns a CommandLineResult with output' do

--- a/spec/integration/git/commands/stash/branch_spec.rb
+++ b/spec/integration/git/commands/stash/branch_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Git::Commands::Stash::Branch, :integration do
 
       # Create changes and stash them
       write_file('file.txt', 'modified content')
-      repo.lib.stash_save('WIP changes')
+      repo.stash_save('WIP changes')
     end
 
     describe 'when the command succeeds' do

--- a/spec/integration/git/commands/stash/drop_spec.rb
+++ b/spec/integration/git/commands/stash/drop_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Git::Commands::Stash::Drop, :integration do
     describe 'when the command succeeds' do
       before do
         write_file('file.txt', "modified\n")
-        repo.lib.stash_save('WIP')
+        repo.stash_save('WIP')
       end
 
       it 'returns a CommandLineResult' do

--- a/spec/integration/git/commands/stash/list_spec.rb
+++ b/spec/integration/git/commands/stash/list_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Git::Commands::Stash::List, :integration do
       context 'with stashes' do
         before do
           write_file('file.txt', 'modified content')
-          repo.lib.stash_save('WIP on feature')
+          repo.stash_save('WIP on feature')
         end
 
         it 'returns CommandLineResult with output' do

--- a/spec/integration/git/commands/stash/pop_spec.rb
+++ b/spec/integration/git/commands/stash/pop_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::Stash::Pop, :integration do
     describe 'when the command succeeds' do
       before do
         write_file('file.txt', "modified content\n")
-        repo.lib.stash_save('WIP')
+        repo.stash_save('WIP')
       end
 
       it 'returns a CommandLineResult with output' do

--- a/spec/integration/git/commands/stash/show_spec.rb
+++ b/spec/integration/git/commands/stash/show_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Commands::Stash::Show, :integration do
     repo.commit('Initial commit')
 
     write_file('file.txt', "modified\n")
-    repo.lib.stash_save('WIP')
+    repo.stash_save('WIP')
   end
 
   describe '#call' do

--- a/spec/integration/git/commands/worktree/repair_spec.rb
+++ b/spec/integration/git/commands/worktree/repair_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Git::Commands::Worktree::Repair, :integration do
         Dir.mktmpdir do |tmpdir|
           non_repo = Git.init(tmpdir, initial_branch: 'main')
           FileUtils.rm_rf(File.join(tmpdir, '.git'))
-          non_git_command = described_class.new(non_repo.lib)
+          non_git_command = described_class.new(non_repo.execution_context)
           expect { non_git_command.call }
             .to raise_error(Git::FailedError, /not a git repository/)
         end

--- a/spec/integration/git/parsers/branch_spec.rb
+++ b/spec/integration/git/parsers/branch_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Git::Parsers::Branch, :integration do
   # Helper to run git branch --list with the parser's format and return raw output
   def git_branch_output(*args)
     format_arg = "--format=#{described_class::FORMAT_STRING}"
-    repo.lib.command_capturing('branch', '--list', format_arg, *args).stdout
+    repo.execution_context.command_capturing('branch', '--list', format_arg, *args).stdout
   end
 
   describe 'FORMAT_STRING validation' do
@@ -154,7 +154,7 @@ RSpec.describe Git::Parsers::Branch, :integration do
         Git.init(bare_dir, bare: true)
         repo.remote_add('origin', bare_dir)
         repo.push('origin', 'main')
-        repo.lib.command_capturing('branch', '-u', 'origin/main', 'main')
+        repo.execution_context.command_capturing('branch', '-u', 'origin/main', 'main')
       end
 
       it 'populates upstream as BranchInfo with refname' do

--- a/spec/integration/git/parsers/fsck_spec.rb
+++ b/spec/integration/git/parsers/fsck_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Git::Parsers::Fsck, :integration do
 
   # Helper to run git fsck and return raw output
   def git_fsck_output(*args)
-    result = repo.lib.command_capturing('fsck', '--no-progress', *args, raise_on_failure: false)
+    result = repo.execution_context.command_capturing('fsck', '--no-progress', *args, raise_on_failure: false)
     result.stdout
   end
 

--- a/spec/integration/git/parsers/stash_spec.rb
+++ b/spec/integration/git/parsers/stash_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Parsers::Stash, :integration do
   # Helper to run git stash list with the parser's format and return raw output
   def git_stash_output
     format_arg = "--format=#{described_class::STASH_FORMAT}"
-    repo.lib.command_capturing('stash', 'list', format_arg).stdout
+    repo.execution_context.command_capturing('stash', 'list', format_arg).stdout
   end
 
   before do
@@ -34,7 +34,7 @@ RSpec.describe Git::Parsers::Stash, :integration do
     context 'with a single stash' do
       before do
         write_file('file.txt', 'modified content')
-        repo.lib.stash_save('WIP on feature')
+        repo.stash_save('WIP on feature')
       end
 
       it 'returns an array with one StashInfo' do
@@ -98,13 +98,13 @@ RSpec.describe Git::Parsers::Stash, :integration do
     context 'with multiple stashes' do
       before do
         write_file('file.txt', 'first change')
-        repo.lib.stash_save('First stash')
+        repo.stash_save('First stash')
 
         write_file('file.txt', 'second change')
-        repo.lib.stash_save('Second stash')
+        repo.stash_save('Second stash')
 
         write_file('file.txt', 'third change')
-        repo.lib.stash_save('Third stash')
+        repo.stash_save('Third stash')
       end
 
       it 'returns stashes in order (newest first)' do
@@ -148,9 +148,9 @@ RSpec.describe Git::Parsers::Stash, :integration do
     context 'with custom message format (no branch prefix)' do
       before do
         write_file('file.txt', 'modified')
-        result = repo.lib.command_capturing('stash', 'create', 'Custom message')
+        result = repo.execution_context.command_capturing('stash', 'create', 'Custom message')
         sha = result.is_a?(String) ? result.strip : result.stdout.strip
-        repo.lib.command_capturing('stash', 'store', '--message=custom: my message', sha)
+        repo.execution_context.command_capturing('stash', 'store', '--message=custom: my message', sha)
       end
 
       it 'parses custom message correctly' do
@@ -169,7 +169,7 @@ RSpec.describe Git::Parsers::Stash, :integration do
 
     before do
       write_file('file.txt', 'modified content')
-      repo.lib.stash_save('Test stash message')
+      repo.stash_save('Test stash message')
     end
 
     it 'uses unit separator (0x1F) as field separator' do

--- a/spec/integration/git/parsers/tag_spec.rb
+++ b/spec/integration/git/parsers/tag_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Parsers::Tag, :integration do
   # Helper to run git tag --list with the parser's format and return raw output
   def git_tag_output(*args)
     format_arg = "--format=#{described_class::FORMAT_STRING}"
-    repo.lib.command_capturing('tag', '--list', format_arg, *args).stdout
+    repo.execution_context.command_capturing('tag', '--list', format_arg, *args).stdout
   end
 
   describe '.parse_list' do

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Git::Repository::Branching, :integration do
     context 'in detached HEAD state' do
       before do
         sha = repo.log(1).execute.first.sha
-        repo.lib.checkout(sha)
+        repo.checkout(sha)
       end
 
       it "returns 'HEAD'" do
@@ -432,7 +432,7 @@ RSpec.describe Git::Repository::Branching, :integration do
     context 'when in detached HEAD state' do
       before do
         sha = repo.log(1).execute.first.sha
-        repo.lib.checkout(sha)
+        repo.checkout(sha)
       end
 
       it 'returns an Array of Git::BranchInfo' do
@@ -510,7 +510,7 @@ RSpec.describe Git::Repository::Branching, :integration do
     context 'in detached HEAD state (checked out at a commit SHA directly)' do
       before do
         sha = repo.log(1).execute.first.sha
-        repo.lib.checkout(sha)
+        repo.checkout(sha)
       end
 
       it 'returns HeadState with state :detached and name HEAD' do

--- a/spec/integration/git/repository/logging_spec.rb
+++ b/spec/integration/git/repository/logging_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Git::Repository::Logging, :integration do
     end
 
     context 'when the repository has commits' do
-      let(:first_sha) { repo.lib.rev_parse('HEAD~1').strip }
+      let(:first_sha) { repo.rev_parse('HEAD~1').strip }
 
       before do
         write_file('README.md', "line one\n")

--- a/spec/integration/git/repository/merging_spec.rb
+++ b/spec/integration/git/repository/merging_spec.rb
@@ -24,12 +24,12 @@ RSpec.describe Git::Repository::Merging, :integration do
   describe '#merge single branch' do
     before do
       # Create and populate a feature branch
-      repo.lib.branch_new('feature')
-      repo.lib.checkout('feature')
+      repo.branch_new('feature')
+      repo.checkout('feature')
       write_file('feature.txt', "feature content\n")
       repo.add('feature.txt')
       repo.commit('Add feature file')
-      repo.lib.checkout('main')
+      repo.checkout('main')
     end
 
     it 'returns a String' do
@@ -56,12 +56,12 @@ RSpec.describe Git::Repository::Merging, :integration do
 
   describe '#merge with a Git::Branch object' do
     before do
-      repo.lib.branch_new('feature')
-      repo.lib.checkout('feature')
+      repo.branch_new('feature')
+      repo.checkout('feature')
       write_file('from_branch_obj.txt', "branch object content\n")
       repo.add('from_branch_obj.txt')
       repo.commit('Add from_branch_obj.txt')
-      repo.lib.checkout('main')
+      repo.checkout('main')
     end
 
     it 'coerces the Git::Branch to a String and merges successfully' do
@@ -77,19 +77,19 @@ RSpec.describe Git::Repository::Merging, :integration do
 
   describe '#merge octopus (Array of branches)' do
     before do
-      repo.lib.branch_new('branch-a')
-      repo.lib.checkout('branch-a')
+      repo.branch_new('branch-a')
+      repo.checkout('branch-a')
       write_file('file_a.txt', "content from branch-a\n")
       repo.add('file_a.txt')
       repo.commit('Add file_a.txt')
-      repo.lib.checkout('main')
+      repo.checkout('main')
 
-      repo.lib.branch_new('branch-b')
-      repo.lib.checkout('branch-b')
+      repo.branch_new('branch-b')
+      repo.checkout('branch-b')
       write_file('file_b.txt', "content from branch-b\n")
       repo.add('file_b.txt')
       repo.commit('Add file_b.txt')
-      repo.lib.checkout('main')
+      repo.checkout('main')
     end
 
     it 'merges all branches and all files appear in the working tree' do
@@ -110,12 +110,12 @@ RSpec.describe Git::Repository::Merging, :integration do
 
   describe '#merge with no_ff: true and a message' do
     before do
-      repo.lib.branch_new('feature')
-      repo.lib.checkout('feature')
+      repo.branch_new('feature')
+      repo.checkout('feature')
       write_file('noff.txt', "no-ff content\n")
       repo.add('noff.txt')
       repo.commit('Add noff.txt')
-      repo.lib.checkout('main')
+      repo.checkout('main')
     end
 
     it 'creates a merge commit whose message is the given string' do
@@ -136,12 +136,12 @@ RSpec.describe Git::Repository::Merging, :integration do
 
   describe '#merge fast-forward with a message' do
     before do
-      repo.lib.branch_new('feature')
-      repo.lib.checkout('feature')
+      repo.branch_new('feature')
+      repo.checkout('feature')
       write_file('ff.txt', "ff content\n")
       repo.add('ff.txt')
       repo.commit('first commit message')
-      repo.lib.checkout('main')
+      repo.checkout('main')
     end
 
     it 'performs the merge successfully (returns a String)' do
@@ -172,12 +172,12 @@ RSpec.describe Git::Repository::Merging, :integration do
   describe '#merge with no_commit: true' do
     before do
       # Branch feature off the initial commit
-      repo.lib.branch_new('feature')
-      repo.lib.checkout('feature')
+      repo.branch_new('feature')
+      repo.checkout('feature')
       write_file('staged.txt', "staged content\n")
       repo.add('staged.txt')
       repo.commit('Add staged.txt')
-      repo.lib.checkout('main')
+      repo.checkout('main')
 
       # Create a commit on main so that main and feature have diverged;
       # this prevents a fast-forward and makes --no-commit effective.
@@ -211,12 +211,12 @@ RSpec.describe Git::Repository::Merging, :integration do
       @common_ancestor_sha = repo.log(1).execute.first.sha
 
       # Add a commit on feature that is NOT on main
-      repo.lib.branch_new('feature')
-      repo.lib.checkout('feature')
+      repo.branch_new('feature')
+      repo.checkout('feature')
       write_file('feature.txt', "feature\n")
       repo.add('feature.txt')
       repo.commit('Feature commit')
-      repo.lib.checkout('main')
+      repo.checkout('main')
 
       # Add a commit on main that is NOT on feature (forces a real divergence)
       write_file('main_extra.txt', "main extra\n")
@@ -257,17 +257,17 @@ RSpec.describe Git::Repository::Merging, :integration do
       # merge_base(M1, M2) returns both B and C.
 
       # B: commit on new_branch_1 (branches off main/A)
-      repo.lib.branch_new('new_branch_1')
-      repo.lib.checkout('new_branch_1')
+      repo.branch_new('new_branch_1')
+      repo.checkout('new_branch_1')
       write_file('b1_1.txt', "b1 first\n")
       repo.add('b1_1.txt')
       repo.commit('B: first commit on branch 1')
       @first_commit_sha = repo.log(1).execute.first.sha
 
       # C: commit on new_branch_2 (branches off main/A independently)
-      repo.lib.checkout('main')
-      repo.lib.branch_new('new_branch_2')
-      repo.lib.checkout('new_branch_2')
+      repo.checkout('main')
+      repo.branch_new('new_branch_2')
+      repo.checkout('new_branch_2')
       write_file('b2_1.txt', "b2 first\n")
       repo.add('b2_1.txt')
       repo.commit('C: first commit on branch 2')
@@ -277,7 +277,7 @@ RSpec.describe Git::Repository::Merging, :integration do
       repo.merge(@first_commit_sha.to_s)
 
       # M1: nb1 merges C → merge commit with parents B and C
-      repo.lib.checkout('new_branch_1')
+      repo.checkout('new_branch_1')
       repo.merge(@second_commit_sha.to_s)
     end
 
@@ -305,20 +305,20 @@ RSpec.describe Git::Repository::Merging, :integration do
 
     context 'when there is a conflict' do
       before do
-        repo.lib.branch_new('branch_ours')
-        repo.lib.checkout('branch_ours')
+        repo.branch_new('branch_ours')
+        repo.checkout('branch_ours')
         write_file('example.txt', "1\n2\n3\n")
         repo.add('example.txt')
         repo.commit('ours: add example.txt')
 
-        repo.lib.checkout('main')
-        repo.lib.branch_new('branch_theirs')
-        repo.lib.checkout('branch_theirs')
+        repo.checkout('main')
+        repo.branch_new('branch_theirs')
+        repo.checkout('branch_theirs')
         write_file('example.txt', "1\n4\n3\n")
         repo.add('example.txt')
         repo.commit('theirs: add example.txt')
 
-        repo.lib.checkout('main')
+        repo.checkout('main')
         repo.merge('branch_ours')
 
         begin
@@ -355,20 +355,20 @@ RSpec.describe Git::Repository::Merging, :integration do
 
     context 'when there is a conflict' do
       before do
-        repo.lib.branch_new('branch_ours')
-        repo.lib.checkout('branch_ours')
+        repo.branch_new('branch_ours')
+        repo.checkout('branch_ours')
         write_file('example.txt', "1\n2\n3\n")
         repo.add('example.txt')
         repo.commit('ours: add example.txt')
 
-        repo.lib.checkout('main')
-        repo.lib.branch_new('branch_theirs')
-        repo.lib.checkout('branch_theirs')
+        repo.checkout('main')
+        repo.branch_new('branch_theirs')
+        repo.checkout('branch_theirs')
         write_file('example.txt', "1\n4\n3\n")
         repo.add('example.txt')
         repo.commit('theirs: add example.txt')
 
-        repo.lib.checkout('main')
+        repo.checkout('main')
         repo.merge('branch_ours')
 
         begin

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
     context 'with a tree object' do
       it 'returns the size of the tree object as an Integer' do
-        tree_sha = repo.lib.rev_parse('HEAD^{tree}')
+        tree_sha = repo.rev_parse('HEAD^{tree}')
         result = described_instance.cat_file_size(tree_sha)
         expect(result).to be_a(Integer)
         expect(result).to be_positive
@@ -114,7 +114,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
     context 'with a tree reference' do
       it 'returns "tree"' do
-        tree_sha = repo.lib.rev_parse('HEAD^{tree}')
+        tree_sha = repo.rev_parse('HEAD^{tree}')
         expect(described_instance.cat_file_type(tree_sha)).to eq('tree')
       end
     end
@@ -171,7 +171,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
     context 'when called with a commit SHA' do
       it 'sets sha to the given SHA string' do
-        sha = repo.lib.rev_parse('HEAD')
+        sha = repo.rev_parse('HEAD')
         result = described_instance.cat_file_commit(sha)
         expect(result['sha']).to eq(sha)
       end
@@ -266,7 +266,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
     context 'with an abbreviated SHA' do
       it 'expands the abbreviated SHA to the full 40-character SHA' do
-        full_sha = repo.lib.rev_parse('HEAD')
+        full_sha = repo.rev_parse('HEAD')
         abbreviated = full_sha[0, 7]
         expect(described_instance.rev_parse(abbreviated)).to eq(full_sha)
       end
@@ -299,7 +299,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
       end
 
       it 'returns the same SHA as rev_parse for the tag' do
-        expected = repo.lib.rev_parse('v1.0')
+        expected = repo.rev_parse('v1.0')
         result = described_instance.tag_sha('v1.0')
         expect(result.chomp).to eq(expected.chomp)
       end
@@ -315,20 +315,20 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
   describe '#full_tree' do
     context 'with the tree SHA for a commit containing one file' do
       it 'returns an Array<String>' do
-        tree_sha = repo.lib.rev_parse('HEAD^{tree}')
+        tree_sha = repo.rev_parse('HEAD^{tree}')
         result = described_instance.full_tree(tree_sha)
         expect(result).to be_a(Array)
         expect(result).to all(be_a(String))
       end
 
       it 'returns one entry per file in the tree' do
-        tree_sha = repo.lib.rev_parse('HEAD^{tree}')
+        tree_sha = repo.rev_parse('HEAD^{tree}')
         result = described_instance.full_tree(tree_sha)
         expect(result.size).to eq(1)
       end
 
       it 'returns entries in the git ls-tree format <mode> <type> <object>\\t<file>' do
-        tree_sha = repo.lib.rev_parse('HEAD^{tree}')
+        tree_sha = repo.rev_parse('HEAD^{tree}')
         result = described_instance.full_tree(tree_sha)
         expect(result.first).to match(/\A\d{6} \w+ [0-9a-f]{40}\t\S+\z/)
       end
@@ -353,13 +353,13 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
   describe '#tree_depth' do
     context 'with the tree SHA for a commit containing one file' do
       it 'returns the recursive entry count as an Integer' do
-        tree_sha = repo.lib.rev_parse('HEAD^{tree}')
+        tree_sha = repo.rev_parse('HEAD^{tree}')
         result = described_instance.tree_depth(tree_sha)
         expect(result).to be_a(Integer)
       end
 
       it 'returns one for the initial repository tree' do
-        tree_sha = repo.lib.rev_parse('HEAD^{tree}')
+        tree_sha = repo.rev_parse('HEAD^{tree}')
         result = described_instance.tree_depth(tree_sha)
         expect(result).to eq(1)
       end
@@ -383,13 +383,13 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
   describe '#name_rev' do
     context 'with a commit SHA that has a symbolic name' do
       it 'returns a String' do
-        sha = repo.lib.rev_parse('HEAD')
+        sha = repo.rev_parse('HEAD')
         result = described_instance.name_rev(sha)
         expect(result).to be_a(String)
       end
 
       it 'returns the symbolic name without a trailing newline' do
-        sha = repo.lib.rev_parse('HEAD')
+        sha = repo.rev_parse('HEAD')
         result = described_instance.name_rev(sha)
         expect(result).not_to end_with("\n")
       end
@@ -695,7 +695,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
     context 'with :object option pointing to a specific commit' do
       it 'searches in that commit instead of HEAD' do
-        sha = repo.lib.rev_parse('HEAD')
+        sha = repo.rev_parse('HEAD')
         result = described_instance.grep('TODO', nil, object: sha)
         expect(result).not_to be_empty
       end

--- a/spec/integration/git/repository/stashing_spec.rb
+++ b/spec/integration/git/repository/stashing_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Git::Repository::Stashing, :integration do
     context 'when there is one stash entry with a branch prefix' do
       before do
         write_file('file.txt', 'modified content')
-        repo.lib.stash_save('my feature work')
+        repo.stash_save('my feature work')
       end
 
       it 'returns a single-element array with index 0' do
@@ -47,10 +47,10 @@ RSpec.describe Git::Repository::Stashing, :integration do
     context 'when there are multiple stash entries' do
       before do
         write_file('file.txt', 'change for stash 1')
-        repo.lib.stash_save('first change')
+        repo.stash_save('first change')
 
         write_file('file.txt', 'change for stash 2')
-        repo.lib.stash_save('second change')
+        repo.stash_save('second change')
       end
 
       it 'returns entries in oldest-first order' do
@@ -65,7 +65,7 @@ RSpec.describe Git::Repository::Stashing, :integration do
     context 'when a stash message contains a colon (e.g. "saving: work")' do
       before do
         write_file('file.txt', 'modified content')
-        repo.lib.stash_save('saving: work')
+        repo.stash_save('saving: work')
       end
 
       it 'strips only the branch prefix and keeps the rest of the message' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -47,14 +47,20 @@ RSpec.configure do |config|
     metadata[:integration] = true
   end
 
-  # Shared setup for all specs
-  config.before(:each) do
-    # Any global setup can go here
+  # Raise on any Git::Deprecation.warn call so that deprecated code paths are
+  # caught immediately as test failures. Tests that intentionally exercise a
+  # deprecated method must wrap the call in Git::Deprecation.silence { ... }
+  # to suppress the raise for that specific invocation.
+  #
+  # Use before(:suite) to apply globally (including before(:all) hooks) and
+  # after(:suite) to restore original behavior to avoid leaking global state.
+  config.before(:suite) do
+    @original_deprecation_behavior = Git::Deprecation.behavior
+    Git::Deprecation.behavior = :raise
   end
 
-  # Shared teardown for all specs
-  config.after(:each) do
-    # Any global teardown can go here
+  config.after(:suite) do
+    Git::Deprecation.behavior = @original_deprecation_behavior
   end
 end
 

--- a/spec/support/contexts/diff_test_repository.rb
+++ b/spec/support/contexts/diff_test_repository.rb
@@ -228,7 +228,7 @@ RSpec.shared_context 'in a diff test repository' do
 
     setup_diff_test_history
 
-    @execution_context = @repo.lib
+    @execution_context = @repo.execution_context
   end
 
   after(:all) do

--- a/spec/support/contexts/empty_repository.rb
+++ b/spec/support/contexts/empty_repository.rb
@@ -314,7 +314,7 @@ RSpec.shared_context 'in an empty repository' do
   let(:repo_dir) { Dir.mktmpdir }
   let(:initial_branch) { 'main' }
   let(:repo) { Git.init(repo_dir, initial_branch:) }
-  let(:execution_context) { repo.lib }
+  let(:execution_context) { repo.execution_context }
 
   before do
     repo.config('user.email', 'test@example.com')

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -173,7 +173,7 @@ module Test
           git = Git.init('test_project')
 
           # Stub git_version to avoid calling real git version during validation
-          stub_lib_git_version(git.lib)
+          stub_lib_git_version(git.execution_context)
 
           # Create a mock for the command method
           mock_command = lambda do |*cmd, **opts|
@@ -189,13 +189,10 @@ module Test
             Git::CommandLineResult.new(['git', *cmd], status, mocked_output, '')
           end
 
-          git.lib.define_singleton_method(method, &mock_command)
-
-          # Also stub the execution context for methods that have been migrated
-          # from Git::Lib to Git::Repository facade modules.
+          # Stub the execution context for all methods (both legacy Git::Lib methods
+          # and facade methods that have been migrated from Git::Lib to Git::Repository).
           facade_ec = git.execution_context
           facade_ec.define_singleton_method(method, &mock_command)
-          facade_ec.define_singleton_method(:git_version) { |timeout: nil| git.lib.git_version } # rubocop:disable Lint/UnusedBlockArgument
 
           Dir.chdir 'test_project' do
             yield(git) if block_given?

--- a/tests/units/test_command_line_env_overrides.rb
+++ b/tests/units/test_command_line_env_overrides.rb
@@ -98,9 +98,9 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
       git = Git.init('test_project')
 
       env = git.execution_context.send(:env_overrides,
-                         'GIT_TRACE' => '1',           # Add new variable
-                         'GIT_INDEX_FILE' => nil,      # Exclude existing variable
-                         'LC_ALL' => 'C')              # Override existing variable
+                                       'GIT_TRACE' => '1',           # Add new variable
+                                       'GIT_INDEX_FILE' => nil,      # Exclude existing variable
+                                       'LC_ALL' => 'C')              # Override existing variable
 
       # Added variable should be present
       assert_equal '1', env['GIT_TRACE']

--- a/tests/units/test_command_line_env_overrides.rb
+++ b/tests/units/test_command_line_env_overrides.rb
@@ -13,11 +13,11 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
 
       assert_command_line_eq(expected_command_line_proc, include_env: true) do |git|
         expected_env = {
-          'GIT_DIR' => git.lib.git_dir,
+          'GIT_DIR' => git.execution_context.git_dir,
           'GIT_EDITOR' => 'true',
-          'GIT_INDEX_FILE' => git.lib.git_index_file,
+          'GIT_INDEX_FILE' => git.execution_context.git_index_file,
           'GIT_SSH' => 'ssh -i /path/to/key',
-          'GIT_WORK_TREE' => git.lib.git_work_dir,
+          'GIT_WORK_TREE' => git.execution_context.git_work_dir,
           'LC_ALL' => 'en_US.UTF-8'
         }
         expected_command_line = [expected_env, 'checkout', {}]
@@ -33,11 +33,11 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
     in_temp_dir do |_path|
       git = Git.init('test_project')
 
-      env = git.lib.send(:env_overrides)
+      env = git.execution_context.send(:env_overrides)
 
-      assert_equal git.lib.git_dir, env['GIT_DIR']
-      assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
-      assert_equal git.lib.git_index_file, env['GIT_INDEX_FILE']
+      assert_equal git.execution_context.git_dir, env['GIT_DIR']
+      assert_equal git.execution_context.git_work_dir, env['GIT_WORK_TREE']
+      assert_equal git.execution_context.git_index_file, env['GIT_INDEX_FILE']
       assert_equal 'en_US.UTF-8', env['LC_ALL']
       assert_equal Git::Base.config.git_ssh, env['GIT_SSH']
     end
@@ -47,12 +47,12 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
     in_temp_dir do |_path|
       git = Git.init('test_project')
 
-      env = git.lib.send(:env_overrides, 'GIT_TRACE' => '1', 'GIT_CURL_VERBOSE' => '1')
+      env = git.execution_context.send(:env_overrides, 'GIT_TRACE' => '1', 'GIT_CURL_VERBOSE' => '1')
 
       # Original variables should still be present
-      assert_equal git.lib.git_dir, env['GIT_DIR']
-      assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
-      assert_equal git.lib.git_index_file, env['GIT_INDEX_FILE']
+      assert_equal git.execution_context.git_dir, env['GIT_DIR']
+      assert_equal git.execution_context.git_work_dir, env['GIT_WORK_TREE']
+      assert_equal git.execution_context.git_index_file, env['GIT_INDEX_FILE']
 
       # Additional variables should be present
       assert_equal '1', env['GIT_TRACE']
@@ -64,15 +64,15 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
     in_temp_dir do |_path|
       git = Git.init('test_project')
 
-      env = git.lib.send(:env_overrides, 'LC_ALL' => 'C', 'GIT_SSH' => '/custom/ssh')
+      env = git.execution_context.send(:env_overrides, 'LC_ALL' => 'C', 'GIT_SSH' => '/custom/ssh')
 
       # Overridden variables should have new values
       assert_equal 'C', env['LC_ALL']
       assert_equal '/custom/ssh', env['GIT_SSH']
 
       # Other variables should remain unchanged
-      assert_equal git.lib.git_dir, env['GIT_DIR']
-      assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
+      assert_equal git.execution_context.git_dir, env['GIT_DIR']
+      assert_equal git.execution_context.git_work_dir, env['GIT_WORK_TREE']
     end
   end
 
@@ -80,15 +80,15 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
     in_temp_dir do |_path|
       git = Git.init('test_project')
 
-      env = git.lib.send(:env_overrides, 'GIT_INDEX_FILE' => nil, 'GIT_SSH' => nil)
+      env = git.execution_context.send(:env_overrides, 'GIT_INDEX_FILE' => nil, 'GIT_SSH' => nil)
 
       # Excluded variables should be set to nil
       assert_nil env['GIT_INDEX_FILE']
       assert_nil env['GIT_SSH']
 
       # Other variables should remain unchanged
-      assert_equal git.lib.git_dir, env['GIT_DIR']
-      assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
+      assert_equal git.execution_context.git_dir, env['GIT_DIR']
+      assert_equal git.execution_context.git_work_dir, env['GIT_WORK_TREE']
       assert_equal 'en_US.UTF-8', env['LC_ALL']
     end
   end
@@ -97,7 +97,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
     in_temp_dir do |_path|
       git = Git.init('test_project')
 
-      env = git.lib.send(:env_overrides,
+      env = git.execution_context.send(:env_overrides,
                          'GIT_TRACE' => '1',           # Add new variable
                          'GIT_INDEX_FILE' => nil,      # Exclude existing variable
                          'LC_ALL' => 'C')              # Override existing variable
@@ -112,8 +112,8 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
       assert_equal 'C', env['LC_ALL']
 
       # Unchanged variables should remain
-      assert_equal git.lib.git_dir, env['GIT_DIR']
-      assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
+      assert_equal git.execution_context.git_dir, env['GIT_DIR']
+      assert_equal git.execution_context.git_work_dir, env['GIT_WORK_TREE']
     end
   end
 
@@ -127,7 +127,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
         Git.init(bare_repo_path, bare: true)
         git = Git.bare(bare_repo_path, git_ssh: '/instance/ssh/script')
 
-        env = git.lib.send(:env_overrides)
+        env = git.execution_context.send(:env_overrides)
         assert_equal '/instance/ssh/script', env['GIT_SSH']
       end
     ensure
@@ -144,7 +144,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
         create_and_init_repo(path)
         git = Git.open(path, git_ssh: '/instance/ssh/script')
 
-        env = git.lib.send(:env_overrides)
+        env = git.execution_context.send(:env_overrides)
         assert_equal '/instance/ssh/script', env['GIT_SSH']
       end
     ensure
@@ -160,7 +160,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
       in_temp_dir do |_path|
         git = Git.init('test_project', git_ssh: '/instance/ssh/script')
 
-        env = git.lib.send(:env_overrides)
+        env = git.execution_context.send(:env_overrides)
         assert_equal '/instance/ssh/script', env['GIT_SSH']
       end
     ensure
@@ -184,7 +184,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
           git = Git.clone(source_repo, target_path, git_ssh: '/instance/ssh/script')
 
           # Verify the env_overrides has the instance git_ssh
-          env = git.lib.send(:env_overrides)
+          env = git.execution_context.send(:env_overrides)
           assert_equal '/instance/ssh/script', env['GIT_SSH']
         end
       end
@@ -202,7 +202,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
         create_and_init_repo(path)
         git = Git.open(path, git_ssh: nil)
 
-        env = git.lib.send(:env_overrides)
+        env = git.execution_context.send(:env_overrides)
         assert_nil env['GIT_SSH'], 'GIT_SSH should be nil when git_ssh: nil is passed'
       end
     ensure
@@ -219,7 +219,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
         create_and_init_repo(path)
         git = Git.open(path)
 
-        env = git.lib.send(:env_overrides)
+        env = git.execution_context.send(:env_overrides)
         assert_equal '/global/ssh/script', env['GIT_SSH']
       end
     ensure
@@ -238,7 +238,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
 
         git = Git.clone(source_repo, target_path, git_ssh: nil)
 
-        env = git.lib.send(:env_overrides)
+        env = git.execution_context.send(:env_overrides)
         assert_nil env['GIT_SSH'], 'GIT_SSH should be nil when git_ssh: nil is passed to Git.clone'
       end
     ensure
@@ -257,7 +257,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
 
         git = Git.clone(source_repo, target_path)
 
-        env = git.lib.send(:env_overrides)
+        env = git.execution_context.send(:env_overrides)
         assert_equal '/global/ssh/script', env['GIT_SSH']
       end
     ensure

--- a/tests/units/test_command_raises_on_failure.rb
+++ b/tests/units/test_command_raises_on_failure.rb
@@ -62,5 +62,4 @@ class TestCommandRaisesOnFailure < Test::Unit::TestCase
       end
     end
   end
-
 end

--- a/tests/units/test_command_raises_on_failure.rb
+++ b/tests/units/test_command_raises_on_failure.rb
@@ -2,7 +2,7 @@
 
 require 'test_helper'
 
-# Tests that Git::Lib#command raises Git::FailedError on non-zero exit status by default
+# Tests that Git::ExecutionContext#command_capturing raises Git::FailedError on non-zero exit status by default
 #
 # This behavior is critical for backward compatibility - the original command
 # method raised on failure, and raise_on_failure: true (the default) preserves this.
@@ -15,7 +15,7 @@ class TestCommandRaisesOnFailure < Test::Unit::TestCase
       Dir.chdir('test_project') do
         # Try to show a non-existent ref - this should fail with exit code 128
         assert_raise(Git::FailedError) do
-          git.lib.command_capturing('show', 'nonexistent-ref-that-does-not-exist')
+          git.execution_context.command_capturing('show', 'nonexistent-ref-that-does-not-exist')
         end
       end
     end
@@ -26,7 +26,7 @@ class TestCommandRaisesOnFailure < Test::Unit::TestCase
       git = Git.init('test_project')
 
       Dir.chdir('test_project') do
-        git.lib.command_capturing('show', 'nonexistent-ref-that-does-not-exist')
+        git.execution_context.command_capturing('show', 'nonexistent-ref-that-does-not-exist')
         flunk 'Expected Git::FailedError to be raised'
       rescue Git::FailedError => e
         assert_not_nil e.result
@@ -42,7 +42,7 @@ class TestCommandRaisesOnFailure < Test::Unit::TestCase
 
       Dir.chdir('test_project') do
         # This should NOT raise - raise_on_failure: false suppresses the error
-        result = git.lib.command_capturing('show', 'nonexistent-ref-that-does-not-exist', raise_on_failure: false)
+        result = git.execution_context.command_capturing('show', 'nonexistent-ref-that-does-not-exist', raise_on_failure: false)
 
         assert_instance_of Git::CommandLineResult, result
         assert_equal false, result.status.success?
@@ -63,20 +63,4 @@ class TestCommandRaisesOnFailure < Test::Unit::TestCase
     end
   end
 
-  test 'tag_sha returns empty string for non-existent tag' do
-    in_temp_dir do |_path|
-      git = Git.init('test_project')
-
-      Dir.chdir('test_project') do
-        # Create a commit so the repo isn't empty
-        File.write('test.txt', 'content')
-        git.add('test.txt')
-        git.commit('Initial commit')
-
-        # tag_sha for non-existent tag should return '' (special handling for exit code 1)
-        result = git.lib.tag_sha('nonexistent-tag')
-        assert_equal '', result
-      end
-    end
-  end
 end

--- a/tests/units/test_deprecations.rb
+++ b/tests/units/test_deprecations.rb
@@ -196,7 +196,7 @@ class TestDeprecations < Test::Unit::TestCase
       'must implement it themselves using: Git.git_version >= Git::MINIMUM_GIT_VERSION.'
     )
 
-    assert_equal(true, Git::Lib.warn_if_old_command(@git.lib))
+    assert_equal(true, Git::Lib.warn_if_old_command(Git::Base.open(@wdir).lib))
   end
 
   def test_clean_ff_deprecation
@@ -210,7 +210,7 @@ class TestDeprecations < Test::Unit::TestCase
       )
 
       # Call clean with deprecated :ff option
-      git.lib.clean(ff: true)
+      git.clean(ff: true)
     end
   end
 

--- a/tests/units/test_each_conflict.rb
+++ b/tests/units/test_each_conflict.rb
@@ -6,7 +6,7 @@ class TestEachConflict < Test::Unit::TestCase
   def test_unmerged_returns_empty_when_no_conflicts
     in_temp_repo('working') do
       g = Git.open('.')
-      assert_equal([], g.lib.unmerged)
+      assert_equal([], g.unmerged)
     end
   end
 
@@ -36,7 +36,7 @@ class TestEachConflict < Test::Unit::TestCase
         assert_match(/CONFLICT/, e.result.stdout)
       end
 
-      assert_equal(['example.txt'], g.lib.unmerged)
+      assert_equal(['example.txt'], g.unmerged)
 
       # Check the conflict
       g.each_conflict do |file, your, their|
@@ -73,7 +73,7 @@ class TestEachConflict < Test::Unit::TestCase
         # expected conflict
       end
 
-      assert_equal(['file1.txt', 'file2.txt'], g.lib.unmerged.sort)
+      assert_equal(['file1.txt', 'file2.txt'], g.unmerged.sort)
     end
   end
 end

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -492,4 +492,10 @@ class TestLib < Test::Unit::TestCase
     stats = @lib.diff_stats('HEAD~1', 'HEAD', path_limiter: ['', ''])
     assert(stats[:files].key?('another.txt'))
   end
+
+  def test_tag_sha_returns_empty_string_for_non_existent_tag
+    # tag_sha for non-existent tag should return '' (special handling for exit code 1)
+    result = Git::Base.open(@wdir).lib.tag_sha('nonexistent-tag')
+    assert_equal '', result
+  end
 end

--- a/tests/units/test_set_index.rb
+++ b/tests/units/test_set_index.rb
@@ -123,9 +123,9 @@ class SetIndexTest < Test::Unit::TestCase
       file.write(new_content)
       file.rewind
       # Use `git hash-object -w` to write the blob to the object database and get its SHA
-      repo.lib.command_capturing('hash-object', '-w', file.path).stdout
+      repo.execution_context.command_capturing('hash-object', '-w', file.path).stdout
     end
-    repo.lib.command_capturing('update-index', '--add', '--cacheinfo', "100644,#{blob_sha},new_file.txt").stdout
+    repo.execution_context.command_capturing('update-index', '--add', '--cacheinfo', "100644,#{blob_sha},new_file.txt").stdout
 
     # 6. Write the state of the custom index to a new tree object in the Git database.
     new_tree_sha = repo.write_tree

--- a/tests/units/test_stash_save.rb
+++ b/tests/units/test_stash_save.rb
@@ -8,7 +8,7 @@ class TestStashSave < Test::Unit::TestCase
       new_file('test-file1', 'content1')
       g.add
 
-      result = g.lib.stash_save('save with changes')
+      result = g.stash_save('save with changes')
 
       assert_equal(true, result)
     end
@@ -16,7 +16,7 @@ class TestStashSave < Test::Unit::TestCase
 
   test 'stash_save returns false when there are no local changes to save' do
     in_bare_repo_clone do |g|
-      result = g.lib.stash_save('save without changes')
+      result = g.stash_save('save without changes')
 
       assert_equal(false, result)
     end
@@ -31,7 +31,7 @@ class TestStashSave < Test::Unit::TestCase
       git = Git.open('.')
 
       assert_raise(Git::FailedError) do
-        git.lib.stash_save('unborn stash')
+        git.stash_save('unborn stash')
       end
     end
   end

--- a/tests/units/test_stashes.rb
+++ b/tests/units/test_stashes.rb
@@ -42,7 +42,7 @@ class TestStashes < Test::Unit::TestCase
       # puts `cat .git/logs/refs/stash`
       # 0000000000000000000000000000000000000000 b9b008cd179b0e8c4b8cda35bac43f7011a0836a James Couball <jcouball@yahoo.com> 1729463252 -0700   On master: testing-stash-all
 
-      stashes = assert_nothing_raised { g.lib.stashes_all }
+      stashes = assert_nothing_raised { g.stashes_all }
 
       expected_stashes = [
         [0, 'testing-stash-all']
@@ -68,7 +68,7 @@ class TestStashes < Test::Unit::TestCase
       # puts `cat .git/logs/refs/stash`
       # 0000000000000000000000000000000000000000 b9b008cd179b0e8c4b8cda35bac43f7011a0836a James Couball <jcouball@yahoo.com> 1729463252 -0700   On master: saving: testing-stash-all
 
-      stashes = assert_nothing_raised { g.lib.stashes_all }
+      stashes = assert_nothing_raised { g.stashes_all }
 
       expected_stashes = [
         [0, 'saving: testing-stash-all']
@@ -94,7 +94,7 @@ class TestStashes < Test::Unit::TestCase
 
       git = Git.open('.')
 
-      stashes = assert_nothing_raised { git.lib.stashes_all }
+      stashes = assert_nothing_raised { git.stashes_all }
 
       expected_stashes = [
         [0, 'custom message']
@@ -122,7 +122,7 @@ class TestStashes < Test::Unit::TestCase
 
       git = Git.open('.')
 
-      stashes = assert_nothing_raised { git.lib.stashes_all }
+      stashes = assert_nothing_raised { git.stashes_all }
 
       expected_stashes = [
         [0, 'testing: custom message']


### PR DESCRIPTION
Replace deprecated `repo.lib` calls with `repo.execution_context` and other appropriate methods across the test suite. This cleanup enforces the use of the updated repository structure and ensures that deprecated methods raise errors during testing. Additionally, implement deprecation behavior in the RSpec suite to catch deprecated usage immediately.