### PR TITLE
docs(commands): remove yard-lint todo exclusions for worktree and version

### DIFF
--- a/.yard-lint-todo.yml
+++ b/.yard-lint-todo.yml
@@ -95,11 +95,6 @@ Documentation/UndocumentedOptions:
     - 'lib/git/commands/stash/show.rb'
     - 'lib/git/commands/stash/store.rb'
     - 'lib/git/commands/status.rb'
-    - 'lib/git/commands/version.rb'
-    - 'lib/git/commands/worktree/add.rb'
-    - 'lib/git/commands/worktree/list.rb'
-    - 'lib/git/commands/worktree/lock.rb'
-    - 'lib/git/commands/worktree/move.rb'
     - 'lib/git/repository/factories.rb'
     - 'lib/git/repository/remote_operations.rb'
 

--- a/lib/git/commands/version.rb
+++ b/lib/git/commands/version.rb
@@ -33,25 +33,28 @@ module Git
         flag_option :build_options
       end
 
-      # @!method call(*, **)
+      # @overload call(**options)
       #
-      #   @overload call(**options)
+      #   Execute the `git version` command
       #
-      #     Execute the `git version` command.
+      #   @param options [Hash] command options
       #
-      #     @param options [Hash] command options
+      #   @option options [Numeric, nil] :timeout (nil) the number of seconds to wait
+      #     for the command to complete; if nil, uses the global timeout from
+      #     {Git::Config}; if 0, no timeout is enforced
       #
-      #     @option options [Boolean, nil] :build_options (nil) include build options in the output
+      #   @option options [Boolean, nil] :build_options (nil) include build options in
+      #     the output
       #
-      #     @option options [Numeric, nil] :timeout (nil) the number of seconds to wait
-      #       for the command to complete; if nil, uses the global timeout from
-      #       {Git::Config}; if 0, no timeout is enforced
+      #   @return [Git::CommandLineResult] the result of calling `git version`
       #
-      #     @return [Git::CommandLineResult] the result of calling `git version`
+      # @raise [ArgumentError] if unsupported options are provided
       #
-      #     @raise [ArgumentError] if unsupported options are provided
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
-      #     @raise [Git::FailedError] if git exits with a non-zero exit status
+      # @api public
+      #
+      def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
     end
   end
 end

--- a/lib/git/commands/worktree/add.rb
+++ b/lib/git/commands/worktree/add.rb
@@ -49,91 +49,90 @@ module Git
           operand :commit_ish
         end
 
-        # @!method call(*, **)
+        # @overload call(path, commit_ish = nil, **options)
         #
-        #   @overload call(path, commit_ish = nil, **options)
+        #   Create a new linked worktree and check out `commit_ish` into it
         #
-        #     Create a new linked worktree and check out `commit_ish` into it
+        #   @param path [String] filesystem path for the new worktree
         #
-        #     @param path [String] filesystem path for the new worktree
+        #   @param commit_ish [String, nil] (nil) branch, tag, or commit to check out
         #
-        #     @param commit_ish [String, nil] (nil) branch, tag, or commit to check out
+        #     When omitted, git creates a new branch named after the final path
+        #     component and checks it out
         #
-        #       When omitted, git creates a new branch named after the final path
-        #       component and checks it out.
+        #   @param options [Hash] command options
         #
-        #     @param options [Hash] command options
+        #   @option options [Boolean, Integer, nil] :force (nil) override safety guards
         #
-        #     @option options [Boolean, Integer, nil] :force (nil) override safety guards
+        #     Pass `true` or `1` to emit `--force` once. Pass `2` to emit
+        #     `--force --force`, which also allows adding worktrees for locked branches.
         #
-        #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit
-        #       `--force --force`, which also allows adding worktrees for locked branches.
+        #     Alias: :f
         #
-        #       Alias: :f
+        #   @option options [String] :b (nil) create a new branch with this name and
+        #     check it out
         #
-        #     @option options [String] :b (nil) create a new branch with this name
-        #       and check it out
+        #   @option options [String] :B (nil) create or reset a branch with this name and
+        #     check it out
         #
-        #     @option options [String] :B (nil) create or reset a branch with this
-        #       name and check it out
+        #   @option options [Boolean, nil] :detach (nil) check out in detached-HEAD state
         #
-        #     @option options [Boolean, nil] :detach (nil) check out in
-        #       detached-HEAD state
+        #     Alias: :d
         #
-        #       Alias: :d
+        #   @option options [Boolean, nil] :checkout (nil) control whether the working
+        #     tree is checked out after creation (`--checkout`)
         #
-        #     @option options [Boolean, nil] :checkout (nil) control whether the working
-        #       tree is checked out after creation (`--checkout`)
+        #   @option options [Boolean, nil] :no_checkout (nil) suppress the initial
+        #     checkout after worktree creation (`--no-checkout`)
         #
