### PR TITLE
docs: add YARD docs to Git::Author and remove from yard-lint exclusions

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -12,7 +12,6 @@
 # Documentation validators
 Documentation/UndocumentedMethodArguments:
   Exclude:
-    - 'lib/git/author.rb'
     - 'lib/git/command_line/capturing.rb'
     - 'lib/git/command_line/streaming.rb'
     - 'lib/git/commands/arguments.rb'
@@ -38,7 +37,6 @@ Documentation/UndocumentedMethodArguments:
 
 Documentation/UndocumentedObjects:
   Exclude:
-    - 'lib/git/author.rb'
     - 'lib/git/commands/arguments.rb'
     - 'lib/git/commands/base.rb'
     - 'lib/git/commands/cat_file/batch.rb'

--- a/lib/git/author.rb
+++ b/lib/git/author.rb
@@ -2,9 +2,26 @@
 
 module Git
   # An author in a Git commit
+  #
   class Author
-    attr_accessor :name, :email, :date
+    # @return [String, nil] the author's name
+    attr_accessor :name
 
+    # @return [String, nil] the author's email
+    attr_accessor :email
+
+    # @return [Time, nil] the date the change was authored (author date, not committer date)
+    attr_accessor :date
+
+    # Initializes a new Author object from a string
+    #
+    # @example
+    #   Git::Author.new("John Doe <john.doe@example.com> 1627849923 +0200")
+    #
+    # @param author_string [String] the author string
+    #
+    # @return [void]
+    #
     def initialize(author_string)
       return unless (m = /(.*?) <(.*?)> (\d+) (.*)/.match(author_string))
 


### PR DESCRIPTION
## Summary

Improves YARD documentation for `Git::Author` and removes the file from yard-lint exclusion lists.

### Changes

- Split the single `attr_accessor :name, :email, :date` into three individual accessors, each with a `@return` tag
- Clarified `date` as the **author date** (when the patch was written), not the committer date — these differ on rebased/cherry-picked/amended commits
- Added `@example`, `@param`, and `@return` to `#initialize`
- Removed `lib/git/author.rb` from `Documentation/UndocumentedMethodArguments` and `Documentation/UndocumentedObjects` exclusion lists in `.yard-lint-todo.yml`