### PR TITLE
feat: deprecate direct access to Git::Lib constant

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -44,12 +44,28 @@ require 'git/worktrees'
 # @author Scott Chacon (mailto:schacon@gmail.com)
 #
 module Git # rubocop:disable Style/OneClassPerFile
+  # Internal alias for Git::Lib, used by the gem itself after the public constant
+  # is deprecated. Code outside the gem should not reference this constant.
+  # @api private
+  LibImpl = remove_const(:Lib)
+
+  # @api private
+  def self.const_missing(name)
+    return super unless name == :Lib
+
+    Git::Deprecation.warn(
+      'Git::Lib is deprecated and will be removed in version 5.x. ' \
+      'Use the #lib accessor on the object returned by Git.init, Git.open, or Git.clone instead.'
+    )
+    const_set(:Lib, LibImpl)
+  end
+
   # g.config('user.name', 'Scott Chacon') # sets value
   # g.config('user.email', 'email@email.com')  # sets value
   # g.config('user.name')  # returns 'Scott Chacon'
   # g.config # returns whole config hash
   def config(name = nil, value = nil)
-    lib = Git::Lib.new
+    lib = LibImpl.new
     if name && value
       # set value
       lib.config_set(name, value)
@@ -287,7 +303,7 @@ module Git # rubocop:disable Style/OneClassPerFile
   # g.config('user.name')  # returns 'Scott Chacon'
   # g.config # returns whole config hash
   def self.global_config(name = nil, value = nil)
-    lib = Git::Lib.new(nil, nil)
+    lib = LibImpl.new(nil, nil)
     if name && value
       # set value
       lib.global_config_set(name, value)
@@ -369,7 +385,7 @@ module Git # rubocop:disable Style/OneClassPerFile
   # @param [String|NilClass] location the target repository location or nil for '.'
   # @return [{String=>Hash}] the available references of the target repo.
   def self.ls_remote(location = nil, options = {})
-    Git::Lib.new.ls_remote(location, options)
+    LibImpl.new.ls_remote(location, options)
   end
 
   # Open a an existing Git working directory

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -23,14 +23,14 @@ module Git
     def self.clone(repository_url, directory, options = {})
       lib_options = {}
       lib_options[:git_ssh] = options[:git_ssh] if options.key?(:git_ssh)
-      new_options = Git::Lib.new(lib_options, options[:log]).clone(repository_url, directory, options)
+      new_options = LibImpl.new(lib_options, options[:log]).clone(repository_url, directory, options)
       normalize_paths(new_options, bare: options[:bare] || options[:mirror])
       new(new_options)
     end
 
     # (see Git.default_branch)
     def self.repository_default_branch(repository, options = {})
-      Git::Lib.new(nil, options[:log]).repository_default_branch(repository)
+      LibImpl.new(nil, options[:log]).repository_default_branch(repository)
     end
 
     # Returns (and initialize if needed) a Git::Config instance
@@ -90,7 +90,7 @@ module Git
       #   repository you have a Git::Base instance for.  This would not
       #   change the existing interface (other than adding to it).
       #
-      Git::Lib.new(options).init(init_options)
+      LibImpl.new(options).init(init_options)
 
       new(options)
     end
@@ -335,7 +335,7 @@ module Git
     # actual 'git' forked system calls.  At some point I hope to replace the Git::Lib
     # class with one that uses native methods or libgit C bindings
     def lib
-      @lib ||= Git::Lib.new(self, @logger)
+      @lib ||= LibImpl.new(self, @logger)
     end
 
     # Returns the per-instance git_ssh configuration value.

--- a/tests/units/test_branch.rb
+++ b/tests/units/test_branch.rb
@@ -76,8 +76,9 @@ class TestBranch < Test::Unit::TestCase
     in_temp_dir do
       `git init --initial-branch=my_initial_branch`
       git = Git.open('.')
-      expected_state = Git::Lib::HeadState.new(:unborn, 'my_initial_branch')
-      assert_equal(expected_state, git.lib.current_branch_state)
+      state = git.lib.current_branch_state
+      assert_equal(:unborn, state.state)
+      assert_equal('my_initial_branch', state.name)
     end
   end
 
@@ -89,8 +90,9 @@ class TestBranch < Test::Unit::TestCase
       `git commit -m "First commit"`
       `git checkout --orphan orphan_branch 2> #{File::NULL}`
       git = Git.open('.')
-      expected_state = Git::Lib::HeadState.new(:unborn, 'orphan_branch')
-      assert_equal(expected_state, git.lib.current_branch_state)
+      state = git.lib.current_branch_state
+      assert_equal(:unborn, state.state)
+      assert_equal('orphan_branch', state.name)
     end
   end
 
@@ -101,8 +103,9 @@ class TestBranch < Test::Unit::TestCase
       `git add file1.txt`
       `git commit -m "First commit"`
       git = Git.open('.')
