### PR TITLE
git: migrate F2 config utilities off Git::Lib

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -74,17 +74,7 @@ module Git
   # g.config('user.name')  # returns 'Scott Chacon'
   # g.config # returns whole config hash
   def config(name = nil, value = nil)
-    lib = Git::Lib.new
-    if name && value
-      # set value
-      lib.config_set(name, value)
-    elsif name
-      # return value
-      lib.config_get(name)
-    else
-      # return hash
-      lib.config_list
-    end
+    Git.__send__(:run_config_utility, name, value, global: false)
   end
 
   # Configures the gem by yielding {Git::Config.instance} to the block
@@ -117,7 +107,7 @@ module Git
   end
 
   def global_config(name = nil, value = nil)
-    self.class.global_config(name, value)
+    Git.global_config(name, value)
   end
 
   # Open a bare repository
@@ -338,17 +328,7 @@ module Git
   # g.config('user.name')  # returns 'Scott Chacon'
   # g.config # returns whole config hash
   def self.global_config(name = nil, value = nil)
-    lib = Git::Lib.new(nil, nil)
-    if name && value
-      # set value
-      lib.global_config_set(name, value)
-    elsif name
-      # return value
-      lib.global_config_get(name)
-    else
-      # return hash
-      lib.global_config_list
-    end
+    run_config_utility(name, value, global: true)
   end
 
   # Create an empty Git repository or reinitialize an existing Git repository
@@ -536,6 +516,36 @@ module Git
     Git::Version.parse(output)
   end
   private_class_method :run_git_version
+
+  # @api private
+  def self.run_config_utility(name, value, global:)
+    context = Git::ExecutionContext::Global.new
+    options = global ? { global: true } : {}
+
+    return Git::Commands::ConfigOptionSyntax::Set.new(context).call(name, value, **options) if name && value
+    return run_config_get(context, name, options) if name
+
+    output = Git::Commands::ConfigOptionSyntax::List.new(context).call(**options).stdout
+    parse_config_list(output.split("\n"))
+  end
+  private_class_method :run_config_utility
+
+  def self.run_config_get(context, name, options)
+    result = Git::Commands::ConfigOptionSyntax::Get.new(context).call(name, **options)
+    raise Git::FailedError, result if result.status.exitstatus != 0
+
+    result.stdout
+  end
+  private_class_method :run_config_get
+
+  # @api private
+  def self.parse_config_list(lines)
+    lines.each_with_object({}) do |line, hsh|
+      key, value = line.split('=', 2)
+      hsh[key] = value || ''
+    end
+  end
+  private_class_method :parse_config_list
 
   # Return the version of the git binary
   #

