### PR TITLE
refactor: remove is_a?(Git::Base) compatibility guards from domain objects

### DIFF
--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -68,17 +68,13 @@ module Git
 
     # Initialize a new Branch object
     #
-    # @param base [Git::Base, Git::Repository] the git repository
-    #
-    #   Accepts either a {Git::Base} (legacy) or a {Git::Repository} (new form).
-    #   The `is_a?(Git::Base)` guard will be removed when {Git::Base} is deleted
-    #   in Phase 4.
+    # @param base [Git::Repository] the git repository
     #
     # @param branch_info_or_name [Git::BranchInfo, String] branch info object or name string
     #
     #   Passing a BranchInfo is preferred; String support is for backward compatibility.
     #
-    # @note Use {Git::Base#branch} or {Git::Base#branches} instead of constructing directly
+    # @note Use {Git::Repository#branch} or {Git::Repository#branches} instead of constructing directly
     #
     # @api private
     #
@@ -464,18 +460,12 @@ module Git
       nil
     end
 
-    # Resolves the {Git::Repository} for this branch
-    #
-    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
-    # The `is_a?(Git::Base)` guard will be removed when {Git::Base} is deleted
-    # in Phase 4.
-    #
     # @return [Git::Repository]
     #
     # @api private
     #
     def branch_repository
-      @base.is_a?(Git::Base) ? @base.facade_repository : @base
+      @base
     end
   end
 end

--- a/lib/git/branches.rb
+++ b/lib/git/branches.rb
@@ -19,7 +19,7 @@ module Git
 
     # Creates a new Branches collection populated from the given repository
     #
-    # @param base [Git::Base, Git::Repository] the repository to enumerate
+    # @param base [Git::Repository] the repository to enumerate
     #   branches from
     #
     # @return [void]
@@ -136,18 +136,12 @@ module Git
 
     private
 
-    # Resolves the {Git::Repository} for this collection of branches
-    #
-    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
-    # The `is_a?(Git::Base)` guard will be removed when {Git::Base} is deleted
-    # in Phase 4.
-    #
     # @return [Git::Repository] the repository used to enumerate branches
     #
     # @api private
     #
     def branch_repository
-      @base.is_a?(Git::Base) ? @base.facade_repository : @base
+      @base
     end
 
     # Indexes all supported lookup keys for a branch without mutating

--- a/lib/git/log.rb
+++ b/lib/git/log.rb
@@ -44,7 +44,8 @@ module Git
     #   git = Git.open('.')
     #   Git::Log.new(git)
     #
-    # @param base [Git::Repository, Git::Base] the git repository object
+    # @param base [Git::Repository] the git repository object
+    #
     # @param max_count [Integer, Symbol, nil] the number of commits to return, or
     #   `:all` or `nil` to return all
     #
@@ -159,15 +160,10 @@ module Git
       self
     end
 
-    # Returns the facade interface for log operations.
-    #
-    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
-    # The `is_a?` guard will be removed when {Git::Base} is deleted in Phase 4.
-    #
     # @return [Git::Repository]
     #
     def log_repository
-      @base.is_a?(Git::Base) ? @base.facade_repository : @base
+      @base
     end
 
     def run_log_if_dirty

--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -126,15 +126,10 @@ module Git
 
       private
 
-      # Returns the facade interface for git object queries.
-      #
-      # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
-      # The `is_a?` guard will be removed when {Git::Base} is deleted in Phase 4.
-      #
       # @return [Git::Repository]
       #
       def object_repository
-        @base.is_a?(Git::Base) ? @base.facade_repository : @base
+        @base
       end
     end
 
@@ -315,19 +310,23 @@ module Git
       attr_accessor :name
 
       # @overload initialize(base, name)
-      #   @param base [Git::Base] The Git base object
-      #   @param name [String] The name of the tag
+      #
+      #   @param base [Git::Repository] the git repository
+      #
+      #   @param name [String] the name of the tag
       #
       # @overload initialize(base, sha, name)
-      #   @param base [Git::Base] The Git base object
-      #   @param sha [String] The SHA of the tag object
-      #   @param name [String] The name of the tag
+      #
+      #   @param base [Git::Repository] the git repository
+      #
+      #   @param sha [String] the SHA of the tag object
+      #
+      #   @param name [String] the name of the tag
       #
       def initialize(base, sha, name = nil)
         if name.nil?
           name = sha
-          repo = base.is_a?(Git::Base) ? base.facade_repository : base
-          sha = repo.tag_sha(name)
+          sha = base.tag_sha(name)
           raise Git::UnexpectedResultError, "Tag '#{name}' does not exist." if sha == ''
         end
 
@@ -394,15 +393,10 @@ module Git
       Git::Object::Tag.new(base, objectish)
     end
 
-    # Returns the facade interface for git object queries.
-    #
-    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
-    # The `is_a?` guard will be removed when {Git::Base} is deleted in Phase 4.
-    #
     # @return [Git::Repository]
     #
     private_class_method def self.object_repository_for(base)
-      base.is_a?(Git::Base) ? base.facade_repository : base
+      base
     end
   end
 end

--- a/lib/git/remote.rb
+++ b/lib/git/remote.rb
@@ -40,16 +40,11 @@ module Git
 
     # Initialize a new Remote object
     #
-    # @param base [Git::Base, Git::Repository] the git repository
-    #
-    #   Accepts either a {Git::Base} (legacy) or a {Git::Repository} (new form).
-    #   The `is_a?(Git::Base)` guard will be removed when {Git::Base} is deleted
-    #   in Phase 4.
+    # @param base [Git::Repository] the git repository
     #
     # @param name [String] the remote name (e.g. `'origin'`)
     #
-    # @note Use {Git::Base#remote} or the `remote` factory method on a
-    #   `Git::Repository` instance instead of constructing directly
+    # @note Use `Git::Repository#remote` instead of constructing directly
     #
     # @api private
     #
@@ -135,18 +130,12 @@ module Git
 
     private
 
-    # Resolves the {Git::Repository} for this remote
-    #
-    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
-    # The `is_a?(Git::Base)` guard will be removed when {Git::Base} is deleted
-    # in Phase 4.
-    #
     # @return [Git::Repository]
     #
     # @api private
     #
     def remote_repository
