### PR TITLE
docs: add YARD docs to CommandLine::Capturing and Streaming private methods

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -12,8 +12,6 @@
 # Documentation validators
 Documentation/UndocumentedMethodArguments:
   Exclude:
-    - 'lib/git/command_line/capturing.rb'
-    - 'lib/git/command_line/streaming.rb'
     - 'lib/git/commands/arguments.rb'
     - 'lib/git/commands/base.rb'
     - 'lib/git/commands/cat_file/batch.rb'
@@ -60,8 +58,6 @@ Documentation/UndocumentedObjects:
 Documentation/UndocumentedOptions:
   Exclude:
     - 'lib/git/branch.rb'
-    - 'lib/git/command_line/capturing.rb'
-    - 'lib/git/command_line/streaming.rb'
     - 'lib/git/commands/add.rb'
     - 'lib/git/commands/am/abort.rb'
     - 'lib/git/commands/am/apply.rb'
@@ -207,8 +203,6 @@ Documentation/UndocumentedOptions:
 Tags/OptionTags:
   Exclude:
     - 'lib/git/branch.rb'
-    - 'lib/git/command_line/capturing.rb'
-    - 'lib/git/command_line/streaming.rb'
     - 'lib/git/commands/arguments.rb'
     - 'lib/git/configuring.rb'
     - 'lib/git/object.rb'

--- a/lib/git/command_line/capturing.rb
+++ b/lib/git/command_line/capturing.rb
@@ -164,12 +164,36 @@ module Git
 
       private
 
+      # Execute the git command with the given arguments and options, capturing the output
+      #
+      # @param args [Array<String>] the git command arguments
+      #
+      # @param options_hash [Hash] the merged run options forwarded from {#run}
+      #
+      #   Only the keys consumed by this method are listed below; remaining keys
+      #   from {RUN_OPTION_DEFAULTS} (`:normalize`, `:chomp`, `:raise_on_failure`)
+      #   are present in the hash but are not used here.
+      #
+      # @option options_hash [IO, nil] :in stdin IO object for the subprocess
+      #
+      # @option options_hash [#write, nil] :out stdout redirect target
+      #
+      # @option options_hash [#write, nil] :err stderr redirect target
+      #
+      # @option options_hash [String, nil] :chdir working directory for the subprocess
+      #
+      # @option options_hash [Numeric, nil] :timeout execution timeout in seconds
+      #
+      # @option options_hash [Boolean] :merge (false) merge stdout into stderr
+      #
+      # @option options_hash [Hash] :env ({}) environment variable overrides
+      #
       # @return [ProcessExecuter::ResultWithCapture] the process result with captured output
       #
       # @api private
       def execute(*args, **options_hash)
         git_cmd = build_git_cmd(args)
-        options = execute_options(**options_hash)
+        options = execution_options(**options_hash)
         run_process_executer do
           ProcessExecuter.run_with_capture(merged_env(options_hash), *git_cmd, **options)
         end
@@ -177,10 +201,24 @@ module Git
 
       # Build the ProcessExecuter options hash for a capturing run
       #
+      # @param options_hash [Hash] the merged run options forwarded from {#run}
+      #
+      # @option options_hash [IO, nil] :in stdin IO object for the subprocess
+      #
+      # @option options_hash [#write, nil] :out stdout redirect target
+      #
+      # @option options_hash [#write, nil] :err stderr redirect target
+      #
+      # @option options_hash [String, nil] :chdir working directory for the subprocess
+      #
+      # @option options_hash [Numeric, nil] :timeout execution timeout in seconds
+      #
+      # @option options_hash [Boolean] :merge (false) merge stdout into stderr
+      #
       # @return [Hash]
       #
       # @api private
-      def execute_options(**options_hash)
+      def execution_options(**options_hash)
         chdir = options_hash[:chdir] || :not_set
         timeout_after = options_hash[:timeout]
         merge_output = options_hash[:merge] || false
@@ -190,14 +228,22 @@ module Git
         end
       end
 
-      # Extract non-nil redirect options (`:in`, `:out`, `:err`) from options_hash
+      # Extract non-nil redirect options (`:in`, `:out`, `:err`) from `options`
       #
-      # @return [Hash]
+      # @param options [Hash] the options hash containing potential redirect options
+      #
+      # @option options [IO, nil] :in the input IO stream
+      #
+      # @option options [#write, nil] :out the output IO stream
+      #
+      # @option options [#write, nil] :err the error IO stream
+      #
+      # @return [Hash] the non-nil redirect options
       #
       # @api private
