### PR TITLE
fix(git): delegate Git::Base#reset_hard through facade_repository

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -500,12 +500,7 @@ module Git
     # @deprecated Use {#reset} with `hard: true` instead.
     #
     def reset_hard(commitish = nil, opts = {})
-      Git::Deprecation.warn(
-        'Git::Base#reset_hard is deprecated and will be removed in a future version. ' \
-        'Use Git::Base#reset(commitish, hard: true) instead.'
-      )
-      opts = { hard: true }.merge(opts)
-      lib.reset(commitish, opts)
+      facade_repository.reset_hard(commitish, opts)
     end
 
     # @return [String] git's stdout from the mv command

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -650,4 +650,37 @@ RSpec.describe Git::Base do
       expect(described_instance.global_config_set('user.name', 'Alice')).to be(set_result)
     end
   end
+
+  describe '#reset_hard' do
+    include_context 'with a stubbed facade_repository'
+
+    subject(:result) { described_instance.reset_hard }
+
+    before do
+      allow(facade_repository).to receive(:reset_hard).and_return('reset output')
+    end
+
+    it 'delegates to facade_repository.reset_hard with nil commitish and empty opts' do
+      expect(facade_repository).to receive(:reset_hard).with(nil, {}).and_return('reset output')
+      expect(result).to eq('reset output')
+    end
+
+    context 'with a commitish' do
+      subject(:result) { described_instance.reset_hard('HEAD~1') }
+
+      it 'passes the commitish to facade_repository.reset_hard' do
+        expect(facade_repository).to receive(:reset_hard).with('HEAD~1', {}).and_return('reset output')
+        result
+      end
+    end
+
+    context 'with opts' do
+      subject(:result) { described_instance.reset_hard('HEAD~1', hard: false) }
+
+      it 'forwards opts to facade_repository.reset_hard' do
+        expect(facade_repository).to receive(:reset_hard).with('HEAD~1', { hard: false }).and_return('reset output')
+        result
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

`Git::Base#reset_hard` was still calling `lib.reset` directly, bypassing the facade layer. This PR fixes that by delegating to `facade_repository.reset_hard`, which already exists in `Git::Repository::Staging` and emits the deprecation warning itself.

## Changes

### `lib/git/base.rb`

Replace the manual implementation with a one-line delegation:

```ruby
# Before
def reset_hard(commitish = nil, opts = {})
  Git::Deprecation.warn(
    'Git::Base#reset_hard is deprecated and will be removed in a future version. ' \
    'Use Git::Base#reset(commitish, hard: true) instead.'
  )
  opts = { hard: true }.merge(opts)
  lib.reset(commitish, opts)
end

# After
def reset_hard(commitish = nil, opts = {})
  facade_repository.reset_hard(commitish, opts)
end
```

The in-body deprecation warning is removed because `Git::Repository::Staging#reset_hard` already emits `Git::Deprecation.warn` with the canonical message.

### `spec/unit/git/base_spec.rb`

Add 3 unit tests for `Git::Base#reset_hard` verifying delegation to `facade_repository.reset_hard` with the correct arguments and return value:
- Default call (nil commitish, empty opts) — asserts delegation and return value pass-through
- With a commitish
- With opts forwarded as-is

## Tests

- All existing tests pass, including `test_base_reset_hard_deprecation` in `tests/units/test_deprecations.rb` (which was already expecting the `Git::Repository::Staging#reset_hard` deprecation message — confirming end-to-end delegation works).
- 3 new unit tests added to `spec/unit/git/base_spec.rb`.
- `bundle exec rake` exits 0.