### PR TITLE
test(config): add integration tests pinning 4.x-equivalent behavior

### DIFF
--- a/spec/integration/git/git_configure_spec.rb
+++ b/spec/integration/git/git_configure_spec.rb
@@ -60,4 +60,44 @@ RSpec.describe Git do
       expect(keys).to include('integration.key', 'integration.other')
     end
   end
+
+  describe '.global_config', skip: unless_git('2.32.0', 'GIT_CONFIG_GLOBAL isolation') do
+    around { |example| with_isolated_global_config { example.run } }
+
+    context 'when called with no arguments (list mode)' do
+      before do
+        Git.config_set('user.name', 'GlobalUser', global: true)
+        Git.config_set('user.email', 'global@example.com', global: true)
+      end
+
+      it 'returns a Hash' do
+        expect(Git.global_config).to be_a(Hash)
+      end
+
+      it 'includes the written entries keyed by dotted name' do
+        result = Git.global_config
+        expect(result).to include('user.name' => 'GlobalUser', 'user.email' => 'global@example.com')
+      end
+    end
+
+    context 'when called with a name only (get mode)' do
+      before { Git.config_set('user.name', 'GlobalUser', global: true) }
+
+      it 'returns the String value for the named key' do
+        expect(Git.global_config('user.name')).to eq('GlobalUser')
+      end
+
+      it 'raises Git::FailedError when the key does not exist' do
+        expect { Git.global_config('ruby-git-rspec.nonexistent-key') }.to raise_error(Git::FailedError)
+      end
+    end
+
+    context 'when called with name and value (set mode)' do
+      it 'persists the value so a subsequent get returns it' do
+        Git.global_config('user.name', 'SetUser')
+
+        expect(Git.global_config('user.name')).to eq('SetUser')
+      end
+    end
+  end
 end

--- a/spec/integration/git/repository/configuring_spec.rb
+++ b/spec/integration/git/repository/configuring_spec.rb
@@ -12,10 +12,12 @@ require 'git/repository/configuring'
 #
 # Single-command get and set modes are covered by dedicated command integration
 # tests under spec/integration/git/commands/config_option_syntax/{get,set,list}_spec.rb.
-# Error-path assertions and argument-forwarding tests are skipped here because
-# they test command behavior, not the facade. The set→get round-trip test is
-# retained to confirm the facade's dispatch logic routes both modes correctly
-# end-to-end against real git.
+# Argument-forwarding tests are skipped here because they test command behavior,
+# not the facade. The missing-key error path is retained to pin the 4.x-equivalent
+# dispatch contract: #config(name) must propagate Git::FailedError when git exits
+# non-zero, which is facade behavior (Private.config_get raises on a non-zero exit). The
+# set→get round-trip test is retained to confirm the facade's dispatch logic routes
+# both modes correctly end-to-end against real git.
 
 RSpec.describe Git::Repository::Configuring, :integration do
   include_context 'in an empty repository'
@@ -33,6 +35,16 @@ RSpec.describe Git::Repository::Configuring, :integration do
       it 'returns the configured user.name value' do
         result = described_instance.config
         expect(result['user.name']).to eq('Test User')
+      end
+    end
+
+    context 'when called with a name only' do
+      it 'returns the config value as a String' do
+        expect(described_instance.config('user.name')).to eq('Test User')
+      end
+
+      it 'raises Git::FailedError when the key does not exist' do
+        expect { described_instance.config('ruby-git-rspec.nonexistent-key') }.to raise_error(Git::FailedError)
       end
     end
 
@@ -65,7 +77,7 @@ RSpec.describe Git::Repository::Configuring, :integration do
     end
   end
 
-  describe '#global_config' do
+  describe '#global_config', skip: unless_git('2.32.0', 'GIT_CONFIG_GLOBAL isolation') do
     around do |example|
       with_isolated_global_config { example.run }
     end
@@ -91,10 +103,18 @@ RSpec.describe Git::Repository::Configuring, :integration do
       end
     end
 
+    context 'when called with name and value' do
+      it 'persists the value so a subsequent get returns it' do
+        described_instance.global_config('user.name', 'SetUser')
+
+        expect(described_instance.global_config('user.name')).to eq('SetUser')
+      end
+    end
+
     def with_isolated_global_config
-      global_config = File.join(repo_dir, 'global.config')
-      FileUtils.touch(global_config)
       saved = ENV.fetch('GIT_CONFIG_GLOBAL', nil)
+      global_config = File.join(repo_dir, 'global.config')
+      File.write(global_config, '')
       ENV['GIT_CONFIG_GLOBAL'] = global_config
       yield
     ensure


### PR DESCRIPTION
## Summary

Adds integration tests that pin the 4.x-equivalent behavior of the three
legacy `config` dispatch methods (`Git.global_config`, `Git::Repository#config`,
`Git::Repository#global_config`). This is the final PR in the `git config`
redesign series.

## What this PR does

All three methods already had correct 4.x-equivalent implementations; the
implementations were not changed. This PR adds integration tests to verify
that behavior against a real git process, ensuring future refactoring cannot
silently regress the contract.

### `spec/integration/git/git_configure_spec.rb`

New `Git.global_config` integration tests (using `GIT_CONFIG_GLOBAL` isolation):
- List mode (no args) returns `Hash{String => String}` with all written entries
- Get mode (name only) returns a `String` value
- Get mode (name only) raises `Git::FailedError` when the key does not exist
- Set mode (name + value) persists — a subsequent get returns the written value

### `spec/integration/git/repository/configuring_spec.rb`

New `Git::Repository#config` integration tests:
- Get mode (name only) returns a `String` value for an existing key
- Get mode (name only) raises `Git::FailedError` when the key does not exist

New `Git::Repository#global_config` integration test:
- Set mode (name + value) persists — a subsequent get returns the written value

## What is NOT changed

No production code was modified. This PR is tests-only.

## PR Series

- PR 1 (merged): Foundation — `Git::ConfigEntryInfo`, `Git::Parsers::ConfigEntry`, `Git::Configuring` mixin
- PR 2 (merged): Mix `Git::Configuring` into `Git::Repository`, remove clashing deprecated aliases
- PR 3 (merged): Extend `Git::Configuring` into the `Git` module
- **PR 4 (this PR)**: Integration tests pinning 4.x-equivalent behavior

## Testing

6285 RSpec examples, 0 failures (+8 new tests). RuboCop and YARD clean.
