### PR TITLE
docs: document Git::Config readers

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -34,7 +34,6 @@ Documentation/UndocumentedObjects:
   Exclude:
     - 'lib/git/commands/cat_file/batch.rb'
     - 'lib/git/commands/update_ref/batch.rb'
-    - 'lib/git/config.rb'
     - 'lib/git/encoding_utils.rb'
     - 'lib/git/errors.rb'
     - 'lib/git/escaped_path.rb'

--- a/lib/git/config.rb
+++ b/lib/git/config.rb
@@ -44,14 +44,41 @@ module Git
       @timeout = nil
     end
 
+    # Returns the git executable path
+    #
+    # Uses an explicitly configured path first, then `GIT_PATH`, then `git`.
+    #
+    # @example Read the default executable
+    #   Git::Config.instance.binary_path #=> "git"
+    #
+    # @return [String] the git executable path
+    #
     def binary_path
       @binary_path || (ENV.fetch('GIT_PATH', nil) && File.join(ENV.fetch('GIT_PATH', nil), 'git')) || 'git'
     end
 
+    # Returns the SSH wrapper path used by git operations
+    #
+    # Uses an explicitly configured wrapper path first, then `GIT_SSH`.
+    #
+    # @example Read the configured SSH wrapper path
+    #   Git::Config.instance.git_ssh #=> "/usr/bin/ssh-wrapper"
+    #
+    # @return [String, nil] the configured SSH wrapper path
+    #
     def git_ssh
       @git_ssh || ENV.fetch('GIT_SSH', nil)
     end
 
+    # Returns the timeout for git operations
+    #
+    # Uses an explicitly configured timeout first, then `GIT_TIMEOUT`.
+    #
+    # @example Read the configured timeout
+    #   Git::Config.instance.timeout #=> 30
+    #
+    # @return [Integer, nil] the timeout in seconds
+    #
     def timeout
       @timeout || (ENV.fetch('GIT_TIMEOUT', nil) && ENV['GIT_TIMEOUT'].to_i)
     end


### PR DESCRIPTION
# Description

Remove the `lib/git/config.rb` baseline exclusion from `.yard-lint-todo.yml` and document the `Git::Config` reader methods so YARD lint passes without that exclusion.

Validation:

- `rake yard:lint`

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).