### PR TITLE
Audit deprecation warning messages

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -93,6 +93,32 @@ require 'git'
 `Git.open` (e.g., `repo.commit`, `repo.status`, `repo.add`) requires no
 changes.
 
+**Monkeypatching `Git::Base` is deprecated:** v5.x includes a temporary
+compatibility shim for applications that define instance methods on `Git::Base`.
+Those methods are made available on `Git::Repository` instances, but each method
+definition emits a deprecation warning and this shim will be removed in v6.0.0.
+
+Move custom repository helpers to an application-owned extension module and
+include or prepend that module into `Git::Repository` during application setup:
+
+```ruby
+# Deprecated in v5.x and will be removed in v6.0.0
+module Git::Base
+  def worktree_clean?
+    status.changed.empty?
+  end
+end
+
+# v5.x — keep the extension in application-owned code
+module MyAppGitRepositoryExtensions
+  def worktree_clean?
+    status.changed.empty?
+  end
+end
+
+Git::Repository.include(MyAppGitRepositoryExtensions)
+```
+
 ---
 
 #### Return type of `Git.open`, `Git.clone`, `Git.init`, `Git.bare`

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -116,7 +116,7 @@ module Git
   # `Git::Base` is a module included in {Git::Repository}, so any instance
   # methods added to `Git::Base` are automatically available on
   # {Git::Repository} instances. A deprecation warning is emitted for each
-  # method added, encouraging migration to {Git::Repository}.
+  # method added, encouraging migration to an application-owned extension module.
   #
   # @example Monkeypatching Git::Base (deprecated)
   #   module Git::Base
@@ -124,16 +124,17 @@ module Git
   #   end
   #   Git.open('.').my_helper  # => "hello"
   #
-  # @deprecated Define instance methods on {Git::Repository} instead.
+  # @deprecated Move custom methods to an application-owned extension module and
+  #   include or prepend it into {Git::Repository}.
   #
   # @api public
   Base = Module.new do
     # Emit a deprecation warning each time a method is defined in Git::Base so
-    # that authors of monkeypatches are nudged toward Git::Repository.
+    # that authors of monkeypatches are nudged toward application-owned extensions.
     def self.method_added(method_name)
       Git::Deprecation.warn(
         'Monkeypatching Git::Base is deprecated and will be removed in v6.0.0. ' \
-        "Define #{method_name} in Git::Repository instead."
+        "Move #{method_name} to an application-owned extension module for Git::Repository."
       )
       super
     end
