### PR TITLE
Document Git::Log path filtering upgrade note

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -10,6 +10,7 @@ to update your code when upgrading from the preceding major version.
     - [`Git::Base` removed](#gitbase-removed)
     - [Return type of `Git.open`, `Git.clone`, `Git.init`, `Git.bare`](#return-type-of-gitopen-gitclone-gitinit-gitbare)
     - [`Git::Lib` removed](#gitlib-removed)
+    - [`Git::Log#object` is not a path limiter](#gitlogobject-is-not-a-path-limiter)
     - [`Git::CommandLineResult` deprecated](#gitcommandlineresult-deprecated)
   - [Deprecated methods](#deprecated-methods)
     - [Facade method renames](#facade-method-renames)
@@ -45,6 +46,7 @@ For information on how to suppress or configure deprecation warnings, see the
 | `Git::Base` removed | Hard break | High for code that references it by name | Replace with `Git::Repository` (returned by `Git.open` etc.) |
 | `Git::Lib` removed | Hard break | High for `.lib.*` callers | Use the equivalent method directly on the repo object (see table below) |
 | `Git.open` etc. return `Git::Repository` (not `Git::Base`) | Hard break | Low for most callers; breaks `is_a?(Git::Base)` | Update type checks and update `be_a(Git::Base)` in tests |
+| `Git::Log#object` is not a path limiter | Behavior change | Medium for code that used `object(path)` to filter logs by path | Use `Git::Log#path` for path filtering |
 | `Git::CommandLineResult` deprecated | Deprecation (removed in v6.0.0) | Low; only affects code that references the constant by name | Use `Git::CommandLine::Result` instead |
 
 ---
@@ -208,6 +210,30 @@ helpers with no plausible external use. They have no replacement in v5.0.0:
 - `parse_config_list`
 - `process_commit_data`
 - `validate_pathspec_types`
+
+---
+
+#### `Git::Log#object` is not a path limiter
+
+In previous 4.x releases, some uses of `Git::Log#object(path)` could appear to
+filter log output by path when combined with `#between` or other revision range
+options. This relied on ambiguous `git log` argument handling and was not the
+intended API for path filtering.
+
+In v5.x, `Git::Log#object` should be treated as a revision expression. When both
+`#object` and `#between` are specified, `#between` takes precedence. Code that
+used `#object` to limit commits to a path should use `#path` instead.
+
+```ruby
+# v4.x — ambiguous; could appear to filter commits touching this path
+git.log(500).object('cookbooks/mycookbook').between('1.0.0', 'HEAD').execute
+
+# v5.x — use #path for path filtering
+git.log(500).path('cookbooks/mycookbook').between('1.0.0', 'HEAD').execute
+
+# #object remains appropriate for revision expressions
+git.log.object('HEAD~10..HEAD').execute
+```
 
 ---
 


### PR DESCRIPTION
## Summary

Document the observable v4-to-v5 upgrade behavior around `Git::Log#object` and path filtering.

## Changes

- Add a v5.x upgrade-guide entry explaining that `Git::Log#object` is a revision expression, not a path limiter.
- Point users to `Git::Log#path` for path filtering.
- Mention the accidental 4.x behavior caused by Git CLI path/revision ambiguity.

## Validation

- `ruby -e '...'` documentation sanity check for the new TOC entry, heading, and fenced code blocks
- `git diff --check`

Fixes #1613