### PR TITLE
docs: mark Phase 4 Step C C1c complete in redesign tracker

### DIFF
--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -44,8 +44,8 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase 1 | ✅ Complete | Foundation and scaffolding | 5% | 100% |
 | Phase 2 | ✅ Complete | Migrating commands (all checklist items done) | 40% | 100% |
 | Phase 3 | ✅ Complete | Refactoring public interface — see [Facade Modules Completed](#facade-modules-completed) and [Facade coverage checklist](#facade-coverage-checklist) | 45% | 100% |
-| Phase 4 | 🚧 In Progress | Final cleanup and release — Steps A and B complete; W6 ✅ (remove stale `Git::Base`/`Git::Lib` skill refs); Step C: C1a ✅ complete (TSV produced), C1c/C2a/C2b/C3 pending | 10% | 82% |
-| **TOTAL** | -- | -- | **100%** | **98%** |
+| Phase 4 | 🚧 In Progress | Final cleanup and release — Steps A and B complete; W6 ✅; Step C: C1a ✅ C1b ✅ C1c ✅ C1d ✅ complete; C2a/C2b/C3 pending | 10% | 90% |
+| **TOTAL** | -- | -- | **100%** | **99%** |
 
 ### Facade Modules Completed
 

--- a/redesign/Phase 4 - Step C.md
+++ b/redesign/Phase 4 - Step C.md
@@ -2,24 +2,22 @@
 
 > **🚧 Status: Partial.**
 >
-> **Documentation coverage is complete.** `yardstick` has been retired and
-> replaced by [`yard-lint`](https://github.com/mensfeld/yard-lint) (config in
-> `.yard-lint.yml`, run via `bundle exec rake yard:lint`). Every file under
-> `lib/` passes `yard-lint` with **no offenses and no baseline exceptions**, so
-> the C1b documentation-coverage work and the C1d coverage-gate work are already
-> done (see Done-When). `UPGRADING.md` also already exists.
->
-> **C1a is ✅ complete.** The public API scope TSV has been produced at
-> `redesign/c1a-public-api-scope.tsv` (255 rows: 42 public, 213 internal).
-> 37 internal constants still need `@api private` flipped in C1c.
+> **C1 (YARD audit) is fully complete:**
+> - **C1a ✅** — Public API scope TSV produced at `redesign/c1a-public-api-scope.tsv`
+>   (255 rows: 42 public, 213 internal).
+> - **C1b ✅** — All of `lib/` passes `bundle exec yard-lint lib/` with no offenses
+>   (`yardstick` retired in favor of `yard-lint`; the `rake yard:lint` alias is
+>   Ruby 3.3+ only).
+> - **C1c ✅** — `@api` tags set for all 37 previously-unmarked internal constants
+>   (commit `83225f3f`).
+> - **C1d ✅** — Coverage gate enforced by `yard-lint` + `.yard-lint.yml`; no PR needed.
 >
 > Remaining work:
 >
-> - **C1c:** flip `@api` tags for the 37 internal constants identified in
->   `redesign/c1a-public-api-scope.tsv` that still have `api_private_current=no`
->   (see TSV for the complete list)
-> - **C2:** confirm `README.md` reflects the new entry points and links to the
->   migration guide, and review `UPGRADING.md`
+> - **C2a:** review and expand `UPGRADING.md` to comprehensively cover all
+>   v4.x → v5.0.0 breaking changes
+> - **C2b:** update `README.md` to reflect the new entry points and link to the
+>   migration guide
 > - **C3:** run the full final documentation verification before v5.0.0 release.
 >
 
@@ -137,21 +135,21 @@ All breaking changes are complete; this step documents them for users.
 
 This step is organized into workstreams, each with **one PR per substep** for finer-grained reviews:
 
-- **C1a: Identify Public API Scope** (1 PR) — informs C1c
+- **C1a: Identify Public API Scope** — ✅ **done** (`redesign/c1a-public-api-scope.tsv` produced)
 - **C1b: Document All Elements** — ✅ **already done** (all of `lib/` passes
   `yard-lint`; no PR needed)
-- **C1c: Set Correct @api Tags (incl. flip topic modules to private)** (1 PR)
+- **C1c: Set Correct @api Tags (incl. flip topic modules to private)** — ✅ **done**
+  (commit `83225f3f`; all 37 previously-unmarked internal constants tagged)
 - **C1d: Coverage Gate** — ✅ **already done** (`yard-lint` + `.yard-lint.yml`
   replaced the retired `yardstick` gate and pass; no PR needed)
 - **C2a: Update UPGRADING.md** (1 PR)
 - **C2b: Update README.md** (1 PR)
 - **C3: Documentation Completeness Verification** (1 PR)
 
-Dependencies (remaining): C1a → C1c → C3; C2a, C2b → C3. (C1b and C1d are
-already complete.)
+Dependencies (remaining): C2a, C2b → C3. (C1a–C1d are all complete.)
 
 **Documentation skill requirements:** Any remaining PR that touches YARD
-comments (e.g., C1c) must apply the
+comments must apply the
 [yard-documentation](../.github/skills/yard-documentation/SKILL.md) skill to all
 YARD comments changed or added. Additionally:
 
@@ -164,25 +162,25 @@ YARD comments changed or added. Additionally:
 graph LR
     C1a["C1a: Identify Scope"]
     C1b["C1b: Add Docs (done)"]
-    C1c["C1c: Mark Private"]
+    C1c["C1c: Mark Private (done)"]
     C1d["C1d: Coverage Gate (done)"]
     C2a["C2a: UPGRADING"]
     C2b["C2b: README"]
     C3["C3: Docs Verification"]
 
-    %% Remaining (active) gating dependencies:
-    C1a --> C1c
-    C1c --> C3
+    %% All C1 steps are complete; C2a/C2b gate C3:
     C2a --> C3
     C2b --> C3
 
-    %% Already-satisfied historical dependencies (C1b, C1d complete):
+    %% Already-satisfied historical dependencies:
     C1a -.-> C1b
     C1b -.-> C1c
+    C1a -.-> C1c
+    C1c -.-> C3
     C1d -.-> C3
 
     classDef done fill:#e6ffe6,stroke:#2e7d32;
-    class C1b,C1d done;
+    class C1a,C1b,C1c,C1d done;
 ```
 
 ---
@@ -412,6 +410,12 @@ For **other public classes** (e.g., `Git::Object`, `Git::Branch`):
    that parameter names, types, and examples are rendered correctly.
 
 ### C1c — Set correct `@api` tags
+
+> ✅ **Done.** Commit `83225f3f` set the correct `@api` tags for all 37 previously-unmarked
+> internal constants identified in `redesign/c1a-public-api-scope.tsv`. All
+> `Git::Repository::*` topic modules are now `@api private`. `bundle exec yard-lint lib/`
+> passes with no offenses (the `rake yard:lint` alias is Ruby 3.3+ only). The steps
+> below are retained for historical context.
 
 **Input:** `redesign/c1a-public-api-scope.tsv` (from C1a). Set the correct `@api`
 tag on **every** element per the TSV: `@api public` for the `public` surface,


### PR DESCRIPTION
## Description

Marks Phase 4 Step C workstream C1c (`@api` tag audit and gap-fill) as complete in the redesign tracker docs. C1c landed in commit `83225f3f` on `main`; this PR records it.

**Changes:**
- `redesign/3_architecture_implementation.md`: marks C1b/C1c/C1d all ✅, removes C1c from pending list, bumps Phase 4 completion to 90% and total to 99%
- `redesign/Phase 4 - Step C.md`: updates status header, workstreams list, dependency note, Mermaid graph (C1a–C1d all green), adds 'already done' callout to the C1c section body

No code changes — documentation/tracker update only.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed. *(No tests — tracker doc update only)*
- [x] Documentation updated where applicable (README and/or YARD). *(This IS the documentation update)*