### PR TITLE
feat: add Git::Base compatibility shim with deprecation warnings

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -110,6 +110,43 @@ module Git
   #
   MINIMUM_GIT_VERSION = Version.parse('2.28.0')
 
+  # Compatibility shim for code that monkeypatches the `Git::Base` class from
+  # versions prior to 5.0.0.
+  #
+  # `Git::Base` is a module included in {Git::Repository}, so any instance
+  # methods added to `Git::Base` are automatically available on
+  # {Git::Repository} instances. A deprecation warning is emitted for each
+  # method added, encouraging migration to {Git::Repository}.
+  #
+  # @example Monkeypatching Git::Base (deprecated)
+  #   module Git::Base
+  #     def my_helper = "hello"
+  #   end
+  #   Git.open('.').my_helper  # => "hello"
+  #
+  # @deprecated Define instance methods on {Git::Repository} instead.
+  #
+  # @api public
+  Base = Module.new do
+    # Emit a deprecation warning each time a method is defined in Git::Base so
+    # that authors of monkeypatches are nudged toward Git::Repository.
+    def self.method_added(method_name)
+      Git::Deprecation.warn(
+        'Monkeypatching Git::Base is deprecated and will be removed in v6.0.0. ' \
+        "Define #{method_name} in Git::Repository instead."
+      )
+      super
+    end
+
+    # Raise a clear error when legacy code calls Git::Base.new directly.
+    def self.new(...)
+      raise NoMethodError,
+            'Git::Base.new is not supported. Use Git.open, Git.clone, or Git.init instead.'
+    end
+  end
+
+  Repository.include(Base)
+
   # Intercept the first lookup of the deprecated `Git::CommandLineResult` constant
   #
   # When `name` is `:CommandLineResult`, caches and returns {Git::CommandLine::Result}

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::Base do
+  describe '.new' do
+    subject { described_class.new }
+
+    it 'raises NoMethodError directing callers to Git.open, Git.clone, or Git.init' do
+      expect { subject }.to raise_error(
+        NoMethodError,
+        'Git::Base.new is not supported. Use Git.open, Git.clone, or Git.init instead.'
+      )
+    end
+  end
+
+  describe '.method_added' do
+    let(:test_method_name) { :git_base_spec_method_added_test }
+
+    after do
+      described_class.remove_method(test_method_name) if described_class.method_defined?(test_method_name)
+    end
+
+    context 'when a method is defined in Git::Base' do
+      it 'emits a deprecation warning naming the method and pointing to Git::Repository' do
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Monkeypatching Git::Base is deprecated and will be removed in v6.0.0. ' \
+          "Define #{test_method_name} in Git::Repository instead."
+        )
+        described_class.define_method(test_method_name) { nil }
+      end
+
+      it 'makes the added method available on Git::Repository instances' do
+        allow(Git::Deprecation).to receive(:warn)
+        described_class.define_method(test_method_name) { nil }
+        expect(Git::Repository.method_defined?(test_method_name)).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

`Git::Base` was the main public class in versions prior to 5.0.0. After the 5.0 rename to `Git::Repository`, users who monkeypatched `Git::Base` would silently lose their methods — the class no longer existed, so Ruby created a new, orphaned `Git::Base` constant that was never wired into the gem.

## Changes

### `lib/git.rb`

`Git::Base` is now a `Module` included in `Git::Repository`:

- **Forwarding via `include`** — any instance method defined in `Git::Base` is automatically available on `Git::Repository` instances through Ruby's normal method lookup. No copying or delegation needed.

- **`method_added` deprecation hook** — fires once per method added to `Git::Base`, emitting a `Git::Deprecation.warn` message that names the specific method and directs the author to `Git::Repository`:

  ```
  DEPRECATION WARNING: Monkeypatching Git::Base is deprecated and will be removed
  in v6.0.0. Define my_helper in Git::Repository instead.
  ```

- **`self.new` error** — replaces the cryptic `NoMethodError: undefined method 'new' for module Git::Base` with an actionable message:

  ```
  Git::Base.new is not supported. Use Git.open, Git.clone, or Git.init instead.
  ```

### `spec/unit/git/base_spec.rb`

Unit tests with 100% coverage of the new code:

- `Git::Base.new` raises `NoMethodError` with the correct message
- Defining a method in `Git::Base` emits the deprecation warning naming the method
- Methods added to `Git::Base` become available on `Git::Repository` instances

Tests use `after` hooks to remove any methods added to `Git::Base` during the example, keeping the suite fully isolated and order-independent.

## Design notes

- `Git::Base = Git::Repository` (a plain constant alias) was considered but rejected: it works for forwarding but `const_missing` is never called for a defined constant, so all deprecation warnings are lost.
- `const_missing` alone was also rejected: Ruby's `class`/`module` keyword bypasses `const_missing` and creates a new, orphaned constant instead of calling the hook.
- The `Module.new` + `include` approach is the only standard Ruby mechanism that satisfies both goals simultaneously.
