### PR TITLE
docs: update README.md for v5.0.0 release (Phase 4 Step C2b)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?log
 - [Errors Raised By This Gem](#errors-raised-by-this-gem)
 - [Specifying And Handling Timeouts](#specifying-and-handling-timeouts)
 - [Deprecations](#deprecations)
+- [Upgrading from v4.x to v5.0.0](#upgrading-from-v4x-to-v500)
 - [Project Policies](#project-policies)
   - [Ruby Version Support Policy](#ruby-version-support-policy)
   - [Git Version Support Policy](#git-version-support-policy)
@@ -64,22 +65,10 @@ Install the gem and add to the application's Gemfile by executing:
 bundle add git
 ```
 
-to install version 1.x:
-
-```shell
-bundle add git --version "~> 1.19"
-```
-
 If bundler is not being used to manage dependencies, install the gem by executing:
 
 ```shell
 gem install git
-```
-
-to install version 1.x:
-
-```shell
-gem install git --version "~> 1.19"
 ```
 
 ## Quick Start
@@ -601,6 +590,14 @@ for more details.
 If deprecation warnings are silenced, you should reenable them before upgrading the
 git gem to the next major version. This will make it easier to identify changes
 needed for the upgrade.
+
+For the full list of deprecated methods and their replacements, see
+[UPGRADING.md](UPGRADING.md).
+
+## Upgrading from v4.x to v5.0.0
+
+v5.0.0 is a major release with breaking changes. See
+[UPGRADING.md](UPGRADING.md) for a comprehensive migration guide.
 
 ## Project Policies
 

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -44,7 +44,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase 1 | ✅ Complete | Foundation and scaffolding | 5% | 100% |
 | Phase 2 | ✅ Complete | Migrating commands (all checklist items done) | 40% | 100% |
 | Phase 3 | ✅ Complete | Refactoring public interface — see [Facade Modules Completed](#facade-modules-completed) and [Facade coverage checklist](#facade-coverage-checklist) | 45% | 100% |
-| Phase 4 | 🚧 In Progress | Final cleanup and release — Steps A and B complete; W6 ✅; Step C: C1a ✅ C1b ✅ C1c ✅ C1d ✅ complete; C2a/C2b/C3 pending | 10% | 90% |
+| Phase 4 | 🚧 In Progress | Final cleanup and release — Steps A and B complete; W6 ✅; Step C: C1a ✅ C1b ✅ C1c ✅ C1d ✅ C2b ✅ complete; C2a/C3 pending | 10% | 95% |
 | **TOTAL** | -- | -- | **100%** | **99%** |
 
 ### Facade Modules Completed

--- a/redesign/3_architecture_implementation.md
+++ b/redesign/3_architecture_implementation.md
@@ -44,7 +44,7 @@ risk and allows for a gradual, controlled migration to the new architecture.
 | Phase 1 | ✅ Complete | Foundation and scaffolding | 5% | 100% |
 | Phase 2 | ✅ Complete | Migrating commands (all checklist items done) | 40% | 100% |
 | Phase 3 | ✅ Complete | Refactoring public interface — see [Facade Modules Completed](#facade-modules-completed) and [Facade coverage checklist](#facade-coverage-checklist) | 45% | 100% |
-| Phase 4 | 🚧 In Progress | Final cleanup and release — Steps A and B complete; W6 ✅; Step C: C1a ✅ C1b ✅ C1c ✅ C1d ✅ C2b ✅ complete; C2a/C3 pending | 10% | 95% |
+| Phase 4 | 🚧 In Progress | Final cleanup and release — Steps A and B complete; W6 ✅; Step C: C1a ✅ C1b ✅ C1c ✅ C1d ✅ C2a ✅ C2b ✅ complete; C3 pending | 10% | 98% |
 | **TOTAL** | -- | -- | **100%** | **99%** |
 
 ### Facade Modules Completed

--- a/redesign/Phase 4 - Step C.md
+++ b/redesign/Phase 4 - Step C.md
@@ -11,13 +11,14 @@
 > - **C1c ✅** — `@api` tags set for all 37 previously-unmarked internal constants
 >   (commit `83225f3f`).
 > - **C1d ✅** — Coverage gate enforced by `yard-lint` + `.yard-lint.yml`; no PR needed.
+> - **C2b ✅** — `README.md` updated: prominent `## Upgrading from v4.x to v5.0.0`
+>   section added, `UPGRADING.md` linked from the Deprecations section, outdated
+>   version-pinned install snippets removed, and ToC updated.
 >
 > Remaining work:
 >
 > - **C2a:** review and expand `UPGRADING.md` to comprehensively cover all
 >   v4.x → v5.0.0 breaking changes
-> - **C2b:** update `README.md` to reflect the new entry points and link to the
->   migration guide
 > - **C3:** run the full final documentation verification before v5.0.0 release.
 >
 
@@ -143,10 +144,11 @@ This step is organized into workstreams, each with **one PR per substep** for fi
 - **C1d: Coverage Gate** — ✅ **already done** (`yard-lint` + `.yard-lint.yml`
   replaced the retired `yardstick` gate and pass; no PR needed)
 - **C2a: Update UPGRADING.md** (1 PR)
-- **C2b: Update README.md** (1 PR)
+- **C2b: Update README.md** — ✅ **done** (prominent upgrade section added,
+  `UPGRADING.md` linked from Deprecations, outdated version-pinned install snippets removed)
 - **C3: Documentation Completeness Verification** (1 PR)
 
-Dependencies (remaining): C2a, C2b → C3. (C1a–C1d are all complete.)
+Dependencies (remaining): C2a → C3. (C1a–C1d and C2b are all complete.)
 
 **Documentation skill requirements:** Any remaining PR that touches YARD
 comments must apply the

--- a/redesign/Phase 4 - Step C.md
+++ b/redesign/Phase 4 - Step C.md
@@ -1,6 +1,6 @@
 # Phase 4 / Step C — Update Documentation: Execution Plan
 
-> **🚧 Status: Partial.**
+> **🚧 Status: Partial — C1 and C2 complete; C3 remains.**
 >
 > **C1 (YARD audit) is fully complete:**
 > - **C1a ✅** — Public API scope TSV produced at `redesign/c1a-public-api-scope.tsv`
@@ -11,14 +11,17 @@
 > - **C1c ✅** — `@api` tags set for all 37 previously-unmarked internal constants
 >   (commit `83225f3f`).
 > - **C1d ✅** — Coverage gate enforced by `yard-lint` + `.yard-lint.yml`; no PR needed.
+>
+> **C2 (guidance & README) is fully complete:**
+> - **C2a ✅** — `UPGRADING.md` expanded with comprehensive v4.x → v5.0.0 migration
+>   guide: beta banner removed, ToC added, breaking-changes quick-reference table,
+>   `Git::Base` removal section with before/after examples (commit `fb66404a`).
 > - **C2b ✅** — `README.md` updated: prominent `## Upgrading from v4.x to v5.0.0`
 >   section added, `UPGRADING.md` linked from the Deprecations section, outdated
 >   version-pinned install snippets removed, and ToC updated.
 >
 > Remaining work:
 >
-> - **C2a:** review and expand `UPGRADING.md` to comprehensively cover all
->   v4.x → v5.0.0 breaking changes
 > - **C3:** run the full final documentation verification before v5.0.0 release.
 >
 
@@ -143,12 +146,14 @@ This step is organized into workstreams, each with **one PR per substep** for fi
   (commit `83225f3f`; all 37 previously-unmarked internal constants tagged)
 - **C1d: Coverage Gate** — ✅ **already done** (`yard-lint` + `.yard-lint.yml`
   replaced the retired `yardstick` gate and pass; no PR needed)
-- **C2a: Update UPGRADING.md** (1 PR)
+- **C2a: Update UPGRADING.md** — ✅ **done** (beta banner removed, ToC added,
+  breaking-changes quick-reference table, `Git::Base` removal section with
+  before/after examples; commit `fb66404a`)
 - **C2b: Update README.md** — ✅ **done** (prominent upgrade section added,
   `UPGRADING.md` linked from Deprecations, outdated version-pinned install snippets removed)
 - **C3: Documentation Completeness Verification** (1 PR)
 
-Dependencies (remaining): C2a → C3. (C1a–C1d and C2b are all complete.)
+Dependencies (remaining): C3 only. (C1a–C1d, C2a, and C2b are all complete.)
 
 **Documentation skill requirements:** Any remaining PR that touches YARD
 comments must apply the


### PR DESCRIPTION
# Description

Phase 4 Step C2b: Update `README.md` for the v5.0.0 release to reflect the new
public entry points and prominently link to the v4.x → v5.0.0 migration guide.

## Changes

**`README.md`**

- Add a new `## Upgrading from v4.x to v5.0.0` section with a concise migration
  callout pointing to `UPGRADING.md`.
- Add a `UPGRADING.md` link to the `Deprecations` section so readers know where to
  find the full deprecation/migration table.
- Add `Upgrading from v4.x to v5.0.0` entry to the Table of Contents.
- Remove outdated version-pinned install snippets (the bare `bundle add git` /
  `gem install git` instructions are sufficient now that v5.0.0 is the current release).

**`redesign/Phase 4 - Step C.md`** and **`redesign/3_architecture_implementation.md`**

- Mark C2a and C2b as complete in both the step plan and the progress tracker.

## Notes

No `Git::Base` or `Git::Lib` references were present in the main README documentation
sections — the Quick Start and Examples sections already correctly use
`Git.open`/`Git.init`/`Git.clone` and reference `Git::Repository`.

This is the C2b PR (scoped to `README.md` only). C2a (`UPGRADING.md` expansion) is
merged. C3 (final verification) remains.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed. (Documentation-only change; no test changes required.)
- [x] Documentation updated where applicable (README and/or YARD).
