### PR TITLE
docs: fix Documentation/OrphanedDocComment offenses

### DIFF
--- a/.github/skills/command-implementation/REFERENCE.md
+++ b/.github/skills/command-implementation/REFERENCE.md
@@ -326,9 +326,14 @@ module Git
       class Bar < Git::Commands::Base  # never name the class Object
         arguments do
           # Group related options with section comments (e.g. # Output, # Safety)
-          # NEVER add trailing inline comments (e.g. `# --verbose`) to DSL entries.
-          # The DSL is self-documenting; inline comments duplicate YARD docs and
-          # were removed project-wide in commit 370dffb.
+          # NEVER add trailing inline comments (e.g. `# --verbose`) to DSL entries;
+          # the DSL is self-documenting and inline comments duplicate the YARD docs.
+          # NEVER put YARD tags (@see, @param, @return, etc.) in comments inside this
+          # block. A DSL call such as `flag_option :x` is not a documentable construct,
+          # so YARD silently drops the whole comment (an orphaned doc comment that
+          # Documentation/OrphanedDocComment flags). Put per-option references in the
+          # matching @option tag (use continuation text for URLs) and command-wide
+          # references in a class-level @see.
         end
 
         # Optional: for commands where non-zero exits are valid

--- a/.github/skills/command-yard-documentation/SKILL.md
+++ b/.github/skills/command-yard-documentation/SKILL.md
@@ -177,6 +177,13 @@ conflicting documentation for the method.
 - Missing `# @!method call(*, **)` directive when there is no `def call` override
   (loses child-specific docs in generated YARD)
 - `@option` docs out of sync with `arguments do`
+- **YARD tags inside the `arguments do` block** — placing a tag (`@see`, `@param`,
+  `@return`, etc.) in a comment above a DSL entry such as `flag_option :x` produces an
+  orphaned doc comment. The DSL call is not a documentable construct, so YARD silently
+  drops the comment and `Documentation/OrphanedDocComment` flags it. Document each
+  option in its `@option` tag (put URLs in continuation text) and use a class-level
+  `@see` for command-wide references. A plain-prose comment (no leading `@tag`) inside
+  the block is fine.
 - **Missing `@raise [ArgumentError]` when `**options` is in the overload signature** —
   every `@overload` that includes `**options` requires
   `@raise [ArgumentError] if unsupported options are provided`. The base `ArgsBuilder`

--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -14,15 +14,6 @@ Documentation/BlankLineBeforeDefinition:
   Exclude:
     - 'lib/git/diff_info.rb'
 
-Documentation/OrphanedDocComment:
-  Exclude:
-    - 'lib/git/commands/cat_file/batch.rb'
-    - 'lib/git/commands/cat_file/filtered.rb'
-    - 'lib/git/commands/cat_file/raw.rb'
-    - 'lib/git/commands/show_ref/exclude_existing.rb'
-    - 'lib/git/commands/show_ref/list.rb'
-    - 'lib/git/commands/show_ref/verify.rb'
-
 Documentation/UndocumentedMethodArguments:
   Exclude:
     - 'lib/git.rb'

--- a/lib/git/commands/cat_file/batch.rb
+++ b/lib/git/commands/cat_file/batch.rb
@@ -47,56 +47,56 @@ module Git
           # Full content mode: header + raw bytes + newline separator per object;
           # accepts a format string to customise the per-object output header
           # (e.g. `"%(objectname) %(objecttype) %(objectsize)"`)
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---batch
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---batch
           flag_or_value_option :batch, inline: true
 
           # Metadata-only mode: one `<sha> <type> <size>` line per object;
           # accepts a format string to customise the per-object output line
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---batch-check
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---batch-check
           flag_or_value_option :batch_check, inline: true
 
           # Command-dispatch mode: stdin carries `contents`/`info`/`flush` verbs;
           # accepts a format string to customise the output of `info` and `contents` commands
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---batch-command
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---batch-command
           flag_or_value_option :batch_command, inline: true
 
           # Enumerate all objects in the repository without reading stdin.
           # Incompatible with `batch_command:`.
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---batch-all-objects
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---batch-all-objects
           flag_option :batch_all_objects
 
           # Use normal stdio buffering; enables explicit `flush` semantics when used
           # with `batch_command:` and improves throughput with `batch_check:`
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---buffer
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---buffer
           flag_option :buffer
 
           # Follow symlinks inside the repository when traversing tree objects
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---follow-symlinks
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---follow-symlinks
           flag_option :follow_symlinks
 
           # Allow `--batch-all-objects` to output objects in an arbitrary, potentially
           # faster order
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---unordered
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---unordered
           flag_option :unordered
 
           # Apply textconv filters to blob content (combine with `batch_command:`)
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---textconv
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---textconv
           flag_option :textconv
 
           # Apply the full working-tree filter pipeline (combine with `batch_command:`)
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---filters
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---filters
           flag_option :filters
 
           # Map committer/author identities through mailmap for all batch modes
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---use-mailmap
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---use-mailmap
           flag_option :use_mailmap, negatable: true
 
           # Omit objects matching the filter spec from the output (batched modes only)
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---filterltfilter-specgt
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---filterltfilter-specgt
           value_option :filter, inline: true
 
           # Use NUL-delimited input/output instead of newline-delimited
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt--Z
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt--Z
           flag_option :Z
 
           # Stream stdout to this IO object instead of buffering in memory.

