### PR TITLE
Remove dead fallbacks and add deprecation warnings

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -3,11 +3,10 @@
 require 'active_support'
 require 'active_support/deprecation'
 
+require 'git/deprecation'
 require 'git/version'
 
 module Git
-  Deprecation = ActiveSupport::Deprecation.new('5.0.0', 'Git')
-
   # Minimum git version required by this gem
   #
   # Commands and features may require newer versions, but this is the absolute

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1227,6 +1227,36 @@ module Git
       facade_repository.diff_full(obj1, obj2, opts.slice(:path_limiter))
     end
 
+    # Returns the per-file insertion and deletion counts between two commits
+    #
+    # @example Get numstat between two commits
+    #   repo.diff_numstat('HEAD~1', 'HEAD')
+    #
+    # @param obj1 [String] the first commit or object to compare; defaults to
+    #   `'HEAD'`
+    #
+    # @param obj2 [String, nil] the second commit or object to compare
+    #
+    #   When `nil`, the comparison is against the index or working tree.
+    #
+    # @param opts [Hash] options to filter the diff
+    #
+    # @option opts [String, Pathname, Array<String, Pathname>, nil] :path_limiter (nil)
+    #   limit the numstat to the given path(s)
+    #
+    # @return [Hash] the per-file insertion/deletion counts
+    #
+    # @note Unknown option keys are silently ignored for backward compatibility;
+    #   only `:path_limiter` is forwarded to the underlying command.
+    #
+    # @raise [Git::FailedError] if git exits outside the allowed range (exit code > 1)
+    #
+    # @see Git::Repository::Diffing#diff_numstat
+    #
+    def diff_numstat(obj1 = 'HEAD', obj2 = nil, opts = {})
+      facade_repository.diff_numstat(obj1, obj2, opts.slice(:path_limiter))
+    end
+
     # Returns a lazy {Git::DiffStats} object for accessing diff statistics
     #
     # Compares (1) two commits, (2) a commit against the working tree, or (3) the

--- a/lib/git/deprecation.rb
+++ b/lib/git/deprecation.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+require 'active_support/deprecation'
+
+# The Git module provides a Ruby interface to Git version control.
+module Git
+  # @api private
+  Deprecation = ActiveSupport::Deprecation.new('5.0.0', 'Git')
+end

--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -102,11 +102,7 @@ module Git
     # @return [String] the raw output of `git diff`
     #
     def patch
-      if @base.respond_to?(:diff_full)
-        @base.diff_full(@from, @to, path_limiter: @path)
-      else
-        @base.lib.diff_full(@from, @to, { path_limiter: @path })
-      end
+      @base.diff_full(@from, @to, path_limiter: @path)
     end
     alias to_s patch
 

--- a/lib/git/diff_path_status.rb
+++ b/lib/git/diff_path_status.rb
@@ -61,21 +61,10 @@ module Git
 
     # Lazily fetches and caches the path status from the git lib
     #
-    # When constructed with a pre-fetched hash, returns it directly.
-    # When `@base` responds to `#diff_name_status` (e.g. {Git::Repository} or
-    # {Git::Base}, which defines it as an alias for `#diff_path_status`),
-    # delegates directly to that method. Otherwise falls back to the legacy
-    # `@base.lib.diff_path_status` call for duck-typed base objects that only
-    # expose path-status via their lib.
-    #
     # @return [Hash{String => String}] a mapping of file paths to status codes
     #
     def fetch_path_status
-      @fetch_path_status ||= if @base.respond_to?(:diff_name_status)
-                               @base.diff_name_status(@from, @to, path_limiter: @path_limiter).to_h
-                             else
-                               @base.lib.diff_path_status(@from, @to, { path_limiter: @path_limiter })
-                             end
+      @fetch_path_status ||= @base.diff_name_status(@from, @to, path_limiter: @path_limiter).to_h
     end
 
     # Sets up legacy (base, from, to, path_limiter) instance state

