### PR TITLE
docs: remove Test::Unit references now that RSpec is the sole suite

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -40,20 +40,15 @@ or explanation does not require a skill.
 | Purpose | Command |
 | --- | --- |
 | First-time setup | `bin/setup` |
-| Run all tests and linters(CI-equivalent) | `bundle exec rake default:parallel` |
-| Run all tests (both suites) | `bundle exec rake test-all:parallel` |
-| Run Test::Unit tests | `bundle exec rake test:parallel` |
+| Run all tests and linters (CI-equivalent) | `bundle exec rake default` |
+| Run all tests and linters (force parallel) | `bundle exec rake default:parallel` |
 | Run all RSpec tests | `bundle exec rake spec:parallel` |
 | Run RSpec unit tests | `bundle exec rake spec:unit:parallel` |
 | Run RSpec integration tests | `bundle exec rake spec:integration:parallel` |
-| Run a specific Test::Unit test | `bundle exec bin/test <test-base-name>` |
 | Run a specific RSpec spec | `bundle exec rspec <path>` |
 | Run linters | `bundle exec rake rubocop yard build` |
 
-**Test suites:** `spec/` (RSpec) is the current suite — all new tests go here.
-`tests/` (Test::Unit) is legacy; only touch it when modifying existing tests there
-or adding pre-migration coverage to verify that a `Git::Lib` → `Git::Commands`
-migration doesn't break existing behavior.
+**Test suite:** `spec/` (RSpec) is the sole test suite — all new tests go here.
 
 ## Commit Conventions
 

--- a/.github/skills/ci-cd-troubleshooting/SKILL.md
+++ b/.github/skills/ci-cd-troubleshooting/SKILL.md
@@ -132,7 +132,7 @@ Based on the failure type, investigate:
 2. Run the failing tests locally:
 
    ```bash
-   bundle exec bin/test <test-name>
+   bundle exec rspec <path/to/spec.rb>
    ```
 
 3. Run linters:
@@ -211,7 +211,7 @@ After implementing fixes:
 1. **Run Affected Tests Locally:**
 
    ```bash
-   bundle exec bin/test <test-name>
+   bundle exec rspec <path/to/spec.rb>
    ```
 
 2. **Run Full CI Suite:**

--- a/.github/skills/development-workflow/SKILL.md
+++ b/.github/skills/development-workflow/SKILL.md
@@ -205,8 +205,8 @@ When all tasks are complete, proceed to **Phase 3: FINALIZE**.
    - **Keep It Minimal:** Only write enough of a test to get an expected, failing
      result (the test should fail for the *right* reason).
    - **Execute and Analyze:** Run the specific test file (e.g.,
-     `bundle exec rspec spec/unit/git/commands/<command>_spec.rb` for RSpec or
-     `bundle exec bin/test <test_file>` for TestUnit) and analyze the output.
+     `bundle exec rspec spec/unit/git/commands/<command>_spec.rb`) and analyze the
+     output.
    - **Confirm Expected Failure:** Confirm it fails with an expected error (e.g.,
      assertion failure or missing definition).
    - **Validate:** If the test passes without implementation, the test is invalid or
@@ -474,20 +474,31 @@ Each task follows this cycle: **RED → GREEN → REFACTOR → VERIFY → COMMIT
 **RED:** Write a failing test that describes the desired behavior.
 
 ```ruby
-def test_creates_new_branch
-  @git.branch('feature').create
-  assert @git.branches.local.map(&:name).include?('feature')
+# spec/unit/git/commands/example_spec.rb
+it 'passes the --force flag when force: true is given' do
+  expect_command_capturing('example', '--force').and_return(command_result(''))
+
+  described_class.new(execution_context).call(force: true)
 end
-# Run: bundle exec bin/test test_branch → fails with NoMethodError
+# Run: bundle exec rspec spec/unit/git/commands/example_spec.rb
+#      → fails: NameError (Git::Commands::Example is not defined yet)
 ```
 
 **GREEN:** Write minimal code to make the test pass.
 
 ```ruby
-def create
-  @base.lib.branch_new(@name)
+# lib/git/commands/example.rb
+module Git
+  module Commands
+    class Example < Base
+      arguments do
+        literal 'example'
+        flag_option :force
+      end
+    end
+  end
 end
-# Run: bundle exec bin/test test_branch → passes
+# Run: bundle exec rspec spec/unit/git/commands/example_spec.rb → passes
 ```
 
 **REFACTOR:** Improve code quality without changing behavior, then run all tests.

