### PR TITLE
docs: document arbitrary option key convention

### DIFF
--- a/.github/skills/yard-documentation/SKILL.md
+++ b/.github/skills/yard-documentation/SKILL.md
@@ -562,6 +562,26 @@ under that `@param` must reference the same parameter name. For keyword argument
 (`**options` or `**kwargs`), use `@param options [Hash]` (or the actual splat
 name) as the preceding `@param`.
 
+For public APIs with known option keys, every `@option` tag must document a real
+supported key, such as `:force` or `:timeout`. Do not invent placeholder option
+keys for a public `options` hash.
+
+For private helpers whose `options` hash accepts arbitrary key-value pairs, use
+`key_name` as the placeholder option key. The description may be generic, or more
+specific when the helper's purpose is clear:
+
+```ruby
+# @param options [Hash<Symbol, Object>] arbitrary key-value pairs
+#
+# @option options [Object] key_name an arbitrary key-value pair
+```
+
+```ruby
+# @param options [Hash<Symbol, Object>] arbitrary key-value pairs to validate
+#
+# @option options [Object] key_name an arbitrary key-value pair to validate
+```
+
 The exception to parameter order: all `@param` tags must come before the first
 `@option` tag, because yard-lint's `Tags/Order` validator rejects a `@param` that
 follows an `@option`. When a positional parameter follows the options hash in the
@@ -677,6 +697,7 @@ Use this matrix to decide whether to use `@overload` and where to place tags:
 | --- | --- |
 | Single named signature, no `*`/`**`/`...` | Standard template (no `@overload`) |
 | Uses anonymous `*`, `**`, or `...` | `@overload` required |
+| Private helper accepts arbitrary option keys | `@option options [Object] key_name ...` |
 | Multiple call shapes (different params and/or return types) | One `@overload` per shape |
 | Shared errors across all call shapes | Top-level `@raise` once |
 | Error only for specific call shape | `@raise` only in that overload |

--- a/.github/skills/yard-documentation/SKILL.md
+++ b/.github/skills/yard-documentation/SKILL.md
@@ -146,6 +146,28 @@ metadata (tag name, `[Type]`, option key, and `(default)`). For example, in:
 
 the summary text is `ignore case distinctions`.
 
+**Documenting option hashes**
+
+For public APIs with known option keys, every `@option` tag must document a real
+supported key, such as `:force` or `:timeout`. Do not invent placeholder option
+keys for a public `options` hash.
+
+For private helpers whose `options` hash accepts arbitrary key-value pairs, use
+`key_name` as the placeholder option key. The description may be generic, or more
+specific when the helper's purpose is clear:
+
+```ruby
+# @param options [Hash<Symbol, Object>] arbitrary key-value pairs
+#
+# @option options [Object] key_name an arbitrary key-value pair
+```
+
+```ruby
+# @param options [Hash<Symbol, Object>] arbitrary key-value pairs to validate
+#
+# @option options [Object] key_name an arbitrary key-value pair to validate
+```
+
 **Tag line and summary length**
 
 Every physical YARD doc line should not exceed `LINE_LIMIT`. When a tag's
@@ -562,26 +584,6 @@ under that `@param` must reference the same parameter name. For keyword argument
 (`**options` or `**kwargs`), use `@param options [Hash]` (or the actual splat
 name) as the preceding `@param`.
 
-For public APIs with known option keys, every `@option` tag must document a real
-supported key, such as `:force` or `:timeout`. Do not invent placeholder option
-keys for a public `options` hash.
-
-For private helpers whose `options` hash accepts arbitrary key-value pairs, use
-`key_name` as the placeholder option key. The description may be generic, or more
-specific when the helper's purpose is clear:
-
-```ruby
-# @param options [Hash<Symbol, Object>] arbitrary key-value pairs
-#
-# @option options [Object] key_name an arbitrary key-value pair
-```
-
-```ruby
-# @param options [Hash<Symbol, Object>] arbitrary key-value pairs to validate
-#
-# @option options [Object] key_name an arbitrary key-value pair to validate
-```
-
 The exception to parameter order: all `@param` tags must come before the first
 `@option` tag, because yard-lint's `Tags/Order` validator rejects a `@param` that
 follows an `@option`. When a positional parameter follows the options hash in the
@@ -697,7 +699,7 @@ Use this matrix to decide whether to use `@overload` and where to place tags:
 | --- | --- |
 | Single named signature, no `*`/`**`/`...` | Standard template (no `@overload`) |
 | Uses anonymous `*`, `**`, or `...` | `@overload` required |
-| Private helper accepts arbitrary option keys | `@option options [Object] key_name ...` |
+| Private helper accepts arbitrary option keys | Use placeholder `@option options [Object] key_name ...` |
 | Multiple call shapes (different params and/or return types) | One `@overload` per shape |
 | Shared errors across all call shapes | Top-level `@raise` once |
 | Error only for specific call shape | `@raise` only in that overload |


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Documents the YARD convention for private helpers whose `options` hash accepts arbitrary key-value pairs. The new guidance uses `key_name` as the placeholder `@option` key and notes that descriptions can be made more specific when the helper's purpose is clear.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).

## Validation

- `bundle exec yard-lint lib/`
- `bundle exec rake`