-      @base.is_a?(Git::Base) ? @base.facade_repository : @base
+      @base
     end
 
     def build_branch_info(refname)

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -393,9 +393,9 @@ module Git
       #
       # @param name [String] the name for the new remote
       #
-      # @param url [String, Git::Base] the URL of the remote repository
+      # @param url [String, Git::Repository] the URL of the remote repository
       #
-      #   A {Git::Base} instance is accepted for local references and converted
+      #   A {Git::Repository} instance is accepted for local references and converted
       #   to `url.repo.to_s`.
       #
       # @param opts [Hash] options for adding the remote
@@ -416,7 +416,7 @@ module Git
       # @raise [Git::FailedError] when git exits with a non-zero status
       #
       def remote_add(name, url, opts = {})
-        url = url.repo.to_s if url.is_a?(Git::Base) || url.is_a?(Git::Repository)
+        url = url.repo.to_s if url.is_a?(Git::Repository)
         opts = Private.normalize_add_remote_keys(opts)
         SharedPrivate.assert_valid_opts!(REMOTE_ADD_ALLOWED_OPTS, **opts)
         Git::Commands::Remote::Add.new(@execution_context).call(name, url, **opts)
@@ -428,9 +428,9 @@ module Git
       #
       # @param name [String] the name for the new remote
       #
-      # @param url [String, Git::Base] the URL of the remote repository
+      # @param url [String, Git::Repository] the URL of the remote repository
       #
-      #   A {Git::Base} instance is accepted for local references and converted
+      #   A {Git::Repository} instance is accepted for local references and converted
       #   to `url.repo.to_s`.
       #
       # @param opts [Hash] options for adding the remote
@@ -505,9 +505,9 @@ module Git
       #
       # @param name [String] the name of the remote to update
       #
-      # @param url [String, Git::Base] the new URL for the remote
+      # @param url [String, Git::Repository] the new URL for the remote
       #
-      #   A {Git::Base} instance is accepted for local references and converted
+      #   A {Git::Repository} instance is accepted for local references and converted
       #   to `url.repo.to_s`.
       #
       # @return [Git::Remote] the updated remote
@@ -515,7 +515,7 @@ module Git
       # @raise [Git::FailedError] when git exits with a non-zero status
       #
       def remote_set_url(name, url)
-        url = url.repo.to_s if url.is_a?(Git::Base) || url.is_a?(Git::Repository)
+        url = url.repo.to_s if url.is_a?(Git::Repository)
         Git::Commands::Remote::SetUrl.new(@execution_context).call(name, url)
 
         Git::Remote.new(self, name)
@@ -525,9 +525,9 @@ module Git
       #
       # @param name [String] the name of the remote to update
       #
-      # @param url [String, Git::Base] the new URL for the remote
+      # @param url [String, Git::Repository] the new URL for the remote
       #
-      #   A {Git::Base} instance is accepted for local references and converted
+      #   A {Git::Repository} instance is accepted for local references and converted
       #   to `url.repo.to_s`.
       #
       # @return [Git::Remote] the updated remote

--- a/lib/git/stash.rb
+++ b/lib/git/stash.rb
@@ -18,7 +18,7 @@ module Git
     # When `existing` is `false` (the default), immediately calls {#save} to push
     # the current working-directory state onto the stash stack.
     #
-    # @param base [Git::Repository, Git::Base] the git repository
+    # @param base [Git::Repository] the git repository
     #
     # @param message [String] the stash message
     #
@@ -93,15 +93,10 @@ module Git
 
     private
 
-    # Returns the facade interface for stash operations
-    #
-    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
-    # The `is_a?` guard will be removed when {Git::Base} is deleted in Phase 4.
-    #
     # @return [Git::Repository]
     #
     def stash_repository
-      @base.is_a?(Git::Base) ? @base.facade_repository : @base
+      @base
     end
   end
 end

--- a/lib/git/stashes.rb
+++ b/lib/git/stashes.rb
@@ -21,7 +21,7 @@ module Git
     #
     # Loads all existing stash entries from the repository at construction time.
     #
-    # @param base [Git::Repository, Git::Base] the git repository
+    # @param base [Git::Repository] the git repository
     #
     # @return [void]
     #
@@ -161,13 +161,10 @@ module Git
 
     # Returns the facade interface for stash operations
     #
-    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
-    # The `is_a?` guard will be removed when {Git::Base} is deleted in Phase 4.
-    #
     # @return [Git::Repository]
     #
     def stash_repository
-      @base.is_a?(Git::Base) ? @base.facade_repository : @base
+      @base
     end
   end
 end

--- a/lib/git/worktree.rb
+++ b/lib/git/worktree.rb
@@ -9,11 +9,6 @@ module Git
   # {Git::Repository::WorktreeOperations#worktree} or populated by
   # {Git::Worktrees}.
   #
-  # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy form)
-  # as the `base` argument. The `is_a?(Git::Base)` guard routes git operations
-  # through the facade repository and will be removed when {Git::Base} is
-  # deleted in Phase 4.
-  #
   # @example Add and remove a linked worktree
   #   worktree = repo.worktree('/path/to/new-worktree')
   #   worktree.add
@@ -37,7 +32,7 @@ module Git
 
     # Creates a new Worktree object
     #
-    # @param base [Git::Base, Git::Repository] the repository that owns this
+    # @param base [Git::Repository] the repository that owns this
     #   worktree
     #
     # @param dir [String] filesystem path of the worktree
@@ -137,18 +132,12 @@ module Git
 
     private
 
-    # Resolves the {Git::Repository} for worktree operations
-    #
-    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
-    # The `is_a?(Git::Base)` guard will be removed when {Git::Base} is deleted
-    # in Phase 4.
-    #
     # @return [Git::Repository] the repository used for worktree operations
     #
     # @api private
     #
     def worktree_repository
-      @base.is_a?(Git::Base) ? @base.facade_repository : @base
+      @base
     end
   end
 end

--- a/lib/git/worktrees.rb
+++ b/lib/git/worktrees.rb
@@ -8,11 +8,6 @@ module Git
   # Wraps every linked and main worktree and provides enumeration and
   # path-based lookup.
   #
