### PR TITLE
refactor: deprecate Git::CommandLineResult in favor of Git::CommandLine::Result

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -84,7 +84,7 @@ module Git
   #
   #   @param value [String, Boolean] the value to set for the git configuration option
   #
-  #   @return [Git::CommandLineResult] the result of the git configuration command
+  #   @return [Git::CommandLine::Result] the result of the git configuration command
   #
   # @overload config(name)
   #   Get the value for the git named configuration option
@@ -147,7 +147,7 @@ module Git
   #
   #   @param value [String, Boolean] the value to set for the git configuration option
   #
-  #   @return [Git::CommandLineResult] the result of the git configuration command
+  #   @return [Git::CommandLine::Result] the result of the git configuration command
   #
   # @overload global_config(name)
   #   Get the value for the git named configuration option
@@ -259,7 +259,7 @@ module Git
   #
   # @param value [Object, nil] the value to set; omit to get or list
   #
-  # @return [String, Hash, Git::CommandLineResult] the config value, all entries,
+  # @return [String, Hash, Git::CommandLine::Result] the config value, all entries,
   #   or the result of the set command
   #
   # @deprecated Use {Git.config_get}, {Git.config_set}, or {Git.config_list} instead.
@@ -490,7 +490,7 @@ module Git
   #   @param global [Boolean] true to use the global git configuration, false for the
   #     local repo config
   #
-  #   @return [Git::CommandLineResult] the result of the git config command
+  #   @return [Git::CommandLine::Result] the result of the git config command
   #
   # @overload legacy_config_set_get_list(name, global:)
   #

--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -347,7 +347,7 @@ module Git
     #
     # @param commit [String] the commit SHA to point this branch at
     #
-    # @return [Git::CommandLineResult] the result of calling `git update-ref`
+    # @return [Git::CommandLine::Result] the result of calling `git update-ref`
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #

--- a/lib/git/command_line.rb
+++ b/lib/git/command_line.rb
@@ -19,7 +19,7 @@ module Git
   # {Git::ExecutionContext#command_streaming}.
   #
   # Results are returned as {Git::CommandLine::Result} objects (also accessible
-  # as {Git::CommandLineResult} for backward compatibility).
+  # as {Git::CommandLine::Result} for backward compatibility).
   #
   # @example Buffered command via Git::CommandLine::Capturing
   #   cli = Git::CommandLine::Capturing.new(

--- a/lib/git/command_line/capturing.rb
+++ b/lib/git/command_line/capturing.rb
@@ -141,7 +141,7 @@ module Git
       #   overrides for this command.  String keys map to String values (to set) or
       #   `nil` (to unset).
       #
-      # @return [Git::CommandLineResult] the result of the command
+      # @return [Git::CommandLine::Result] the result of the command
       #
       # @raise [ArgumentError] if `args` contains an array or an unknown option is
       #   passed
@@ -265,7 +265,7 @@ module Git
       #
       # @option options [Boolean] :raise_on_failure (true) raise {Git::FailedError} on non-zero exit
       #
-      # @return [Git::CommandLineResult]
+      # @return [Git::CommandLine::Result]
       #
       # @raise [Git::FailedError] if the command failed and raise_on_failure is true
       #

--- a/lib/git/command_line/streaming.rb
+++ b/lib/git/command_line/streaming.rb
@@ -91,7 +91,7 @@ module Git
       #   overrides for this command.  String keys map to String values (to set) or
       #   `nil` (to unset).
       #
-      # @return [Git::CommandLineResult] the result of the command
+      # @return [Git::CommandLine::Result] the result of the command
       #
       #   `result.stdout` will always be `''` (empty) — stdout was streamed to `out:`.
       #   `result.stderr` contains any stderr output captured for diagnostics.
@@ -206,7 +206,7 @@ module Git
         end
       end
 
-      # Process the result of a streaming command and return a Git::CommandLineResult
+      # Process the result of a streaming command and return a Git::CommandLine::Result
       #
       # Constructs stdout as `''` (not captured) and stderr from the internal StringIO.
       #
@@ -220,7 +220,7 @@ module Git
       #
       # @option options [Boolean] :raise_on_failure (true) raise {Git::FailedError} on non-zero exit
       #
-      # @return [Git::CommandLineResult]
+      # @return [Git::CommandLine::Result]
       #
       # @api private
       def process_result(result, err_io, options)

--- a/lib/git/command_line_result.rb
+++ b/lib/git/command_line_result.rb
@@ -1,8 +1,31 @@
 # frozen_string_literal: true
 
 require 'git/command_line/result'
+require 'git/deprecation'
 
+# The Git module provides a Ruby interface to Git version control.
 module Git
-  # Backward-compatible alias for {Git::CommandLine::Result}
-  CommandLineResult = Git::CommandLine::Result
+  # Intercept the first lookup of the deprecated `Git::CommandLineResult` constant
+  #
+  # When `name` is `:CommandLineResult`, caches and returns {Git::CommandLine::Result}
+  # after emitting a deprecation warning. Calls `super` for any other unknown constant,
+  # preserving normal Ruby `NameError` behaviour.
+  #
+  # @param name [Symbol] the name of the missing constant
+  #
+  # @return [Class] the resolved constant value
+  #
+  # @api private
+  def self.const_missing(name)
+    return super unless name == :CommandLineResult
+
+    # Cache the constant first so subsequent accesses are zero-cost even if
+    # the deprecation behavior raises (e.g. in the test suite).
+    const_set(:CommandLineResult, Git::CommandLine::Result)
+    Git::Deprecation.warn(
+      'Git::CommandLineResult is deprecated and will be removed in v6.0.0. ' \
+      'Use Git::CommandLine::Result instead.'
+    )
+    Git::CommandLine::Result
+  end
 end

--- a/lib/git/commands.rb
+++ b/lib/git/commands.rb
@@ -58,7 +58,7 @@ module Git
   # Each git operation is represented by a class within this namespace. Command
   # classes define the CLI contract via the {Arguments} DSL, bind caller-supplied
   # parameters to command-line flags and operands, execute the subprocess through
-  # {Git::CommandLine}, and return a raw {Git::CommandLineResult}.
+  # {Git::CommandLine}, and return a raw {Git::CommandLine::Result}.
   #
   # Commands do **not** parse output — that responsibility belongs to the
   # {Git::Parsers} layer, orchestrated by the facade ({Git::Repository}).

--- a/lib/git/commands/add.rb
+++ b/lib/git/commands/add.rb
@@ -123,7 +123,7 @@ module Git
       #   @option options [Boolean, nil] :pathspec_file_nul (nil) separate pathspec
       #     elements with NUL when reading from a file
       #
-      #   @return [Git::CommandLineResult] the result of calling `git add`
+      #   @return [Git::CommandLine::Result] the result of calling `git add`
       #
       #   @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/am/abort.rb
+++ b/lib/git/commands/am/abort.rb
@@ -34,7 +34,7 @@ module Git
         #
         #     Abort the in-progress am session and restore the branch
         #
-        #     @return [Git::CommandLineResult] the result of calling `git am --abort`
+        #     @return [Git::CommandLine::Result] the result of calling `git am --abort`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end

--- a/lib/git/commands/am/apply.rb
+++ b/lib/git/commands/am/apply.rb
@@ -246,7 +246,7 @@ module Git
         #
         #     Not passed to the git CLI.
         #
-        #   @return [Git::CommandLineResult] the result of calling `git am`
+        #   @return [Git::CommandLine::Result] the result of calling `git am`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/am/continue.rb
+++ b/lib/git/commands/am/continue.rb
@@ -34,7 +34,7 @@ module Git
         #
         #     Resume applying patches after conflicts have been resolved
         #
-        #     @return [Git::CommandLineResult] the result of calling `git am --continue`
+        #     @return [Git::CommandLine::Result] the result of calling `git am --continue`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end

--- a/lib/git/commands/am/quit.rb
+++ b/lib/git/commands/am/quit.rb
@@ -34,7 +34,7 @@ module Git
         #
         #     Abort the am session but keep the current HEAD position
         #
-        #     @return [Git::CommandLineResult] the result of calling `git am --quit`
+        #     @return [Git::CommandLine::Result] the result of calling `git am --quit`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end

--- a/lib/git/commands/am/retry.rb
+++ b/lib/git/commands/am/retry.rb
@@ -38,7 +38,7 @@ module Git
         #
         #     Retry applying the most-recently-failed patch
         #
-        #     @return [Git::CommandLineResult] the result of calling `git am --retry`
+        #     @return [Git::CommandLine::Result] the result of calling `git am --retry`
         #
         #     @raise [Git::VersionError] if git version is below 2.46.0
         #

--- a/lib/git/commands/am/show_current_patch.rb
+++ b/lib/git/commands/am/show_current_patch.rb
@@ -41,7 +41,7 @@ module Git
         #
         #   @param options [Hash] command options
         #
-        #   @return [Git::CommandLineResult] the result of calling
+        #   @return [Git::CommandLine::Result] the result of calling
         #     `git am --show-current-patch`
         #
         #   @raise [ArgumentError] if `show_current_patch` is `false` or `nil`

--- a/lib/git/commands/am/skip.rb
+++ b/lib/git/commands/am/skip.rb
@@ -33,7 +33,7 @@ module Git
         #
         #     Skip the current patch and continue with remaining patches
         #
-        #     @return [Git::CommandLineResult] the result of calling `git am --skip`
+        #     @return [Git::CommandLine::Result] the result of calling `git am --skip`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end

--- a/lib/git/commands/apply.rb
+++ b/lib/git/commands/apply.rb
@@ -230,7 +230,7 @@ module Git
       #     @option options [String] :chdir (nil) change to this directory before
       #       running git; not passed to the git CLI
       #
-      #     @return [Git::CommandLineResult] the result of calling `git apply`
+      #     @return [Git::CommandLine::Result] the result of calling `git apply`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/archive.rb
+++ b/lib/git/commands/archive.rb
@@ -116,7 +116,7 @@ module Git
       #     @option options [IO, #write] :out (nil) stream archive output to this IO object
       #       instead of capturing it; the result's `.stdout` will be `''`
       #
-      #     @return [Git::CommandLineResult] the result of calling `git archive`
+      #     @return [Git::CommandLine::Result] the result of calling `git archive`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/archive/list_formats.rb
+++ b/lib/git/commands/archive/list_formats.rb
@@ -37,7 +37,7 @@ module Git
         #
         #     Execute `git archive --list` to show available formats.
         #
-        #     @return [Git::CommandLineResult] the result of calling `git archive --list`
+        #     @return [Git::CommandLine::Result] the result of calling `git archive --list`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end

--- a/lib/git/commands/base.rb
+++ b/lib/git/commands/base.rb
@@ -230,7 +230,7 @@ module Git
       #
       #   @param kwargs [Hash] keyword arguments forwarded to {Arguments#bind}
       #
-      # @return [Git::CommandLineResult] the result of calling `git`
+      # @return [Git::CommandLine::Result] the result of calling `git`
       #
       # @raise [ArgumentError] if no arguments definition is declared on the command class
       #
@@ -261,7 +261,7 @@ module Git
       #
       # @param bound [Git::Commands::Arguments::Bound] bound command arguments
       #
-      # @return [Git::CommandLineResult] the command result
+      # @return [Git::CommandLine::Result] the command result
       #
       def execute_command(bound)
         exec_opts = execution_opts(bound)
@@ -359,7 +359,7 @@ module Git
 
       # Validate that a command result has an accepted exit status
       #
-      # @param result [Git::CommandLineResult] command result to validate
+      # @param result [Git::CommandLine::Result] command result to validate
       #
       # @return [void]
       #

--- a/lib/git/commands/branch/copy.rb
+++ b/lib/git/commands/branch/copy.rb
@@ -62,7 +62,7 @@ module Git
         #
         #     Alias: :f
         #
-        #   @return [Git::CommandLineResult] the result of calling `git branch --copy`
+        #   @return [Git::CommandLine::Result] the result of calling `git branch --copy`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #
@@ -85,7 +85,7 @@ module Git
         #
         #     Alias: :f
         #
-        #   @return [Git::CommandLineResult] the result of calling `git branch --copy`
+        #   @return [Git::CommandLine::Result] the result of calling `git branch --copy`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/branch/create.rb
+++ b/lib/git/commands/branch/create.rb
@@ -101,7 +101,7 @@ module Git
         #   @option options [Boolean, nil] :no_create_reflog (nil) forcibly disable the
         #     branch's reflog (`--no-create-reflog`)
         #
-        #   @return [Git::CommandLineResult] the result of calling `git branch`
+        #   @return [Git::CommandLine::Result] the result of calling `git branch`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #
@@ -160,7 +160,7 @@ module Git
         #   @option options [Boolean, nil] :no_create_reflog (nil) forcibly disable the
         #     branch's reflog (`--no-create-reflog`)
         #
-        #   @return [Git::CommandLineResult] the result of calling `git branch`
+        #   @return [Git::CommandLine::Result] the result of calling `git branch`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/branch/delete.rb
+++ b/lib/git/commands/branch/delete.rb
@@ -69,7 +69,7 @@ module Git
         #
         #     Alias: :r
         #
-        #   @return [Git::CommandLineResult] the result of calling `git branch --delete`
+        #   @return [Git::CommandLine::Result] the result of calling `git branch --delete`
         #
         #   @raise [ArgumentError] if no branch names are provided
         #

--- a/lib/git/commands/branch/list.rb
+++ b/lib/git/commands/branch/list.rb
@@ -161,7 +161,7 @@ module Git
         #     newline after formatted refs where the format expands to the empty
         #     string
         #
-        #   @return [Git::CommandLineResult] the result of calling `git branch --list`
+        #   @return [Git::CommandLine::Result] the result of calling `git branch --list`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/branch/move.rb
+++ b/lib/git/commands/branch/move.rb
@@ -62,7 +62,7 @@ module Git
         #
         #     Alias: :f
         #
-        #   @return [Git::CommandLineResult] the result of calling `git branch --move`
+        #   @return [Git::CommandLine::Result] the result of calling `git branch --move`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #
@@ -85,7 +85,7 @@ module Git
         #
         #     Alias: :f
         #
-        #   @return [Git::CommandLineResult] the result of calling `git branch --move`
+        #   @return [Git::CommandLine::Result] the result of calling `git branch --move`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/branch/set_upstream.rb
+++ b/lib/git/commands/branch/set_upstream.rb
@@ -52,7 +52,7 @@ module Git
         #
         #       Alias: :u
         #
-        #     @return [Git::CommandLineResult] the result of calling `git branch --set-upstream-to`
+        #     @return [Git::CommandLine::Result] the result of calling `git branch --set-upstream-to`
         #
         #     @raise [ArgumentError] if set_upstream_to is not provided
         #
@@ -73,7 +73,7 @@ module Git
         #
         #       Alias: :u
         #
-        #     @return [Git::CommandLineResult] the result of calling `git branch --set-upstream-to`
+        #     @return [Git::CommandLine::Result] the result of calling `git branch --set-upstream-to`
         #
         #     @raise [ArgumentError] if set_upstream_to is not provided
         #

--- a/lib/git/commands/branch/show_current.rb
+++ b/lib/git/commands/branch/show_current.rb
@@ -40,7 +40,7 @@ module Git
         #
         #     Execute the `git branch --show-current` command
         #
-        #     @return [Git::CommandLineResult] the result of calling `git branch --show-current`
+        #     @return [Git::CommandLine::Result] the result of calling `git branch --show-current`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end

--- a/lib/git/commands/branch/unset_upstream.rb
+++ b/lib/git/commands/branch/unset_upstream.rb
@@ -44,7 +44,7 @@ module Git
         #     @param branch_name [String, nil] the branch to remove upstream tracking for
         #       (defaults to current branch if omitted)
         #
-        #     @return [Git::CommandLineResult] the result of calling `git branch --unset-upstream`
+        #     @return [Git::CommandLine::Result] the result of calling `git branch --unset-upstream`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
       end

--- a/lib/git/commands/cat_file/batch.rb
+++ b/lib/git/commands/cat_file/batch.rb
@@ -154,7 +154,7 @@ module Git
         #   @option options [#write, nil] :out (nil) stream stdout to this IO object
         #     instead of buffering in memory; when given, `result.stdout` will be `''`
         #
-        #   @return [Git::CommandLineResult] the result of calling `git cat-file`
+        #   @return [Git::CommandLine::Result] the result of calling `git cat-file`
         #
         #     Stdout contains the batch output stream (or `''` when `out:` is given)
         #
@@ -196,7 +196,7 @@ module Git
         #   @option options [#write, nil] :out (nil) stream stdout to this IO object
         #     instead of buffering in memory; when given, `result.stdout` will be `''`
         #
-        #   @return [Git::CommandLineResult] the result of calling `git cat-file`
+        #   @return [Git::CommandLine::Result] the result of calling `git cat-file`
         #
         #     Stdout contains one metadata line per object (or `''` when `out:` is given)
         #
@@ -236,7 +236,7 @@ module Git
         #   @option options [#write, nil] :out (nil) stream stdout to this IO object
         #     instead of buffering in memory; when given, `result.stdout` will be `''`
         #
-        #   @return [Git::CommandLineResult] the result of calling `git cat-file`
+        #   @return [Git::CommandLine::Result] the result of calling `git cat-file`
         #
         #     Stdout contains the interleaved command output (or `''` when `out:` is given)
         #
@@ -270,7 +270,7 @@ module Git
         #   @option options [#write, nil] :out (nil) stream stdout to this IO object
         #     instead of buffering in memory; when given, `result.stdout` will be `''`
         #
-        #   @return [Git::CommandLineResult] the result of calling `git cat-file`
+        #   @return [Git::CommandLine::Result] the result of calling `git cat-file`
         #
         #     Stdout contains the full batch output (or `''` when `out:` is given)
         #
