### PR TITLE
Restructure YARD documentation skill

### DIFF
--- a/.github/skills/facade-yard-documentation/SKILL.md
+++ b/.github/skills/facade-yard-documentation/SKILL.md
@@ -16,6 +16,7 @@ parser, or execution context that implements the behavior.
 
 ## Contents
 
+- [Contents](#contents)
 - [Related skills](#related-skills)
 - [Input](#input)
 - [Reference](#reference)
@@ -27,7 +28,12 @@ parser, or execution context that implements the behavior.
   - [Cross-referencing the implementation](#cross-referencing-the-implementation)
   - [Common issues](#common-issues)
 - [Workflow](#workflow)
+  - [1. Module-level docs](#1-module-level-docs)
+  - [2. Method-level docs (per method)](#2-method-level-docs-per-method)
+  - [3. Formatting consistency](#3-formatting-consistency)
 - [Output](#output)
+  - [When writing new facade YARD docs](#when-writing-new-facade-yard-docs)
+  - [When reviewing existing facade YARD docs](#when-reviewing-existing-facade-yard-docs)
 
 ## Related skills
 
@@ -82,7 +88,7 @@ end
 ```
 
 Module-level tags appear in the order required by
-[YARD Documentation — Modules](../yard-documentation/SKILL.md#element-specific-rules):
+[YARD element rules — Modules](../yard-documentation/element-rules.md#modules):
 `@note`, `@deprecated`, `@see`, `@api`. (Facade modules do not use module-level
 `@example` — see the override note below.)
 
@@ -104,7 +110,7 @@ Do **not** add:
   link is misleading; for single-command modules it is redundant with the
   method-level link.
 - `@example` blocks at the module level — **facade-specific override of
-  [YARD Documentation — Modules](../yard-documentation/SKILL.md#element-specific-rules)**,
+  [YARD element rules — Modules](../yard-documentation/element-rules.md#modules)**,
   which permits module-level `@example` when a module provides standalone
   methods. Facade modules do provide standalone methods, but every facade
   method already carries its own `@example`, so a module-level example would

--- a/.github/skills/make-skill-template/SKILL.md
+++ b/.github/skills/make-skill-template/SKILL.md
@@ -9,11 +9,19 @@ A meta-skill for creating new Agent Skills. Use this skill when you need to scaf
 
 ## Contents
 
+- [Contents](#contents)
 - [How to use this skill](#how-to-use-this-skill)
 - [Related skills](#related-skills)
 - [When to Use This Skill](#when-to-use-this-skill)
 - [Prerequisites](#prerequisites)
 - [Creating a New Skill](#creating-a-new-skill)
+  - [Step 1: Create the Skill Directory](#step-1-create-the-skill-directory)
+  - [Step 2: Generate SKILL.md with Frontmatter](#step-2-generate-skillmd-with-frontmatter)
+    - [Frontmatter Field Requirements](#frontmatter-field-requirements)
+    - [Description Best Practices](#description-best-practices)
+  - [Step 3: Write the Skill Body](#step-3-write-the-skill-body)
+  - [Step 4: Add Optional Directories (If Needed)](#step-4-add-optional-directories-if-needed)
+- [Skill Body Organization](#skill-body-organization)
 - [Example: Complete Skill Structure](#example-complete-skill-structure)
 - [Quick Start: Duplicate This Template](#quick-start-duplicate-this-template)
 - [Validation Checklist](#validation-checklist)
@@ -54,7 +62,7 @@ check discoverability quality before committing.
 
 Create a new folder with a lowercase, hyphenated name:
 
-```
+```text
 .github/skills/<skill-name>/
 └── SKILL.md          # Required
 ```
@@ -114,6 +122,17 @@ After the frontmatter, add markdown instructions. Recommended sections:
 | `## Troubleshooting` | Common issues and solutions |
 | `## References` | Links to bundled docs |
 
+For standards and review skills, rules are mandatory unless explicitly marked
+`Optional`. For advisory skills, distinguish requirements, recommendations, and
+examples with consistent labels.
+
+Define named thresholds, modes, phases, or terms before first use, and keep one
+authoritative definition for each concept.
+
+Use real markdown headings for durable rule sections. Avoid bold paragraphs as
+pseudo-headings when the section may need a table-of-contents entry, deep link,
+or review reference.
+
 ### Step 4: Add Optional Directories (If Needed)
 
 | Folder | Purpose | When to Use |
@@ -123,9 +142,35 @@ After the frontmatter, add markdown instructions. Recommended sections:
 | `assets/` | Static files used AS-IS | Images, fonts, templates |
 | `templates/` | Starter code agent modifies | Scaffolds to extend |
 
+## Skill Body Organization
+
+Target `SKILL.md` under 500 lines; review carefully above 600 lines. Exceeding
+the target is acceptable when splitting always-needed workflow or review rules
+would make the skill less effective. Split situational references first.
+
+Keep these in `SKILL.md`:
+
+- Routing, prerequisites, and precedence rules
+- The main workflow and required feedback loops
+- Mandatory validation or review checklists
+- Rules needed on nearly every invocation
+
+Move these to reference files:
+
+- Element-specific, type-specific, or platform-specific rules
+- Long examples and templates
+- Rare edge cases and background material
+- Appendices or migration notes
+
+Each reference file should state its purpose and when the agent should load it.
+Keep references one level deep from `SKILL.md`.
+
+When one skill extends another, state what it inherits, overrides, or adds. Link
+to the parent skill or reference file and keep child-skill overrides narrow.
+
 ## Example: Complete Skill Structure
 
-```
+```text
 my-awesome-skill/
 ├── SKILL.md                    # Required instructions
 ├── LICENSE.txt                 # Optional license file
@@ -158,7 +203,12 @@ my-awesome-skill/
 - [ ] `description` is 10-1024 characters
 - [ ] `description` explains WHAT and WHEN
 - [ ] `description` is wrapped in single quotes
-- [ ] Body content is under 500 lines
+- [ ] Body content targets under 500 lines and is reviewed carefully above 600 lines
+- [ ] Always-needed workflow and review rules remain in `SKILL.md`
+- [ ] Situational details are split into reference files with clear load conditions
+- [ ] Named thresholds, modes, phases, or terms are defined before first use
+- [ ] Standards/review rules are mandatory unless explicitly marked `Optional`
+- [ ] Deep links, TOC anchors, and referenced files resolve after heading changes
 - [ ] Bundled assets are under 5MB each
 
 ## Troubleshooting

--- a/.github/skills/pr-readiness-review/SKILL.md
+++ b/.github/skills/pr-readiness-review/SKILL.md
@@ -5,12 +5,15 @@ description: "Performs a comprehensive pre-PR readiness review covering tests, c
 
 # PR Readiness Review Workflow
 
-Use this at the end of implementation to prepare for PR submission:
+Use this at the end of implementation to prepare for PR submission. Example
+request:
 
-**"I've completed the implementation. Please perform a comprehensive PR readiness review."**
+> I've completed the implementation. Please perform a comprehensive PR readiness
+> review.
 
 ## Contents
 
+- [Contents](#contents)
 - [How to use this skill](#how-to-use-this-skill)
 - [Prerequisites](#prerequisites)
 - [Related skills](#related-skills)
@@ -50,16 +53,21 @@ Before starting, you **MUST** load the following skill(s) in their entirety:
   unit/integration test conventions for `Git::Repository::*` facade methods
 - [Facade YARD Documentation](../facade-yard-documentation/SKILL.md) — verify
   facade module/method documentation completeness and consistency
+- [Reviewing Skills](../reviewing-skills/SKILL.md) — audit skill quality,
+  discoverability, reference structure, and cross-skill links when skill files
+  change
 
 ## 1. Run Final Validation
 
 Execute and report results for:
+
 - `bundle exec rake default` - all tests and linters must pass
 - Check test output for any Ruby warnings
 
 ## 2. Verify Testing Quality
 
 **Unit Tests (Critical):**
+
 - [ ] **100% coverage of all changed code** - every branch, edge case, error condition
 - [ ] All external dependencies properly mocked (execution_context, git commands)
 - [ ] Each test verifies one specific behavior
@@ -67,6 +75,7 @@ Execute and report results for:
 - [ ] Test only through public interfaces (see RSpec Unit Testing Standards Rule 6)
 
 **Integration Tests (Essential Only):**
+
 - [ ] **Minimal and purposeful** - only test what unit tests cannot verify
 - [ ] Each test validates one specific git interaction pattern
 - [ ] Tests verify mocked assumptions match real git behavior
@@ -74,6 +83,7 @@ Execute and report results for:
 - [ ] Follow CONTRIBUTING.md guidelines: test gem's interaction with git, not git itself
 
 **Command Tests (if any `Git::Commands::*` specs are included):**
+
 - [ ] Apply the [Command Test Conventions](../command-test-conventions/SKILL.md) skill to
   every new or modified unit and integration spec file for command classes. Resolve
   all findings before proceeding.
@@ -123,6 +133,10 @@ Execute and report results for:
 - [ ] README.md updated if public API changed
 - [ ] Examples are clear and demonstrate common use cases
 - [ ] All `@param`, `@return`, `@raise` tags are accurate
+- [ ] **Skill docs (if any `.github/skills/**` files are included):** Apply the
+  [Reviewing Skills](../reviewing-skills/SKILL.md) skill to every new or
+  modified skill. Verify TOC anchors, relative links, cross-skill deep links,
+  referenced files, and any stated inheritance/override relationships.
 
 ## 7. Verify Branch Placement
 
@@ -143,22 +157,26 @@ history), or recommit (uncommitted changes) — based on the situation.
 Provide a comprehensive report with:
 
 **Implementation Summary:**
+
 - What was implemented and why
 - Key design decisions made
 - Any trade-offs or limitations
 
 **Test Coverage:**
+
 - Unit tests: X examples covering Y scenarios
 - Integration tests: Z examples validating specific git interactions
 - Coverage: 100% of changed lines (or explain gaps)
 - Edge cases tested: [list critical ones]
 
 **Quality Verification:**
+
 - ✅ Items that passed all checks
 - ⚠️ Items that need attention (if any)
 - Reference to relevant documentation verified
 
 **Suggested PR Materials:**
+
 - PR Title: `type: clear description of change`
 - PR Description draft including:
   - Summary of changes
@@ -168,6 +186,7 @@ Provide a comprehensive report with:
   - Checklist from .github/pull_request_template.md
 
 **PR Body Editing Safety:**
+
 - The terminal tool mangles multi-line markdown (backticks, asterisks, newlines) in
   any shell command, including heredocs. Always write the PR body using the
   **`create_file` tool** (the VS Code Copilot agent tool that writes file content
@@ -180,6 +199,7 @@ Provide a comprehensive report with:
 - If the body is garbled, rewrite the file with `create_file` and re-run `gh pr edit`
 
 **Next Steps:**
+
 - Any remaining items to address before PR submission
 - Confirmation that all checklist items are complete
 - Make sure to create a feature branch for the PR -- never push directly to main

--- a/.github/skills/resolve-feedback/SKILL.md
+++ b/.github/skills/resolve-feedback/SKILL.md
@@ -1,0 +1,288 @@
+---
+name: resolve-feedback
+description: 'Resolves unresolved pull request review threads on the current branch, folds each fix into the existing commit that last touched the same file, force-pushes with lease, and requests a fresh Copilot review. Use when addressing PR feedback, resolving review comments or threads, amending fixes into prior commits, or asking Copilot to re-review after changes.'
+---
+
+# Resolve Feedback
+
+Address the unresolved review threads on the pull request for the current
+branch, folding each fix into the existing commit that last touched the affected
+file, then force-push and request another Copilot review.
+
+## Contents
+
+- [Contents](#contents)
+- [How to use this skill](#how-to-use-this-skill)
+- [Related skills](#related-skills)
+- [Prerequisites](#prerequisites)
+- [Terms](#terms)
+- [Safety and stop points](#safety-and-stop-points)
+- [Workflow](#workflow)
+- [Step 1: Identify the PR and branch](#step-1-identify-the-pr-and-branch)
+- [Step 2: Fetch unresolved review threads](#step-2-fetch-unresolved-review-threads)
+- [Step 3: Triage each thread](#step-3-triage-each-thread)
+- [Step 4: Implement the changes](#step-4-implement-the-changes)
+- [Step 5: Fold each change into the matching commit](#step-5-fold-each-change-into-the-matching-commit)
+- [Step 6: Force-push the branch](#step-6-force-push-the-branch)
+- [Step 7: Reply to and resolve threads](#step-7-reply-to-and-resolve-threads)
+- [Step 8: Request another Copilot review](#step-8-request-another-copilot-review)
+- [Troubleshooting](#troubleshooting)
+
+## How to use this skill
+
+Attach this file to your Copilot Chat context and invoke it when a PR has review
+feedback to address on the current branch. Work top to bottom. Stop and ask the
+user whenever a thread needs a clarification or decision (Step 3) and before the
+history-rewriting force-push (Step 6).
+
+## Related skills
+
+- [Pull Request Review](../pull-request-review/SKILL.md) — the review workflow
+  that produces the threads this skill resolves
+- [PR Readiness Review](../pr-readiness-review/SKILL.md) — pre-PR quality gate to
+  run before pushing follow-up changes
+- [Development Workflow](../development-workflow/SKILL.md) — TDD process and
+  branch rules that govern the fixes made here
+
+## Prerequisites
+
+- The `gh` CLI is installed and authenticated (`gh auth status`).
+- The current branch has an open PR and is a topic branch (not `main` or `4.x`).
+- The working tree has no unrelated uncommitted changes before starting.
+
+## Terms
+
+- **Unresolved review thread** — a PR review thread whose `isResolved` is
+  `false` in the GitHub GraphQL API.
+- **Base** — the merge-base between the PR base branch and `HEAD`, computed with
+  `git merge-base origin/<base-branch> HEAD`. All commit lookups are scoped to
+  `<base>..HEAD` so only this branch's commits are considered.
+- **Target commit** — the newest commit in `<base>..HEAD` that last touched the
+  file a fix applies to. Each fix is folded into its target commit.
+
+## Safety and stop points
+
+These rules are mandatory:
+
+- Never rewrite history on `main` or `4.x`. Confirm the branch first with
+  `git branch --show-current`.
+- Stop and ask the user whenever a thread requests a clarification or decision
+  (Step 3). Do not guess on ambiguous feedback.
+- Force-push only with `--force-with-lease`, and only after the user confirms
+  (Step 6).
+- Do not resolve a thread until its fix is committed and pushed (Step 7).
+
+## Workflow
+
+1. [Identify the PR and branch](#step-1-identify-the-pr-and-branch)
+2. [Fetch unresolved review threads](#step-2-fetch-unresolved-review-threads)
+3. [Triage each thread](#step-3-triage-each-thread) — ask for clarifications or
+   decisions as needed
+4. [Implement the changes](#step-4-implement-the-changes)
+5. [Fold each change into the matching commit](#step-5-fold-each-change-into-the-matching-commit)
+6. [Force-push the branch](#step-6-force-push-the-branch)
+7. [Reply to and resolve threads](#step-7-reply-to-and-resolve-threads)
+8. [Request another Copilot review](#step-8-request-another-copilot-review)
+
+## Step 1: Identify the PR and branch
+
+Confirm the branch and locate the PR for it:
+
+```bash
+git branch --show-current
+gh pr view --json number,title,headRefName,baseRefName,url,state
+```
+
+Record the PR number, `baseRefName` (the base branch), and URL. If no PR is
+associated with the branch, stop and tell the user.
+
+## Step 2: Fetch unresolved review threads
+
+List the first 100 review threads and keep the ones where `isResolved` is
+`false`. For unusually active PRs with more than 100 review threads, paginate
+before assuming no unresolved threads remain.
+
+```bash
+OWNER=$(gh repo view --json owner --jq '.owner.login')
+REPO=$(gh repo view --json name --jq '.name')
+PR_NUMBER=$(gh pr view --json number --jq '.number')
+
+gh api graphql -f query='
+  query($owner:String!, $repo:String!, $pr:Int!) {
+    repository(owner:$owner, name:$repo) {
+      pullRequest(number:$pr) {
+        reviewThreads(first:100) {
+          nodes {
+            id
+            isResolved
+            isOutdated
+            path
+            line
+            comments(first:30) {
+              nodes { databaseId author { login } body }
+            }
+          }
+        }
+      }
+    }
+  }' -F owner="$OWNER" -F repo="$REPO" -F pr="$PR_NUMBER" \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)'
+```
+
+For each unresolved thread, note its `id` (thread ID, needed to resolve it), the
+first comment `databaseId` (needed to reply), the `path`, and the `line`.
+
+## Step 3: Triage each thread
+
+For each unresolved thread, classify it and act:
+
+- **Actionable and unambiguous** → plan the concrete code or doc change.
+- **Needs a clarification or decision** → stop and ask the user. Present the
+  thread's file, line, and comment text, and the specific question or the
+  options you see. Wait for the answer before implementing.
+- **Not applicable / disagree** → do not change code; draft a short, respectful
+  reply explaining why (used in Step 7). Ask the user if you are unsure whether
+  to push back.
+
+Do not proceed to Step 4 for a thread until its resolution is clear.
+
+## Step 4: Implement the changes
+
+Apply the agreed changes in the workspace. Keep edits for each thread minimal and
+scoped to what the feedback asks. If the project has tests or linters, run the
+relevant checks before folding changes into commits:
+
+```bash
+bundle exec rake default
+```
+
+Fix any failures before continuing.
+
+## Step 5: Fold each change into the matching commit
+
+Amend each change into its target commit — the existing commit on this branch
+that last touched the file — instead of adding new follow-up commits.
+
+1. Compute the base once:
+
+   ```bash
+   BASE=$(git merge-base origin/<base-branch> HEAD)
+   ```
+
+2. For each changed file, find its target commit (the topmost line is newest):
+
+   ```bash
+   git log --oneline "$BASE"..HEAD -- <path>
+   ```
+
+3. Stage that file and create a fixup commit aimed at its target SHA:
+
+   ```bash
+   git add <path>
+   git commit --fixup=<target-sha>
+   ```
+
+   Repeat for each changed file. When several files share the same target
+   commit, stage them together for one fixup.
+
+4. Autosquash the fixups into their targets non-interactively:
+
+   ```bash
+   GIT_SEQUENCE_EDITOR=: git rebase -i --autosquash "$BASE"
+   ```
+
+5. Verify the result — the fixup commits should be gone and history should be
+   clean:
+
+   ```bash
+   git --no-pager log --oneline "$BASE"..HEAD
+   git status --short --branch
+   ```
+
+If a change does not correspond to any existing commit (e.g. a brand-new file
+requested in review), ask the user whether to fold it into a related commit or
+add a new, conventionally formatted commit.
+
+## Step 6: Force-push the branch
+
+History was rewritten, so the branch must be force-pushed. This is a
+history-rewriting operation — confirm with the user first, then use a lease to
+avoid clobbering unseen remote commits:
+
+```bash
+git push --force-with-lease
+```
+
+If the push is rejected, someone updated the remote branch. Fetch and reconcile
+before retrying; do not use `--force` to override the lease.
+
+## Step 7: Reply to and resolve threads
+
+For each thread that is now addressed:
+
+1. Reply to the thread, referencing what changed. Keep reply bodies shell-safe:
+   use single quotes for simple one-line replies, or assign a quoted heredoc to a
+   variable for arbitrary text. Do not put human-written reply text directly in a
+   double-quoted shell argument; review comments can contain characters such as
+   `!`, `$`, backticks, or quotes that the shell may expand before `gh` runs.
+
+```bash
+COMMENT_DATABASE_ID=COMMENT_DATABASE_ID_FROM_THREAD
+reply_body='Addressed in the latest push: <short summary>.'
+
+gh api \
+  "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_DATABASE_ID/replies" \
+  -f body="$reply_body"
+```
+
+For multi-line replies or text that may contain shell metacharacters, use a
+single-quoted heredoc delimiter:
+
+```bash
+COMMENT_DATABASE_ID=COMMENT_DATABASE_ID_FROM_THREAD
+reply_body=$(cat <<'EOF'
+Addressed in the latest push: the guidance now covers `@!method` declarations.
+EOF
+)
+
+gh api \
+  "repos/$OWNER/$REPO/pulls/$PR_NUMBER/comments/$COMMENT_DATABASE_ID/replies" \
+  -f body="$reply_body"
+```
+
+2. Resolve the thread:
+
+   ```bash
+   gh api graphql -f query='
+     mutation($threadId:ID!) {
+       resolveReviewThread(input:{threadId:$threadId}) {
+         thread { id isResolved }
+       }
+     }' -F threadId=THREAD_ID
+   ```
+
+Only resolve threads whose feedback was actually addressed (or that the user
+agreed to close after a reply). Leave threads open when the user still owes a
+decision.
+
+## Step 8: Request another Copilot review
+
+Request a fresh Copilot review on the PR so it re-reviews the amended commits.
+
+- Preferred: activate the pull request management tools, then request a Copilot
+  review via the GitHub pull request tooling (`request_copilot_review`).
+- Do **not** create a new Copilot PR task for a re-review; that opens separate
+  work instead of re-reviewing this PR.
+
+Finish by reporting to the user: the threads resolved, any threads left open and
+why, the new commit list, and the PR URL.
+
+## Troubleshooting
+
+| Issue | Solution |
+| ----- | -------- |
+| `git log "$BASE"..HEAD -- <path>` is empty | The file is new on this branch; ask the user whether to fold into a related commit or add a new commit. |
+| Rebase stops with conflicts | Resolve the conflict, `git add` the files, then `git rebase --continue`. |
+| Force-push rejected despite `--force-with-lease` | The remote branch moved; run `git fetch`, review the remote changes, reconcile, and retry. |
+| A thread has no obvious file/line (`path` is null) | It is a PR-level comment; reply at the PR level and resolve only if addressed. |
+| Unsure whether to push back on feedback | Stop and ask the user before replying or resolving. |

--- a/.github/skills/reviewing-skills/SKILL.md
+++ b/.github/skills/reviewing-skills/SKILL.md
@@ -10,6 +10,7 @@ adherence to the Anthropic skill-authoring best practices.
 
 ## Contents
 
+- [Contents](#contents)
 - [How to use this skill](#how-to-use-this-skill)
 - [Related skills](#related-skills)
 - [Input](#input)
@@ -76,11 +77,16 @@ skill is selected from potentially hundreds of available skills.
 
 ### 3. Body structure and size
 
-- [ ] SKILL.md body is **under 600 lines** (optimal performance threshold)
-- [ ] If approaching the limit, content is split into separate reference files
+- [ ] SKILL.md body targets **under 500 lines** and is reviewed carefully above
+      600 lines
+- [ ] Exceeding the target is justified when splitting always-needed workflow or
+      review rules would make the skill less effective
+- [ ] If approaching the limit, situational content is split into separate
+      reference files before core workflows or checklists are split
 - [ ] Reference files are at most **one level deep** from SKILL.md (no
       deeply-nested chains like SKILL → A.md → B.md → actual content)
 - [ ] Reference files longer than 100 lines include a table of contents
+- [ ] Reference files state their purpose and when the agent should load them
 
 ### 4. Conciseness
 
@@ -108,6 +114,10 @@ Match instruction specificity to task fragility:
 
 - [ ] SKILL.md serves as an overview / table of contents
 - [ ] Detailed materials are in separate files loaded only when needed
+- [ ] Mandatory workflow steps, validation loops, and review checklist items stay
+      in SKILL.md even when detailed examples move to references
+- [ ] Situational, element-specific, type-specific, or platform-specific rules
+      are good candidates for reference files
 - [ ] File names are descriptive (not `doc1.md`, `file2.md`)
 - [ ] Directory structure is organized by domain or feature
 
@@ -119,15 +129,26 @@ Match instruction specificity to task fragility:
       (run validator → fix errors → repeat until clean)
 - [ ] Decision points use conditional workflow patterns (if X → workflow A,
       if Y → workflow B)
+- [ ] For standards and review skills, rules are mandatory unless explicitly
+      marked `Optional`; advisory skills consistently distinguish requirements,
+      recommendations, and examples
 
 ### 8. Content quality
 
 - [ ] No time-sensitive information (dates that will become stale); if legacy
       context is needed, it is in a collapsible "old patterns" section
 - [ ] Consistent terminology throughout (one term per concept, not synonyms)
+- [ ] Named thresholds, modes, phases, or terms are defined before first use and
+      have one authoritative definition
 - [ ] Examples are concrete, not abstract
+- [ ] Examples and domain facts are technically accurate; repo-specific skills
+      use real project patterns where practical
 - [ ] All file paths use forward slashes (no Windows-style backslashes)
 - [ ] No "voodoo constants" — every magic number or config value is justified
+- [ ] Important rule sections use real markdown headings, not bold paragraphs as
+      pseudo-headings
+- [ ] Duplicate rationale and repeated examples are removed, while short
+      normative checklist rules remain self-contained
 
 ### 9. Cross-skill consistency
 
@@ -138,8 +159,12 @@ When reviewing multiple skills in the same repository:
 - [ ] Shared policies (branch rules, commit conventions, quality gates,
       changelog policy) do not contradict each other
 - [ ] Cross-skill links in `## Related skills` resolve to existing files
+- [ ] Intra-skill links, cross-skill deep links, table-of-contents anchors, and
+      referenced files resolve after heading or file moves
 - [ ] Every skill referenced in `.github/copilot-instructions.md`'s routing
       table resolves to an existing `.github/skills/*/SKILL.md` file
+- [ ] Skills that extend other skills clearly state what they inherit, override,
+      or add
 - [ ] Stop/ask checkpoints are used consistently for comparable risk levels
 
 ### 10. Discoverability sections
@@ -182,7 +207,7 @@ Key principles distilled:
 | No time-sensitive info | Avoid dates that will become stale |
 | Consistent terminology | One term per concept throughout |
 | One-level references | No deeply nested file chains |
-| Under 600 lines | Split if approaching the limit |
+| Size targets | Target under 500 lines; review carefully above 600 lines |
 | Test with real usage | Iterate based on observed agent behavior |
 
 > **Branch workflow:** Implement any fixes on a feature branch. Never commit or

--- a/.github/skills/yard-documentation/SKILL.md
+++ b/.github/skills/yard-documentation/SKILL.md
@@ -12,15 +12,50 @@ General YARD documentation rules and workflow for all Ruby source code.
 - [Contents](#contents)
 - [How to use this skill](#how-to-use-this-skill)
 - [Related skills](#related-skills)
-- [Documentation Standards](#documentation-standards)
-  - [YARD Formatting Rules](#yard-formatting-rules)
-  - [Element-Specific Rules](#element-specific-rules)
+- [Reference files](#reference-files)
+- [Precedence](#precedence)
+- [Workflow](#workflow)
+- [Named length limits](#named-length-limits)
 - [Step 1: Identify What Needs Documentation](#step-1-identify-what-needs-documentation)
 - [Step 2: Write Documentation](#step-2-write-documentation)
   - [Standard template (no `@overload`)](#standard-template-no-overload)
   - [Overload template](#overload-template)
+  - [Overload decision matrix](#overload-decision-matrix)
   - [Documenting anonymous splats with `@overload`](#documenting-anonymous-splats-with-overload)
+  - [Documenting other elements](#documenting-other-elements)
 - [Step 3: Verify Documentation](#step-3-verify-documentation)
+  - [Line and summary length checks](#line-and-summary-length-checks)
+- [Documentation Standards](#documentation-standards)
+  - [Formatting Rules](#formatting-rules)
+    - [Doc comment placement](#doc-comment-placement)
+    - [Blank lines around tags](#blank-lines-around-tags)
+    - [Never use raw blank lines inside a doc comment block](#never-use-raw-blank-lines-inside-a-doc-comment-block)
+    - [Short descriptions](#short-descriptions)
+    - [Line and summary length](#line-and-summary-length)
+    - [`@return` must always include a type](#return-must-always-include-a-type)
+    - [No shell calls in `@example` blocks](#no-shell-calls-in-example-blocks)
+    - [Blank lines within `@example` blocks](#blank-lines-within-example-blocks)
+    - [`@example` titles are required](#example-titles-are-required)
+    - [Cross-reference links only resolve to objects included in generated docs](#cross-reference-links-only-resolve-to-objects-included-in-generated-docs)
+    - [Inline code formatting](#inline-code-formatting)
+    - [Escaping opening braces in descriptions](#escaping-opening-braces-in-descriptions)
+    - [Cross-reference links](#cross-reference-links)
+    - [Type specifier conventions](#type-specifier-conventions)
+    - [`Array<...>` (collection) vs `Array(...)` (tuple)](#array-collection-vs-array-tuple)
+    - [`@api private` vs `@private`](#api-private-vs-private)
+    - [`@since` tags are not used](#since-tags-are-not-used)
+    - [`@todo` tags are not used](#todo-tags-are-not-used)
+    - [`@abstract`](#abstract)
+  - [Method Rules](#method-rules)
+    - [Short description](#short-description)
+    - [Standard tags](#standard-tags)
+    - [`@example` on non-private methods](#example-on-non-private-methods)
+    - [Yield tags](#yield-tags)
+    - [`@overload` for distinct signatures](#overload-for-distinct-signatures)
+    - [`@overload` for anonymous splats](#overload-for-anonymous-splats)
+    - [`@note` for callouts (Optional)](#note-for-callouts-optional)
+    - [`@deprecated` on deprecated methods](#deprecated-on-deprecated-methods)
+    - [`@api` on methods (Optional)](#api-on-methods-optional)
 - [Command Reference](#command-reference)
 
 ## How to use this skill
@@ -29,31 +64,61 @@ Attach this file to your Copilot Chat context, then invoke it with the source
 files that need YARD updates. Use it when adding new APIs, fixing doc warnings,
 or improving existing YARD quality and examples.
 
+Work top to bottom: follow the three-step [Workflow](#workflow), reaching into the
+[Documentation Standards](#documentation-standards) reference below as you write,
+and into [`element-rules.md`](element-rules.md) when documenting a class, module,
+constant, attribute, dynamically defined method, or value object.
+
 ## Related skills
 
 - [Command YARD Documentation](../command-yard-documentation/SKILL.md) — command-specific rules for writing and reviewing YARD docs on `Git::Commands::Base` subclasses
 
-## Documentation Standards
+## Reference files
 
-ruby-git uses YARD for API documentation:
+Situational rules live in a sibling file, loaded only when the element type calls
+for it:
 
-All classes, modules, constants, attributes, and methods must have YARD
-documentation. Methods with Ruby `private` visibility require a short description
-and all applicable tags from the [Methods](#methods) rules — `@param`, `@return`,
-`@raise`, `@yield`/`@yieldparam`/`@yieldreturn`, and `@overload` — with the
-exception that `@example` may be omitted unless an example materially clarifies
-the behavior. Private methods still need YARD docs for developer reference in
-source, even though YARD excludes them from generated HTML by default.
+- [`element-rules.md`](element-rules.md) — per-element requirements for **classes,
+  modules, constants, attributes, dynamically defined methods**, and value
+  objects (`Data.define` / `Struct.new`). Read it whenever you document one
+  of those elements. Rules for **methods** and rules that apply to **every** doc
+  comment stay in this file.
 
-### YARD Formatting Rules
+## Precedence
 
-Doc comments are rendered as **markdown** via the redcarpet gem. Write all
-free-text descriptions, tag values, and examples using markdown syntax. These rules
-apply to all documentation regardless of element type:
+When a more specific YARD skill applies, its rules override this general skill:
 
-**Named length limits**
+- [Command YARD Documentation](../command-yard-documentation/SKILL.md) overrides
+  these rules for `Git::Commands::Base` subclasses.
+- [Facade YARD Documentation](../facade-yard-documentation/SKILL.md) overrides these
+  rules for `Git::Repository::*` topic modules.
 
-Three named limits govern line and description length throughout this document:
+Otherwise, the rules in this file apply to all Ruby source.
+
+## Workflow
+
+Documenting or fixing YARD docs follows three steps:
+
+1. [Step 1: Identify What Needs Documentation](#step-1-identify-what-needs-documentation)
+2. [Step 2: Write Documentation](#step-2-write-documentation) — apply the
+   templates and the [Documentation Standards](#documentation-standards)
+3. [Step 3: Verify Documentation](#step-3-verify-documentation) — lint, build,
+   and manually check
+
+ruby-git uses YARD for API documentation. All classes, modules, constants,
+attributes, and methods must have YARD documentation. Methods with Ruby `private`
+visibility require a short description and all applicable tags from the
+[Method Rules](#method-rules) — `@param`, `@return`, `@raise`,
+`@yield`/`@yieldparam`/`@yieldreturn`, and `@overload` — with the exception that
+`@example` may be omitted unless an example materially clarifies the behavior.
+Private methods still need YARD docs for developer reference in source, even though
+YARD excludes them from generated HTML by default.
+
+## Named length limits
+
+Three named limits govern line and description length throughout this skill. They
+are referenced by name in [Step 3](#step-3-verify-documentation) and the
+[Formatting Rules](#formatting-rules):
 
 - **`LINE_LIMIT`** (90 characters) — the preferred maximum length of any
   physical YARD comment line, measured from column 1 and including every
@@ -72,449 +137,14 @@ Three named limits govern line and description length throughout this document:
     cannot be reflowed without changing its meaning
   - **Markdown table rows** — pipe-delimited table rows that cannot be
     split across lines
-- **`SUMMARY_LIMIT`** (90 characters) — the maximum length of a tag's
-  description text, measured by concatenating the description from the first
-  tag line with all immediately following indented continuation lines
-  (stripping the leading `#   ` from each and joining with a single space).
-  Applies to the description text only — not the tag name, `[Type]`, option
-  key, or `(default)`.
-
-**Doc comment placement**
-
-YARD doc comments must appear immediately above the element they document (class,
-module, method, constant, or attribute) with no intervening blank lines or
-non-comment code.
-
-**Blank lines around tags**
-
-Every individual YARD tag must be preceded by a blank comment line (`#`) unless it is the very first line of a doc comment.
-A YARD tag is any comment token matching `@!?[a-z_]+` — that is, `@word` (regular
-tags such as `@param`, `@return`, `@raise`, `@api`, `@abstract`, `@deprecated`,
-etc.) or `@!word` (directives such as `@!attribute`, `@!method`, `@!scope`, etc.).
-
-Within the tag block there are no other exceptions: consecutive same-kind tags (e.g.
-multiple `@param` lines) each require their own preceding blank line.
-
-**Never use raw blank lines inside a doc comment block**
-
-A raw blank line — an empty line with no leading `#` — terminates the YARD doc
-comment block at that point. Any comment lines that follow the raw blank line are
-treated as separate, unattached comments and will not appear in the generated
-documentation. Always use a blank comment line (`#`) to separate paragraphs or
-continuation text within a YARD block:
-
-Correct — blank comment line keeps the block intact:
-
-```ruby
-# @option options [Boolean, nil] :ipv4 (nil) use IPv4 addresses only
-#
-#   Alias: :"4"
-```
-
-Incorrect — raw blank line silently drops the alias note:
-
-```ruby
-# @option options [Boolean, nil] :ipv4 (nil) use IPv4 addresses only
-
-#   Alias: :"4"
-```
-
-Watch for editors that auto-strip trailing spaces from `#` lines, silently
-creating raw blank lines.
-
-**Short descriptions**
-
-The short description (the first sentence of any doc comment, or the inline text of
-a `@param`, `@return`, `@raise`, etc. tag) must:
-
-- Be a single sentence
-- Not end with sentence-ending punctuation (`.`, `?`, `!`)
-- **Element-level short descriptions** (on classes, modules, and methods) **start
-  with an uppercase letter** (e.g. `Returns the commit count`,
-  `Represents a Git branch`)
-- **Tag short descriptions** (`@option`, `@param`, `@return`, `@raise`, `@yield`,
-  `@yieldparam`, etc.) **all start with a lowercase letter** (e.g. `@option options
-  [Boolean, nil] :force (nil) overwrite existing files`, `@param name [String] the branch
-  name`, `@return [String] the result`, `@raise [ArgumentError] when no name is provided`)
-
-For tags, the **summary text** is the description that follows the tag
-metadata (tag name, `[Type]`, option key, and `(default)`). For example, in:
-
-```
-@option options [Boolean, nil] :ignore_case (nil) ignore case distinctions
-```
-
-the summary text is `ignore case distinctions`.
-
-**Tag line and summary length**
-
-Every physical YARD doc line should not exceed `LINE_LIMIT`. When a tag's
-description would push a line past `LINE_LIMIT`, split it at a word boundary
-onto a continuation line indented two extra spaces. For content that cannot
-be wrapped (URLs, long inline code spans, long `[Type]` expressions,
-`@example` code lines, markdown table rows), lines may extend up to
-`LINE_MAX` but must not exceed it.
-
-Additionally, the concatenated description — the description text from the
-first tag line joined with all continuation lines — must not exceed
-`SUMMARY_LIMIT`. If the concatenated description exceeds `SUMMARY_LIMIT`,
-shorten it and move the excess detail into a paragraph after a blank `#` line.
-
-For example, this tag has a description of 84 characters (within
-`SUMMARY_LIMIT`), but the single physical line is 102 characters (exceeds
-`LINE_LIMIT`) and must be split:
-
-```ruby
-# @return [Array] a two-element tuple `[target, options]` containing the translated checkout arguments
-```
-
-Split so each physical line fits within `LINE_LIMIT`:
-
-```ruby
-# @return [Array] a two-element tuple `[target, options]` containing the
-#   translated checkout arguments
-```
-
-If the tag metadata itself is long (e.g. a long `[Type]` or `@option` key),
-start the description on an indented continuation line so only the metadata
-appears on the first physical line.
-
-If more explanation is needed, add continuation paragraphs after a blank
-comment line (`#`). Every physical line — in the summary and in any
-continuation paragraph — must independently fit within `LINE_LIMIT`
-(or `LINE_MAX` for unwrappable content such as URLs, long inline code
-spans, long `[Type]` expressions, `@example` code, or table rows).
-
-These rules apply equally to tag text (`@param`, `@return`, etc.) — the first
-sentence of a tag is its short description. The no-punctuation rule applies only to
-short descriptions; continuation paragraphs use normal prose punctuation (periods).
-Separate continuation paragraphs with a blank comment line.
-
-Correct — tag title without punctuation, blank line before continuation:
-
-```ruby
-# @option options [Boolean, nil] :ignore_case (nil) ignore case
-#   distinctions in both the pattern and the file contents
-#
-#   Alias: :i
-#
-# @option options [String, Array<String>] :pattern the search pattern
-#   (required; must not be nil)
-#
-#   Pass a String for a simple pattern (emitted as `-e <pattern>`).
-#   Pass an Array of raw CLI arguments for compound boolean
-#   expressions.
-#
-# @return [Git::CommandLineResult] the result of calling `git grep`
-#
-#   Exit status 0 means matches were found; exit status 1 means no
-#   lines were selected (not an error).
-```
-
-Incorrect — trailing period on title, missing blank line before continuation, and `@return` concatenated summary exceeds `SUMMARY_LIMIT` (132 chars):
-
-```ruby
-# @option options [Boolean, nil] :ignore_case (nil) ignore case
-#   distinctions in both the pattern and the file contents.
-#   Alias: :i
-#
-# @return [Git::CommandLineResult] the result of calling `git grep`.
-#   Exit status 0 means matches were found; exit status 1 means no
-#   lines were selected (not an error).
-```
-
-**`@return` must always include a type**
-
-Every `@return` tag must include a `[Type]` specifier. `@return the value` is
-incorrect; write `@return [Object] the value` (or a more specific type). If the
-return value is the block's return value, use `@return [Object]`.
-
-**No shell calls in `@example` blocks**
-
-Never use backtick shell calls (`` `true` ``, `` `git version` ``) or process-status
-globals (`$?`, `$CHILD_STATUS`) in `@example` blocks. They are side-effecting,
-environment-dependent, and confuse readers about the type of object being
-demonstrated. Construct example objects directly in Ruby instead:
-
-Incorrect:
-
-```ruby
-# @example Incorrect shell call
-#   `true`
-#   result = Git::CommandLine::Result.new([], $?, '', '')
-```
-
-Correct:
-
-```ruby
-# @example Constructing a result with a double
-#   status = instance_double(ProcessExecuter::Result)
-#   result = Git::CommandLine::Result.new([], status, '', '')
-```
-
-**Blank lines within `@example` blocks**
-
-Within `@example` blocks, blank comment lines (`#`) render as literal blank lines in
-the displayed code. Use them for readability between setup and assertions, but be
-aware they are literal content, not tag separators.
-
-**`@example` titles are required**
-
-Every `@example` tag must include a title — the descriptive text on the same line
-after `@example`. Write `@example Basic usage`, not bare `@example`. Titles appear
-as headings in generated docs and help readers scan multiple examples.
-
-**Cross-reference links only resolve to objects included in generated docs**
-
-YARD renders `{ClassName#method}` as a hyperlink only when the target method is
-included in the generated documentation. Public objects are included by default,
-and objects marked with `@api private` remain included with a private annotation.
-Ruby private methods are excluded by default. Do not write
-`{Git::Commands::Base#execute_command}` — it will render as plain text and may
-generate an unresolved reference warning.
-
-If you need to refer to a private method, describe it in prose instead, or link to
-the public method that callers should use.
-
-**Inline code formatting**
-
-Use backtick code spans for inline code (`` `true` ``, `` `nil` ``, symbols, type
-names, method calls). Do not use the RDoc `+value+` style; it is inconsistent with
-the project's markdown rendering via redcarpet.
-
-**Escaping `{` in descriptions**
-
-YARD treats `{` as the start of a cross-reference link. Because redcarpet consumes
-one `\` before YARD sees it, write `\\{` (two backslashes) to produce a literal
-`{` — redcarpet reduces `\\` to `\`, leaving `\{` for YARD. For example, use
-`'stash@\\{0}'` to render as `stash@{0}`. Using only `\{` still triggers a YARD
-unresolved link warning.
-
-**Cross-reference links**
-
-Link to other code objects anywhere in a doc comment using `{ClassName}`,
-`{ClassName#method}`, `{#method_in_same_class}`, or `{Class::CONSTANT}`. An
-optional title follows the reference separated by a space:
-`{Git::Repository#log the log method}`. Do not use brace syntax inside `@see` tags —
-`@see` links automatically without braces. `@see` accepts three target forms:
-
-- Code objects: `@see Git::Repository#log`
-- URLs: `@see https://git-scm.com/docs/git-log`
-- Quoted text: `@see "Pro Git, Chapter 2"`
-
-**Type specifier conventions**
-
-The `[Types]` field in `@param`, `@return`, `@raise`, etc. supports:
-
-- Plain types: `[String]`, `[Integer]`, `[Git::Repository]`
-- Multiple types: `[String, nil]`, `[String, Array<String>]`
-- Parametrized collections: `[Array<String>]`, `[Hash<Symbol, String>]`
-- Fixed-position tuples: `[Array(String, Integer)]`, `[Array(Symbol, (Integer, nil))]`
-- Duck-types (responds to): `[#read]`, `[#to_s]`
-- `[Boolean]` — conventional meta-type for `true` or `false` (not a real Ruby class)
-- `[void]` — for `@return` tags on methods whose return value must not be used
-
-**`Array<...>` (collection) vs `Array(...)` (tuple)**
-
-YARD treats angle brackets and parentheses as distinct type constructors, so
-choose the one that matches the value's shape:
-
-- `Array<T>` (angle brackets) — a **collection**: an array *of* `T` with any
-  number of elements, e.g. `Array<String>` is zero or more strings. Listing
-  several types inside `<...>` means each element is one *of* those types
-  (`Array<String, Symbol>` is an array whose elements are each a String or a
-  Symbol), **not** a fixed sequence.
-- `Array(A, B)` (parentheses) — a **tuple**: an array *containing* exactly `A`
-  then `B` in that order, e.g. `Array(String, Integer)` is a two-element
-  `[name, count]`. Use this whenever a method returns or accepts a
-  fixed-position array such as `[status, similarity]` or `[path, options]`.
-
-The same rule applies to nested types: `Array<Array(Integer, String)>` is a
-collection of `[index, message]` tuples. Use `[Array]` with a prose description
-only when the element types cannot be expressed concisely.
-
-**`@api private` vs `@private`**
-
-Use `@api private` (not `@private`) to mark internal classes and modules. `@api
-private` includes the object in generated docs with a private annotation; YARD's
-`@private` tag excludes the object from docs entirely.
-
-**`@since` — do not use**
-
-Do not add `@since` tags. The project has no historical `@since` annotations, and
-retroactively tagging existing APIs is impractical at v4.x. Version introduction
-history is tracked through git blame and the CHANGELOG instead.
-
-**`@todo` — do not use**
-
-Do not add `@todo` tags. Track incomplete work in GitHub Issues, not in source
-comments. YARD renders `@todo` prominently in generated docs, and these annotations
-go stale quickly.
-
-**`@abstract`**
-
-Use `@abstract` on classes or methods that must be subclassed or overridden before
-use. Include guidance text describing what the subclass must implement:
-`@abstract Subclass and implement {#run}`. Do not use `@abstract` on concrete
-classes or fully implemented methods.
-
-### Element-Specific Rules
-
-**Classes**
-
-- One-sentence class description as a **noun phrase** (or starting with "Represents…") — the description should pass
-  the "This class is a…" litmus test (i.e. you should be able to prefix "This class
-  is a" and produce a grammatical sentence). "Represents…" is an accepted convention.
-  Do not start descriptions with "This class is…", "Provides…", or "Encapsulates…".
-  - Good: `Wrapper around the git binary`, `Immutable value object for a branch
-    delete result`, `Represents a git branch`
-  - Bad: `This class wraps the git binary`, `Provides branch deletion`,
-    `Encapsulates branch state`
-- `@api public` or `@api private` tag to declare visibility — use `@api public` for
-  stable user-facing classes; use `@api private` for internal implementation classes
-  (e.g., `Git::ExecutionContext::*`, `Git::Commands::*`, parsers)
-- At least one `@example` showing typical instantiation or primary usage — this
-  applies to all classes including `@api private` classes
-- Error/exception classes must also state when the error is raised in class-level
-  prose, using caller-facing wording such as `Raised when branch deletion fails`
-- Deprecated classes must include `@deprecated` explaining the migration path
-- When present, class-level tags must appear in this order: `@example`, `@note`,
-  `@deprecated`, `@see`, `@api`, `@abstract`
-
-**Modules**
-
-- One-sentence description — "Namespace for…", "Provides helpers for…", or
-  "Mixin that adds…"
-- `@api public` or `@api private` — use `@api public` for stable user-facing modules;
-  use `@api private` for internal implementation modules
-- No `@example` required unless the module provides standalone methods
-- Deprecated modules must include `@deprecated` explaining the migration path
-- When present, module-level tags must appear in the same order as class-level
-  tags: `@example`, `@note`, `@deprecated`, `@see`, `@api`
-
-**Constants**
-
-- A comment immediately above the constant describing its purpose and valid values
-- No special YARD tag is needed; YARD picks up the preceding comment automatically
-- Add `# @return [Type]` when the constant holds a collection, frozen structure, or
-  domain-specific type whose shape is not immediately obvious from the value
-
-**Attributes**
-
-- For explicitly written `attr_reader`, `attr_accessor`, and `attr_writer` declarations,
-  place the documentation directly above the attribute; do **not** use the `@!attribute`
-  directive
-- For dynamically created attributes, `Data.define` members, or `Struct.new`
-  members, you **must** use a `# @!attribute [r/rw/w] name` YARD directive
-- Must include `@return [Type] description` explaining the value and its units or
-  constraints if relevant
-- For explicit `attr_reader`/`attr_accessor`/`attr_writer`, include a short
-  description paragraph above the attribute in addition to `@return`
-- For `@!attribute` directives (in `Data.define` / `Struct.new`), the `@return`
-  tag inside the directive block serves as the sole documentation — no separate
-  short description is needed
-- Tags inside `@!attribute` (and `@!method`) directive blocks must be indented
-  two extra spaces relative to the directive itself
-- Must be defined at the class level, not inside method bodies
-
-**Dynamically defined methods (`@!method`)**
-
-Use the `# @!method name(params)` directive for methods created via
-metaprogramming (`define_method`, method-generating DSLs, etc.) that have no
-literal `def`. Place the directive and its doc comment where the method would
-logically appear in the class body. Tags inside the directive block follow the
-same indentation rule as `@!attribute` — indented two extra spaces relative to
-the directive.
-
-**`Data.define` classes**
-
-Immutable value objects defined with `Data.define` use the following conventions
-(see `Git::BranchDeleteFailure` for a canonical example):
-
-- Class-level doc: noun-phrase short description, `@example`, `@see`, `@api`
-- One `@!attribute [r]` directive per member with `@return [Type] description`
-- Attribute directives are placed after class-level tags and before the
-  `Data.define` line
-- Custom methods defined inside the `Data.define` block follow standard method
-  rules
-
-**`Struct.new` classes**
-
-Document `Struct.new` classes using the same conventions as `Data.define` classes:
-class-level doc with a noun-phrase short description, `@example`, `@see`, `@api`,
-and one `@!attribute` directive per member with `@return [Type] description`.
-
-```ruby
-# Immutable value object for a failed branch delete
-#
-# @example Create a failure object
-#   failure = Git::BranchDeleteFailure.new(name: 'feature', result: result)
-#   failure.name   #=> "feature"
-#   failure.result #=> #<Git::CommandLineResult ...>
-#
-# @see Git::BranchDeleteResult
-#
-# @api public
-#
-# @!attribute [r] name
-#
-#   @return [String] the branch name that failed to delete
-#
-# @!attribute [r] result
-#
-#   @return [Git::CommandLineResult] the result of the failed delete
-#
-BranchDeleteFailure = Data.define(:name, :result)
-```
-
-**Methods**
-
-- All methods must have a short description that:
-  - Starts with a verb (`Returns`, `Resets`, `Finds` — not "The…" or "This method…")
-  - Omits the subject — write "Returns the commit count", not "This method returns
-    the commit count"
-  - States the outcome, not the mechanism — `Finds the nearest tagged ancestor` not
-    `Iterates through commits checking tags`
-  - Mentions key parameters inline — `Resets HEAD to the given ref` rather than
-    relying solely on param tags
-  - Avoids restating the method name — add specificity about what kind, from where,
-    or what is returned
-  - Is specific about return values — `Returns true if the branch exists, false
-    otherwise` beats `Returns a Boolean`
-  - Omits implementation details — callers don't care about internal loops or temp
-    variables
-- Methods use these standard YARD tags:
-  - `@param` for each method parameter, in signature order; omit `@param` entirely
-    on zero-argument methods
-  - `@return` on every method; use `[void]` when the return value must not be used
-  - `@raise` for each caller-relevant exception the method can raise as part of its
-    contract; omit `@raise` when the method has no documented exceptional path
-- Methods without Ruby `private` visibility must have one or more `@example`s;
-  Ruby-private methods may omit `@example` unless usage would otherwise be unclear
-- Methods that yield to a block must include `@yield [param_names]`, one
-  `@yieldparam name [Type]` per yielded parameter, and `@yieldreturn [Type]`; omit
-  all yield tags on methods that do not yield
-- Use `@overload` when a method has distinct call signatures with different
-  parameters or return types — each overload gets its own full set of tags.
-  Methods that yield only when an optional block is given should use `@overload`
-  to document the with-block and without-block signatures separately
-- Methods whose signature uses an **anonymous keyword splat** (`**`),
-  **anonymous positional splat** (`*`), or the **argument forwarding
-  parameter** (`...`) must document their call shapes with `@overload` blocks
-  that name the parameters. `@param`, `@option`, `@yield`, and `@yieldparam`
-  cannot bind to an anonymous splat or to `...` — the named overload signature
-  is what gives YARD a parameter to attach the docs to. Do **not** introduce a
-  named splat (or expand `...` into `*args, **kwargs, &block`) solely so the
-  tags will bind; that conflicts with RuboCop's `Style/ArgumentsForwarding`
-  cop, and the `@overload` form satisfies both
-- Use `@note` for callouts that need visual emphasis: thread-safety warnings,
-  significant side effects, or platform-specific behaviour
-- Deprecated methods must include `@deprecated` explaining the migration path,
-  e.g. `@deprecated Use {#new_method} instead`
-- `@api` is optional on methods — when omitted, the method inherits the containing
-  class's `@api` level. Use it only when the method's intended visibility differs
-  from the class's level (e.g. an `@api private` helper inside an `@api public`
-  class)
+- **`SUMMARY_LIMIT`** (90 characters) — the maximum length of a short
+  description — either a tag's description text or a documentable object's short
+  description (class, module, method, constant, or attribute) — measured by
+  concatenating the text from the first line with all immediately following
+  indented continuation lines (stripping the leading `#` and continuation indent
+  from each and joining with a single space).
+  For tags, this covers the description text only — not the tag name, `[Type]`,
+  option key, or `(default)`.
 
 ## Step 1: Identify What Needs Documentation
 
@@ -528,29 +158,26 @@ bundle exec yard doc lib/git/repository.rb --no-output
 
 ## Step 2: Write Documentation
 
-Follow the YARD documentation templates below. Use the **standard template** when a
-method has a single call signature. Use the **overload template** when a method has
-distinct call signatures with different parameters or return types.
+Follow the YARD documentation templates below and apply the
+[Documentation Standards](#documentation-standards) as you write. Use the
+**standard template** when a method has a single call signature. Use the
+**overload template** when a method has distinct call signatures with different
+parameters or return types.
 
 When `@overload` blocks are present:
 
 - Keep `@param`, `@option`, and `@return` inside overload blocks only
 - Keep overload-specific `@raise` inside the relevant overload block
-- Keep shared `@raise` at top level only once (do not duplicate inside overloads)
+- Keep shared `@raise` at top level only once (do not duplicate inside
+  overloads); duplicating it produces conflicting or noisy generated docs
 - Keep non-signature tags (`@note`, `@deprecated`, `@see`, `@api`) at top level
 
-Avoid duplicating the same `@raise` at both top level and overload level. This
-causes conflicting or noisy generated docs.
-
-**Trigger: always use `@overload` when the signature contains `*`, `**`, or `...`**
+**Trigger: always use `@overload` for anonymous `*`, anonymous `**`, or `...`**
 
 Anonymous splats and the forwarding parameter give `@param`, `@option`, `@yield`,
-and `@yieldparam` no named parameter to bind to. YARD silently drops or
-mis-renders these tags when the signature is, for example, `def foo(**)` or
-`def foo(paths = '.', **)` — even though `paths` is named, the keyword options
-have no name so every `@option` is unbound. As soon as any parameter in the
-signature is anonymous (`*`, `**`, or `...`), switch to `@overload` for the entire
-signature (see [Documenting anonymous splats with `@overload`](#documenting-anonymous-splats-with-overload)).
+and `@yieldparam` no named parameter to bind to, so YARD silently drops them.
+Switch to `@overload` for the entire signature — see
+[Documenting anonymous splats with `@overload`](#documenting-anonymous-splats-with-overload).
 
 ### Standard template (no `@overload`)
 
@@ -568,9 +195,13 @@ keys for a public `options` hash.
 
 For private helpers that accept arbitrary keyword collectors whose keys are
 validated elsewhere, use a neutral splat name such as `candidate_keywords` and
-document the collector shape with a single pseudo-option entry named `key`. This
-is only for arbitrary-keyword helpers where the accepted keys are intentionally
-not known at that abstraction layer:
+document the collector shape with a single pseudo-option entry named `key_name`.
+A pseudo-option is required because yard-lint's `Documentation/UndocumentedOptions`
+flags any documented `**` collector that has no `@option` tag, and that check has
+no type, name, or visibility exemption for double-splats. Use `key_name` rather
+than a literal-looking `key` so it is not mistaken for a real option key. This is
+only for arbitrary-keyword helpers where the accepted keys are intentionally not
+known at that abstraction layer:
 
 ```ruby
 # Validate that candidate option keys are listed in `allowed`
@@ -579,7 +210,7 @@ not known at that abstraction layer:
 #
 # @param candidate_keywords [Hash<Symbol, Object>] the keywords to validate
 #
-# @option candidate_keywords [Object] key a candidate keyword value
+# @option candidate_keywords [Object] key_name a candidate keyword value
 #
 # @return [void]
 #
@@ -604,10 +235,10 @@ after the later positional `@param` rather than in strict signature order:
 #
 # @example Basic usage
 #   git = Git.open('/path/to/repo')
-#   result = git.method_name('arg')
+#   result = git.method_name('arg', {}, '/path')
 #
 # @example With options
-#   git.method_name('arg', option: true)
+#   git.method_name('arg', { option: true }, '/path')
 #
 # @param name [Type] description of parameter
 #
@@ -641,7 +272,7 @@ after the later positional `@param` rather than in strict signature order:
 #
 # @api public
 #
-def method_name(name, options = {})
+def method_name(name, options = {}, path)
 end
 ```
 
@@ -674,7 +305,7 @@ at the top level:
 #   Two-argument form description
 #
 #   @example With options
-#     result = git.method_name('arg', force: true)
+#     result = git.method_name('arg', { force: true })
 #
 #   @param arg [String] the argument
 #
@@ -692,7 +323,7 @@ at the top level:
 #
 # @api public
 #
-def method_name(name, options = {})
+def method_name(arg, options = {})
 end
 ```
 
@@ -704,13 +335,10 @@ Use this matrix to decide whether to use `@overload` and where to place tags:
 | --- | --- |
 | Single named signature, no `*`/`**`/`...` | Standard template (no `@overload`) |
 | Uses anonymous `*`, `**`, or `...` | `@overload` required |
-| Private arbitrary keyword collector | Neutral splat name plus pseudo-option `key` |
+| Private arbitrary keyword collector | Neutral splat name plus pseudo-option `key_name` |
 | Multiple call shapes (different params and/or return types) | One `@overload` per shape |
 | Shared errors across all call shapes | Top-level `@raise` once |
 | Error only for specific call shape | `@raise` only in that overload |
-
-For overload docs, keep `@param`/`@option`/`@return` in overload blocks. Use
-top-level `@raise` only for errors that apply to every overload.
 
 ### Documenting anonymous splats with `@overload`
 
@@ -792,6 +420,13 @@ anonymous `&`. Use a named block parameter (`&block`) and a `@param block
 first-class `Proc` value (stored, returned, or passed elsewhere) rather than
 yielded to.
 
+### Documenting other elements
+
+The templates above cover **methods**. When documenting a **class, module,
+constant, attribute, dynamically defined method (`@!method`)**, or a value
+object (`Data.define` / `Struct.new`), follow the per-element requirements
+in [`element-rules.md`](element-rules.md).
+
 ## Step 3: Verify Documentation
 
 First, run the automated linter. `yard-lint` enforces many of the rules in this
@@ -825,31 +460,410 @@ Then generate and review the rendered docs:
 ```bash
 # Generate and review docs
 bundle exec yard doc
-open doc/index.html
+# then open doc/index.html in your browser
 
 # Check for warnings
-bundle exec yard doc 2>&1 | grep -i "warn"
+bundle exec yard doc 2>&1 | ruby -ne 'puts $_ if $_ =~ /warn/i'
 ```
 
 Verify `@example` code runs correctly in `bundle exec bin/console`.
 Check that all `@see` references point to valid targets.
 
-**Review checklist — tag line length**
+### Line and summary length checks
 
-For every `@param`, `@return`, `@raise`, `@option`, `@yield`, `@yieldparam`,
-and `@yieldreturn` tag, check both limits:
+Apply these checks to every YARD doc comment — the description on a class,
+module, method, constant, or attribute, and every tag within it (`@param`,
+`@return`, `@raise`, `@option`, `@yield`, `@yieldparam`, `@yieldreturn`, etc.).
+Check all three limits:
 
 1. **`LINE_LIMIT`**: Count every character from column 1 (indentation, `#`,
    metadata, text) on each physical line. If any wrappable line exceeds
    `LINE_LIMIT`, split at a word boundary onto a continuation line (indented
    two extra spaces). Apply this check to every continuation line
-   independently. Lines containing URLs, long inline code spans, long `[Type]`
-   expressions, `@example` code, or markdown table rows may extend up to
-   `LINE_MAX`.
-2. **`SUMMARY_LIMIT`**: Strip `#   ` from each continuation line and join
-   with a single space. If the concatenated description exceeds
-   `SUMMARY_LIMIT`, shorten it and move the excess into a paragraph after
-   a blank `#` line.
+   independently.
+2. **`LINE_MAX`**: Confirm no physical line exceeds `LINE_MAX` — the hard
+   ceiling that nothing may cross. Only unwrappable content (URLs, long inline
+   code spans, long `[Type]` expressions, `@example` code, markdown table rows)
+   may sit between `LINE_LIMIT` and `LINE_MAX`; every other line must stay
+   within `LINE_LIMIT`.
+3. **`SUMMARY_LIMIT`**: For each short description — a tag's description or a
+   documented object's short description — strip the leading `#` and its
+   indentation from every continuation line and join with a single space. If the
+   concatenated text exceeds `SUMMARY_LIMIT`, shorten it and move the excess into
+   a paragraph after a blank `#` line.
+
+## Documentation Standards
+
+The rules below are the reference the [Workflow](#workflow) draws on. The
+[Formatting Rules](#formatting-rules) apply to every doc comment regardless of
+element type; the [Method Rules](#method-rules) govern method doc comments.
+Per-element rules for classes, modules, constants, attributes, and value objects
+are in [`element-rules.md`](element-rules.md).
+
+Treat every rule in this section as mandatory unless its heading is marked
+**(SHOULD)** or **(Optional)**. Headings that name a descriptive topic (e.g.
+type-specifier conventions) are reference material; any obligations they carry are
+stated with “must” inline.
+
+### Formatting Rules
+
+Doc comments are rendered as **markdown** via the redcarpet gem. Write all
+free-text descriptions, tag values, and examples using markdown syntax. These rules
+apply to all documentation regardless of element type. They reference the three
+[Named length limits](#named-length-limits) (`LINE_LIMIT`, `LINE_MAX`,
+`SUMMARY_LIMIT`) defined earlier.
+
+#### Doc comment placement
+
+YARD doc comments must appear immediately above the element they document (class,
+module, method, constant, or attribute) with no intervening blank lines or
+non-comment code.
+
+#### Blank lines around tags
+
+Every individual YARD tag must be preceded by a blank comment line (`#`) unless it is the very first line of a doc comment.
+A YARD tag is any comment token matching `@!?[a-z_]+` — that is, `@word` (regular
+tags such as `@param`, `@return`, `@raise`, `@api`, `@abstract`, `@deprecated`,
+etc.) or `@!word` (directives such as `@!attribute`, `@!method`, `@!scope`, etc.).
+
+Within the tag block there are no other exceptions: consecutive same-kind tags (e.g.
+multiple `@param` lines) each require their own preceding blank line.
+
+#### Never use raw blank lines inside a doc comment block
+
+A raw blank line — an empty line with no leading `#` — terminates the YARD doc
+comment block at that point. Any comment lines that follow the raw blank line are
+treated as separate, unattached comments and will not appear in the generated
+documentation. Always use a blank comment line (`#`) to separate paragraphs or
+continuation text within a YARD block:
+
+Correct — blank comment line keeps the block intact:
+
+```ruby
+# @option options [Boolean, nil] :ipv4 (nil) use IPv4 addresses only
+#
+#   Alias: :"4"
+```
+
+Incorrect — raw blank line silently drops the alias note:
+
+```ruby
+# @option options [Boolean, nil] :ipv4 (nil) use IPv4 addresses only
+
+#   Alias: :"4"
+```
+
+Watch for editors that auto-strip trailing spaces from `#` lines, silently
+creating raw blank lines.
+
+#### Short descriptions
+
+The short description (the first sentence of any doc comment, or the inline text of
+a `@param`, `@return`, `@raise`, etc. tag) must:
+
+- Be a single sentence
+- Not end with sentence-ending punctuation (`.`, `?`, `!`)
+- **Element-level short descriptions** (on classes, modules, and methods) **start
+  with an uppercase letter** (e.g. `Returns the commit count`,
+  `Represents a Git branch`)
+- **Tag short descriptions** (`@option`, `@param`, `@return`, `@raise`, `@yield`,
+  `@yieldparam`, etc.) **all start with a lowercase letter** (e.g. `@option options
+  [Boolean, nil] :force (nil) overwrite existing files`, `@param name [String] the branch
+  name`, `@return [String] the result`, `@raise [ArgumentError] when no name is provided`)
+
+For tags, the **summary text** is the description that follows the tag
+metadata (tag name, `[Type]`, option key, and `(default)`). For example, in:
+
+```text
+@option options [Boolean, nil] :ignore_case (nil) ignore case distinctions
+```
+
+the summary text is `ignore case distinctions`.
+
+#### Line and summary length
+
+Every physical YARD doc line should not exceed `LINE_LIMIT`. When a description
+would push a line past `LINE_LIMIT`, split it at a word boundary
+onto a continuation line indented two extra spaces. For content that cannot
+be wrapped (URLs, long inline code spans, long `[Type]` expressions,
+`@example` code lines, markdown table rows), lines may extend up to
+`LINE_MAX` but must not exceed it.
+
+Additionally, the concatenated description — the description text from the
+first line joined with all continuation lines — must not exceed
+`SUMMARY_LIMIT`. If the concatenated description exceeds `SUMMARY_LIMIT`,
+shorten it and move the excess detail into a paragraph after a blank `#` line.
+
+For example, this tag has a description of 84 characters (within
+`SUMMARY_LIMIT`), but the single physical line is 102 characters (exceeds
+`LINE_LIMIT`) and must be split:
+
+```ruby
+# @return [Array] a two-element array `[target, options]` containing the translated checkout arguments
+```
+
+Split so each physical line fits within `LINE_LIMIT`:
+
+```ruby
+# @return [Array] a two-element array `[target, options]` containing the
+#   translated checkout arguments
+```
+
+If the tag metadata itself is long (e.g. a long `[Type]` or `@option` key),
+start the description on an indented continuation line so only the metadata
+appears on the first physical line.
+
+If more explanation is needed, add continuation paragraphs after a blank
+comment line (`#`). Every physical line — in the summary and in any
+continuation paragraph — must independently fit within `LINE_LIMIT`
+(or `LINE_MAX` for unwrappable content such as URLs, long inline code
+spans, long `[Type]` expressions, `@example` code, or table rows).
+
+These rules apply to every doc comment — an object's short description and a
+tag's text alike; the first sentence is the short description. The no-punctuation rule applies only to
+short descriptions; continuation paragraphs use normal prose punctuation (periods).
+Separate continuation paragraphs with a blank comment line.
+
+Correct — tag title without punctuation, blank line before continuation:
+
+```ruby
+# @option options [Boolean, nil] :ignore_case (nil) ignore case
+#   distinctions in both the pattern and the file contents
+#
+#   Alias: :i
+#
+# @option options [String, Array<String>] :pattern the search pattern
+#   (required; must not be nil)
+#
+#   Pass a String for a simple pattern (emitted as `-e <pattern>`).
+#   Pass an Array of raw CLI arguments for compound boolean
+#   expressions.
+#
+# @return [Git::CommandLineResult] the result of calling `git grep`
+#
+#   Exit status 0 means matches were found; exit status 1 means no
+#   lines were selected (not an error).
+```
+
+Incorrect — trailing period on title, missing blank line before continuation, and `@return` concatenated summary exceeds `SUMMARY_LIMIT` (132 chars):
+
+```ruby
+# @option options [Boolean, nil] :ignore_case (nil) ignore case
+#   distinctions in both the pattern and the file contents.
+#   Alias: :i
+#
+# @return [Git::CommandLineResult] the result of calling `git grep`.
+#   Exit status 0 means matches were found; exit status 1 means no
+#   lines were selected (not an error).
+```
+
+#### `@return` must always include a type
+
+Every `@return` tag must include a `[Type]` specifier. `@return the value` is
+incorrect; write `@return [Object] the value` (or a more specific type). If the
+return value is the block's return value, use `@return [Object]`.
+
+#### No shell calls in `@example` blocks
+
+Never use backtick shell calls (`` `true` ``, `` `git version` ``) or process-status
+globals (`$?`, `$CHILD_STATUS`) in `@example` blocks. They are side-effecting,
+environment-dependent, and confuse readers about the type of object being
+demonstrated. Construct example objects directly in Ruby instead:
+
+Incorrect:
+
+```ruby
+# @example Incorrect shell call
+#   `true`
+#   result = Git::CommandLine::Result.new([], $?, '', '')
+```
+
+Correct:
+
+```ruby
+# @example Constructing a result with a double
+#   status = instance_double(ProcessExecuter::Result)
+#   result = Git::CommandLine::Result.new([], status, '', '')
+```
+
+#### Blank lines within `@example` blocks
+
+Within `@example` blocks, blank comment lines (`#`) render as literal blank lines in
+the displayed code. Use them for readability between setup and assertions, but be
+aware they are literal content, not tag separators.
+
+#### `@example` titles are required
+
+Every `@example` tag must include a title — the descriptive text on the same line
+after `@example`. Write `@example Basic usage`, not bare `@example`. Titles appear
+as headings in generated docs and help readers scan multiple examples.
+
+#### Cross-reference links only resolve to objects included in generated docs
+
+YARD renders `{ClassName#method}` as a hyperlink only when the target method is
+included in the generated documentation. Public objects are included by default,
+and objects marked with `@api private` remain included with a private annotation.
+Ruby private methods are excluded by default. Do not write
+`{Git::Commands::Base#execute_command}` — it will render as plain text and may
+generate an unresolved reference warning.
+
+If you need to refer to a private method, describe it in prose instead, or link to
+the public method that callers should use.
+
+#### Inline code formatting
+
+Use backtick code spans for inline code (`` `true` ``, `` `nil` ``, symbols, type
+names, method calls). Do not use the RDoc `+value+` style; it is inconsistent with
+the project's markdown rendering via redcarpet.
+
+#### Escaping opening braces in descriptions
+
+YARD treats `{` as the start of a cross-reference link. Because redcarpet consumes
+one `\` before YARD sees it, write `\\{` (two backslashes) to produce a literal
+`{` — redcarpet reduces `\\` to `\`, leaving `\{` for YARD. For example, use
+`'stash@\\{0}'` to render as `stash@{0}`. Using only `\{` still triggers a YARD
+unresolved link warning.
+
+#### Cross-reference links
+
+Link to other code objects anywhere in a doc comment using `{ClassName}`,
+`{ClassName#method}`, `{#method_in_same_class}`, or `{Class::CONSTANT}`. An
+optional title follows the reference separated by a space:
+`{Git::Repository#log the log method}`. Do not use brace syntax inside `@see` tags —
+`@see` links automatically without braces. `@see` accepts three target forms:
+
+- Code objects: `@see Git::Repository#log`
+- URLs: `@see https://git-scm.com/docs/git-log`
+- Quoted text: `@see "Pro Git, Chapter 2"`
+
+#### Type specifier conventions
+
+The `[Types]` field in `@param`, `@return`, `@raise`, etc. supports:
+
+- Plain types: `[String]`, `[Integer]`, `[Git::Repository]`
+- Multiple types: `[String, nil]`, `[String, Array<String>]`
+- Parametrized collections: `[Array<String>]`, `[Hash<Symbol, String>]`
+- Fixed-position tuples: `[Array(String, Integer)]`, `[Array(Symbol, (Integer, nil))]`
+- Duck-types (responds to): `[#read]`, `[#to_s]`
+- `[Boolean]` — conventional meta-type for `true` or `false` (not a real Ruby class)
+- `[void]` — for `@return` tags on methods whose return value must not be used
+
+#### `Array<...>` (collection) vs `Array(...)` (tuple)
+
+YARD treats angle brackets and parentheses as distinct type constructors, so
+choose the one that matches the value's shape:
+
+- `Array<T>` (angle brackets) — a **collection**: an array *of* `T` with any
+  number of elements, e.g. `Array<String>` is zero or more strings. Listing
+  several types inside `<...>` means each element is one *of* those types
+  (`Array<String, Symbol>` is an array whose elements are each a String or a
+  Symbol), **not** a fixed sequence.
+- `Array(A, B)` (parentheses) — a **tuple**: an array *containing* exactly `A`
+  then `B` in that order, e.g. `Array(String, Integer)` is a two-element
+  `[name, count]`. Use this whenever a method returns or accepts a
+  fixed-position array such as `[status, similarity]` or `[path, options]`.
+
+The same rule applies to nested types: `Array<Array(Integer, String)>` is a
+collection of `[index, message]` tuples. Use `[Array]` with a prose description
+only when the element types cannot be expressed concisely.
+
+#### `@api private` vs `@private`
+
+Use `@api private` (not `@private`) to mark internal classes and modules. `@api
+private` includes the object in generated docs with a private annotation; YARD's
+`@private` tag excludes the object from docs entirely.
+
+#### `@since` tags are not used
+
+Do not add `@since` tags. The project has no historical `@since` annotations, and
+retroactively tagging existing APIs is impractical at v4.x. Version introduction
+history is tracked through git blame and the CHANGELOG instead.
+
+#### `@todo` tags are not used
+
+Do not add `@todo` tags. Track incomplete work in GitHub Issues, not in source
+comments. YARD renders `@todo` prominently in generated docs, and these annotations
+go stale quickly.
+
+#### `@abstract`
+
+Use `@abstract` on classes or methods that must be subclassed or overridden before
+use. Include guidance text describing what the subclass must implement:
+`@abstract Subclass and implement {#run}`. Do not use `@abstract` on concrete
+classes or fully implemented methods.
+
+### Method Rules
+
+#### Short description
+
+Every method must have a short description that:
+
+- Starts with a verb (`Returns`, `Resets`, `Finds` — not "The…" or "This method…")
+- Omits the subject — write "Returns the commit count", not "This method returns
+  the commit count"
+- States the outcome, not the mechanism — `Finds the nearest tagged ancestor` not
+  `Iterates through commits checking tags`
+- Mentions key parameters inline — `Resets HEAD to the given ref` rather than
+  relying solely on param tags
+- Avoids restating the method name — add specificity about what kind, from where,
+  or what is returned
+- Is specific about return values — `Returns true if the branch exists, false
+  otherwise` beats `Returns a Boolean`
+- Omits implementation details — callers don't care about internal loops or temp
+  variables
+
+#### Standard tags
+
+Methods use these standard YARD tags:
+
+- `@param` for each method parameter, in signature order; omit `@param` entirely
+  on zero-argument methods
+- `@return` on every method; use `[void]` when the return value must not be used
+- `@raise` for each caller-relevant exception the method can raise as part of its
+  contract; omit `@raise` when the method has no documented exceptional path
+
+#### `@example` on non-private methods
+
+Methods without Ruby `private` visibility must have one or more `@example`s;
+Ruby-private methods may omit `@example` unless usage would otherwise be unclear.
+
+#### Yield tags
+
+Methods that yield to a block must include `@yield [param_names]`, one
+`@yieldparam name [Type]` per yielded parameter, and `@yieldreturn [Type]`; omit
+all yield tags on methods that do not yield.
+
+#### `@overload` for distinct signatures
+
+Use `@overload` when a method has distinct call signatures with different
+parameters or return types — each overload gets its own full set of tags.
+Methods that yield only when an optional block is given should use `@overload`
+to document the with-block and without-block signatures separately.
+
+#### `@overload` for anonymous splats
+
+Methods whose signature uses an anonymous `*`, `**`, or `...` must document their
+call shapes with named `@overload` blocks. Do **not** name the splat or expand
+`...` into `*args, **kwargs, &block` to make tags bind — that conflicts with
+RuboCop's `Style/ArgumentsForwarding` cop. See
+[Documenting anonymous splats with `@overload`](#documenting-anonymous-splats-with-overload).
+
+#### `@note` for callouts (Optional)
+
+Use `@note` for callouts that need visual emphasis: thread-safety warnings,
+significant side effects, or platform-specific behavior.
+
+#### `@deprecated` on deprecated methods
+
+Deprecated methods must include `@deprecated` explaining the migration path,
+e.g. `@deprecated Use {#new_method} instead`.
+
+#### `@api` on methods (Optional)
+
+`@api` is optional on methods — when omitted, the method inherits the containing
+class's `@api` level. Use it only when the method's intended visibility differs
+from the class's level (e.g. an `@api private` helper inside an `@api public`
+class).
 
 ## Command Reference
 

--- a/.github/skills/yard-documentation/element-rules.md
+++ b/.github/skills/yard-documentation/element-rules.md
@@ -1,0 +1,158 @@
+# YARD Element-Specific Rules
+
+Per-element YARD requirements for classes, modules, constants, attributes,
+dynamically defined methods, and value objects
+(`Data.define` / `Struct.new`).
+
+Consult this file when documenting one of those elements. Rules that apply to
+**every** doc comment (formatting, length limits, tag order) and to **methods**
+live in [SKILL.md](SKILL.md).
+
+## Contents
+
+- [Contents](#contents)
+- [Classes](#classes)
+- [Modules](#modules)
+- [Constants](#constants)
+- [Attributes](#attributes)
+- [Dynamically defined methods (`@!method`)](#dynamically-defined-methods-method)
+- [`Data.define` classes](#datadefine-classes)
+- [`Struct.new` classes](#structnew-classes)
+
+## Classes
+
+- One-sentence class description as a **noun phrase** (or starting with "Represents…") — the description should pass
+  the "This class is a…" litmus test (i.e. you should be able to prefix "This class
+  is a" and produce a grammatical sentence). "Represents…" is an accepted convention.
+  Do not start descriptions with "This class is…", "Provides…", or "Encapsulates…".
+  - Good: `Wrapper around the git binary`, `Immutable value object for a branch
+    delete result`, `Represents a git branch`
+  - Bad: `This class wraps the git binary`, `Provides branch deletion`,
+    `Encapsulates branch state`
+- `@api public` or `@api private` tag to declare visibility — use `@api public` for
+  stable user-facing classes; use `@api private` for internal implementation classes
+  (e.g., `Git::ExecutionContext::*`, `Git::Commands::*`, parsers)
+- At least one `@example` showing typical instantiation or primary usage — this
+  applies to all classes including `@api private` classes
+- Error/exception classes must also state when the error is raised in class-level
+  prose, using caller-facing wording such as `Raised when branch deletion fails`
+- Deprecated classes must include `@deprecated` explaining the migration path
+- When present, class-level tags must appear in this order: `@example`, `@note`,
+  `@deprecated`, `@see`, `@api`, `@abstract`
+
+## Modules
+
+- One-sentence description — "Namespace for…", "Provides helpers for…", or
+  "Mixin that adds…"
+- `@api public` or `@api private` — use `@api public` for stable user-facing modules;
+  use `@api private` for internal implementation modules
+- No `@example` required unless the module provides standalone methods
+- Deprecated modules must include `@deprecated` explaining the migration path
+- When present, module-level tags must appear in the same order as class-level
+  tags: `@example`, `@note`, `@deprecated`, `@see`, `@api`
+
+## Constants
+
+- A comment immediately above the constant describing its purpose and valid values
+- No special YARD tag is needed; YARD picks up the preceding comment automatically
+- Add `# @return [Type]` when the constant holds a collection, frozen structure, or
+  domain-specific type whose shape is not immediately obvious from the value
+
+## Attributes
+
+- For explicitly written `attr_reader`, `attr_accessor`, and `attr_writer` declarations,
+  place the documentation directly above the attribute; do **not** use the `@!attribute`
+  directive
+- For dynamically created attributes, `Data.define` members, or `Struct.new`
+  members, you **must** use a `# @!attribute [r/rw/w] name` YARD directive
+- Must include `@return [Type] description` explaining the value and its units or
+  constraints if relevant
+- For explicit `attr_reader`/`attr_accessor`/`attr_writer`, include a short
+  description paragraph above the attribute in addition to `@return`
+- For `@!attribute` directives (in `Data.define` / `Struct.new`), the `@return`
+  tag inside the directive block serves as the sole documentation — no separate
+  short description is needed
+- Tags inside `@!attribute` (and `@!method`) directive blocks must be indented
+  two extra spaces relative to the directive itself
+- Must be defined at the class level, not inside method bodies
+
+## Dynamically defined methods (`@!method`)
+
+Use the `# @!method name(params)` directive for methods created via
+metaprogramming (`define_method`, method-generating DSLs, etc.) that have no
+literal `def`. Place the directive and its doc comment where the method would
+logically appear in the class body. Tags inside the directive block follow the
+same indentation rule as `@!attribute` — indented two extra spaces relative to
+the directive.
+
+## `Data.define` classes
+
+Immutable value objects defined with `Data.define` use the following conventions
+(see `Git::BranchDeleteFailure` for a canonical example):
+
+- Class-level doc: noun-phrase short description, `@example`, `@see`, `@api`
+- One `@!attribute [r]` directive per member with `@return [Type] description`
+- Attribute directives are placed after class-level tags and before the
+  `Data.define` line
+- Custom methods defined inside the `Data.define` block follow standard method
+  rules
+
+```ruby
+# Immutable value object for a failed branch delete
+#
+# @example Create a failure object
+#   failure = BranchDeleteFailure.new(
+#     name: 'nonexistent',
+#     error_message: "branch 'nonexistent' not found."
+#   )
+#   failure.name          #=> 'nonexistent'
+#   failure.error_message #=> "branch 'nonexistent' not found."
+#
+# @see Git::BranchDeleteResult
+#
+# @api public
+#
+# @!attribute [r] name
+#
+#   @return [String] the branch name that failed to delete
+#
+# @!attribute [r] error_message
+#
+#   @return [String] the git error message explaining the failure
+#
+BranchDeleteFailure = Data.define(:name, :error_message)
+```
+
+## `Struct.new` classes
+
+Document `Struct.new` classes using the same conventions as `Data.define` classes:
+class-level doc with a noun-phrase short description, `@example`, `@see`, `@api`,
+and one `@!attribute` directive per member with `@return [Type] description`.
+
+Unlike `Data.define`, a `Struct.new` class is **mutable** — it generates
+read-write accessors — so use `@!attribute [rw]` (not `[r]`) for its members and
+do not describe it as immutable.
+
+```ruby
+# Value object for a diff hunk's location within a file
+#
+# @example Create and update a hunk location
+#   loc = HunkLocation.new(start_line: 10, line_count: 3)
+#   loc.start_line #=> 10
+#   loc.line_count = 4
+#   loc.line_count #=> 4
+#
+# @see Git::DiffInfo
+#
+# @api public
+#
+# @!attribute [rw] start_line
+#
+#   @return [Integer] the 1-based line where the hunk begins
+#
+# @!attribute [rw] line_count
+#
+#   @return [Integer] the number of lines the hunk spans
+#
+HunkLocation = Struct.new(:start_line, :line_count, keyword_init: true)
+```


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Restructure the YARD documentation skill so agents can follow a workflow-first path, with situational element rules moved into a dedicated reference file. Also improves the meta-skills used to author and review skills, and adds a new skill for resolving PR feedback.

Summary:
- Reorganizes `.github/skills/yard-documentation/SKILL.md` around workflow, precedence, named length limits, templates, and reviewable standards.
- Adds `.github/skills/yard-documentation/element-rules.md` for non-method element guidance, including `Data.define` and mutable `Struct.new` conventions.
- Updates facade YARD links to the moved module rules.
- Improves skill-authoring and skill-review guidance for size targets, progressive disclosure, anchor/link validation, inheritance/override clarity, and PR readiness checks for skill changes.
- Adds `.github/skills/resolve-feedback/SKILL.md`: a workflow to resolve unresolved PR review threads, fold each fix into the existing commit that last touched the file, force-push with lease, and request a fresh Copilot review.

Validation:
- VS Code diagnostics: no errors found for the changed skill files.
- Link/anchor validator: all changed skill links and anchors resolve.
- `git diff --check`: passed.
- `bundle exec rake default`: not run; changes are documentation/agent-skill guidance only.

Commits:
- `docs: restructure YARD documentation skill`
- `docs: improve skill authoring review guidance`
- `docs: add resolve-feedback skill`

## Checklist

- [ ] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [ ] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
