### PR TITLE
docs(prompts): improve Copilot review wait logic with timestamp validation

### DIFF
--- a/.github/prompts/iteratively-address-copilot-reviews.prompt.md
+++ b/.github/prompts/iteratively-address-copilot-reviews.prompt.md
@@ -1,45 +1,188 @@
 ---
 agent: agent
 model: claude-sonnet-4.6
-description: Address all unresolved review comments on the active pull request in a loop until Copilot review has no remaining comments
+description: Address all unresolved Copilot review threads on the active pull request until there are no remaining unresolved review threads
 ---
 
-Address the unresolved **Copilot** review comments from the active pull request, asking me for any clarifications or decisions needed along the way. Only Copilot review comments are in scope; ignore comments from human reviewers.
+Address unresolved **Copilot** review threads on the active pull request. Ignore threads opened by human reviewers. Ask me for clarification or decisions as needed.
 
-This prompt references specific models by name (see below). If any named model is not available, stop and ask me which model to use instead rather than silently falling back to a default.
+If any terminal script command fails, stop immediately. Do not continue the loop, do not resolve additional threads, and do not request a new review. Report: the failed command, exit code, and the most relevant stderr output. **Exception**: the reply POST in Step 3 is intentionally non-fatal — a 404 after a force-push is expected and the resolve step must still run.
 
-Run the following in a loop, up to a maximum of **${input:maxIterations:5} iterations**. Each iteration of addressing issues must be performed using a subagent with the **"Claude Sonnet 4.6 (copilot)"** model. Continue iterating until a Copilot review completes with no remaining comments, or until ${input:maxIterations:5} iterations have run.
+## Terminology
 
-If there are no unresolved Copilot comments on the first pass, report that and exit without making any changes.
+- **Review** — a top-level review submission by `copilot-pull-request-reviewer`, with a `submittedAt` timestamp and an optional summary body. A single review may contain zero or more Review Threads.
+- **Review Thread** — an inline comment thread attached to a specific code location. Key fields: `id` (GraphQL node ID, e.g. `PRRT_…`), `isResolved` (manually resolved by a maintainer), `isOutdated` (the underlying code changed since the thread was created). Each thread has one or more comments; the first comment is Copilot's suggestion.
+- **Check Run** — a standard CI status object on the HEAD commit. Note: Copilot Reviews do **not** create a Check Run; use the Reviews API to detect completion instead.
 
-To keep token usage low, subagents must return only a short structured summary to the orchestrator (e.g. `Files changed: ...; Comments resolved: N; Rake: pass/fail`), never full diffs, file contents, or comment text. The orchestrator should pass only IDs and outcomes between steps; each subagent fetches the comments and reads the files it needs itself.
+## Before the Loop
 
-## Per-Iteration Steps
+Run in terminal to establish `OWNER`, `REPO`, and `PR_NUMBER` for use throughout:
 
-1. For each unresolved Copilot review comment (group comments by file and address all comments for a file in a single pass to avoid re-reading it):
-   - Verify that the suggestion is valid and the best approach before accepting it.
-   - If the suggestion is invalid, out of scope, or should not be acted on, do not change code. Instead, reply to the comment explaining why, then resolve it.
-   - Otherwise, implement the change using TDD where possible.
-   - Make sure that there is test coverage for any code changed or added.
-   - Make sure to `rake` after the changes are done to ensure the CI build will succeed. If `rake` fails, capture only the failing summary (e.g. `rake 2>&1 | tail -n 50`) rather than full output, and fix the failure before continuing.
+```bash
+set -euo pipefail
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+PR_NUMBER=$(gh pr view --json number --jq '.number')
+: "${OWNER:?failed to resolve OWNER}"
+: "${REPO:?failed to resolve REPO}"
+: "${PR_NUMBER:?failed to resolve PR_NUMBER}"
+```
 
-2. Once all comments in this iteration have been addressed, amend each change into the most relevant previous commit on this branch based on file name. If a change spans multiple commits or does not clearly map to any single commit, ask me which commit to amend into (or whether to create a new commit). Before force pushing, confirm the working tree is clean and `rake` passes, then force push the result.
+Fetch unresolved, non-outdated Copilot Review Threads:
 