@@ -307,7 +307,7 @@ module Git
         #
         #   @option options [Numeric, nil] :timeout (nil) abort the command after this many seconds
         #
-        #   @return [Git::CommandLineResult] the result of calling `git cat-file`
+        #   @return [Git::CommandLine::Result] the result of calling `git cat-file`
         #
         #     Stdout contains one metadata line per object (or `''` when `out:` is given)
         #
@@ -332,7 +332,7 @@ module Git
         #
         # @param reader [IO] read end of the stdin pipe
         #
-        # @return [Git::CommandLineResult]
+        # @return [Git::CommandLine::Result]
         #
         def run_batch(bound, reader)
           result = if bound.execution_options.key?(:out)
@@ -350,7 +350,7 @@ module Git
         #
         # @param reader [IO] read end of the stdin pipe
         #
-        # @return [Git::CommandLineResult] the command result
+        # @return [Git::CommandLine::Result] the command result
         #
         def run_batch_streaming(bound, reader)
           @execution_context.command_streaming(
@@ -367,7 +367,7 @@ module Git
         #
         # @param reader [IO] read end of the stdin pipe
         #
-        # @return [Git::CommandLineResult] the command result
+        # @return [Git::CommandLine::Result] the command result
         #
         def run_batch_capturing(bound, reader)
           @execution_context.command_capturing(

--- a/lib/git/commands/cat_file/filtered.rb
+++ b/lib/git/commands/cat_file/filtered.rb
@@ -71,7 +71,7 @@ module Git
         #     @option options [String] :path (nil)
         #       path to the blob when `rev` is a bare revision
         #
-        #     @return [Git::CommandLineResult] the result of calling `git cat-file`
+        #     @return [Git::CommandLine::Result] the result of calling `git cat-file`
         #
         #       Stdout contains the textconv-processed content
         #
@@ -92,7 +92,7 @@ module Git
         #     @option options [String] :path (nil)
         #       path to the blob when `rev` is a bare revision
         #
-        #     @return [Git::CommandLineResult] the result of calling `git cat-file`
+        #     @return [Git::CommandLine::Result] the result of calling `git cat-file`
         #
         #       Stdout contains the filter-processed content
         #

--- a/lib/git/commands/cat_file/raw.rb
+++ b/lib/git/commands/cat_file/raw.rb
@@ -96,7 +96,7 @@ module Git
         #
         #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
-        #   @return [Git::CommandLineResult] the result of calling `git cat-file`
+        #   @return [Git::CommandLine::Result] the result of calling `git cat-file`
         #
         #     Exit status 0 means the object exists; exit status 1 means it does not
         #
@@ -120,7 +120,7 @@ module Git
         #
         #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
-        #   @return [Git::CommandLineResult] the result of calling `git cat-file`
+        #   @return [Git::CommandLine::Result] the result of calling `git cat-file`
         #
         #     Stdout contains the object type string
         #
@@ -144,7 +144,7 @@ module Git
         #
         #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
-        #   @return [Git::CommandLineResult] the result of calling `git cat-file`
+        #   @return [Git::CommandLine::Result] the result of calling `git cat-file`
         #
         #     Stdout contains the object size as a decimal string
         #
@@ -165,7 +165,7 @@ module Git
         #
         #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
-        #   @return [Git::CommandLineResult] the result of calling `git cat-file`
+        #   @return [Git::CommandLine::Result] the result of calling `git cat-file`
         #
         #     Stdout contains the formatted object content
         #
@@ -186,7 +186,7 @@ module Git
         #
         #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
         #
-        #   @return [Git::CommandLineResult] the result of calling `git cat-file`
+        #   @return [Git::CommandLine::Result] the result of calling `git cat-file`
         #
         #     Stdout contains the raw object content
         #

--- a/lib/git/commands/checkout/branch.rb
+++ b/lib/git/commands/checkout/branch.rb
@@ -136,7 +136,7 @@ module Git
         #     @option options [String] :chdir (nil) change to this directory before
         #       running git; not passed to the git CLI
         #
-        #     @return [Git::CommandLineResult] the result of calling `git checkout`
+        #     @return [Git::CommandLine::Result] the result of calling `git checkout`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/checkout/files.rb
+++ b/lib/git/commands/checkout/files.rb
@@ -99,7 +99,7 @@ module Git
         #     @option options [String] :chdir (nil) change to this directory before
         #       running git; not passed to the git CLI
         #
-        #     @return [Git::CommandLineResult] the result of calling `git checkout`
+        #     @return [Git::CommandLine::Result] the result of calling `git checkout`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/checkout_index.rb
+++ b/lib/git/commands/checkout_index.rb
@@ -90,7 +90,7 @@ module Git
       #     @option options [Boolean, nil] :ignore_skip_worktree_bits (nil) check out
       #       all files, including those with the skip-worktree bit set
       #
-      #     @return [Git::CommandLineResult] the result of calling `git checkout-index`
+      #     @return [Git::CommandLine::Result] the result of calling `git checkout-index`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/clean.rb
+++ b/lib/git/commands/clean.rb
@@ -86,7 +86,7 @@ module Git
       #     @option options [String, nil] :chdir (nil) change to this directory before
       #       running git; not passed to the git CLI
       #
-      #     @return [Git::CommandLineResult] the result of calling `git clean`
+      #     @return [Git::CommandLine::Result] the result of calling `git clean`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/clone.rb
+++ b/lib/git/commands/clone.rb
@@ -225,7 +225,7 @@ module Git
       #     @option options [String, nil] :chdir (nil) the working directory in which to
       #       run the git clone command
       #
-      #     @return [Git::CommandLineResult] the result of calling `git clone`
+      #     @return [Git::CommandLine::Result] the result of calling `git clone`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/commit.rb
+++ b/lib/git/commands/commit.rb
@@ -257,7 +257,7 @@ module Git
       #     @option options [Boolean, nil] :pathspec_file_nul (nil) pathspec elements in
       #       `:pathspec_from_file` are NUL-separated instead of newline-separated
       #
-      #     @return [Git::CommandLineResult] the result of calling `git commit`
+      #     @return [Git::CommandLine::Result] the result of calling `git commit`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/commit_tree.rb
+++ b/lib/git/commands/commit_tree.rb
@@ -82,7 +82,7 @@ module Git
       #       Use `"-"` to read from standard input. Can be given more than
       #       once; each file's content becomes its own paragraph.
       #
-      #     @return [Git::CommandLineResult] the result of calling
+      #     @return [Git::CommandLine::Result] the result of calling
       #       `git commit-tree`
       #
       #     @raise [ArgumentError] if unsupported options are provided

--- a/lib/git/commands/config_option_syntax/add.rb
+++ b/lib/git/commands/config_option_syntax/add.rb
@@ -70,7 +70,7 @@ module Git
         #
         #     @option options [String] :type (nil) ensure the value conforms to the given type
         #
-        #     @return [Git::CommandLineResult] the result of calling `git config --add`
+        #     @return [Git::CommandLine::Result] the result of calling `git config --add`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/config_option_syntax/get.rb
+++ b/lib/git/commands/config_option_syntax/get.rb
@@ -104,7 +104,7 @@ module Git
         #
         #     @option options [String] :default (nil) default value when the key is not found
         #
-        #     @return [Git::CommandLineResult] the result of calling `git config --get`
+        #     @return [Git::CommandLine::Result] the result of calling `git config --get`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/config_option_syntax/get_all.rb
+++ b/lib/git/commands/config_option_syntax/get_all.rb
@@ -102,7 +102,7 @@ module Git
         #
         #       Alias: :z
         #
-        #     @return [Git::CommandLineResult] the result of calling `git config --get-all`
+        #     @return [Git::CommandLine::Result] the result of calling `git config --get-all`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/config_option_syntax/get_color.rb
+++ b/lib/git/commands/config_option_syntax/get_color.rb
@@ -78,7 +78,7 @@ module Git
         #     @option options [Boolean, nil] :no_includes (nil) suppress include directive processing
         #       (`--no-includes`)
         #
-        #     @return [Git::CommandLineResult] the result of calling `git config --get-color`
+        #     @return [Git::CommandLine::Result] the result of calling `git config --get-color`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/config_option_syntax/get_color_bool.rb
+++ b/lib/git/commands/config_option_syntax/get_color_bool.rb
@@ -80,7 +80,7 @@ module Git
         #
         #     @option options [Boolean, nil] :no_includes (nil) disable include directive processing (`--no-includes`)
         #
-        #     @return [Git::CommandLineResult] the result of calling `git config --get-colorbool`
+        #     @return [Git::CommandLine::Result] the result of calling `git config --get-colorbool`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/config_option_syntax/get_regexp.rb
+++ b/lib/git/commands/config_option_syntax/get_regexp.rb
@@ -102,7 +102,7 @@ module Git
         #
         #     @option options [Boolean, nil] :name_only (nil) output only the names of config keys
         #
-        #     @return [Git::CommandLineResult] the result of calling `git config --get-regexp`
+        #     @return [Git::CommandLine::Result] the result of calling `git config --get-regexp`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/config_option_syntax/get_urlmatch.rb
+++ b/lib/git/commands/config_option_syntax/get_urlmatch.rb
@@ -94,7 +94,7 @@ module Git
         #
         #     @option options [Boolean, nil] :show_scope (nil) show the scope of each config entry
         #
-        #     @return [Git::CommandLineResult] the result of calling `git config --get-urlmatch`
+        #     @return [Git::CommandLine::Result] the result of calling `git config --get-urlmatch`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/config_option_syntax/list.rb
+++ b/lib/git/commands/config_option_syntax/list.rb
@@ -94,7 +94,7 @@ module Git
         #
         #     @option options [String] :type (nil) ensure values conform to the given type
         #
-        #     @return [Git::CommandLineResult] the result of calling `git config --list`
+        #     @return [Git::CommandLine::Result] the result of calling `git config --list`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/config_option_syntax/remove_section.rb
+++ b/lib/git/commands/config_option_syntax/remove_section.rb
@@ -68,7 +68,7 @@ module Git
         #
         #     @option options [String] :blob (nil) read from the specified blob
         #
-        #     @return [Git::CommandLineResult] the result of calling `git config --remove-section`
+        #     @return [Git::CommandLine::Result] the result of calling `git config --remove-section`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/config_option_syntax/rename_section.rb
+++ b/lib/git/commands/config_option_syntax/rename_section.rb
@@ -72,7 +72,7 @@ module Git
         #
         #     @option options [String] :blob (nil) read from the specified blob
         #
-        #     @return [Git::CommandLineResult] the result of calling `git config --rename-section`
+        #     @return [Git::CommandLine::Result] the result of calling `git config --rename-section`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/config_option_syntax/replace_all.rb
+++ b/lib/git/commands/config_option_syntax/replace_all.rb
@@ -98,7 +98,7 @@ module Git
         #     @option options [Boolean, nil] :no_type (nil) unset the previously set type specifier;
         #       `true` emits `--no-type`
         #
-        #     @return [Git::CommandLineResult] the result of calling `git config --replace-all`
+        #     @return [Git::CommandLine::Result] the result of calling `git config --replace-all`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/config_option_syntax/set.rb
+++ b/lib/git/commands/config_option_syntax/set.rb
@@ -108,7 +108,7 @@ module Git
         #     @option options [Boolean, nil] :no_type (nil) unset the previously set type specifier;
         #       `true` emits `--no-type`
         #
-        #     @return [Git::CommandLineResult] the result of calling `git config`
+        #     @return [Git::CommandLine::Result] the result of calling `git config`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/config_option_syntax/unset.rb
+++ b/lib/git/commands/config_option_syntax/unset.rb
@@ -76,7 +76,7 @@ module Git
         #
         #     @option options [Boolean, nil] :fixed_value (nil) treat the value regex as an exact string
         #
-        #     @return [Git::CommandLineResult] the result of calling `git config --unset`
+        #     @return [Git::CommandLine::Result] the result of calling `git config --unset`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/config_option_syntax/unset_all.rb
+++ b/lib/git/commands/config_option_syntax/unset_all.rb
@@ -83,7 +83,7 @@ module Git
         #
         #     @option options [Boolean, nil] :fixed_value (nil) treat the value regex as an exact string
         #
-        #     @return [Git::CommandLineResult] the result of calling `git config --unset-all`
+        #     @return [Git::CommandLine::Result] the result of calling `git config --unset-all`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/describe.rb
+++ b/lib/git/commands/describe.rb
@@ -139,7 +139,7 @@ module Git
       #     @option options [Boolean, nil] :first_parent (nil) follow only the
       #       first parent of a merge commit
       #
-      #     @return [Git::CommandLineResult] the result of calling
+      #     @return [Git::CommandLine::Result] the result of calling
       #       `git describe`
       #
       #     @raise [ArgumentError] if unsupported options are provided

--- a/lib/git/commands/diff.rb
+++ b/lib/git/commands/diff.rb
@@ -164,7 +164,7 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @return [Git::CommandLineResult] the result of calling `git diff`
+      #     @return [Git::CommandLine::Result] the result of calling `git diff`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #
@@ -189,7 +189,7 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @return [Git::CommandLineResult] the result of calling `git diff`
+      #     @return [Git::CommandLine::Result] the result of calling `git diff`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #
@@ -211,7 +211,7 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @return [Git::CommandLineResult] the result of calling `git diff`
+      #     @return [Git::CommandLine::Result] the result of calling `git diff`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #
@@ -232,7 +232,7 @@ module Git
       #
       #     @param options [Hash] command options
       #
-      #     @return [Git::CommandLineResult] the result of calling `git diff`
+      #     @return [Git::CommandLine::Result] the result of calling `git diff`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #
@@ -640,7 +640,7 @@ module Git
       #     @option options [Array<String>] :path (nil) zero or more paths
       #       to limit diff to
       #
-      #     @return [Git::CommandLineResult] the result of calling
+      #     @return [Git::CommandLine::Result] the result of calling
       #       `git diff`
       #
       #     @raise [ArgumentError] if unsupported options are provided

--- a/lib/git/commands/diff_files.rb
+++ b/lib/git/commands/diff_files.rb
@@ -487,7 +487,7 @@ module Git
       #     @option options [Integer, String] :max_depth (nil) maximum directory depth to
       #       descend for pathspecs
       #
-      #     @return [Git::CommandLineResult] the result of calling `git diff-files`
+      #     @return [Git::CommandLine::Result] the result of calling `git diff-files`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #
@@ -503,7 +503,7 @@ module Git
       #
       #     @param options [Hash] command options (same as the no-path overload)
       #
-      #     @return [Git::CommandLineResult] the result of calling `git diff-files`
+      #     @return [Git::CommandLine::Result] the result of calling `git diff-files`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/diff_index.rb
+++ b/lib/git/commands/diff_index.rb
@@ -459,7 +459,7 @@ module Git
       #     @option options [Integer, String] :max_depth (nil) maximum directory depth to descend for
       #       each pathspec (tree-to-tree diffs only)
       #
-      #     @return [Git::CommandLineResult] the result of calling `git diff-index`
+      #     @return [Git::CommandLine::Result] the result of calling `git diff-index`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #
@@ -484,7 +484,7 @@ module Git
       #
       #     @param options [Hash] command options (same as the single-argument overload)
       #
-      #     @return [Git::CommandLineResult] the result of calling `git diff-index`
+      #     @return [Git::CommandLine::Result] the result of calling `git diff-index`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/fetch.rb
+++ b/lib/git/commands/fetch.rb
@@ -338,7 +338,7 @@ module Git
       #       Pass `true` to capture git fetch output (which is written to stderr
       #       by default).
       #
-      #     @return [Git::CommandLineResult] the result of calling `git fetch`
+      #     @return [Git::CommandLine::Result] the result of calling `git fetch`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/fsck.rb
+++ b/lib/git/commands/fsck.rb
@@ -121,7 +121,7 @@ module Git
       #     @option options [Boolean, nil] :no_references (nil) skip reference checking
       #       (`--no-references`)
       #
-      #     @return [Git::CommandLineResult] the result of calling `git fsck`
+      #     @return [Git::CommandLine::Result] the result of calling `git fsck`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/gc.rb
+++ b/lib/git/commands/gc.rb
@@ -118,7 +118,7 @@ module Git
       #
       #       When `true`, `gc.bigPackThreshold` is ignored.
       #
-      #     @return [Git::CommandLineResult] the result of calling `git gc`
+      #     @return [Git::CommandLine::Result] the result of calling `git gc`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/grep.rb
+++ b/lib/git/commands/grep.rb
@@ -317,7 +317,7 @@ module Git
       #       Multiple pathspecs may be passed as an Array. Appended to the
       #       command after `--`.
       #
-      #     @return [Git::CommandLineResult] the result of calling `git grep`
+      #     @return [Git::CommandLine::Result] the result of calling `git grep`
       #
       #       Exit status 0 means matches were found; exit status 1 means no
       #       lines were selected (not an error).

--- a/lib/git/commands/init.rb
+++ b/lib/git/commands/init.rb
@@ -85,7 +85,7 @@ module Git
       #       Pass a string (e.g. `'group'`, `'all'`, `'0660'`) to emit
       #       `--shared=<permissions>`.
       #
-      #     @return [Git::CommandLineResult] the result of calling `git init`
+      #     @return [Git::CommandLine::Result] the result of calling `git init`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/log.rb
+++ b/lib/git/commands/log.rb
@@ -618,7 +618,7 @@ module Git
       #   @option options [Integer, Float] :timeout (nil) number of seconds to wait before the
       #     command is aborted with a timeout error
       #
-      #   @return [Git::CommandLineResult] the result of calling `git log`
+      #   @return [Git::CommandLine::Result] the result of calling `git log`
       #
       #   @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/ls_files.rb
+++ b/lib/git/commands/ls_files.rb
@@ -180,7 +180,7 @@ module Git
       #
       #   @option options [String] :chdir (nil) run the command from the specified directory
       #
-      #   @return [Git::CommandLineResult] the result of calling `git ls-files`
+      #   @return [Git::CommandLine::Result] the result of calling `git ls-files`
       #
       #   @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/ls_remote.rb
+++ b/lib/git/commands/ls_remote.rb
@@ -146,7 +146,7 @@ module Git
       #
       #   @option options [Numeric] :timeout (nil) execution timeout in seconds
       #
-      #   @return [Git::CommandLineResult] the result of calling `git ls-remote`
+      #   @return [Git::CommandLine::Result] the result of calling `git ls-remote`
       #
       #   @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/ls_tree.rb
+++ b/lib/git/commands/ls_tree.rb
@@ -118,7 +118,7 @@ module Git
       #
       #     Cannot be combined with `:long`, `:name_only`, or `:object_only`.
       #
-      #   @return [Git::CommandLineResult] the result of calling `git ls-tree`
+      #   @return [Git::CommandLine::Result] the result of calling `git ls-tree`
       #
       #   @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/maintenance/register.rb
+++ b/lib/git/commands/maintenance/register.rb
@@ -59,7 +59,7 @@ module Git
         #   @option options [Hash] :env (nil) environment variables to set for the git
         #     process; merged with the default environment; not passed to the git CLI
         #
-        #   @return [Git::CommandLineResult] the result of calling `git maintenance register`
+        #   @return [Git::CommandLine::Result] the result of calling `git maintenance register`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/maintenance/run.rb
+++ b/lib/git/commands/maintenance/run.rb
@@ -94,7 +94,7 @@ module Git
         #     @option options [Hash] :env (nil) environment variables to set for the git
         #       process; merged with the default environment; not passed to the git CLI
         #
-        #     @return [Git::CommandLineResult] the result of calling `git maintenance run`
+        #     @return [Git::CommandLine::Result] the result of calling `git maintenance run`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/maintenance/start.rb
+++ b/lib/git/commands/maintenance/start.rb
@@ -58,7 +58,7 @@ module Git
         #     @option options [Hash] :env (nil) environment variables to set for the git
         #       process; merged with the default environment; not passed to the git CLI
         #
-        #     @return [Git::CommandLineResult] the result of calling `git maintenance start`
+        #     @return [Git::CommandLine::Result] the result of calling `git maintenance start`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/maintenance/stop.rb
+++ b/lib/git/commands/maintenance/stop.rb
@@ -47,7 +47,7 @@ module Git
         #     @option options [Hash] :env (nil) environment variables to set for the git
         #       process; merged with the default environment; not passed to the git CLI
         #
-        #     @return [Git::CommandLineResult] the result of calling `git maintenance stop`
+        #     @return [Git::CommandLine::Result] the result of calling `git maintenance stop`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/maintenance/unregister.rb
+++ b/lib/git/commands/maintenance/unregister.rb
@@ -69,7 +69,7 @@ module Git
         #     @option options [Hash] :env (nil) environment variables to set for the git
         #       process; merged with the default environment; not passed to the git CLI
         #
-        #     @return [Git::CommandLineResult] the result of calling `git maintenance unregister`
+        #     @return [Git::CommandLine::Result] the result of calling `git maintenance unregister`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/merge/abort.rb
+++ b/lib/git/commands/merge/abort.rb
@@ -34,7 +34,7 @@ module Git
         #
         #     Abort the current merge and reconstruct the pre-merge state
         #
-        #     @return [Git::CommandLineResult] the result of calling
+        #     @return [Git::CommandLine::Result] the result of calling
         #       `git merge --abort`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status

--- a/lib/git/commands/merge/continue.rb
+++ b/lib/git/commands/merge/continue.rb
@@ -34,7 +34,7 @@ module Git
         #
         #     Resume the in-progress merge after conflicts have been resolved
         #
-        #     @return [Git::CommandLineResult] the result of calling
+        #     @return [Git::CommandLine::Result] the result of calling
         #       `git merge --continue`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status

--- a/lib/git/commands/merge/quit.rb
+++ b/lib/git/commands/merge/quit.rb
@@ -36,7 +36,7 @@ module Git
         #     Forget about the current merge in progress, leaving the index
         #     and working tree as-is
         #
-        #     @return [Git::CommandLineResult] the result of calling
+        #     @return [Git::CommandLine::Result] the result of calling
         #       `git merge --quit`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status

--- a/lib/git/commands/merge/start.rb
+++ b/lib/git/commands/merge/start.rb
@@ -239,7 +239,7 @@ module Git
         #     @option options [Boolean, nil] :no_overwrite_ignore (nil) abort if the merge result
         #       would overwrite any ignored files (`--no-overwrite-ignore`)
         #
-        #     @return [Git::CommandLineResult] the result of calling `git merge`
+        #     @return [Git::CommandLine::Result] the result of calling `git merge`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/merge_base.rb
+++ b/lib/git/commands/merge_base.rb
@@ -79,7 +79,7 @@ module Git
       #
       #       Alias: :a
       #
-      #     @return [Git::CommandLineResult] the result of calling
+      #     @return [Git::CommandLine::Result] the result of calling
       #       `git merge-base`
       #
       #     @raise [ArgumentError] if unsupported options are provided

--- a/lib/git/commands/mv.rb
+++ b/lib/git/commands/mv.rb
@@ -72,7 +72,7 @@ module Git
       #
       #     @option options [Boolean, nil] :k (nil) skip move or rename actions which would lead to an error
       #
-      #     @return [Git::CommandLineResult] the result of calling `git mv`
+      #     @return [Git::CommandLine::Result] the result of calling `git mv`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/name_rev.rb
+++ b/lib/git/commands/name_rev.rb
@@ -108,7 +108,7 @@ module Git
       #     @option options [Boolean, nil] :always (nil) show uniquely abbreviated
       #       commit object as fallback
       #
-      #     @return [Git::CommandLineResult] the result of calling
+      #     @return [Git::CommandLine::Result] the result of calling
       #       `git name-rev`
       #
       #     @raise [ArgumentError] if unsupported options are provided

--- a/lib/git/commands/pull.rb
+++ b/lib/git/commands/pull.rb
@@ -371,7 +371,7 @@ module Git
       #
       #       If nil, uses the global timeout from {Git::Config}.
       #
-      #     @return [Git::CommandLineResult] the result of calling `git pull`
+      #     @return [Git::CommandLine::Result] the result of calling `git pull`
       #
       #     @raise [ArgumentError] if argument validation fails (e.g., unsupported options
       #       are provided or option values are invalid)

--- a/lib/git/commands/push.rb
+++ b/lib/git/commands/push.rb
@@ -240,7 +240,7 @@ module Git
       #
       #     @option options [Integer] :timeout (nil) maximum seconds to wait for the command to complete
       #
-      #     @return [Git::CommandLineResult] the result of calling `git push`
+      #     @return [Git::CommandLine::Result] the result of calling `git push`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/read_tree.rb
+++ b/lib/git/commands/read_tree.rb
@@ -142,7 +142,7 @@ module Git
       #
       #       Alias: `:q`
       #
-      #     @return [Git::CommandLineResult] the result of calling
+      #     @return [Git::CommandLine::Result] the result of calling
       #       `git read-tree`
       #
       #     @raise [ArgumentError] if unsupported options are provided

--- a/lib/git/commands/remote/add.rb
+++ b/lib/git/commands/remote/add.rb
@@ -85,7 +85,7 @@ module Git
         #
         #       Common values are `'fetch'` and `'push'`.
         #
-        #     @return [Git::CommandLineResult] the result of calling `git remote add`
+        #     @return [Git::CommandLine::Result] the result of calling `git remote add`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/remote/get_url.rb
+++ b/lib/git/commands/remote/get_url.rb
@@ -55,7 +55,7 @@ module Git
         #
         #     @option options [Boolean, nil] :all (nil) return all configured URLs instead of only the first one
         #
-        #     @return [Git::CommandLineResult] the result of calling `git remote get-url`
+        #     @return [Git::CommandLine::Result] the result of calling `git remote get-url`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/remote/list.rb
+++ b/lib/git/commands/remote/list.rb
@@ -43,7 +43,7 @@ module Git
         #
         #       Alias: :v
         #
-        #     @return [Git::CommandLineResult] the result of calling `git remote`
+        #     @return [Git::CommandLine::Result] the result of calling `git remote`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/remote/prune.rb
+++ b/lib/git/commands/remote/prune.rb
@@ -50,7 +50,7 @@ module Git
         #
         #       Alias: :n
         #
-        #     @return [Git::CommandLineResult] the result of calling `git remote prune`
+        #     @return [Git::CommandLine::Result] the result of calling `git remote prune`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/remote/remove.rb
+++ b/lib/git/commands/remote/remove.rb
@@ -43,7 +43,7 @@ module Git
         #
         #     @param name [String] the remote name to remove
         #
-        #     @return [Git::CommandLineResult] the result of calling `git remote remove`
+        #     @return [Git::CommandLine::Result] the result of calling `git remote remove`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
         #

--- a/lib/git/commands/remote/rename.rb
+++ b/lib/git/commands/remote/rename.rb
@@ -58,7 +58,7 @@ module Git
         #
         #     @option options [Boolean, nil] :no_progress (nil) suppress progress output (`--no-progress`)
         #
-        #     @return [Git::CommandLineResult] the result of calling `git remote rename`
+        #     @return [Git::CommandLine::Result] the result of calling `git remote rename`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/remote/set_branches.rb
+++ b/lib/git/commands/remote/set_branches.rb
@@ -57,7 +57,7 @@ module Git
         #
         #     @option options [Boolean, nil] :add (nil) append the given branches instead of replacing them
         #
-        #     @return [Git::CommandLineResult] the result of calling `git remote set-branches`
+        #     @return [Git::CommandLine::Result] the result of calling `git remote set-branches`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/remote/set_head.rb
+++ b/lib/git/commands/remote/set_head.rb
@@ -54,7 +54,7 @@ module Git
         #
         #     @param branch [String] the branch to set as the remote HEAD
         #
-        #     @return [Git::CommandLineResult] the result of calling `git remote set-head`
+        #     @return [Git::CommandLine::Result] the result of calling `git remote set-head`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
         #
@@ -76,7 +76,7 @@ module Git
         #
         #       Mutually exclusive with `:auto`. Alias: :d
         #
-        #     @return [Git::CommandLineResult] the result of calling `git remote set-head`
+        #     @return [Git::CommandLine::Result] the result of calling `git remote set-head`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/remote/set_url.rb
+++ b/lib/git/commands/remote/set_url.rb
@@ -65,7 +65,7 @@ module Git
         #
         #     @option options [Boolean, nil] :push (nil) update push URLs instead of fetch URLs
         #
-        #     @return [Git::CommandLineResult] the result of calling `git remote set-url`
+        #     @return [Git::CommandLine::Result] the result of calling `git remote set-url`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/remote/set_url_add.rb
+++ b/lib/git/commands/remote/set_url_add.rb
@@ -57,7 +57,7 @@ module Git
         #
         #     @option options [Boolean, nil] :push (nil) add a push URL instead of a fetch URL
         #
-        #     @return [Git::CommandLineResult] the result of calling `git remote set-url --add`
+        #     @return [Git::CommandLine::Result] the result of calling `git remote set-url --add`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/remote/set_url_delete.rb
+++ b/lib/git/commands/remote/set_url_delete.rb
@@ -58,7 +58,7 @@ module Git
         #
         #     @option options [Boolean, nil] :push (nil) delete push URLs instead of fetch URLs
         #
-        #     @return [Git::CommandLineResult] the result of calling `git remote set-url --delete`
+        #     @return [Git::CommandLine::Result] the result of calling `git remote set-url --delete`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/remote/show.rb
+++ b/lib/git/commands/remote/show.rb
@@ -60,7 +60,7 @@ module Git
         #
         #     Uses cached information instead of contacting the remote server.
         #
-        #   @return [Git::CommandLineResult] the result of calling `git remote show`
+        #   @return [Git::CommandLine::Result] the result of calling `git remote show`
         #
         # @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/remote/update.rb
+++ b/lib/git/commands/remote/update.rb
@@ -62,7 +62,7 @@ module Git
         #
         #     Alias: :p
         #
-        #   @return [Git::CommandLineResult] the result of calling `git remote update`
+        #   @return [Git::CommandLine::Result] the result of calling `git remote update`
         #
         # @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/repack.rb
+++ b/lib/git/commands/repack.rb
@@ -265,7 +265,7 @@ module Git
       #   @option options [Boolean, nil] :path_walk (nil) pass `--path-walk` to
       #     `git pack-objects`
       #
-      #   @return [Git::CommandLineResult] the result of calling `git repack`
+      #   @return [Git::CommandLine::Result] the result of calling `git repack`
       #
       # @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/reset.rb
+++ b/lib/git/commands/reset.rb
@@ -138,7 +138,7 @@ module Git
       #     reset in the index; when given, only the index entries for the
       #     matching paths are updated
       #
-      #   @return [Git::CommandLineResult] the result of calling `git reset`
+      #   @return [Git::CommandLine::Result] the result of calling `git reset`
       #
       # @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/rev_parse.rb
+++ b/lib/git/commands/rev_parse.rb
@@ -287,7 +287,7 @@ module Git
       #   @option options [String, nil] :chdir (nil) change to this directory
       #     before running git; not passed to the git CLI
       #
-      #   @return [Git::CommandLineResult] the result of calling
+      #   @return [Git::CommandLine::Result] the result of calling
       #     `git rev-parse`
       #
       # @raise [ArgumentError] if unsupported options are provided

--- a/lib/git/commands/revert/abort.rb
+++ b/lib/git/commands/revert/abort.rb
@@ -35,7 +35,7 @@ module Git
         #     Cancel the in-progress revert and restore the branch to its
         #     pre-revert state
         #
-        #     @return [Git::CommandLineResult] the result of calling
+        #     @return [Git::CommandLine::Result] the result of calling
         #       `git revert --abort`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status

--- a/lib/git/commands/revert/continue.rb
+++ b/lib/git/commands/revert/continue.rb
@@ -50,7 +50,7 @@ module Git
         #     @option options [Boolean, nil] :no_edit (nil) suppress the editor for
         #       the commit message (`--no-edit`)
         #
-        #     @return [Git::CommandLineResult] the result of calling
+        #     @return [Git::CommandLine::Result] the result of calling
         #       `git revert --continue`
         #
         #     @raise [ArgumentError] if unsupported options are provided

--- a/lib/git/commands/revert/quit.rb
+++ b/lib/git/commands/revert/quit.rb
@@ -37,7 +37,7 @@ module Git
         #     working tree as-is. If no revert is in progress, this is a
         #     no-op and still succeeds.
         #
-        #     @return [Git::CommandLineResult] the result of calling
+        #     @return [Git::CommandLine::Result] the result of calling
         #       `git revert --quit`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status

--- a/lib/git/commands/revert/skip.rb
+++ b/lib/git/commands/revert/skip.rb
@@ -34,7 +34,7 @@ module Git
         #
         #     Skip the current commit and continue with the remaining sequence
         #
-        #     @return [Git::CommandLineResult] the result of calling
+        #     @return [Git::CommandLine::Result] the result of calling
         #       `git revert --skip`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status

--- a/lib/git/commands/revert/start.rb
+++ b/lib/git/commands/revert/start.rb
@@ -147,7 +147,7 @@ module Git
         #     @option options [Boolean, nil] :reference (nil) use compact reference
         #       format in the revert commit message instead of the full object name
         #
-        #     @return [Git::CommandLineResult] the result of calling `git revert`
+        #     @return [Git::CommandLine::Result] the result of calling `git revert`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/rm.rb
+++ b/lib/git/commands/rm.rb
@@ -97,7 +97,7 @@ module Git
       #   @option options [Boolean, nil] :pathspec_file_nul (nil) when used with
       #     `:pathspec_from_file`, separate pathspec elements with NUL instead of newlines
       #
-      #   @return [Git::CommandLineResult] the result of calling `git rm`
+      #   @return [Git::CommandLine::Result] the result of calling `git rm`
       #
       #   @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/show.rb
+++ b/lib/git/commands/show.rb
@@ -611,7 +611,7 @@ module Git
       #     @option options [IO, #write] :out (nil) stream output to this IO object
       #       instead of capturing it; `result.stdout` will be `''`
       #
-      #     @return [Git::CommandLineResult] the result of calling `git show`
+      #     @return [Git::CommandLine::Result] the result of calling `git show`
       #
       #        If `out:` is given, output is streamed directly to the provided IO
       #        object and `result.stdout` is `''`.

--- a/lib/git/commands/show_ref/exclude_existing.rb
+++ b/lib/git/commands/show_ref/exclude_existing.rb
@@ -74,7 +74,7 @@ module Git
         #   @option options [Numeric] :timeout (nil) abort the command after this many
         #     seconds
         #
-        #   @return [Git::CommandLineResult] the result of calling
+        #   @return [Git::CommandLine::Result] the result of calling
         #     `git show-ref --exclude-existing`
         #
         #   @raise [Git::FailedError] if git exits with a non-zero exit status
@@ -99,7 +99,7 @@ module Git
         #
         # @param reader [IO] readable IO connected to git's stdin
         #
-        # @return [Git::CommandLineResult] the result of calling
+        # @return [Git::CommandLine::Result] the result of calling
         #   `git show-ref --exclude-existing`
         #
         # @raise [Git::FailedError] if git exits with a non-zero exit status

--- a/lib/git/commands/show_ref/exists.rb
+++ b/lib/git/commands/show_ref/exists.rb
@@ -63,7 +63,7 @@ module Git
         #   @option options [Numeric] :timeout (nil) abort the command after this many
         #     seconds
         #
-        #   @return [Git::CommandLineResult] the result of calling
+        #   @return [Git::CommandLine::Result] the result of calling
         #     `git show-ref --exists`
         #
         #   @raise [ArgumentError] if unsupported options are provided

--- a/lib/git/commands/show_ref/list.rb
+++ b/lib/git/commands/show_ref/list.rb
@@ -133,7 +133,7 @@ module Git
         #
         #   @option options [Numeric] :timeout (nil) abort the command after this many seconds
         #
-        #   @return [Git::CommandLineResult] the result of calling `git show-ref`
+        #   @return [Git::CommandLine::Result] the result of calling `git show-ref`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/show_ref/verify.rb
+++ b/lib/git/commands/show_ref/verify.rb
@@ -106,7 +106,7 @@ module Git
         #   @option options [Numeric] :timeout (nil) abort the command after this many
         #     seconds
         #
-        #   @return [Git::CommandLineResult] the result of calling `git show-ref --verify`
+        #   @return [Git::CommandLine::Result] the result of calling `git show-ref --verify`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/stash/apply.rb
+++ b/lib/git/commands/stash/apply.rb
@@ -66,7 +66,7 @@ module Git
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #
-        # @return [Git::CommandLineResult] the result of calling `git stash apply`
+        # @return [Git::CommandLine::Result] the result of calling `git stash apply`
         #
         # @raise [Git::FailedError] if git exits with a non-zero exit status
         #

--- a/lib/git/commands/stash/branch.rb
+++ b/lib/git/commands/stash/branch.rb
@@ -56,7 +56,7 @@ module Git
         #
         #     @param stash [String] stash reference (e.g., 'stash@\\{0}', '0')
         #
-        #   @return [Git::CommandLineResult] the result of calling `git stash branch`
+        #   @return [Git::CommandLine::Result] the result of calling `git stash branch`
         #
         #   @raise [Git::FailedError] if git exits with a non-zero exit status
         #

--- a/lib/git/commands/stash/clear.rb
+++ b/lib/git/commands/stash/clear.rb
@@ -32,7 +32,7 @@ module Git
         #
         #     Clear all stash entries
         #
-        #   @return [Git::CommandLineResult] the result of calling `git stash clear`
+        #   @return [Git::CommandLine::Result] the result of calling `git stash clear`
         #
         #   @raise [Git::FailedError] if git exits with a non-zero exit status
         #

--- a/lib/git/commands/stash/create.rb
+++ b/lib/git/commands/stash/create.rb
@@ -49,7 +49,7 @@ module Git
         #
         #     @param message [String] optional message for the stash commit
         #
-        #   @return [Git::CommandLineResult] the result of calling `git stash create`
+        #   @return [Git::CommandLine::Result] the result of calling `git stash create`
         #
         #   @raise [Git::FailedError] if git exits with a non-zero exit status
         #

--- a/lib/git/commands/stash/drop.rb
+++ b/lib/git/commands/stash/drop.rb
@@ -62,7 +62,7 @@ module Git
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #
-        #   @return [Git::CommandLineResult] the result of calling `git stash drop`
+        #   @return [Git::CommandLine::Result] the result of calling `git stash drop`
         #
         #   @raise [Git::FailedError] if git exits with a non-zero exit status
         #

--- a/lib/git/commands/stash/list.rb
+++ b/lib/git/commands/stash/list.rb
@@ -32,7 +32,7 @@ module Git
         #
         #   @overload call()
         #
-        #     @return [Git::CommandLineResult] the result of calling `git stash list`
+        #     @return [Git::CommandLine::Result] the result of calling `git stash list`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
         #

--- a/lib/git/commands/stash/pop.rb
+++ b/lib/git/commands/stash/pop.rb
@@ -58,7 +58,7 @@ module Git
         #
         #       Alias: :q
         #
-        #     @return [Git::CommandLineResult] the result of calling `git stash pop`
+        #     @return [Git::CommandLine::Result] the result of calling `git stash pop`
         #
         #   @overload call(stash, **options)
         #
@@ -74,7 +74,7 @@ module Git
         #
         #       Alias: :q
         #
-        #     @return [Git::CommandLineResult] the result of calling `git stash pop`
+        #     @return [Git::CommandLine::Result] the result of calling `git stash pop`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/stash/push.rb
+++ b/lib/git/commands/stash/push.rb
@@ -98,7 +98,7 @@ module Git
         #
         #     @option options [Boolean, nil] :pathspec_file_nul (nil) pathspecs in the file are NUL-separated
         #
-        #     @return [Git::CommandLineResult] the result of calling `git stash push`
+        #     @return [Git::CommandLine::Result] the result of calling `git stash push`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/stash/show.rb
+++ b/lib/git/commands/stash/show.rb
@@ -99,7 +99,7 @@ module Git
         #
         #       Pass `true` for default, or a string like `'lines,cumulative'` for options.
         #
-        #     @return [Git::CommandLineResult] the result of calling `git stash show`
+        #     @return [Git::CommandLine::Result] the result of calling `git stash show`
         #
         #   @overload call(stash, **options)
         #
@@ -145,7 +145,7 @@ module Git
         #
         #       Pass `true` for default, or a string like `'lines,cumulative'` for options.
         #
-        #     @return [Git::CommandLineResult] the result of calling `git stash show`
+        #     @return [Git::CommandLine::Result] the result of calling `git stash show`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/stash/store.rb
+++ b/lib/git/commands/stash/store.rb
@@ -59,7 +59,7 @@ module Git
         #
         #       Alias: :q
         #
-        #     @return [Git::CommandLineResult] the result of calling `git stash store`
+        #     @return [Git::CommandLine::Result] the result of calling `git stash store`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/status.rb
+++ b/lib/git/commands/status.rb
@@ -162,7 +162,7 @@ module Git
       #       When `true`, enables rename detection without a threshold. When a string
       #       (e.g. `'50'`), adds `--find-renames=<n>`.
       #
-      #     @return [Git::CommandLineResult] the result of calling `git status`
+      #     @return [Git::CommandLine::Result] the result of calling `git status`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/symbolic_ref/delete.rb
+++ b/lib/git/commands/symbolic_ref/delete.rb
@@ -52,7 +52,7 @@ module Git
         #
         #     Alias: :q
         #
-        #   @return [Git::CommandLineResult] the result of calling
+        #   @return [Git::CommandLine::Result] the result of calling
         #     `git symbolic-ref --delete`
         #
         #   @raise [ArgumentError] if unsupported options are provided

--- a/lib/git/commands/symbolic_ref/read.rb
+++ b/lib/git/commands/symbolic_ref/read.rb
@@ -79,7 +79,7 @@ module Git
         #   @option options [Boolean, nil] :no_recurse (nil) stop after a single level
         #     of dereferencing (`--no-recurse`)
         #
-        #   @return [Git::CommandLineResult] the result of calling
+        #   @return [Git::CommandLine::Result] the result of calling
         #     `git symbolic-ref`
         #
         #   @raise [ArgumentError] if unsupported options are provided

--- a/lib/git/commands/symbolic_ref/update.rb
+++ b/lib/git/commands/symbolic_ref/update.rb
@@ -57,7 +57,7 @@ module Git
         #   @option options [String] :m (nil) a reflog message for
         #     the update
         #
-        #   @return [Git::CommandLineResult] the result of calling
+        #   @return [Git::CommandLine::Result] the result of calling
         #     `git symbolic-ref`
         #
         #   @raise [ArgumentError] if unsupported options are provided

--- a/lib/git/commands/tag/create.rb
+++ b/lib/git/commands/tag/create.rb
@@ -125,7 +125,7 @@ module Git
         #
         #     Enables date-based sha1 expressions such as `tag@{yesterday}`.
         #
-        #   @return [Git::CommandLineResult] the result of calling `git tag`
+        #   @return [Git::CommandLine::Result] the result of calling `git tag`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/tag/delete.rb
+++ b/lib/git/commands/tag/delete.rb
@@ -43,7 +43,7 @@ module Git
         #
         #     @param tagname [Array<String>] one or more tag names to delete
         #
-        #     @return [Git::CommandLineResult] the result of calling `git tag --delete`
+        #     @return [Git::CommandLine::Result] the result of calling `git tag --delete`
         #
         #     @raise [ArgumentError] if no tag names are provided
         #

--- a/lib/git/commands/tag/list.rb
+++ b/lib/git/commands/tag/list.rb
@@ -132,7 +132,7 @@ module Git
         #
         #   @option options [String] :format (nil) output format string for each tag
         #
-        #   @return [Git::CommandLineResult] the result of calling `git tag --list`
+        #   @return [Git::CommandLine::Result] the result of calling `git tag --list`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/tag/verify.rb
+++ b/lib/git/commands/tag/verify.rb
@@ -55,7 +55,7 @@ module Git
         #
         #     The format is the same as that of git-for-each-ref(1)
         #
-        #   @return [Git::CommandLineResult] the result of calling `git tag --verify`
+        #   @return [Git::CommandLine::Result] the result of calling `git tag --verify`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/update_ref/batch.rb
+++ b/lib/git/commands/update_ref/batch.rb
@@ -108,7 +108,7 @@ module Git
         #
         #   @option options [Numeric] :timeout (nil) abort the command after this many seconds
         #
-        #   @return [Git::CommandLineResult] the result of calling
+        #   @return [Git::CommandLine::Result] the result of calling
         #     `git update-ref --stdin`
         #
         #   @raise [ArgumentError] if unsupported options are provided

--- a/lib/git/commands/update_ref/delete.rb
+++ b/lib/git/commands/update_ref/delete.rb
@@ -74,7 +74,7 @@ module Git
         #   @option options [Numeric] :timeout (nil) abort the command after this many
         #     seconds
         #
-        #   @return [Git::CommandLineResult] the result of calling `git update-ref -d`
+        #   @return [Git::CommandLine::Result] the result of calling `git update-ref -d`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/update_ref/update.rb
+++ b/lib/git/commands/update_ref/update.rb
@@ -87,7 +87,7 @@ module Git
         #   @option options [Numeric] :timeout (nil) abort the command after this many
         #     seconds
         #
-        #   @return [Git::CommandLineResult] the result of calling `git update-ref`
+        #   @return [Git::CommandLine::Result] the result of calling `git update-ref`
         #
         #   @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/version.rb
+++ b/lib/git/commands/version.rb
@@ -46,7 +46,7 @@ module Git
       #   @option options [Boolean, nil] :build_options (nil) include build options in
       #     the output
       #
-      #   @return [Git::CommandLineResult] the result of calling `git version`
+      #   @return [Git::CommandLine::Result] the result of calling `git version`
       #
       # @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/commands/worktree/add.rb
+++ b/lib/git/commands/worktree/add.rb
@@ -124,7 +124,7 @@ module Git
         #
         #     Only meaningful when used with `:lock`.
         #
-        #   @return [Git::CommandLineResult] the result of calling `git worktree add`
+        #   @return [Git::CommandLine::Result] the result of calling `git worktree add`
         #
         # @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/worktree/list.rb
+++ b/lib/git/commands/worktree/list.rb
@@ -49,7 +49,7 @@ module Git
         #   @option options [String] :expire (nil) annotate missing worktrees as
         #     prunable if older than this time expression
         #
-        #   @return [Git::CommandLineResult] the result of calling `git worktree list`
+        #   @return [Git::CommandLine::Result] the result of calling `git worktree list`
         #
         # @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/worktree/lock.rb
+++ b/lib/git/commands/worktree/lock.rb
@@ -43,7 +43,7 @@ module Git
         #   @option options [String] :reason (nil) human-readable explanation stored
         #     alongside the lock
         #
-        #   @return [Git::CommandLineResult] the result of calling `git worktree lock`
+        #   @return [Git::CommandLine::Result] the result of calling `git worktree lock`
         #
         # @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/worktree/move.rb
+++ b/lib/git/commands/worktree/move.rb
@@ -51,7 +51,7 @@ module Git
         #
         #     Alias: :f
         #
-        #   @return [Git::CommandLineResult] the result of calling `git worktree move`
+        #   @return [Git::CommandLine::Result] the result of calling `git worktree move`
         #
         # @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/worktree/prune.rb
+++ b/lib/git/commands/worktree/prune.rb
@@ -54,7 +54,7 @@ module Git
         #     @option options [String] :expire (nil) only prune entries older than
         #       this time expression
         #
-        #     @return [Git::CommandLineResult] the result of calling `git worktree prune`
+        #     @return [Git::CommandLine::Result] the result of calling `git worktree prune`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/worktree/remove.rb
+++ b/lib/git/commands/worktree/remove.rb
@@ -50,7 +50,7 @@ module Git
         #
         #       Alias: :f
         #
-        #     @return [Git::CommandLineResult] the result of calling `git worktree remove`
+        #     @return [Git::CommandLine::Result] the result of calling `git worktree remove`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/worktree/repair.rb
+++ b/lib/git/commands/worktree/repair.rb
@@ -61,7 +61,7 @@ module Git
         #       repair to update linking files if there is an absolute/relative
         #       mismatch, even if the links are already correct.
         #
-        #     @return [Git::CommandLineResult] the result of calling `git worktree repair`
+        #     @return [Git::CommandLine::Result] the result of calling `git worktree repair`
         #
         #     @raise [ArgumentError] if unsupported options are provided
         #

--- a/lib/git/commands/worktree/unlock.rb
+++ b/lib/git/commands/worktree/unlock.rb
@@ -36,7 +36,7 @@ module Git
         #     @param worktree [String] path or unique suffix identifying the worktree
         #       to unlock
         #
-        #     @return [Git::CommandLineResult] the result of calling `git worktree unlock`
+        #     @return [Git::CommandLine::Result] the result of calling `git worktree unlock`
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
         #

--- a/lib/git/commands/write_tree.rb
+++ b/lib/git/commands/write_tree.rb
@@ -55,7 +55,7 @@ module Git
       #
       #       The prefix path should end with `/` (e.g., `'lib/'`).
       #
-      #     @return [Git::CommandLineResult] the result of calling `git write-tree`
+      #     @return [Git::CommandLine::Result] the result of calling `git write-tree`
       #
       #     @raise [ArgumentError] if unsupported options are provided
       #

--- a/lib/git/errors.rb
+++ b/lib/git/errors.rb
@@ -100,11 +100,11 @@ module Git
     #
     # @example
     #   `exit 1` # set $? appropriately for this example
-    #   result = Git::CommandLineResult.new(%w[git status], $?, 'stdout', 'stderr')
+    #   result = Git::CommandLine::Result.new(%w[git status], $?, 'stdout', 'stderr')
     #   error = Git::CommandLineError.new(result)
     #   error.to_s #=> '["git", "status"], status: pid 89784 exit 1, stderr: "stderr"'
     #
-    # @param result [Git::CommandLineResult] the result of the git command including
+    # @param result [Git::CommandLine::Result] the result of the git command including
     #   the git command, status, stdout, and stderr
     #
     def initialize(result)
@@ -126,9 +126,9 @@ module Git
     # The result of the git command including the git command and its status and output
     #
     # @example
-    #   error.result #=> #<Git::CommandLineResult:0x00000001046bd488 ...>
+    #   error.result #=> #<Git::CommandLine::Result:0x00000001046bd488 ...>
     #
-    # @return [Git::CommandLineResult]
+    # @return [Git::CommandLine::Result]
     #
     attr_reader :result
   end
@@ -164,12 +164,12 @@ module Git
     #   command = %w[sleep 10]
     #   timeout_duration = 1
     #   status = ProcessExecuter.spawn(*command, timeout: timeout_duration)
-    #   result = Git::CommandLineResult.new(command, status, 'stdout', 'err output')
+    #   result = Git::CommandLine::Result.new(command, status, 'stdout', 'err output')
     #   error = Git::TimeoutError.new(result, timeout_duration)
     #   error.error_message
     #   #=> '["sleep", "10"], status: pid 70144 SIGKILL (signal 9), stderr: "err output", timed out after 1s'
     #
-    # @param result [Git::CommandLineResult] the result of the git command including
+    # @param result [Git::CommandLine::Result] the result of the git command including
     #   the git command, status, stdout, and stderr
     #
     # @param timeout_duration [Numeric] the amount of time the subprocess was allowed
@@ -196,7 +196,7 @@ module Git
     #
     # @example
     #   `kill -9 $$` # set $? appropriately for this example
-    #   result = Git::CommandLineResult.new(%w[git status], $?, '', "killed")
+    #   result = Git::CommandLine::Result.new(%w[git status], $?, '', "killed")
     #   error = Git::TimeoutError.new(result, 10)
     #   error.timeout_duration #=> 10
     #

--- a/lib/git/execution_context.rb
+++ b/lib/git/execution_context.rb
@@ -239,7 +239,7 @@ module Git
     #
     #   @param args [Array<String>] the command and its arguments
     #
-    #   @return [Git::CommandLineResult] the result of the command
+    #   @return [Git::CommandLine::Result] the result of the command
     #
     # @param options_hash [Hash] the options to pass to the command
     #
@@ -295,7 +295,7 @@ module Git
     # @raise [Git::ProcessIOError] if an exception was raised while collecting
     #   subprocess output
     #
-    #   The exception's `result` attribute is a {Git::CommandLineResult} which will
+    #   The exception's `result` attribute is a {Git::CommandLine::Result} which will
     #   contain the result of the command including the exit status, stdout, and stderr.
     #
     # @note Individual command classes (under {Git::Commands}) can selectively expose
@@ -338,7 +338,7 @@ module Git
     #
     #   @param args [Array<String>] the git command and its arguments
     #
-    #   @return [Git::CommandLineResult] the result of the command
+    #   @return [Git::CommandLine::Result] the result of the command
     #
     # @param options_hash [Hash] the options to pass to the command
     #

--- a/lib/git/remote.rb
+++ b/lib/git/remote.rb
@@ -131,7 +131,7 @@ module Git
     # @example Remove the upstream remote
     #   git.remote('upstream').remove
     #
-    # @return [Git::CommandLineResult] the result of `git remote remove`
+    # @return [Git::CommandLine::Result] the result of `git remote remove`
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -232,7 +232,7 @@ module Git
     #
     # @option options [String, nil] :file (nil) path to a custom config file
     #
-    # @return [Hash{String => String}, String, Git::CommandLineResult] all config
+    # @return [Hash{String => String}, String, Git::CommandLine::Result] all config
     #   entries, a single value, or the command result for set mode
     #
     # @raise [ArgumentError] if unsupported options are provided
@@ -293,7 +293,7 @@ module Git
     #   @param value [#to_s] the value to assign; any object is accepted and
     #     converted to a String via `#to_s` before being passed to git
     #
-    #   @return [Git::CommandLineResult] the raw result of
+    #   @return [Git::CommandLine::Result] the raw result of
     #     `git config --global <name> <value>`
     #
     #   @raise [Git::FailedError] if git exits with a non-zero exit status
@@ -380,7 +380,7 @@ module Git
     #
     #   @option options [String, nil] :file (nil) path to a custom config file
     #
-    #   @return [Git::CommandLineResult] the command result
+    #   @return [Git::CommandLine::Result] the command result
     #
     #   @raise [ArgumentError] if unsupported options are provided
     #
@@ -471,7 +471,7 @@ module Git
     #
     # @param value [#to_s] the value to assign
     #
-    # @return [Git::CommandLineResult] the command result
+    # @return [Git::CommandLine::Result] the command result
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -549,7 +549,7 @@ module Git
       #
       # @param commit [String] the commit SHA to point the branch at
       #
-      # @return [Git::CommandLineResult] the result of calling `git update-ref`
+      # @return [Git::CommandLine::Result] the result of calling `git update-ref`
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #

--- a/lib/git/repository/diffing.rb
+++ b/lib/git/repository/diffing.rb
@@ -552,7 +552,7 @@ module Git
         #
         # @param pathspecs [Array<String>, nil] path limiters
         #
-        # @return [Git::CommandLineResult] the result of calling `git diff`
+        # @return [Git::CommandLine::Result] the result of calling `git diff`
         #
         def call_diff_command(execution_context, from, to, pathspecs)
           Git::Commands::Diff.new(execution_context).call(

--- a/lib/git/repository/factories.rb
+++ b/lib/git/repository/factories.rb
@@ -360,7 +360,7 @@ module Git
       # @option context_opts [Logger, nil] :logger logger used for clone
       #   operations
       #
-      # @return [Git::CommandLineResult] the result of running `git clone`
+      # @return [Git::CommandLine::Result] the result of running `git clone`
       #
       # @raise [ArgumentError] if unsupported options are provided
       #
@@ -380,7 +380,7 @@ module Git
 
       # Resolve repository paths from a completed clone result
       #
-      # @param clone_result [Git::CommandLineResult] the completed clone result
+      # @param clone_result [Git::CommandLine::Result] the completed clone result
       #
       # @param opts [Hash] command-ready clone options
       #
@@ -616,7 +616,7 @@ module Git
       #
       # @option options [Logger, nil] :log logger used for git operations
       #
-      # @return [Git::CommandLineResult] the result of running `git init`
+      # @return [Git::CommandLine::Result] the result of running `git init`
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -1060,7 +1060,7 @@ module Git
 
         # Parses the result of a git grep command
         #
-        # @param result [Git::CommandLineResult] the result of a git grep command
+        # @param result [Git::CommandLine::Result] the result of a git grep command
         #
         # @return [Hash<String, Array<Array(Integer, String)>>] hash mapping "treeish:filename"
         #   keys to arrays of [line_number, text] pairs
@@ -1195,7 +1195,7 @@ module Git
         # @option opts [String] :remote (nil) remote repository from which to
         #   retrieve the archive
         #
-        # @return [Git::CommandLineResult] the result of the git command
+        # @return [Git::CommandLine::Result] the result of the git command
         #
         # @api private
         #

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -389,7 +389,7 @@ module Git
       #
       # @param name [String] the name of the remote to remove
       #
-      # @return [Git::CommandLineResult] the result of calling `git remote remove`
+      # @return [Git::CommandLine::Result] the result of calling `git remote remove`
       #
       # @raise [Git::FailedError] when git exits with a non-zero status
       #
@@ -399,7 +399,7 @@ module Git
 
       # @param name [String] the name of the remote to remove
       #
-      # @return [Git::CommandLineResult] the result of calling `git remote remove`
+      # @return [Git::CommandLine::Result] the result of calling `git remote remove`
       #
       # @raise [Git::FailedError] when git exits with a non-zero status
       #
@@ -773,7 +773,7 @@ module Git
         # @option opts [String, Array<String>] :push_option (nil) one or more
         #   push-option values
         #
-        # @return [Git::CommandLineResult]
+        # @return [Git::CommandLine::Result]
         #
         # @api private
         #
@@ -816,7 +816,7 @@ module Git
         # @option opts [String, Array<String>] :push_option (nil) one or more
         #   push-option values
         #
-        # @return [Git::CommandLineResult]
+        # @return [Git::CommandLine::Result]
         #
         # @api private
         #

--- a/spec/integration/git/command_line_spec.rb
+++ b/spec/integration/git/command_line_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'CommandLine::Capturing#run raise_on_failure integration' do
     it 'returns CommandLineResult without raising on non-zero exit' do
       result = command_line.run('rev-parse', 'nonexistent-ref', chdir: repo_dir, raise_on_failure: false)
 
-      expect(result).to be_a(Git::CommandLineResult)
+      expect(result).to be_a(Git::CommandLine::Result)
       expect(result.status.success?).to be false
       expect(result.stderr).to include('unknown revision')
     end

--- a/spec/integration/git/commands/add_spec.rb
+++ b/spec/integration/git/commands/add_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Git::Commands::Add, :integration do
         it 'returns a CommandLineResult' do
           result = command.call('new.txt')
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
 
@@ -32,7 +32,7 @@ RSpec.describe Git::Commands::Add, :integration do
         it 'returns a CommandLineResult' do
           result = command.call(all: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
     end

--- a/spec/integration/git/commands/am/abort_spec.rb
+++ b/spec/integration/git/commands/am/abort_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Git::Commands::Am::Abort, :integration do
 
       it 'aborts the in-progress am session' do
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/am/apply_spec.rb
+++ b/spec/integration/git/commands/am/apply_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Git::Commands::Am::Apply, :integration do
       it 'returns a CommandLineResult' do
         result = command.call(mbox_file, chdir: repo_dir)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'applies the patch as a new commit' do

--- a/spec/integration/git/commands/am/continue_spec.rb
+++ b/spec/integration/git/commands/am/continue_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Git::Commands::Am::Continue, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/am/quit_spec.rb
+++ b/spec/integration/git/commands/am/quit_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Git::Commands::Am::Quit, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/am/retry_spec.rb
+++ b/spec/integration/git/commands/am/retry_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Git::Commands::Am::Retry, :integration,
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/am/show_current_patch_spec.rb
+++ b/spec/integration/git/commands/am/show_current_patch_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Git::Commands::Am::ShowCurrentPatch, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/am/skip_spec.rb
+++ b/spec/integration/git/commands/am/skip_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Git::Commands::Am::Skip, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/apply_spec.rb
+++ b/spec/integration/git/commands/apply_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Git::Commands::Apply, :integration do
       it 'returns a CommandLineResult' do
         result = command.call(patch_file, chdir: repo_dir)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'applies the patch to the working tree' do
@@ -44,7 +44,7 @@ RSpec.describe Git::Commands::Apply, :integration do
       it 'checks the patch cleanly without applying it when :check is passed' do
         result = command.call(patch_file, check: true, chdir: repo_dir)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(File.read(File.join(repo_dir, 'file.txt'))).to eq("line1\n")
       end
     end

--- a/spec/integration/git/commands/archive/list_formats_spec.rb
+++ b/spec/integration/git/commands/archive/list_formats_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::Archive::ListFormats, :integration do
       it 'returns a CommandLineResult with output' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
     end

--- a/spec/integration/git/commands/archive_spec.rb
+++ b/spec/integration/git/commands/archive_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Git::Commands::Archive, :integration do
         # Capture in-memory and compare byte-for-byte
         result = command.call('HEAD', format: 'tar')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq(streamed_bytes)
       end
 

--- a/spec/integration/git/commands/branch/copy_spec.rb
+++ b/spec/integration/git/commands/branch/copy_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::Branch::Copy, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('main-copy')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/branch/create_spec.rb
+++ b/spec/integration/git/commands/branch/create_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::Branch::Create, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('feature-branch')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/branch/delete_spec.rb
+++ b/spec/integration/git/commands/branch/delete_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Git::Commands::Branch::Delete, :integration do
 
         result = command.call('feature')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
 
@@ -46,7 +46,7 @@ RSpec.describe Git::Commands::Branch::Delete, :integration do
         # Exit code 1 does not raise, but exit code > 1 would
         result = command.call('nonexistent')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(1)
       end
     end

--- a/spec/integration/git/commands/branch/list_spec.rb
+++ b/spec/integration/git/commands/branch/list_spec.rb
@@ -17,14 +17,14 @@ RSpec.describe Git::Commands::Branch::List, :integration do
 
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
 
       it 'returns empty output when there are no branches' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to be_empty
       end
     end

--- a/spec/integration/git/commands/branch/move_spec.rb
+++ b/spec/integration/git/commands/branch/move_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::Branch::Move, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('main-renamed')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/branch/set_upstream_spec.rb
+++ b/spec/integration/git/commands/branch/set_upstream_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Git::Commands::Branch::SetUpstream, :integration do
       it 'returns a CommandLineResult with output' do
         result = command.call(set_upstream_to: 'origin/main')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
     end

--- a/spec/integration/git/commands/branch/show_current_spec.rb
+++ b/spec/integration/git/commands/branch/show_current_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Git::Commands::Branch::ShowCurrent, :integration do
 
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
     end

--- a/spec/integration/git/commands/branch/unset_upstream_spec.rb
+++ b/spec/integration/git/commands/branch/unset_upstream_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Git::Commands::Branch::UnsetUpstream, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/cat_file/batch_spec.rb
+++ b/spec/integration/git/commands/cat_file/batch_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::CatFile::Batch, :integration do
         it 'returns a CommandLineResult with output for the specified object' do
           result = command.call('HEAD:README.md', batch: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
 
@@ -35,7 +35,7 @@ RSpec.describe Git::Commands::CatFile::Batch, :integration do
         it 'returns a CommandLineResult with metadata for the specified object' do
           result = command.call('HEAD', batch_check: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
 
@@ -50,7 +50,7 @@ RSpec.describe Git::Commands::CatFile::Batch, :integration do
         it 'enumerates all objects and returns non-empty output' do
           result = command.call(batch_all_objects: true, batch_check: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
       end

--- a/spec/integration/git/commands/cat_file/filtered_spec.rb
+++ b/spec/integration/git/commands/cat_file/filtered_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe Git::Commands::CatFile::Filtered, :integration do
         it 'returns a CommandLineResult with the processed blob content' do
           result = command.call('HEAD:README.md', textconv: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
 
         it 'accepts a blob ref with --path= to identify the filter path' do
           result = command.call('HEAD:README.md', textconv: true, path: 'README.md')
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
       end
@@ -36,7 +36,7 @@ RSpec.describe Git::Commands::CatFile::Filtered, :integration do
         it 'returns a CommandLineResult with the processed blob content' do
           result = command.call('HEAD:README.md', filters: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
       end

--- a/spec/integration/git/commands/cat_file/raw_spec.rb
+++ b/spec/integration/git/commands/cat_file/raw_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::CatFile::Raw, :integration do
         it 'returns exit status 0 when the object exists' do
           result = command.call('HEAD', e: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.status.exitstatus).to eq(0)
         end
 
@@ -35,7 +35,7 @@ RSpec.describe Git::Commands::CatFile::Raw, :integration do
         it 'returns a CommandLineResult with the object type' do
           result = command.call('HEAD', t: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
       end
@@ -44,7 +44,7 @@ RSpec.describe Git::Commands::CatFile::Raw, :integration do
         it 'returns a CommandLineResult with the object size' do
           result = command.call('HEAD', s: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
       end
@@ -53,7 +53,7 @@ RSpec.describe Git::Commands::CatFile::Raw, :integration do
         it 'returns a CommandLineResult with the pretty-printed object content' do
           result = command.call('HEAD', p: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
       end
@@ -62,7 +62,7 @@ RSpec.describe Git::Commands::CatFile::Raw, :integration do
         it 'returns a CommandLineResult when the type matches' do
           result = command.call('blob', 'HEAD:README.md')
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
       end

--- a/spec/integration/git/commands/checkout/branch_spec.rb
+++ b/spec/integration/git/commands/checkout/branch_spec.rb
@@ -21,13 +21,13 @@ RSpec.describe Git::Commands::Checkout::Branch, :integration do
 
         result = command.call('feature')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns a CommandLineResult when creating a new branch' do
         result = command.call(b: 'new-feature')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/checkout/files_spec.rb
+++ b/spec/integration/git/commands/checkout/files_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Git::Commands::Checkout::Files, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('HEAD', pathspec: ['file.txt'])
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/checkout_index_spec.rb
+++ b/spec/integration/git/commands/checkout_index_spec.rb
@@ -19,19 +19,19 @@ RSpec.describe Git::Commands::CheckoutIndex, :integration do
       it 'returns a CommandLineResult' do
         result = command.call(all: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns a CommandLineResult with force option' do
         result = command.call(all: true, force: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns a CommandLineResult for a specific file' do
         result = command.call('file.txt')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/clean_spec.rb
+++ b/spec/integration/git/commands/clean_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Git::Commands::Clean, :integration do
         it 'returns a CommandLineResult' do
           result = command.call(force: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
 
@@ -34,7 +34,7 @@ RSpec.describe Git::Commands::Clean, :integration do
         it 'returns a CommandLineResult' do
           result = command.call(force: true, d: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
     end

--- a/spec/integration/git/commands/clone_spec.rb
+++ b/spec/integration/git/commands/clone_spec.rb
@@ -33,20 +33,20 @@ RSpec.describe Git::Commands::Clone, :integration do
       it 'returns a CommandLineResult' do
         result = command.call(source_dir, File.join(clone_dir, 'cloned'))
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns a CommandLineResult when cloning with chdir' do
         result = command.call(source_dir, 'chdir-cloned', chdir: clone_dir)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(File.directory?(File.join(clone_dir, 'chdir-cloned'))).to be true
       end
 
       it 'returns a CommandLineResult for a bare clone' do
         result = command.call(source_dir, File.join(clone_dir, 'bare.git'), bare: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(File.directory?(File.join(clone_dir, 'bare.git'))).to be true
       end
     end

--- a/spec/integration/git/commands/commit_spec.rb
+++ b/spec/integration/git/commands/commit_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Git::Commands::Commit, :integration do
       it 'returns a CommandLineResult' do
         result = command.call(message: 'Test commit')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       context 'with allow_empty option' do
@@ -27,7 +27,7 @@ RSpec.describe Git::Commands::Commit, :integration do
         it 'returns a CommandLineResult' do
           result = command.call(message: 'Empty commit', allow_empty: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
     end

--- a/spec/integration/git/commands/commit_tree_spec.rb
+++ b/spec/integration/git/commands/commit_tree_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Git::Commands::CommitTree, :integration do
       it 'returns a CommandLineResult with the new commit SHA on stdout' do
         result = command.call(tree_sha, m: 'Test commit')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to match(/\A[0-9a-f]{40}\z/)
       end
 

--- a/spec/integration/git/commands/config_option_syntax/add_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/add_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::Add, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('test.multi', 'value1')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/config_option_syntax/get_all_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_all_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::GetAll, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('user.name')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns the configured value in stdout' do

--- a/spec/integration/git/commands/config_option_syntax/get_color_bool_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_color_bool_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::GetColorBool, :integration do
         repo.config_set('color.test', 'always')
         result = command.call('color.test')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
 

--- a/spec/integration/git/commands/config_option_syntax/get_color_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_color_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::GetColor, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('color.test.slot')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns result with exit status 0' do

--- a/spec/integration/git/commands/config_option_syntax/get_regexp_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_regexp_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::GetRegexp, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('user\\..*')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns exit status 0 when entries match' do

--- a/spec/integration/git/commands/config_option_syntax/get_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::Get, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('user.name')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns exit code 0 when the key exists' do

--- a/spec/integration/git/commands/config_option_syntax/get_urlmatch_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_urlmatch_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::GetUrlmatch, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('http.proxy', 'https://example.com')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
 

--- a/spec/integration/git/commands/config_option_syntax/list_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/list_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::List, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/config_option_syntax/remove_section_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/remove_section_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::RemoveSection, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('testsection')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns result with exit status 0' do

--- a/spec/integration/git/commands/config_option_syntax/rename_section_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/rename_section_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::RenameSection, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('oldsection', 'newsection')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns result with exit status 0' do

--- a/spec/integration/git/commands/config_option_syntax/replace_all_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/replace_all_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::ReplaceAll, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('test.multi', 'new-value')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/config_option_syntax/set_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/set_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::Set, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('test.key', 'test-value')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns result with exit status 0' do

--- a/spec/integration/git/commands/config_option_syntax/unset_all_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/unset_all_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::UnsetAll, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('test.multi')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns exit status 0 when the key exists' do

--- a/spec/integration/git/commands/config_option_syntax/unset_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/unset_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::Unset, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('test.key')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns result with exit status 0' do

--- a/spec/integration/git/commands/describe_spec.rb
+++ b/spec/integration/git/commands/describe_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe Git::Commands::Describe, :integration do
       it 'returns a CommandLineResult describing HEAD' do
         result = command.call(tags: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
 
       it 'returns a CommandLineResult with :long option' do
         result = command.call(tags: true, long: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
 
@@ -38,7 +38,7 @@ RSpec.describe Git::Commands::Describe, :integration do
 
         result = command.call(always: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
     end

--- a/spec/integration/git/commands/diff_files_spec.rb
+++ b/spec/integration/git/commands/diff_files_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Git::Commands::DiffFiles, :integration do
     context 'when the command succeeds' do
       it 'returns a CommandLineResult with exit code 0 when no unstaged changes exist' do
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
 
@@ -26,13 +26,13 @@ RSpec.describe Git::Commands::DiffFiles, :integration do
         write_file('file.txt', "modified content\n")
 
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
 
       it 'accepts a path operand and returns a CommandLineResult' do
         result = command.call('file.txt')
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/diff_index_spec.rb
+++ b/spec/integration/git/commands/diff_index_spec.rb
@@ -18,19 +18,19 @@ RSpec.describe Git::Commands::DiffIndex, :integration do
     context 'when the command succeeds' do
       it 'returns a CommandLineResult with exit code 0 when no working-tree changes exist' do
         result = command.call('HEAD')
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
 
       it 'returns a CommandLineResult with exit code 0 when nothing is staged' do
         result = command.call('HEAD', cached: true)
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
 
       it 'accepts a path operand and returns a CommandLineResult' do
         result = command.call('HEAD', 'file.txt')
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'exits with status 1 when staged changes are present and --exit-code is given' do

--- a/spec/integration/git/commands/diff_spec.rb
+++ b/spec/integration/git/commands/diff_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Git::Commands::Diff, :integration do
                               numstat: true, shortstat: true,
                               src_prefix: 'a/', dst_prefix: 'b/')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
 

--- a/spec/integration/git/commands/fetch_spec.rb
+++ b/spec/integration/git/commands/fetch_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Git::Commands::Fetch, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('origin', merge: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/fsck/fsck_spec.rb
+++ b/spec/integration/git/commands/fsck/fsck_spec.rb
@@ -24,14 +24,14 @@ RSpec.describe Git::Commands::Fsck, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       context 'with options' do
         it 'accepts multiple options' do
           result = command.call(root: true, strict: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
 
@@ -40,7 +40,7 @@ RSpec.describe Git::Commands::Fsck, :integration do
           head_sha = execution_context.command_capturing('rev-parse', 'HEAD').stdout.strip
           result = command.call(head_sha)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
     end

--- a/spec/integration/git/commands/gc_spec.rb
+++ b/spec/integration/git/commands/gc_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::Gc, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
     end

--- a/spec/integration/git/commands/grep_spec.rb
+++ b/spec/integration/git/commands/grep_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::Grep, :integration do
       it 'returns a CommandLineResult with exit status 0' do
         result = command.call('HEAD', pattern: 'foo')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
         expect(result.stdout).to include('foo')
       end

--- a/spec/integration/git/commands/init_spec.rb
+++ b/spec/integration/git/commands/init_spec.rb
@@ -20,14 +20,14 @@ RSpec.describe Git::Commands::Init, :integration do
       it 'returns a CommandLineResult' do
         result = command.call(init_dir)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       context 'with bare option' do
         it 'returns a CommandLineResult' do
           result = command.call(init_dir, bare: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
     end

--- a/spec/integration/git/commands/log_spec.rb
+++ b/spec/integration/git/commands/log_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Git::Commands::Log, :integration do
       it 'returns a CommandLineResult with non-empty output' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
 
@@ -32,7 +32,7 @@ RSpec.describe Git::Commands::Log, :integration do
           first_sha = repo.rev_parse('HEAD~1')
           result = command.call("#{first_sha}..")
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
       end

--- a/spec/integration/git/commands/ls_files_spec.rb
+++ b/spec/integration/git/commands/ls_files_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::LsFiles, :integration do
         it 'returns a CommandLineResult' do
           result = command.call
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
 
@@ -28,7 +28,7 @@ RSpec.describe Git::Commands::LsFiles, :integration do
         it 'returns a CommandLineResult' do
           result = command.call('.', stage: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
 
@@ -38,7 +38,7 @@ RSpec.describe Git::Commands::LsFiles, :integration do
         it 'returns a CommandLineResult' do
           result = command.call(others: true, exclude_standard: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
 
@@ -53,7 +53,7 @@ RSpec.describe Git::Commands::LsFiles, :integration do
         it 'returns a CommandLineResult' do
           result = command.call(others: true, ignored: true, exclude_standard: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
 

--- a/spec/integration/git/commands/ls_remote_spec.rb
+++ b/spec/integration/git/commands/ls_remote_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Git::Commands::LsRemote, :integration do
       it 'returns a CommandLineResult with refs output' do
         result = command.call(bare_dir)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
         expect(result.stdout).not_to be_empty
       end

--- a/spec/integration/git/commands/ls_tree_spec.rb
+++ b/spec/integration/git/commands/ls_tree_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Git::Commands::LsTree, :integration do
       it 'returns a CommandLineResult with output' do
         result = command.call('HEAD')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
 
@@ -29,7 +29,7 @@ RSpec.describe Git::Commands::LsTree, :integration do
         it 'returns a CommandLineResult' do
           result = command.call('HEAD', r: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
 
@@ -37,7 +37,7 @@ RSpec.describe Git::Commands::LsTree, :integration do
         it 'returns a CommandLineResult' do
           result = command.call('HEAD', r: true, name_only: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
 
@@ -45,7 +45,7 @@ RSpec.describe Git::Commands::LsTree, :integration do
         it 'returns a CommandLineResult' do
           result = command.call('HEAD', 'lib/')
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
     end

--- a/spec/integration/git/commands/maintenance/register_spec.rb
+++ b/spec/integration/git/commands/maintenance/register_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Git::Commands::Maintenance::Register, :integration,
       it 'returns a CommandLineResult' do
         result = command.call(config_file: global_config.path, env: isolated_env)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns exit code 0' do

--- a/spec/integration/git/commands/maintenance/run_spec.rb
+++ b/spec/integration/git/commands/maintenance/run_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Git::Commands::Maintenance::Run, :integration,
       it 'returns a CommandLineResult' do
         result = command.call(env: isolated_env)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns exit code 0' do

--- a/spec/integration/git/commands/maintenance/start_spec.rb
+++ b/spec/integration/git/commands/maintenance/start_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe Git::Commands::Maintenance::Start, :integration,
       it 'returns a CommandLineResult' do
         result = command.call(scheduler: scheduler, env: isolated_env)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns exit code 0' do

--- a/spec/integration/git/commands/maintenance/stop_spec.rb
+++ b/spec/integration/git/commands/maintenance/stop_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Git::Commands::Maintenance::Stop, :integration,
       it 'returns a CommandLineResult' do
         result = command.call(env: isolated_env)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns exit code 0' do

--- a/spec/integration/git/commands/maintenance/unregister_spec.rb
+++ b/spec/integration/git/commands/maintenance/unregister_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Git::Commands::Maintenance::Unregister, :integration,
       it 'returns a CommandLineResult' do
         result = command.call(config_file: global_config.path, env: isolated_env)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns exit code 0' do

--- a/spec/integration/git/commands/merge/abort_spec.rb
+++ b/spec/integration/git/commands/merge/abort_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Git::Commands::Merge::Abort, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/merge/continue_spec.rb
+++ b/spec/integration/git/commands/merge/continue_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Git::Commands::Merge::Continue, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/merge/quit_spec.rb
+++ b/spec/integration/git/commands/merge/quit_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Git::Commands::Merge::Quit, :integration do
         it 'returns a CommandLineResult' do
           result = command.call
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
 

--- a/spec/integration/git/commands/merge/start_spec.rb
+++ b/spec/integration/git/commands/merge/start_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Git::Commands::Merge::Start, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('feature')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/merge_base_spec.rb
+++ b/spec/integration/git/commands/merge_base_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Git::Commands::MergeBase, :integration do
       it 'returns a CommandLineResult with output' do
         result = command.call('main', 'feature')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
 

--- a/spec/integration/git/commands/mv_spec.rb
+++ b/spec/integration/git/commands/mv_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::Mv, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('original.txt', 'renamed.txt')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/name_rev_spec.rb
+++ b/spec/integration/git/commands/name_rev_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::NameRev, :integration do
       it 'returns a CommandLineResult with the symbolic name' do
         result = command.call('HEAD')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to include('main')
       end
 

--- a/spec/integration/git/commands/pull_spec.rb
+++ b/spec/integration/git/commands/pull_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe Git::Commands::Pull, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('origin', 'main')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/push_spec.rb
+++ b/spec/integration/git/commands/push_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Git::Commands::Push, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('origin', 'main')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns result with exit status 0' do

--- a/spec/integration/git/commands/read_tree_spec.rb
+++ b/spec/integration/git/commands/read_tree_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::ReadTree, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('HEAD')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/remote/add_spec.rb
+++ b/spec/integration/git/commands/remote/add_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Git::Commands::Remote::Add, :integration do
       it 'adds a new remote' do
         result = command.call('origin', remote_repo.dir.to_s)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(repo.remotes.map(&:name)).to include('origin')
       end
     end

--- a/spec/integration/git/commands/remote/get_url_spec.rb
+++ b/spec/integration/git/commands/remote/get_url_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Git::Commands::Remote::GetUrl, :integration do
 
         result = command.call('origin')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout.strip).to eq(remote_repo.dir.to_s)
       end
     end

--- a/spec/integration/git/commands/remote/list_spec.rb
+++ b/spec/integration/git/commands/remote/list_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Git::Commands::Remote::List, :integration do
 
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout.lines.map(&:strip)).to include('origin')
       end
     end

--- a/spec/integration/git/commands/remote/prune_spec.rb
+++ b/spec/integration/git/commands/remote/prune_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Git::Commands::Remote::Prune, :integration do
 
         result = command.call('origin', dry_run: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'prunes stale tracking refs for a configured remote' do
@@ -37,7 +37,7 @@ RSpec.describe Git::Commands::Remote::Prune, :integration do
 
         result = command.call('origin')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/remote/remove_spec.rb
+++ b/spec/integration/git/commands/remote/remove_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Git::Commands::Remote::Remove, :integration do
 
         result = command.call('origin')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(repo.remotes.map(&:name)).not_to include('origin')
       end
     end

--- a/spec/integration/git/commands/remote/rename_spec.rb
+++ b/spec/integration/git/commands/remote/rename_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Git::Commands::Remote::Rename, :integration do
 
         result = command.call('origin', 'upstream')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(repo.remotes.map(&:name)).to include('upstream')
         expect(repo.remotes.map(&:name)).not_to include('origin')
       end

--- a/spec/integration/git/commands/remote/set_branches_spec.rb
+++ b/spec/integration/git/commands/remote/set_branches_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Git::Commands::Remote::SetBranches, :integration do
 
         result = command.call('origin', 'feature/*')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns a CommandLineResult with :add option' do
@@ -33,7 +33,7 @@ RSpec.describe Git::Commands::Remote::SetBranches, :integration do
 
         result = command.call('origin', 'release/*', add: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/remote/set_head_spec.rb
+++ b/spec/integration/git/commands/remote/set_head_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Git::Commands::Remote::SetHead, :integration do
 
         result = command.call('origin', initial_branch)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'auto-detects the remote HEAD with :auto' do
@@ -38,7 +38,7 @@ RSpec.describe Git::Commands::Remote::SetHead, :integration do
 
         result = command.call('origin', auto: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'deletes the remote HEAD when :delete is given' do
@@ -48,7 +48,7 @@ RSpec.describe Git::Commands::Remote::SetHead, :integration do
 
         result = command.call('origin', delete: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/remote/set_url_add_spec.rb
+++ b/spec/integration/git/commands/remote/set_url_add_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Git::Commands::Remote::SetUrlAdd, :integration do
 
         result = command.call('origin', extra_repo.dir.to_s)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'adds a push url when :push is given' do
@@ -37,7 +37,7 @@ RSpec.describe Git::Commands::Remote::SetUrlAdd, :integration do
 
         result = command.call('origin', extra_repo.dir.to_s, push: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/remote/set_url_delete_spec.rb
+++ b/spec/integration/git/commands/remote/set_url_delete_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Git::Commands::Remote::SetUrlDelete, :integration do
 
         result = command.call('origin', extra_repo.dir.to_s)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'deletes a push url when :push is given' do
@@ -41,7 +41,7 @@ RSpec.describe Git::Commands::Remote::SetUrlDelete, :integration do
 
         result = command.call('origin', extra_repo.dir.to_s, push: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/remote/set_url_spec.rb
+++ b/spec/integration/git/commands/remote/set_url_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Git::Commands::Remote::SetUrl, :integration do
 
         result = command.call('origin', replacement_repo.dir.to_s)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(repo.remote('origin').url).to eq(replacement_repo.dir.to_s)
       end
 
@@ -38,7 +38,7 @@ RSpec.describe Git::Commands::Remote::SetUrl, :integration do
 
         result = command.call('origin', replacement_repo.dir.to_s, push: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/remote/show_spec.rb
+++ b/spec/integration/git/commands/remote/show_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Git::Commands::Remote::Show, :integration do
 
         result = command.call('origin', n: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/remote/update_spec.rb
+++ b/spec/integration/git/commands/remote/update_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Git::Commands::Remote::Update, :integration do
 
         result = command.call('origin')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(repo.branches.remote.map(&:full)).to include("remotes/origin/#{initial_branch}")
       end
     end

--- a/spec/integration/git/commands/repack_spec.rb
+++ b/spec/integration/git/commands/repack_spec.rb
@@ -13,14 +13,14 @@ RSpec.describe Git::Commands::Repack, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
 
       it 'returns a CommandLineResult with :a and :d options' do
         result = command.call(a: true, d: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
     end

--- a/spec/integration/git/commands/reset_spec.rb
+++ b/spec/integration/git/commands/reset_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Git::Commands::Reset, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns a result with exit status 0' do
@@ -36,7 +36,7 @@ RSpec.describe Git::Commands::Reset, :integration do
       it 'hard resets the index and working tree' do
         result = command.call(hard: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
 
@@ -46,7 +46,7 @@ RSpec.describe Git::Commands::Reset, :integration do
 
         result = command.call(pathspec: ['file.txt'])
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
     end

--- a/spec/integration/git/commands/rev_parse_spec.rb
+++ b/spec/integration/git/commands/rev_parse_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe Git::Commands::RevParse, :integration do
       it 'returns a CommandLineResult for --verify HEAD' do
         result = command.call('HEAD', verify: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
 
       it 'returns a CommandLineResult for --show-toplevel' do
         result = command.call(show_toplevel: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
     end

--- a/spec/integration/git/commands/revert/abort_spec.rb
+++ b/spec/integration/git/commands/revert/abort_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Git::Commands::Revert::Abort, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/revert/continue_spec.rb
+++ b/spec/integration/git/commands/revert/continue_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Git::Commands::Revert::Continue, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/revert/quit_spec.rb
+++ b/spec/integration/git/commands/revert/quit_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Git::Commands::Revert::Quit, :integration do
         it 'returns a CommandLineResult' do
           result = command.call
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
 
@@ -44,7 +44,7 @@ RSpec.describe Git::Commands::Revert::Quit, :integration do
         it 'returns a CommandLineResult (no-op unlike --abort)' do
           result = command.call
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
     end

--- a/spec/integration/git/commands/revert/skip_spec.rb
+++ b/spec/integration/git/commands/revert/skip_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe Git::Commands::Revert::Skip, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/revert/start_spec.rb
+++ b/spec/integration/git/commands/revert/start_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Git::Commands::Revert::Start, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('HEAD')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/rm_spec.rb
+++ b/spec/integration/git/commands/rm_spec.rb
@@ -19,14 +19,14 @@ RSpec.describe Git::Commands::Rm, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('file.txt')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       context 'with cached option' do
         it 'returns a CommandLineResult' do
           result = command.call('file.txt', cached: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
     end

--- a/spec/integration/git/commands/show_ref/exclude_existing_spec.rb
+++ b/spec/integration/git/commands/show_ref/exclude_existing_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::ShowRef::ExcludeExisting, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns exit status 0' do

--- a/spec/integration/git/commands/show_ref/exists_spec.rb
+++ b/spec/integration/git/commands/show_ref/exists_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::ShowRef::Exists, :integration, skip: unless_git('2
       it 'returns a CommandLineResult for an existing ref' do
         result = command.call('refs/heads/main')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns exit code 0 when the ref exists' do

--- a/spec/integration/git/commands/show_ref/list_spec.rb
+++ b/spec/integration/git/commands/show_ref/list_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::ShowRef::List, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns exit status 0 when refs are found' do

--- a/spec/integration/git/commands/show_ref/verify_spec.rb
+++ b/spec/integration/git/commands/show_ref/verify_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::ShowRef::Verify, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('refs/heads/main')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns exit status 0 for an existing ref' do

--- a/spec/integration/git/commands/show_spec.rb
+++ b/spec/integration/git/commands/show_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::Show, :integration do
       it 'returns a CommandLineResult with commit information' do
         result = command.call('HEAD')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.success?).to be true
         expect(result.stdout).not_to be_empty
       end

--- a/spec/integration/git/commands/stash/apply_spec.rb
+++ b/spec/integration/git/commands/stash/apply_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Git::Commands::Stash::Apply, :integration do
       it 'returns a CommandLineResult with output' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
     end

--- a/spec/integration/git/commands/stash/branch_spec.rb
+++ b/spec/integration/git/commands/stash/branch_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Git::Commands::Stash::Branch, :integration do
       it 'returns a CommandLineResult with output' do
         result = command.call('stash-branch')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
     end

--- a/spec/integration/git/commands/stash/clear_spec.rb
+++ b/spec/integration/git/commands/stash/clear_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::Stash::Clear, :integration do
       it 'returns CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
     end

--- a/spec/integration/git/commands/stash/create_spec.rb
+++ b/spec/integration/git/commands/stash/create_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Git::Commands::Stash::Create, :integration do
         it 'returns a CommandLineResult with output' do
           result = command.call
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout.strip).not_to be_empty
         end
       end
@@ -31,7 +31,7 @@ RSpec.describe Git::Commands::Stash::Create, :integration do
         it 'returns a CommandLineResult with empty output' do
           result = command.call
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout.strip).to be_empty
         end
       end

--- a/spec/integration/git/commands/stash/drop_spec.rb
+++ b/spec/integration/git/commands/stash/drop_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Git::Commands::Stash::Drop, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/stash/list_spec.rb
+++ b/spec/integration/git/commands/stash/list_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Git::Commands::Stash::List, :integration do
         it 'returns CommandLineResult with empty output' do
           result = command.call
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.status.exitstatus).to eq(0)
           expect(result.stdout).to be_empty
         end
@@ -37,7 +37,7 @@ RSpec.describe Git::Commands::Stash::List, :integration do
         it 'returns CommandLineResult with output' do
           result = command.call
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.status.exitstatus).to eq(0)
           expect(result.stdout).not_to be_empty
         end

--- a/spec/integration/git/commands/stash/pop_spec.rb
+++ b/spec/integration/git/commands/stash/pop_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Git::Commands::Stash::Pop, :integration do
       it 'returns a CommandLineResult with output' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
     end

--- a/spec/integration/git/commands/stash/push_spec.rb
+++ b/spec/integration/git/commands/stash/push_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Git::Commands::Stash::Push, :integration do
         it 'returns a CommandLineResult with output' do
           result = command.call
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
       end
@@ -34,7 +34,7 @@ RSpec.describe Git::Commands::Stash::Push, :integration do
         it 'returns a CommandLineResult' do
           result = command.call
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
       end

--- a/spec/integration/git/commands/stash/show_spec.rb
+++ b/spec/integration/git/commands/stash/show_spec.rb
@@ -22,21 +22,21 @@ RSpec.describe Git::Commands::Stash::Show, :integration do
       it 'returns a CommandLineResult with numstat output' do
         result = command.call(numstat: true, shortstat: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
 
       it 'returns a CommandLineResult with patch output' do
         result = command.call(patch: true, numstat: true, shortstat: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
 
       it 'returns a CommandLineResult with raw output' do
         result = command.call(raw: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
     end

--- a/spec/integration/git/commands/stash/store_spec.rb
+++ b/spec/integration/git/commands/stash/store_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Git::Commands::Stash::Store, :integration do
 
         result = command.call(sha)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/status_spec.rb
+++ b/spec/integration/git/commands/status_spec.rb
@@ -19,13 +19,13 @@ RSpec.describe Git::Commands::Status, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns a CommandLineResult with a path operand' do
         result = command.call('file.txt')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/symbolic_ref/delete_spec.rb
+++ b/spec/integration/git/commands/symbolic_ref/delete_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe Git::Commands::SymbolicRef::Delete, :integration do
 
         result = command.call('refs/heads/sym-link')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
     end

--- a/spec/integration/git/commands/symbolic_ref/read_spec.rb
+++ b/spec/integration/git/commands/symbolic_ref/read_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::SymbolicRef::Read, :integration do
       it 'returns the full ref path' do
         result = command.call('HEAD')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout.strip).to eq('refs/heads/main')
       end
 

--- a/spec/integration/git/commands/symbolic_ref/update_spec.rb
+++ b/spec/integration/git/commands/symbolic_ref/update_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::SymbolicRef::Update, :integration do
       it 'changes the symbolic ref target' do
         result = command.call('HEAD', 'refs/heads/new-branch')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
 
         head_content = File.read(File.join(repo_dir, '.git', 'HEAD')).strip

--- a/spec/integration/git/commands/tag/create_spec.rb
+++ b/spec/integration/git/commands/tag/create_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::Tag::Create, :integration do
       it 'returns a CommandLineResult' do
         result = command.call('v1.0.0')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/tag/delete_spec.rb
+++ b/spec/integration/git/commands/tag/delete_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::Tag::Delete, :integration do
       it 'returns a CommandLineResult with output' do
         result = command.call('v1.0.0')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
 

--- a/spec/integration/git/commands/tag/list_spec.rb
+++ b/spec/integration/git/commands/tag/list_spec.rb
@@ -18,14 +18,14 @@ RSpec.describe Git::Commands::Tag::List, :integration do
 
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
 
       it 'returns empty stdout when there are no tags' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to be_empty
       end
     end

--- a/spec/integration/git/commands/update_ref/batch_spec.rb
+++ b/spec/integration/git/commands/update_ref/batch_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Git::Commands::UpdateRef::Batch, :integration do
           "create refs/heads/batch-b #{head_sha}"
         )
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(repo.rev_parse('refs/heads/batch-a')).to eq(head_sha)
         expect(repo.rev_parse('refs/heads/batch-b')).to eq(head_sha)
       end
@@ -35,7 +35,7 @@ RSpec.describe Git::Commands::UpdateRef::Batch, :integration do
 
         result = command.call("delete refs/heads/to-delete #{head_sha}")
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect { repo.rev_parse('refs/heads/to-delete') }.to raise_error(Git::FailedError)
       end
 
@@ -55,7 +55,7 @@ RSpec.describe Git::Commands::UpdateRef::Batch, :integration do
           "delete refs/heads/to-delete #{head_sha}"
         )
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(repo.rev_parse('refs/heads/to-update')).to eq(new_sha)
         expect { repo.rev_parse('refs/heads/to-delete') }.to raise_error(Git::FailedError)
       end

--- a/spec/integration/git/commands/update_ref/delete_spec.rb
+++ b/spec/integration/git/commands/update_ref/delete_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Git::Commands::UpdateRef::Delete, :integration do
       it 'deletes a ref' do
         result = command.call('refs/heads/doomed')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect { repo.rev_parse('refs/heads/doomed') }.to raise_error(Git::FailedError)
       end
     end

--- a/spec/integration/git/commands/update_ref/update_spec.rb
+++ b/spec/integration/git/commands/update_ref/update_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Git::Commands::UpdateRef::Update, :integration do
 
         result = command.call('refs/heads/test-branch', new_sha)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(repo.rev_parse('refs/heads/test-branch')).to eq(new_sha)
       end
     end

--- a/spec/integration/git/commands/version_spec.rb
+++ b/spec/integration/git/commands/version_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::Version, :integration do
       it 'returns a CommandLineResult' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
         expect(result.stdout).to match(/\Agit version \d+\.\d+/)
         expect(result.stderr).to be_empty

--- a/spec/integration/git/commands/worktree/add_spec.rb
+++ b/spec/integration/git/commands/worktree/add_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Git::Commands::Worktree::Add, :integration do
 
         it 'returns a CommandLineResult' do
           result = command.call(worktree_path)
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
 
         it 'creates the worktree directory on disk' do
@@ -45,7 +45,7 @@ RSpec.describe Git::Commands::Worktree::Add, :integration do
 
         it 'creates a detached HEAD worktree' do
           result = command.call(worktree_path, detach: true)
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(File.directory?(worktree_path)).to be(true)
         end
       end

--- a/spec/integration/git/commands/worktree/list_spec.rb
+++ b/spec/integration/git/commands/worktree/list_spec.rb
@@ -18,30 +18,30 @@ RSpec.describe Git::Commands::Worktree::List, :integration do
     context 'when the command succeeds' do
       it 'returns a CommandLineResult with no options' do
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns a CommandLineResult with the :porcelain option' do
         result = command.call(porcelain: true)
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns a CommandLineResult with the :verbose option',
          skip: unless_git('2.33.0', 'git worktree list --verbose') do
         result = command.call(verbose: true)
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns a CommandLineResult with the :z option combined with :porcelain',
          skip: unless_git('2.36.0', 'git worktree list --porcelain -z') do
         result = command.call(porcelain: true, z: true)
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns a CommandLineResult with the :expire option',
          skip: unless_git('2.33.0', 'git worktree list --expire') do
         result = command.call(expire: '2.weeks.ago')
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/worktree/lock_spec.rb
+++ b/spec/integration/git/commands/worktree/lock_spec.rb
@@ -25,12 +25,12 @@ RSpec.describe Git::Commands::Worktree::Lock, :integration do
 
       it 'returns a CommandLineResult' do
         result = command.call(worktree_path)
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'locks the worktree with a reason' do
         result = command.call(worktree_path, reason: 'on NFS share')
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/worktree/move_spec.rb
+++ b/spec/integration/git/commands/worktree/move_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Git::Commands::Worktree::Move, :integration do
 
       it 'returns a CommandLineResult' do
         result = command.call(src_path, dst_path)
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/worktree/prune_spec.rb
+++ b/spec/integration/git/commands/worktree/prune_spec.rb
@@ -18,17 +18,17 @@ RSpec.describe Git::Commands::Worktree::Prune, :integration do
     context 'when the command succeeds' do
       it 'returns a CommandLineResult' do
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns a CommandLineResult with --dry-run' do
         result = command.call(dry_run: true)
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'returns a CommandLineResult with --verbose' do
         result = command.call(verbose: true)
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/worktree/remove_spec.rb
+++ b/spec/integration/git/commands/worktree/remove_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Git::Commands::Worktree::Remove, :integration do
 
       it 'returns a CommandLineResult' do
         result = command.call(worktree_path)
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'removes the worktree directory from disk' do

--- a/spec/integration/git/commands/worktree/repair_spec.rb
+++ b/spec/integration/git/commands/worktree/repair_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Git::Commands::Worktree::Repair, :integration do
         # test runner's CWD.
         Dir.chdir(repo_dir) do
           result = command.call
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
     end

--- a/spec/integration/git/commands/worktree/unlock_spec.rb
+++ b/spec/integration/git/commands/worktree/unlock_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe Git::Commands::Worktree::Unlock, :integration do
 
       it 'returns a CommandLineResult' do
         result = command.call(worktree_path)
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/integration/git/commands/write_tree_spec.rb
+++ b/spec/integration/git/commands/write_tree_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::WriteTree, :integration do
       it 'returns a CommandLineResult with the tree SHA on stdout' do
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to match(/\A[0-9a-f]{40}\z/)
       end
 
@@ -30,7 +30,7 @@ RSpec.describe Git::Commands::WriteTree, :integration do
 
           result = command.call(prefix: 'sub/')
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).to match(/\A[0-9a-f]{40}\z/)
         end
       end

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -496,9 +496,9 @@ RSpec.describe Git::Repository::Branching, :integration do
       expect(repo.revparse('refs/heads/feature')).to eq(new_sha)
     end
 
-    it 'returns a Git::CommandLineResult' do
+    it 'returns a Git::CommandLine::Result' do
       result = described_instance.update_ref('feature', repo.revparse('HEAD'))
-      expect(result).to be_a(Git::CommandLineResult)
+      expect(result).to be_a(Git::CommandLine::Result)
     end
   end
 

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -230,9 +230,9 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       expect(repo.remotes.map(&:name)).not_to include('origin')
     end
 
-    it 'returns a Git::CommandLineResult' do
+    it 'returns a Git::CommandLine::Result' do
       result = described_instance.remote_remove('origin')
-      expect(result).to be_a(Git::CommandLineResult)
+      expect(result).to be_a(Git::CommandLine::Result)
     end
 
     it 'raises Git::FailedError when the remote does not exist' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -186,10 +186,10 @@ warn '[spec_helper] spec_helper fully loaded' if RUBY_ENGINE == 'jruby'
 # @param stdout [String] the stdout to return
 # @param stderr [String] the stderr to return (default: '')
 # @param exitstatus [Integer] the exit status code (default: 0)
-# @return [Git::CommandLineResult] a CommandLineResult object
+# @return [Git::CommandLine::Result] a CommandLineResult object
 def command_result(stdout = '', stderr: '', exitstatus: 0)
   status = double('status', success?: exitstatus.zero?, exitstatus: exitstatus, signaled?: false)
-  Git::CommandLineResult.new(%w[git], status, stdout, stderr)
+  Git::CommandLine::Result.new(%w[git], status, stdout, stderr)
 end
 
 # Helper to expect a command call with raise_on_failure: false automatically included

--- a/spec/unit/git/command_line/capturing_spec.rb
+++ b/spec/unit/git/command_line/capturing_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe Git::CommandLine::Capturing do
       end
 
       it 'returns a result with the captured output' do
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq("git version 2.39.1\n")
         expect(result.stderr).to eq('')
       end
@@ -283,7 +283,7 @@ RSpec.describe Git::CommandLine::Capturing do
       end
 
       it 'returns a CommandLineResult without raising when success? is false' do
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.success?).to be false
         expect(result.status.exitstatus).to eq(1)
         expect(result.stdout).to eq("Changes to be committed:\n  modified: foo.rb\n")

--- a/spec/unit/git/command_line/streaming_spec.rb
+++ b/spec/unit/git/command_line/streaming_spec.rb
@@ -49,7 +49,7 @@ RSpec.describe Git::CommandLine::Streaming do
       end
 
       it 'returns a result with empty stdout and stderr' do
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq('')
         expect(result.stderr).to eq('')
       end
@@ -188,7 +188,7 @@ RSpec.describe Git::CommandLine::Streaming do
       end
 
       it 'returns a CommandLineResult without raising when success? is false' do
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.success?).to be false
         expect(result.status.exitstatus).to eq(1)
         expect(result.stderr).to eq('fatal: not a git repository')

--- a/spec/unit/git/command_line_error_spec.rb
+++ b/spec/unit/git/command_line_error_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::CommandLineError do
   end
 
   let(:result) do
-    Git::CommandLineResult.new(%w[git status], status, 'stdout', 'stderr')
+    Git::CommandLine::Result.new(%w[git status], status, 'stdout', 'stderr')
   end
 
   let(:described_instance) { described_class.new(result) }

--- a/spec/unit/git/command_line_result_spec.rb
+++ b/spec/unit/git/command_line_result_spec.rb
@@ -3,8 +3,22 @@
 require 'spec_helper'
 require 'git/command_line_result'
 
-RSpec.describe Git::CommandLineResult do
-  it 'is a backward-compatible alias for Git::CommandLine::Result' do
-    expect(described_class).to be(Git::CommandLine::Result)
+RSpec.describe 'Git::CommandLineResult (deprecated)' do
+  before do
+    Git.send(:remove_const, :CommandLineResult) if Git.const_defined?(:CommandLineResult, false)
+  end
+
+  after do
+    Git.send(:remove_const, :CommandLineResult) if Git.const_defined?(:CommandLineResult, false)
+  end
+
+  it 'resolves to Git::CommandLine::Result' do
+    allow(Git::Deprecation).to receive(:warn)
+    expect(Git::CommandLineResult).to be(Git::CommandLine::Result)
+  end
+
+  it 'emits a deprecation warning when accessed' do
+    expect(Git::Deprecation).to receive(:warn).with(/Git::CommandLineResult is deprecated/)
+    Git::CommandLineResult
   end
 end

--- a/spec/unit/git/commands/base_spec.rb
+++ b/spec/unit/git/commands/base_spec.rb
@@ -422,7 +422,7 @@ RSpec.describe Git::Commands::Base do
           .and_return(command_result)
 
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -441,7 +441,7 @@ RSpec.describe Git::Commands::Base do
           .and_return(command_result)
 
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
   end

--- a/spec/unit/git/commands/branch/copy_spec.rb
+++ b/spec/unit/git/commands/branch/copy_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Git::Commands::Branch::Copy do
 
         result = command.call('new-name')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq('')
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe Git::Commands::Branch::Copy do
 
         result = command.call('old-name', 'new-name')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe Git::Commands::Branch::Copy do
 
         result = command.call('new-name', force: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'adds --force flag when copying specific branch' do
@@ -47,7 +47,7 @@ RSpec.describe Git::Commands::Branch::Copy do
 
         result = command.call('old-name', 'new-name', force: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'does not add flag when false' do
@@ -56,7 +56,7 @@ RSpec.describe Git::Commands::Branch::Copy do
 
         result = command.call('new-name', force: false)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -67,7 +67,7 @@ RSpec.describe Git::Commands::Branch::Copy do
 
         result = command.call('new-name', f: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'adds --force flag when copying specific branch' do
@@ -76,7 +76,7 @@ RSpec.describe Git::Commands::Branch::Copy do
 
         result = command.call('old-name', 'new-name', f: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/unit/git/commands/branch/delete_spec.rb
+++ b/spec/unit/git/commands/branch/delete_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Git::Commands::Branch::Delete do
 
         result = command.call('feature-branch')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq("Deleted branch feature-branch (was abc1234).\n")
       end
     end
@@ -30,7 +30,7 @@ RSpec.describe Git::Commands::Branch::Delete do
 
         result = command.call('branch1', 'branch2', 'branch3')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -41,7 +41,7 @@ RSpec.describe Git::Commands::Branch::Delete do
 
         result = command.call('feature-branch', force: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'accepts :f alias' do
@@ -50,7 +50,7 @@ RSpec.describe Git::Commands::Branch::Delete do
 
         result = command.call('feature-branch', f: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -61,7 +61,7 @@ RSpec.describe Git::Commands::Branch::Delete do
 
         result = command.call('origin/feature', remotes: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'accepts :r alias' do
@@ -70,7 +70,7 @@ RSpec.describe Git::Commands::Branch::Delete do
 
         result = command.call('origin/feature', r: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -81,7 +81,7 @@ RSpec.describe Git::Commands::Branch::Delete do
 
         result = command.call('origin/feature', force: true, remotes: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -92,7 +92,7 @@ RSpec.describe Git::Commands::Branch::Delete do
 
         result = command.call('feature')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
 
@@ -108,7 +108,7 @@ RSpec.describe Git::Commands::Branch::Delete do
 
         result = command.call('feature', 'nonexistent')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(1)
       end
 

--- a/spec/unit/git/commands/branch/move_spec.rb
+++ b/spec/unit/git/commands/branch/move_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Git::Commands::Branch::Move do
 
         result = command.call('new-name')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq('')
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe Git::Commands::Branch::Move do
 
         result = command.call('old-name', 'new-name')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe Git::Commands::Branch::Move do
 
         result = command.call('new-name', force: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'adds --force flag when renaming specific branch' do
@@ -47,7 +47,7 @@ RSpec.describe Git::Commands::Branch::Move do
 
         result = command.call('old-name', 'new-name', force: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'does not add flag when false' do
@@ -56,7 +56,7 @@ RSpec.describe Git::Commands::Branch::Move do
 
         result = command.call('new-name', force: false)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -67,7 +67,7 @@ RSpec.describe Git::Commands::Branch::Move do
 
         result = command.call('new-name', f: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'adds --force flag when renaming specific branch' do
@@ -76,7 +76,7 @@ RSpec.describe Git::Commands::Branch::Move do
 
         result = command.call('old-name', 'new-name', f: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/unit/git/commands/branch/set_upstream_spec.rb
+++ b/spec/unit/git/commands/branch/set_upstream_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Git::Commands::Branch::SetUpstream do
 
         result = command.call(set_upstream_to: 'origin/main')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq("branch 'main' set up to track 'origin/main'.\n")
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe Git::Commands::Branch::SetUpstream do
 
         result = command.call(u: 'origin/main')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe Git::Commands::Branch::SetUpstream do
 
         result = command.call('feature', set_upstream_to: 'origin/main')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe Git::Commands::Branch::SetUpstream do
 
         result = command.call(set_upstream_to: 'upstream/develop')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/unit/git/commands/branch/unset_upstream_spec.rb
+++ b/spec/unit/git/commands/branch/unset_upstream_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Git::Commands::Branch::UnsetUpstream do
 
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq('')
       end
     end
@@ -27,7 +27,7 @@ RSpec.describe Git::Commands::Branch::UnsetUpstream do
 
         result = command.call('feature')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -38,7 +38,7 @@ RSpec.describe Git::Commands::Branch::UnsetUpstream do
 
         result = command.call(nil)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 

--- a/spec/unit/git/commands/diff_index_spec.rb
+++ b/spec/unit/git/commands/diff_index_spec.rb
@@ -947,7 +947,7 @@ RSpec.describe Git::Commands::DiffIndex do
 
         result = command.call('HEAD')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
 
@@ -957,7 +957,7 @@ RSpec.describe Git::Commands::DiffIndex do
 
         result = command.call('HEAD')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(1)
       end
 

--- a/spec/unit/git/commands/diff_spec.rb
+++ b/spec/unit/git/commands/diff_spec.rb
@@ -1057,7 +1057,7 @@ RSpec.describe Git::Commands::Diff do
 
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
 
@@ -1066,7 +1066,7 @@ RSpec.describe Git::Commands::Diff do
 
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(1)
       end
 
@@ -1076,7 +1076,7 @@ RSpec.describe Git::Commands::Diff do
 
         result = command.call(check: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(2)
       end
 

--- a/spec/unit/git/commands/fsck_spec.rb
+++ b/spec/unit/git/commands/fsck_spec.rb
@@ -207,28 +207,28 @@ RSpec.describe Git::Commands::Fsck do
       it 'handles exit code 0 (no issues)' do
         mock_command('fsck')
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'handles exit code 1 (errors found)' do
         output = "missing tree 1234567890abcdef1234567890abcdef12345678\n"
         mock_command('fsck', stdout: output, exitstatus: 1)
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'handles exit code 2 (missing objects)' do
         output = "missing blob abcdef1234567890abcdef1234567890abcdef12\n"
         mock_command('fsck', stdout: output, exitstatus: 2)
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'handles exit code 4 (warnings)' do
         output = "warning in commit 1234567890abcdef1234567890abcdef12345678: bad date\n"
         mock_command('fsck', stdout: output, exitstatus: 4)
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       # Exit codes are bit flags that can be combined
@@ -239,7 +239,7 @@ RSpec.describe Git::Commands::Fsck do
         OUTPUT
         mock_command('fsck', stdout: output, exitstatus: 3)
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'handles exit code 5 (errors + warnings)' do
@@ -249,7 +249,7 @@ RSpec.describe Git::Commands::Fsck do
         OUTPUT
         mock_command('fsck', stdout: output, exitstatus: 5)
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'handles exit code 6 (missing + warnings)' do
@@ -259,7 +259,7 @@ RSpec.describe Git::Commands::Fsck do
         OUTPUT
         mock_command('fsck', stdout: output, exitstatus: 6)
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'handles exit code 7 (errors + missing + warnings)' do
@@ -270,7 +270,7 @@ RSpec.describe Git::Commands::Fsck do
         OUTPUT
         mock_command('fsck', stdout: output, exitstatus: 7)
         result = command.call
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'raises for exit code > 7 (fatal errors)' do

--- a/spec/unit/git/commands/stash/apply_spec.rb
+++ b/spec/unit/git/commands/stash/apply_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Commands::Stash::Apply do
 
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq('')
       end
     end

--- a/spec/unit/git/commands/stash/branch_spec.rb
+++ b/spec/unit/git/commands/stash/branch_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Git::Commands::Stash::Branch do
 
         result = command.call('my-feature')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq("Switched to a new branch 'my-feature'\n")
       end
     end

--- a/spec/unit/git/commands/stash/create_spec.rb
+++ b/spec/unit/git/commands/stash/create_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Git::Commands::Stash::Create do
 
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq("abc123def456789\n")
       end
     end

--- a/spec/unit/git/commands/stash/drop_spec.rb
+++ b/spec/unit/git/commands/stash/drop_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Commands::Stash::Drop do
 
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq('')
       end
     end

--- a/spec/unit/git/commands/stash/list_spec.rb
+++ b/spec/unit/git/commands/stash/list_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Git::Commands::Stash::List do
 
       result = command.call
 
-      expect(result).to be_a(Git::CommandLineResult)
+      expect(result).to be_a(Git::CommandLine::Result)
       expect(result.stdout).to eq(stash_output)
     end
   end

--- a/spec/unit/git/commands/stash/pop_spec.rb
+++ b/spec/unit/git/commands/stash/pop_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Commands::Stash::Pop do
 
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq('')
       end
     end

--- a/spec/unit/git/commands/tag/create_spec.rb
+++ b/spec/unit/git/commands/tag/create_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -24,7 +24,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', 'abc123')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'accepts a branch as target' do
@@ -32,7 +32,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', 'main')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'accepts HEAD as target' do
@@ -40,7 +40,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', 'HEAD')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -50,7 +50,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', annotate: true, message: 'Release')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'accepts :a alias' do
@@ -58,7 +58,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', a: true, message: 'Release')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'does not add flag when false' do
@@ -66,7 +66,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', annotate: false)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', sign: true, message: 'Release')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'accepts :s alias' do
@@ -84,7 +84,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', s: true, message: 'Release')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       context 'when :no_sign is true' do
@@ -93,7 +93,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
           result = command.call('v1.0.0', no_sign: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
     end
@@ -105,7 +105,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', local_user: 'ABCD1234', message: 'Release')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'accepts :u alias' do
@@ -114,7 +114,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', u: 'ABCD1234', message: 'Release')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -124,7 +124,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', force: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'accepts :f alias' do
@@ -132,7 +132,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', f: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'does not add flag when false' do
@@ -140,7 +140,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', force: false)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -150,7 +150,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', message: 'Release version 1.0.0')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'accepts :m alias' do
@@ -158,7 +158,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', m: 'Release')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'handles message with special characters' do
@@ -166,7 +166,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', message: 'Release "quoted"')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -176,7 +176,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', file: '/path/to/message.txt')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'accepts :F alias' do
@@ -184,7 +184,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', F: '/path/to/message.txt')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'supports reading from stdin with -' do
@@ -192,7 +192,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', file: '-')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -202,7 +202,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', edit: true, message: 'Release')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'accepts :e alias' do
@@ -210,7 +210,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', e: true, message: 'Release')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       context 'when :no_edit is true' do
@@ -219,7 +219,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
           result = command.call('v1.0.0', message: 'Release', no_edit: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
     end
@@ -230,7 +230,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', create_reflog: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'does not add flag when false' do
@@ -238,7 +238,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', create_reflog: false)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -249,7 +249,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', annotate: true, force: true, message: 'Release')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'creates a signed tag at specific commit' do
@@ -258,7 +258,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', 'abc123', sign: true, message: 'Signed release')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'creates tag with custom signing key at specific commit' do
@@ -267,7 +267,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', 'main', local_user: 'KEY123', message: 'Release')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'combines create_reflog with annotated tag' do
@@ -276,7 +276,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', annotate: true, create_reflog: true, message: 'Release')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'allows annotate with file instead of message' do
@@ -285,7 +285,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', annotate: true, file: '/path/to/msg.txt')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -296,7 +296,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', message: 'Release', trailer: { 'Signed-off-by' => 'John Doe' })
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'includes multiple trailers' do
@@ -312,7 +312,7 @@ RSpec.describe Git::Commands::Tag::Create do
                                 'Reviewed-by' => 'Jane Smith'
                               })
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'includes trailers with array of pairs' do
@@ -328,7 +328,7 @@ RSpec.describe Git::Commands::Tag::Create do
                                 %w[Co-authored-by Bob]
                               ])
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -339,7 +339,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', message: 'Release', cleanup: 'strip')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'includes --cleanup=verbatim' do
@@ -348,7 +348,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', message: 'Release', cleanup: 'verbatim')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'includes --cleanup=whitespace' do
@@ -357,7 +357,7 @@ RSpec.describe Git::Commands::Tag::Create do
 
         result = command.call('v1.0.0', message: 'Release', cleanup: 'whitespace')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
   end

--- a/spec/unit/git/commands/tag/list_spec.rb
+++ b/spec/unit/git/commands/tag/list_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq(sample_output)
       end
     end
@@ -39,7 +39,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call('v1.*')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'adds multiple pattern arguments after end-of-options separator' do
@@ -47,7 +47,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call('v1.*', 'v2.*')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -57,7 +57,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(sort: 'refname')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'includes multiple --sort flags for array' do
@@ -66,7 +66,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(sort: ['refname', '-creatordate'])
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'supports version:refname sort key' do
@@ -74,7 +74,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(sort: 'version:refname')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -84,7 +84,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(contains: 'abc123')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'includes --contains flag when true' do
@@ -92,7 +92,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(contains: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -102,7 +102,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(no_contains: 'abc123')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'includes --no-contains flag when true' do
@@ -110,7 +110,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(no_contains: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -120,7 +120,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(merged: 'main')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'includes --merged flag when true' do
@@ -128,7 +128,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(merged: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -138,7 +138,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(no_merged: 'main')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'includes --no-merged flag when true' do
@@ -146,7 +146,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(no_merged: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -156,7 +156,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(points_at: 'HEAD')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'includes --points-at flag when true' do
@@ -164,7 +164,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(points_at: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -174,7 +174,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(n: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'includes -n<num> when given an integer' do
@@ -182,7 +182,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(n: 5)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'does not add flag when nil' do
@@ -190,7 +190,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(n: nil)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -200,7 +200,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(color: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'includes --color=<value> when given a string' do
@@ -208,7 +208,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(color: 'always')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -218,7 +218,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(ignore_case: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'accepts :i alias' do
@@ -226,7 +226,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(i: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'does not add flag when false' do
@@ -234,7 +234,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(ignore_case: false)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -244,7 +244,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(omit_empty: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
 
@@ -254,7 +254,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(column: true)
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'includes --column=<value> when given a string' do
@@ -262,7 +262,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call(column: 'always')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       context 'when :no_column is true' do
@@ -271,7 +271,7 @@ RSpec.describe Git::Commands::Tag::List do
 
           result = command.call(no_column: true)
 
-          expect(result).to be_a(Git::CommandLineResult)
+          expect(result).to be_a(Git::CommandLine::Result)
         end
       end
     end
@@ -283,7 +283,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call('v1.*', sort: 'refname', contains: 'abc123')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
 
       it 'combines multiple patterns with options' do
@@ -292,7 +292,7 @@ RSpec.describe Git::Commands::Tag::List do
 
         result = command.call('release-*', 'v*', merged: 'main')
 
-        expect(result).to be_a(Git::CommandLineResult)
+        expect(result).to be_a(Git::CommandLine::Result)
       end
     end
   end

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -944,7 +944,7 @@ RSpec.describe Git::Repository::Branching do
       result
     end
 
-    it 'returns the Git::CommandLineResult from the command' do
+    it 'returns the Git::CommandLine::Result from the command' do
       expect(result).to eq(update_ref_result)
     end
 

--- a/spec/unit/git/repository/configuring_spec.rb
+++ b/spec/unit/git/repository/configuring_spec.rb
@@ -123,7 +123,7 @@ RSpec.describe Git::Repository do
         result
       end
 
-      it 'returns the Git::CommandLineResult from the set command' do
+      it 'returns the Git::CommandLine::Result from the set command' do
         allow(set_command).to receive(:call).with('user.name', 'Alice').and_return(set_result)
         expect(result).to eq(set_result)
       end
@@ -323,7 +323,7 @@ RSpec.describe Git::Repository do
         result
       end
 
-      it 'returns the Git::CommandLineResult from the set command' do
+      it 'returns the Git::CommandLine::Result from the set command' do
         allow(set_command).to receive(:call).with('user.name', 'Alice', global: true).and_return(set_result)
         expect(result).to eq(set_result)
       end

--- a/spec/unit/git/repository/merging_spec.rb
+++ b/spec/unit/git/repository/merging_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe Git::Repository::Merging do
   describe '#each_conflict' do
     let(:diff_command) { instance_double(Git::Commands::Diff) }
     let(:show_command) { instance_double(Git::Commands::Show) }
-    let(:show_result) { instance_double(Git::CommandLineResult) }
+    let(:show_result) { instance_double(Git::CommandLine::Result) }
 
     before do
       allow(Git::Commands::Diff).to receive(:new).with(execution_context).and_return(diff_command)

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -1258,7 +1258,7 @@ RSpec.describe Git::Repository::ObjectOperations do
     subject(:result) { described_instance.tags }
 
     let(:list_command) { instance_double(Git::Commands::Tag::List) }
-    let(:command_result) { instance_double(Git::CommandLineResult, stdout: 'raw-stdout') }
+    let(:command_result) { instance_double(Git::CommandLine::Result, stdout: 'raw-stdout') }
     let(:tag_first) { instance_double(Git::Object::Tag) }
     let(:tag_second) { instance_double(Git::Object::Tag) }
 
@@ -1304,7 +1304,7 @@ RSpec.describe Git::Repository::ObjectOperations do
 
   describe '#tag_add' do
     let(:create_command) { instance_double(Git::Commands::Tag::Create) }
-    let(:command_result) { instance_double(Git::CommandLineResult) }
+    let(:command_result) { instance_double(Git::CommandLine::Result) }
     let(:tag_object) { instance_double(Git::Object::Tag) }
 
     before do
@@ -1505,7 +1505,7 @@ RSpec.describe Git::Repository::ObjectOperations do
     let(:status) { instance_double(Process::Status, exitstatus: 0) }
     let(:command_result) do
       instance_double(
-        Git::CommandLineResult,
+        Git::CommandLine::Result,
         stdout: "Deleted tag 'v1.0.0' (was abc123)\n", stderr: '', status: status,
         git_cmd: %w[git tag --delete v1.0.0]
       )

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -751,7 +751,7 @@ RSpec.describe Git::Repository::RemoteOperations do
       result
     end
 
-    it 'returns the Git::CommandLineResult' do
+    it 'returns the Git::CommandLine::Result' do
       expect(result).to be(remove_result)
     end
   end

--- a/spec/unit/git/timeout_error_spec.rb
+++ b/spec/unit/git/timeout_error_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::TimeoutError do
   end
 
   let(:result) do
-    Git::CommandLineResult.new(%w[git status], status, 'stdout', 'Waiting...')
+    Git::CommandLine::Result.new(%w[git status], status, 'stdout', 'Waiting...')
   end
 
   let(:timeout_duration) { 10 }


### PR DESCRIPTION
# Description

Deprecates `Git::CommandLineResult` in favor of the canonical `Git::CommandLine::Result` and
updates every internal reference throughout `lib/` and `spec/`.

## Motivation

`Git::CommandLineResult` was introduced as a backward-compatible constant alias when the class
was reorganized under `Git::CommandLine::Result`. Now that the codebase is stable, the alias
should warn external callers to migrate before it is removed in v6.0.0.

## Changes

### `lib/git/command_line_result.rb`

Replaces the simple constant assignment (`CommandLineResult = Git::CommandLine::Result`) with a
`Git.const_missing` hook:

- On the **first access** of `Git::CommandLineResult` in a process, emits a
  `Git::Deprecation.warn` message pointing callers to `Git::CommandLine::Result`.
- After the warning, caches the constant via `const_set` so **subsequent accesses are
  zero-cost** and produce no further warnings.
- Calls `super` for any other unknown constant, preserving normal Ruby `NameError` behavior.

### `lib/**/*.rb` and `spec/**/*.rb` (305 files)

Updated all YARD tags (`@return`, `@param`, `@raise`), `instance_double` calls, `be_a`
matchers, `.new` calls, and test description strings from `Git::CommandLineResult` to
`Git::CommandLine::Result`. The two files that still reference the deprecated name
(`lib/git/command_line_result.rb` and the matching spec) do so intentionally.

### `spec/unit/git/command_line_result_spec.rb`

Replaced the single alias-identity test with two focused tests:

1. Verifies that `Git::CommandLine::Result` is the resolved value.
2. Verifies that a deprecation warning matching `/Git::CommandLineResult is deprecated/` is
   emitted on first access.

## Upgrade path for external callers

Replace `Git::CommandLineResult` with `Git::CommandLine::Result` everywhere.
The old name continues to work (with a one-time deprecation warning per process) until v6.0.0.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
