### PR TITLE
chore(yard): remove am quit yard-lint todo exclusion

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -35,7 +35,6 @@ Documentation/UndocumentedOptions:
   Exclude:
     - 'lib/git/commands/am/abort.rb'
     - 'lib/git/commands/am/apply.rb'
-    - 'lib/git/commands/am/quit.rb'
     - 'lib/git/commands/am/retry.rb'
     - 'lib/git/commands/am/skip.rb'
     - 'lib/git/commands/apply.rb'

--- a/lib/git/commands/am/quit.rb
+++ b/lib/git/commands/am/quit.rb
@@ -28,7 +28,7 @@ module Git
           literal '--quit'
         end
 
-        # @!method call(*, **)
+        # @!method call()
         #
         #   @overload call()
         #


### PR DESCRIPTION
## Description

This PR removes the `.yard-lint-todo.yml` exclusion for `lib/git/commands/am/quit.rb`
and fixes the underlying YARD lint issue in that command file.

### What changed

- Removed `lib/git/commands/am/quit.rb` from
  `Documentation/UndocumentedOptions` excludes in `.yard-lint-todo.yml`
- Updated `Git::Commands::Am::Quit` YARD directive from `@!method call(*, **)`
  to `@!method call()` so the command no longer advertises keyword options it
  does not support

### Verification

- `bundle exec rake yard:lint`
- `bundle exec rake rubocop`
- `bundle exec rake default`

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
