### PR TITLE
docs(logging): remove yard-lint logging exclusions

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -20,7 +20,6 @@ Documentation/UndocumentedMethodArguments:
     - 'lib/git/log.rb'
     - 'lib/git/parsers/stash.rb'
     - 'lib/git/remote.rb'
-    - 'lib/git/repository/logging.rb'
     - 'lib/git/repository/object_operations.rb'
     - 'lib/git/url.rb'
 
@@ -33,7 +32,6 @@ Documentation/UndocumentedObjects:
     - 'lib/git/parsers/branch.rb'
     - 'lib/git/parsers/stash.rb'
     - 'lib/git/remote.rb'
-    - 'lib/git/repository/logging.rb'
     - 'lib/git/repository/object_operations.rb'
 
 Documentation/UndocumentedOptions:
@@ -162,7 +160,6 @@ Documentation/UndocumentedOptions:
     - 'lib/git/commands/worktree/unlock.rb'
     - 'lib/git/commands/write_tree.rb'
     - 'lib/git/repository/factories.rb'
-    - 'lib/git/repository/logging.rb'
     - 'lib/git/repository/object_operations.rb'
     - 'lib/git/repository/shared_private.rb'
     - 'lib/git/repository/staging.rb'
@@ -171,7 +168,6 @@ Documentation/UndocumentedOptions:
 Tags/OptionTags:
   Exclude:
     - 'lib/git/repository/factories.rb'
-    - 'lib/git/repository/logging.rb'
     - 'lib/git/repository/object_operations.rb'
     - 'lib/git/repository/shared_private.rb'
     - 'lib/git/repository/staging.rb'

--- a/lib/git/repository/logging.rb
+++ b/lib/git/repository/logging.rb
@@ -13,6 +13,10 @@ module Git
     # @api public
     #
     module Logging
+      # Allowed option keys for {#full_log_commits}
+      #
+      # @return [Array<Symbol>] the supported option keys
+      #
       FULL_LOG_COMMITS_ALLOWED_OPTS = %i[
         count all cherry since until grep author between object path_limiter skip merges
       ].freeze
@@ -20,56 +24,59 @@ module Git
 
       # Returns commits within the given revision range
       #
-      # @overload full_log_commits(opts = {})
+      # @example Return commits from all refs
+      #   repo.full_log_commits(all: true).first['sha']
+      #   #=> "a1b2c3d4..."
       #
-      #   @example Return commits from all refs
-      #     repo.full_log_commits(all: true).first['sha']
-      #     #=> "a1b2c3d4..."
+      # @example Return commits between two revisions
+      #   repo.full_log_commits(between: ['v1.0.0', 'HEAD']).map { |c| c['sha'] }
+      #   #=> ["d4e5f6...", "a1b2c3..."]
       #
-      #   @example Return commits between two revisions
-      #     repo.full_log_commits(between: ['v1.0.0', 'HEAD']).map { |c| c['sha'] }
-      #     #=> ["d4e5f6...", "a1b2c3..."]
+      # @param opts [Hash] options for the log query
       #
-      #   @param opts [Hash] options for the log query
+      # @option opts [Integer, nil] :count (nil) maximum number of commits to return
       #
-      #   @option opts [Integer, nil] :count (nil) maximum number of commits to return
+      # @option opts [Boolean, nil] :all (nil) include commits reachable from any ref
       #
-      #   @option opts [Boolean, nil] :all (nil) include commits reachable from any ref
+      # @option opts [Boolean, nil] :cherry (nil) omit commits equivalent to
+      #   cherry-picked commits
       #
-      #   @option opts [Boolean, nil] :cherry (nil) omit commits equivalent to cherry-picked commits
+      # @option opts [String] :since (nil) include commits newer than this date expression
       #
-      #   @option opts [String] :since (nil) include commits newer than this date expression
+      # @option opts [String] :until (nil) include commits older than this date expression
       #
-      #   @option opts [String] :until (nil) include commits older than this date expression
+      # @option opts [String] :grep (nil) only include commits whose message matches
+      #   this pattern
       #
-      #   @option opts [String] :grep (nil) only include commits whose message matches this pattern
+      # @option opts [String] :author (nil) only include commits whose author matches
+      #   this pattern
       #
-      #   @option opts [String] :author (nil) only include commits whose author matches this pattern
+      # @option opts [Array(String, String), nil] :between (nil) revision range as
+      #   two commit-ish values
       #
