### PR TITLE
docs(yard): remove todo exclusions for worktree and write-tree commands

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -101,11 +101,6 @@ Documentation/UndocumentedOptions:
     - 'lib/git/commands/worktree/list.rb'
     - 'lib/git/commands/worktree/lock.rb'
     - 'lib/git/commands/worktree/move.rb'
-    - 'lib/git/commands/worktree/prune.rb'
-    - 'lib/git/commands/worktree/remove.rb'
-    - 'lib/git/commands/worktree/repair.rb'
-    - 'lib/git/commands/worktree/unlock.rb'
-    - 'lib/git/commands/write_tree.rb'
     - 'lib/git/repository/factories.rb'
     - 'lib/git/repository/remote_operations.rb'
 

--- a/lib/git/commands/worktree/prune.rb
+++ b/lib/git/commands/worktree/prune.rb
@@ -34,7 +34,7 @@ module Git
           value_option :expire
         end
 
-        # @!method call(*, **)
+        # @!method call(*)
         #
         #   @overload call(**options)
         #

--- a/lib/git/commands/worktree/remove.rb
+++ b/lib/git/commands/worktree/remove.rb
@@ -31,7 +31,7 @@ module Git
           operand :worktree, required: true
         end
 
-        # @!method call(*, **)
+        # @!method call(*)
         #
         #   @overload call(worktree, **options)
         #

--- a/lib/git/commands/worktree/repair.rb
+++ b/lib/git/commands/worktree/repair.rb
@@ -37,7 +37,7 @@ module Git
         # git worktree repair was introduced in git 2.29.0
         requires_git_version '2.29.0'
 
-        # @!method call(*, **)
+        # @!method call(*)
         #
         #   @overload call(*path, **options)
         #

--- a/lib/git/commands/worktree/unlock.rb
+++ b/lib/git/commands/worktree/unlock.rb
@@ -27,7 +27,7 @@ module Git
           operand :worktree, required: true
         end
 
-        # @!method call(*, **)
+        # @!method call(*)
         #
         #   @overload call(worktree)
         #

--- a/lib/git/commands/write_tree.rb
+++ b/lib/git/commands/write_tree.rb
@@ -38,7 +38,7 @@ module Git
         value_option :prefix, inline: true
       end
 
-      # @!method call(*, **)
+      # @!method call(*)
       #
       #   @overload call(**options)
       #


### PR DESCRIPTION
## Description

Removes the YARD lint baseline exclusions for:

- `lib/git/commands/worktree/prune.rb`
- `lib/git/commands/worktree/remove.rb`
- `lib/git/commands/worktree/repair.rb`
- `lib/git/commands/worktree/unlock.rb`
- `lib/git/commands/write_tree.rb`

To make those files pass `yard-lint` directly, this updates their `@!method` call
directives from `call(*, **)` to `call(*)`, matching the existing passing command
documentation pattern while preserving the existing overload documentation.

Validation run:

- `bundle exec rake yard:lint`
- `bundle exec rake rubocop`
- `bundle exec rake default`

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