--- a/lib/git/diff_stats.rb
+++ b/lib/git/diff_stats.rb
@@ -88,17 +88,9 @@ module Git
 
     # Lazily fetches and caches the stats from the git lib
     #
-    # When `@base` implements `#diff_numstat`, delegates directly to that
-    # method. Otherwise falls back to the legacy `@base.lib.diff_stats` call
-    # so that existing `Git::Base`-backed callers continue to work unchanged.
-    #
     # @return [Hash] the fetched stats hash
     def fetch_stats
-      @fetch_stats ||= if @base.respond_to?(:diff_numstat)
-                         @base.diff_numstat(@from, @to, path_limiter: @path_limiter)
-                       else
-                         @base.lib.diff_stats(@from, @to, { path_limiter: @path_limiter })
-                       end
+      @fetch_stats ||= @base.diff_numstat(@from, @to, path_limiter: @path_limiter)
     end
   end
 end

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -166,20 +166,6 @@ module Git
     # @api private
     def binary_path = execution_context.binary_path
 
-    # Runs a git command; delegates to the execution context.
-    #
-    # @api private
-    def command_capturing(...)
-      execution_context.command_capturing(...)
-    end
-
-    # Streams a git command; delegates to the execution context.
-    #
-    # @api private
-    def command_streaming(...)
-      execution_context.command_streaming(...)
-    end
-
     # Returns the size of the repository directory in bytes
     #
     # Sums the sizes of every regular file under the repository (`.git`)
@@ -205,16 +191,6 @@ module Git
         next
       end
       total
-    end
-
-    private
-
-    # Builds the git environment variable overrides for this repository;
-    # delegates to the execution context.
-    #
-    # @api private
-    def env_overrides(**additional_overrides)
-      execution_context.env_overrides(**additional_overrides)
     end
   end
 end

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -3,6 +3,7 @@
 require 'find'
 require 'pathname'
 
+require 'git/deprecation'
 require 'git/execution_context/repository'
 require 'git/repository/branching'
 require 'git/repository/context_helpers'
@@ -117,14 +118,23 @@ module Git
       index_file && Pathname.new(index_file)
     end
 
-    # Returns `self` so that legacy code using `git.lib.some_method` continues
-    # to work when `some_method` is a facade method on `Git::Repository`.
+    # Returns `self` after emitting a deprecation warning.
+    #
+    # Legacy callers that used `git.lib.some_method` can migrate to calling the
+    # facade method directly on the repository object. This shim will be removed
+    # in v6.0.0.
     #
     # @return [self]
     #
     # @api private
     #
-    def lib = self
+    def lib
+      Git::Deprecation.warn(
+        'Git::Repository#lib is deprecated and will be removed in v6.0.0. ' \
+        'Use the repository object directly.'
+      )
+      self
+    end
 
     # @return [String, nil] the git directory path
     #

--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -281,18 +281,10 @@ module Git
     class StatusFileFactory
       # Create a new factory backed by the given git object
       #
-      # When `base` is a {Git::Repository} (which exposes `#diff_index`
-      # directly), it is used as the data provider. When `base` is a
-      # {Git::Base} (the legacy path), `base.lib` is used instead.
-      #
-      # @param base [Git::Base, Git::Repository] the git object used as the
-      #   status data provider
+      # @param base [Git::Base, Git::Repository] the git object used as the status data provider
       #
       def initialize(base)
         @base = base
-        # When base is Git::Repository (which exposes #diff_index directly),
-        # use it as the data provider. Otherwise use base.lib (legacy path).
-        @provider = base.respond_to?(:diff_index) ? base : base.lib
       end
 
       # Gather all status data and build a hash of file paths to StatusFile objects
@@ -314,7 +306,7 @@ module Git
       # @return [Hash{String => Hash}] raw per-file status data keyed by path
       #
       def fetch_all_files_data
-        files = @provider.ls_files # Start with files tracked in the index.
+        files = @base.ls_files # Start with files tracked in the index.
         merge_untracked_files(files)
         merge_modified_files(files)
         merge_head_diffs(files)