-      #   @option opts [Array<String>] :between (nil) revision range as two commit-ish values
+      #   When both `:between` and `:object` are provided, `:between` takes precedence.
       #
-      #     When both `:between` and `:object` are provided, `:between` takes precedence.
+      # @option opts [String] :object (nil) single revision range expression for
+      #   `git log`
       #
-      #   @option opts [String] :object (nil) single revision range expression for git log
+      #   Ignored when `:between` is provided.
       #
-      #     Ignored when `:between` is provided.
+      # @option opts [String, Pathname, Array<String, Pathname>, nil] :path_limiter (nil)
+      #   only include commits that impact files from the specified path(s)
       #
-      #   @option opts [String, Pathname, Array<String, Pathname>] :path_limiter (nil)
-      #     only include commits that impact files from the specified path(s)
+      # @option opts [Integer, nil] :skip (nil) skip this many commits before output
       #
-      #   @option opts [Integer] :skip (nil) skip this many commits before output
+      # @option opts [Boolean, nil] :merges (nil) include only merge commits
       #
-      #   @option opts [Boolean, nil] :merges (nil) include only merge commits
+      # @return [Array<Hash>] the parsed raw log output for each commit
       #
-      #   @return [Array<Hash>] the parsed raw log output for each commit
+      # @raise [ArgumentError] if unsupported options are provided
       #
-      #   @raise [ArgumentError] if unsupported options are provided
+      # @raise [ArgumentError] if `:count` is not an Integer
       #
-      #   @raise [ArgumentError] if `:count` is not an Integer
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
-      #   @raise [Git::FailedError] if git exits with a non-zero exit status
-      #
-      #   @see https://git-scm.com/docs/git-log git-log
+      # @see https://git-scm.com/docs/git-log git-log
       #
       def full_log_commits(opts = {})
         SharedPrivate.assert_valid_opts!(FULL_LOG_COMMITS_ALLOWED_OPTS, **opts)
@@ -110,6 +117,9 @@ module Git
         #
         # @param opts [Hash] the log options
         #
+        # @option opts [Integer, nil] :count (nil) the maximum number of commits to
+        #   return
+        #
         # @return [void]
         #
         # @raise [ArgumentError] if the log count option is not an Integer
@@ -124,9 +134,13 @@ module Git
         #
         # @param opts [Hash] the log options
         #
+        # @option opts [Array(String, String), nil] :between (nil) the two-commit
+        #   revision range to validate
+        #
         # @return [void]
         #
-        # @raise [ArgumentError] if the :between option is not an Array with exactly two non-nil values
+        # @raise [ArgumentError] if the :between option is not an Array with exactly
+        #   two non-nil values
         #
         def validate_log_between_option!(opts)
           between = opts[:between]
@@ -137,6 +151,17 @@ module Git
                 "The log between option must be an Array with exactly two non-nil values but was #{between.inspect}"
         end
 
+        # Builds positional revision arguments for `git log`
+        #
+        # @param opts [Hash] the log options
+        #
+        # @option opts [Array(String, String), nil] :between (nil) a two-revision
+        #   range where index `0` is the start and index `1` is the end
+        #
+        # @option opts [String, nil] :object (nil) a single revision range expression
+        #
+        # @return [Array<String>] zero or one positional revision arguments
+        #
         def log_revision_range_args(opts)
           if opts[:between]
             ["#{opts[:between][0]}..#{opts[:between][1]}"]
@@ -147,6 +172,40 @@ module Git
           end
         end
 
+        # Builds keyword options passed to {Git::Commands::Log#call}
+        #
+        # @param opts [Hash] the log options
+        #
+        # @param extra [Hash] additional keyword options merged into the call options
+        #
+        # @option opts [Boolean, nil] :all (nil) include commits reachable from any ref
+        #
+        # @option opts [Boolean, nil] :cherry (nil) omit commits equivalent to
+        #   cherry-picked commits
+        #
+        # @option opts [String, nil] :since (nil) include commits newer than this date
+        #   expression
+        #
+        # @option opts [String, nil] :until (nil) include commits older than this date
+        #   expression
+        #
+        # @option opts [String, nil] :grep (nil) only include commits whose message
+        #   matches this pattern
+        #
+        # @option opts [String, nil] :author (nil) only include commits whose author
+        #   matches this pattern
+        #
+        # @option opts [Integer, nil] :count (nil) maximum number of commits to return
+        #
+        # @option opts [String, Pathname, Array<String, Pathname>, nil] :path_limiter (nil)
+        #   only include commits that impact files from the specified path(s)
+        #
+        # @option extra [Integer, nil] :skip (nil) skip this many commits before output
+        #
+        # @option extra [Boolean, nil] :merges (nil) include only merge commits
+        #
+        # @return [Hash] keyword options for {Git::Commands::Log#call}
+        #
         def log_base_call_options(opts, extra = {})
           {
             all: opts[:all],
@@ -160,6 +219,18 @@ module Git
           }.merge(extra).compact
         end
 
