### PR TITLE
refactor(git): rewire Git.default_branch off Git::Base (Phase 4 PR 1a)

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -306,7 +306,9 @@ module Git
   # @return [String] the name of the default branch
   #
   def self.default_branch(repository, options = {})
-    Base.repository_default_branch(repository, options)
+    context = Git::ExecutionContext::Global.new(logger: options[:log])
+    output = Git::Commands::LsRemote.new(context).call(repository, 'HEAD', symref: true).stdout
+    Git::Parsers::LsRemote.parse_default_branch(output)
   end
 
   # Export the current HEAD (or a branch, if <tt>options[:branch]</tt>

--- a/spec/unit/git/git_remote_utilities_spec.rb
+++ b/spec/unit/git/git_remote_utilities_spec.rb
@@ -56,14 +56,33 @@ RSpec.describe Git do
   end
 
   describe '.default_branch' do
-    it 'delegates to Git::Base.repository_default_branch preserving options' do
+    let(:context) { instance_double(Git::ExecutionContext::Global) }
+    let(:ls_remote_command) { instance_double(Git::Commands::LsRemote) }
+
+    before do
+      allow(Git::ExecutionContext::Global).to receive(:new).with(logger: nil).and_return(context)
+      allow(Git::Commands::LsRemote).to receive(:new).with(context).and_return(ls_remote_command)
+    end
+
+    it 'uses the direct LsRemote + parser path (not Git::Base)' do
+      stdout = "ref: refs/heads/main\tHEAD\nabc123\tHEAD\n"
+
+      expect(Git::Base).not_to receive(:repository_default_branch)
+      expect(ls_remote_command).to receive(:call)
+        .with('origin', 'HEAD', symref: true).and_return(command_result(stdout))
+
+      expect(described_class.default_branch('origin')).to eq('main')
+    end
+
+    it 'passes options[:log] to the execution context' do
       logger = instance_double(Logger)
+      allow(Git::ExecutionContext::Global).to receive(:new).with(logger: logger).and_return(context)
+      allow(ls_remote_command).to receive(:call).and_return(command_result("ref: refs/heads/main\tHEAD\n"))
 
-      expect(Git::Base).to receive(:repository_default_branch)
-        .with('origin', { log: logger })
-        .and_return('main')
+      result = described_class.default_branch('origin', log: logger)
 
-      expect(described_class.default_branch('origin', log: logger)).to eq('main')
+      expect(Git::ExecutionContext::Global).to have_received(:new).with(logger: logger)
+      expect(result).to eq('main')
     end
   end
 end


### PR DESCRIPTION
# Description

Phase 4 Step A — PR 1a: rewire `Git.default_branch` to call the command/parser
layer directly, removing its delegation to `Git::Base.repository_default_branch`.

## What changed

**`lib/git.rb`** — `Git.default_branch` no longer calls
`Base.repository_default_branch`. It now directly:
1. Creates a `Git::ExecutionContext::Global` (passing `options[:log]` as the logger)
2. Calls `Git::Commands::LsRemote` with `(repository, 'HEAD', symref: true)`
3. Parses the output via `Git::Parsers::LsRemote.parse_default_branch`

This is an exact inline of what `Base.repository_default_branch` was doing —
behavior is identical from callers' perspective.

**`spec/unit/git/git_remote_utilities_spec.rb`** — the `.default_branch` example
that asserted `expect(Git::Base).to receive(:repository_default_branch)` is
replaced with two examples that verify the direct path:
- Asserts `Git::Base` is **not** called
- Verifies the `LsRemote` command receives the correct arguments
- Confirms `options[:log]` flows through to `ExecutionContext::Global`

## Why

This is PR 1a from the Phase 4 Step A execution plan (`redesign/Phase 4 - Step A.md`).
The goal of the phase is to remove `Git::Base` and `Git::Lib` entirely. This PR
eliminates one runtime caller of `Git::Base` without any breaking change — it is
releasable independently.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [ ] Documentation updated where applicable (README and/or YARD).