### PR TITLE
yard: remove errors.rb exclusion and document VersionError message builder

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -33,7 +33,6 @@ Documentation/UndocumentedObjects:
     - 'lib/git/commands/cat_file/batch.rb'
     - 'lib/git/commands/update_ref/batch.rb'
     - 'lib/git/encoding_utils.rb'
-    - 'lib/git/errors.rb'
     - 'lib/git/escaped_path.rb'
     - 'lib/git/log.rb'
     - 'lib/git/parsers/branch.rb'

--- a/lib/git/errors.rb
+++ b/lib/git/errors.rb
@@ -270,6 +270,10 @@ module Git
 
     private
 
+    # Builds the error message for the violated version constraint.
+    #
+    # @return [String]
+    #
     def build_message
       if constraint.too_new?(actual_version)
         "#{subject} requires git < #{constraint.before} (found #{actual_version})"


### PR DESCRIPTION
## Summary
- remove `lib/git/errors.rb` from `.yard-lint-todo.yml` exclusions
- add YARD documentation for `Git::VersionError#build_message`
- keep `rake yard:lint` and `rake rubocop` clean after removing the exclusion

## Why
This tightens YARD lint coverage by removing a suppression and documenting the remaining undocumented private method in `lib/git/errors.rb`.

## Validation
- `bundle exec rake default`
- `bundle exec rake yard:lint`
- `bundle exec rake rubocop`