### PR TITLE
docs: align skill tag-order examples with Tags/Order config

### DIFF
--- a/.github/skills/command-implementation/REFERENCE.md
+++ b/.github/skills/command-implementation/REFERENCE.md
@@ -156,11 +156,11 @@ the pattern of `cat_file.rb`. The file has three required sections in this order
 4. A "This module contains command classes split by…" paragraph with a bullet for
    every sub-command class using `{Foo::Bar}` YARD links followed by ` — ` and a
    short description
-5. `@api private`
-6. `@see https://git-scm.com/docs/git-foo git-foo documentation`
-7. At least two `@example` blocks — one per sub-command class; each example should
+5. At least two `@example` blocks — one per sub-command class; each example should
    demonstrate the most common (non-error-path) call using a local variable named
    `cmd` and `lib` as the constructor argument
+6. `@see https://git-scm.com/docs/git-foo git-foo documentation`
+7. `@api private`
 8. Empty `module Foo` + `end` block (no methods, no constants)
 
 **Tag ordering inside the YARD comment block:**
@@ -173,10 +173,6 @@ the pattern of `cat_file.rb`. The file has three required sections in this order
 # - {Foo::Bar} — short description
 # - {Foo::Baz} — short description
 #
-# @api private
-#
-# @see https://git-scm.com/docs/git-foo git-foo documentation
-#
 # @example <Short description of the Bar use case>
 #   cmd = Git::Commands::Foo::Bar.new(lib)
 #   cmd.call(...)
@@ -184,6 +180,10 @@ the pattern of `cat_file.rb`. The file has three required sections in this order
 # @example <Short description of the Baz use case>
 #   cmd = Git::Commands::Foo::Baz.new(lib)
 #   cmd.call(...)
+#
+# @see https://git-scm.com/docs/git-foo git-foo documentation
+#
+# @api private
 ```
 
 **Full template:**
@@ -203,10 +203,6 @@ module Git
     # - {Foo::Bar} — what Bar does
     # - {Foo::Baz} — what Baz does
     #
-    # @api private
-    #
-    # @see https://git-scm.com/docs/git-foo git-foo documentation
-    #
     # @example <Short description for bar>
     #   cmd = Git::Commands::Foo::Bar.new(lib)
     #   cmd.call(...)
@@ -214,6 +210,10 @@ module Git
     # @example <Short description for baz>
     #   cmd = Git::Commands::Foo::Baz.new(lib)
     #   cmd.call(...)
+    #
+    # @see https://git-scm.com/docs/git-foo git-foo documentation
+    #
+    # @api private
     #
     module Foo
     end
@@ -233,7 +233,7 @@ module's overview.
 - [ ] `@see` link points to `git-scm.com/docs/git-foo` documentation
 - [ ] At least one `@example` block per sub-command class
 - [ ] Each example uses `cmd = Git::Commands::Foo::Bar.new(lib)` form (variable `cmd`, arg `lib`)
-- [ ] Tag order: summary → bullet list → `@api private` → `@see` → `@examples`
+- [ ] Tag order: summary → bullet list → `@example` blocks → `@see` → `@api private`
 - [ ] No class is defined inside the module file; the `module Foo` block is empty
 
 ## Architecture contract

--- a/.github/skills/yard-documentation/SKILL.md
+++ b/.github/skills/yard-documentation/SKILL.md
@@ -555,11 +555,19 @@ signature (see [Documenting anonymous splats with `@overload`](#documenting-anon
 ### Standard template (no `@overload`)
 
 When present, tags must appear in the order shown. `@param` tags appear in
-parameter order; `@option` tags appear immediately after the `@param` for the hash
-they describe. Every `@option` tag **must** be preceded by a `@param` for the
-options hash, and all `@option` tags under that `@param` must reference the same
-parameter name. For keyword arguments (`**options` or `**kwargs`), use
-`@param options [Hash]` (or the actual splat name) as the preceding `@param`:
+parameter order, with one exception described below; `@option` tags appear
+immediately after the `@param` for the hash they describe. Every `@option` tag
+**must** be preceded by a `@param` for the options hash, and all `@option` tags
+under that `@param` must reference the same parameter name. For keyword arguments
+(`**options` or `**kwargs`), use `@param options [Hash]` (or the actual splat
+name) as the preceding `@param`.
+
+The exception to parameter order: all `@param` tags must come before the first
+`@option` tag, because yard-lint's `Tags/Order` validator rejects a `@param` that
+follows an `@option`. When a positional parameter follows the options hash in the
+signature, document the options-hash `@param` (and its `@option` tags) last so the
+`@option` tags stay grouped at the end — that is, move the options-hash `@param`
+after the later positional `@param` rather than in strict signature order:
 
 ```ruby
 # Short description of what the method does
@@ -576,11 +584,11 @@ parameter name. For keyword arguments (`**options` or `**kwargs`), use
 #
 # @param name [Type] description of parameter
 #
+# @param path [String] a parameter that follows the options hash in the signature
+#
 # @param options [Hash] options hash description
 #
 # @option options [Type] :key description of option
-#
-# @param path [String] a parameter after the options hash
 #
 # @return [Type] description of return value
 #


### PR DESCRIPTION
## Summary

Two Agent Skill templates taught a YARD tag order that the project's own
`.yard-lint.yml` `Tags/Order` validator rejects. This PR realigns those
templates (and the related checklist/prose) with the configured order so the
skills stop teaching an order that yard-lint flags as an offense.

This is a **skills-only, documentation change** — no library or spec code is
touched.

## Why

The project's `.yard-lint.yml` sets an example-first / api-last `EnforcedOrder`:

```
example, param, option, return, raise, yield, yieldparam, yieldreturn,
note, deprecated, see, api
```

Two skill templates disagreed with that config:

1. **`command-implementation/REFERENCE.md`** — the *namespace-module* template
   (the `module Foo` scaffold, e.g. `cat_file.rb`) placed `@api private` and
   `@see` **before** the `@example` blocks (api-first). The configured order is
   example-first with `@api` last. This appeared in four spots: the
   required-elements list, the "Tag ordering" illustration, the full template,
   and the checklist prose.

2. **`yard-documentation/SKILL.md`** — the standard method template placed a
   `@param` **after** an `@option`. The `Tags/Order` validator requires every
   `@param` to precede the first `@option` (all options group at the end of the
   parameter list).

Both were confirmed as real `Tags/Order` violations against the project config
using an isolated yard-lint fixture.

## Changes

- **`command-implementation/REFERENCE.md`** — reorder the namespace-module
  template to example-first / api-last (example → see → api) in all four spots.
  The command-class scaffold elsewhere in the file was already correct and is
  left unchanged.
- **`yard-documentation/SKILL.md`** — reorder the standard template so all
  `@param` tags precede the first `@option`, and add prose explaining that
  `Tags/Order` rejects a `@param` following an `@option` (document a parameter
  that follows the options hash in the signature *before* the options-hash
  `@param`).

## Scope note

This PR only fixes the **skill templates**. The separate source-file
`Tags/Order` cleanup (reordering tags in `lib/` and removing the `Tags/Order`
section from `.yard-lint-todo.yml`) is a larger future task and is intentionally
not included here.

## Checklist

- [x] Docs-only change; `bundle exec rake default` passes (exit 0)
- [x] Changes on a feature branch targeting `main`
- [x] Conventional Commits format
- [x] No library or spec code changed