@@ -328,7 +320,7 @@ module Git
       # @return [void]
       #
       def merge_untracked_files(files)
-        @provider.untracked_files.each do |file|
+        @base.untracked_files.each do |file|
           files[file] = { path: file, untracked: true }
         end
       end
@@ -341,7 +333,7 @@ module Git
       #
       def merge_modified_files(files)
         # Merge changes between the index and the working directory.
-        @provider.diff_files.each do |path, data|
+        @base.diff_files.each do |path, data|
           (files[path] ||= {}).merge!(data)
         end
       end
@@ -353,12 +345,11 @@ module Git
       # @return [void]
       #
       def merge_head_diffs(files)
-        # Git::Repository exposes #no_commits?; Git::Lib exposes #empty?.
-        is_empty = @provider.respond_to?(:no_commits?) ? @provider.no_commits? : @provider.empty?
+        is_empty = @base.no_commits?
         return if is_empty
 
         # Merge changes between HEAD and the index.
-        @provider.diff_index('HEAD').each do |path, data|
+        @base.diff_index('HEAD').each do |path, data|
           (files[path] ||= {}).merge!(data)
         end
       end

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -103,6 +103,37 @@ RSpec.describe Git::Base do
     end
   end
 
+  describe '#diff_numstat' do
+    include_context 'with a stubbed facade_repository'
+
+    subject(:result) { described_instance.diff_numstat(obj1, obj2, opts) }
+
+    let(:obj1) { 'HEAD~1' }
+    let(:obj2) { 'HEAD' }
+    let(:opts) { { path_limiter: 'lib/' } }
+    let(:numstat_result) do
+      { total: { insertions: 2, deletions: 1, lines: 3, files: 1 }, files: {} }
+    end
+
+    it 'delegates to facade_repository.diff_numstat forwarding obj1, obj2, and path_limiter' do
+      expect(facade_repository).to receive(:diff_numstat)
+        .with(obj1, obj2, { path_limiter: 'lib/' })
+        .and_return(numstat_result)
+      expect(result).to be(numstat_result)
+    end
+
+    context 'when opts contains unknown keys' do
+      let(:opts) { { path_limiter: 'lib/', unknown: true } }
+
+      it 'strips unknown keys and forwards only path_limiter' do
+        expect(facade_repository).to receive(:diff_numstat)
+          .with(obj1, obj2, { path_limiter: 'lib/' })
+          .and_return(numstat_result)
+        result
+      end
+    end
+  end
+
   describe '#diff' do
     include_context 'with a stubbed facade_repository'
 

--- a/spec/unit/git/diff_path_status_spec.rb
+++ b/spec/unit/git/diff_path_status_spec.rb
@@ -10,12 +10,8 @@ RSpec.describe Git::DiffPathStatus do
   let(:repository_base)      { instance_double(Git::Repository) }
   let(:diff_name_status_obj) { instance_double(described_class, to_h: name_status_hash) }
 
-  let(:legacy_lib)  { double('legacy_lib') }
-  let(:legacy_base) { double('legacy_base', lib: legacy_lib) }
-
   before do
     allow(repository_base).to receive(:diff_name_status).and_return(diff_name_status_obj)
-    allow(legacy_lib).to receive(:diff_path_status).and_return(name_status_hash)
   end
 
   describe '#initialize' do
@@ -39,68 +35,42 @@ RSpec.describe Git::DiffPathStatus do
   end
 
   describe '#to_h' do
-    context 'when base responds to :diff_name_status (Git::Repository form)' do
-      subject(:result) { described_class.new(repository_base, 'HEAD~1', 'HEAD').to_h }
+    subject(:result) { described_class.new(repository_base, 'HEAD~1', 'HEAD').to_h }
 
