### PR TITLE
Document branch archive options

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -55,7 +55,6 @@ Documentation/UndocumentedObjects:
 
 Documentation/UndocumentedOptions:
   Exclude:
-    - 'lib/git/branch.rb'
     - 'lib/git/commands/add.rb'
     - 'lib/git/commands/am/abort.rb'
     - 'lib/git/commands/am/apply.rb'
@@ -199,7 +198,6 @@ Documentation/UndocumentedOptions:
 # Tags validators
 Tags/OptionTags:
   Exclude:
-    - 'lib/git/branch.rb'
     - 'lib/git/configuring.rb'
     - 'lib/git/object.rb'
     - 'lib/git/remote.rb'

--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -139,7 +139,7 @@ module Git
     # Archives this branch and writes the result to a file
     #
     # @example Archive to a tar file
-    #   git.branch('main').archive('/tmp/main.tar')
+    #   git.branch('main').archive('/tmp/main.tar', format: 'tar')
     #
     # @example Archive to a zip file
     #   git.branch('main').archive('/tmp/main.zip', format: 'zip')
@@ -150,6 +150,21 @@ module Git
     # @param file [String] path to the destination archive file
     #
     # @param opts [Hash] archive options (see {Git::Repository#archive})
+    #
+    # @option opts [String] :format ('zip') archive format for this wrapper:
+    #   `'tar'`, `'zip'`, or `'tgz'`
+    #
+    # @option opts [String] :prefix (nil) prefix prepended to every filename
+    #   in the archive
+    #
+    # @option opts [String] :path (nil) path within the tree to include in the
+    #   archive
+    #
+    # @option opts [String] :remote (nil) retrieve the archive from a remote
+    #   repository
+    #
+    # @option opts [Boolean, nil] :add_gzip (nil) apply gzip compression after
+    #   writing the archive; set automatically when `format: 'tgz'` is given
     #
     # @return [String] the path to the written archive file
     #


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Documents the `Git::Branch#archive` option hash and removes `lib/git/branch.rb` from the YARD lint todo baseline now that `rake yard:lint` passes for the file.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).