+        # Executes git log and parses the raw output
+        #
+        # @param execution_context [Git::ExecutionContext] the execution context
+        #
+        # @param revision_range_args [Array<String>] positional revision range arguments
+        #
+        # @param call_opts [Hash] keyword options for {Git::Commands::Log#call}
+        #
+        # @return [Array<Hash>] parsed commits from the command output
+        #
+        # @raise [Git::FailedError] if git exits with a non-zero exit status
+        #
         def run_log_command(execution_context, revision_range_args, call_opts)
           log_or_empty_on_unborn do
             result = Git::Commands::Log.new(execution_context).call(
@@ -172,6 +243,16 @@ module Git
           end
         end
 
+        # Returns an empty result when the repository has no commits yet
+        #
+        # @return [Array<Hash>] parsed commits or an empty array for unborn repositories
+        #
+        # @raise [Git::FailedError] if git fails for a reason other than unborn history
+        #
+        # @yield [] runs the wrapped log command
+        #
+        # @yieldreturn [Array<Hash>] the parsed commits from the wrapped command
+        #
         def log_or_empty_on_unborn
           yield
         rescue Git::FailedError => e
@@ -186,6 +267,12 @@ module Git
         # @api private
         #
         class RawLogParser
+          # Initializes a parser for raw git log output lines
+          #
+          # @param lines [Array<String>] raw output lines from `git log --pretty=raw`
+          #
+          # @return [void]
+          #
           def initialize(lines)
             @lines = lines
             @commits = []
@@ -206,6 +293,12 @@ module Git
 
           private
 
+          # Routes a raw line to message or metadata parsing
+          #
+          # @param line [String] the current raw log output line
+          #
+          # @return [void]
+          #
           def process_line(line)
             if line.empty?
               @in_message = !@in_message
@@ -217,10 +310,22 @@ module Git
             @in_message ? process_message_line(line) : process_metadata_line(line)
           end
 
+          # Appends a commit message line to the current commit buffer
+          #
+          # @param line [String] an indented message line from raw output
+          #
+          # @return [void]
+          #
           def process_message_line(line)
             @current_commit['message'] << "#{line[4..]}\n"
           end
 
+          # Parses metadata lines and multi-line metadata continuations
+          #
+          # @param line [String] a metadata line from raw output
+          #
+          # @return [void]
+          #
           def process_metadata_line(line)
             if line.start_with?(' ') && @last_metadata_key
               @current_commit[@last_metadata_key] << "\n#{line[1..]}"
@@ -233,6 +338,14 @@ module Git
             dispatch_metadata_key(key, value)
           end
 
+          # Applies a metadata key/value pair to the current commit
+          #
+          # @param key [String] the metadata key from the raw log line
+          #
+          # @param value [String] the parsed metadata value
+          #
+          # @return [void]
+          #
           def dispatch_metadata_key(key, value)
             case key
             when 'commit'
@@ -245,12 +358,22 @@ module Git
             end
           end
 
+          # Starts a new commit record in the parser state
+          #
+          # @param sha [String] the commit SHA for the new record
+          #
+          # @return [void]
+          #
           def start_new_commit(sha)
             finalize_commit
             @current_commit = { 'sha' => sha, 'message' => +'', 'parent' => [] }
             @last_metadata_key = nil
           end
 
+          # Appends the current commit to the parsed results when present
+          #
+          # @return [void]
+          #
           def finalize_commit
             @commits << @current_commit if @current_commit
           end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

This PR removes all `lib/git/repository/logging.rb` exclusions from `.yard-lint-todo.yml`
and fixes the resulting YARD lint offenses by adding complete documentation in
`lib/git/repository/logging.rb`.

Specifically:

- Removed `lib/git/repository/logging.rb` from all relevant `Exclude` lists in
  `.yard-lint-todo.yml`
- Added missing YARD docs for:
  - `FULL_LOG_COMMITS_ALLOWED_OPTS`
  - private `Logging::Private` helper methods
  - private `Logging::Private::RawLogParser` methods
- Kept behavior unchanged; this is documentation and lint baseline cleanup only

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