-      expected_state = Git::Lib::HeadState.new(:active, 'my_branch')
-      assert_equal(expected_state, git.lib.current_branch_state)
+      state = git.lib.current_branch_state
+      assert_equal(:active, state.state)
+      assert_equal('my_branch', state.name)
     end
   end
 
@@ -117,8 +120,9 @@ class TestBranch < Test::Unit::TestCase
       `git commit -m "Second commit"`
       `git checkout HEAD~1 2> #{File::NULL}`
       git = Git.open('.')
-      expected_state = Git::Lib::HeadState.new(:detached, 'HEAD')
-      assert_equal(expected_state, git.lib.current_branch_state)
+      state = git.lib.current_branch_state
+      assert_equal(:detached, state.state)
+      assert_equal('HEAD', state.name)
     end
   end
 

--- a/tests/units/test_deprecations.rb
+++ b/tests/units/test_deprecations.rb
@@ -176,13 +176,13 @@ class TestDeprecations < Test::Unit::TestCase
 
   def test_lib_warn_if_old_command_deprecation
     # Ensure class-level check does not short-circuit the call in this test
-    Git::Lib.instance_variable_set(:@version_checked, nil)
+    Git::LibImpl.instance_variable_set(:@version_checked, nil)
 
     Git::Deprecation.expects(:warn).with(
       'Git::Lib#warn_if_old_command is deprecated. Use meets_required_version?.'
     )
 
-    assert_equal(true, Git::Lib.warn_if_old_command(@git.lib))
+    assert_equal(true, Git::LibImpl.warn_if_old_command(@git.lib))
   end
 
   # --- Git::Path deprecations ---

--- a/tests/units/test_lib.rb
+++ b/tests/units/test_lib.rb
@@ -358,7 +358,7 @@ class TestLib < Test::Unit::TestCase
       saved_git_ssh = Git::Base.config.git_ssh
       Git::Base.config.git_ssh = '/global/ssh'
 
-      lib = Git::Lib.new
+      lib = Git::LibImpl.new
 
       env = lib.send(:env_overrides)
       assert_equal '/global/ssh', env['GIT_SSH'], 'env_overrides should honor global git_ssh'
@@ -442,7 +442,7 @@ class TestLib < Test::Unit::TestCase
   end
 
   def test_compare_version_to
-    lib = Git::Lib.new(nil, nil)
+    lib = Git::LibImpl.new(nil, nil)
     current_version = [2, 42, 0]
     lib.define_singleton_method(:current_command_version) { current_version }
     assert lib.compare_version_to(0, 43, 9) == 1

--- a/tests/units/test_lib_meets_required_version.rb
+++ b/tests/units/test_lib_meets_required_version.rb
@@ -4,14 +4,14 @@ require 'test_helper'
 
 class TestLibMeetsRequiredVersion < Test::Unit::TestCase
   def test_with_supported_command_version
-    lib = Git::Lib.new(nil, nil)
+    lib = Git::LibImpl.new(nil, nil)
     major_version, minor_version = lib.required_command_version
     lib.define_singleton_method(:current_command_version) { [major_version, minor_version] }
     assert lib.meets_required_version?
   end
 
   def test_with_old_command_version
-    lib = Git::Lib.new(nil, nil)
+    lib = Git::LibImpl.new(nil, nil)
     major_version, minor_version = lib.required_command_version
 
     # Set the major version to be returned by #current_command_version to be an
@@ -23,7 +23,7 @@ class TestLibMeetsRequiredVersion < Test::Unit::TestCase
   end
 
   def test_parse_version