-3. After the force push succeeds, for each addressed comment add a reply explaining what was changed and how the issue was resolved, then resolve the comment.
+```bash
+set -euo pipefail
+: "${OWNER:?missing OWNER}"
+: "${REPO:?missing REPO}"
+: "${PR_NUMBER:?missing PR_NUMBER}"
+threads_json=$(gh api graphql -f query='
+  query($owner:String!,$repo:String!,$pr:Int!){
+    repository(owner:$owner,name:$repo){
+      pullRequest(number:$pr){
+        reviewThreads(first:100){nodes{id isResolved isOutdated path
+          comments(first:1){nodes{databaseId author{login} createdAt body}}}}}}
+  }' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUMBER" \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes')
+if [[ $(echo "$threads_json" | jq 'length') -ge 100 ]]; then
+  echo "Error: the PR already has 100 threads or more. Aborting."
+  exit 1
+fi
+echo "$threads_json" | jq '[.[] |
+  select(.isResolved==false) |
+  select(.isOutdated==false) |
+  select(.comments.nodes[0].author.login=="copilot-pull-request-reviewer")]'
+```
 
-4. Ask Copilot for a new review.
+- **Results non-empty** → proceed directly to the iteration loop.
+- **Results empty** → record `REVIEW_REQUESTED_AT` (current UTC, `YYYY-MM-DDTHH:MM:SSZ`, e.g. `2026-06-16T12:00:00Z`), request a new Copilot Review using the `mcp_github_mcp_se_request_copilot_review` tool (owner, repo, pullNumber), then jump to the **Wait for Review** section below.
 
-5. Report for this iteration:
-   - What issue(s) were addressed
-   - How each issue was resolved
+## Iteration Loop
 
-6. **[BLOCKING — do not proceed until complete]** Wait for the new Copilot review to complete using a subagent with the cheapest available model (e.g. **"GPT-5.4 mini (copilot)"**). That subagent should poll the review status every ~30 seconds and return only a single line per poll (`pending` or `done: N comments`), outputting "Waiting for Copilot review to complete... (Xs elapsed)" after each poll until the review is done. It must not re-fetch or print the full PR state. Do NOT move to step 7 or begin the next iteration until this subagent returns `done`.
+Repeat up to **${input:maxIterations:5}** iterations:
 