--- a/.github/skills/pull-request-review/SKILL.md
+++ b/.github/skills/pull-request-review/SKILL.md
@@ -48,9 +48,9 @@ confirms.
 
 Evaluate the PR against these criteria:
 
-**Code Quality:** Ruby style (Rubocop-compliant), `frozen_string_literal: true`, proper naming (snake_case/PascalCase), single-responsibility, no duplication, Ruby 3.2+ idioms.
+**Code Quality:** Ruby style (RuboCop-compliant), `frozen_string_literal: true`, proper naming (snake_case/PascalCase), single-responsibility, no duplication, Ruby 3.2+ idioms.
 
-**Testing:** Changes are covered by atomic RSpec specs (`spec/`), well-named, and passing CI. Legacy Test::Unit tests (`tests/units/`) require justification to modify.
+**Testing:** Changes are covered by atomic RSpec specs (`spec/`), well-named, and passing CI.
 
 **Documentation:** YARD docs on public methods with `@param`, `@return`, `@raise`, `@example`. README updated for user-facing changes. Platform differences and security documented. For `Git::Commands::*` classes, `@raise [Git::FailedError]` must use the canonical generic wording — **never** enumerate failure causes; see the `@raise` wording table in [Command YARD Documentation](../command-yard-documentation/SKILL.md#3-return-and-raise-tags).
 

--- a/.github/skills/test-debugging/SKILL.md
+++ b/.github/skills/test-debugging/SKILL.md
@@ -40,17 +40,14 @@ requests unless the user asks for implementation.
 1. **Run the failing test:**
 
    ```bash
-   # TestUnit (legacy tests in tests/units/)
-   bundle exec bin/test <test_file_name>
-
    # RSpec unit test
    bundle exec rspec spec/unit/git/commands/<command>_spec.rb
 
    # RSpec integration test
    bundle exec rspec spec/integration/git/commands/<command>_spec.rb
 
-   # Specific test method (TestUnit)
-   bundle exec ruby -I lib:tests tests/units/test_base.rb -n test_method_name
+   # Specific example, by line number
+   bundle exec rspec spec/unit/git/commands/<command>_spec.rb:42
    ```
 
 2. **For suspected flaky tests, run multiple times:**
@@ -58,15 +55,15 @@ requests unless the user asks for implementation.
    ```bash
    for i in {1..20}; do
      echo "Run $i"
-     bundle exec bin/test <test_file> || break
+     bundle exec rspec <spec_file> || break
    done
    ```
 
 3. **Check test isolation** — run the test alone vs. within the full suite:
 
    ```bash
-   bundle exec bin/test <test_file>   # alone
-   bundle exec rake default           # full suite
+   bundle exec rspec <spec_file>   # alone
+   bundle exec rake default        # full suite
    ```
 
 ## Step 2: Investigate Root Cause
@@ -129,13 +126,12 @@ Present diagnostic findings to the user:
 
 ```bash
 # Run the specific test
-bundle exec bin/test <test_file>        # TestUnit
-bundle exec rspec <spec_file>           # RSpec
+bundle exec rspec <spec_file>
 
 # For flaky test fixes, run many times
 for i in {1..50}; do
   echo "Run $i"
-  bundle exec bin/test <test_file> || break
+  bundle exec rspec <spec_file> || break
 done
 
 # Run full suite
@@ -144,17 +140,22 @@ bundle exec rake default
 
 ## Project-Specific Considerations
 
-**Test frameworks:** This project uses both TestUnit (legacy tests in `tests/units/`)
-and RSpec (new tests in `spec/`). Run both when verifying changes.
+**Test framework:** This project uses RSpec exclusively (`spec/unit/` and
+`spec/integration/`).
 
-**Test helpers:** Use `clone_working_repo`, `create_temp_repo`, `in_temp_dir` from
-test helpers for TestUnit. Use `include_context` shared contexts for RSpec.
+**Test helpers:** Use the `'in an empty repository'` shared context (and other
+`spec/support/contexts/` shared contexts) plus `Git::IntegrationTestHelpers` methods
+(e.g. `write_file`) for integration specs. Use `let`/`let!` and verifying doubles for
+unit specs — see [RSpec Unit Testing Standards](../rspec-unit-testing-standards/SKILL.md).
 
-**Mocking:** The project uses Mocha for TestUnit mocking and RSpec doubles for RSpec.
-Be careful with stubs — they can mask real issues.
+**Mocking:** The project uses RSpec doubles (`instance_double`, `class_double`) for
+unit specs. Be careful with stubs — they can mask real issues.
 
-**Test data:** Fixtures are in `tests/files/`. Use test helpers to create temporary
-repos. Clean up in teardown.
+**Test data:** Integration specs create temporary repos on the fly (e.g. via
+`Dir.mktmpdir` and the shared contexts above). Static fixture files in
+`spec/support/fixtures/` exist for a small number of specs that need pre-built
+content (e.g. `spec/integration/git/command_line_spec.rb`); prefer dynamic helpers
+for new specs. Clean up any state created outside those helpers.
 
 **CI vs. local differences:** If tests pass locally but fail in CI, use the
 ci-cd-troubleshooting skill.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -862,11 +862,7 @@ process.stdin.on('end', () =>
 - The entire test suite must pass when `bundle exec rake default` is run from the
   project's local working copy.
 
-This project uses two test frameworks:
-
-- **RSpec** (`spec/`) - **Primary framework for all new tests.**
-- **Test::Unit** (`tests/units/`) - **Legacy test suite.** Maintained for existing
-  coverage but should not be extended for new features unless absolutely necessary.
+This project uses **RSpec** (`spec/`) as its sole test framework.
 
 #### RSpec best practices
 
@@ -919,13 +915,7 @@ correctly parses git's branch list format, not that git can create branches.
 While working on specific features, you can run tests using:
 
 ```bash
-# Run all tests (TestUnit + RSpec):
-$ bundle exec rake test_all
-
-# Run only TestUnit integration tests:
-$ bundle exec rake test
-
-# Run only RSpec tests (unit + integration):
+# Run all RSpec tests (unit + integration):
 $ bundle exec rake spec
 
 # Run only RSpec unit tests:
@@ -934,17 +924,11 @@ $ bundle exec rake spec:unit
 # Run only RSpec integration tests:
 $ bundle exec rake spec:integration
 
-# Run a single TestUnit file (from tests/units):
-$ bin/test test_object
-
-# Run multiple TestUnit files:
-$ bin/test test_object test_archive
-
 # Run a specific RSpec file:
 $ bundle exec rspec spec/unit/git/commands/add_spec.rb
 
-# Run TestUnit tests with a different version of the git command line:
-$ GIT_PATH=/Users/james/Downloads/git-2.30.2/bin-wrappers bin/test
+# Run tests with a different version of the git command line:
+$ GIT_PATH=/Users/james/Downloads/git-2.30.2/bin-wrappers bundle exec rake spec
 ```
 
 New and updated public-facing features should be documented in the project's
@@ -1011,7 +995,7 @@ assert_equal(Git::Version.new(2, 30, 2), Git.git_version)
 Tests can be run using the newly built Git version as follows:
 
 ```shell
-GIT_PATH=/Users/james/Downloads/git-2.30.2/bin-wrappers bin/test
+GIT_PATH=/Users/james/Downloads/git-2.30.2/bin-wrappers bundle exec rake spec
 ```
 
 Note: `GIT_PATH` refers to the directory containing the `git` executable.


### PR DESCRIPTION
# Description

Phase 4 Step B (W4b) of the v5.0.0 architectural redesign: with the legacy
Test::Unit suite and tooling removed (W3), this PR removes the remaining
documentation and skill references to Test::Unit, `bin/test`, and
`tests/units/` so the docs accurately describe RSpec as the sole test
framework.

Changes:

- `.github/copilot-instructions.md` — drop the Test::Unit commands table
  rows; restate the "Test suites" section around RSpec.
- `CONTRIBUTING.md` — rewrite the "two test frameworks" section and shell
  examples around RSpec only; replace a `GIT_PATH=... bin/test` example
  with an RSpec equivalent (`GIT_PATH` is still honored by `Git::Config`).
- `.github/skills/ci-cd-troubleshooting/SKILL.md` — replace
  `bundle exec bin/test <name>` with `bundle exec rspec <path>`.
- `.github/skills/development-workflow/SKILL.md` — rewrite the stale
  "Example TDD Cycle" from Test::Unit syntax and the deleted
  `Git::Base`/`Git::Lib` architecture to RSpec syntax and the current
  command-class architecture.
- `.github/skills/test-debugging/SKILL.md` — rewrite all run/verify
  command examples, mocking guidance, and test-data notes around RSpec.
- `.github/skills/pull-request-review/SKILL.md` — drop the note requiring
  justification to modify legacy Test::Unit tests.
- `.github/skills/project-context/SKILL.md` — drop the stale
  `tests/units/` entry from the key-directories list.

Verified via a repo-wide grep (excluding `CHANGELOG.md`, `redesign/`
historical docs, and `.github/skills-deprecated/`) that no live
Test::Unit references remain.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed. (Docs-only change; no test changes needed.)
- [x] Documentation updated where applicable (README and/or YARD).
