### PR TITLE
chore: run bin/setup once per worktree session

### DIFF
--- a/.github/hooks/bin-setup-on-worktree.json
+++ b/.github/hooks/bin-setup-on-worktree.json
@@ -1,0 +1,11 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "type": "command",
+        "command": ".github/hooks/run-bin-setup-once.sh",
+        "timeout": 900
+      }
+    ]
+  }
+}

--- a/.github/hooks/run-bin-setup-once.sh
+++ b/.github/hooks/run-bin-setup-once.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Skip if this repo does not use bin/setup.
+[[ -x "./bin/setup" ]] || exit 0
+
+# Keep setup idempotent per-worktree.
+command -v git >/dev/null 2>&1 || exit 0
+marker="$(git rev-parse --git-path copilot-bin-setup.done 2>/dev/null)" || exit 0
+[[ -f "$marker" ]] && exit 0
+
+./bin/setup
+mkdir -p "$(dirname "$marker")"
+touch "$marker"


### PR DESCRIPTION
# Description

Add workspace-level Copilot hook automation so `bin/setup` runs automatically once per worktree.

## What changed

- Added `.github/hooks/bin-setup-on-worktree.json` with a `SessionStart` hook
- Added `.github/hooks/run-bin-setup-once.sh` (executable)
- Script behavior:
  - exits if `./bin/setup` is not present/executable
  - uses `git rev-parse --git-path copilot-bin-setup.done` as a per-worktree marker
  - runs `./bin/setup` only when the marker does not exist, then writes the marker

## Validation

- Ran `bin/setup`
- Ran `bundle exec rake default` before changes
- Ran `bundle exec rake default` after changes
- Manually verified the script runs setup on first invocation and skips on second

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