@@ -751,7 +752,7 @@ module Git
   def self.binary_version(binary_path = nil)
     binary_path ||= Git::Config.instance.binary_path
     Git::Deprecation.warn(
-      'Git.binary_version is deprecated and will be removed in 6.0. ' \
+      'Git.binary_version is deprecated and will be removed in v6.0.0. ' \
       'Use Git.git_version instead, which returns a Git::Version ' \
       '(not an Array). For the legacy array shape, call: Git.git_version.to_a. ' \
       'The optional binary_path argument is preserved: Git.git_version(binary_path).'

--- a/lib/git/log.rb
+++ b/lib/git/log.rb
@@ -222,7 +222,8 @@ module Git
     # @deprecated Use {#execute} and call `each` on the result.
     def each(&)
       Git::Deprecation.warn(
-        'Calling Git::Log#each is deprecated. Call #execute and then #each on the result object.'
+        'Calling Git::Log#each is deprecated and will be removed in v6.0.0. ' \
+        'Call #execute and then #each on the result object.'
       )
       run_log_if_dirty
       @commits.each(&)
@@ -231,7 +232,8 @@ module Git
     # @deprecated Use {#execute} and call `size` on the result.
     def size
       Git::Deprecation.warn(
-        'Calling Git::Log#size is deprecated. Call #execute and then #size on the result object.'
+        'Calling Git::Log#size is deprecated and will be removed in v6.0.0. ' \
+        'Call #execute and then #size on the result object.'
       )
       run_log_if_dirty
       @commits.size
@@ -240,7 +242,8 @@ module Git
     # @deprecated Use {#execute} and call `to_s` on the result.
     def to_s
       Git::Deprecation.warn(
-        'Calling Git::Log#to_s is deprecated. Call #execute and then #to_s on the result object.'
+        'Calling Git::Log#to_s is deprecated and will be removed in v6.0.0. ' \
+        'Call #execute and then #to_s on the result object.'
       )
       run_log_if_dirty
       @commits.join("\n")
@@ -249,7 +252,8 @@ module Git
     # @deprecated Use {#execute} and call the method on the result.
     def first
       Git::Deprecation.warn(
-        'Calling Git::Log#first is deprecated. Call #execute and then #first on the result object.'
+        'Calling Git::Log#first is deprecated and will be removed in v6.0.0. ' \
+        'Call #execute and then #first on the result object.'
       )
       run_log_if_dirty
       @commits.first
@@ -258,7 +262,8 @@ module Git
     # @deprecated Use {#execute} and call the method on the result.
     def last
       Git::Deprecation.warn(
-        'Calling Git::Log#last is deprecated. Call #execute and then #last on the result object.'
+        'Calling Git::Log#last is deprecated and will be removed in v6.0.0. ' \
+        'Call #execute and then #last on the result object.'
       )
       run_log_if_dirty
       @commits.last
@@ -273,7 +278,8 @@ module Git
     #
     def [](index)
       Git::Deprecation.warn(
-        'Calling Git::Log#[] is deprecated. Call #execute and then #[] on the result object.'
+        'Calling Git::Log#[] is deprecated and will be removed in v6.0.0. ' \
+        'Call #execute and then #[] on the result object.'
       )
       run_log_if_dirty
       @commits[index]

--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -485,7 +485,7 @@ module Git
       #
       def set_commit(data) # rubocop:disable Naming/AccessorMethodName
         Git::Deprecation.warn(
-          'Git::Object::Commit#set_commit is deprecated and will be removed in a future version. ' \
+          'Git::Object::Commit#set_commit is deprecated and will be removed in v6.0.0. ' \
           'Use #from_data instead.'
         )
         from_data(data)
@@ -660,7 +660,10 @@ module Git
     # @deprecated use `Git::Object::Tag.new` instead
     #
     private_class_method def self.new_tag(base, objectish)
-      Git::Deprecation.warn('Git::Object.new with is_tag argument is deprecated. Use Git::Object::Tag.new instead.')
+      Git::Deprecation.warn(
+        'Git::Object.new with is_tag argument is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Object::Tag.new instead.'
+      )
       Git::Object::Tag.new(base, objectish)
     end
 

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -277,7 +277,7 @@ module Git
       #
       def is_local_branch?(branch) # rubocop:disable Naming/PredicatePrefix
         Git::Deprecation.warn(
-          'Git::Repository#is_local_branch? is deprecated and will be removed in a future version. ' \
+          'Git::Repository#is_local_branch? is deprecated and will be removed in v6.0.0. ' \
           'Use Git::Repository#local_branch? instead.'
         )
         local_branch?(branch)
@@ -299,7 +299,7 @@ module Git
       #
       def is_remote_branch?(branch) # rubocop:disable Naming/PredicatePrefix
         Git::Deprecation.warn(
-          'Git::Repository#is_remote_branch? is deprecated and will be removed in a future version. ' \
+          'Git::Repository#is_remote_branch? is deprecated and will be removed in v6.0.0. ' \
           'Use Git::Repository#remote_branch? instead.'
         )
         remote_branch?(branch)
@@ -321,7 +321,7 @@ module Git
       #
       def is_branch?(branch) # rubocop:disable Naming/PredicatePrefix
         Git::Deprecation.warn(
-          'Git::Repository#is_branch? is deprecated and will be removed in a future version. ' \
+          'Git::Repository#is_branch? is deprecated and will be removed in v6.0.0. ' \
           'Use Git::Repository#branch? instead.'
         )
         branch?(branch)

--- a/lib/git/repository/committing.rb
+++ b/lib/git/repository/committing.rb
@@ -73,12 +73,7 @@ module Git
       # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def commit(message, opts = {})
-        opts = opts.dup
-        if opts.key?(:add_all)
-          Git::Deprecation.warn('The :add_all option for #commit is deprecated, use :all instead')
-          opts[:all] = opts.delete(:add_all)
-        end
-
+        opts = normalize_commit_options(opts)
         SharedPrivate.assert_valid_opts!(COMMIT_ALLOWED_OPTS, **opts)
 
         call_opts = { no_edit: true }
@@ -221,6 +216,30 @@ module Git
       #
       def write_and_commit_tree(opts = {})
         commit_tree(write_tree, opts)
+      end
+
+      private
+
+      # Normalizes deprecated commit options into their supported form
+      #
+      # @param opts [Hash] caller-provided commit options
+      #
+      # @option opts [Boolean, nil] :add_all (nil) deprecated alias for `:all`
+      #
+      # @return [Hash] options with deprecated aliases translated
+      #
+      # @api private
+      #
+      def normalize_commit_options(opts)
+        opts = opts.dup
+        return opts unless opts.key?(:add_all)
+
+        Git::Deprecation.warn(
+          'The :add_all option for #commit is deprecated and will be removed in v6.0.0. ' \
+          'Use :all instead.'
+        )
+        opts[:all] = opts.delete(:add_all)
+        opts
       end
     end
   end

--- a/lib/git/repository/context_helpers.rb
+++ b/lib/git/repository/context_helpers.rb
@@ -242,7 +242,7 @@ module Git
       def context_helpers_deprecate_check_argument(check, must_exist)
         if !check.nil? && defined?(Git::Deprecation)
           Git::Deprecation.warn(
-            'The "check" argument is deprecated and will be removed in a future version. ' \
+            'The "check" argument is deprecated and will be removed in v6.0.0. ' \
             'Use "must_exist:" instead.'
           )
         end

--- a/lib/git/repository/diffing.rb
+++ b/lib/git/repository/diffing.rb
@@ -517,7 +517,8 @@ module Git
             opts[:path_limiter]
           elsif opts.key?(:path)
             Git::Deprecation.warn(
-              'Git::Repository#diff_path_status :path option is deprecated. Use :path_limiter instead.'
+              'Git::Repository#diff_path_status :path option is deprecated and will be removed in v6.0.0. ' \
+              'Use :path_limiter instead.'
             )
             opts[:path]
           end

--- a/lib/git/repository/factories.rb
+++ b/lib/git/repository/factories.rb
@@ -750,7 +750,10 @@ module Git
         return unless opts.key?(:path)
 
         if defined?(Git::Deprecation)
-          Git::Deprecation.warn('The :path option for Git.clone is deprecated, use :chdir instead')
+          Git::Deprecation.warn(
+            'The :path option for Git.clone is deprecated and will be removed in v6.0.0. ' \
+            'Use :chdir instead.'
+          )
         end
         path = opts.delete(:path)
         opts[:chdir] ||= path
@@ -775,7 +778,8 @@ module Git
 
         if defined?(Git::Deprecation)
           Git::Deprecation.warn(
-            'The :recursive option for Git.clone is deprecated, use :recurse_submodules instead'
+            'The :recursive option for Git.clone is deprecated and will be removed in v6.0.0. ' \
+            'Use :recurse_submodules instead.'
           )
         end
         opts[:recurse_submodules] = opts.delete(:recursive)
@@ -798,7 +802,10 @@ module Git
         return unless opts.key?(:remote)
 
         if defined?(Git::Deprecation)
-          Git::Deprecation.warn('The :remote option for Git.clone is deprecated, use :origin instead')
+          Git::Deprecation.warn(
+            'The :remote option for Git.clone is deprecated and will be removed in v6.0.0. ' \
+            'Use :origin instead.'
+          )
         end
         opts[:origin] = opts.delete(:remote)
       end

--- a/lib/git/repository/merging.rb
+++ b/lib/git/repository/merging.rb
@@ -245,7 +245,7 @@ module Git
       #
       def conflicts(&)
         Git::Deprecation.warn(
-          'Git::Repository#conflicts is deprecated and will be removed in a future version. ' \
+          'Git::Repository#conflicts is deprecated and will be removed in v6.0.0. ' \
           'Use Git::Repository#each_conflict instead.'
         )
         each_conflict(&)

--- a/lib/git/repository/staging.rb
+++ b/lib/git/repository/staging.rb
@@ -118,8 +118,8 @@ module Git
       #
       def reset_hard(commitish = nil, opts = {})
         Git::Deprecation.warn(
-          'Git::Repository::Staging#reset_hard is deprecated and will be removed in a future version. ' \
-          'Use #reset(commitish, hard: true) instead.'
+          'Git::Repository#reset_hard is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#reset(commitish, hard: true) instead.'
         )
         reset(commitish, **opts, hard: true)
       end
@@ -438,8 +438,17 @@ module Git
         # @raise [ArgumentError] when a deprecated value is not `true`, `false`, or `nil`
         #
         def migrate_clean_legacy_options(opts)
-          opts = deprecate_clean_option(:ff, ':ff option is deprecated. Use force: 2 instead.', opts)
-          deprecate_clean_option(:force_force, ':force_force option is deprecated. Use force: 2 instead.', opts)
+          opts = deprecate_clean_option(
+            :ff,
+            ':ff option is deprecated and will be removed in v6.0.0. Use force: 2 instead.',
+            opts
+          )
+
+          deprecate_clean_option(
+            :force_force,
+            ':force_force option is deprecated and will be removed in v6.0.0. Use force: 2 instead.',
+            opts
+          )
         end
 
         # Translate a single deprecated clean option key onto `:force`

--- a/lib/git/repository/stashing.rb
+++ b/lib/git/repository/stashing.rb
@@ -65,7 +65,7 @@ module Git
       #
       def stash_list
         Git::Deprecation.warn(
-          'Git::Repository#stash_list is deprecated and will be removed in a future version. ' \
+          'Git::Repository#stash_list is deprecated and will be removed in v6.0.0. ' \
           'Use Git::Repository#stashes_all instead.'
         )
         result = Git::Commands::Stash::List.new(@execution_context).call

--- a/lib/git/repository/status_operations.rb
+++ b/lib/git/repository/status_operations.rb
@@ -58,7 +58,7 @@ module Git
       #
       def empty?
         Git::Deprecation.warn(
-          'Git::Repository#empty? is deprecated and will be removed in a future version. ' \
+          'Git::Repository#empty? is deprecated and will be removed in v6.0.0. ' \
           'Use Git::Repository#no_commits? instead.'
         )
         no_commits?

--- a/spec/unit/git/base_spec.rb
+++ b/spec/unit/git/base_spec.rb
@@ -22,10 +22,10 @@ RSpec.describe Git::Base do
     end
 
     context 'when a method is defined in Git::Base' do
-      it 'emits a deprecation warning naming the method and pointing to Git::Repository' do
+      it 'emits a deprecation warning naming the method and recommending an extension module' do
         expect(Git::Deprecation).to receive(:warn).with(
           'Monkeypatching Git::Base is deprecated and will be removed in v6.0.0. ' \
-          "Define #{test_method_name} in Git::Repository instead."
+          "Move #{test_method_name} to an application-owned extension module for Git::Repository."
         )
         described_class.define_method(test_method_name) { nil }
       end

--- a/spec/unit/git/git_version_spec.rb
+++ b/spec/unit/git/git_version_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe Git do
       described_class.binary_version
 
       expect(Git::Deprecation).to have_received(:warn).with(
-        'Git.binary_version is deprecated and will be removed in 6.0. ' \
+        'Git.binary_version is deprecated and will be removed in v6.0.0. ' \
         'Use Git.git_version instead, which returns a Git::Version ' \
         '(not an Array). For the legacy array shape, call: Git.git_version.to_a. ' \
         'The optional binary_path argument is preserved: Git.git_version(binary_path).'

--- a/spec/unit/git/log_spec.rb
+++ b/spec/unit/git/log_spec.rb
@@ -260,7 +260,8 @@ RSpec.describe Git::Log do
     describe '#each' do
       it 'emits a deprecation warning directing callers to #execute' do
         expect(Git::Deprecation).to receive(:warn).with(
-          'Calling Git::Log#each is deprecated. Call #execute and then #each on the result object.'
+          'Calling Git::Log#each is deprecated and will be removed in v6.0.0. ' \
+          'Call #execute and then #each on the result object.'
         )
         described_instance.each { |_commit| nil }
       end
@@ -273,7 +274,8 @@ RSpec.describe Git::Log do
     describe '#size' do
       it 'emits a deprecation warning directing callers to #execute' do
         expect(Git::Deprecation).to receive(:warn).with(
-          'Calling Git::Log#size is deprecated. Call #execute and then #size on the result object.'
+          'Calling Git::Log#size is deprecated and will be removed in v6.0.0. ' \
+          'Call #execute and then #size on the result object.'
         )
         described_instance.size
       end
@@ -286,7 +288,8 @@ RSpec.describe Git::Log do
     describe '#to_s' do
       it 'emits a deprecation warning directing callers to #execute' do
         expect(Git::Deprecation).to receive(:warn).with(
-          'Calling Git::Log#to_s is deprecated. Call #execute and then #to_s on the result object.'
+          'Calling Git::Log#to_s is deprecated and will be removed in v6.0.0. ' \
+          'Call #execute and then #to_s on the result object.'
         )
         described_instance.to_s
       end
@@ -299,7 +302,8 @@ RSpec.describe Git::Log do
     describe '#first' do
       it 'emits a deprecation warning directing callers to #execute' do
         expect(Git::Deprecation).to receive(:warn).with(
-          'Calling Git::Log#first is deprecated. Call #execute and then #first on the result object.'
+          'Calling Git::Log#first is deprecated and will be removed in v6.0.0. ' \
+          'Call #execute and then #first on the result object.'
         )
         described_instance.first
       end
@@ -312,7 +316,8 @@ RSpec.describe Git::Log do
     describe '#last' do
       it 'emits a deprecation warning directing callers to #execute' do
         expect(Git::Deprecation).to receive(:warn).with(
-          'Calling Git::Log#last is deprecated. Call #execute and then #last on the result object.'
+          'Calling Git::Log#last is deprecated and will be removed in v6.0.0. ' \
+          'Call #execute and then #last on the result object.'
         )
         described_instance.last
       end
@@ -325,7 +330,8 @@ RSpec.describe Git::Log do
     describe '#[]' do
       it 'emits a deprecation warning directing callers to #execute' do
         expect(Git::Deprecation).to receive(:warn).with(
-          'Calling Git::Log#[] is deprecated. Call #execute and then #[] on the result object.'
+          'Calling Git::Log#[] is deprecated and will be removed in v6.0.0. ' \
+          'Call #execute and then #[] on the result object.'
         )
         described_instance[0]
       end

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -1061,7 +1061,7 @@ RSpec.describe Git::Repository::Branching do
 
     it 'emits a deprecation warning mentioning is_local_branch? and local_branch?' do
       expect(Git::Deprecation).to receive(:warn).with(
-        'Git::Repository#is_local_branch? is deprecated and will be removed in a future version. ' \
+        'Git::Repository#is_local_branch? is deprecated and will be removed in v6.0.0. ' \
         'Use Git::Repository#local_branch? instead.'
       )
       result
@@ -1105,7 +1105,7 @@ RSpec.describe Git::Repository::Branching do
 
     it 'emits a deprecation warning mentioning is_remote_branch? and remote_branch?' do
       expect(Git::Deprecation).to receive(:warn).with(
-        'Git::Repository#is_remote_branch? is deprecated and will be removed in a future version. ' \
+        'Git::Repository#is_remote_branch? is deprecated and will be removed in v6.0.0. ' \
         'Use Git::Repository#remote_branch? instead.'
       )
       result
@@ -1149,7 +1149,7 @@ RSpec.describe Git::Repository::Branching do
 
     it 'emits a deprecation warning mentioning is_branch? and branch?' do
       expect(Git::Deprecation).to receive(:warn).with(
-        'Git::Repository#is_branch? is deprecated and will be removed in a future version. ' \
+        'Git::Repository#is_branch? is deprecated and will be removed in v6.0.0. ' \
         'Use Git::Repository#branch? instead.'
       )
       result

--- a/spec/unit/git/repository/context_helpers_spec.rb
+++ b/spec/unit/git/repository/context_helpers_spec.rb
@@ -158,7 +158,7 @@ RSpec.describe Git::Repository::ContextHelpers do
 
       it 'warns with the documented "check" argument deprecation message' do
         expect(Git::Deprecation).to receive(:warn).with(
-          'The "check" argument is deprecated and will be removed in a future version. ' \
+          'The "check" argument is deprecated and will be removed in v6.0.0. ' \
           'Use "must_exist:" instead.'
         )
         described_instance.set_index('/nonexistent/index', false)
@@ -334,7 +334,7 @@ RSpec.describe Git::Repository::ContextHelpers do
 
       it 'warns with the documented "check" argument deprecation message' do
         expect(Git::Deprecation).to receive(:warn).with(
-          'The "check" argument is deprecated and will be removed in a future version. ' \
+          'The "check" argument is deprecated and will be removed in v6.0.0. ' \
           'Use "must_exist:" instead.'
         )
         described_instance.set_working('/nonexistent/dir', false)

--- a/spec/unit/git/repository/diffing_spec.rb
+++ b/spec/unit/git/repository/diffing_spec.rb
@@ -634,7 +634,8 @@ RSpec.describe Git::Repository::Diffing do
 
       it 'emits a deprecation warning naming the facade method' do
         expect(Git::Deprecation).to receive(:warn).with(
-          'Git::Repository#diff_path_status :path option is deprecated. Use :path_limiter instead.'
+          'Git::Repository#diff_path_status :path option is deprecated and will be removed in v6.0.0. ' \
+          'Use :path_limiter instead.'
         )
         subject
       end

--- a/spec/unit/git/repository/staging_spec.rb
+++ b/spec/unit/git/repository/staging_spec.rb
@@ -492,7 +492,8 @@ RSpec.describe Git::Repository::Staging do
         # The facade passes force: 0 through to the Clean command, which rejects
         # values <= 0. The ff: true should not mask the invalid force value.
         allow(Git::Commands::Clean).to receive(:new).with(execution_context).and_call_original
-        expect(Git::Deprecation).to receive(:warn).with(':ff option is deprecated. Use force: 2 instead.')
+        expected_message = ':ff option is deprecated and will be removed in v6.0.0. Use force: 2 instead.'
+        expect(Git::Deprecation).to receive(:warn).with(expected_message)
         expect { result }.to raise_error(ArgumentError, /force.*positive Integer/)
       end
     end


### PR DESCRIPTION
# Description

Audit deprecation warning messages so they consistently name the v6.0.0 removal horizon and point callers at the appropriate replacement APIs.

This PR:

- Updates deprecation warnings across core, repository facade, log, object, and staging paths to use the explicit `v6.0.0` horizon.
- Clarifies the `reset_hard` warning to name the public `Git::Repository#reset_hard` facade method and replacement.
- Updates affected specs to assert the revised warning text.
- Adds UPGRADING guidance for the temporary `Git::Base` monkeypatch compatibility shim.

## Validation

- `bundle exec rspec spec/unit/git/base_spec.rb spec/unit/git/git_version_spec.rb spec/unit/git/log_spec.rb spec/unit/git/repository/branching_spec.rb spec/unit/git/repository/context_helpers_spec.rb spec/unit/git/repository/diffing_spec.rb spec/unit/git/repository/staging_spec.rb` — 348 examples, 0 failures
- `bundle exec rspec spec/unit/git/repository/committing_spec.rb` — 42 examples, 0 failures
- `bundle exec rake` — passed; includes unit specs, integration specs, RuboCop, YARD build/lint/example tests, and gem build

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).