-      it 'calls diff_name_status with from, to, and path_limiter: nil' do
+    it 'calls diff_name_status with from, to, and path_limiter: nil' do
+      expect(repository_base).to receive(:diff_name_status)
+        .with('HEAD~1', 'HEAD', path_limiter: nil)
+        .and_return(diff_name_status_obj)
+      result
+    end
+
+    it 'returns the name-status hash' do
+      expect(result).to eq(name_status_hash)
+    end
+
+    context 'when path_limiter is given' do
+      it 'forwards path_limiter to diff_name_status' do
         expect(repository_base).to receive(:diff_name_status)
-          .with('HEAD~1', 'HEAD', path_limiter: nil)
+          .with('HEAD~1', 'HEAD', path_limiter: 'lib/')
           .and_return(diff_name_status_obj)
-        result
-      end
-
-      it 'returns the name-status hash' do
-        expect(result).to eq(name_status_hash)
-      end
-
-      context 'when path_limiter is given' do
-        it 'forwards path_limiter to diff_name_status' do
-          expect(repository_base).to receive(:diff_name_status)
-            .with('HEAD~1', 'HEAD', path_limiter: 'lib/')
-            .and_return(diff_name_status_obj)
-          described_class.new(repository_base, 'HEAD~1', 'HEAD', 'lib/').to_h
-        end
-      end
-
-      context 'when obj2 is nil' do
-        it 'passes nil as the second positional argument to diff_name_status' do
-          expect(repository_base).to receive(:diff_name_status)
-            .with('HEAD', nil, path_limiter: nil)
-            .and_return(diff_name_status_obj)
-          described_class.new(repository_base, 'HEAD', nil).to_h
-        end
-      end
-
-      it 'memoizes the result across multiple to_h calls' do
-        expect(repository_base).to receive(:diff_name_status).once.and_return(diff_name_status_obj)
-        status = described_class.new(repository_base, 'HEAD', nil)
-        status.to_h
-        status.to_h
+        described_class.new(repository_base, 'HEAD~1', 'HEAD', 'lib/').to_h
       end
     end
 
-    context 'when base does not respond to :diff_name_status (legacy Git::Base form)' do
-      subject(:result) { described_class.new(legacy_base, 'HEAD~1', 'HEAD').to_h }
-
-      it 'calls base.lib.diff_path_status with from, to, and path_limiter option' do
-        expect(legacy_lib).to receive(:diff_path_status)
-          .with('HEAD~1', 'HEAD', { path_limiter: nil })
-          .and_return(name_status_hash)
-        result
+    context 'when obj2 is nil' do
+      it 'passes nil as the second positional argument to diff_name_status' do
+        expect(repository_base).to receive(:diff_name_status)
+          .with('HEAD', nil, path_limiter: nil)
+          .and_return(diff_name_status_obj)
+        described_class.new(repository_base, 'HEAD', nil).to_h
       end
+    end
 
-      it 'returns the name-status hash' do
-        expect(result).to eq(name_status_hash)
-      end
-
-      context 'when path_limiter is given' do
-        it 'forwards path_limiter to base.lib.diff_path_status' do
-          expect(legacy_lib).to receive(:diff_path_status)
-            .with('HEAD~1', 'HEAD', { path_limiter: 'lib/' })
-            .and_return(name_status_hash)
-          described_class.new(legacy_base, 'HEAD~1', 'HEAD', 'lib/').to_h
-        end
-      end
+    it 'memoizes the result across multiple to_h calls' do
+      expect(repository_base).to receive(:diff_name_status).once.and_return(diff_name_status_obj)
+      status = described_class.new(repository_base, 'HEAD', nil)
+      status.to_h
+      status.to_h
     end
   end
 

--- a/spec/unit/git/diff_spec.rb
+++ b/spec/unit/git/diff_spec.rb
@@ -11,16 +11,8 @@ RSpec.describe Git::Diff do
 
   let(:repository_base) { instance_double(Git::Repository) }
 
