### PR TITLE
feat(config): deprecate Git::Repository#config and #global_config

### DIFF
--- a/lib/git/repository/configuring.rb
+++ b/lib/git/repository/configuring.rb
@@ -29,6 +29,16 @@ module Git
       CONFIG_READ_ALLOWED_OPTS = %i[file].freeze
       private_constant :CONFIG_READ_ALLOWED_OPTS
 
+      CONFIG_DEPRECATION_WARNING = 'Git::Repository#config is deprecated and will be removed in v6.0.0. ' \
+                                   'Use config_get(name), config_set(name, value), or config_list instead.'
+      private_constant :CONFIG_DEPRECATION_WARNING
+
+      GLOBAL_CONFIG_DEPRECATION_WARNING =
+        'Git::Repository#global_config is deprecated and will be removed in v6.0.0. ' \
+        'Use config_get(name, global: true), config_set(name, value, global: true), ' \
+        'or config_list(global: true) instead.'
+      private_constant :GLOBAL_CONFIG_DEPRECATION_WARNING
+
       # Read or write a git configuration entry
       #
       # Dispatches to one of three modes depending on the arguments supplied:
@@ -108,6 +118,7 @@ module Git
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
       def config(name = nil, value = nil, options = {})
+        Git::Deprecation.warn(CONFIG_DEPRECATION_WARNING)
         name, value, options = Private.normalize_config_args(name, value, options)
 
         if !name.nil? && !value.nil?
@@ -166,6 +177,7 @@ module Git
       #   @raise [Git::FailedError] if git exits with a non-zero exit status
       #
       def global_config(name = nil, value = nil)
+        Git::Deprecation.warn(GLOBAL_CONFIG_DEPRECATION_WARNING)
         if !name.nil? && !value.nil?
           Private.global_config_set(@execution_context, name, value)
         elsif !name.nil?

--- a/lib/git/status.rb
+++ b/lib/git/status.rb
@@ -173,16 +173,14 @@ module Git
     # Return `true` when git is configured to ignore filename case
     #
     # Reads `core.ignoreCase` from the repository config. Returns `false` if
-    # the config value is absent or if reading it raises {Git::FailedError}.
+    # the config value is absent.
     #
     # @return [Boolean] `true` when `core.ignoreCase` is `"true"`
     #
     def ignore_case?
-      return @_ignore_case if defined?(@_ignore_case)
+      return @ignore_case if defined?(@ignore_case)
 
-      @_ignore_case = (@base.config('core.ignoreCase') == 'true')
-    rescue Git::FailedError
-      @_ignore_case = false
+      @ignore_case = (@base.config_get('core.ignoreCase')&.value == 'true')
     end
   end
 end

--- a/spec/integration/git/commands/clone_spec.rb
+++ b/spec/integration/git/commands/clone_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Git::Commands::Clone, :integration do
 
   before do
     source_repo = Git.init(source_dir, initial_branch: 'main')
-    source_repo.config('user.email', 'test@example.com')
-    source_repo.config('user.name', 'Test User')
+    source_repo.config_set('user.email', 'test@example.com')
+    source_repo.config_set('user.name', 'Test User')
     File.write(File.join(source_dir, 'file.txt'), "content\n")
     source_repo.add('file.txt')
     source_repo.commit('Initial commit')

--- a/spec/integration/git/commands/config_option_syntax/get_color_bool_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_color_bool_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::GetColorBool, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       it 'returns a CommandLineResult with exit status 0 when color is enabled' do
-        repo.config('color.test', 'always')
+        repo.config_set('color.test', 'always')
         result = command.call('color.test')
 
         expect(result).to be_a(Git::CommandLineResult)
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::GetColorBool, :integration do
       end
 
       it 'returns exit status 1 when color is disabled' do
-        repo.config('color.test', 'never')
+        repo.config_set('color.test', 'never')
         result = command.call('color.test')
 
         expect(result.status.exitstatus).to eq(1)

--- a/spec/integration/git/commands/config_option_syntax/get_color_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_color_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::GetColor, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       before do
-        repo.config('color.test.slot', 'red')
+        repo.config_set('color.test.slot', 'red')
       end
 
       it 'returns a CommandLineResult' do

