### PR TITLE
test: silence empty-repository clone warnings in url_spec

### DIFF
--- a/spec/integration/git/url_spec.rb
+++ b/spec/integration/git/url_spec.rb
@@ -13,7 +13,8 @@ RSpec.describe Git::URL, :integration do
     around do |example|
       Dir.mktmpdir do |dir|
         Dir.chdir(dir) do
-          init_test_repo('server/my_project')
+          repo = init_test_repo('server/my_project')
+          repo.commit('Initial commit', allow_empty: true)
           example.run
         end
       end


### PR DESCRIPTION
# Description

Running `bundle exec rspec spec/integration/git/url_spec.rb` printed
`warning: You appear to have cloned an empty repository.` to stderr for each
example.

The `Git::URL.clone_to` integration examples clone a freshly initialized source
repository. Because `init_test_repo` creates a repo with no commits, `git clone`
warned that it had cloned an empty repository once per example.

This adds an initial empty commit to the source repository in the `around` hook
so the plain, `--bare`, and `--mirror` clones no longer trigger the warning. The
examples' assertions are unaffected — they only verify the directory that
`Git::URL.clone_to` predicts `git clone` will create.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).