-  # Duck-type collaborator: the legacy path models any base that exposes #lib
-  # but does NOT itself respond to #diff_full. No single concrete class in the
-  # codebase matches this interface (Git::Base defines #diff_full directly), so
-  # instance_double cannot be used here.
-  let(:legacy_lib)  { double('Git::Lib') }
-  let(:legacy_base) { double('legacy_base', lib: legacy_lib) }
-
   before do
     allow(repository_base).to receive(:diff_full).and_return(patch_text)
-    allow(legacy_lib).to receive(:diff_full).and_return(patch_text)
   end
 
   let(:described_instance) { described_class.new(repository_base, 'HEAD~1', 'HEAD') }
@@ -70,60 +62,34 @@ RSpec.describe Git::Diff do
   end
 
   describe '#patch' do
-    context 'when base responds to :diff_full (Git::Repository form)' do
-      subject(:result) { described_class.new(repository_base, 'HEAD~1', 'HEAD').patch }
+    subject(:result) { described_class.new(repository_base, 'HEAD~1', 'HEAD').patch }
 
-      it 'calls diff_full with from, to, and path_limiter: nil' do
+    it 'calls diff_full with from, to, and path_limiter: nil' do
+      expect(repository_base).to receive(:diff_full)
+        .with('HEAD~1', 'HEAD', path_limiter: nil)
+        .and_return(patch_text)
+      result
+    end
+
+    it 'returns the patch text' do
+      expect(result).to eq(patch_text)
+    end
+
+    context 'when a path filter has been set' do
+      it 'forwards the path to diff_full as path_limiter' do
         expect(repository_base).to receive(:diff_full)
-          .with('HEAD~1', 'HEAD', path_limiter: nil)
+          .with('HEAD~1', 'HEAD', path_limiter: 'lib/')
           .and_return(patch_text)
-        result
-      end
-
-      it 'returns the patch text' do
-        expect(result).to eq(patch_text)
-      end
-
-      context 'when a path filter has been set' do
-        it 'forwards the path to diff_full as path_limiter' do
-          expect(repository_base).to receive(:diff_full)
-            .with('HEAD~1', 'HEAD', path_limiter: 'lib/')
-            .and_return(patch_text)
-          described_class.new(repository_base, 'HEAD~1', 'HEAD').path('lib/').patch
-        end
-      end
-
-      context 'when obj2 is nil' do
-        it 'passes nil as the second positional argument to diff_full' do
-          expect(repository_base).to receive(:diff_full)
-            .with('HEAD', nil, path_limiter: nil)
-            .and_return(patch_text)
-          described_class.new(repository_base, 'HEAD', nil).patch
-        end
+        described_class.new(repository_base, 'HEAD~1', 'HEAD').path('lib/').patch
       end
     end
 
-    context 'when base does not respond to :diff_full (legacy Git::Base form)' do
-      subject(:result) { described_class.new(legacy_base, 'HEAD~1', 'HEAD').patch }
-
-      it 'calls base.lib.diff_full with from, to, and path_limiter option' do
-        expect(legacy_lib).to receive(:diff_full)
-          .with('HEAD~1', 'HEAD', { path_limiter: nil })
+    context 'when obj2 is nil' do
+      it 'passes nil as the second positional argument to diff_full' do
+        expect(repository_base).to receive(:diff_full)
+          .with('HEAD', nil, path_limiter: nil)
           .and_return(patch_text)
-        result
-      end
-
-      it 'returns the patch text' do
-        expect(result).to eq(patch_text)
-      end
-
-      context 'when a path filter has been set' do
-        it 'forwards the path to base.lib.diff_full as path_limiter' do
-          expect(legacy_lib).to receive(:diff_full)
-            .with('HEAD~1', 'HEAD', { path_limiter: 'lib/' })
-            .and_return(patch_text)
-          described_class.new(legacy_base, 'HEAD~1', 'HEAD').path('lib/').patch
-        end
+        described_class.new(repository_base, 'HEAD', nil).patch
       end
     end
   end

