### PR TITLE
docs(branch): remove branch parser YARD baseline exclusion

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -35,7 +35,6 @@ Documentation/UndocumentedObjects:
     - 'lib/git/config.rb'
     - 'lib/git/errors.rb'
     - 'lib/git/log.rb'
-    - 'lib/git/parsers/branch.rb'
     - 'lib/git/parsers/diff.rb'
     - 'lib/git/parsers/stash.rb'
     - 'lib/git/parsers/tag.rb'

--- a/lib/git/parsers/branch.rb
+++ b/lib/git/parsers/branch.rb
@@ -5,6 +5,10 @@ require 'git/branch_delete_result'
 require 'git/branch_delete_failure'
 
 module Git
+  # Internal parsers that translate raw git command output into structured Ruby objects.
+  #
+  # @api private
+  #
   module Parsers
     # Parser for git branch command output
     #


### PR DESCRIPTION
## Summary
- remove `lib/git/parsers/branch.rb` from `.yard-lint-todo.yml` under `Documentation/UndocumentedObjects`
- add YARD docs to the `Git::Parsers` namespace in `lib/git/parsers/branch.rb`

## Why
This burns down one baseline exclusion and keeps `yard:lint` green after removing it.

## Validation
- `bundle exec rake yard:lint`
- `bundle exec rake rubocop`
- `bundle exec rake default`