### PR TITLE
Configure Git deprecation behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -583,6 +583,18 @@ You can silence deprecation warnings by adding this line to your source code:
 Git::Deprecation.behavior = :silence
 ```
 
+Or by setting this environment variable before loading the gem:
+
+```sh
+GIT_DEPRECATION_BEHAVIOR=silence
+```
+
+Accepted environment variable values are the behavior names supported by your
+installed ActiveSupport version.
+
+If `GIT_DEPRECATION_BEHAVIOR` is set to an unsupported value, loading the gem
+raises `ArgumentError` with the accepted behavior names.
+
 See [the Active Support Deprecation
 documentation](https://api.rubyonrails.org/classes/ActiveSupport/Deprecation.html)
 for more details.

--- a/lib/git/deprecation.rb
+++ b/lib/git/deprecation.rb
@@ -7,5 +7,5 @@ module Git
   # The deprecation instance used to emit deprecation warnings for the Git gem
   #
   # @api private
-  Deprecation = ActiveSupport::Deprecation.new('5.0.0', 'Git')
+  Deprecation = ActiveSupport::Deprecation.new('6.0.0', 'Git')
 end

--- a/lib/git/deprecation.rb
+++ b/lib/git/deprecation.rb
@@ -6,6 +6,19 @@ require 'active_support/deprecation'
 module Git
   # The deprecation instance used to emit deprecation warnings for the Git gem
   #
-  # @api private
+  # @api public
   Deprecation = ActiveSupport::Deprecation.new('6.0.0', 'Git')
+
+  if (behavior = ENV.fetch('GIT_DEPRECATION_BEHAVIOR', nil))
+    behavior = behavior.strip
+    allowed_behaviors = ActiveSupport::Deprecation::DEFAULT_BEHAVIORS.keys.map(&:to_s)
+
+    unless allowed_behaviors.include?(behavior)
+      raise ArgumentError,
+            "Invalid GIT_DEPRECATION_BEHAVIOR=#{behavior.inspect}; " \
+            "expected one of: #{allowed_behaviors.join(', ')}"
+    end
+
+    Deprecation.behavior = behavior.to_sym
+  end
 end

--- a/spec/unit/git/deprecation_spec.rb
+++ b/spec/unit/git/deprecation_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'open3'
+require 'rbconfig'
+
+RSpec.describe Git::Deprecation do
+  describe '.deprecation_horizon' do
+    it 'is 6.0.0' do
+      expect(described_class.deprecation_horizon).to eq('6.0.0')
+    end
+  end
+
+  describe 'GIT_DEPRECATION_BEHAVIOR' do
+    around do |example|
+      original_verbose = $VERBOSE
+      $VERBOSE = nil
+      example.run
+    ensure
+      $VERBOSE = original_verbose
+    end
+
+    subject(:load_deprecation) do
+      Open3.capture3(
+        env,
+        RbConfig.ruby,
+        '-Ilib',
+        '-e',
+        script,
+        chdir: project_root
+      )
+    end
+
+    let(:project_root) { File.expand_path('../../..', __dir__) }
+    let(:env) { { 'GIT_DEPRECATION_BEHAVIOR' => behavior } }
+    let(:allowed_behaviors) { ActiveSupport::Deprecation::DEFAULT_BEHAVIORS.keys.map(&:to_s) }
+    let(:deprecation_path) { File.join(project_root, 'lib/git/deprecation.rb') }
+    let(:script) do
+      <<~RUBY
+        require 'git/deprecation'
+        Git::Deprecation.warn('deprecated message')
+      RUBY
+    end
+
+    context 'when set to silence' do
+      let(:behavior) { 'silence' }
+
+      it 'silences deprecation warnings' do
+        _stdout, stderr, status = load_deprecation
+
+        expect(status).to be_success
+        expect(stderr).not_to include('DEPRECATION WARNING: deprecated message')
+      end
+
+      it 'sets the behavior when loaded in the current process' do
+        original_behavior = ENV.fetch('GIT_DEPRECATION_BEHAVIOR', nil)
+
+        ENV['GIT_DEPRECATION_BEHAVIOR'] = behavior
+        hide_const('Git::Deprecation')
+        load deprecation_path
+
+        expect { Git::Deprecation.warn('deprecated message') }.not_to output(
+          /DEPRECATION WARNING: deprecated message/
+        ).to_stderr
+      ensure
+        if original_behavior.nil?
+          ENV.delete('GIT_DEPRECATION_BEHAVIOR')
+        else
+          ENV['GIT_DEPRECATION_BEHAVIOR'] = original_behavior
+        end
+      end
+    end
+
+    context 'when set to an invalid behavior' do
+      let(:behavior) { 'silent' }
+      let(:script) { "require 'git/deprecation'" }
+
+      it 'raises a descriptive error' do
+        _stdout, stderr, status = load_deprecation
+
+        expect(status).not_to be_success
+        expect(stderr).to include('Invalid GIT_DEPRECATION_BEHAVIOR="silent"')
+        expect(stderr).to include("expected one of: #{allowed_behaviors.join(', ')}")
+      end
+
+      it 'raises a descriptive error when loaded in the current process' do
+        original_behavior = ENV.fetch('GIT_DEPRECATION_BEHAVIOR', nil)
+
+        ENV['GIT_DEPRECATION_BEHAVIOR'] = behavior
+        hide_const('Git::Deprecation')
+
+        expect { load deprecation_path }.to raise_error(
+          ArgumentError,
+          /Invalid GIT_DEPRECATION_BEHAVIOR="silent"; expected one of: #{Regexp.escape(allowed_behaviors.join(', '))}/
+        )
+      ensure
+        if original_behavior.nil?
+          ENV.delete('GIT_DEPRECATION_BEHAVIOR')
+        else
+          ENV['GIT_DEPRECATION_BEHAVIOR'] = original_behavior
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Updates the `Git::Deprecation` ActiveSupport deprecation horizon from `5.0.0` to `6.0.0` so the shared deprecation emitter matches the removal version used by current deprecation messages.

Also adds support for configuring `Git::Deprecation.behavior` before load time with a single environment variable value:

```sh
GIT_DEPRECATION_BEHAVIOR=silence
```

Supported values are the ActiveSupport built-in behaviors: `raise`, `stderr`, `log`, `notify`, `silence`, and `report`. Invalid values fail fast with a descriptive `ArgumentError`.

## Validation

- `ruby -Ilib -e "require 'git/deprecation'; puts Git::Deprecation.deprecation_horizon"`
- `bundle exec rubocop lib/git/deprecation.rb`
- `bundle exec rspec spec/unit/git/deprecation_spec.rb`
- `bundle exec rubocop lib/git/deprecation.rb spec/unit/git/deprecation_spec.rb`

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [ ] I ran `bundle exec rake` locally on this branch and it passed (see [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).