### PR TITLE
chore: release v5.0.0.beta.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?log
   - [Ruby Version Support Policy](#ruby-version-support-policy)
   - [Git Version Support Policy](#git-version-support-policy)
 - [📢 Project Announcements 📢](#-project-announcements-)
+  - [2026-06-25: v5.0.0.beta.2 Released](#2026-06-25-v500beta2-released)
   - [2026-06-04: v5.0.0.beta.1 Released](#2026-06-04-v500beta1-released)
   - [2026-01-07: AI Policy Introduced](#2026-01-07-ai-policy-introduced)
   - [2025-07-09: Architectural Redesign](#2025-07-09-architectural-redesign)
@@ -650,10 +651,35 @@ notes.
 
 ## 📢 Project Announcements 📢
 
+### 2026-06-25: v5.0.0.beta.2 Released
+
+The architectural redesign is approximately **90% complete** and we have published
+[`git v5.0.0.beta.2`](https://rubygems.org/gems/git/versions/5.0.0.beta.2) as our
+second pre-release.
+
+**To try the beta**, add the pre-release version to your `Gemfile`:
+
+```ruby
+gem 'git', '~> 5.0.0.beta'
+```
+
+Or install it directly:
+
+```sh
+gem install git --pre
+```
+
+The intent is full backward compatibility with v4.x, but given the size and scope of
+the redesign, some incompatibilities may exist. Please give the latest beta a try and
+[open an issue](https://github.com/ruby-git/ruby-git/issues) if you hit anything
+unexpected — your feedback helps us ship a solid v5.0.0.
+
+See [UPGRADING.md](UPGRADING.md) for a full list of deprecations and breaking changes.
+
 ### 2026-06-04: v5.0.0.beta.1 Released
 
 The architectural redesign is approximately **65% complete** and we have published
-[`git 5.0.0.beta.1`](https://rubygems.org/gems/git/versions/5.0.0.beta.1) as our
+[`git v5.0.0.beta.1`](https://rubygems.org/gems/git/versions/5.0.0.beta.1) as our
 first pre-release.
 
 **To try the beta**, add the pre-release version to your `Gemfile`:

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -4,7 +4,7 @@ module Git
   # The current gem version
   #
   # @return [String] the current gem version
-  VERSION = '5.0.0.beta.1'
+  VERSION = '5.0.0.beta.2'
 
   # Represents a git version with major, minor, and patch components
   #


### PR DESCRIPTION
Bump version to 5.0.0.beta.2 and update README announcement (90% complete).