### PR TITLE
refactor(tests): PR 3b — patch incidental Git::Base/Git::Lib refs in Test::Unit

### DIFF
--- a/tests/units/test_branch.rb
+++ b/tests/units/test_branch.rb
@@ -14,7 +14,7 @@ class TestBranch < Test::Unit::TestCase
     @branches = @git.branches
   end
 
-  test 'Git::Lib#branch with no args should return current branch' do
+  test 'Git::Repository#branch with no args should return current branch' do
     in_temp_dir do
       git = Git.init('.', initial_branch: 'my_branch')
       File.write('file.txt', 'hello world')
@@ -26,7 +26,7 @@ class TestBranch < Test::Unit::TestCase
     end
   end
 
-  test 'Git::Base#branches' do
+  test 'Git::Repository#branches' do
     in_temp_dir do
       remote_git = Git.init('remote_git', initial_branch: 'master')
       File.write('remote_git/file.txt', 'hello world')
@@ -50,7 +50,7 @@ class TestBranch < Test::Unit::TestCase
     end
   end
 
-  test 'Git::Base#branches when checked out branch is a remote branch' do
+  test 'Git::Repository#branches when checked out branch is a remote branch' do
     in_temp_dir do
       Dir.mkdir('remote_git')
       Dir.chdir('remote_git') do
@@ -122,9 +122,9 @@ class TestBranch < Test::Unit::TestCase
     end
   end
 
-  # Git::Lib#branch_current
+  # Git::Repository::Branching#current_branch
 
-  test 'Git::Lib#branch_current -- active branch' do
+  test 'Git::Repository::Branching#current_branch -- active branch' do
     in_temp_dir do
       `git init --initial-branch=main`
       `echo "hello world" > file1.txt`
@@ -135,7 +135,7 @@ class TestBranch < Test::Unit::TestCase
     end
   end
 
-  test 'Git::Lib#branch_current -- unborn branch' do
+  test 'Git::Repository::Branching#current_branch -- unborn branch' do
     in_temp_dir do
       `git init --initial-branch=new_branch`
       git = Git.open('.')
@@ -143,7 +143,7 @@ class TestBranch < Test::Unit::TestCase
     end
   end
 
-  test 'Git::Lib#branch_current -- detached HEAD' do
+  test 'Git::Repository::Branching#current_branch -- detached HEAD' do
     in_temp_dir do
       `git init --initial-branch=main`
       `echo "hello world" > file1.txt`
@@ -158,9 +158,9 @@ class TestBranch < Test::Unit::TestCase
     end
   end
 
-  # Git::Base#branch
+  # Git::Repository#branch
 
-  test 'Git::Base#branch with detached head' do
+  test 'Git::Repository#branch with detached head' do
     in_temp_dir do
       `git init`
       `echo "hello world" > file1.txt`
@@ -178,9 +178,9 @@ class TestBranch < Test::Unit::TestCase
     end
   end
 
-  # Git::Base#branchs
+  # Git::Repository#branches
 
-  test 'Git::Base#branchs with detached head' do
+  test 'Git::Repository#branches with detached head' do
     in_temp_dir do
       git = Git.init('.', initial_branch: 'master')
       File.write('file1.txt', 'hello world')

--- a/tests/units/test_command_line_env_overrides.rb
+++ b/tests/units/test_command_line_env_overrides.rb
@@ -3,13 +3,13 @@
 require 'test_helper'
 
 class TestCommandLineEnvOverrides < Test::Unit::TestCase
-  test 'it should set the GIT_SSH environment variable from Git::Base.config.git_ssh' do
+  test 'it should set the GIT_SSH environment variable from Git.config.git_ssh' do
     expected_command_line = nil
     expected_command_line_proc = -> { expected_command_line }
 
-    saved_git_ssh = Git::Base.config.git_ssh
+    saved_git_ssh = Git.config.git_ssh
     begin
