### PR TITLE
fix(am): remove abort YARD lint todo exclusion

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -34,7 +34,6 @@ Documentation/UndocumentedObjects:
 Documentation/UndocumentedOptions:
   Exclude:
     - 'lib/git/commands/add.rb'
-    - 'lib/git/commands/am/abort.rb'
     - 'lib/git/commands/am/apply.rb'
     - 'lib/git/commands/am/continue.rb'
     - 'lib/git/commands/am/quit.rb'

--- a/lib/git/commands/am/abort.rb
+++ b/lib/git/commands/am/abort.rb
@@ -28,7 +28,7 @@ module Git
           literal '--abort'
         end
 
-        # @!method call(*, **)
+        # @!method call()
         #
         #   @overload call()
         #


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Removes the `lib/git/commands/am/abort.rb` baseline exclusion from
`.yard-lint-todo.yml` and fixes the resulting YARD lint violation.

Specifically, this updates the `@!method` directive in
`Git::Commands::Am::Abort` to document a zero-argument `call()` overload, which
aligns with this command's argument DSL (no options) and resolves
`Documentation/UndocumentedOptions`.

## Verification

- `bundle exec rake yard:lint`
- `bundle exec rake rubocop`
- `bundle exec rspec spec/unit/git/commands/am/abort_spec.rb`
- `bundle exec rake default`

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
