### PR TITLE
remote: remove YARD exclusions and document missing API tags

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -19,7 +19,6 @@ Documentation/UndocumentedMethodArguments:
     - 'lib/git/escaped_path.rb'
     - 'lib/git/log.rb'
     - 'lib/git/parsers/tag.rb'
-    - 'lib/git/remote.rb'
     - 'lib/git/repository.rb'
     - 'lib/git/repository/context_helpers.rb'
     - 'lib/git/repository/logging.rb'
@@ -35,7 +34,6 @@ Documentation/UndocumentedObjects:
     - 'lib/git/errors.rb'
     - 'lib/git/parsers/branch.rb'
     - 'lib/git/parsers/tag.rb'
-    - 'lib/git/remote.rb'
     - 'lib/git/repository.rb'
     - 'lib/git/repository/context_helpers.rb'
     - 'lib/git/repository/logging.rb'
@@ -166,7 +164,6 @@ Documentation/UndocumentedOptions:
     - 'lib/git/commands/worktree/repair.rb'
     - 'lib/git/commands/worktree/unlock.rb'
     - 'lib/git/commands/write_tree.rb'
-    - 'lib/git/remote.rb'
     - 'lib/git/repository.rb'
     - 'lib/git/repository/committing.rb'
     - 'lib/git/repository/context_helpers.rb'
@@ -181,7 +178,6 @@ Documentation/UndocumentedOptions:
 # Tags validators
 Tags/OptionTags:
   Exclude:
-    - 'lib/git/remote.rb'
     - 'lib/git/repository.rb'
     - 'lib/git/repository/committing.rb'
     - 'lib/git/repository/diffing.rb'

--- a/lib/git/remote.rb
+++ b/lib/git/remote.rb
@@ -59,7 +59,31 @@ module Git
     # @example Fetch from origin
     #   git.remote('origin').fetch
     #
-    # @param opts [Hash] fetch options (see `Git::Repository#fetch`)
+    # @param opts [Hash] options for the fetch command
+    #
+    # @option opts [Boolean, nil] :tags (nil) fetch all tags from the remote
+    #   (`--tags`)
+    #
+    # @option opts [Boolean, nil] :prune (nil) remove remote-tracking references
+    #   that no longer exist on the remote (`--prune`)
+    #
+    # @option opts [Boolean, nil] :prune_tags (nil) remove local tags that no
+    #   longer exist on the remote (`--prune-tags`)
+    #
+    # @option opts [Boolean, nil] :force (nil) override the fast-forward check
+    #   when using explicit refspecs (`--force`)
+    #
+    # @option opts [Boolean, nil] :update_head_ok (nil) allow `git fetch` to
+    #   update the branch pointed to by `HEAD` (`--update-head-ok`)
+    #
+    # @option opts [Boolean, nil] :unshallow (nil) convert a shallow clone into a
+    #   full repository (`--unshallow`)
+    #
+    # @option opts [String, Integer, nil] :depth (nil) limit history to N commits
+    #   from each branch tip (`--depth=N`)
+    #
+    # @option opts [String, Array<String>, nil] :ref (nil) one or more refspecs to
+    #   fetch as positional arguments after the remote name
     #
     # @return [String] git's stdout from the fetch
     #
@@ -136,6 +160,14 @@ module Git
       @base
     end
 
+    # Builds branch metadata for a remote-tracking branch
+    #
+    # @param refname [String] remote-tracking branch name (for example,
+    #   `'origin/main'`)
+    #
+    # @return [Git::BranchInfo] minimal branch metadata for constructing
+    #   {Git::Branch}
+    #
     def build_branch_info(refname)
       Git::BranchInfo.new(
         refname: refname,


### PR DESCRIPTION
## Summary
- remove all `lib/git/remote.rb` exclusions from `.yard-lint-todo.yml`
- add missing YARD `@option` tags for `Git::Remote#fetch`
- document `Git::Remote#build_branch_info` arguments and return type

## Why
This keeps `lib/git/remote.rb` fully linted by `yard-lint` instead of relying on baseline exclusions.

## Validation
- `bundle exec rake yard:lint`
- `bundle exec rake rubocop`
- `bundle exec rake default`