### PR TITLE
fix: correct deprecation messages for Git#config and Git#global_config mixins

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -75,11 +75,11 @@ module Git
   extend Git::Configuring
 
   # @deprecated Mixing in the `Git` module is deprecated and will be removed in v6.0.0.
-  #   Use `Git.open(Dir.pwd).config(...)` instead.
+  #   Use `Git.config_get(name)`, `Git.config_set(name, value)`, or `Git.config_list` instead.
   def config(name = nil, value = nil)
     Git::Deprecation.warn(
       'Git#config is deprecated and will be removed in v6.0.0. ' \
-      'Use Git.open(Dir.pwd).config(...) instead.'
+      'Use Git.config_get(name), Git.config_set(name, value), or Git.config_list instead.'
     )
     Git.__send__(:run_config_utility, name, value, global: false)
   end
@@ -114,11 +114,13 @@ module Git
   end
 
   # @deprecated Mixing in the `Git` module is deprecated and will be removed in v6.0.0.
-  #   Use `Git.global_config(...)` instead.
+  #   Use `Git.config_get(name, global: true)`, `Git.config_set(name, value, global: true)`, or
+  #   `Git.config_list(global: true)` instead.
   def global_config(name = nil, value = nil)
     Git::Deprecation.warn(
       'Git#global_config is deprecated and will be removed in v6.0.0. ' \
-      'Use Git.global_config(...) instead.'
+      'Use Git.config_get(name, global: true), Git.config_set(name, value, global: true), ' \
+      'or Git.config_list(global: true) instead.'
     )
     Git.global_config(name, value)
   end


### PR DESCRIPTION
## Summary

The deprecation messages in the `Git#config` and `Git#global_config` mixin instance methods pointed to the wrong replacements.

### `Git#config`

**Before:** `Use Git.open(Dir.pwd).config(...) instead.`

**Problem:** `Git.open(Dir.pwd)` requires `Dir.pwd` to be a valid git repo and raises if it isn't. The old mixin called `run_config_utility` via `Git::ExecutionContext::Global.new` — no repo required.

**After:** `Use Git.config_get(name), Git.config_set(name, value), or Git.config_list instead.`

### `Git#global_config`

**Before:** `Use Git.global_config(...) instead.`

**Problem:** `Git.global_config` uses the old polymorphic `config()` API, not the new `Git::Configuring` methods.

**After:** `Use Git.config_get(name, global: true), Git.config_set(name, value, global: true), or Git.config_list(global: true) instead.`

Both replacements are correct because `Git` already extends `Git::Configuring`, making `Git.config_get`, `Git.config_set`, and `Git.config_list` available directly on the module.