--- a/spec/unit/git/diff_stats_spec.rb
+++ b/spec/unit/git/diff_stats_spec.rb
@@ -13,12 +13,9 @@ RSpec.describe Git::DiffStats do
   end
 
   let(:repository_base) { instance_double(Git::Repository) }
-  let(:legacy_lib)      { double('legacy_lib') }
-  let(:legacy_base)     { double('legacy_base', lib: legacy_lib) }
 
   before do
     allow(repository_base).to receive(:diff_numstat).and_return(stats_hash)
-    allow(legacy_lib).to receive(:diff_stats).and_return(stats_hash)
   end
 
   describe '#initialize' do
@@ -34,68 +31,42 @@ RSpec.describe Git::DiffStats do
   end
 
   describe '#insertions' do
-    context 'when base responds to :diff_numstat (Git::Repository form)' do
-      subject(:result) { described_class.new(repository_base, 'HEAD~1', 'HEAD').insertions }
+    subject(:result) { described_class.new(repository_base, 'HEAD~1', 'HEAD').insertions }
 
-      it 'calls diff_numstat with from, to, and path_limiter: nil' do
+    it 'calls diff_numstat with from, to, and path_limiter: nil' do
+      expect(repository_base).to receive(:diff_numstat)
+        .with('HEAD~1', 'HEAD', path_limiter: nil)
+        .and_return(stats_hash)
+      result
+    end
+
+    it 'returns the total insertions from the diff_numstat result' do
+      expect(result).to eq(5)
+    end
+
+    context 'when path_limiter is given' do
+      it 'forwards path_limiter to diff_numstat' do
         expect(repository_base).to receive(:diff_numstat)
-          .with('HEAD~1', 'HEAD', path_limiter: nil)
+          .with('HEAD~1', 'HEAD', path_limiter: 'lib/')
           .and_return(stats_hash)
-        result
-      end
-
-      it 'returns the total insertions from the diff_numstat result' do
-        expect(result).to eq(5)
-      end
-
-      context 'when path_limiter is given' do
-        it 'forwards path_limiter to diff_numstat' do
-          expect(repository_base).to receive(:diff_numstat)
-            .with('HEAD~1', 'HEAD', path_limiter: 'lib/')
-            .and_return(stats_hash)
-          described_class.new(repository_base, 'HEAD~1', 'HEAD', 'lib/').insertions
-        end
-      end
-
-      context 'when obj2 is nil' do
-        it 'passes nil as the second positional argument to diff_numstat' do
-          expect(repository_base).to receive(:diff_numstat)
-            .with('HEAD', nil, path_limiter: nil)
-            .and_return(stats_hash)
-          described_class.new(repository_base, 'HEAD', nil).insertions
-        end
-      end
-
-      it 'memoizes the diff_numstat result across multiple accessor calls' do
-        expect(repository_base).to receive(:diff_numstat).once.and_return(stats_hash)
-        stats = described_class.new(repository_base, 'HEAD', nil)
-        stats.insertions
-        stats.deletions
+        described_class.new(repository_base, 'HEAD~1', 'HEAD', 'lib/').insertions
       end
     end
 
-    context 'when base does not respond to :diff_numstat (legacy Git::Base form)' do
-      subject(:result) { described_class.new(legacy_base, 'HEAD~1', 'HEAD').insertions }
-
-      it 'calls base.lib.diff_stats with from, to, and path_limiter option' do
-        expect(legacy_lib).to receive(:diff_stats)
-          .with('HEAD~1', 'HEAD', { path_limiter: nil })
+    context 'when obj2 is nil' do
+      it 'passes nil as the second positional argument to diff_numstat' do
+        expect(repository_base).to receive(:diff_numstat)
+          .with('HEAD', nil, path_limiter: nil)
           .and_return(stats_hash)
-        result
+        described_class.new(repository_base, 'HEAD', nil).insertions
       end
+    end
 
