### PR TITLE
chore: release v5.0.0.beta.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?log
   - [Ruby Version Support Policy](#ruby-version-support-policy)
   - [Git Version Support Policy](#git-version-support-policy)
 - [📢 Project Announcements 📢](#-project-announcements-)
+  - [2026-06-26: v5.0.0.beta.3 Released](#2026-06-26-v500beta3-released)
   - [2026-06-25: v5.0.0.beta.2 Released](#2026-06-25-v500beta2-released)
   - [2026-06-04: v5.0.0.beta.1 Released](#2026-06-04-v500beta1-released)
   - [2026-01-07: AI Policy Introduced](#2026-01-07-ai-policy-introduced)
@@ -652,6 +653,31 @@ impractical. Such changes will be clearly documented in the CHANGELOG and releas
 notes.
 
 ## 📢 Project Announcements 📢
+
+### 2026-06-26: v5.0.0.beta.3 Released
+
+The architectural redesign is approximately **93% complete** and we have published
+[`git v5.0.0.beta.3`](https://rubygems.org/gems/git/versions/5.0.0.beta.3) as our
+third pre-release.
+
+**To try the beta**, add the pre-release version to your `Gemfile`:
+
+```ruby
+gem 'git', '~> 5.0.0.beta'
+```
+
+Or install it directly:
+
+```sh
+gem install git --pre
+```
+
+The intent is full backward compatibility with v4.x, but given the size and scope of
+the redesign, some incompatibilities may exist. Please give the latest beta a try and
+[open an issue](https://github.com/ruby-git/ruby-git/issues) if you hit anything
+unexpected — your feedback helps us ship a solid v5.0.0.
+
+See [UPGRADING.md](UPGRADING.md) for a full list of deprecations and breaking changes.
 
 ### 2026-06-25: v5.0.0.beta.2 Released
 

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -4,7 +4,7 @@ module Git
   # The current gem version
   #
   # @return [String] the current gem version
-  VERSION = '5.0.0.beta.2'
+  VERSION = '5.0.0.beta.3'
 
   # Represents a git version with major, minor, and patch components
   #


### PR DESCRIPTION
# Description

Manual beta release of `v5.0.0.beta.3` following the process in
[`redesign/beta_release.md`](redesign/beta_release.md).

Changes:

- Bump `lib/git/version.rb` to `5.0.0.beta.3`.
- Add the `2026-06-26: v5.0.0.beta.3 Released` announcement to `README.md`
  (~93% complete) and link it in the table of contents.

Per the beta process, `.release-please-manifest.json` is intentionally left
untouched so release-please keeps accumulating commits toward the final `5.0.0`
release.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).