-      Git::Base.config.git_ssh = 'ssh -i /path/to/key'
+      Git.config.git_ssh = 'ssh -i /path/to/key'
 
       assert_command_line_eq(expected_command_line_proc, include_env: true) do |git|
         expected_env = {
@@ -25,7 +25,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
         git.checkout
       end
     ensure
-      Git::Base.config.git_ssh = saved_git_ssh
+      Git.config.git_ssh = saved_git_ssh
     end
   end
 
@@ -39,7 +39,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
       assert_equal git.execution_context.git_work_dir, env['GIT_WORK_TREE']
       assert_equal git.execution_context.git_index_file, env['GIT_INDEX_FILE']
       assert_equal 'en_US.UTF-8', env['LC_ALL']
-      assert_equal Git::Base.config.git_ssh, env['GIT_SSH']
+      assert_equal Git.config.git_ssh, env['GIT_SSH']
     end
   end
 
@@ -118,9 +118,9 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
   end
 
   test 'instance git_ssh option should override global config in Git.bare' do
-    saved_git_ssh = Git::Base.config.git_ssh
+    saved_git_ssh = Git.config.git_ssh
     begin
-      Git::Base.config.git_ssh = '/global/ssh/script'
+      Git.config.git_ssh = '/global/ssh/script'
 
       in_temp_dir do |path|
         bare_repo_path = File.join(path, 'test_project.git')
@@ -131,14 +131,14 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
         assert_equal '/instance/ssh/script', env['GIT_SSH']
       end
     ensure
-      Git::Base.config.git_ssh = saved_git_ssh
+      Git.config.git_ssh = saved_git_ssh
     end
   end
 
   test 'instance git_ssh option should override global config in Git.open' do
-    saved_git_ssh = Git::Base.config.git_ssh
+    saved_git_ssh = Git.config.git_ssh
     begin
-      Git::Base.config.git_ssh = '/global/ssh/script'
+      Git.config.git_ssh = '/global/ssh/script'
 
       in_temp_dir do |path|
         create_and_init_repo(path)
@@ -148,14 +148,14 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
         assert_equal '/instance/ssh/script', env['GIT_SSH']
       end
     ensure
-      Git::Base.config.git_ssh = saved_git_ssh
+      Git.config.git_ssh = saved_git_ssh
     end
   end
 
   test 'instance git_ssh option should override global config in Git.init' do
-    saved_git_ssh = Git::Base.config.git_ssh
+    saved_git_ssh = Git.config.git_ssh
     begin
-      Git::Base.config.git_ssh = '/global/ssh/script'
+      Git.config.git_ssh = '/global/ssh/script'
 
       in_temp_dir do |_path|
         git = Git.init('test_project', git_ssh: '/instance/ssh/script')
@@ -164,14 +164,14 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
         assert_equal '/instance/ssh/script', env['GIT_SSH']
       end
     ensure
-      Git::Base.config.git_ssh = saved_git_ssh
+      Git.config.git_ssh = saved_git_ssh
     end
   end
 
   test 'instance git_ssh option should override global config in Git.clone' do
-    saved_git_ssh = Git::Base.config.git_ssh
+    saved_git_ssh = Git.config.git_ssh
     begin
-      Git::Base.config.git_ssh = '/global/ssh/script'
+      Git.config.git_ssh = '/global/ssh/script'
 
       in_temp_dir do |path|
         source_repo = create_and_init_repo(File.join(path, 'source'))
@@ -189,14 +189,14 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
         end
       end
     ensure
-      Git::Base.config.git_ssh = saved_git_ssh
+      Git.config.git_ssh = saved_git_ssh
     end
   end
 
   test 'instance git_ssh: nil should disable SSH (not use global config)' do
-    saved_git_ssh = Git::Base.config.git_ssh
+    saved_git_ssh = Git.config.git_ssh
     begin
-      Git::Base.config.git_ssh = '/global/ssh/script'
+      Git.config.git_ssh = '/global/ssh/script'
 
       in_temp_dir do |path|
         create_and_init_repo(path)
@@ -206,14 +206,14 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
         assert_nil env['GIT_SSH'], 'GIT_SSH should be nil when git_ssh: nil is passed'
       end
     ensure
-      Git::Base.config.git_ssh = saved_git_ssh
+      Git.config.git_ssh = saved_git_ssh
     end
   end
 
   test 'no instance git_ssh option should use global config' do
-    saved_git_ssh = Git::Base.config.git_ssh
+    saved_git_ssh = Git.config.git_ssh
     begin
-      Git::Base.config.git_ssh = '/global/ssh/script'
+      Git.config.git_ssh = '/global/ssh/script'
 
       in_temp_dir do |path|
         create_and_init_repo(path)
@@ -223,14 +223,14 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
         assert_equal '/global/ssh/script', env['GIT_SSH']
       end
     ensure
-      Git::Base.config.git_ssh = saved_git_ssh
+      Git.config.git_ssh = saved_git_ssh
     end
   end
 
   test 'instance git_ssh: nil should disable SSH in Git.clone' do
-    saved_git_ssh = Git::Base.config.git_ssh
+    saved_git_ssh = Git.config.git_ssh
     begin
-      Git::Base.config.git_ssh = '/global/ssh/script'
+      Git.config.git_ssh = '/global/ssh/script'
 
       in_temp_dir do |path|
         source_repo = create_and_init_repo(File.join(path, 'source'))
@@ -242,14 +242,14 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
         assert_nil env['GIT_SSH'], 'GIT_SSH should be nil when git_ssh: nil is passed to Git.clone'
       end
     ensure
-      Git::Base.config.git_ssh = saved_git_ssh
+      Git.config.git_ssh = saved_git_ssh
     end
   end
 
   test 'Git.clone without git_ssh option should use global config' do
-    saved_git_ssh = Git::Base.config.git_ssh
+    saved_git_ssh = Git.config.git_ssh
     begin
-      Git::Base.config.git_ssh = '/global/ssh/script'
+      Git.config.git_ssh = '/global/ssh/script'
 
       in_temp_dir do |path|
         source_repo = create_and_init_repo(File.join(path, 'source'))
@@ -261,7 +261,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
         assert_equal '/global/ssh/script', env['GIT_SSH']
       end
     ensure
-      Git::Base.config.git_ssh = saved_git_ssh
+      Git.config.git_ssh = saved_git_ssh
     end
   end
 

--- a/tests/units/test_config.rb
+++ b/tests/units/test_config.rb
@@ -38,22 +38,22 @@ class TestConfig < Test::Unit::TestCase
   end
 
   def test_env_config
-    assert_equal(Git::Base.config.binary_path, 'git')
-    assert_equal(Git::Base.config.git_ssh, nil)
+    assert_equal('git', Git.config.binary_path)
+    assert_nil(Git.config.git_ssh)
 
     ENV['GIT_PATH'] = '/env/bin'
     ENV['GIT_SSH'] = '/env/git/ssh'
 
-    assert_equal(Git::Base.config.binary_path, '/env/bin/git')
-    assert_equal(Git::Base.config.git_ssh, '/env/git/ssh')
+    assert_equal('/env/bin/git', Git.config.binary_path)
+    assert_equal('/env/git/ssh', Git.config.git_ssh)
 
     Git.configure do |config|
       config.binary_path = '/usr/bin/git'
       config.git_ssh = '/path/to/ssh/script'
     end
 
-    assert_equal(Git::Base.config.binary_path, '/usr/bin/git')
-    assert_equal(Git::Base.config.git_ssh, '/path/to/ssh/script')
+    assert_equal('/usr/bin/git', Git.config.binary_path)
+    assert_equal('/path/to/ssh/script', Git.config.git_ssh)
 
     @git.log
   ensure

--- a/tests/units/test_deprecations.rb
+++ b/tests/units/test_deprecations.rb
@@ -182,23 +182,6 @@ class TestDeprecations < Test::Unit::TestCase
     commit.set_commit(data)
   end
 
-  # --- Git::Lib deprecations ---
-
-  def test_lib_warn_if_old_command_deprecation
-    # Ensure class-level check does not short-circuit the call in this test
-    Git::Lib.instance_variable_set(:@version_checked, nil)
-
-    Git::Deprecation.expects(:warn).with(
-      'Git::Lib.warn_if_old_command is deprecated and will be removed in 6.0. ' \
-      'Version validation is now handled automatically by Git::Commands::Base#validate_version!, ' \
-      'which RAISES Git::VersionError on failure (the old method only printed a warning ' \
-      'once per process and continued). Callers wanting the old warn-and-continue behavior ' \
-      'must implement it themselves using: Git.git_version >= Git::MINIMUM_GIT_VERSION.'
-    )
-
-    assert_equal(true, Git::Lib.warn_if_old_command(Git::Base.open(@wdir).lib))
-  end
-
   def test_clean_ff_deprecation
     Dir.mktmpdir('git_clean') do |dir|
       git = Git.init(dir)

--- a/tests/units/test_git_clone.rb
+++ b/tests/units/test_git_clone.rb
@@ -158,23 +158,5 @@ class TestGitClone < Test::Unit::TestCase
 
       assert_match(/depth/, error.result.stderr)
     end
-
-    #   git = Git.init('.')
-
-    #   # Mock the Git::Lib#command method to capture the actual command line args
-    #   git.lib.define_singleton_method(:command_capturing) do |cmd, *opts, &block|
-    #     actual_command_line = [cmd, *opts.flatten]
-    #   end
-
-    #   git.lib.clone(repository_url, destination, depth: -1)
-    # end
-
-    # expected_command_line = [
-    #   'clone',
-    #   '--depth', '-1',
-    #   '--', repository_url, destination, {timeout: nil}
-    # ]
-
-    # assert_equal(expected_command_line, actual_command_line)
   end
 end

--- a/tests/units/test_git_default_branch.rb
+++ b/tests/units/test_git_default_branch.rb
@@ -5,9 +5,9 @@ require "#{File.dirname(__FILE__)}/../test_helper"
 require 'logger'
 require 'stringio'
 
-# Tests for Git::Lib#repository_default_branch
+# Tests for Git.default_branch
 #
-class TestLibRepositoryDefaultBranch < Test::Unit::TestCase
+class TestGitDefaultBranch < Test::Unit::TestCase
   def test_default_branch
     repository = 'new_repo'
     in_temp_dir do

--- a/tests/units/test_git_dir.rb
+++ b/tests/units/test_git_dir.rb
@@ -83,7 +83,7 @@ class TestGitDir < Test::Unit::TestCase
     end
   end
 
-  # Test that Git::Lib::Diff.to_a works from a linked working tree (not the
+  # Test that Git::Diff#to_a works from a linked working tree (not the
   # main working tree).  See https://git-scm.com/docs/git-worktree for a
   # description of 'main' and 'linked' working tree.
   #

--- a/tests/units/test_per_instance_config.rb
+++ b/tests/units/test_per_instance_config.rb
@@ -3,40 +3,6 @@
 require 'test_helper'
 
 class TestPerInstanceConfig < Test::Unit::TestCase
-  test 'Git::Lib initialized without base uses global git_ssh' do
-    saved_git_ssh = Git::Base.config.git_ssh
-    begin
-      Git::Base.config.git_ssh = '/global/ssh'
-
-      lib = Git::Lib.new
-      env = lib.send(:env_overrides)
-
-      assert_equal '/global/ssh', env['GIT_SSH']
-    ensure
-      Git::Base.config.git_ssh = saved_git_ssh
-    end
-  end
-
-  test 'Git::Lib initialized with nil base uses global git_ssh' do
-    saved_git_ssh = Git::Base.config.git_ssh
-    begin
-      Git::Base.config.git_ssh = '/global/ssh'
-
-      lib = Git::Lib.new(nil, Logger.new(nil))
-      env = lib.send(:env_overrides)
-
-      assert_equal '/global/ssh', env['GIT_SSH']
-    ensure
-      Git::Base.config.git_ssh = saved_git_ssh
-    end
-  end
-
-  test 'Git::Lib initialized from hash sets git_ssh' do
-    lib = Git::Lib.new(git_ssh: '/custom/ssh')
-    env = lib.send(:env_overrides)
-    assert_equal '/custom/ssh', env['GIT_SSH']
-  end
-
   test 'Git.clone passes git_ssh through execution context' do
     git_ssh = '/custom/ssh'
 

--- a/tests/units/test_set_index.rb
+++ b/tests/units/test_set_index.rb
@@ -5,9 +5,9 @@ require 'git'
 require 'fileutils'
 require 'tmpdir'
 
-# A test case to demonstrate the use of Git::Base#set_index
+# A test case to demonstrate the use of Git::Repository#set_index
 #
-# This test case will to programmatically create a new commit without affecting the
+# This test case will programmatically create a new commit without affecting the
 # main working directory or index.
 #
 class SetIndexTest < Test::Unit::TestCase

--- a/tests/units/test_set_working.rb
+++ b/tests/units/test_set_working.rb
@@ -5,7 +5,7 @@ require 'git'
 require 'fileutils'
 require 'tmpdir'
 
-# A test case to demonstrate the use of Git::Base#set_working
+# A test case to demonstrate the use of Git::Repository#set_working
 class SetWorkingTest < Test::Unit::TestCase
   # Set up a temporary Git repository before each test.
   def setup

--- a/tests/units/test_thread_safety.rb
+++ b/tests/units/test_thread_safety.rb
@@ -9,10 +9,10 @@ class TestThreadSafety < Test::Unit::TestCase
 
   teardown
   def clean_environment
-    # TODO: this was needed because test_thread_safety.rb ocassionally leaks setting GIT_DIR.
+    # TODO: this was needed because test_thread_safety.rb occasionally leaks setting GIT_DIR.
     # Once that is fixed, this can be removed.
-    # I think it will be fixed by using System.spawn or something similar instead
-    # of backticks to run git in Git::Lib#command.
+    # I think it will be fixed by using Process.spawn or something similar instead
+    # of backticks to run git in Git::ExecutionContext#command_capturing.
     ENV['GIT_DIR'] = nil
     ENV['GIT_WORK_TREE'] = nil
     ENV['GIT_INDEX_FILE'] = nil

--- a/tests/units/test_tree_ops.rb
+++ b/tests/units/test_tree_ops.rb
@@ -24,7 +24,7 @@ class TestTreeOps < Test::Unit::TestCase
       actual_output = git.write_tree
     end
 
-    # the git output should be returned from Git::Base#write_tree
+    # the git output should be returned from Git::Repository#write_tree
     assert_equal(expected_output, actual_output)
   end
 
@@ -76,7 +76,7 @@ class TestTreeOps < Test::Unit::TestCase
     assert_command_line_eq(expected_command_line) { |git| git.commit_tree(tree, parents: parents, message: message) }
   end
 
-  # Examples of how to use Git::Base#commit_tree, write_tree, and commit_tree
+  # Examples of how to use Git::Repository#commit_tree and #write_tree
   #
   # def test_tree_ops
   #   in_bare_repo_clone do |g|


### PR DESCRIPTION
## Description

This is **PR 3b** in the [Phase 4 / Step A execution plan](redesign/Phase%204%20-%20Step%20A.md) — one of the preparatory PRs before the atomic `Git::Base` / `Git::Lib` removal in PR 4. It has no production behavior changes.

After PR 3a deletes the five files that test removed API wholesale, 12 remaining `tests/units/` files still contained incidental `Git::Base` / `Git::Lib` references. This PR clears all of them across four groups:

### Group 1 — Comments and test-name strings only (8 files)

`test_branch.rb`, `test_set_index.rb`, `test_git_default_branch.rb`, `test_tree_ops.rb`, `test_git_dir.rb`, `test_thread_safety.rb`, `test_set_working.rb`, `test_git_clone.rb`

Updated test-name strings and file-level comments to reference `Git::Repository` / `Git::Repository::Branching` instead of `Git::Base` / `Git::Lib`. All tests already call through `Git.open` / `Git.init` — no runtime code changed. Also deleted a stale commented-out code block in `test_git_clone.rb` that documented an old `Git::Lib#command` mocking pattern.

### Group 2 — Runtime `Git::Base.config` → `Git.config` (2 files)

`test_command_line_env_overrides.rb`, `test_config.rb`

`Git::Base.config` is a thin forwarder to `Git::Config.instance`, which is exactly what `Git.config` returns. Replaced every occurrence.

### Group 3 — Drop `Git::Lib.new` tests (1 file)

`test_per_instance_config.rb`

Removed three tests that directly instantiate `Git::Lib.new` and probe its private `env_overrides` method — an internal implementation detail of a class being deleted in PR 4. Behavioral coverage for the same scenarios already exists in `spec/unit/git/execution_context_config_spec.rb` and in `test_command_line_env_overrides.rb`. The four remaining tests in the file (which use `Git.open` / `Git.init`) are retained unchanged.

### Group 4 — Drop `Git::Lib` deprecation test (1 file)

`test_deprecations.rb`

Removed `test_lib_warn_if_old_command_deprecation`, which resets `Git::Lib.instance_variable_set(:@version_checked, nil)` and calls `Git::Lib.warn_if_old_command`. Both the deprecation shim and its state are deleted alongside `Git::Lib` in PR 4; there is no surviving behavior to port.

---

**Gate:** `grep -rEn 'Git::Base|Git::Lib' tests/units/` returns nothing except the PR 3a files (scheduled for their own deletion). Full CI green.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
