### PR TITLE
chore: release v5.0.0.beta.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?log
   - [Ruby Version Support Policy](#ruby-version-support-policy)
   - [Git Version Support Policy](#git-version-support-policy)
 - [📢 Project Announcements 📢](#-project-announcements-)
+  - [2026-07-13: v5.0.0.beta.5 Released](#2026-07-13-v500beta5-released)
   - [2026-07-11: v5.0.0.beta.4 Released](#2026-07-11-v500beta4-released)
   - [2026-06-26: v5.0.0.beta.3 Released](#2026-06-26-v500beta3-released)
   - [2026-06-25: v5.0.0.beta.2 Released](#2026-06-25-v500beta2-released)
@@ -663,6 +664,37 @@ impractical. Such changes will be clearly documented in the CHANGELOG and releas
 notes.
 
 ## 📢 Project Announcements 📢
+
+### 2026-07-13: v5.0.0.beta.5 Released
+
+We have published
+[`git v5.0.0.beta.5`](https://rubygems.org/gems/git/versions/5.0.0.beta.5) as our
+fifth pre-release.
+
+The main user-visible change is a temporary compatibility shim for users who
+monkeypatch `Git::Base`. In v5.0.0, `Git::Base` has been replaced by
+`Git::Repository`; the shim forwards methods defined on `Git::Base` to repository
+instances and emits deprecation warnings so applications can migrate those patches
+to `Git::Repository` before v6.0.0.
+
+**To try the beta**, add the pre-release version to your `Gemfile`:
+
+```ruby
+gem 'git', '~> 5.0.0.beta'
+```
+
+Or install it directly:
+
+```sh
+gem install git --pre
+```
+
+The intent is full backward compatibility with v4.x, but given the size and scope of
+the redesign, some incompatibilities may exist. Please give the latest beta a try and
+[open an issue](https://github.com/ruby-git/ruby-git/issues) if you hit anything
+unexpected — your feedback helps us ship a solid v5.0.0.
+
+See [UPGRADING.md](UPGRADING.md) for a full list of deprecations and breaking changes.
 
 ### 2026-07-11: v5.0.0.beta.4 Released
 

--- a/lib/git/version.rb
+++ b/lib/git/version.rb
@@ -4,7 +4,7 @@ module Git
   # The current gem version
   #
   # @return [String] the current gem version
-  VERSION = '5.0.0.beta.4'
+  VERSION = '5.0.0.beta.5'
 
   # Represents a git version with major, minor, and patch components
   #


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

Prepares the manual `v5.0.0.beta.5` release.

The main user-visible change in this beta is PR #1614: a temporary compatibility shim for users who monkeypatch `Git::Base`. The shim keeps methods defined on `Git::Base` available on `Git::Repository` instances while emitting deprecation warnings so applications can migrate those monkeypatches before v6.0.0.

This release also includes the documentation updates merged since `v5.0.0.beta.4`, including the Git::Log path filtering upgrade note, reverse dependency query docs, and stricter option validation upgrading note.

Release prep changes:

- Bump `Git::VERSION` to `5.0.0.beta.5`
- Add the `v5.0.0.beta.5` README announcement
- Leave `.release-please-manifest.json` unchanged so release-please continues accumulating changes for final `v5.0.0`

## Validation

- [x] `bundle exec rake`

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