--- a/spec/unit/git/git_config_utilities_spec.rb
+++ b/spec/unit/git/git_config_utilities_spec.rb
@@ -1,0 +1,125 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git do
+  describe '.global_config' do
+    let(:context) { instance_double(Git::ExecutionContext::Global) }
+
+    before do
+      allow(Git::ExecutionContext::Global).to receive(:new).and_return(context)
+    end
+
+    it 'lists global config values via execution context + command path (not Git::Lib)' do
+      list_command = instance_double(Git::Commands::ConfigOptionSyntax::List)
+      allow(Git::Commands::ConfigOptionSyntax::List).to receive(:new).with(context).and_return(list_command)
+
+      expect(Git::Lib).not_to receive(:new)
+      expect(list_command).to receive(:call).with(global: true).and_return(
+        command_result("user.name=Alice\ncore.bare=false\nurl.value=https://a=b.example\nempty\n")
+      )
+
+      expect(described_class.global_config).to eq(
+        'user.name' => 'Alice',
+        'core.bare' => 'false',
+        'url.value' => 'https://a=b.example',
+        'empty' => ''
+      )
+    end
+
+    it 'gets a global config value via execution context + command path (not Git::Lib)' do
+      get_command = instance_double(Git::Commands::ConfigOptionSyntax::Get)
+      allow(Git::Commands::ConfigOptionSyntax::Get).to receive(:new).with(context).and_return(get_command)
+
+      expect(Git::Lib).not_to receive(:new)
+      expect(get_command).to receive(:call).with('user.name', global: true).and_return(command_result('Alice'))
+
+      expect(described_class.global_config('user.name')).to eq('Alice')
+    end
+
+    it 'sets a global config value via execution context + command path (not Git::Lib)' do
+      set_command = instance_double(Git::Commands::ConfigOptionSyntax::Set)
+      allow(Git::Commands::ConfigOptionSyntax::Set).to receive(:new).with(context).and_return(set_command)
+      set_result = command_result
+
+      expect(Git::Lib).not_to receive(:new)
+      expect(set_command).to receive(:call).with('user.name', 'Alice', global: true).and_return(set_result)
+
+      expect(described_class.global_config('user.name', 'Alice')).to be(set_result)
+    end
+
+    it 'raises Git::FailedError when get exits non-zero' do
+      get_command = instance_double(Git::Commands::ConfigOptionSyntax::Get)
+      allow(Git::Commands::ConfigOptionSyntax::Get).to receive(:new).with(context).and_return(get_command)
+      result = command_result('', stderr: "error\n", exitstatus: 1)
+      allow(get_command).to receive(:call).with('missing.key', global: true).and_return(result)
+
+      expect { described_class.global_config('missing.key') }.to raise_error(Git::FailedError, /error/)
+    end
+  end
+
+  describe '#config' do
+    let(:instance) { Class.new { include Git }.new }
+    let(:context) { instance_double(Git::ExecutionContext::Global) }
+
+    before do
+      allow(Git::ExecutionContext::Global).to receive(:new).and_return(context)
+    end
+
+    it 'lists config values via execution context + command path (not Git::Lib)' do
+      list_command = instance_double(Git::Commands::ConfigOptionSyntax::List)
+      allow(Git::Commands::ConfigOptionSyntax::List).to receive(:new).with(context).and_return(list_command)
+
+      expect(Git::Lib).not_to receive(:new)
+      expect(list_command).to receive(:call).with(no_args).and_return(
+        command_result("user.name=Alice\ncore.bare=false\nurl.value=https://a=b.example\nempty\n")
+      )
+
+      expect(instance.config).to eq(
+        'user.name' => 'Alice',
+        'core.bare' => 'false',
+        'url.value' => 'https://a=b.example',
+        'empty' => ''
+      )
+    end
+
+    it 'gets a config value via execution context + command path (not Git::Lib)' do
+      get_command = instance_double(Git::Commands::ConfigOptionSyntax::Get)
+      allow(Git::Commands::ConfigOptionSyntax::Get).to receive(:new).with(context).and_return(get_command)
+
+      expect(Git::Lib).not_to receive(:new)
+      expect(get_command).to receive(:call).with('user.name').and_return(command_result('Alice'))
+
+      expect(instance.config('user.name')).to eq('Alice')
+    end
+
+    it 'sets a config value via execution context + command path (not Git::Lib)' do
+      set_command = instance_double(Git::Commands::ConfigOptionSyntax::Set)
+      allow(Git::Commands::ConfigOptionSyntax::Set).to receive(:new).with(context).and_return(set_command)
+      set_result = command_result
+
+      expect(Git::Lib).not_to receive(:new)
+      expect(set_command).to receive(:call).with('user.name', 'Alice').and_return(set_result)
+
+      expect(instance.config('user.name', 'Alice')).to be(set_result)
+    end
+
+    it 'raises Git::FailedError when get exits non-zero' do
+      get_command = instance_double(Git::Commands::ConfigOptionSyntax::Get)
+      allow(Git::Commands::ConfigOptionSyntax::Get).to receive(:new).with(context).and_return(get_command)
+      result = command_result('', stderr: "error\n", exitstatus: 1)
+      allow(get_command).to receive(:call).with('missing.key').and_return(result)
+
+      expect { instance.config('missing.key') }.to raise_error(Git::FailedError, /error/)
+    end
+  end
+
+  describe '#global_config' do
+    let(:instance) { Class.new { include Git }.new }
+
+    it 'delegates to Git.global_config' do
+      expect(Git).to receive(:global_config).with('user.name', 'Alice').and_return(:ok)
+      expect(instance.global_config('user.name', 'Alice')).to eq(:ok)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- implement architectural redesign Step F2 by migrating `Git.global_config` off `Git::Lib`
- reimplement module instance `#config` (`include Git` callers) via `Git::ExecutionContext::Global` and `Git::Commands::ConfigOptionSyntax::{Get,List,Set}`
- keep module instance `#global_config` delegating to `Git.global_config`
- add focused unit coverage in `spec/unit/git/git_config_utilities_spec.rb` for list/get/set behavior, error propagation, list parsing semantics, and non-`Git::Lib` routing

## Why
Phase 4 cleanup requires eliminating remaining `Git::Lib` usage from top-level Git-module utility methods while preserving existing behavior and return contracts.

## Notes for reviewers
- `list` mode preserves previous parsing behavior by splitting each line on the first `=` and preserving additional `=` in values.
- `get` mode continues to raise `Git::FailedError` on non-zero command status.
- full suite (`bundle exec rake default:parallel`) passes after this change.