### PR TITLE
chore(yard): remove url todo exclusion and document clone_to args

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -21,7 +21,6 @@ Documentation/UndocumentedMethodArguments:
     - 'lib/git/parsers/stash.rb'
     - 'lib/git/remote.rb'
     - 'lib/git/repository/object_operations.rb'
-    - 'lib/git/url.rb'
 
 Documentation/UndocumentedObjects:
   Exclude:

--- a/lib/git/url.rb
+++ b/lib/git/url.rb
@@ -31,7 +31,7 @@ module Git
     # The URI returned can be converted back to a string with 'to_s'. This is
     # guaranteed to return the same URL string that was parsed.
     #
-    # @example
+    # @example Parsing clone target from HTTPS and local paths
     #   uri = Git::URL.parse('https://github.com/ruby-git/ruby-git.git')
     #     #=> #<Addressable::URI:0x44c URI:https://github.com/ruby-git/ruby-git.git>
     #   uri.scheme #=> "https"
@@ -55,10 +55,14 @@ module Git
 
     # The directory `git clone` would use for the repository directory for the given URL
     #
-    # @example
+    # @example Deriving the clone directory name
     #   Git::URL.clone_to('https://github.com/ruby-git/ruby-git.git') #=> 'ruby-git'
     #
     # @param url [String] the Git URL containing the repository directory
+    #
+    # @param bare [Boolean] whether the repository should be cloned as bare
+    #
+    # @param mirror [Boolean] whether the repository should be cloned as a mirror
     #
     # @return [String] the name of the repository directory
     #


### PR DESCRIPTION
# Description

Removes the `lib/git/url.rb` baseline exclusion from `.yard-lint-todo.yml` and fixes
its YARD lint offense by documenting `bare:` and `mirror:` keyword arguments on
`Git::URL.clone_to`.

This makes `lib/git/url.rb` fully lint-clean without relying on the todo exclusion.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
