### PR TITLE
docs: replace {Git::Base}/{Git::Lib} YARD cross-references in domain and command files (Phase 4 PR 1d)

### DIFF
--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -6,8 +6,8 @@ module Git
   # Represents a Git branch
   #
   # Branch objects provide access to branch metadata and operations like checkout,
-  # delete, and merge. They should be obtained via {Git::Base#branch} or
-  # {Git::Base#branches}, not constructed directly.
+  # delete, and merge. They should be obtained via {Git::Repository#branch} or
+  # {Git::Repository#branches}, not constructed directly.
   #
   # @example Getting a branch
   #   git = Git.open('.')
@@ -23,7 +23,7 @@ module Git
     # The full refname of this branch
     #
     # For local branches this is the short name (e.g. `'main'`). For
-    # remote-tracking branches obtained via {Git::Base#branches} this includes
+    # remote-tracking branches obtained via {Git::Repository#branches} this includes
     # the `remotes/` prefix (e.g. `'remotes/origin/main'`). Branches constructed
     # by {Git::Remote#branch} use the `<remote>/<branch>` form (e.g.
     # `'origin/main'`) which does **not** populate {#remote}.
@@ -146,7 +146,7 @@ module Git
     #
     # @param file [String] path to the destination archive file
     #
-    # @param opts [Hash] archive options (see {Git::Base#archive})
+    # @param opts [Hash] archive options (see {Git::Repository#archive})
     #
     # @return [String] the path to the written archive file
     #

--- a/lib/git/commands/base.rb
+++ b/lib/git/commands/base.rb
@@ -173,8 +173,8 @@ module Git
         end
       end
 
-      # @param execution_context [Git::ExecutionContext, Git::Lib] context that provides
-      #   {Git::Lib#command_capturing} and {Git::Lib#command_streaming}
+      # @param execution_context [Git::ExecutionContext] context that provides
+      #   {Git::ExecutionContext#command_capturing} and {Git::ExecutionContext#command_streaming}
       def initialize(execution_context)
         @execution_context = execution_context
       end
@@ -351,7 +351,7 @@ module Git
       # the read end. The write and close happen concurrently with the block.
       #
       # The read end can be passed as the `in:` keyword to
-      # {Git::Lib#command_capturing} / {Git::CommandLine#run_with_capture}, connecting it directly to
+      # {Git::ExecutionContext#command_capturing} / {Git::CommandLine#run_with_capture}, connecting it directly to
       # the spawned git process's stdin without an intermediate file or shell
       # heredoc. This is required because `Process.spawn` only accepts real IO
       # objects with a file descriptor — `StringIO` does not work.

--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -102,7 +102,7 @@ module Git
       #
       # @param file [String, nil] destination file path; a temp file is created if `nil`
       #
-      # @param opts [Hash] archive options (see {Git::Lib#archive})
+      # @param opts [Hash] archive options (see {Git::Repository#archive})
       #
       # @return [String] the path to the written archive file
       #

--- a/lib/git/remote.rb
+++ b/lib/git/remote.rb
@@ -7,9 +7,8 @@ module Git
   # A remote in a Git repository
   #
   # Remote objects provide access to remote metadata and operations like fetch,
-  # merge, and remove. They should be obtained via {Git::Base#remote} or the
-  # `remote` factory method on a `Git::Repository` instance, not constructed
-  # directly.
+  # merge, and remove. They should be obtained via `Git::Repository#remote`,
+  # not constructed directly.
   #
   # @example Getting a remote
   #   git = Git.open('.')
@@ -60,7 +59,7 @@ module Git
     # @example Fetch from origin
     #   git.remote('origin').fetch
     #
-    # @param opts [Hash] fetch options (see {Git::Base#fetch})
+    # @param opts [Hash] fetch options (see `Git::Repository#fetch`)
     #
     # @return [String] git's stdout from the fetch
     #

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -100,7 +100,7 @@ module Git
     # Return the version as an array of integers
     #
     # Useful when legacy code expects the array shape returned by the
-    # deprecated {Git::Lib#current_command_version} method.
+    # deprecated `Git::Lib#current_command_version` method.
     #
     # @return [Array<Integer>] [major, minor, patch]
     #


### PR DESCRIPTION
# Description

**Phase 4 / Step A — PR 1d:** Replace `{Git::Base#…}` and `{Git::Lib#…}` YARD cross-reference links in domain-object and command files with `{Git::Repository#…}` equivalents (or bare code literals where the referent will not survive PR 4).

`.yardopts` sets `--fail-on-warning`. Any `{Git::Base#…}` or `{Git::Lib#…}` YARD cross-reference link that survives into PR 4 becomes a CI failure the moment `Git::Base` and `Git::Lib` are deleted. PRs 2a–2c cover the command layer, repository layer, and diff/status domain types; this PR covers the five additional files not handled by those PRs.

### Changes

| File | Changes |
| --- | --- |
| `lib/git/branch.rb` | Class docstring: `{Git::Base#branch}` → `{Git::Repository#branch}`, `{Git::Base#branches}` → `{Git::Repository#branches}`; `attr_accessor :full` docstring: `{Git::Base#branches}` → `{Git::Repository#branches}`; `#archive` param: `{Git::Base#archive}` → `{Git::Repository#archive}` |
| `lib/git/remote.rb` | Class docstring: `{Git::Base#remote}` → `{Git::Repository#remote}` (simplified); `#fetch` param: `{Git::Base#fetch}` → `{Git::Repository#fetch}` |
| `lib/git/object.rb` | `#archive` param: `{Git::Lib#archive}` → `{Git::Repository#archive}` |
| `lib/git/commands/base.rb` | `#initialize` param type: `[Git::ExecutionContext, Git::Lib]` → `[Git::ExecutionContext]`; two `{Git::Lib#command_capturing}` / `{Git::Lib#command_streaming}` → `{Git::ExecutionContext#command_capturing}` / `{Git::ExecutionContext#command_streaming}` |
| `lib/git/version.rb` | `#to_a` docstring: `{Git::Lib#current_command_version}` → `` `Git::Lib#current_command_version` `` (code literal, since `Git::Lib` will not exist after PR 4) |

No behavior changes. Documentation only.

**Gate:** `bundle exec rake rubocop yard build` passes.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
