### PR TITLE
docs(commands): update command-layer YARD to reference Git::Repository/ExecutionContext

### DIFF
--- a/lib/git/command_line.rb
+++ b/lib/git/command_line.rb
@@ -14,9 +14,9 @@ module Git
   #   Use this for commands (e.g. `cat-file -p <blob>`) whose output may be
   #   too large to buffer.
   #
-  # Both classes inherit from {Git::CommandLine::Base} and are instantiated
-  # via factory helpers in {Git::Lib}: {Git::Lib#command_capturing} and
-  # {Git::Lib#command_streaming}.
+  # Both classes inherit from {Git::CommandLine::Base} and are used internally
+  # by {Git::ExecutionContext#command_capturing} and
+  # {Git::ExecutionContext#command_streaming}.
   #
   # Results are returned as {Git::CommandLine::Result} objects (also accessible
   # as {Git::CommandLineResult} for backward compatibility).

--- a/lib/git/command_line/capturing.rb
+++ b/lib/git/command_line/capturing.rb
@@ -9,7 +9,7 @@ module Git
     # {Git::CommandLine::Capturing} is the buffering strategy: it calls
     # `ProcessExecuter.run_with_capture`, which reads all subprocess output into
     # `String` objects before returning.  Use this class (via
-    # {Git::Lib#command_capturing}) for the vast majority of git subcommands whose
+    # {Git::ExecutionContext#command_capturing}) for the vast majority of git subcommands whose
     # output fits comfortably in memory.
     #
     # {Git::CommandLine::Streaming} is the complementary strategy for commands
@@ -23,7 +23,7 @@ module Git
     #   result.stdout   # => "abc1234 Initial commit\n..."
     #   result.stderr   # => ""
     #
-    # @see Git::Lib#command_capturing
+    # @see Git::ExecutionContext#command_capturing
     #
     # @see Git::CommandLine::Streaming
     #

--- a/lib/git/command_line/streaming.rb
+++ b/lib/git/command_line/streaming.rb
@@ -12,7 +12,7 @@ module Git
     # IO object.  Stderr is always captured internally in a `StringIO` for error
     # diagnostics and is available as `result.stderr`.
     #
-    # Use this class (via {Git::Lib#command_streaming}) for commands such as
+    # Use this class (via {Git::ExecutionContext#command_streaming}) for commands such as
     # `cat-file -p <blob>` whose stdout may be too large to buffer in memory.
     #
     # {Git::CommandLine::Capturing} is the complementary strategy for the common case
@@ -26,7 +26,7 @@ module Git
     #     streaming.run('cat-file', 'blob', sha, out: f)
     #   end
     #
-    # @see Git::Lib#command_streaming
+    # @see Git::ExecutionContext#command_streaming
     #
     # @see Git::CommandLine::Capturing
     #

--- a/lib/git/commands.rb
+++ b/lib/git/commands.rb
@@ -61,19 +61,17 @@ module Git
   # {Git::CommandLine}, and return a raw {Git::CommandLineResult}.
   #
   # Commands do **not** parse output — that responsibility belongs to the
-  # {Git::Parsers} layer, orchestrated by the facade ({Git::Lib} / future
-  # {Git::Repository}).
+  # {Git::Parsers} layer, orchestrated by the facade ({Git::Repository}).
   #
   # All classes in this namespace are internal (`@api private`). End users
-  # should interact with the public API on {Git::Base} instead.
+  # should interact with the public API on {Git::Repository} instead.
   #
   # ## Architecture
   #
   # ```
-  # Git::Base (public API)
-  #   └── Git::Lib / Git::Repository (facade — orchestrates commands + parsers)
-  #         └── Git::Commands::* (defines CLI API, binds args, executes)
-  #               └── Git::CommandLine (subprocess execution)
+  # Git::Repository (public API / facade — orchestrates commands + parsers)
+  #   └── Git::Commands::* (defines CLI API, binds args, executes)
+  #         └── Git::CommandLine (subprocess execution)
   # ```
   #
   # Simple commands inherit from {Commands::Base} and only need an `arguments`


### PR DESCRIPTION
# Description

Part of the Phase 4 / Step A preparation for removing `Git::Base` and `Git::Lib`.

Updates YARD comments in the command-layer files to reference `Git::Repository` /
`Git::ExecutionContext` in place of the soon-to-be-deleted `Git::Base` / `Git::Lib`.
No behavior changes.

**Files changed:**

- `lib/git/commands.rb` — collapsed the `Git::Base` / `Git::Lib` architecture
  diagram to `Git::Repository`; updated end-user redirect to `{Git::Repository}`.
- `lib/git/command_line.rb` — updated factory-helper references from
  `{Git::Lib#command_capturing}` / `{Git::Lib#command_streaming}` to
  `{Git::ExecutionContext#command_capturing}` / `{Git::ExecutionContext#command_streaming}`.
- `lib/git/command_line/capturing.rb` — updated prose and `@see` tag to
  `Git::ExecutionContext#command_capturing`.
- `lib/git/command_line/streaming.rb` — updated prose and `@see` tag to
  `Git::ExecutionContext#command_streaming`.

See `redesign/Phase 4 - Step A.md` § PR 2a for full context.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed. (Documentation-only; no test changes required.)
- [x] Documentation updated where applicable (README and/or YARD).