-  # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy
-  # form) as the `base` argument. The `is_a?(Git::Base)` guard routes git
-  # operations through the facade repository and will be removed when
-  # {Git::Base} is deleted in Phase 4.
-  #
   # @example Enumerate all worktrees
   #   worktrees = repo.worktrees
   #   worktrees.each { |wt| puts wt.dir }
@@ -24,7 +19,7 @@ module Git
 
     # Creates a new Worktrees collection populated from the given repository
     #
-    # @param base [Git::Base, Git::Repository] the repository to enumerate
+    # @param base [Git::Repository] the repository to enumerate
     #   worktrees from
     #
     # @return [void]
@@ -130,18 +125,12 @@ module Git
 
     private
 
-    # Resolves the {Git::Repository} for this collection of worktrees
-    #
-    # Accepts either a {Git::Repository} (new form) or a {Git::Base} (legacy).
-    # The `is_a?(Git::Base)` guard will be removed when {Git::Base} is deleted
-    # in Phase 4.
-    #
     # @return [Git::Repository] the repository used to enumerate worktrees
     #
     # @api private
     #
     def worktree_repository
-      @base.is_a?(Git::Base) ? @base.facade_repository : @base
+      @base
     end
   end
 end

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -38,9 +38,9 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | ----- | ------ | ----------- | :--------------: | :--------------: |
 | Phase 1 | ✅ Complete | Foundation and scaffolding | 5% | 100% |
 | Phase 2 | ✅ Complete | Migrating commands (all checklist items done) | 40% | 100% |