--- a/spec/integration/git/commands/config_option_syntax/get_urlmatch_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_urlmatch_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::GetUrlmatch, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       before do
-        repo.config('http.https://example.com.proxy', 'http://proxy.example.com')
+        repo.config_set('http.https://example.com.proxy', 'http://proxy.example.com')
       end
 
       it 'returns a CommandLineResult' do

--- a/spec/integration/git/commands/config_option_syntax/rename_section_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/rename_section_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::RenameSection, :integration do
   describe '#call' do
     context 'when the command succeeds' do
       before do
-        repo.config('oldsection.key', 'value')
+        repo.config_set('oldsection.key', 'value')
       end
 
       it 'returns a CommandLineResult' do
@@ -29,7 +29,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::RenameSection, :integration do
       it 'renames the section' do
         command.call('oldsection', 'newsection')
 
-        expect(repo.config('newsection.key')).to eq('value')
+        expect(repo.config_get('newsection.key').value).to eq('value')
       end
     end
 

--- a/spec/integration/git/commands/diff_spec.rb
+++ b/spec/integration/git/commands/diff_spec.rb
@@ -51,9 +51,9 @@ RSpec.describe Git::Commands::Diff, :integration do
       before(:all) do
         @check_repo_dir = Dir.mktmpdir
         check_repo = Git.init(@check_repo_dir, initial_branch: 'main')
-        check_repo.config('user.email', 'test@example.com')
-        check_repo.config('user.name', 'Test User')
-        check_repo.config('commit.gpgsign', 'false')
+        check_repo.config_set('user.email', 'test@example.com')
+        check_repo.config_set('user.name', 'Test User')
+        check_repo.config_set('commit.gpgsign', 'false')
 
         # Initial commit with clean content
         File.write(File.join(@check_repo_dir, 'file.txt'), "clean content\n")

--- a/spec/integration/git/commands/pull_spec.rb
+++ b/spec/integration/git/commands/pull_spec.rb
@@ -31,9 +31,9 @@ RSpec.describe Git::Commands::Pull, :integration do
       # so the original repo can pull it
       Git.clone(bare_dir, second_clone_dir)
       second_clone = Git.open(second_clone_dir)
-      second_clone.config('user.email', 'test@example.com')
-      second_clone.config('user.name', 'Test User')
-      second_clone.config('commit.gpgsign', 'false')
+      second_clone.config_set('user.email', 'test@example.com')
+      second_clone.config_set('user.name', 'Test User')
+      second_clone.config_set('commit.gpgsign', 'false')
       File.write(File.join(second_clone_dir, 'new_file.txt'), 'New content')
       second_clone.add('new_file.txt')
       second_clone.commit('Second commit')

