### PR TITLE
docs: document remaining @api private objects for 100% YARD coverage

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -692,6 +692,10 @@ module Git
     end
   end
 
+  # Clear the cached git version for all binary paths
+  #
+  # @return [void]
+  #
   # @api private
   def self.clear_git_version_cache
     @git_version_cache_mutex.synchronize do

--- a/lib/git/deprecation.rb
+++ b/lib/git/deprecation.rb
@@ -4,6 +4,8 @@ require 'active_support/deprecation'
 
 # The Git module provides a Ruby interface to Git version control.
 module Git
+  # The deprecation instance used to emit deprecation warnings for the Git gem
+  #
   # @api private
   Deprecation = ActiveSupport::Deprecation.new('5.0.0', 'Git')
 end


### PR DESCRIPTION
## Summary

Adds YARD prose descriptions to the two remaining objects that `bundle exec rake
yard:build` counted as undocumented, bringing the reported coverage from **99.83% →
100.00% documented**.

Both objects already carried `@api private` tags (so `yard-lint`'s per-object
`Documentation/UndocumentedObjects` gate considered them documented and the build was
green), but they lacked a description, so YARD's own `% documented` statistic did not
reach 100%. This change adds the missing one-line descriptions so the reported
coverage matches the enforced "no undocumented objects" bar.

## Changes

- `lib/git.rb` — describe `Git.clear_git_version_cache` (with `@return [void]` to
  match its sibling `Git.cached_git_version`).
- `lib/git/deprecation.rb` — describe the `Git::Deprecation` constant.

## Verification

- `bundle exec rake yard:build` → **100.00% documented** (0 undocumented objects).
- `bundle exec yard-lint lib/` → **No offenses found**.
- `bundle exec rubocop lib/git.rb lib/git/deprecation.rb` → no offenses.

No behavior changes; documentation only.
