### PR TITLE
ci(workflow): temporarily disable windows, jruby, and truffleruby builds

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -21,15 +21,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Only the latest versions of JRuby and TruffleRuby are tested
-        ruby: ["3.2", "3.4", "4.0", "truffleruby-24.2.1", "jruby-10.0.0.1"]
+        ruby: ["3.2", "3.4", "4.0"]
+        # Temporarily disabled; restore in a follow-up PR.
+        # ruby: ["3.2", "3.4", "4.0", "truffleruby-24.2.1", "jruby-10.0.0.1"]
         operating-system: [ubuntu-latest]
         experimental: [No]
         java_version: [""]
-        include:
-          - ruby: 3.2
-            operating-system: windows-latest
-            experimental: No
+        include: []
+          # Temporarily disabled; restore in a follow-up PR.
+          # - ruby: 3.2
+          #   operating-system: windows-latest
+          #   experimental: No
 
     steps:
       - name: Checkout Code


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Temporarily disables Windows, JRuby, and TruffleRuby builds in the primary CI
workflow matrix.

The removed matrix entries are kept as comments in
`.github/workflows/continuous_integration.yml` so they can be restored easily in
a follow-up PR.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
