### PR TITLE
chore: remove commitlint.test

### DIFF
--- a/commitlint.test
+++ b/commitlint.test
@@ -1,4 +1,0 @@
-test: update the tests
-
-Wow I really want to edit the PR #1024 but I can't.
-


### PR DESCRIPTION
## Summary

Removes the `commitlint.test` file from the repository root. This file appears to be a test artifact for commitlint configuration and does not belong in the repository.