### PR TITLE
Fix circular require warnings

### DIFF
--- a/lib/git/command_line/base.rb
+++ b/lib/git/command_line/base.rb
@@ -1,7 +1,8 @@
 # frozen_string_literal: true
 
-require 'git/command_line'
+require 'git/command_line/result'
 require 'git/errors'
+require 'process_executer'
 
 module Git
   module CommandLine

--- a/lib/git/command_line/capturing.rb
+++ b/lib/git/command_line/capturing.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
-require 'git/command_line'
+require 'git/command_line/base'
+require 'git/encoding_utils'
 
 module Git
   module CommandLine

--- a/lib/git/command_line/streaming.rb
+++ b/lib/git/command_line/streaming.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/command_line'
+require 'git/command_line/base'
 require 'stringio'
 
 module Git

--- a/lib/git/commands/show_ref/exclude_existing.rb
+++ b/lib/git/commands/show_ref/exclude_existing.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'git/commands/base'
-require 'git/commands/show_ref'
 
 module Git
   module Commands

--- a/lib/git/commands/show_ref/exists.rb
+++ b/lib/git/commands/show_ref/exists.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'git/commands/base'
-require 'git/commands/show_ref'
 
 module Git
   module Commands

--- a/lib/git/commands/show_ref/list.rb
+++ b/lib/git/commands/show_ref/list.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'git/commands/base'
-require 'git/commands/show_ref'
 
 module Git
   module Commands

--- a/lib/git/commands/show_ref/verify.rb
+++ b/lib/git/commands/show_ref/verify.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'git/commands/base'
-require 'git/commands/show_ref'
 
 module Git
   module Commands

--- a/lib/git/execution_context.rb
+++ b/lib/git/execution_context.rb
@@ -501,6 +501,3 @@ module Git
     end
   end
 end
-
-require 'git/execution_context/global'
-require 'git/execution_context/repository'

--- a/spec/integration/git/load_spec.rb
+++ b/spec/integration/git/load_spec.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'open3'
+require 'rbconfig'
+
+RSpec.describe 'loading git' do
+  let(:project_root) { File.expand_path('../../..', __dir__) }
+  let(:lib_path) { File.join(project_root, 'lib') }
+
+  subject(:load_git) do
+    Open3.capture3(
+      RbConfig.ruby,
+      '-w',
+      "-I#{lib_path}",
+      '-rgit',
+      '-e',
+      'puts :ok',
+      chdir: project_root
+    )
+  end
+
+  it 'does not emit circular require warnings' do
+    stdout, stderr, status = load_git
+
+    expect(status).to be_success
+    expect(stdout).to eq("ok\n")
+    expect(stderr).not_to include('circular require considered harmful')
+  end
+end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Fixes circular require warnings emitted when loading the gem with Ruby warnings enabled.

The change replaces aggregator back-requires in command-line and show-ref internals with direct dependencies, and removes the `ExecutionContext` base file's child aggregation that caused a parent/child require cycle. It also adds an integration regression that loads `git` in a fresh Ruby process with `-w` and asserts no `circular require considered harmful` warning is emitted.

## Validation

- `bundle exec rspec spec/integration/git/load_spec.rb`
- `bundle exec rubocop spec/integration/git/load_spec.rb`
- `bundle exec rspec spec/unit/git/command_line spec/unit/git/execution_context spec/unit/git/commands/show_ref spec/integration/git/commands/show_ref`
- `bundle exec rubocop lib/git/command_line/base.rb lib/git/command_line/capturing.rb lib/git/command_line/streaming.rb lib/git/execution_context.rb lib/git/commands/show_ref/exclude_existing.rb lib/git/commands/show_ref/exists.rb lib/git/commands/show_ref/list.rb lib/git/commands/show_ref/verify.rb spec/integration/git/load_spec.rb`

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).