--- a/lib/git/commands/cat_file/filtered.rb
+++ b/lib/git/commands/cat_file/filtered.rb
@@ -37,16 +37,16 @@ module Git
           literal 'cat-file'
 
           # Apply only the textconv filter (binary-to-text conversion)
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---textconv
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---textconv
           flag_option :textconv
 
           # Apply the full working-tree filter pipeline (smudge, EOL, textconv)
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---filters
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---filters
           flag_option :filters
 
           # Specify the path separately when the rev is passed as a bare revision.
           # When used, the `rev` operand must be a plain revision (not `<rev>:<path>`).
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---pathltpathgt
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---pathltpathgt
           value_option :path, inline: true
 
           end_of_options

--- a/lib/git/commands/cat_file/raw.rb
+++ b/lib/git/commands/cat_file/raw.rb
@@ -34,28 +34,28 @@ module Git
           literal 'cat-file'
 
           # Exit 0 if object exists and is valid; exit 1 otherwise (no output)
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt--e
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt--e
           flag_option :e
 
           # Pretty-print the object content based on its type
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt--p
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt--p
           flag_option :p
 
           # Print the object type (`blob`, `tree`, `commit`, or `tag`)
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt--t
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt--t
           flag_option :t
 
           # Print the object size in bytes
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt--s
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt--s
           flag_option :s
 
           # Allow -t and -s to query broken or corrupt objects of unknown type;
           # rejected by git in any other mode — enforced by constraint below
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---allow-unknown-type
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---allow-unknown-type
           flag_option :allow_unknown_type
 
           # Map committer/author identities through the mailmap before reporting size
-          # @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---use-mailmap
+          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---use-mailmap
           flag_option :use_mailmap, negatable: true
 
           # Stream stdout to this IO object instead of buffering in memory.

--- a/lib/git/commands/show_ref/exclude_existing.rb
+++ b/lib/git/commands/show_ref/exclude_existing.rb
@@ -44,7 +44,7 @@ module Git
 
           # Mode selector: pass `true` (default) to test all refs, or a pattern
           # string to restrict testing to refs whose names start with the pattern.
-          # @see https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---exclude-existingltpatterngt
+          # See https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---exclude-existingltpatterngt
           flag_or_value_option :exclude_existing, inline: true
 
           execution_option :timeout

--- a/lib/git/commands/show_ref/list.rb
+++ b/lib/git/commands/show_ref/list.rb
@@ -49,34 +49,34 @@ module Git
           literal 'show-ref'
 
           # Include the HEAD ref even if it would normally be filtered out
-          # @see https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---head
+          # See https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---head
           flag_option :head
 
           # Dereference annotated tags; outputs an additional line per tag with
           # the de-referenced object SHA followed by `^{}`
-          # @see https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---dereference
+          # See https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---dereference
           flag_option %i[dereference d]
 
           # Show only the SHA part of the ref, optionally abbreviated to <n> hex digits;
           # pass `true` for full-length SHA, or an integer for the abbreviation length
-          # @see https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---hashn
+          # See https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---hashn
           flag_or_value_option %i[hash s], inline: true
 
           # Abbreviate the object names to at least <n> hex digits; pass `true` to
           # use the default abbreviation length, or an integer for an explicit length
