### PR TITLE
docs: update @param base YARD types to Git::Repository only in diff files

### DIFF
--- a/lib/git/diff.rb
+++ b/lib/git/diff.rb
@@ -25,7 +25,7 @@ module Git
     # @example
     #   diff = Git::Diff.new(base, 'HEAD~1', 'HEAD')
     #
-    # @param base [Git::Base, Git::Repository] the git repository
+    # @param base [Git::Repository] the git repository
     #
     # @param from [String, nil] the starting commit ref, or `nil` to compare
     #   from the index
@@ -283,7 +283,7 @@ module Git
       #     mode: '100644', src: 'abc123', dst: 'def456',
       #     type: 'modified', binary: false)
       #
-      # @param base [Git::Base, Git::Repository] the git repository
+      # @param base [Git::Repository] the git repository
       #
       # @param hash [Hash] the parsed diff attributes
       #
@@ -398,7 +398,7 @@ module Git
     class FullDiffParser
       # Creates a new FullDiffParser
       #
-      # @param base [Git::Base, Git::Repository] the git repository
+      # @param base [Git::Repository] the git repository
       #
       # @param patch_text [String] the raw `git diff` output to parse
       #

--- a/lib/git/diff_path_status.rb
+++ b/lib/git/diff_path_status.rb
@@ -69,7 +69,7 @@ module Git
 
     # Sets up legacy (base, from, to, path_limiter) instance state
     #
-    # @param base [Git::Base, Git::Repository] the git object
+    # @param base [Git::Repository] the git object
     #
     # @param from [String] the first commit or object to compare
     #


### PR DESCRIPTION
## Description

Updates the remaining `@param base` YARD type annotations in `lib/git/diff.rb` and `lib/git/diff_path_status.rb` from `[Git::Base, Git::Repository]` to `[Git::Repository]`.

This is the final step of Phase 4 PR 2c from the architectural redesign plan (Phase 4 / Step A).

**Files changed:**
- `lib/git/diff.rb` — 3 occurrences: `Git::Diff#initialize`, `Git::Diff::DiffFile#initialize`, and `Git::Diff::FullDiffParser#initialize`
- `lib/git/diff_path_status.rb` — 1 occurrence: `Git::DiffPathStatus#initialize`

**Why now:** `.yardopts` sets `--fail-on-warning`. When PR 4 (atomic removal) deletes `Git::Base`, any surviving `{Git::Base}` type annotation becomes an unresolved YARD reference and breaks CI. This cleans up the last such annotations before that happens.

No behavior changes — documentation only.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed. (Documentation only — no behavior changes.)
- [x] Documentation updated where applicable (README and/or YARD).