-      it 'returns the total insertions from the legacy diff_stats result' do
-        expect(result).to eq(5)
-      end
-
-      context 'when path_limiter is given' do
-        it 'forwards path_limiter to base.lib.diff_stats' do
-          expect(legacy_lib).to receive(:diff_stats)
-            .with('HEAD~1', 'HEAD', { path_limiter: 'lib/' })
-            .and_return(stats_hash)
-          described_class.new(legacy_base, 'HEAD~1', 'HEAD', 'lib/').insertions
-        end
-      end
+    it 'memoizes the diff_numstat result across multiple accessor calls' do
+      expect(repository_base).to receive(:diff_numstat).once.and_return(stats_hash)
+      stats = described_class.new(repository_base, 'HEAD', nil)
+      stats.insertions
+      stats.deletions
     end
   end
 

--- a/spec/unit/git/repository_spec.rb
+++ b/spec/unit/git/repository_spec.rb
@@ -176,12 +176,16 @@ RSpec.describe Git::Repository do
     end
 
     context 'when a file disappears during traversal' do
-      let(:vanishing_file) { File.join(repo_dir, 'vanishing.txt') }
-
+      let(:vanishing_file) do
+        File.join(repo_dir, 'vanishing.txt')
+      end
       before do
         File.write(vanishing_file, 'z' * 500)
         allow(File).to receive(:lstat).and_wrap_original do |original, path|
-          raise Errno::ENOENT, path if File.expand_path(path) == File.expand_path(vanishing_file)
+          if File.expand_path(path) == File.expand_path(vanishing_file)
+            raise Errno::ENOENT,
+                  path
+          end
 
           original.call(path)
         end
@@ -190,6 +194,23 @@ RSpec.describe Git::Repository do
       it 'skips the missing file and totals the remaining files' do
         expect(repo_size).to eq(150)
       end
+    end
+  end
+
+  describe '#lib' do
+    subject(:lib_result) { described_instance.lib }
+
+    it 'returns self' do
+      allow(Git::Deprecation).to receive(:warn)
+      expect(lib_result).to be(described_instance)
+    end
+
+    it 'emits a deprecation warning' do
+      allow(Git::Deprecation).to receive(:warn)
+      described_instance.lib
+      expect(Git::Deprecation).to have_received(:warn).with(
+        a_string_including('Git::Repository#lib', 'deprecated', 'v6.0.0')
+      )
     end
   end
 end

--- a/spec/unit/git/status_spec.rb
+++ b/spec/unit/git/status_spec.rb
@@ -4,34 +4,17 @@ require 'spec_helper'
 require 'git/status'
 require 'git/repository'
 
-# Unit tests for Git::Status::StatusFileFactory polymorphism.
-#
-# The factory has two provider paths:
-#   1. Git::Repository path — when base responds to :diff_index (has it as a
-#      facade method), the factory uses base directly as the provider.
-#   2. Legacy Git::Base path — when base does not respond to :diff_index, the
-#      factory falls back to base.lib.
-#
-# Each path has two sub-branches in #merge_head_diffs:
-#   - When the provider reports no commits (no_commits? / empty? is true), the
-#     factory skips the diff_index call entirely.
-#   - When there are commits, the factory calls diff_index('HEAD') to merge
-#     HEAD diffs into the status hash.
 RSpec.describe Git::Status::StatusFileFactory do
   describe '#construct_files' do
     subject(:result) { described_class.new(base).construct_files }
 
-    context 'when base is a Git::Repository (responds to :diff_index)' do
+    context 'when base is a Git::Repository' do
       let(:base) { instance_double(Git::Repository) }
 
       before do
         allow(base).to receive(:ls_files).and_return({})
         allow(base).to receive(:untracked_files).and_return([])
         allow(base).to receive(:diff_files).and_return({})
-        # instance_double(Git::Repository) already responds to :diff_index
-        # because the real class defines it. This stub provides a return value
-        # for any call that reaches it (overridden with specific expectations
-        # in nested contexts).
         allow(base).to receive(:diff_index).and_return({})
       end
 
