### PR TITLE
docs(redesign): sync architecture implementation tracker

### DIFF
--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -9,7 +9,8 @@ risk and allows for a gradual, controlled migration to the new architecture.
   - [Facade Modules Completed](#facade-modules-completed)
     - [Facade module naming convention](#facade-module-naming-convention)
   - [Next Task](#next-task)
-    - [Phase 3 Public Interface Completion](#phase-3-public-interface-completion)
+    - [D2 / Phase 4 is the remaining redesign step](#d2--phase-4-is-the-remaining-redesign-step)
+    - [Phase 3 Overview](#phase-3-overview)
     - [Workstream A — Fill facade coverage gaps](#workstream-a--fill-facade-coverage-gaps)
     - [Workstream B — C0: Redirect `Git::Base` factory methods to `facade_repository`](#workstream-b--c0-redirect-gitbase-factory-methods-to-facade_repository)
     - [Workstream C — C1: Prepare and flip top-level entry points to return `Git::Repository`](#workstream-c--c1-prepare-and-flip-top-level-entry-points-to-return-gitrepository)
@@ -46,40 +47,48 @@ risk and allows for a gradual, controlled migration to the new architecture.
 
 | Module | File | Included in `Git::Repository` | `Git::Base` delegates |
 | ------ | ---- | ------------------------------ | --------------------- |
-| `Git::Repository::Staging` | `lib/git/repository/staging.rb` | ✅ | `add`, `reset`, `rm`, `clean`, `ignored_files` |
+| `Git::Repository::Staging` | `lib/git/repository/staging.rb` | ✅ | `add`, `reset`, `reset_hard`, `apply`, `apply_mail`, `read_tree`, `rm`, `mv`, `clean`, `ignored_files` |
 | `Git::Repository::Committing` | `lib/git/repository/committing.rb` | ✅ | `commit`, `commit_all`, `write_tree`; `commit_tree` and `write_and_commit_tree` wrap the SHA result in `Git::Object::Commit.new(self, ...)` |
-| `Git::Repository::Branching` | `lib/git/repository/branching.rb` | ✅ | `checkout`, `checkout_file`, `checkout_index`, `current_branch`, `local_branch?`, `remote_branch?`, `branch?`, `branch_delete`, `branch_new`, `branch_contains`, `branches_all`, `update_ref` |
+| `Git::Repository::Branching` | `lib/git/repository/branching.rb` | ✅ | `checkout`, `checkout_file`, `checkout_index`, `current_branch`, `current_branch_state`, `local_branch?`, `remote_branch?`, `branch?`, `branch`, `branches`, `branch_delete`, `branch_new`, `change_head_branch`, `branch_contains`, `branches_all`, `update_ref` |
+| `Git::Repository::ContextHelpers` | `lib/git/repository/context_helpers.rb` | ✅ | `chdir`, `with_index`, `with_temp_index`, `with_working`, `with_temp_working`, `set_index`, `set_working` |
 | `Git::Repository::Merging` | `lib/git/repository/merging.rb` | ✅ | `merge`, `revert`, `each_conflict`; `merge_base` wraps the returned SHA strings in `Git::Object::Commit.new(self, ...)` instances |
-| `Git::Repository::RemoteOperations` | `lib/git/repository/remote_operations.rb` | ✅ | `fetch`, `pull`, `push`, `add_remote`, `remove_remote`, `config_remote`, `remotes`, `set_remote_url`, `remote_set_branches` |
-| `Git::Repository::Stashing` | `lib/git/repository/stashing.rb` | ✅ | `stash_save`, `stash_apply`, `stash_clear`, `stashes_all` |
-| `Git::Repository::Diffing` | `lib/git/repository/diffing.rb` | ✅ | `diff_path_status`, `diff_name_status`, `diff_full` |
-| `Git::Repository::Inspecting` | `lib/git/repository/inspecting.rb` | ✅ | `show`, `fsck` |
-| `Git::Repository::ObjectOperations` | `lib/git/repository/object_operations.rb` | ✅ | `rev_parse`, `tree_depth`, `ls_tree`, `grep`, `archive`, `tags`, `add_tag`, `delete_tag` |
+| `Git::Repository::RemoteOperations` | `lib/git/repository/remote_operations.rb` | ✅ | `fetch`, `pull`, `push`, remote add/remove/url helpers, `config_remote`, `remote`, `remotes`, `ls_remote`, `remote_set_branches` |
+| `Git::Repository::Stashing` | `lib/git/repository/stashing.rb` | ✅ | `stash_list`, `stash_save`, `stash_apply`, `stash_clear`, `stashes_all` |
+| `Git::Repository::Diffing` | `lib/git/repository/diffing.rb` | ✅ | `diff_full`, `diff_numstat`, `diff_stats`, `diff`, `diff_path_status`, `diff_files`, `diff_index` |
+| `Git::Repository::Inspecting` | `lib/git/repository/inspecting.rb` | ✅ | `describe`, `show`, `fsck` |
 | `Git::Repository::Logging` | `lib/git/repository/logging.rb` | ✅ | `log`, `full_log_commits` |
-| `Git::Repository::StatusOperations` | `lib/git/repository/status_operations.rb` | ✅ | `ls_files`, `no_commits?` (renamed from `Git::Lib#empty?`), `untracked_files`, `status`; `Git::Base#ls_files` delegates to facade |
-| `Git::Repository::Configuring` | `lib/git/repository/configuring.rb` | ✅ | `config`; `Git::Base#config` delegates to facade |
+| `Git::Repository::Maintenance` | `lib/git/repository/maintenance.rb` | ✅ | `repack`, `gc` |
+| `Git::Repository::ObjectOperations` | `lib/git/repository/object_operations.rb` | ✅ | `cat_file_contents`, `cat_file_size`, `cat_file_type`, `cat_file_commit`, `cat_file_tag`, `rev_parse`, `tag_sha`, `full_tree`, `tree_depth`, `name_rev`, `ls_tree`, `grep`, `archive`, `gblob`, `gcommit`, `gtree`, `tag`, `object`, `tags`, `add_tag`, `delete_tag` |
+| `Git::Repository::StatusOperations` | `lib/git/repository/status_operations.rb` | ✅ | `ls_files`, `no_commits?` / `empty?`, `untracked_files`, `status` |
+| `Git::Repository::Configuring` | `lib/git/repository/configuring.rb` | ✅ | `config`, `config_get`, `config_list`, `config_set`, `global_config`, `global_config_get`, `global_config_list`, `global_config_set` |
 | `Git::Repository::WorktreeOperations` | `lib/git/repository/worktree_operations.rb` | ✅ | `worktrees_all`, `worktree_add`, `worktree_remove`, `worktree_prune`, `worktree`, `worktrees` |
 
 #### Facade module naming convention
 
-New topic modules follow a **two-tier** convention:
+New topic modules follow a **three-tier** convention:
 
 - **Gerund** (verb-ing) when a single action word clearly names the whole module:
-  `Staging`, `Committing`, `Branching`, `Merging`, `Logging`, `Diffing`, `Stashing`, `Configuring`.
+  `Staging`, `Committing`, `Branching`, `Merging`, `Logging`, `Diffing`, `Stashing`,
+  `Configuring`, `Inspecting`.
 - **Noun + `Operations`** when the module is a mixed bag of methods grouped by git
   concept rather than a single action: `RemoteOperations`, `ObjectOperations`,
   `StatusOperations`, `WorktreeOperations`.
+- **Descriptive utility names** for cross-cutting helpers or housekeeping APIs that
+  are not domain-object names: `ContextHelpers`, `Maintenance`.
 
 Do **not** use plain nouns that clash with existing domain-object class names
 such as `Branch`, `Diff`, `Log`, `Object`, `Remote`, `Status`, `Worktree`, etc.
 
 ### Next Task
 
-#### F2 is ✅ complete — Phase 4 prerequisites met
+#### D2 / Phase 4 is the remaining redesign step
 
-F1 and F2 are both ✅ complete. All Phase 4 prerequisites are now satisfied.
+F1 and F2 are both ✅ complete. All Phase 4 prerequisites are now satisfied, and
+the remaining unchecked redesign item is D2.
 
 Phase 4 (final cleanup and release — deleting `Git::Base`/`Git::Lib`) can now begin.
+The first cleanup PR should remove the `base_object` / `from_base` bridge in the
+same releasable change that deletes or retires `Git::Base`.
 The following are also required and are already ✅ complete:
 
 | Step | Status |
@@ -184,9 +193,10 @@ These are read-only repository inspection operations that don't fit an existing 
 
 Files touched: `lib/git/repository/inspecting.rb` (new), `lib/git/repository.rb` (add `include Git::Repository::Inspecting`), `spec/unit/git/repository/inspecting_spec.rb` (new), `lib/git/base.rb`
 
-**Not covered by A1–A4:** lower-level public methods such as `describe`, `repack`,
-`gc`, `apply`, `apply_mail`, `read_tree`, and `cat_file` are handled by the C1c-2
-public-API parity audit before `Git.open` starts returning `Git::Repository`.
+**Later covered by C1c-2:** lower-level public methods such as `describe`,
+`repack`, `gc`, `apply`, `apply_mail`, `read_tree`, and `cat_file_*` were
+subsequently migrated into `Inspecting`, `Maintenance`, `Staging`, and
+`ObjectOperations` before `Git.open` started returning `Git::Repository`.
 
 ---
 
@@ -324,7 +334,7 @@ Required audit buckets:
 | --- | --- |
 | Path/accessors | `dir`, `repo`, `index`, `repo_size` must exist on `Git::Repository` (C1a-1 owns this) |
 | Compatibility aliases/wrappers | `remove`, `revparse`, `diff_name_status`, `reset_hard`, `is_local_branch?`, `is_remote_branch?`, `is_branch?`, `checkout` must be migrated or intentionally removed with upgrade notes (`checkout` is called by `Git.export` on the `Git.clone` result) |
-| Low-level public methods | `describe`, `repack`, `gc`, `apply`, `apply_mail`, `read_tree`, `cat_file` must be migrated to topic modules or intentionally removed with upgrade notes |
+| Low-level public methods | Resolved in the current tree: `describe` → `Inspecting`; `repack`/`gc` → `Maintenance`; `apply`/`apply_mail`/`read_tree` → `Staging`; `cat_file_*` → `ObjectOperations`. Any intentional removals still require upgrade notes. |
 | Factory/domain-object returns | Confirm B plus A2/A3 cover `branch`, `branches`, `remote`, `remotes`, `tag`, `tags`, object factories, and tag create/delete return shapes |
 | Keyword-arg facades | For `legacy-contract` methods, preserve the exact 4.x call shape (including rare `**opts` signatures); for `5.x-native` methods, use `opts = {}` style for consistency |
 
@@ -449,8 +459,8 @@ or explicitly deprecated with removal in v6.0. The recommended path is migration
 removed at the same time, since `with_index`/`with_working` depend on the same
 invalidation logic.
 
-Files touched: `lib/git/repository.rb` (or a new `Git::Repository::ContextHelpers`
-module), `lib/git/base.rb`, `spec/unit/git/repository/` (new or extended spec)
+Files touched: `lib/git/repository/context_helpers.rb`, `lib/git/base.rb`,
+`spec/unit/git/repository/` (new or extended spec)
 
 ---
 
@@ -610,7 +620,7 @@ logic. The gem will be fully functional after this phase.*
 1. **Create New Directory Structure**
 
    - `lib/git/commands/` ✅
-   - `lib/git/repository/` ✅ — populated with 12 facade modules in Phase 3 (see [Facade Modules Completed](#facade-modules-completed))
+   - `lib/git/repository/` ✅ — populated with 15 included modules in Phase 3 (see [Facade Modules Completed](#facade-modules-completed))
 
 2. **Eliminate Custom Path Classes**
 
@@ -632,7 +642,7 @@ logic. The gem will be fully functional after this phase.*
      - `Git::ExecutionContext::Global` subclass in `lib/git/execution_context/global.rb` ✅
 
    - `Git::Repository` in `lib/git/repository.rb` ✅
-     - Now includes 12 facade modules (see [Facade Modules Completed](#facade-modules-completed))
+     - Now includes 15 modules via `include` (see [Facade Modules Completed](#facade-modules-completed))
 
    - `Git::Commands::Arguments` DSL in `lib/git/commands/arguments.rb` ✅
      - Provides declarative argument definition for command classes
@@ -1513,7 +1523,9 @@ order: Basic Snapshotting → Branching & Merging → etc.
 ***Goal**: Switch the public-facing classes to use the new architecture directly,
 breaking the final ties to the old implementation.*
 
-> **Status**: Task 1 below is complete; Task 2 is in progress — see the [Next Task](#next-task) section above for the current plan.
+> **Status**: Phase 3 is ✅ complete. Tasks 1 and 2 are both complete; the remaining
+> redesign work is the Phase 4 cleanup described in the [Next Task](#next-task)
+> section above.
 
 1. **Add `binary_path:` to `Git::ExecutionContext`** ✅
 
@@ -1523,15 +1535,15 @@ breaking the final ties to the old implementation.*
    stopgap in `Git.run_git_version` was replaced with
    `Git::Commands::Version.new(Git::ExecutionContext::Global.new(...)).call`.
 
-2. **Implement the Facade** ⏳
+2. **Implement the Facade** ✅
 
-   `Git::Repository` now includes 12 facade modules (see
-   [Facade Modules Completed](#facade-modules-completed)). `Git::Base` wraps the
-   corresponding methods via `facade_repository`. The domain-object migration
-   iterations (iters 1–9) add further facade methods, but full `Git::Base`
-   coverage requires additional facade PRs for methods not touched by those
-   iterations (e.g. `clean`, `rm`, `tags`/`add_tag`, `fsck`, `show`, `remotes`,
-   remote URL/branch helpers) before the cleanup PR can run.
+   `Git::Repository` now includes 15 modules via `include` in
+   `lib/git/repository.rb` (see [Facade Modules Completed](#facade-modules-completed)).
+   `Git::Base` wraps the corresponding methods via `facade_repository`, and the
+   end-of-Phase-3 parity sweep landed the remaining low-level facade coverage
+   needed before the entry-point flip — including `describe`, `show`, `fsck`,
+   `apply`, `apply_mail`, `read_tree`, `cat_file_*`, `repack`, `gc`, helper/path
+   context methods, and the remaining remote/tag convenience APIs.
 
 ## Phase 4: Final Cleanup and Release Preparation
 

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -14,7 +14,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
     - [Workstream A — Fill facade coverage gaps](#workstream-a--fill-facade-coverage-gaps)
     - [Workstream B — C0: Redirect `Git::Base` factory methods to `facade_repository`](#workstream-b--c0-redirect-gitbase-factory-methods-to-facade_repository)
     - [Workstream C — C1: Prepare and flip top-level entry points to return `Git::Repository`](#workstream-c--c1-prepare-and-flip-top-level-entry-points-to-return-gitrepository)
-    - [Workstream D — C2+C3: Remove compatibility bridges](#workstream-d--c2c3-remove-compatibility-bridges)
+    - [Workstream D — C3: Remove compatibility fallbacks](#workstream-d--c3-remove-compatibility-fallbacks)
     - [Workstream E — Migrate or deprecate instance helper methods](#workstream-e--migrate-or-deprecate-instance-helper-methods)
     - [Workstream F — `Git` module utility methods still using `Git::Lib` directly](#workstream-f--git-module-utility-methods-still-using-gitlib-directly)
     - [Phase 3 dependency order](#phase-3-dependency-order)
@@ -32,6 +32,10 @@ risk and allows for a gradual, controlled migration to the new architecture.
     - [⏳ Commands To Migrate](#-commands-to-migrate)
 - [Phase 3: Refactoring the Public Interface](#phase-3-refactoring-the-public-interface)
 - [Phase 4: Final Cleanup and Release Preparation](#phase-4-final-cleanup-and-release-preparation)
+  - [Phase 4 step graph](#phase-4-step-graph)
+    - [Step A — Remove old code](#step-a--remove-old-code)
+    - [Step B — Finalize test suite](#step-b--finalize-test-suite)
+    - [Step C — Update documentation](#step-c--update-documentation)
 
 ## Progress Tracker
 
@@ -52,9 +56,9 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | `Git::Repository::Branching` | `lib/git/repository/branching.rb` | ✅ | `checkout`, `checkout_file`, `checkout_index`, `current_branch`, `current_branch_state`, `local_branch?`, `remote_branch?`, `branch?`, `branch`, `branches`, `branch_delete`, `branch_new`, `change_head_branch`, `branch_contains`, `branches_all`, `update_ref` |
 | `Git::Repository::ContextHelpers` | `lib/git/repository/context_helpers.rb` | ✅ | `chdir`, `with_index`, `with_temp_index`, `with_working`, `with_temp_working`, `set_index`, `set_working` |
 | `Git::Repository::Merging` | `lib/git/repository/merging.rb` | ✅ | `merge`, `revert`, `each_conflict`; `merge_base` wraps the returned SHA strings in `Git::Object::Commit.new(self, ...)` instances |
-| `Git::Repository::RemoteOperations` | `lib/git/repository/remote_operations.rb` | ✅ | `fetch`, `pull`, `push`, remote add/remove/url helpers, `config_remote`, `remote`, `remotes`, `ls_remote`, `remote_set_branches` |
+| `Git::Repository::RemoteOperations` | `lib/git/repository/remote_operations.rb` | ✅ | `fetch`, `pull`, `push`, `remote_add` (alias: `add_remote`), `remote_remove` (alias: `remove_remote`), `remote_set_url` (alias: `set_remote_url`), `config_remote`, `remote`, `remotes`, `ls_remote`, `remote_set_branches` |
 | `Git::Repository::Stashing` | `lib/git/repository/stashing.rb` | ✅ | `stash_list`, `stash_save`, `stash_apply`, `stash_clear`, `stashes_all` |
-| `Git::Repository::Diffing` | `lib/git/repository/diffing.rb` | ✅ | `diff_full`, `diff_numstat`, `diff_stats`, `diff`, `diff_path_status`, `diff_files`, `diff_index` |
+| `Git::Repository::Diffing` | `lib/git/repository/diffing.rb` | ✅ | `diff_full`, `diff_numstat`, `diff_stats`, `diff`, `diff_path_status` (alias: `diff_name_status`), `diff_files`, `diff_index` |
 | `Git::Repository::Inspecting` | `lib/git/repository/inspecting.rb` | ✅ | `describe`, `show`, `fsck` |
 | `Git::Repository::Logging` | `lib/git/repository/logging.rb` | ✅ | `log`, `full_log_commits` |
 | `Git::Repository::Maintenance` | `lib/git/repository/maintenance.rb` | ✅ | `repack`, `gc` |
@@ -374,7 +378,7 @@ in the [Next Task](#next-task) section for the full per-phase breakdown.
 
 ---
 
-#### Workstream D — C2+C3: Remove compatibility bridges
+#### Workstream D — C3: Remove compatibility fallbacks
 
 ⚠️ These are v5-only cleanup steps. They are not 4.x-compatible and must be kept out
 of 4.x release candidates unless an explicit breaking-change decision has already
@@ -418,20 +422,6 @@ Also remove legacy `@base.lib` fallback paths that only exist to support
 After D1, domain objects should assume their provider is `Git::Repository` (or a
 compatible object that implements the repository facade methods directly), not an
 object with a `.lib` escape hatch.
-
-##### Step D2 — Remove the `base_object` bridge
-
-⚠️ Do **not** ship D2 as a standalone PR while `Git::Base` remains functional.
-`Git::Base#facade_repository` currently depends on
-`Git::ExecutionContext::Repository.from_base(self)`, so deleting the bridge before
-deleting or retiring `Git::Base` would leave the tree unreleasable.
-
-D2 belongs in the Phase 4 old-code deletion PR (or in the same v5 cleanup PR that
-removes `Git::Base` as a usable public entry point):
-
-- Delete `attr_reader :base_object`
-- Remove `base_object:` from `#initialize` and body
-- Remove or convert `from_base` factory
 
 ---
 
@@ -543,10 +533,6 @@ classified as a v5-only PR with upgrade-note coverage before it lands.
 | C1c-2 | ✅ | End-of-Phase-3 public-API parity audit and remediation sweep ([#1370](https://github.com/ruby-git/ruby-git/issues/1370)) | 4.x-compatible | All four parity audit buckets resolved (fix or documented removal) before C1d; no unclassified compatibility gap remains. |
 | C1d | ✅ | Flip `Git.open`/`.clone`/`.init`/`.bare` to return `Git::Repository` | v5 boundary | Explicit breaking change because class identity changes from `Git::Base` to `Git::Repository`; method-level parity must be complete first. Split into C1d-1 (entry point flip), C1d-2 (eliminate internal .lib callers + add deprecation enforcement to both test suites), and C1d-3 (remove dead fallbacks + replace silent lib shim with real deprecation warning). |
 | D1 | ✅ | Remove domain-object `Git::Base` guards and `@base.lib` fallbacks | v5 cleanup | Explicitly drops direct `Git::Base` provider support in domain-object constructors; normal factory-created objects remain supported. |
-| D2 / Phase 4 | ⬜ | Remove `base_object`/`from_base` with `Git::Base` deletion or retirement | v5 cleanup | Must land with the old-code deletion path; not releasable as a standalone PR while `Git::Base#facade_repository` depends on it. |
-
----
-
 #### Phase 3 completion criteria
 
 Use this table to decide whether a checklist item can be marked complete. A step is
@@ -566,7 +552,6 @@ done only when its code, focused specs, and delegation/cleanup checks are all tr
 | C1c-2: public-API parity audit and remediation | End-of-Phase-3 sweep complete (Issue #1370): a public-method inventory compares `Git::Base` and `Git::Repository`; every surviving public method has a repository implementation and focused coverage; every intentional removal has an upgrade-note/deprecation decision; no unclassified compatibility gap remains. |
 | C1d: entry-point flip | `Git.open`, `Git.clone`, `Git.init`, and `Git.bare` return `Git::Repository`; common existing workflows still pass through those entry points; YARD return docs are updated; no top-level factory method calls `Git::Base.*`; full suite passes. |
 | D1: domain-object fallback removal | No `is_a?(Git::Base)` guards remain; no `@base.lib` fallback remains in domain objects; direct `Git::Base` provider support is documented as a v5-only removal; full suite passes. |
-| D2 / Phase 4: `base_object` bridge removal | `Git::ExecutionContext::Repository` no longer accepts or exposes `base_object`; `from_base` is removed or converted to a non-`Git::Base` path; this lands only with the PR that deletes or retires `Git::Base`, so no releasable state contains a broken `Git::Base#facade_repository`. |
 | E: instance helper methods | `Git::Repository` implements or explicitly deprecates `chdir`, `with_index`, `with_temp_index`, `with_working`, `with_temp_working`, `set_index`, and `set_working`; context rebuilding after index/worktree changes is covered by specs; helpers yield the same values and restore state after block exit/errors. |
 | F: `Git` module utilities off `Git::Lib` | `Git.default_branch`, `Git.global_config`, `Git.ls_remote`, module instance `#config`, and module instance `#global_config` no longer call `Git::Lib.new`; `Git::Base.repository_default_branch` migrated to use `Git::Commands::LsRemote` directly; existing `LsRemote` and `ConfigOptionSyntax` commands provide the behavior; parser/helper code needed from `Git::Lib` has moved; `grep -n 'Lib.new' lib/git.rb` returns no matches. |
 
@@ -588,7 +573,6 @@ done only when its code, focused specs, and delegation/cleanup checks are all tr
 | C1c-2: End-of-Phase-3 public-API parity audit and remediation (#1370) | ✅ |
 | C1d: Entry-point flip (`Git.open` etc. → `Git::Repository`) | ✅ |
 | D1 (C3): Remove `is_a?(Git::Base)` guards + `@base.lib` fallbacks | ✅ |
-| D2 (C2 / Phase 4): Remove `base_object` bridge with `Git::Base` deletion | ⬜ (v5 cleanup) |
 | E: Instance helpers (`#chdir`, `#with_index`, `#with_temp_index`, `#with_working`, `#with_temp_working`) | ✅ |
 | F: `Git` module utilities (`default_branch`, `global_config`, `ls_remote`) off `Git::Lib` | ✅ |
 
@@ -649,7 +633,7 @@ logic. The gem will be fully functional after this phase.*
 
 4. **Set Up RSpec Environment**
 
-    RSpec configured and working alongside TestUnit. Specs live in `spec/` and can be
+    RSpec configured and working alongside Test::Unit. Specs live in `spec/` and can be
     run with `bundle exec rspec`. ✅
 
 ## Phase 2: The Strangler Fig Pattern - Migrating Commands
@@ -1294,7 +1278,7 @@ future work:
     instantiate and call the new `Git::Commands::Add` object, passing `self` as the
     context.
 
-  - **Verify**: Run the full test suite (both TestUnit and RSpec). The existing tests
+  - **Verify**: Run the full test suite (both Test::Unit and RSpec). The existing tests
     for `g.add` should still pass, but they will now be executing the new, refactored
     code.
 
@@ -1550,28 +1534,39 @@ breaking the final ties to the old implementation.*
 ***Goal**: Remove all old code, finalize the test suite, and prepare for the v5.0.0
 release.*
 
-1. **Remove Old Code**:
+### Phase 4 step graph
 
-   - Delete the `Git::Lib` class entirely.
+```mermaid
+graph LR
+    A --> B
+    B --> C
+```
 
-   - Delete the `Git::Base` class file.
+#### Step A — Remove old code
 
-   - Remove any other dead code that was part of the old implementation.
+- Delete `attr_reader :base_object`, remove `base_object:` from `#initialize`, and remove or convert `from_base`.
+- Delete the `Git::Lib` class entirely.
+- Delete the `Git::Base` class file.
+- Remove any other dead code that was part of the old implementation.
 
-2. **Finalize Test Suite**:
+**Done when**: `lib/git/lib.rb` and `lib/git/base.rb` are deleted; `Git::ExecutionContext::Repository` no longer accepts or exposes `base_object`; no references to `Git::Lib` or `Git::Base` remain in `lib/`.
 
-   - Convert any remaining, relevant TestUnit tests to RSpec.
+**Planning tip**: Before generating a deletion plan, audit all remaining callers of `Git::Lib`, `Git::Base`, and `from_base` across `lib/` and `spec/`. The bridge removal and `Git::Base` deletion must land atomically in the same PR — plan for a single large deletion commit rather than incremental removals.
 
-   - Remove the `test-unit` dependency from the `Gemfile`.
+#### Step B — Finalize test suite
 
-   - Ensure the RSpec suite has comprehensive coverage for the new architecture.
+- Convert any remaining, relevant Test::Unit tests to RSpec.
+- Remove the `test-unit` dependency from the `Gemfile`.
+- Ensure the RSpec suite has comprehensive coverage for the new architecture.
 
-3. **Update Documentation**:
+**Done when**: The `tests/` directory is empty or removed; `test-unit` is no longer
+in `Gemfile`; RSpec is the sole test framework.
 
-   - Thoroughly document the new public API (`Git`, `Git::Repository`, etc.).
+#### Step C — Update documentation
 
-   - Mark all internal classes (`ExecutionContext`, `Commands`, `*Path`) with `@api
-     private` in the YARD documentation.
+- Thoroughly document the new public API (`Git`, `Git::Repository`, etc.).
+- Mark all internal classes (`ExecutionContext`, `Commands`, `*Path`) with `@api private` in the YARD documentation.
+- Update the `README.md` and create a `UPGRADING.md` guide explaining the breaking changes for v5.0.0.
 
-   - Update the `README.md` and create a `UPGRADING.md` guide explaining the breaking
-     changes for v5.0.0.
+**Done when**: `yard stats` reports no missing docs on public API; `UPGRADING.md`
+covers all breaking changes; `README.md` reflects the new entry points.


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Synchronize `redesign/3_architecture_implementation.md` with the current codebase state.

This updates the tracker to reflect the current `Git::Repository` module surface,
marks the stale Phase 3 narrative as complete, and records D2 / Phase 4 as the
remaining redesign step. It also fixes the facade summary tables and parity-audit
notes so they describe the code that is already in the tree.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).