--- a/spec/integration/git/commands/remote/add_spec.rb
+++ b/spec/integration/git/commands/remote/add_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Git::Commands::Remote::Add, :integration do
   let(:remote_dir) { Dir.mktmpdir }
   let(:remote_repo) do
     test_repo = Git.init(remote_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     File.write(File.join(remote_dir, 'README.md'), "seed\n")
     test_repo.add('README.md')
     test_repo.commit('Initial commit')

--- a/spec/integration/git/commands/remote/get_url_spec.rb
+++ b/spec/integration/git/commands/remote/get_url_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Git::Commands::Remote::GetUrl, :integration do
   let(:remote_dir) { Dir.mktmpdir }
   let(:remote_repo) do
     test_repo = Git.init(remote_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     test_repo
   end
 

--- a/spec/integration/git/commands/remote/list_spec.rb
+++ b/spec/integration/git/commands/remote/list_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Git::Commands::Remote::List, :integration do
   let(:remote_dir) { Dir.mktmpdir }
   let(:remote_repo) do
     test_repo = Git.init(remote_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     test_repo
   end
 

--- a/spec/integration/git/commands/remote/prune_spec.rb
+++ b/spec/integration/git/commands/remote/prune_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Git::Commands::Remote::Prune, :integration do
   let(:remote_dir) { Dir.mktmpdir }
   let(:remote_repo) do
     test_repo = Git.init(remote_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     File.write(File.join(remote_dir, 'README.md'), "seed\n")
     test_repo.add('README.md')
     test_repo.commit('Initial commit')

--- a/spec/integration/git/commands/remote/remove_spec.rb
+++ b/spec/integration/git/commands/remote/remove_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Git::Commands::Remote::Remove, :integration do
   let(:remote_dir) { Dir.mktmpdir }
   let(:remote_repo) do
     test_repo = Git.init(remote_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     test_repo
   end
 

--- a/spec/integration/git/commands/remote/rename_spec.rb
+++ b/spec/integration/git/commands/remote/rename_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Git::Commands::Remote::Rename, :integration do
   let(:remote_dir) { Dir.mktmpdir }
   let(:remote_repo) do
     test_repo = Git.init(remote_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     test_repo
   end
 

--- a/spec/integration/git/commands/remote/set_branches_spec.rb
+++ b/spec/integration/git/commands/remote/set_branches_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Git::Commands::Remote::SetBranches, :integration do
   let(:remote_dir) { Dir.mktmpdir }
   let(:remote_repo) do
     test_repo = Git.init(remote_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     test_repo
   end
 

--- a/spec/integration/git/commands/remote/set_head_spec.rb
+++ b/spec/integration/git/commands/remote/set_head_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Git::Commands::Remote::SetHead, :integration do
   let(:remote_dir) { Dir.mktmpdir }
   let(:remote_repo) do
     test_repo = Git.init(remote_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     File.write(File.join(remote_dir, 'README.md'), "seed\n")
     test_repo.add('README.md')
     test_repo.commit('Initial commit')

--- a/spec/integration/git/commands/remote/set_url_add_spec.rb
+++ b/spec/integration/git/commands/remote/set_url_add_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Git::Commands::Remote::SetUrlAdd, :integration do
   let(:extra_dir) { Dir.mktmpdir }
   let(:remote_repo) do
     test_repo = Git.init(remote_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     test_repo
   end
   let(:extra_repo) do
     test_repo = Git.init(extra_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     test_repo
   end
 

--- a/spec/integration/git/commands/remote/set_url_delete_spec.rb
+++ b/spec/integration/git/commands/remote/set_url_delete_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Git::Commands::Remote::SetUrlDelete, :integration do
   let(:extra_dir) { Dir.mktmpdir }
   let(:remote_repo) do
     test_repo = Git.init(remote_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     test_repo
   end
   let(:extra_repo) do
     test_repo = Git.init(extra_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     test_repo
   end
 

--- a/spec/integration/git/commands/remote/set_url_spec.rb
+++ b/spec/integration/git/commands/remote/set_url_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe Git::Commands::Remote::SetUrl, :integration do
   let(:replacement_dir) { Dir.mktmpdir }
   let(:remote_repo) do
     test_repo = Git.init(remote_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     test_repo
   end
   let(:replacement_repo) do
     test_repo = Git.init(replacement_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     test_repo
   end
 

--- a/spec/integration/git/commands/remote/show_spec.rb
+++ b/spec/integration/git/commands/remote/show_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Git::Commands::Remote::Show, :integration do
   let(:remote_dir) { Dir.mktmpdir }
   let(:remote_repo) do
     test_repo = Git.init(remote_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     File.write(File.join(remote_dir, 'README.md'), "seed\n")
     test_repo.add('README.md')
     test_repo.commit('Initial commit')

--- a/spec/integration/git/commands/remote/update_spec.rb
+++ b/spec/integration/git/commands/remote/update_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Git::Commands::Remote::Update, :integration do
   let(:remote_dir) { Dir.mktmpdir }
   let(:remote_repo) do
     test_repo = Git.init(remote_dir, initial_branch:)
-    test_repo.config('user.email', 'test@example.com')
-    test_repo.config('user.name', 'Test User')
+    test_repo.config_set('user.email', 'test@example.com')
+    test_repo.config_set('user.name', 'Test User')
     File.write(File.join(remote_dir, 'README.md'), "seed\n")
     test_repo.add('README.md')
     test_repo.commit('Initial commit')

--- a/spec/integration/git/repository/configuring_spec.rb
+++ b/spec/integration/git/repository/configuring_spec.rb
@@ -25,6 +25,8 @@ RSpec.describe Git::Repository::Configuring, :integration do
   let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
 
   describe '#config' do
+    before { allow(Git::Deprecation).to receive(:warn) }
+
     context 'when called with no arguments' do
       it 'returns a Hash containing expected config keys' do
         result = described_instance.config
@@ -78,6 +80,8 @@ RSpec.describe Git::Repository::Configuring, :integration do
   end
 
   describe '#global_config', skip: unless_git('2.32.0', 'GIT_CONFIG_GLOBAL isolation') do
+    before { allow(Git::Deprecation).to receive(:warn) }
+
     around do |example|
       with_isolated_global_config { example.run }
     end

--- a/spec/integration/git/repository_spec.rb
+++ b/spec/integration/git/repository_spec.rb
@@ -82,9 +82,9 @@ RSpec.describe Git::Repository, :integration do
 
     before do
       source = Git.init(source_dir, initial_branch: 'main')
-      source.config('user.email', 'test@example.com')
-      source.config('user.name', 'Test User')
-      source.config('commit.gpgsign', 'false')
+      source.config_set('user.email', 'test@example.com')
+      source.config_set('user.name', 'Test User')
+      source.config_set('commit.gpgsign', 'false')
       File.write(File.join(source_dir, 'README.md'), '# Test')
       source.add('README.md')
       source.commit('Initial commit')

--- a/spec/support/contexts/diff_test_repository.rb
+++ b/spec/support/contexts/diff_test_repository.rb
@@ -118,8 +118,8 @@ module DiffTestRepositorySetup
     # Create a separate repository to use as submodule
     submodule_source = Dir.mktmpdir('submodule-source')
     sub_repo = Git.init(submodule_source, initial_branch: 'main')
-    sub_repo.config('user.email', 'test@example.com')
-    sub_repo.config('user.name', 'Test User')
+    sub_repo.config_set('user.email', 'test@example.com')
+    sub_repo.config_set('user.name', 'Test User')
     File.write(File.join(submodule_source, 'sub.txt'), "Submodule content\n")
     sub_repo.add('sub.txt')
     sub_repo.commit('Initial submodule commit')
@@ -221,10 +221,10 @@ RSpec.shared_context 'in a diff test repository' do
   before(:all) do
     @repo_dir = Dir.mktmpdir
     @repo = Git.init(@repo_dir, initial_branch: 'main')
-    @repo.config('user.email', 'test@example.com')
-    @repo.config('user.name', 'Test User')
-    @repo.config('commit.gpgsign', 'false')
-    @repo.config('core.editor', 'false')
+    @repo.config_set('user.email', 'test@example.com')
+    @repo.config_set('user.name', 'Test User')
+    @repo.config_set('commit.gpgsign', 'false')
+    @repo.config_set('core.editor', 'false')
 
     setup_diff_test_history
 

--- a/spec/support/contexts/empty_repository.rb
+++ b/spec/support/contexts/empty_repository.rb
@@ -317,10 +317,10 @@ RSpec.shared_context 'in an empty repository' do
   let(:execution_context) { repo.execution_context }
 
   before do
-    repo.config('user.email', 'test@example.com')
-    repo.config('user.name', 'Test User')
-    repo.config('commit.gpgsign', 'false')
-    repo.config('core.editor', 'false') # fail fast if editor is invoked
+    repo.config_set('user.email', 'test@example.com')
+    repo.config_set('user.name', 'Test User')
+    repo.config_set('commit.gpgsign', 'false')
+    repo.config_set('core.editor', 'false') # fail fast if editor is invoked
   end
 
   after do

--- a/spec/unit/git/repository/configuring_spec.rb
+++ b/spec/unit/git/repository/configuring_spec.rb
@@ -9,6 +9,18 @@ RSpec.describe Git::Repository::Configuring do
   let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
 
   describe '#config' do
+    before { allow(Git::Deprecation).to receive(:warn) }
+
+    it 'emits a deprecation warning' do
+      get_command = instance_double(Git::Commands::ConfigOptionSyntax::Get)
+      allow(Git::Commands::ConfigOptionSyntax::Get)
+        .to receive(:new).with(execution_context).and_return(get_command)
+      allow(get_command).to receive(:call).with('user.name').and_return(command_result('Alice'))
+
+      expect(Git::Deprecation).to receive(:warn).with(a_string_including('Git::Repository#config is deprecated'))
+      described_instance.config('user.name')
+    end
+
     context 'when called with no arguments' do
       subject(:result) { described_instance.config }
 
@@ -224,6 +236,18 @@ RSpec.describe Git::Repository::Configuring do
   end
 
   describe '#global_config' do
+    before { allow(Git::Deprecation).to receive(:warn) }
+
+    it 'emits a deprecation warning' do
+      get_command = instance_double(Git::Commands::ConfigOptionSyntax::Get)
+      allow(Git::Commands::ConfigOptionSyntax::Get)
+        .to receive(:new).with(execution_context).and_return(get_command)
+      allow(get_command).to receive(:call).with('user.name', global: true).and_return(command_result('Alice'))
+
+      expect(Git::Deprecation).to receive(:warn).with(a_string_including('Git::Repository#global_config is deprecated'))
+      described_instance.global_config('user.name')
+    end
+
     context 'when called with no arguments' do
       subject(:result) { described_instance.global_config }
 

--- a/tests/units/test_command_raises_on_failure.rb
+++ b/tests/units/test_command_raises_on_failure.rb
@@ -57,7 +57,7 @@ class TestCommandRaisesOnFailure < Test::Unit::TestCase
       Dir.chdir('test_project') do
         # git config --get returns exit code 1 when key doesn't exist
         assert_raise(Git::FailedError) do
-          git.config('nonexistent.config.key.that.does.not.exist')
+          Git::Deprecation.silence { git.config('nonexistent.config.key.that.does.not.exist') }
         end
       end
     end

--- a/tests/units/test_config.rb
+++ b/tests/units/test_config.rb
@@ -2,6 +2,10 @@
 
 require 'test_helper'
 
+# Tests for the deprecated Git::Repository#config method.
+# Git::Deprecation.silence is used around each call because the test helper
+# configures Git::Deprecation.behavior = :raise and these tests intentionally
+# exercise the deprecated method to verify backward-compatible behavior.
 class TestConfig < Test::Unit::TestCase
   def setup
     clone_working_repo
@@ -9,30 +13,30 @@ class TestConfig < Test::Unit::TestCase
   end
 
   def test_config
-    c = @git.config
+    c = Git::Deprecation.silence { @git.config }
     assert_equal('Scott Chacon', c['user.name'])
     assert_equal('false', c['core.bare'])
   end
 
   def test_read_config
-    assert_equal('Scott Chacon', @git.config('user.name'))
-    assert_equal('false', @git.config('core.bare'))
+    assert_equal('Scott Chacon', Git::Deprecation.silence { @git.config('user.name') })
+    assert_equal('false', Git::Deprecation.silence { @git.config('core.bare') })
   end
 
   def test_set_config
-    assert_not_equal('bully', @git.config('user.name'))
-    @git.config('user.name', 'bully')
-    assert_equal('bully', @git.config('user.name'))
+    assert_not_equal('bully', Git::Deprecation.silence { @git.config('user.name') })
+    Git::Deprecation.silence { @git.config('user.name', 'bully') }
+    assert_equal('bully', Git::Deprecation.silence { @git.config('user.name') })
   end
 
   def test_set_config_with_custom_file
     Dir.chdir(@wdir) do
       custom_config_path = "#{Dir.pwd}/.git/custom-config"
-      assert_not_equal('bully', @git.config('user.name'))
-      @git.config('user.name', 'bully', file: custom_config_path)
-      assert_not_equal('bully', @git.config('user.name'))
-      @git.config('include.path', custom_config_path)
-      assert_equal('bully', @git.config('user.name'))
+      assert_not_equal('bully', Git::Deprecation.silence { @git.config('user.name') })
+      Git::Deprecation.silence { @git.config('user.name', 'bully', file: custom_config_path) }
+      assert_not_equal('bully', Git::Deprecation.silence { @git.config('user.name') })
+      Git::Deprecation.silence { @git.config('include.path', custom_config_path) }
+      assert_equal('bully', Git::Deprecation.silence { @git.config('user.name') })
       assert_equal("[user]\n\tname = bully\n", File.read(custom_config_path))
     end
   end

--- a/tests/units/test_diff.rb
+++ b/tests/units/test_diff.rb
@@ -118,7 +118,7 @@ class TestDiff < Test::Unit::TestCase
 
   def test_diff_hashkey_min
     git = Git.open(@wdir)
-    git.config('core.abbrev', 4)
+    git.config_set('core.abbrev', 4)
     diff = git.diff('gitsearch1', 'v2.5')
     assert_equal('5d46', diff['scott/newfile'].src)
     assert_nil(diff['scott/newfile'].blob(:dst))
@@ -127,7 +127,7 @@ class TestDiff < Test::Unit::TestCase
 
   def test_diff_hashkey_max
     git = Git.open(@wdir)
-    git.config('core.abbrev', 40)
+    git.config_set('core.abbrev', 40)
     diff = git.diff('gitsearch1', 'v2.5')
     assert_equal('5d4606820736043f9eed2a6336661d6892c820a5', diff['scott/newfile'].src)
     assert_nil(diff['scott/newfile'].blob(:dst))

--- a/tests/units/test_git_clone.rb
+++ b/tests/units/test_git_clone.rb
@@ -132,7 +132,7 @@ class TestGitClone < Test::Unit::TestCase
 
       shallow_path = File.join(path, 'shallow')
       shallow_clone = Git.clone(repository_path, shallow_path, depth: 1, no_single_branch: true)
-      fetch_spec = shallow_clone.config('remote.origin.fetch')
+      fetch_spec = shallow_clone.config_get('remote.origin.fetch').value
 
       assert_equal('+refs/heads/*:refs/remotes/origin/*', fetch_spec)
     end

--- a/tests/units/test_init.rb
+++ b/tests/units/test_init.rb
@@ -50,7 +50,7 @@ class TestInit < Test::Unit::TestCase
       repo = Git.init(path)
       assert(File.directory?(File.join(path, '.git')))
       assert(File.exist?(File.join(path, '.git', 'config')))
-      assert_equal('false', repo.config('core.bare'))
+      assert_equal('false', repo.config_get('core.bare').value)
 
       branch = `git config --get init.defaultBranch`.strip
       branch = 'master' if branch.empty?
@@ -62,7 +62,7 @@ class TestInit < Test::Unit::TestCase
     in_temp_dir do |path|
       repo = Git.init(path, bare: true)
       assert(File.exist?(File.join(path, 'config')))
-      assert_equal('true', repo.config('core.bare'))
+      assert_equal('true', repo.config_get('core.bare').value)
     end
   end
 
@@ -93,7 +93,7 @@ class TestInit < Test::Unit::TestCase
       repo = Git.init(path, initial_branch: 'main')
       assert(File.directory?(File.join(path, '.git')))
       assert(File.exist?(File.join(path, '.git', 'config')))
-      assert_equal('false', repo.config('core.bare'))
+      assert_equal('false', repo.config_get('core.bare').value)
       assert_equal("ref: refs/heads/main\n", File.read("#{path}/.git/HEAD"))
     end
   end
@@ -132,7 +132,7 @@ class TestInit < Test::Unit::TestCase
   def test_git_clone_config
     in_temp_dir do |_path|
       g = Git.clone(BARE_REPO_PATH, 'config.git', config: 'receive.denyCurrentBranch=ignore')
-      assert_equal('ignore', g.config['receive.denycurrentbranch'])
+      assert_equal('ignore', g.config_get('receive.denycurrentbranch').value)
       assert(File.exist?(File.join(g.repo.to_s, 'config')))
       assert(g.dir)
     end

--- a/tests/units/test_remotes.rb
+++ b/tests/units/test_remotes.rb
@@ -102,8 +102,8 @@ class TestRemotes < Test::Unit::TestCase
   def test_remote_set_branches_fetches_additional_branch
     in_temp_dir do |_path|
       upstream = Git.clone(BARE_REPO_PATH, 'upstream', config: 'receive.denyCurrentBranch=ignore')
-      upstream.config('user.name', 'Test User')
-      upstream.config('user.email', 'test@example.com')
+      upstream.config_set('user.name', 'Test User')
+      upstream.config_set('user.email', 'test@example.com')
 
       upstream.chdir do
         default_branch = upstream.current_branch
@@ -116,7 +116,7 @@ class TestRemotes < Test::Unit::TestCase
 
       local = Git.clone(upstream.dir.to_s, 'local', branch: upstream.current_branch, single_branch: true)
       fetch_refspec = "+refs/heads/#{upstream.current_branch}:refs/remotes/origin/#{upstream.current_branch}"
-      local.config('remote.origin.fetch', fetch_refspec)
+      local.config_set('remote.origin.fetch', fetch_refspec)
 
       assert(!local.branches.remote.map(&:full).include?('remotes/origin/nondefault'))
 
@@ -130,8 +130,8 @@ class TestRemotes < Test::Unit::TestCase
   def test_remote_set_branches_replaces_fetch_refspecs
     in_temp_dir do |_path|
       upstream = Git.clone(BARE_REPO_PATH, 'upstream', config: 'receive.denyCurrentBranch=ignore')
-      upstream.config('user.name', 'Test User')
-      upstream.config('user.email', 'test@example.com')
+      upstream.config_set('user.name', 'Test User')
+      upstream.config_set('user.email', 'test@example.com')
 
       upstream.chdir do
         default_branch = upstream.current_branch

--- a/tests/units/test_status.rb
+++ b/tests/units/test_status.rb
@@ -90,7 +90,7 @@ class TestStatus < Test::Unit::TestCase
   def test_added_boolean
     in_temp_dir do |_path|
       git = Git.clone(@wdir, 'test_dot_files_status')
-      git.config('core.ignorecase', 'false')
+      git.config_set('core.ignorecase', 'false')
 
       create_file('test_dot_files_status/test_file_1', 'content tets_file_1')
       create_file('test_dot_files_status/test_file_2', 'content tets_file_2')
@@ -101,7 +101,7 @@ class TestStatus < Test::Unit::TestCase
       assert(!git.status.added?('test_file_2'))
       assert(!git.status.added?('TEST_FILE_1'))
 
-      git.config('core.ignorecase', 'true')
+      git.config_set('core.ignorecase', 'true')
       assert(git.status.added?('TEST_FILE_1'))
     end
   end
@@ -109,7 +109,7 @@ class TestStatus < Test::Unit::TestCase
   def test_changed_boolean
     in_temp_dir do |_path|
       git = Git.clone(@wdir, 'test_dot_files_status')
-      git.config('core.ignorecase', 'false')
+      git.config_set('core.ignorecase', 'false')
 
       create_file('test_dot_files_status/test_file_1', 'content tets_file_1')
       create_file('test_dot_files_status/test_file_2', 'content tets_file_2')
@@ -126,7 +126,7 @@ class TestStatus < Test::Unit::TestCase
       assert(git.status.changed?('scott/text.txt'))
       assert(!git.status.changed?('scott/TEXT.txt'))
 
-      git.config('core.ignorecase', 'true')
+      git.config_set('core.ignorecase', 'true')
       assert(git.status.changed?('scott/TEXT.txt'))
     end
   end
@@ -134,7 +134,7 @@ class TestStatus < Test::Unit::TestCase
   def test_deleted_boolean
     in_temp_dir do |_path|
       git = Git.clone(@wdir, 'test_dot_files_status')
-      git.config('core.ignorecase', 'false')
+      git.config_set('core.ignorecase', 'false')
 
       create_file('test_dot_files_status/test_file_1', 'content tets_file_1')
       create_file('test_dot_files_status/test_file_2', 'content tets_file_2')
@@ -147,7 +147,7 @@ class TestStatus < Test::Unit::TestCase
       assert(!git.status.deleted?('test_file_2'))
       assert(!git.status.deleted?('TEST_FILE_1'))
 
-      git.config('core.ignorecase', 'true')
+      git.config_set('core.ignorecase', 'true')
       assert(git.status.deleted?('TEST_FILE_1'))
     end
   end
@@ -205,7 +205,7 @@ class TestStatus < Test::Unit::TestCase
   def test_untracked_boolean
     in_temp_dir do |_path|
       git = Git.clone(@wdir, 'test_dot_files_status')
-      git.config('core.ignorecase', 'false')
+      git.config_set('core.ignorecase', 'false')
 
       create_file('test_dot_files_status/test_file_1', 'content tets_file_1')
       create_file('test_dot_files_status/test_file_2', 'content tets_file_2')
@@ -215,7 +215,7 @@ class TestStatus < Test::Unit::TestCase
       assert(!git.status.untracked?('test_file_2'))
       assert(!git.status.untracked?('TEST_FILE_1'))
 
-      git.config('core.ignorecase', 'true')
+      git.config_set('core.ignorecase', 'true')
       assert(git.status.untracked?('TEST_FILE_1'))
     end
   end

--- a/tests/units/test_tags.rb
+++ b/tests/units/test_tags.rb
@@ -7,10 +7,10 @@ class TestTags < Test::Unit::TestCase
     in_temp_dir do |_path|
       r1 = Git.clone(BARE_REPO_PATH, 'repo1')
       r2 = Git.clone(BARE_REPO_PATH, 'repo2')
-      r1.config('user.name', 'Test User')
-      r1.config('user.email', 'test@email.com')
-      r2.config('user.name', 'Test User')
-      r2.config('user.email', 'test@email.com')
+      r1.config_set('user.name', 'Test User')
+      r1.config_set('user.email', 'test@email.com')
+      r2.config_set('user.name', 'Test User')
+      r2.config_set('user.email', 'test@email.com')
 
       error = assert_raise Git::UnexpectedResultError do
         r1.tag('first')


### PR DESCRIPTION
## Summary

Adds deprecation warnings to `Git::Repository#config` and `Git::Repository#global_config`,
both of which are 4.x-compatibility façades that will be removed in v6.0.0. Callers should
migrate to the structured methods provided by `Git::Configuring`:

| Deprecated call | Replacement |
| --- | --- |
| `repo.config('key')` | `repo.config_get('key')&.value` |
| `repo.config('key', 'value')` | `repo.config_set('key', 'value')` |
| `repo.config` | `repo.config_list.map { ... }` |
| `repo.global_config('key')` | `repo.config_get('key', global: true)&.value` |
| `repo.global_config('key', 'value')` | `repo.config_set('key', 'value', global: true)` |
| `repo.global_config` | `repo.config_list(global: true).map { ... }` |

Deprecation message style follows the pattern established in issue 1464
(merged to main as `c1895a43`).

## Changes

### `lib/git/repository/configuring.rb`

- Added `CONFIG_DEPRECATION_WARNING` and `GLOBAL_CONFIG_DEPRECATION_WARNING` constants
  with `private_constant`.
- `#config` and `#global_config` call `Git::Deprecation.warn` with the appropriate
  constant before dispatching.

### `lib/git/status.rb`

- `ignore_case?` migrated from `@base.config('core.ignoreCase') == 'true'` to
  `@base.config_get('core.ignoreCase')&.value == 'true'`. Since `config_get` returns
  `nil` for missing keys (rather than raising), the `rescue Git::FailedError` is removed.
- Memoized ivar renamed from `@_ignore_case` to `@ignore_case` (RuboCop
  `Naming/MemoizedInstanceVariableName` convention).

### Test suite updates

All callers of the deprecated methods in `spec/` and `tests/` are migrated so that the
deprecation-as-raise behavior configured by the test helpers does not cause widespread failures:

- Incidental set-mode calls (`repo.config('key', 'value')`) → `repo.config_set('key', 'value')`
- Incidental get-mode calls (`repo.config('key')`) → `repo.config_get('key').value`
- Tests specifically exercising `#config`/`#global_config` use `Git::Deprecation.silence { }`
  or add `before { allow(Git::Deprecation).to receive(:warn) }` stubs.

## Test coverage

New unit tests added to `spec/unit/git/repository/configuring_spec.rb`:

- `#config emits a deprecation warning` — asserts `Git::Deprecation.warn` is called with
  a message including `'Git::Repository#config is deprecated'`.
- `#global_config emits a deprecation warning` — same for `#global_config`.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake default:parallel` locally on this branch and it passed.
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (YARD on the deprecated methods).