@@ -104,54 +87,6 @@ RSpec.describe Git::Status::StatusFileFactory do
         it 'merges diff_index data for files not already in ls_files' do
           expect(result['b.rb']).to be_a(Git::Status::StatusFile)
           expect(result['b.rb'].type).to eq('A')
-        end
-      end
-    end
-
-    context 'when base is a legacy Git::Base (does not respond to :diff_index)' do
-      # Plain doubles are used here because:
-      # - base must NOT respond to :diff_index to exercise the legacy code path;
-      #   instance_double(Git::Base) would verify against the real class, which
-      #   may include modules that define :diff_index, making the test brittle.
-      # - lib_double represents Git::Lib, a large class not loaded in this spec;
-      #   a plain double avoids pulling in that dependency.
-      let(:lib_double) { double('lib') }                           # plain double: Git::Lib not loaded in this spec
-      let(:base)       { double('legacy_base', lib: lib_double) }  # plain double: must NOT respond to :diff_index
-
-      before do
-        allow(lib_double).to receive(:ls_files).and_return({})
-        allow(lib_double).to receive(:untracked_files).and_return([])
-        allow(lib_double).to receive(:diff_files).and_return({})
-      end
-
-      context 'when empty? returns true (repository has no commits)' do
-        before do
-          allow(lib_double).to receive(:empty?).and_return(true)
-        end
-
-        it 'does not call diff_index' do
-          expect(lib_double).not_to receive(:diff_index)
-          result
-        end
-
-        it 'returns an empty hash' do
-          expect(result).to eq({})
-        end
-      end
-
-      context 'when empty? returns false (repository has commits)' do
-        before do
-          allow(lib_double).to receive(:empty?).and_return(false)
-          allow(lib_double).to receive(:diff_index).with('HEAD').and_return({})
-        end
-
-        it 'calls diff_index with HEAD on the lib provider' do
-          expect(lib_double).to receive(:diff_index).with('HEAD').and_return({})
-          result
-        end
-
-        it 'returns an empty hash when all data is empty' do
-          expect(result).to eq({})
         end
       end
     end

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -148,13 +148,13 @@ class TestRemotes < Test::Unit::TestCase
       local.remote_set_branches('origin', upstream.current_branch, add: true)
       local.remote_set_branches('origin', 'feature/*', add: true)
 
-      fetch_refspecs_before = local.lib.command_capturing('config', '--get-all', 'remote.origin.fetch').stdout.split("\n")
+      fetch_refspecs_before = local.execution_context.command_capturing('config', '--get-all', 'remote.origin.fetch').stdout.split("\n")
       assert(fetch_refspecs_before.size > 1)
       assert_equal(1, fetch_refspecs_before.count('+refs/heads/feature/*:refs/remotes/origin/feature/*'))
 
       local.remote_set_branches('origin', 'feature/*')
 
-      fetch_refspecs_after = local.lib.command_capturing('config', '--get-all', 'remote.origin.fetch').stdout.split("\n")
+      fetch_refspecs_after = local.execution_context.command_capturing('config', '--get-all', 'remote.origin.fetch').stdout.split("\n")
       assert_equal(['+refs/heads/feature/*:refs/remotes/origin/feature/*'], fetch_refspecs_after)
     end
   end

--- a/tests/units/test_signed_commits.rb
+++ b/tests/units/test_signed_commits.rb
@@ -34,7 +34,7 @@ class TestSignedCommits < Test::Unit::TestCase
       `git add README.md`
       `git commit -S -m "Signed, sealed, delivered"`
 
-      data = Git.open('.').lib.cat_file_commit('HEAD')
+      data = Git.open('.').cat_file_commit('HEAD')
 
       assert_match(SSH_SIGNATURE_REGEXP, data['gpgsig'])
       assert_equal("Signed, sealed, delivered\n", data['message'])


### PR DESCRIPTION
Eliminate unused fallback methods in domain objects and replace them with direct calls. Introduce a deprecation warning for the `lib` method in `Git::Repository`, guiding users to transition to direct method calls. Add unit tests to ensure the deprecation is enforced.