### PR TITLE
refactor: remove require 'git/base' from domain object files (Phase 4 PR 1c)

### DIFF
--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'git/base'
 require_relative 'branch_info'
 
 module Git

--- a/lib/git/branches.rb
+++ b/lib/git/branches.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'git/base'
-
 module Git
   # Collection of all Git branches in a repository
   #

--- a/lib/git/log.rb
+++ b/lib/git/log.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'git/base'
-
 module Git
   # Builds and executes a `git log` query
   #

--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -4,7 +4,6 @@ require 'git/author'
 require 'git/diff'
 require 'git/errors'
 require 'git/log'
-require 'git/base'
 
 module Git
   # represents a git object

--- a/lib/git/remote.rb
+++ b/lib/git/remote.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'git/base'
 require 'git/branch'
 require 'git/branch_info'
 

--- a/lib/git/stash.rb
+++ b/lib/git/stash.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'git/base'
-
 module Git
   # Represents a single stash entry in a Git repository
   #

--- a/lib/git/stashes.rb
+++ b/lib/git/stashes.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'git/base'
-
 module Git
   # Collection of stash entries for a Git repository
   #

--- a/lib/git/worktree.rb
+++ b/lib/git/worktree.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'git/base'
-
 module Git
   # A worktree in a Git repository
   #

--- a/lib/git/worktrees.rb
+++ b/lib/git/worktrees.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'git/base'
-
 module Git
   # Collection of all Git worktrees in a repository
   #


### PR DESCRIPTION
# Description

**Phase 4 / Step A — PR 1c:** Remove `require 'git/base'` from domain object files.

Each of the following files contained a top-level `require 'git/base'` that caused
`git/base` to load early, out of order, regardless of the actual entry point:

- `lib/git/branch.rb`
- `lib/git/branches.rb`
- `lib/git/remote.rb`
- `lib/git/object.rb`
- `lib/git/log.rb`
- `lib/git/stash.rb`
- `lib/git/stashes.rb`
- `lib/git/worktree.rb`
- `lib/git/worktrees.rb`

Both `Git::Base` and `Git::Lib` remain loaded because `lib/git.rb` still requires
them directly. Removing these lines has no runtime effect — the only change is that
domain files no longer force an out-of-order load of `base.rb`.

This is backward-compatible prep work for Phase 4 / Step A. It shrinks PR 4 (the
atomic breaking change) and validates `lib/git.rb`'s load order under CI ahead of
that change.

No spec changes are needed — no test asserts on the presence of `require 'git/base'`
in domain files, and all tests run through `lib/git.rb`'s load order already.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
