### PR TITLE
yard: remove diff_stats exclusion and document initializer args

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -14,7 +14,6 @@ Documentation/UndocumentedMethodArguments:
   Exclude:
     - 'lib/git/commands/cat_file/batch.rb'
     - 'lib/git/commands/update_ref/batch.rb'
-    - 'lib/git/diff_stats.rb'
     - 'lib/git/encoding_utils.rb'
     - 'lib/git/escaped_path.rb'
     - 'lib/git/log.rb'

--- a/lib/git/diff_stats.rb
+++ b/lib/git/diff_stats.rb
@@ -13,7 +13,22 @@ module Git
   #
   # @api public
   class DiffStats
+    # Initializes diff-stats state for a tree comparison.
+    #
     # @private
+    #
+    # @param base [Git::Repository] the git object used to fetch diff stats
+    #
+    # @param from [String] the first commit or object to compare
+    #
+    # @param to [String, nil] the second commit or object to compare
+    #
+    # @param path_limiter [String, Pathname, Array<String, Pathname>, nil]
+    #   path(s) to limit the diff
+    #
+    # @return [void]
+    #
+    # @raise [ArgumentError] when `from` or `to` starts with `"-"`
     def initialize(base, from, to, path_limiter = nil)
       # Eagerly check for invalid arguments
       [from, to].compact.each do |arg|


### PR DESCRIPTION
## Summary
- remove `lib/git/diff_stats.rb` from `Documentation/UndocumentedMethodArguments` exclusions in `.yard-lint-todo.yml`
- add missing YARD argument/return/raise docs for `Git::DiffStats#initialize`

## Why
This enables `lib/git/diff_stats.rb` to pass YARD lint without a file-level exclusion.

## Validation
- `bundle exec rake default`
- `bundle exec rake yard:lint`
- `bundle exec rake rubocop`
- `bundle exec rspec spec/unit/git/diff_stats_spec.rb`