-7. If the new Copilot review has no remaining comments, exit the loop. Otherwise, begin the next iteration (unless ${input:maxIterations:5} iterations have already run).
+### 1. Address threads
+
+Re-fetch unresolved, non-outdated Copilot Review Threads using the same `gh api graphql` query from Before the Loop. Group by file. For each file, read it once and address all its threads in that single pass:
+- Validate each suggestion before accepting it.
+- If a suggestion is invalid or out of scope: reply explaining why, then resolve the thread without changing code.
+- Otherwise: implement the change using TDD where possible; ensure test coverage.
+
+Skip any thread where `isOutdated` is true — the code it references has already changed; Copilot will re-evaluate it in the next Review.
+
+After all threads are addressed, run `rake`. If it fails, capture `rake 2>&1 | tail -n 50` and fix the failure before continuing.
+
+### 2. Commit and push
+
+Amend each change into the most relevant existing commit on the branch based on file name. If a change spans multiple commits or doesn't map clearly to one, ask me which commit to amend into (or whether to create a new commit). Confirm the working tree is clean and `rake` passes, then force push.
+
+### 3. Reply and resolve
+
+For each addressed thread object from the unresolved-threads query, in the same `run_in_terminal` script block that performs reply/resolve, export:
+
+- `COMMENT_DBID=.comments.nodes[0].databaseId`
+- `THREAD_ID=.id`
+- `EXPLANATION` to your plain-language fix summary for that thread
+
+Set the per-thread variables (`COMMENT_DBID`, `THREAD_ID`, `EXPLANATION`) immediately before running the commands below — do not rely on them surviving from a prior terminal invocation.
+
+Then post a reply and resolve it:
+
+```bash
+set -euo pipefail
+: "${OWNER:?missing OWNER}"
+: "${REPO:?missing REPO}"
+: "${COMMENT_DBID:?missing COMMENT_DBID}"
+: "${EXPLANATION:?missing EXPLANATION}"
+
+# Reply (COMMENT_DBID = databaseId of the thread's first comment)
+# Build JSON via jq to safely handle quotes/newlines/special chars in EXPLANATION.
+# EXPLANATION should contain the full reply text (e.g. "Fixed: ..." or "Not addressing this because...").
+BODY_JSON=$(jq -n --arg body "$EXPLANATION" '{body:$body}')
+# Non-fatal: a force-push can mark threads as outdated, causing the REST reply to return 404.
+# Always continue to the GraphQL resolve step regardless.
+gh api "repos/$OWNER/$REPO/pulls/comments/$COMMENT_DBID/replies" \
+  -X POST --input - <<<"$BODY_JSON" \
+  || echo "Warning: reply POST failed (thread may be outdated after force-push) — skipping reply, will still resolve"
+
+: "${THREAD_ID:?missing THREAD_ID}"
+
+# Resolve (THREAD_ID = GraphQL node id, e.g. PRRT_...)
+gh api graphql \
+  -f query='mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{isResolved}}}' \
+  -f id="$THREAD_ID"
+```
+
+### 4. Request review
+
+**If this was the ${input:maxIterations:5}th iteration**, skip steps 4 and 6 entirely — go directly to step 5 (Report) and then produce the Final Report.
+
+Otherwise, capture `REVIEW_REQUESTED_AT` by running `date -u +%Y-%m-%dT%H:%M:%SZ` in the terminal immediately before requesting the review. Then request a new Copilot Review using the `mcp_github_mcp_se_request_copilot_review` tool (owner, repo, pullNumber).
+
+### 5. Report
+
+List what was addressed and how each issue was resolved.
+
+### 6. Wait
+
+Jump to the **Wait for Review** section below. Return here to begin the next iteration once the new Copilot Review has been submitted.
+
+## Wait for Review
+
+**[BLOCKING — do not proceed until complete]** Poll for a new Copilot Review submission using the Reviews API. A Review with `submittedAt >= REVIEW_REQUESTED_AT` is the authoritative completion signal — it fires even when Copilot produces zero Review Threads.
+
+Run the following script via `run_in_terminal` (sync mode, timeout 750000 ms). Set the four variables on the first line to their actual values. On success, capture the script's last output line; on failure, follow the global failure-reporting rule (failed command, exit code, relevant stderr):
+
+```bash
+set -euo pipefail
+# Replace with actual values. REVIEW_REQUESTED_AT = output of `date -u +%Y-%m-%dT%H:%M:%SZ` captured just before requesting the review.
+OWNER="ruby-git"; REPO="ruby-git"; PR_NUMBER="1439"; REVIEW_REQUESTED_AT="2026-06-16T12:00:00Z"
+: "${OWNER:?missing OWNER}"
+: "${REPO:?missing REPO}"
+: "${PR_NUMBER:?missing PR_NUMBER}"
+: "${REVIEW_REQUESTED_AT:?missing REVIEW_REQUESTED_AT}"
+START=$(date +%s)
+for i in $(seq 1 60); do
+  new_review=$(gh pr view "$PR_NUMBER" --repo "$OWNER/$REPO" --json reviews \
+    --jq "[.reviews[] | select(.author.login==\"copilot-pull-request-reviewer\") | select(.submittedAt != null) | select(.submittedAt | fromdateiso8601 >= (\"$REVIEW_REQUESTED_AT\" | fromdateiso8601))] | length") \
+    || { rc=$?; echo "Error: gh pr view failed (exit $rc)"; exit $rc; }
+  if [[ -n "$new_review" && "$new_review" -gt 0 ]]; then
+    raw_nodes=$(gh api graphql -f query='
+      query($owner:String!,$repo:String!,$pr:Int!){
+        repository(owner:$owner,name:$repo){
+          pullRequest(number:$pr){
+            reviewThreads(first:100){nodes{isResolved isOutdated comments(first:1){nodes{author{login}}}}}
+          }
+        }
+      }' -f owner="$OWNER" -f repo="$REPO" -F pr="$PR_NUMBER" \
+      --jq '.data.repository.pullRequest.reviewThreads.nodes') \
+      || { rc=$?; echo "Error: gh api graphql failed (exit $rc)"; exit $rc; }
+    if [[ $(echo "$raw_nodes" | jq 'length') -ge 100 ]]; then
+      echo "Error: the PR already has 100 threads or more. Aborting."
+      exit 1
+    fi
+    count=$(echo "$raw_nodes" | jq "[.[] |
+      select(.isResolved==false) |
+      select(.isOutdated==false) |
+      select(.comments.nodes[0].author.login==\"copilot-pull-request-reviewer\")] | length")
+    echo "done: $count threads"  # count of all unresolved non-outdated Copilot Review Threads
+    exit 0
+  fi
+  elapsed=$(( $(date +%s) - START ))
+  echo "Waiting for Copilot Review to complete... (${elapsed}s elapsed)"
+  sleep 10
+done
+echo "timed out after 60 polls"
+exit 1
+```
+
+**If `timed out after 60 polls`**: stop immediately and ask me whether to re-request the review and retry, or abort.
+
+**If `done: 0 threads`**: the loop is complete — exit.
+
+**If `done: N threads`** (N > 0): begin the next iteration.
 
 ## Final Report
 
