### PR TITLE
diff: remove DiffPathStatus YARD todo exclusion

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -14,7 +14,6 @@ Documentation/UndocumentedMethodArguments:
   Exclude:
     - 'lib/git/commands/cat_file/batch.rb'
     - 'lib/git/commands/update_ref/batch.rb'
-    - 'lib/git/diff_path_status.rb'
     - 'lib/git/diff_stats.rb'
     - 'lib/git/encoding_utils.rb'
     - 'lib/git/escaped_path.rb'
@@ -200,4 +199,3 @@ Tags/OptionTags:
     - 'lib/git/repository/remote_operations.rb'
     - 'lib/git/repository/shared_private.rb'
     - 'lib/git/repository/staging.rb'
-

--- a/lib/git/diff_path_status.rb
+++ b/lib/git/diff_path_status.rb
@@ -13,6 +13,19 @@ module Git
     include Enumerable
 
     # @private
+    #
+    # @param base_or_hash [Git::Repository, Hash{String => String}] either a
+    #   repository object for legacy initialization or a pre-fetched name-status hash
+    #
+    # @param from [String, nil] the first commit/object to compare when using
+    #   legacy initialization
+    #
+    # @param to [String, nil] the second commit/object to compare when using
+    #   legacy initialization
+    #
+    # @param path_limiter [String, Pathname, Array, nil] path(s) to limit the
+    #   diff when using legacy initialization
+    #
     def initialize(base_or_hash, from = nil, to = nil, path_limiter = nil)
       if base_or_hash.is_a?(Hash)
         # New form: pre-fetched hash passed directly from Git::Repository::Diffing


### PR DESCRIPTION
## Summary
- remove `lib/git/diff_path_status.rb` from `.yard-lint-todo.yml` exclusions
- add missing `@param` documentation for `DiffPathStatus#initialize`

## Why
This file was still excluded from YARD argument documentation checks. Adding the missing docs allows the exclusion to be removed while keeping lint clean.

## Validation
- `rake yard:lint`
- `rake rubocop`
- `bundle exec rake default`