-        #     @option options [Boolean, nil] :no_checkout (nil) suppress the initial
-        #       checkout after worktree creation (`--no-checkout`)
+        #   @option options [Boolean, nil] :guess_remote (nil) base new branch on a
+        #     matching remote-tracking branch (`--guess-remote`)
         #
-        #     @option options [Boolean, nil] :guess_remote (nil) base new branch on a
-        #       matching remote-tracking branch (`--guess-remote`)
+        #     Applied when no `commit_ish` argument is provided.
         #
-        #       Applied when no `commit_ish` argument is provided.
+        #   @option options [Boolean, nil] :no_guess_remote (nil) disable guess-remote
+        #     behavior (`--no-guess-remote`)
         #
-        #     @option options [Boolean, nil] :no_guess_remote (nil) disable guess-remote
-        #       behavior (`--no-guess-remote`)
+        #   @option options [Boolean, nil] :relative_paths (nil) link worktrees using
+        #     relative paths (`--relative-paths`)
         #
-        #     @option options [Boolean, nil] :relative_paths (nil) link worktrees using
-        #       relative paths (`--relative-paths`)
+        #     Overrides the `worktree.useRelativePaths` config option.
         #
-        #       Overrides the `worktree.useRelativePaths` config option.
+        #   @option options [Boolean, nil] :no_relative_paths (nil) use absolute paths for
+        #     worktree links (`--no-relative-paths`)
         #
-        #     @option options [Boolean, nil] :no_relative_paths (nil) use absolute paths
-        #       for worktree links (`--no-relative-paths`)
+        #     Overrides the `worktree.useRelativePaths` config option.
         #
-        #       Overrides the `worktree.useRelativePaths` config option.
+        #   @option options [Boolean, nil] :track (nil) mark the upstream branch for
+        #     tracking (`--track`)
         #
-        #     @option options [Boolean, nil] :track (nil) mark the upstream branch for
-        #       tracking (`--track`)
+        #   @option options [Boolean, nil] :no_track (nil) do not mark the upstream
+        #     branch for tracking (`--no-track`)
         #
-        #     @option options [Boolean, nil] :no_track (nil) do not mark the upstream
-        #       branch for tracking (`--no-track`)
+        #   @option options [Boolean, nil] :lock (nil) lock the worktree immediately after
+        #     creation
         #
-        #     @option options [Boolean, nil] :lock (nil) lock the worktree immediately
-        #       after creation
+        #   @option options [Boolean, nil] :orphan (nil) create an empty worktree
+        #     associated with a new unborn branch
         #
-        #     @option options [Boolean, nil] :orphan (nil) create an empty worktree
-        #       associated with a new unborn branch
+        #   @option options [Boolean, nil] :quiet (nil) suppress informational messages
         #
-        #     @option options [Boolean, nil] :quiet (nil) suppress informational messages
+        #     Alias: :q
         #
-        #       Alias: :q
+        #   @option options [String] :reason (nil) explanation for why the worktree is
+        #     locked
         #
-        #     @option options [String] :reason (nil) explanation for why the worktree
-        #       is locked
+        #     Only meaningful when used with `:lock`.
         #
-        #       Only meaningful when used with `:lock`.
+        #   @return [Git::CommandLineResult] the result of calling `git worktree add`
         #
-        #     @return [Git::CommandLineResult] the result of calling `git worktree add`
+        # @raise [ArgumentError] if unsupported options are provided
         #
-        #     @raise [ArgumentError] if unsupported options are provided
+        # @raise [Git::FailedError] if git exits with a non-zero exit status
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero exit status
+        # @api public
         #
-        #     @api public
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/git/commands/worktree/list.rb
+++ b/lib/git/commands/worktree/list.rb
@@ -29,35 +29,35 @@ module Git
           value_option :expire
         end
 
-        # @!method call(*, **)
+        # @overload call(**options)
         #
-        #   @overload call(**options)
+        #   List all worktrees attached to the repository
         #
-        #     List all worktrees attached to the repository
+        #   @param options [Hash] command options
         #
-        #     @param options [Hash] command options
+        #   @option options [Boolean, nil] :porcelain (nil) produce machine-readable
+        #     output
         #
-        #     @option options [Boolean, nil] :porcelain (nil) produce machine-readable
-        #       output
+        #   @option options [Boolean, nil] :z (nil) terminate output lines with NUL
+        #     bytes (use with `:porcelain`)
         #
-        #     @option options [Boolean, nil] :z (nil) terminate output lines with NUL
-        #       bytes (use with `:porcelain`)
+        #   @option options [Boolean, nil] :verbose (nil) output additional information
+        #     about worktrees
         #
-        #     @option options [Boolean, nil] :verbose (nil) output additional information
-        #       about worktrees
+        #     Alias: :v
         #
