### PR TITLE
ci: restore ruby 3.4, jruby, truffleruby, and windows builds

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -21,17 +21,16 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "4.0"]
-        # Temporarily disabled; restore in a follow-up PR.
-        # ruby: ["3.2", "3.4", "4.0", "truffleruby-24.2.1", "jruby-10.0.0.1"]
+        # Only the minimum required versions of JRuby and TruffleRuby are tested
+        ruby: ["3.2", "3.4", "4.0", "truffleruby-24.2.1", "jruby-10.0.0.1"]
         operating-system: [ubuntu-latest]
         experimental: [No]
         java_version: [""]
-        include: []
-          # Temporarily disabled; restore in a follow-up PR.
-          # - ruby: 3.2
-          #   operating-system: windows-latest
-          #   experimental: No
+        include:
+          - ruby: "3.2"
+            operating-system: windows-latest
+            experimental: No
+            java_version: ""
 
     steps:
       - name: Checkout Code

--- a/Rakefile
+++ b/Rakefile
@@ -36,7 +36,7 @@ module Rake
       # rake rubocop      # => do not output the task name
       # rake rubocop yard # => output task name for rubocop and yard
       top_level_tasks = Rake.application.top_level_tasks
-      box("Rake task: #{name}") unless top_level_tasks.length == 1 && name == top_level_tasks[0]
+      box("rake #{name}") unless top_level_tasks.length == 1 && name == top_level_tasks[0]
       original_execute(args)
     end
 


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Restores the CI build matrix entries that were temporarily disabled in:

- #1558 — disabled Windows, JRuby, and TruffleRuby builds
- #1559 — removed Ruby 3.4

The full matrix is now restored to:
- **Ruby versions (ubuntu-latest):** 3.2, 3.4, 4.0, truffleruby-24.2.1, jruby-10.0.0.1
- **Windows:** Ruby 3.2 on windows-latest

The temporary comments added by those PRs are also removed.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