-          # @see https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---abbrevlength
+          # See https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---abbrevlength
           flag_or_value_option :abbrev, inline: true
 
           # Limit to refs under refs/heads/ only (preferred over :heads on git >= 2.46)
-          # @see https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---branches
+          # See https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---branches
           flag_option :branches
 
           # Limit to refs under refs/heads/ only (deprecated synonym for :branches in git >= 2.46)
-          # @see https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---branches
+          # See https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---branches
           flag_option :heads
 
           # Limit to refs under refs/tags/ only
-          # @see https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---tags
+          # See https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---tags
           flag_option :tags
 
           execution_option :timeout

--- a/lib/git/commands/show_ref/verify.rb
+++ b/lib/git/commands/show_ref/verify.rb
@@ -49,19 +49,19 @@ module Git
           literal '--verify'
 
           # Suppress output; useful when you only care whether the ref exists
-          # @see https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---quiet
+          # See https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---quiet
           flag_option %i[quiet q]
 
           # Dereference annotated tags; emit an extra line per tag with SHA^{}
-          # @see https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---dereference
+          # See https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---dereference
           flag_option %i[dereference d]
 
           # Show only the SHA; pass `true` for full-length or an integer for abbreviated length
-          # @see https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---hashn
+          # See https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---hashn
           flag_or_value_option %i[hash s], inline: true
 
           # Abbreviate object names; pass `true` for default or integer for explicit length
-          # @see https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---abbrevlength
+          # See https://git-scm.com/docs/git-show-ref#Documentation/git-show-ref.txt---abbrevlength
           flag_or_value_option :abbrev, inline: true
 
           execution_option :timeout


### PR DESCRIPTION
# Description

Fixes all `Documentation/OrphanedDocComment` offenses that were baselined in
`.yard-lint-todo.yml`, continuing the incremental cleanup of the yard-lint
todo file.

## What was wrong

The `cat-file` and `show-ref` command classes document each option inside their
`arguments do ... end` blocks with an inline comment that ended in a `@see`
tag pointing at the relevant git documentation anchor, for example:

```ruby
# Use normal stdio buffering; enables explicit `flush` semantics when used
# with `batch_command:` and improves throughput with `batch_check:`
# @see https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---buffer
flag_option :buffer
```

YARD **silently drops** these comments: a DSL option call such as
`flag_option :buffer` is not a documentable construct, and the comment block
carries no implicit-docstring tag (`@method`, `@attribute`, `@overload`, …),
so the `@see` tags never reach the YARD registry. The
`Documentation/OrphanedDocComment` validator flags exactly this situation —
YARD tags in a comment that will be ignored.

## The fix

Convert each orphaned inline `@see <url>` into a plain-text `See <url>`
reference. This keeps the useful per-option documentation links for anyone
reading the source while removing the YARD tags that were being discarded.

Class-level `@see` tags (which attach correctly to the command class and are
rendered by YARD) are intentionally left unchanged.

33 inline tags were converted across 6 files:

| File | Converted |
| --- | --- |
| `lib/git/commands/cat_file/batch.rb` | 12 |
| `lib/git/commands/cat_file/filtered.rb` | 3 |
| `lib/git/commands/cat_file/raw.rb` | 6 |
| `lib/git/commands/show_ref/exclude_existing.rb` | 1 |
| `lib/git/commands/show_ref/list.rb` | 7 |
| `lib/git/commands/show_ref/verify.rb` | 4 |

The now-resolved `Documentation/OrphanedDocComment` section is removed from
`.yard-lint-todo.yml`.

## Preventing recurrence

A second commit updates the command-building skills so this class of offense is
not reintroduced:

- `command-implementation/REFERENCE.md` — the `arguments do` scaffold note now
  warns that YARD tags (`@see`, `@param`, `@return`, …) placed in *any* comment
  inside the block become orphaned doc comments (YARD drops them; the validator
  flags them), and points authors to the `@option` tag / class-level `@see`.
- `command-yard-documentation/SKILL.md` — adds a matching **Common issues**
  entry for reviewers.

## Verification

- `bundle exec yard-lint lib/` → **No offenses found**
- `bundle exec rake default` → passes (tests, RuboCop, YARD, build) with no
  warnings

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed. (No behavior change — documentation-only.)
- [x] Documentation updated where applicable (README and/or YARD).
