### PR TITLE
docs(repository): update Git::Base/Lib YARD refs (Phase 4 PR 2b)

### DIFF
--- a/lib/git/repository/factories.rb
+++ b/lib/git/repository/factories.rb
@@ -142,13 +142,13 @@ module Git
       #   SSH executable
       #
       #   Pass `:use_global_config` (the default) to use
-      #   `Git::Base.config.git_ssh`.
+      #   `Git.config.git_ssh`.
       #
       # @option options [String, :use_global_config] :binary_path path to the git
       #   binary
       #
       #   Pass `:use_global_config` (the default) to use
-      #   `Git::Base.config.binary_path`.
+      #   `Git.config.binary_path`.
       #
       # @option options [Logger, nil] :log logger used for git operations
       #
@@ -216,13 +216,13 @@ module Git
       #   SSH executable
       #
       #   Pass `:use_global_config` (the default) to use
-      #   `Git::Base.config.git_ssh`.
+      #   `Git.config.git_ssh`.
       #
       # @option options [String, :use_global_config] :binary_path path to the git
       #   binary
       #
       #   Pass `:use_global_config` (the default) to use
-      #   `Git::Base.config.binary_path`.
+      #   `Git.config.binary_path`.
       #
       # @option options [Logger, nil] :log logger used for git operations
       #
@@ -275,13 +275,13 @@ module Git
       #   path to a custom SSH executable
       #
       #   Pass `:use_global_config` (the default) to use
-      #   `Git::Base.config.git_ssh`.
+      #   `Git.config.git_ssh`.
       #
       # @option options [String, :use_global_config] :binary_path
       #   path to the git binary
       #
       #   Pass `:use_global_config` (the default) to use
-      #   `Git::Base.config.binary_path`.
+      #   `Git.config.binary_path`.
       #
       # @return [Git::Repository] a repository bound to the resolved paths
       #
@@ -319,13 +319,13 @@ module Git
       #   path to a custom SSH executable
       #
       #   Pass `:use_global_config` (the default) to use
-      #   `Git::Base.config.git_ssh`.
+      #   `Git.config.git_ssh`.
       #
       # @option options [String, :use_global_config] :binary_path
       #   path to the git binary
       #
       #   Pass `:use_global_config` (the default) to use
-      #   `Git::Base.config.binary_path`.
+      #   `Git.config.binary_path`.
       #
       # @return [Git::Repository] a repository bound to the bare repository directory
       #
@@ -636,7 +636,7 @@ module Git
         return unless opts.key?(:path)
 
         if defined?(Git::Deprecation)
-          Git::Deprecation.warn('The :path option for Git::Lib#clone is deprecated, use :chdir instead')
+          Git::Deprecation.warn('The :path option for Git::Repository.clone is deprecated, use :chdir instead')
         end
         path = opts.delete(:path)
         opts[:chdir] ||= path
@@ -655,7 +655,7 @@ module Git
 
         if defined?(Git::Deprecation)
           Git::Deprecation.warn(
-            'The :recursive option for Git::Lib#clone is deprecated, use :recurse_submodules instead'
+            'The :recursive option for Git::Repository.clone is deprecated, use :recurse_submodules instead'
           )
         end
         opts[:recurse_submodules] = opts.delete(:recursive)
@@ -673,7 +673,7 @@ module Git
         return unless opts.key?(:remote)
 
         if defined?(Git::Deprecation)
-          Git::Deprecation.warn('The :remote option for Git::Lib#clone is deprecated, use :origin instead')
+          Git::Deprecation.warn('The :remote option for Git::Repository.clone is deprecated, use :origin instead')
         end
         opts[:origin] = opts.delete(:remote)
       end

--- a/lib/git/repository/path_resolver.rb
+++ b/lib/git/repository/path_resolver.rb
@@ -70,7 +70,7 @@ module Git
       # @param binary_path [String, :use_global_config] path to the git binary
       #
       #   Controls which git binary is invoked during root detection. Defaults to
-      #   `:use_global_config`, which resolves to `Git::Base.config.binary_path`.
+      #   `:use_global_config`, which resolves to `Git.config.binary_path`.
       #
       # @param git_ssh [String, nil, :use_global_config] the SSH wrapper path
       #


### PR DESCRIPTION
## Summary

YARD documentation updates and deprecation-message text corrections.

Replaces `Git::Base` / `Git::Lib` YARD references in the repository layer so
the YARD build stays clean after those classes are deleted in Phase 4, PR 4.
Also updates three runtime deprecation warning strings to reference the new class
name (`Git::Repository.clone` instead of the legacy `Git::Lib#clone`).

This is **PR 2b** from the [Phase 4 Step A execution plan](redesign/Phase%204%20-%20Step%20A.md).

## Changes

### `lib/git/repository/path_resolver.rb`

- `root_of_worktree` `:binary_path` param doc: `Git::Base.config.binary_path` → `Git.config.binary_path`

### `lib/git/repository/factories.rb`

- Eight `@option` YARD doc strings across `clone`, `init`, `open`, and `bare` factory methods:
  `Git::Base.config.git_ssh` → `Git.config.git_ssh` and
  `Git::Base.config.binary_path` → `Git.config.binary_path`
  `Git::Lib#clone` → `Git::Repository.clone`

## Testing

The deprecation warning text is updated to reference `Git::Repository.clone`
instead of the now-removed `Git::Lib#clone`. This is an intentional minor
behavior change (updated warning message text) to keep messages accurate as the
architecture evolves. No other behavior changes.

Gate: `bundle exec rake rubocop yard build` — all passing.

## Checklist

- [x] `bundle exec rake rubocop yard build` passes
- [x] No new tests needed (YARD documentation and deprecation message text only)