-After all iterations are complete, report:
-- Total number of iterations completed
-- Total number of issues addressed
-- Number of Copilot review comments found in the last iteration (this should be 0 if the loop ended because the reviewer had nothing to comment on)
+- Total iterations completed
+- Total threads addressed
+- Unresolved threads in the final Copilot review (should be 0 if the loop exited cleanly)

--- a/git.gemspec
+++ b/git.gemspec
@@ -48,6 +48,11 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov-rspec', '~> 0.4'
   spec.add_development_dependency 'test-unit', '~> 3.7'
 
+  if RUBY_ENGINE == 'truffleruby' && Gem::Version.new(RUBY_ENGINE_VERSION) < Gem::Version.new('34.0.0')
+    # i18n 1.15+ uses Fiber.[] (Ruby 3.2 Fiber storage) which TruffleRuby < 34.0.0 does not implement
+    spec.add_development_dependency 'i18n', '< 1.15'
+  end
+
   unless RUBY_PLATFORM == 'java' || RUBY_ENGINE == 'truffleruby'
     spec.add_development_dependency 'irb', '~> 1.16'
     spec.add_development_dependency 'redcarpet', '~> 3.6'


### PR DESCRIPTION
## Summary

Improves the polling logic in the iterative Copilot review prompt to correctly detect when a *new* review has completed (rather than mistakenly counting an old review as the new one).

Also pins the `i18n` development dependency to `< 1.15` on TruffleRuby < 34.0.0, fixing a CI failure caused by `i18n` 1.15.0's use of `Fiber.[]` (Ruby 3.2 Fiber-local storage), which TruffleRuby did not implement until version 34.0.0.

## Changes

### Prompt (`iteratively-address-copilot-reviews.prompt.md`)
- **Terminology section**: Defines Review, Review Thread, and Check Run with precise field names
- **Before the Loop**: Replaced extension tool calls with `gh` CLI commands; filters out outdated threads; detects 100-thread limit
- **Iteration Loop**: Restructured into numbered steps; added explicit Step 6 to jump to Wait for Review before next iteration
- **Step 3**: Added `gh api` commands for posting replies and resolving threads via GraphQL mutation; reply is non-fatal (force-push can cause 404s)
- **Step 4**: Uses `mcp_github_mcp_se_request_copilot_review` tool (REST endpoint doesn't support Copilot reviewer); captures `REVIEW_REQUESTED_AT` via `date -u`
- **Wait for Review**: Polls the Reviews API (`gh pr view --json reviews`) for a new Review with `submittedAt >= REVIEW_REQUESTED_AT` — Copilot Reviews do not create Check Runs; polls every 10 seconds for up to 60 polls (10 minutes)
- **Count query**: Counts all unresolved, non-outdated Copilot Review Threads (not filtered by timestamp)
- **Exit-code preservation**: Error handlers capture real exit code via `rc=$?` and propagate it

### Gemspec (`git.gemspec`)
- Pins `i18n < 1.15` as a development dependency on TruffleRuby < 34.0.0 to prevent `NoMethodError` on `Fiber.[]` in CI