### PR TITLE
chore(yard): remove diffing exclusions and document options

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -166,7 +166,6 @@ Documentation/UndocumentedOptions:
     - 'lib/git/commands/write_tree.rb'
     - 'lib/git/repository/committing.rb'
     - 'lib/git/repository/context_helpers.rb'
-    - 'lib/git/repository/diffing.rb'
     - 'lib/git/repository/factories.rb'
     - 'lib/git/repository/logging.rb'
     - 'lib/git/repository/object_operations.rb'
@@ -178,7 +177,6 @@ Documentation/UndocumentedOptions:
 Tags/OptionTags:
   Exclude:
     - 'lib/git/repository/committing.rb'
-    - 'lib/git/repository/diffing.rb'
     - 'lib/git/repository/factories.rb'
     - 'lib/git/repository/logging.rb'
     - 'lib/git/repository/object_operations.rb'

--- a/lib/git/repository/diffing.rb
+++ b/lib/git/repository/diffing.rb
@@ -503,6 +503,12 @@ module Git
         #
         # @param opts [Hash] the options hash from {#diff_path_status}
         #
+        # @option opts [String, Pathname, Array<String, Pathname>, nil] :path_limiter (nil)
+        #   primary path limiter value used as-is when present
+        #
+        # @option opts [String, Pathname, Array<String, Pathname>, nil] :path (nil)
+        #   **deprecated** — fallback path limiter when `:path_limiter` is not provided
+        #
         # @return [String, Pathname, Array<String, Pathname>, nil]
         #   the effective path limiter
         #


### PR DESCRIPTION
## Description

Removed `lib/git/repository/diffing.rb` from YARD lint baselines and fixed the
resulting documentation offenses.

- Removed `lib/git/repository/diffing.rb` from:
  - `Documentation/UndocumentedOptions` excludes
  - `Tags/OptionTags` excludes
- Added missing `@option` tags for `Git::Repository::Diffing::Private#resolve_path_limiter`
  so YARD documents the supported `opts` keys (`:path_limiter` and deprecated
  `:path` fallback).
- Re-ran validations:
  - `bundle exec rake yard:lint`
  - `bundle exec rake rubocop`
  - `bundle exec rake default`

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