-      def redirect_options(options_hash)
+      def redirect_options(options)
         %i[in out err].filter_map do |key|
-          val = options_hash[key]
+          val = options[key]
           [key, val] unless val.nil?
         end.to_h
       end
@@ -207,7 +253,15 @@ module Git
       #
       # @param result [ProcessExecuter::ResultWithCapture] the raw result
       #
-      # @param options [Hash] the merged run options
+      # @param options [Hash] the merged run options forwarded from {#run}
+      #
+      # @option options [Boolean] :normalize (false) normalize encoding of captured output
+      #
+      # @option options [Boolean] :chomp (false) chomp trailing newlines from captured output
+      #
+      # @option options [Numeric, nil] :timeout execution timeout used to construct the result
+      #
+      # @option options [Boolean] :raise_on_failure (true) raise {Git::FailedError} on non-zero exit
       #
       # @return [Git::CommandLineResult]
       #

--- a/lib/git/command_line/streaming.rb
+++ b/lib/git/command_line/streaming.rb
@@ -122,6 +122,28 @@ module Git
 
       private
 
+      # Execute the git command in streaming mode
+      #
+      # @param args [Array<String>] the git command arguments
+      #
+      # @param err_io [StringIO, #write] the internal stderr destination
+      #
+      # @param options_hash [Hash] the merged run options forwarded from {#run}
+      #
+      #   Only the keys consumed by this method are listed below; `:err` and
+      #   `:raise_on_failure` are present in the hash but not used here (`:err`
+      #   is handled via the separate `err_io:` argument).
+      #
+      # @option options_hash [IO, nil] :in stdin IO object for the subprocess
+      #
+      # @option options_hash [#write, nil] :out stdout streaming destination
+      #
+      # @option options_hash [String, nil] :chdir working directory for the subprocess
+      #
+      # @option options_hash [Numeric, nil] :timeout execution timeout in seconds
+      #
+      # @option options_hash [Hash] :env ({}) environment variable overrides
+      #
       # @return [ProcessExecuter::Result] the result of running the command (non-capturing)
       #
       # @api private
@@ -134,6 +156,18 @@ module Git
       end
 
       # Build the ProcessExecuter options hash for a streaming run
+      #
+      # @param err_io [StringIO, #write] the stderr destination (internal buffer or tee)
+      #
+      # @param options_hash [Hash] the merged run options forwarded from {#run}
+      #
+      # @option options_hash [IO, nil] :in stdin IO object for the subprocess
+      #
+      # @option options_hash [#write, nil] :out stdout streaming destination
+      #
+      # @option options_hash [String, nil] :chdir working directory for the subprocess
+      #
+      # @option options_hash [Numeric, nil] :timeout execution timeout in seconds
       #
       # @return [Hash]
       #
@@ -178,7 +212,11 @@ module Git
       #
       # @param err_io [StringIO] the internal StringIO that captured stderr
       #
-      # @param options [Hash] the merged run options
+      # @param options [Hash] the merged run options forwarded from {#run}
+      #
+      # @option options [Numeric, nil] :timeout execution timeout used to construct the result
+      #
+      # @option options [Boolean] :raise_on_failure (true) raise {Git::FailedError} on non-zero exit
       #
       # @return [Git::CommandLineResult]
       #


### PR DESCRIPTION
## Summary

Adds missing YARD documentation to private methods in `Git::CommandLine::Capturing` and `Git::CommandLine::Streaming`, and removes both files from the yard-lint exclusion lists.

### Changes

**`lib/git/command_line/capturing.rb`**
- `execute`: added `@param args`, `@param options_hash`, and `@option` tags for all consumed keys (`:in`, `:out`, `:err`, `:chdir`, `:timeout`, `:merge`, `:env`)
- `execution_options` (renamed from `execute_options` for clarity): added `@param options_hash` and `@option` tags
- `process_result`: added `@option` tags for the keys it reads (`:normalize`, `:chomp`, `:timeout`, `:raise_on_failure`)

**`lib/git/command_line/streaming.rb`**
- `execute`: added `@param args`, `@param err_io`, `@param options_hash`, and `@option` tags
- `execute_options`: added `@param err_io`, `@param options_hash`, and `@option` tags
- `process_result`: added `@option` tags for `:timeout` and `:raise_on_failure`

**`.yard-lint-todo.yml`**
- Removed `lib/git/command_line/capturing.rb` and `lib/git/command_line/streaming.rb` from `Documentation/UndocumentedMethodArguments`, `Documentation/UndocumentedOptions`, and `Tags/OptionTags` exclusion lists