-| Phase 3 | ⏳ In Progress | Refactoring public interface — see [Facade Modules Completed](#facade-modules-completed) and [Facade coverage checklist](#facade-coverage-checklist) | 45% | 60% |
+| Phase 3 | ⏳ In Progress | Refactoring public interface — see [Facade Modules Completed](#facade-modules-completed) and [Facade coverage checklist](#facade-coverage-checklist) | 45% | 90% |
 | Phase 4 | 🔲 Not Started | Final cleanup and release | 10% | 0% |
-| **TOTAL** | -- | -- | **100%** | **72%** |
+| **TOTAL** | -- | -- | **100%** | **86%** |
 
 ### Facade Modules Completed
 
@@ -75,74 +75,20 @@ such as `Branch`, `Diff`, `Log`, `Object`, `Remote`, `Status`, `Worktree`, etc.
 
 ### Next Task
 
-#### Step C1d — Flip `Git.open`/`.clone`/`.init`/`.bare` to return `Git::Repository`
+#### Step D2 / Phase 4 — Remove `base_object` bridge and delete `Git::Base`
 
-All prerequisite workstreams are ✅ complete. Step C1d is split into three sub-steps:
+D1 is ✅ complete. The next major step is Phase 4, which removes `Git::Base` and `Git::Lib`
+entirely. D2 is bundled with that deletion (see Step D2 below).
 
-- **C1d-1** — Entry point flip (the breaking change itself): `Git.open`/`.bare`/`.clone`/`.init`
-  now return `Git::Repository` instead of `Git::Base`. Beyond the type change, some methods have
-  different return semantics — for example, `Git::Repository#merge_base` returns plain SHA strings
-  while `Git::Base#merge_base` returned `Git::Object::Commit` objects, and `commit_tree` returns
-  a raw SHA string rather than a typed object. Upgrade notes and downstream code must account for
-  these differences.
-- **C1d-2** — Eliminate all internal `.lib` callers in tests; add deprecation enforcement to both test suites
-- **C1d-3** — Remove dead fallback branches; replace silent `lib` shim with real deprecation warning
+Before Phase 4 can start, F1 and F2 (moving `Git` module utilities off `Git::Lib`) must complete.
+The following are also required and are already ✅ complete:
 
-**All C1d prerequisites met:**
-
-| Prerequisite | Status |
-| ------------ | ------ |
-| A1–A4: facade coverage gaps filled | ✅ |
-| B: `Git::Base` domain-object factories redirected to `facade_repository` | ✅ |
-| C1a-1: `Git::Repository.open`/`.bare` + path state | ✅ |
-| C1a-2: `Git::Repository.clone`/`.init` | ✅ |
-| C1b: global config singleton moved off `Git::Base` | ✅ [#1385](https://github.com/ruby-git/ruby-git/pull/1385) |
-| C1c-1: signature-compatibility guidance | ✅ |
+| Step | Status |
+| ---- | ------ |
 | C1c-2: public-API parity audit and remediation sweep | ✅ |
 | E: block-based helper/path-context methods migrated | ✅ |
 
-**What C1d-1 requires** (see [Step C1d-1](#step-c1d-1--flip-entry-points) below for full spec):
-
-1. Change `Git.open`/`.bare`/`.clone` bodies from `Base.*` calls to `Git::Repository.*` calls.
-2. Simplify `Git.init` to delegate to `Git::Repository.init`; remove `open_initialized_repository`.
-3. Update all four `@return [Git::Base]` YARD tags to `@return [Git::Repository]`.
-4. Flip the return-type regression specs in `spec/integration/git/repository_spec.rb`
-   from `be_a(Git::Base)` to `be_a(Git::Repository)`.
-5. **Prerequisite fix before landing:** delete `spec/integration/git/lib/config_spec.rb` after
-   confirming coverage exists in `spec/integration/git/repository/configuring_spec.rb`. The shim
-   `def lib = self` causes `subject(:lib) { repo.lib }` to return `Git::Repository`, triggering 19
-   deprecation warnings from deprecated aliases (config_set, config_get, global_config_set, etc.).
-
-**Commit type for C1d-1:** `feat!` with a `BREAKING CHANGE:` footer (explicit v5 boundary step).
-
-**What C1d-2 requires** (see [Step C1d-2](#step-c1d-2--eliminate-internal-lib-callers) below):
-
-Clean up all internal `.lib` callers across both test suites — while the silent `def lib = self`
-shim is still in place — then add `Git::Deprecation.behavior = :raise` to both test suites. The
-RSpec cleanup must happen before wiring up the RSpec enforcement. The Test::Unit cleanup must
-happen before C1d-3 because `tests/test_helper.rb` already sets `behavior = :raise` and will
-hard-fail the moment the real deprecation warning lands.
-
-The cleanup phases in order (each a separate commit):
-
-| Phase | Files | Change |
-| ----- | ----- | ------ |
-| A | `spec/integration/git/repository/{merging,branching,stashing,object_operations,logging}_spec.rb`, stash command specs | `repo.lib.method(...)` → `repo.method(...)` |
-| B | `spec/support/contexts/{empty_repository,diff_test_repository}.rb`, `spec/integration/git/commands/{worktree/repair,diff}_spec.rb` | `repo.lib` → `repo.execution_context` (passed to command constructors) |
-| C | `spec/integration/git/parsers/{branch,stash,fsck,tag}_spec.rb` | `repo.lib.command_capturing(...)` → `repo.execution_context.command_capturing(...)`; `repo.lib.stash_save(...)` → `repo.stash_save(...)` |
-| D | `spec/spec_helper.rb` | Add `Git::Deprecation.behavior = :raise` inside `RSpec.configure` — safe only after Phases A–C. Document `collect_deprecations` pattern for tests that intentionally trigger deprecated methods. |
-| E | `tests/units/test_{branch,stashes,each_conflict,diff_path_status,stash_save}.rb` | `git.lib.facade_method(...)` → `git.facade_method(...)` |
-| F | `tests/units/test_command_raises_on_failure.rb`, `tests/units/test_set_index.rb`, `tests/units/test_lib.rb` | `git.lib.command_capturing(...)` → `git.execution_context.command_capturing(...)`; move `tag_sha` test (no facade equivalent) to `test_lib.rb` using `Git::Base.open(dir).lib` |
-| G | `tests/units/test_command_line_env_overrides.rb` | Introduce `lib = Git::Base.open(git.dir.to_s).lib` per-test; replace all `git.lib` references with `lib` |
-| H | `tests/test_helper.rb`, `tests/units/test_signed_commits.rb`, `tests/units/test_deprecations.rb` | Audit and update stubs; `Git.open(...).lib.lib_method` → `Git::Base.open(...).lib.lib_method`; `git.lib.facade_method` → `git.facade_method` |
-
-**What C1d-3 requires** (see [Step C1d-3](#step-c1d-3--remove-dead-fallbacks-and-add-deprecation-warning) below):
-
-1. Add `diff_numstat` delegator to `Git::Base` (prerequisite: `Git::Base` does not currently respond to `diff_numstat`).
-2. Remove dead `respond_to?` + `.lib` fallback branches from `lib/git/diff.rb`, `lib/git/diff_stats.rb`, `lib/git/diff_path_status.rb`, `lib/git/status.rb`.
-3. Replace `def lib = self` in `lib/git/repository.rb` with a `Git::Deprecation.warn` body that emits a `v6.0.0` removal message and returns `self`.
-4. Remove `command_capturing`, `command_streaming`, and the private `env_overrides` (using `send`) from `lib/git/repository.rb` — added only to feed the silent shim, have no production callers.
-5. Add a unit test in `spec/unit/git/repository_spec.rb` asserting the deprecation warning fires and `self` is returned. Use `Git::Deprecation.collect_deprecations { repo.lib }` to capture without raising.
+Steps C1d-1, C1d-2, and C1d-3 are ✅ complete (see their detail sections below for full specs).
 
 ---
 
@@ -586,8 +532,8 @@ classified as a v5-only PR with upgrade-note coverage before it lands.
 | F2 | ⬜ | Move `Git.global_config`, module `#config`, and module `#global_config` off `Git::Lib` | 4.x-compatible | Config methods keep the same return formats and write behavior. |
 | C1c-1 | ✅ | Guidance/process: signature-compatibility policy for extraction and review ([#1369](https://github.com/ruby-git/ruby-git/issues/1369)) | 4.x-compatible / docs-only | Guidance and review checklists define legacy-contract vs 5.x-native signatures, including test expectations. |
 | C1c-2 | ✅ | End-of-Phase-3 public-API parity audit and remediation sweep ([#1370](https://github.com/ruby-git/ruby-git/issues/1370)) | 4.x-compatible | All four parity audit buckets resolved (fix or documented removal) before C1d; no unclassified compatibility gap remains. |
-| C1d | ⬜ | Flip `Git.open`/`.clone`/`.init`/`.bare` to return `Git::Repository` | v5 boundary | Explicit breaking change because class identity changes from `Git::Base` to `Git::Repository`; method-level parity must be complete first. Split into C1d-1 (entry point flip), C1d-2 (eliminate internal .lib callers + add deprecation enforcement to both test suites), and C1d-3 (remove dead fallbacks + replace silent lib shim with real deprecation warning). |
-| D1 | ⬜ | Remove domain-object `Git::Base` guards and `@base.lib` fallbacks | v5 cleanup | Explicitly drops direct `Git::Base` provider support in domain-object constructors; normal factory-created objects remain supported. |
+| C1d | ✅ | Flip `Git.open`/`.clone`/`.init`/`.bare` to return `Git::Repository` | v5 boundary | Explicit breaking change because class identity changes from `Git::Base` to `Git::Repository`; method-level parity must be complete first. Split into C1d-1 (entry point flip), C1d-2 (eliminate internal .lib callers + add deprecation enforcement to both test suites), and C1d-3 (remove dead fallbacks + replace silent lib shim with real deprecation warning). |
+| D1 | ✅ | Remove domain-object `Git::Base` guards and `@base.lib` fallbacks | v5 cleanup | Explicitly drops direct `Git::Base` provider support in domain-object constructors; normal factory-created objects remain supported. |
 | D2 / Phase 4 | ⬜ | Remove `base_object`/`from_base` with `Git::Base` deletion or retirement | v5 cleanup | Must land with the old-code deletion path; not releasable as a standalone PR while `Git::Base#facade_repository` depends on it. |
 
 ---
@@ -631,8 +577,8 @@ done only when its code, focused specs, and delegation/cleanup checks are all tr
 | C1b: Global config ownership (`Base.config` → `Git::Config`) | ✅ |
 | C1c-1: Guidance/process updates for signature compatibility (#1369) | ✅ |
 | C1c-2: End-of-Phase-3 public-API parity audit and remediation (#1370) | ✅ |
-| C1d: Entry-point flip (`Git.open` etc. → `Git::Repository`) | ⬜ |
-| D1 (C3): Remove `is_a?(Git::Base)` guards + `@base.lib` fallbacks | ⬜ (v5 cleanup) |
+| C1d: Entry-point flip (`Git.open` etc. → `Git::Repository`) | ✅ |
+| D1 (C3): Remove `is_a?(Git::Base)` guards + `@base.lib` fallbacks | ✅ |
 | D2 (C2 / Phase 4): Remove `base_object` bridge with `Git::Base` deletion | ⬜ (v5 cleanup) |
 | E: Instance helpers (`#chdir`, `#with_index`, `#with_temp_index`, `#with_working`, `#with_temp_working`) | ✅ |
 | F: `Git` module utilities (`default_branch`, `global_config`, `ls_remote`) off `Git::Lib` | ⬜ (Phase 4 prereq) |

--- a/spec/unit/git/branch_spec.rb
+++ b/spec/unit/git/branch_spec.rb
@@ -3,10 +3,6 @@
 require 'spec_helper'
 
 RSpec.describe Git::Branch do
-  # Git::Branch accepts either Git::Repository (new form) or Git::Base (legacy) as base.
-  # These specs cover the Git::Repository path; the Git::Base path is exercised by the
-  # legacy integration tests in tests/units/test_branch.rb.
-
   let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
   let(:base) { Git::Repository.new(execution_context: execution_context) }
 
@@ -216,26 +212,6 @@ RSpec.describe Git::Branch do
 
       it 'returns false' do
         expect(branch.current).to be false
-      end
-    end
-
-    context 'when base is a Git::Base instance' do
-      subject(:branch) { described_class.new(base_like, branch_info) }
-
-      let(:facade_repo) { instance_double(Git::Repository) }
-      # Plain object with is_a?(Git::Base) returning true — simulates the legacy
-      # Git::Base path without requiring a real Git repository on disk.
-      let(:base_like) do
-        repo = facade_repo
-        Object.new.tap do |obj|
-          obj.define_singleton_method(:facade_repository) { repo }
-          obj.define_singleton_method(:is_a?) { |klass| klass == Git::Base || super(klass) }
-        end
-      end
-
-      it 'delegates current_branch through facade_repository' do
-        expect(facade_repo).to receive(:current_branch).and_return('feature')
-        expect(branch.current).to be true
       end
     end
   end

--- a/spec/unit/git/branches_spec.rb
+++ b/spec/unit/git/branches_spec.rb
@@ -37,7 +37,6 @@ RSpec.describe Git::Branches do
       let(:base) { instance_double(Git::Repository) }
 
       before do
-        allow(base).to receive(:is_a?).with(Git::Base).and_return(false)
         allow(base).to receive(:branches_all).and_return([local_info, remote_info])
         allow(Git::Branch).to receive(:new).with(base, local_info).and_return(local_branch)
         allow(Git::Branch).to receive(:new).with(base, remote_info).and_return(remote_branch)
@@ -54,28 +53,6 @@ RSpec.describe Git::Branches do
         described_class.new(base)
       end
     end
-
-    context 'when passed a Git::Base' do
-      let(:facade_repo) { instance_double(Git::Repository) }
-      let(:base) { instance_double(Git::Base) }
-
-      before do
-        allow(base).to receive(:is_a?).with(Git::Base).and_return(true)
-        allow(base).to receive(:facade_repository).and_return(facade_repo)
-        allow(facade_repo).to receive(:branches_all).and_return([local_info])
-        allow(Git::Branch).to receive(:new).with(base, local_info).and_return(local_branch)
-      end
-
-      it 'calls branches_all on the facade_repository, not on base directly' do
-        expect(facade_repo).to receive(:branches_all).and_return([local_info])
-        described_class.new(base)
-      end
-
-      it 'creates Git::Branch objects with the original base (not the facade repository)' do
-        expect(Git::Branch).to receive(:new).with(base, local_info).and_return(local_branch)
-        described_class.new(base)
-      end
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -87,7 +64,6 @@ RSpec.describe Git::Branches do
   let(:described_instance) { described_class.new(repo_base) }
 
   before do
-    allow(repo_base).to receive(:is_a?).with(Git::Base).and_return(false)
     allow(repo_base).to receive(:branches_all).and_return(branch_infos)
     allow(Git::Branch).to receive(:new).with(repo_base, local_info).and_return(local_branch)
     allow(Git::Branch).to receive(:new).with(repo_base, remote_info).and_return(remote_branch)

--- a/spec/unit/git/log_spec.rb
+++ b/spec/unit/git/log_spec.rb
@@ -17,16 +17,6 @@ RSpec.describe Git::Log do
       end
     end
 
-    context 'when base is a Git::Base (legacy)' do
-      subject(:log) { described_class.new(base, 10) }
-
-      let(:base) { instance_double(Git::Base) }
-
-      it 'accepts Git::Base without raising' do
-        expect { log }.not_to raise_error
-      end
-    end
-
     context 'when max_count defaults to 30' do
       subject(:log) { described_class.new(repository) }
 
@@ -66,37 +56,6 @@ RSpec.describe Git::Log do
 
       it 'calls full_log_commits directly on the repository' do
         expect(repository).to receive(:full_log_commits).and_return(commit_data)
-        result
-      end
-
-      it 'returns a Git::Log::Result' do
-        expect(result).to be_a(Git::Log::Result)
-      end
-    end
-
-    context 'when base is a Git::Base (legacy)' do
-      subject(:result) { log.execute }
-
-      let(:base) { instance_double(Git::Base) }
-      let(:facade_repository) { instance_double(Git::Repository) }
-      let(:log) { described_class.new(base) }
-
-      before do
-        allow(base).to receive(:is_a?).with(Git::Base).and_return(true)
-        allow(base).to receive(:facade_repository).and_return(facade_repository)
-        allow(facade_repository).to receive(:full_log_commits).and_return(commit_data)
-        allow(Git::Object::Commit).to receive(:new).with(base, 'abc123', commit_data.first)
-                                                   .and_return(instance_double(Git::Object::Commit))
-      end
-
-      it 'routes full_log_commits through facade_repository' do
-        expect(facade_repository).to receive(:full_log_commits).and_return(commit_data)
-        result
-      end
-
-      it 'passes base (not facade_repository) to Git::Object::Commit.new' do
-        expect(Git::Object::Commit).to receive(:new).with(base, 'abc123', commit_data.first)
-                                                    .and_return(instance_double(Git::Object::Commit))
         result
       end
 

--- a/spec/unit/git/object_spec.rb
+++ b/spec/unit/git/object_spec.rb
@@ -3,9 +3,8 @@
 require 'spec_helper'
 require 'git/object'
 
-# These specs cover Git::Object::* classes, exercising both the Git::Repository
-# (new form) and Git::Base (legacy) polymorphism branches.
-# Full integration via Git::Base is covered by tests/units/test_object.rb (Test::Unit).
+# These specs cover Git::Object::* classes.
+# Full integration is covered by tests/units/test_object.rb (Test::Unit).
 
 RSpec.describe Git::Object::Blob do
   # Git::Object::Blob is the concrete subclass used to exercise all
@@ -60,23 +59,6 @@ RSpec.describe Git::Object::Blob do
 
     it 'returns the object size in bytes from the repository' do
       expect(result).to eq(42)
-    end
-
-    context 'when initialized with a Git::Base (legacy path)' do
-      # instance_double is viable: facade_repository is defined on Git::Base
-      # (lib/git/base.rb) and is_a? is verifiable via Kernel.
-      let(:described_instance) { described_class.new(legacy_base, objectish) }
-      let(:legacy_base) { instance_double(Git::Base) }
-
-      before do
-        allow(legacy_base).to receive(:is_a?).with(Git::Base).and_return(true)
-        allow(legacy_base).to receive(:facade_repository).and_return(repository)
-        allow(repository).to receive(:cat_file_size).with(objectish).and_return(99)
-      end
-
-      it 'delegates through the facade_repository of the Git::Base instance' do
-        expect(result).to eq(99)
-      end
     end
   end
 
@@ -624,26 +606,6 @@ RSpec.describe Git::Object::Tag do
         expect(tag.name).to eq('v1.0')
       end
     end
-
-    context 'with name only and a Git::Base (legacy path)' do
-      # instance_double is viable: facade_repository is defined on Git::Base
-      # (lib/git/base.rb) and is_a? is verifiable via Kernel.
-      let(:base) { legacy_base }
-      let(:sha) { 'v1.0' }
-      let(:name) { nil }
-      let(:legacy_base) { instance_double(Git::Base) }
-
-      before do
-        allow(legacy_base).to receive(:is_a?).with(Git::Base).and_return(true)
-        allow(legacy_base).to receive(:facade_repository).and_return(repository)
-        allow(repository).to receive(:tag_sha).with('v1.0').and_return('tagsha123abc')
-      end
-
-      it 'resolves the SHA via the facade_repository of the Git::Base' do
-        expect(tag.objectish).to eq('tagsha123abc')
-        expect(tag.name).to eq('v1.0')
-      end
-    end
   end
 
   describe '#annotated?' do
@@ -836,24 +798,6 @@ RSpec.describe Git::Object do
       it 'raises NoMethodError due to nil class' do
         expect { described_class.new(repository, 'abc123', 'unknown') }
           .to raise_error(NoMethodError, /undefined method [`']new[`'].*nil/)
-      end
-    end
-
-    context 'when base is a Git::Base (legacy path)' do
-      # instance_double is viable: facade_repository is defined on Git::Base
-      # (lib/git/base.rb) and is_a? is verifiable via Kernel.
-      subject(:result) { described_class.new(legacy_base, 'HEAD') }
-
-      let(:legacy_base) { instance_double(Git::Base) }
-
-      before do
-        allow(legacy_base).to receive(:is_a?).with(Git::Base).and_return(true)
-        allow(legacy_base).to receive(:facade_repository).and_return(repository)
-        allow(repository).to receive(:cat_file_type).with('HEAD').and_return('commit')
-      end
-
-      it 'determines the object type via the facade_repository of the Git::Base' do
-        expect(result).to be_a(Git::Object::Commit)
       end
     end
   end

--- a/spec/unit/git/remote_spec.rb
+++ b/spec/unit/git/remote_spec.rb
@@ -4,10 +4,6 @@ require 'spec_helper'
 require 'git/remote'
 
 RSpec.describe Git::Remote do
-  # Git::Remote accepts either Git::Repository (new form) or Git::Base (legacy) as base.
-  # These specs cover both the Git::Repository path and the Git::Base duck-type path
-  # for the remote_repository bridge method.
-
   let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
   let(:base) { Git::Repository.new(execution_context: execution_context) }
   let(:remote_config) do
@@ -43,38 +39,6 @@ RSpec.describe Git::Remote do
       it 'calls config_remote on the repository' do
         expect(base).to receive(:config_remote).with('origin').and_return(remote_config)
         remote
-      end
-    end
-
-    context 'when base is a Git::Base instance' do
-      subject(:remote) { described_class.new(base_like, 'origin') }
-
-      let(:facade_repo) { instance_double(Git::Repository) }
-      # Plain object with is_a?(Git::Base) returning true — simulates the legacy
-      # Git::Base path without requiring a real Git repository on disk.
-      let(:base_like) do
-        repo = facade_repo
-        Object.new.tap do |obj|
-          obj.define_singleton_method(:facade_repository) { repo }
-          obj.define_singleton_method(:is_a?) { |klass| klass == Git::Base || super(klass) }
-        end
-      end
-
-      before do
-        allow(facade_repo).to receive(:config_remote).with('origin').and_return(remote_config)
-      end
-
-      it 'delegates config_remote through facade_repository' do
-        expect(facade_repo).to receive(:config_remote).with('origin').and_return(remote_config)
-        remote
-      end
-
-      it 'sets the name' do
-        expect(remote.name).to eq('origin')
-      end
-
-      it 'sets the url from config' do
-        expect(remote.url).to eq('https://github.com/test/repo.git')
       end
     end
   end

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -611,28 +611,6 @@ RSpec.describe Git::Repository::RemoteOperations do
       end
     end
 
-    context 'with url as Git::Base' do
-      let(:url_base) do
-        Object.new.tap do |obj|
-          def obj.repo
-            Pathname.new('/tmp/source.git')
-          end
-
-          def obj.is_a?(klass)
-            klass == Git::Base || super
-          end
-        end
-      end
-
-      subject(:result) { described_instance.remote_add('upstream', url_base) }
-
-      it 'normalizes url to repo.to_s before calling the command' do
-        expect(remote_add_command)
-          .to receive(:call).with('upstream', '/tmp/source.git').and_return(remote_add_result)
-        result
-      end
-    end
-
     # --- :fetch option -------------------------------------------------------
 
     context 'with fetch: true' do
@@ -679,6 +657,24 @@ RSpec.describe Git::Repository::RemoteOperations do
         expect(remote_add_command).not_to receive(:call)
         expect { described_instance.remote_add('upstream', 'https://example.com/repo.git', unknown_opt: true) }
           .to raise_error(ArgumentError, /unknown_opt/)
+      end
+    end
+
+    # --- Git::Repository URL normalization -----------------------------------
+
+    context 'when url is a Git::Repository instance' do
+      let(:url_execution_context) do
+        instance_double(Git::ExecutionContext::Repository, git_dir: '/path/to/repo')
+      end
+      let(:url_repo) { Git::Repository.new(execution_context: url_execution_context) }
+
+      subject(:result) { described_instance.remote_add('upstream', url_repo) }
+
+      it 'converts the repository to a path string before calling the command' do
+        expect(remote_add_command)
+          .to receive(:call).with('upstream', '/path/to/repo')
+          .and_return(remote_add_result)
+        result
       end
     end
   end
@@ -903,24 +899,20 @@ RSpec.describe Git::Repository::RemoteOperations do
       end
     end
 
-    context 'with url as a Git::Base' do
-      let(:url_base) do
-        Object.new.tap do |obj|
-          def obj.repo
-            Pathname.new('/tmp/source.git')
-          end
+    # --- Git::Repository URL normalization -----------------------------------
 
-          def obj.is_a?(klass)
-            klass == Git::Base || super
-          end
-        end
+    context 'when url is a Git::Repository instance' do
+      let(:url_execution_context) do
+        instance_double(Git::ExecutionContext::Repository, git_dir: '/path/to/repo')
       end
+      let(:url_repo) { Git::Repository.new(execution_context: url_execution_context) }
 
-      subject(:result) { described_instance.remote_set_url('origin', url_base) }
+      subject(:result) { described_instance.remote_set_url('origin', url_repo) }
 
-      it 'normalizes the url to repo.to_s before calling the command' do
+      it 'converts the repository to a path string before calling the command' do
         expect(set_url_command)
-          .to receive(:call).with('origin', '/tmp/source.git').and_return(set_url_result)
+          .to receive(:call).with('origin', '/path/to/repo')
+          .and_return(set_url_result)
         result
       end
     end

--- a/spec/unit/git/worktree_spec.rb
+++ b/spec/unit/git/worktree_spec.rb
@@ -11,10 +11,6 @@ RSpec.describe Git::Worktree do
   let(:base) { instance_double(Git::Repository) }
   let(:dir)  { '/path/to/wt' }
 
-  before do
-    allow(base).to receive(:is_a?).with(Git::Base).and_return(false)
-  end
-
   # ---------------------------------------------------------------------------
   # #initialize
   # ---------------------------------------------------------------------------
@@ -84,27 +80,6 @@ RSpec.describe Git::Worktree do
         wt.gcommit
       end
     end
-
-    context 'when base is a Git::Base (legacy form) and no gcommit was given' do
-      let(:facade_repo) { instance_double(Git::Repository) }
-      let(:base) { instance_double(Git::Base) }
-      let(:commit_object) { instance_double(Git::Object::Commit) }
-
-      before do
-        allow(base).to receive(:is_a?).with(Git::Base).and_return(true)
-        allow(base).to receive(:facade_repository).and_return(facade_repo)
-        allow(facade_repo).to receive(:gcommit).with(dir).and_return(commit_object)
-      end
-
-      it 'resolves facade_repository and calls gcommit on it with the full descriptor' do
-        expect(facade_repo).to receive(:gcommit).with(dir)
-        wt.gcommit
-      end
-
-      it 'returns the result from facade_repository.gcommit' do
-        expect(result).to eq(commit_object)
-      end
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -132,32 +107,6 @@ RSpec.describe Git::Worktree do
         end
       end
     end
-
-    context 'when base is a Git::Base (legacy form)' do
-      let(:facade_repo) { instance_double(Git::Repository) }
-      let(:base) { instance_double(Git::Base) }
-
-      before do
-        allow(base).to receive(:is_a?).with(Git::Base).and_return(true)
-        allow(base).to receive(:facade_repository).and_return(facade_repo)
-      end
-
-      context 'when gcommit is nil' do
-        it 'resolves facade_repository and calls worktree_add on it with dir and nil' do
-          expect(facade_repo).to receive(:worktree_add).with(dir, nil).and_return('output')
-          wt.add
-        end
-      end
-
-      context 'when gcommit is set' do
-        let(:gcommit) { 'main' }
-
-        it 'resolves facade_repository and calls worktree_add on it with dir and gcommit' do
-          expect(facade_repo).to receive(:worktree_add).with(dir, gcommit).and_return('output')
-          wt.add
-        end
-      end
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -170,21 +119,6 @@ RSpec.describe Git::Worktree do
     context 'when base is a Git::Repository (new form)' do
       it 'calls worktree_remove on base directly with dir' do
         expect(base).to receive(:worktree_remove).with(dir).and_return('')
-        wt.remove
-      end
-    end
-
-    context 'when base is a Git::Base (legacy form)' do
-      let(:facade_repo) { instance_double(Git::Repository) }
-      let(:base) { instance_double(Git::Base) }
-
-      before do
-        allow(base).to receive(:is_a?).with(Git::Base).and_return(true)
-        allow(base).to receive(:facade_repository).and_return(facade_repo)
-      end
-
-      it 'resolves facade_repository and calls worktree_remove on it with dir' do
-        expect(facade_repo).to receive(:worktree_remove).with(dir).and_return('')
         wt.remove
       end
     end

--- a/spec/unit/git/worktrees_spec.rb
+++ b/spec/unit/git/worktrees_spec.rb
@@ -17,7 +17,6 @@ RSpec.describe Git::Worktrees do
   let(:described_instance) { described_class.new(repo_base) }
 
   before do
-    allow(repo_base).to receive(:is_a?).with(Git::Base).and_return(false)
     allow(repo_base).to receive(:worktrees_all).and_return([
                                                              ['/repo',        'abc123'],
                                                              ['/repo/linked', 'def456']
@@ -35,7 +34,6 @@ RSpec.describe Git::Worktrees do
       let(:base) { instance_double(Git::Repository) }
 
       before do
-        allow(base).to receive(:is_a?).with(Git::Base).and_return(false)
         allow(base).to receive(:worktrees_all).and_return([
                                                             ['/repo',        'abc123'],
                                                             ['/repo/linked', 'def456']
@@ -57,33 +55,6 @@ RSpec.describe Git::Worktrees do
 
       it 'populates the collection with both worktrees' do
         expect(described_class.new(base).size).to eq(2)
-      end
-    end
-
-    context 'when base is a Git::Base (legacy form)' do
-      let(:facade_repo) { instance_double(Git::Repository) }
-      let(:base)        { instance_double(Git::Base) }
-
-      before do
-        allow(base).to receive(:is_a?).with(Git::Base).and_return(true)
-        allow(base).to receive(:facade_repository).and_return(facade_repo)
-        allow(facade_repo).to receive(:worktrees_all).and_return([
-                                                                   ['/repo',        'abc123'],
-                                                                   ['/repo/linked', 'def456']
-                                                                 ])
-        allow(Git::Worktree).to receive(:new).with(base, '/repo',        'abc123').and_return(wt_main)
-        allow(Git::Worktree).to receive(:new).with(base, '/repo/linked', 'def456').and_return(wt_linked)
-      end
-
-      it 'resolves facade_repository and calls worktrees_all on it' do
-        expect(facade_repo).to receive(:worktrees_all).and_return([])
-        described_class.new(base)
-      end
-
-      it 'passes the original base (not facade_repo) to Git::Worktree children' do
-        expect(Git::Worktree).to receive(:new).with(base, '/repo',        'abc123').and_return(wt_main)
-        expect(Git::Worktree).to receive(:new).with(base, '/repo/linked', 'def456').and_return(wt_linked)
-        described_class.new(base)
       end
     end
   end
@@ -186,24 +157,6 @@ RSpec.describe Git::Worktrees do
 
     it 'returns the result from worktree_prune' do
       expect(result).to eq('pruned output')
-    end
-
-    context 'when base is a Git::Base (legacy form)' do
-      let(:described_instance) { described_class.new(base) }
-      let(:facade_repo) { instance_double(Git::Repository) }
-      let(:base)        { instance_double(Git::Base) }
-
-      before do
-        allow(base).to receive(:is_a?).with(Git::Base).and_return(true)
-        allow(base).to receive(:facade_repository).and_return(facade_repo)
-        allow(facade_repo).to receive(:worktrees_all).and_return([])
-        allow(Git::Worktree).to receive(:new)
-      end
-
-      it 'resolves facade_repository and calls worktree_prune on it' do
-        expect(facade_repo).to receive(:worktree_prune).and_return('')
-        result
-      end
     end
   end
 end


### PR DESCRIPTION
## Summary

Removes the `is_a?(Git::Base)` compatibility guards that were added to domain
objects during the Phase 3 migration. Since step C1d flipped `Git.open`,
`Git.bare`, `Git.clone`, and `Git.init` to return `Git::Repository`, the
`Git::Base` branch in each `*_repository` helper is permanently dead code.

## Changes

**Implementation** — 10 files simplified:

Each of the following classes had a private `*_repository` helper of the form:

```ruby
@base.is_a?(Git::Base) ? @base.facade_repository : @base
```

Simplified to `@base` in:

- `lib/git/branch.rb` (`branch_repository`)
- `lib/git/branches.rb` (`branch_repository`)
- `lib/git/log.rb` (`log_repository`)
- `lib/git/object.rb` (`object_repository`, `object_repository_for`, inline in `Tag#initialize`)
- `lib/git/remote.rb` (`remote_repository`)
- `lib/git/stash.rb` (`stash_repository`)
- `lib/git/stashes.rb` (`stash_repository`)
- `lib/git/worktree.rb` (`worktree_repository`)
- `lib/git/worktrees.rb` (`worktree_repository`)
- `lib/git/repository/remote_operations.rb` — `url.is_a?(Git::Base) || url.is_a?(Git::Repository)` → `url.is_a?(Git::Repository)` in `remote_add` and `remote_set_url`

**Tests** — dead-code tests removed from 8 spec files:

- `spec/unit/git/branch_spec.rb`
- `spec/unit/git/branches_spec.rb`
- `spec/unit/git/log_spec.rb`
- `spec/unit/git/object_spec.rb`
- `spec/unit/git/remote_spec.rb`
- `spec/unit/git/repository/remote_operations_spec.rb`
- `spec/unit/git/worktree_spec.rb`
- `spec/unit/git/worktrees_spec.rb`

**Redesign tracker** — `redesign/3_architecture_implementation.md`:

- C1d and D1 marked ✅
- &#34;Next Task&#34; updated to D2 / Phase 4
- Progress: Phase 3 60% → 90%, TOTAL 72% → 86%

## Breaking change classification

This is classified as `refactor:` — not a breaking change — because `Git::Base`
itself still exists. The true breaking change (removing `Git::Base` entirely) will
carry the `feat!` / `BREAKING CHANGE:` tag in Phase 4.

## Checklist

- [x] All tests pass (`bundle exec rake default`)
- [x] RuboCop clean
- [x] YARD clean
- [x] No `is_a?(Git::Base)` guards remain in `lib/` (verified with grep)