-        #       Alias: :v
+        #   @option options [String] :expire (nil) annotate missing worktrees as
+        #     prunable if older than this time expression
         #
-        #     @option options [String] :expire (nil) annotate missing worktrees as
-        #       prunable if older than this time expression
+        #   @return [Git::CommandLineResult] the result of calling `git worktree list`
         #
-        #     @return [Git::CommandLineResult] the result of calling `git worktree list`
+        # @raise [ArgumentError] if unsupported options are provided
         #
-        #     @raise [ArgumentError] if unsupported options are provided
+        # @raise [Git::FailedError] if git exits with a non-zero exit status
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero exit status
+        # @api public
         #
-        #     @api public
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/git/commands/worktree/lock.rb
+++ b/lib/git/commands/worktree/lock.rb
@@ -31,27 +31,27 @@ module Git
           operand :worktree, required: true
         end
 
-        # @!method call(*, **)
+        # @overload call(worktree, **options)
         #
-        #   @overload call(worktree, **options)
+        #   Lock a worktree to prevent it from being pruned
         #
-        #     Lock a worktree to prevent it from being pruned
+        #   @param worktree [String] path or unique suffix identifying the
+        #     worktree to lock
         #
-        #     @param worktree [String] path or unique suffix identifying the
-        #       worktree to lock
+        #   @param options [Hash] command options
         #
-        #     @param options [Hash] command options
+        #   @option options [String] :reason (nil) human-readable explanation stored
+        #     alongside the lock
         #
-        #     @option options [String] :reason (nil) human-readable explanation stored
-        #       alongside the lock
+        #   @return [Git::CommandLineResult] the result of calling `git worktree lock`
         #
-        #     @return [Git::CommandLineResult] the result of calling `git worktree lock`
+        # @raise [ArgumentError] if unsupported options are provided
         #
-        #     @raise [ArgumentError] if unsupported options are provided
+        # @raise [Git::FailedError] if git exits with a non-zero exit status
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero exit status
+        # @api public
         #
-        #     @api public
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end

--- a/lib/git/commands/worktree/move.rb
+++ b/lib/git/commands/worktree/move.rb
@@ -32,34 +32,34 @@ module Git
           operand :new_path, required: true
         end
 
-        # @!method call(*, **)
+        # @overload call(worktree, new_path, **options)
         #
-        #   @overload call(worktree, new_path, **options)
+        #   Move a linked worktree to a new filesystem location
         #
-        #     Move a linked worktree to a new filesystem location
+        #   @param worktree [String] path or unique suffix identifying the
+        #     worktree to move
         #
-        #     @param worktree [String] path or unique suffix identifying the
-        #       worktree to move
+        #   @param new_path [String] destination path for the worktree
         #
-        #     @param new_path [String] destination path for the worktree
+        #   @param options [Hash] command options
         #
-        #     @param options [Hash] command options
+        #   @option options [Boolean, Integer, nil] :force (nil) allow moving a
+        #     locked worktree
         #
-        #     @option options [Boolean, Integer, nil] :force (nil) allow moving a
-        #       locked worktree
+        #     Pass `true` or `1` to emit `--force` once. Pass `2` to emit
+        #     `--force --force`, which also handles locked or missing destinations.
         #
-        #       Pass `true` or `1` to emit `--force` once. Pass `2` to emit
-        #       `--force --force`, which also handles locked or missing destinations.
+        #     Alias: :f
         #
-        #       Alias: :f
+        #   @return [Git::CommandLineResult] the result of calling `git worktree move`
         #
-        #     @return [Git::CommandLineResult] the result of calling `git worktree move`
+        # @raise [ArgumentError] if unsupported options are provided
         #
-        #     @raise [ArgumentError] if unsupported options are provided
+        # @raise [Git::FailedError] if git exits with a non-zero exit status
         #
-        #     @raise [Git::FailedError] if git exits with a non-zero exit status
+        # @api public
         #
-        #     @api public
+        def call(...) = super # rubocop:disable Lint/UselessMethodDefinition
       end
     end
   end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Removes YARD baseline exclusions for:

- `lib/git/commands/version.rb`
- `lib/git/commands/worktree/add.rb`
- `lib/git/commands/worktree/list.rb`
- `lib/git/commands/worktree/lock.rb`
- `lib/git/commands/worktree/move.rb`

Then fixes the resulting `Documentation/UndocumentedOptions` offenses by updating
command `call` YARD anchors and option docs so `rake yard:lint` passes without
those exclusions.

Also aligns the forwarding `call` anchors with project guidance by using:

`def call(...) = super # rubocop:disable Lint/UselessMethodDefinition`

This keeps docs attached to each command while satisfying `rake rubocop`.

Validated with:

- `bundle exec rake yard:lint`
- `bundle exec rake rubocop`
- `bundle exec rake default`

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
