### PR TITLE
docs(am): remove yard-lint baseline exclusion for continue

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -35,7 +35,6 @@ Documentation/UndocumentedOptions:
   Exclude:
     - 'lib/git/commands/am/abort.rb'
     - 'lib/git/commands/am/apply.rb'
-    - 'lib/git/commands/am/continue.rb'
     - 'lib/git/commands/am/quit.rb'
     - 'lib/git/commands/am/retry.rb'
     - 'lib/git/commands/am/skip.rb'

--- a/lib/git/commands/am/continue.rb
+++ b/lib/git/commands/am/continue.rb
@@ -28,7 +28,7 @@ module Git
           literal '--continue'
         end
 
-        # @!method call(*, **)
+        # @!method call()
         #
         #   @overload call()
         #


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Removes the `lib/git/commands/am/continue.rb` exclusion from `.yard-lint-todo.yml`
and fixes the now-exposed YARD lint offense in `Git::Commands::Am::Continue`.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
