### PR TITLE
Add reverse dependency query

### DIFF
--- a/redesign/reverse_dependencies.sql
+++ b/redesign/reverse_dependencies.sql
@@ -1,0 +1,44 @@
+WITH matching_dependencies AS (
+  SELECT
+    dependent_gem.name AS dependent_gem_name,
+    dependent_version.number AS dependent_version_number,
+    dependent_version.canonical_number AS dependent_version_canonical_number,
+    COALESCE(dependent_version.built_at, dependent_version.created_at) AS dependent_version_released_at,
+    dependencies.requirements,
+    COALESCE(linksets.code, linksets.home) AS url
+  FROM rubygems target_gem
+  JOIN dependencies
+    ON dependencies.rubygem_id = target_gem.id
+  JOIN versions dependent_version
+    ON dependent_version.id = dependencies.version_id
+  JOIN rubygems dependent_gem
+    ON dependent_gem.id = dependent_version.rubygem_id
+  LEFT JOIN linksets
+    ON linksets.rubygem_id = dependent_gem.id
+  WHERE target_gem.name = 'git'
+    AND (
+      dependencies.requirements LIKE '~> 4.%'
+      OR dependencies.requirements LIKE '>= %'
+    )
+),
+latest_dependencies AS (
+  SELECT DISTINCT ON (dependent_gem_name)
+    dependent_gem_name,
+    dependent_version_number,
+    dependent_version_released_at,
+    requirements,
+    url
+  FROM matching_dependencies
+  ORDER BY
+    dependent_gem_name,
+    dependent_version_canonical_number DESC NULLS LAST,
+    dependent_version_number DESC
+)
+SELECT
+  dependent_gem_name,
+  dependent_version_number,
+  dependent_version_released_at,
+  requirements,
+  url
+FROM latest_dependencies
+ORDER BY dependent_version_released_at DESC;


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Adds `redesign/reverse_dependencies.sql`, a PostgreSQL query for the public RubyGems data dump that identifies gems requiring the `git` gem as a dependency.

The query reports the latest matching dependent gem version, release timestamp, dependency requirement string, and project URL. This is intended to support redesign planning by showing reverse dependencies that may be affected by compatibility or API changes.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [ ] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
  Not run: this PR only adds a standalone SQL analysis query.
- [x] Tests added/updated as needed.
  Not applicable: no Ruby behavior changes.
- [x] Documentation updated where applicable (README and/or YARD).
  The added artifact is redesign documentation/query material.