-    lib = Git::Lib.new(nil, nil)
+    lib = Git::LibImpl.new(nil, nil)
 
     versions_to_test = [
       { version_string: 'git version 2.1', expected_result: [2, 1, 0] },

--- a/tests/units/test_per_instance_config.rb
+++ b/tests/units/test_per_instance_config.rb
@@ -8,7 +8,7 @@ class TestPerInstanceConfig < Test::Unit::TestCase
     begin
       Git::Base.config.git_ssh = '/global/ssh'
 
-      lib = Git::Lib.new
+      lib = Git::LibImpl.new
       env = lib.send(:env_overrides)
 
       assert_equal '/global/ssh', env['GIT_SSH']
@@ -22,7 +22,7 @@ class TestPerInstanceConfig < Test::Unit::TestCase
     begin
       Git::Base.config.git_ssh = '/global/ssh'
 
-      lib = Git::Lib.new(nil, Logger.new(nil))
+      lib = Git::LibImpl.new(nil, Logger.new(nil))
       env = lib.send(:env_overrides)
 
       assert_equal '/global/ssh', env['GIT_SSH']
@@ -32,7 +32,7 @@ class TestPerInstanceConfig < Test::Unit::TestCase
   end
 
   test 'Git::Lib initialized from hash sets git_ssh' do
-    lib = Git::Lib.new(git_ssh: '/custom/ssh')
+    lib = Git::LibImpl.new(git_ssh: '/custom/ssh')
     env = lib.send(:env_overrides)
     assert_equal '/custom/ssh', env['GIT_SSH']
   end
@@ -43,7 +43,7 @@ class TestPerInstanceConfig < Test::Unit::TestCase
     # Git.clone calls Git::Lib.new({git_ssh: ...}, ...).clone(...)
     # We verify that Git::Lib.new is called with the correct git_ssh option
 
-    Git::Lib.expects(:new).with(has_entry(git_ssh: git_ssh), anything).returns(stub_everything(clone: {}))
+    Git::LibImpl.expects(:new).with(has_entry(git_ssh: git_ssh), anything).returns(stub_everything(clone: {}))
 
     begin
       Git.clone('url', 'dir', git_ssh: git_ssh)
@@ -61,7 +61,7 @@ class TestPerInstanceConfig < Test::Unit::TestCase
       end
 
       # When git_ssh: nil is passed, GIT_SSH should not be set for clone
-      Git::Lib.stubs(:new).with(has_entry(git_ssh: nil), anything).returns(stub_everything(clone: {}))
+      Git::LibImpl.stubs(:new).with(has_entry(git_ssh: nil), anything).returns(stub_everything(clone: {}))
       begin
         Git.clone('url', 'dir', git_ssh: nil)
       rescue StandardError
@@ -69,7 +69,7 @@ class TestPerInstanceConfig < Test::Unit::TestCase
       end
 
       # For env_overrides, use the real class
-      lib_real = Git::Lib.allocate
+      lib_real = Git::LibImpl.allocate
       lib_real.send(:initialize_from_hash, { git_ssh: nil })
       env = lib_real.send(:env_overrides)
       assert_nil env['GIT_SSH'], 'GIT_SSH should not be set when git_ssh: nil is passed'
@@ -83,7 +83,7 @@ class TestPerInstanceConfig < Test::Unit::TestCase
 
     # Git.init passes the options hash (including git_ssh) to Git::Lib.new(options).init(init_options)
 
-    Git::Lib.expects(:new).with(has_entry(git_ssh: git_ssh)).returns(stub_everything(init: true))
+    Git::LibImpl.expects(:new).with(has_entry(git_ssh: git_ssh)).returns(stub_everything(init: true))
 
     begin
       Git.init('dir', git_ssh: git_ssh)

--- a/tests/units/test_worktree.rb
+++ b/tests/units/test_worktree.rb
@@ -31,7 +31,7 @@ class TestWorktree < Test::Unit::TestCase
   end
 
   test 'adding a worktree when there are no commits should fail' do
-    omit('Omitted since git version is >= 2.42.0') if Git::Lib.new(nil, nil).compare_version_to(2, 42, 0) >= 0
+    omit('Omitted since git version is >= 2.42.0') if (Git.binary_version <=> [2, 42, 0]) >= 0
 
     in_temp_dir do |_path|
       Dir.mkdir('main_worktree')
@@ -50,7 +50,7 @@ class TestWorktree < Test::Unit::TestCase
   end
 
   test 'adding a worktree when there are no commits should succeed' do
-    omit('Omitted since git version is < 2.42.0') if Git::Lib.new(nil, nil).compare_version_to(2, 42, 0).negative?
+    omit('Omitted since git version is < 2.42.0') if (Git.binary_version <=> [2, 42, 0]).negative?
 
     in_temp_dir do |path|
       Dir.mkdir('main_worktree')


### PR DESCRIPTION
## Summary

`Git::Lib` is an internal implementation class tagged `@api private`, but it has been accessible as a public constant. This PR adds a deprecation warning that fires the first time `Git::Lib` is referenced directly, signalling that the constant will be removed in version 5.x.

## Implementation

- **`lib/git.rb`**: After loading `git/lib`, the `Lib` constant is removed from the public `Git` namespace and stored under the internal alias `Git::LibImpl`. A `Git.const_missing(:Lib)` hook emits a `Git::Deprecation.warn` on the first lookup, then re-registers `Git::Lib` via `const_set` so subsequent lookups are a no-op (warning fires only once per process).
- **`lib/git/base.rb`** and **`lib/git.rb`**: All internal `Git::Lib.new` call sites updated to `LibImpl.new` so gem internals never trigger the warning.

## Deprecation message

```
DEPRECATION WARNING: Git::Lib is deprecated and will be removed in version 5.x.
Use the #lib accessor on the object returned by Git.init, Git.open, or Git.clone instead.
```

## Test updates

ActiveSupport raises `DeprecationException` on any `Git::Deprecation.warn` call during tests, so tests that accessed `Git::Lib` directly needed updating:

- `test_lib.rb`, `test_lib_meets_required_version.rb`, `test_per_instance_config.rb`, `test_deprecations.rb`: `Git::Lib` → `Git::LibImpl`
- `test_branch.rb`: `Git::Lib::HeadState` struct comparisons replaced with individual field assertions (`state.state`, `state.name`)
- `test_worktree.rb`: `Git::Lib.new(nil, nil).compare_version_to(...)` replaced with `Git.binary_version <=> [...]`