### PR TITLE
Remove 328 excessive integration tests to reduce CI build time

### DIFF
--- a/redesign/integration_test_analysis.md
+++ b/redesign/integration_test_analysis.md
@@ -1,5 +1,14 @@
 # Excessive Integration Tests
 
+- [Summary](#summary)
+- [Integration elapsed time data](#integration-elapsed-time-data)
+- [Success criteria](#success-criteria)
+- [Criteria used](#criteria-used)
+- [Tests to remove](#tests-to-remove)
+- [Controversial removals](#controversial-removals)
+
+## Summary
+
 The integration test suite takes **3m 6s** when run sequentially and **4m 22s** on the Windows CI build (which runs tests in parallel). Many of those tests do not add signal beyond what the unit tests already cover — they test git's own behavior, duplicate other integration tests, exercise option variants whose argument building is already verified by unit specs, or exercise single-command delegators that are already covered by the underlying command's own integration spec. Removing them will reduce sequential and CI build times without reducing meaningful coverage.
 
 This document identifies **350 tests** in the [Tests to remove](#tests-to-remove) section that do not satisfy the criteria in the project's three test-standards skills
@@ -94,12 +103,12 @@ The primary success target is the Windows CI parallel build, the current worst-c
 
 | Build | Before | After (measured) | Reduction | Target |
 | ----- | ------ | ---------------- | --------- | ------ |
-| Sequential (local, macOS) | 3m 06s | — | — | < 2m 00s |
-| Parallel (local, macOS) | 0m 31s | — | — | < 0m 25s |
+| Sequential (local, macOS) | 3m 06s | 1m 54s | 38% | < 2m 00s |
+| Parallel (local, macOS) | 0m 31s | 0m 18s | 42% | < 0m 25s |
 | Parallel (Windows CI) | 4m 22s | — | — | < 3m 00s |
 | Parallel (TruffleRuby CI) | 2m 04s | — | — | < 1m 30s |
 | Parallel (JRuby CI) | 1m 52s | — | — | < 1m 20s |
-| Integration test count | 885 | — | — | 557 |
+| Integration test count | 885 | 557 | 37% | 557 |
 
 The work is considered successful when:
 

--- a/redesign/integration_test_analysis.md
+++ b/redesign/integration_test_analysis.md
@@ -84,11 +84,11 @@ On the JRuby 10.0.0.1 build, running integration tests takes 1m 52s.
 
 ## Success criteria
 
-**Scope of the planned deletion work:** remove all 328 tests listed in [Tests to remove](#tests-to-remove) that
+**Scope of the deletion work:** remove all 328 tests listed in [Tests to remove](#tests-to-remove) that
 are *not* also listed in [Controversial removals](#controversial-removals). The 22 controversial
 tests are explicitly out of scope and should not be touched until a separate discussion has reached
-a disposition on each one. This document does not perform any deletions; it records the analysis
-so the deletion work can be done in a subsequent PR.
+a disposition on each one. This document records the analysis and rationale; the deletions are
+implemented in [PR #1622](https://github.com/ruby-git/ruby-git/pull/1622).
 
 328 deletions from a suite of 885 leaves **557 integration tests** (885 − 328 = 557).
 
@@ -101,14 +101,14 @@ builds**.
 
 The primary success target is the Windows CI parallel build, the current worst-case at 4m 22s.
 
-| Build | Before | After (measured) | Reduction | Target |
-| ----- | ------ | ---------------- | --------- | ------ |
-| Sequential (local, macOS) | 3m 06s | 1m 54s | 38% | < 2m 00s |
-| Parallel (local, macOS) | 0m 31s | 0m 18s | 42% | < 0m 25s |
-| Parallel (Windows CI) | 4m 22s | — | — | < 3m 00s |
-| Parallel (TruffleRuby CI) | 2m 04s | — | — | < 1m 30s |
-| Parallel (JRuby CI) | 1m 52s | — | — | < 1m 20s |
-| Integration test count | 885 | 557 | 37% | 557 |
+| Build | Before | After (measured) | Reduction | Target | Success |
+| ----- | ------ | ---------------- | --------- | ------ | ------- |
+| Sequential (local, macOS) | 3m 06s | 1m 54s | 38% | < 2m 00s | YES |
+| Parallel (local, macOS) | 0m 31s | 0m 18s | 42% | < 0m 25s | YES |
+| Parallel (Windows CI) | 4m 22s | 3m 11s | 35% | < 3m 00s | **NO** |
+| Parallel (TruffleRuby CI) | 2m 04s | 1m 19s | 36% | < 1m 30s | YES |
+| Serial (JRuby CI) | 1m 52s | 1m 20s | 29% | < 1m 20s | **NO** |
+| Integration test count | 885 | 557 | 37% | 557 | YES |
 
 The work is considered successful when:
 

--- a/spec/integration/git/commands/add_spec.rb
+++ b/spec/integration/git/commands/add_spec.rb
@@ -28,12 +28,6 @@ RSpec.describe Git::Commands::Add, :integration do
 
       context 'with the all option' do
         before { write_file('file.txt', "modified\n") }
-
-        it 'returns a CommandLineResult' do
-          result = command.call(all: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-        end
       end
     end
 

--- a/spec/integration/git/commands/add_spec.rb
+++ b/spec/integration/git/commands/add_spec.rb
@@ -25,10 +25,6 @@ RSpec.describe Git::Commands::Add, :integration do
           expect(result).to be_a(Git::CommandLine::Result)
         end
       end
-
-      context 'with the all option' do
-        before { write_file('file.txt', "modified\n") }
-      end
     end
 
     describe 'when the command fails' do

--- a/spec/integration/git/commands/am/apply_spec.rb
+++ b/spec/integration/git/commands/am/apply_spec.rb
@@ -35,12 +35,6 @@ RSpec.describe Git::Commands::Am::Apply, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'applies the patch as a new commit' do
-        command.call(mbox_file, chdir: repo_dir)
-
-        expect(File.read(File.join(repo_dir, 'file.txt'))).to eq("line1\nline2\n")
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/apply_spec.rb
+++ b/spec/integration/git/commands/apply_spec.rb
@@ -34,19 +34,6 @@ RSpec.describe Git::Commands::Apply, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'applies the patch to the working tree' do
-        command.call(patch_file, chdir: repo_dir)
-
-        expect(File.read(File.join(repo_dir, 'file.txt'))).to eq("line1\nline2\n")
-      end
-
-      it 'checks the patch cleanly without applying it when :check is passed' do
-        result = command.call(patch_file, check: true, chdir: repo_dir)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(File.read(File.join(repo_dir, 'file.txt'))).to eq("line1\n")
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/archive_spec.rb
+++ b/spec/integration/git/commands/archive_spec.rb
@@ -32,16 +32,6 @@ RSpec.describe Git::Commands::Archive, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to eq(streamed_bytes)
       end
-
-      it 'streams output to a file when out: is given' do
-        Tempfile.create(%w[archive .tar]) do |f|
-          f.binmode
-          result = command.call('HEAD', format: 'tar', out: f)
-          f.flush
-          expect(f.size).to be > 0
-          expect(result.stdout).to eq('')
-        end
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/branch/delete_spec.rb
+++ b/spec/integration/git/commands/branch/delete_spec.rb
@@ -16,15 +16,6 @@ RSpec.describe Git::Commands::Branch::Delete, :integration do
     end
 
     describe 'when the command succeeds' do
-      it 'returns a CommandLineResult with output' do
-        repo.branch('feature').create
-
-        result = command.call('feature')
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.stdout).not_to be_empty
-      end
-
       it 'returns exit code 0 when all branches deleted' do
         repo.branch('feature').create
 
@@ -32,14 +23,6 @@ RSpec.describe Git::Commands::Branch::Delete, :integration do
 
         expect(result.status.exitstatus).to eq(0)
         expect(result.stdout).not_to be_empty
-      end
-
-      it 'returns exit code 1 for partial failure' do
-        repo.branch('exists').create
-
-        result = command.call('exists', 'nonexistent')
-
-        expect(result.status.exitstatus).to eq(1)
       end
 
       it 'returns exit code 1 for nonexistent branch' do

--- a/spec/integration/git/commands/branch/list_spec.rb
+++ b/spec/integration/git/commands/branch/list_spec.rb
@@ -20,13 +20,6 @@ RSpec.describe Git::Commands::Branch::List, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
-
-      it 'returns empty output when there are no branches' do
-        result = command.call
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.stdout).to be_empty
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/branch/set_upstream_spec.rb
+++ b/spec/integration/git/commands/branch/set_upstream_spec.rb
@@ -38,10 +38,6 @@ RSpec.describe Git::Commands::Branch::SetUpstream, :integration do
       it 'raises FailedError when upstream does not exist' do
         expect { command.call(set_upstream_to: 'origin/nonexistent') }.to raise_error(Git::FailedError)
       end
-
-      it 'raises FailedError when branch does not exist' do
-        expect { command.call('nonexistent', set_upstream_to: 'origin/main') }.to raise_error(Git::FailedError)
-      end
     end
   end
 end

--- a/spec/integration/git/commands/branch/unset_upstream_spec.rb
+++ b/spec/integration/git/commands/branch/unset_upstream_spec.rb
@@ -40,10 +40,6 @@ RSpec.describe Git::Commands::Branch::UnsetUpstream, :integration do
 
         expect { command.call }.to raise_error(Git::FailedError)
       end
-
-      it 'raises FailedError when branch does not exist' do
-        expect { command.call('nonexistent') }.to raise_error(Git::FailedError)
-      end
     end
   end
 end

--- a/spec/integration/git/commands/cat_file/batch_spec.rb
+++ b/spec/integration/git/commands/cat_file/batch_spec.rb
@@ -23,36 +23,6 @@ RSpec.describe Git::Commands::CatFile::Batch, :integration do
           expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
-
-        it 'reports missing objects inline without raising' do
-          result = command.call('0000000000000000000000000000000000000000', batch: true)
-
-          expect(result.status.exitstatus).to eq(0)
-        end
-      end
-
-      context 'with --batch-check mode' do
-        it 'returns a CommandLineResult with metadata for the specified object' do
-          result = command.call('HEAD', batch_check: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-          expect(result.stdout).not_to be_empty
-        end
-
-        it 'accepts multiple objects and returns output for each' do
-          result = command.call('HEAD', 'HEAD', batch_check: true)
-
-          expect(result.stdout).not_to be_empty
-        end
-      end
-
-      context 'with --batch-all-objects and --batch-check' do
-        it 'enumerates all objects and returns non-empty output' do
-          result = command.call(batch_all_objects: true, batch_check: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-          expect(result.stdout).not_to be_empty
-        end
       end
     end
 

--- a/spec/integration/git/commands/cat_file/filtered_spec.rb
+++ b/spec/integration/git/commands/cat_file/filtered_spec.rb
@@ -23,22 +23,6 @@ RSpec.describe Git::Commands::CatFile::Filtered, :integration do
           expect(result).to be_a(Git::CommandLine::Result)
           expect(result.stdout).not_to be_empty
         end
-
-        it 'accepts a blob ref with --path= to identify the filter path' do
-          result = command.call('HEAD:README.md', textconv: true, path: 'README.md')
-
-          expect(result).to be_a(Git::CommandLine::Result)
-          expect(result.stdout).not_to be_empty
-        end
-      end
-
-      context 'with --filters mode' do
-        it 'returns a CommandLineResult with the processed blob content' do
-          result = command.call('HEAD:README.md', filters: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-          expect(result.stdout).not_to be_empty
-        end
       end
     end
 

--- a/spec/integration/git/commands/cat_file/raw_spec.rb
+++ b/spec/integration/git/commands/cat_file/raw_spec.rb
@@ -30,53 +30,12 @@ RSpec.describe Git::Commands::CatFile::Raw, :integration do
           expect(result.status.exitstatus).to eq(1)
         end
       end
-
-      context 'with -t mode' do
-        it 'returns a CommandLineResult with the object type' do
-          result = command.call('HEAD', t: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-          expect(result.stdout).not_to be_empty
-        end
-      end
-
-      context 'with -s mode' do
-        it 'returns a CommandLineResult with the object size' do
-          result = command.call('HEAD', s: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-          expect(result.stdout).not_to be_empty
-        end
-      end
-
-      context 'with -p mode' do
-        it 'returns a CommandLineResult with the pretty-printed object content' do
-          result = command.call('HEAD', p: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-          expect(result.stdout).not_to be_empty
-        end
-      end
-
-      context 'with a type operand' do
-        it 'returns a CommandLineResult when the type matches' do
-          result = command.call('blob', 'HEAD:README.md')
-
-          expect(result).to be_a(Git::CommandLine::Result)
-          expect(result.stdout).not_to be_empty
-        end
-      end
     end
 
     context 'when the command fails' do
       it 'raises FailedError when the type does not match the object type' do
         # git's error message varies by version — Rule 22 version-variance exception applies
         expect { command.call('tree', 'HEAD:README.md') }.to raise_error(Git::FailedError)
-      end
-
-      it 'raises FailedError with a nonexistent path in -p mode' do
-        # git's error message varies by version — Rule 22 version-variance exception applies
-        expect { command.call('HEAD:nonexistent_file.txt', p: true) }.to raise_error(Git::FailedError)
       end
     end
   end

--- a/spec/integration/git/commands/checkout/branch_spec.rb
+++ b/spec/integration/git/commands/checkout/branch_spec.rb
@@ -23,12 +23,6 @@ RSpec.describe Git::Commands::Checkout::Branch, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns a CommandLineResult when creating a new branch' do
-        result = command.call(b: 'new-feature')
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
     end
 
     describe 'when the command fails' do

--- a/spec/integration/git/commands/checkout_index_spec.rb
+++ b/spec/integration/git/commands/checkout_index_spec.rb
@@ -21,18 +21,6 @@ RSpec.describe Git::Commands::CheckoutIndex, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns a CommandLineResult with force option' do
-        result = command.call(all: true, force: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
-
-      it 'returns a CommandLineResult for a specific file' do
-        result = command.call('file.txt')
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
     end
 
     describe 'when the command fails' do

--- a/spec/integration/git/commands/clean_spec.rb
+++ b/spec/integration/git/commands/clean_spec.rb
@@ -30,12 +30,6 @@ RSpec.describe Git::Commands::Clean, :integration do
         before do
           write_file('subdir/untracked.txt', "content\n")
         end
-
-        it 'returns a CommandLineResult' do
-          result = command.call(force: true, d: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-        end
       end
     end
 

--- a/spec/integration/git/commands/clean_spec.rb
+++ b/spec/integration/git/commands/clean_spec.rb
@@ -25,12 +25,6 @@ RSpec.describe Git::Commands::Clean, :integration do
           expect(result).to be_a(Git::CommandLine::Result)
         end
       end
-
-      context 'with untracked directories' do
-        before do
-          write_file('subdir/untracked.txt', "content\n")
-        end
-      end
     end
 
     describe 'when the command fails' do

--- a/spec/integration/git/commands/clone_spec.rb
+++ b/spec/integration/git/commands/clone_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Git::Commands::Clone, :integration do
   end
 
   describe '#call' do
-    describe 'when the command succeeds' do
+    context 'when the command succeeds' do
       it 'returns a CommandLineResult' do
         result = command.call(source_dir, File.join(clone_dir, 'cloned'))
 
@@ -37,17 +37,11 @@ RSpec.describe Git::Commands::Clone, :integration do
       end
     end
 
-    describe 'when the command fails' do
+    context 'when the command fails' do
       it 'raises FailedError with a nonexistent source' do
         nonexistent = File.join(clone_dir, 'nonexistent_source')
         expect { command.call(nonexistent, File.join(clone_dir, 'cloned')) }.to raise_error(Git::FailedError)
       end
-    end
-
-    describe 'when the execution context has a logger' do
-      let(:log_output) { StringIO.new }
-      let(:logger) { Logger.new(log_output, level: Logger::DEBUG) }
-      let(:execution_context) { Git::ExecutionContext::Global.new(logger: logger) }
     end
   end
 end

--- a/spec/integration/git/commands/clone_spec.rb
+++ b/spec/integration/git/commands/clone_spec.rb
@@ -35,20 +35,6 @@ RSpec.describe Git::Commands::Clone, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns a CommandLineResult when cloning with chdir' do
-        result = command.call(source_dir, 'chdir-cloned', chdir: clone_dir)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(File.directory?(File.join(clone_dir, 'chdir-cloned'))).to be true
-      end
-
-      it 'returns a CommandLineResult for a bare clone' do
-        result = command.call(source_dir, File.join(clone_dir, 'bare.git'), bare: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(File.directory?(File.join(clone_dir, 'bare.git'))).to be true
-      end
     end
 
     describe 'when the command fails' do
@@ -62,12 +48,6 @@ RSpec.describe Git::Commands::Clone, :integration do
       let(:log_output) { StringIO.new }
       let(:logger) { Logger.new(log_output, level: Logger::DEBUG) }
       let(:execution_context) { Git::ExecutionContext::Global.new(logger: logger) }
-
-      it 'logs the clone command to the configured logger' do
-        command.call(source_dir, File.join(clone_dir, 'logged'))
-
-        expect(log_output.string).to match(/clone/)
-      end
     end
   end
 end

--- a/spec/integration/git/commands/commit_spec.rb
+++ b/spec/integration/git/commands/commit_spec.rb
@@ -23,12 +23,6 @@ RSpec.describe Git::Commands::Commit, :integration do
 
       context 'with allow_empty option' do
         before { repo.commit('Initial commit') }
-
-        it 'returns a CommandLineResult' do
-          result = command.call(message: 'Empty commit', allow_empty: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-        end
       end
     end
 

--- a/spec/integration/git/commands/commit_spec.rb
+++ b/spec/integration/git/commands/commit_spec.rb
@@ -20,10 +20,6 @@ RSpec.describe Git::Commands::Commit, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      context 'with allow_empty option' do
-        before { repo.commit('Initial commit') }
-      end
     end
 
     describe 'when the command fails' do

--- a/spec/integration/git/commands/commit_tree_spec.rb
+++ b/spec/integration/git/commands/commit_tree_spec.rb
@@ -28,30 +28,6 @@ RSpec.describe Git::Commands::CommitTree, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to match(/\A[0-9a-f]{40}\z/)
       end
-
-      it 'creates a commit with the specified parent' do
-        result = command.call(tree_sha, p: initial_commit_sha, m: 'Child commit')
-        new_sha = result.stdout
-
-        # Verify the parent relationship using cat-file
-        commit_content = execution_context.command_capturing('cat-file', '-p', new_sha).stdout
-        expect(commit_content).to include("parent #{initial_commit_sha}")
-      end
-
-      it 'creates a merge commit with multiple parents' do
-        # Create a second branch with a different commit
-        second_sha = command.call(tree_sha, p: initial_commit_sha, m: 'Second branch').stdout
-
-        result = command.call(
-          tree_sha,
-          p: [initial_commit_sha, second_sha],
-          m: 'Merge commit'
-        )
-
-        commit_content = execution_context.command_capturing('cat-file', '-p', result.stdout).stdout
-        expect(commit_content).to include("parent #{initial_commit_sha}")
-        expect(commit_content).to include("parent #{second_sha}")
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/config_option_syntax/get_all_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_all_spec.rb
@@ -16,12 +16,6 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::GetAll, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
       end
 
-      it 'returns the configured value in stdout' do
-        result = command.call('user.name', local: true)
-
-        expect(result.stdout.strip).to eq('Test User')
-      end
-
       it 'returns result with exit status 1 when the key is not found' do
         result = command.call('nonexistent.key')
 

--- a/spec/integration/git/commands/config_option_syntax/get_color_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_color_spec.rb
@@ -19,18 +19,6 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::GetColor, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns result with exit status 0' do
-        result = command.call('color.test.slot')
-
-        expect(result.status.exitstatus).to eq(0)
-      end
-
-      it 'returns exit status 0 when a default is provided for an unset key' do
-        result = command.call('color.nonexistent.slot', 'green')
-
-        expect(result.status.exitstatus).to eq(0)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/config_option_syntax/get_regexp_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_regexp_spec.rb
@@ -10,12 +10,6 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::GetRegexp, :integration do
 
   describe '#call' do
     context 'when the command succeeds' do
-      it 'returns a CommandLineResult' do
-        result = command.call('user\\..*')
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
-
       it 'returns exit status 0 when entries match' do
         result = command.call('user\\..*')
 

--- a/spec/integration/git/commands/config_option_syntax/get_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/get_spec.rb
@@ -10,12 +10,6 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::Get, :integration do
 
   describe '#call' do
     context 'when the command succeeds' do
-      it 'returns a CommandLineResult' do
-        result = command.call('user.name')
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
-
       it 'returns exit code 0 when the key exists' do
         result = command.call('user.name')
 

--- a/spec/integration/git/commands/config_option_syntax/remove_section_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/remove_section_spec.rb
@@ -22,20 +22,6 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::RemoveSection, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns result with exit status 0' do
-        result = command.call('testsection')
-
-        expect(result.status.exitstatus).to eq(0)
-      end
-
-      it 'removes the section entirely' do
-        command.call('testsection')
-
-        get = Git::Commands::ConfigOptionSyntax::Get.new(execution_context)
-        result = get.call('testsection.key')
-        expect(result.status.exitstatus).to eq(1)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/config_option_syntax/rename_section_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/rename_section_spec.rb
@@ -19,18 +19,6 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::RenameSection, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns result with exit status 0' do
-        result = command.call('oldsection', 'newsection')
-
-        expect(result.status.exitstatus).to eq(0)
-      end
-
-      it 'renames the section' do
-        command.call('oldsection', 'newsection')
-
-        expect(repo.config_get('newsection.key').value).to eq('value')
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/config_option_syntax/set_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/set_spec.rb
@@ -16,26 +16,6 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::Set, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns result with exit status 0' do
-        result = command.call('test.key', 'test-value')
-
-        expect(result.status.exitstatus).to eq(0)
-      end
-
-      it 'persists the value' do
-        command.call('test.key', 'test-value')
-
-        get = Git::Commands::ConfigOptionSyntax::Get.new(execution_context)
-        expect(get.call('test.key').stdout.strip).to eq('test-value')
-      end
-
-      it 'validates the value against the type when :type option is given' do
-        command.call('test.flag', 'yes', type: 'bool')
-
-        get = Git::Commands::ConfigOptionSyntax::Get.new(execution_context)
-        expect(get.call('test.flag').stdout.strip).to eq('true')
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/config_option_syntax/unset_all_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/unset_all_spec.rb
@@ -17,12 +17,6 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::UnsetAll, :integration do
         add.call('test.multi', 'value2')
       end
 
-      it 'returns a CommandLineResult' do
-        result = command.call('test.multi')
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
-
       it 'returns exit status 0 when the key exists' do
         result = command.call('test.multi')
 

--- a/spec/integration/git/commands/config_option_syntax/unset_spec.rb
+++ b/spec/integration/git/commands/config_option_syntax/unset_spec.rb
@@ -17,24 +17,10 @@ RSpec.describe Git::Commands::ConfigOptionSyntax::Unset, :integration do
         set.call('test.key', 'test-value')
       end
 
-      it 'returns a CommandLineResult' do
-        result = command.call('test.key')
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
-
       it 'returns result with exit status 0' do
         result = command.call('test.key')
 
         expect(result.status.exitstatus).to eq(0)
-      end
-
-      it 'removes the config entry' do
-        command.call('test.key')
-
-        get = Git::Commands::ConfigOptionSyntax::Get.new(execution_context)
-        result = get.call('test.key')
-        expect(result.status.exitstatus).to eq(1)
       end
 
       it 'returns exit status 5 when the key does not exist' do

--- a/spec/integration/git/commands/describe_spec.rb
+++ b/spec/integration/git/commands/describe_spec.rb
@@ -23,24 +23,6 @@ RSpec.describe Git::Commands::Describe, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
-
-      it 'returns a CommandLineResult with :long option' do
-        result = command.call(tags: true, long: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.stdout).not_to be_empty
-      end
-
-      it 'returns a CommandLineResult with :always option when no tag is reachable' do
-        write_file('file2.txt', 'more content')
-        repo.add('file2.txt')
-        repo.commit('Second commit')
-
-        result = command.call(always: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.stdout).not_to be_empty
-      end
     end
 
     describe 'when the command fails' do

--- a/spec/integration/git/commands/diff_files_spec.rb
+++ b/spec/integration/git/commands/diff_files_spec.rb
@@ -21,19 +21,6 @@ RSpec.describe Git::Commands::DiffFiles, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
-
-      it 'returns a CommandLineResult with diff output when unstaged changes exist' do
-        write_file('file.txt', "modified content\n")
-
-        result = command.call
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.stdout).not_to be_empty
-      end
-
-      it 'accepts a path operand and returns a CommandLineResult' do
-        result = command.call('file.txt')
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/diff_index_spec.rb
+++ b/spec/integration/git/commands/diff_index_spec.rb
@@ -22,27 +22,11 @@ RSpec.describe Git::Commands::DiffIndex, :integration do
         expect(result.status.exitstatus).to eq(0)
       end
 
-      it 'returns a CommandLineResult with exit code 0 when nothing is staged' do
-        result = command.call('HEAD', cached: true)
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.status.exitstatus).to eq(0)
-      end
-
-      it 'accepts a path operand and returns a CommandLineResult' do
-        result = command.call('HEAD', 'file.txt')
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
-
       it 'exits with status 1 when staged changes are present and --exit-code is given' do
         write_file('file.txt', "changed\n")
         repo.add('file.txt')
         result = command.call('HEAD', cached: true, exit_code: true)
         expect(result.status.exitstatus).to eq(1)
-      end
-
-      it 'exits with status 0 when no staged changes and --exit-code is given' do
-        result = command.call('HEAD', cached: true, exit_code: true)
-        expect(result.status.exitstatus).to eq(0)
       end
     end
 

--- a/spec/integration/git/commands/diff_spec.rb
+++ b/spec/integration/git/commands/diff_spec.rb
@@ -10,15 +10,6 @@ RSpec.describe Git::Commands::Diff, :integration do
 
   describe '#call' do
     context 'when the command succeeds' do
-      it 'returns a CommandLineResult' do
-        result = command.call('initial', 'after_modify',
-                              numstat: true, shortstat: true,
-                              src_prefix: 'a/', dst_prefix: 'b/')
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.stdout).not_to be_empty
-      end
-
       it 'returns exit code 0 with no differences' do
         result = command.call('initial', 'initial',
                               numstat: true, shortstat: true,

--- a/spec/integration/git/commands/fsck/fsck_spec.rb
+++ b/spec/integration/git/commands/fsck/fsck_spec.rb
@@ -26,23 +26,6 @@ RSpec.describe Git::Commands::Fsck, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      context 'with options' do
-        it 'accepts multiple options' do
-          result = command.call(root: true, strict: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-        end
-      end
-
-      context 'with specific objects' do
-        it 'checks specific objects by oid' do
-          head_sha = execution_context.command_capturing('rev-parse', 'HEAD').stdout.strip
-          result = command.call(head_sha)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-        end
-      end
     end
 
     describe 'when the command fails' do

--- a/spec/integration/git/commands/grep_spec.rb
+++ b/spec/integration/git/commands/grep_spec.rb
@@ -24,38 +24,6 @@ RSpec.describe Git::Commands::Grep, :integration do
         expect(result.status.exitstatus).to eq(0)
         expect(result.stdout).to include('foo')
       end
-
-      it 'respects the :ignore_case option' do
-        result_sensitive = command.call('HEAD', pattern: 'HELLO')
-        result_insensitive = command.call('HEAD', pattern: 'HELLO', ignore_case: true)
-
-        expect(result_sensitive.status.exitstatus).to eq(1)
-        expect(result_insensitive.status.exitstatus).to eq(0)
-        expect(result_insensitive.stdout).to include('hello')
-      end
-
-      it 'respects the :invert_match option' do
-        result = command.call('HEAD', pattern: 'foo', invert_match: true)
-
-        expect(result.status.exitstatus).to eq(0)
-        expect(result.stdout).not_to include('foo')
-      end
-
-      it 'respects the :extended_regexp option' do
-        result = command.call('HEAD', pattern: 'foo|hello', extended_regexp: true)
-
-        expect(result.status.exitstatus).to eq(0)
-        expect(result.stdout).to include('hello')
-        expect(result.stdout).to include('foo')
-      end
-
-      it 'respects the :pathspec option' do
-        result = command.call('HEAD', pattern: 'foo', pathspec: 'file.txt')
-
-        expect(result.status.exitstatus).to eq(0)
-        expect(result.stdout).to include('file.txt')
-        expect(result.stdout).not_to include('other.txt')
-      end
     end
 
     context 'when no lines are selected (no matches)' do
@@ -64,37 +32,6 @@ RSpec.describe Git::Commands::Grep, :integration do
 
         expect(result.status.exitstatus).to eq(1)
         expect(result.stdout).to be_empty
-      end
-    end
-
-    context 'when the pattern is missing' do
-      it 'raises ArgumentError before executing git' do
-        expect { command.call('HEAD') }.to raise_error(ArgumentError, /pattern/)
-      end
-    end
-
-    context 'with an Array pattern (compound boolean expression)' do
-      it 'matches lines containing both patterns with --and' do
-        result = command.call('HEAD', pattern: ['-e', 'foo', '--and', '-e', 'bar'])
-
-        expect(result.status.exitstatus).to eq(0)
-        expect(result.stdout).to include('foo bar')
-      end
-
-      it 'matches lines containing either pattern with --or' do
-        result = command.call('HEAD', pattern: ['-e', 'hello', '--or', '-e', 'foo'])
-
-        expect(result.status.exitstatus).to eq(0)
-        expect(result.stdout).to include('hello')
-        expect(result.stdout).to include('foo')
-      end
-
-      it 'negates a pattern with --not' do
-        result = command.call('HEAD', pattern: ['--not', '-e', 'foo'])
-
-        expect(result.status.exitstatus).to eq(0)
-        expect(result.stdout).to include('hello')
-        expect(result.stdout).not_to match(/foo/)
       end
     end
   end

--- a/spec/integration/git/commands/init_spec.rb
+++ b/spec/integration/git/commands/init_spec.rb
@@ -22,14 +22,6 @@ RSpec.describe Git::Commands::Init, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      context 'with bare option' do
-        it 'returns a CommandLineResult' do
-          result = command.call(init_dir, bare: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-        end
-      end
     end
 
     describe 'when the command fails' do

--- a/spec/integration/git/commands/log_spec.rb
+++ b/spec/integration/git/commands/log_spec.rb
@@ -26,16 +26,6 @@ RSpec.describe Git::Commands::Log, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
-
-      context 'with a revision range operand' do
-        it 'returns a CommandLineResult for the given range' do
-          first_sha = repo.rev_parse('HEAD~1')
-          result = command.call("#{first_sha}..")
-
-          expect(result).to be_a(Git::CommandLine::Result)
-          expect(result.stdout).not_to be_empty
-        end
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/ls_files_spec.rb
+++ b/spec/integration/git/commands/ls_files_spec.rb
@@ -24,22 +24,8 @@ RSpec.describe Git::Commands::LsFiles, :integration do
         end
       end
 
-      context 'with the :stage option and a pathspec' do
-        it 'returns a CommandLineResult' do
-          result = command.call('.', stage: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-        end
-      end
-
       context 'with :others and :exclude_standard options' do
         before { write_file('untracked.txt', "new content\n") }
-
-        it 'returns a CommandLineResult' do
-          result = command.call(others: true, exclude_standard: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-        end
       end
 
       context 'with :others, :ignored, and :exclude_standard options' do
@@ -49,33 +35,10 @@ RSpec.describe Git::Commands::LsFiles, :integration do
           repo.add('.gitignore')
           repo.commit('Add gitignore')
         end
-
-        it 'returns a CommandLineResult' do
-          result = command.call(others: true, ignored: true, exclude_standard: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-        end
-      end
-
-      context 'with the :chdir execution option' do
-        it 'reports paths relative to the chdir directory' do
-          write_file('subdir/untracked.txt', "content\n")
-
-          result_from_root = command.call(others: true, exclude_standard: true, chdir: repo_dir)
-          result_from_subdir = command.call(others: true, exclude_standard: true,
-                                            chdir: File.join(repo_dir, 'subdir'))
-
-          expect(result_from_root.stdout.split("\n")).to include('subdir/untracked.txt')
-          expect(result_from_subdir.stdout.split("\n")).to include('untracked.txt')
-        end
       end
     end
 
     context 'when the command fails' do
-      it 'raises ArgumentError for unsupported options' do
-        expect { command.call(unknown_flag: true) }.to raise_error(ArgumentError, /Unsupported options/)
-      end
-
       it 'raises FailedError when a path is not in the index' do
         expect { command.call('nonexistent.txt', error_unmatch: true) }
           .to raise_error(Git::FailedError)

--- a/spec/integration/git/commands/ls_files_spec.rb
+++ b/spec/integration/git/commands/ls_files_spec.rb
@@ -23,19 +23,6 @@ RSpec.describe Git::Commands::LsFiles, :integration do
           expect(result).to be_a(Git::CommandLine::Result)
         end
       end
-
-      context 'with :others and :exclude_standard options' do
-        before { write_file('untracked.txt', "new content\n") }
-      end
-
-      context 'with :others, :ignored, and :exclude_standard options' do
-        before do
-          write_file('ignored_file.log', "log content\n")
-          write_file('.gitignore', "*.log\n")
-          repo.add('.gitignore')
-          repo.commit('Add gitignore')
-        end
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/ls_tree_spec.rb
+++ b/spec/integration/git/commands/ls_tree_spec.rb
@@ -24,30 +24,6 @@ RSpec.describe Git::Commands::LsTree, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
-
-      context 'with the :r option (recursive)' do
-        it 'returns a CommandLineResult' do
-          result = command.call('HEAD', r: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-        end
-      end
-
-      context 'with the :name_only option' do
-        it 'returns a CommandLineResult' do
-          result = command.call('HEAD', r: true, name_only: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-        end
-      end
-
-      context 'with a path operand' do
-        it 'returns a CommandLineResult' do
-          result = command.call('HEAD', 'lib/')
-
-          expect(result).to be_a(Git::CommandLine::Result)
-        end
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/maintenance/register_spec.rb
+++ b/spec/integration/git/commands/maintenance/register_spec.rb
@@ -34,12 +34,6 @@ RSpec.describe Git::Commands::Maintenance::Register, :integration,
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns exit code 0' do
-        result = command.call(config_file: global_config.path, env: isolated_env)
-
-        expect(result.status.exitstatus).to eq(0)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/maintenance/run_spec.rb
+++ b/spec/integration/git/commands/maintenance/run_spec.rb
@@ -30,12 +30,6 @@ RSpec.describe Git::Commands::Maintenance::Run, :integration,
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns exit code 0' do
-        result = command.call(env: isolated_env)
-
-        expect(result.status.exitstatus).to eq(0)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/maintenance/start_spec.rb
+++ b/spec/integration/git/commands/maintenance/start_spec.rb
@@ -53,12 +53,6 @@ RSpec.describe Git::Commands::Maintenance::Start, :integration,
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns exit code 0' do
-        result = command.call(scheduler: scheduler, env: isolated_env)
-
-        expect(result.status.exitstatus).to eq(0)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/maintenance/stop_spec.rb
+++ b/spec/integration/git/commands/maintenance/stop_spec.rb
@@ -35,12 +35,6 @@ RSpec.describe Git::Commands::Maintenance::Stop, :integration,
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns exit code 0' do
-        result = command.call(env: isolated_env)
-
-        expect(result.status.exitstatus).to eq(0)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/maintenance/unregister_spec.rb
+++ b/spec/integration/git/commands/maintenance/unregister_spec.rb
@@ -38,12 +38,6 @@ RSpec.describe Git::Commands::Maintenance::Unregister, :integration,
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns exit code 0' do
-        result = command.call(config_file: global_config.path, env: isolated_env)
-
-        expect(result.status.exitstatus).to eq(0)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/merge/continue_spec.rb
+++ b/spec/integration/git/commands/merge/continue_spec.rb
@@ -44,22 +44,6 @@ RSpec.describe Git::Commands::Merge::Continue, :integration do
       it 'raises FailedError when no merge is in progress' do
         expect { command.call }.to raise_error(Git::FailedError)
       end
-
-      it 'raises FailedError when conflicts are not fully resolved' do
-        repo.branch('feature').checkout
-        write_file('file.txt', "feature change\n")
-        repo.add('file.txt')
-        repo.commit('Feature commit')
-
-        repo.checkout('main')
-        write_file('file.txt', "main change\n")
-        repo.add('file.txt')
-        repo.commit('Main commit')
-
-        expect { repo.merge('feature') }.to raise_error(Git::FailedError)
-
-        expect { command.call }.to raise_error(Git::FailedError)
-      end
     end
   end
 end

--- a/spec/integration/git/commands/merge/quit_spec.rb
+++ b/spec/integration/git/commands/merge/quit_spec.rb
@@ -37,12 +37,6 @@ RSpec.describe Git::Commands::Merge::Quit, :integration do
           expect(result).to be_a(Git::CommandLine::Result)
         end
       end
-
-      it 'succeeds when no merge is in progress' do
-        skip 'requires git 2.35.0 or later' unless Git.git_version >= Git::Version.new(2, 35, 0)
-
-        expect { command.call }.not_to raise_error
-      end
     end
 
     describe 'when the command fails' do

--- a/spec/integration/git/commands/merge/start_spec.rb
+++ b/spec/integration/git/commands/merge/start_spec.rb
@@ -32,20 +32,6 @@ RSpec.describe Git::Commands::Merge::Start, :integration do
     end
 
     describe 'when the command fails' do
-      it 'raises FailedError with conflicting changes' do
-        repo.branch('feature').checkout
-        write_file('file.txt', "feature change\n")
-        repo.add('file.txt')
-        repo.commit('Feature commit')
-
-        repo.checkout('main')
-        write_file('file.txt', "main change\n")
-        repo.add('file.txt')
-        repo.commit('Main commit')
-
-        expect { command.call('feature') }.to raise_error(Git::FailedError)
-      end
-
       it 'raises FailedError with a nonexistent ref' do
         expect { command.call('nonexistent') }.to raise_error(Git::FailedError)
       end

--- a/spec/integration/git/commands/merge_base_spec.rb
+++ b/spec/integration/git/commands/merge_base_spec.rb
@@ -24,13 +24,6 @@ RSpec.describe Git::Commands::MergeBase, :integration do
         repo.checkout('main')
       end
 
-      it 'returns a CommandLineResult with output' do
-        result = command.call('main', 'feature')
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.stdout).not_to be_empty
-      end
-
       it 'returns exit 0 without raising when the first commit is an ancestor' do
         result = command.call('main', 'feature', is_ancestor: true)
 

--- a/spec/integration/git/commands/name_rev_spec.rb
+++ b/spec/integration/git/commands/name_rev_spec.rb
@@ -22,14 +22,6 @@ RSpec.describe Git::Commands::NameRev, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to include('main')
       end
-
-      it 'resolves using only tags when :tags is given' do
-        repo.tag_add('v1.0')
-
-        result = command.call('HEAD', tags: true)
-
-        expect(result.stdout).to include('tags/v1.0')
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/push_spec.rb
+++ b/spec/integration/git/commands/push_spec.rb
@@ -30,12 +30,6 @@ RSpec.describe Git::Commands::Push, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns result with exit status 0' do
-        result = command.call('origin', 'main')
-
-        expect(result.status.exitstatus).to eq(0)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/remote/prune_spec.rb
+++ b/spec/integration/git/commands/remote/prune_spec.rb
@@ -23,14 +23,6 @@ RSpec.describe Git::Commands::Remote::Prune, :integration do
 
   describe '#call' do
     context 'when the command succeeds' do
-      it 'supports dry-run pruning for a configured remote' do
-        repo.remote_add('origin', remote_repo.dir.to_s)
-
-        result = command.call('origin', dry_run: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
-
       it 'prunes stale tracking refs for a configured remote' do
         repo.remote_add('origin', remote_repo.dir.to_s)
         repo.fetch('origin')

--- a/spec/integration/git/commands/remote/set_branches_spec.rb
+++ b/spec/integration/git/commands/remote/set_branches_spec.rb
@@ -26,15 +26,6 @@ RSpec.describe Git::Commands::Remote::SetBranches, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns a CommandLineResult with :add option' do
-        repo.remote_add('origin', remote_repo.dir.to_s)
-        command.call('origin', 'main')
-
-        result = command.call('origin', 'release/*', add: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/remote/set_head_spec.rb
+++ b/spec/integration/git/commands/remote/set_head_spec.rb
@@ -31,25 +31,6 @@ RSpec.describe Git::Commands::Remote::SetHead, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'auto-detects the remote HEAD with :auto' do
-        repo.remote_add('origin', remote_repo.dir.to_s)
-        repo.fetch('origin')
-
-        result = command.call('origin', auto: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
-
-      it 'deletes the remote HEAD when :delete is given' do
-        repo.remote_add('origin', remote_repo.dir.to_s)
-        repo.fetch('origin')
-        command.call('origin', initial_branch)
-
-        result = command.call('origin', delete: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/remote/set_url_add_spec.rb
+++ b/spec/integration/git/commands/remote/set_url_add_spec.rb
@@ -31,14 +31,6 @@ RSpec.describe Git::Commands::Remote::SetUrlAdd, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'adds a push url when :push is given' do
-        repo.remote_add('origin', remote_repo.dir.to_s)
-
-        result = command.call('origin', extra_repo.dir.to_s, push: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/remote/set_url_delete_spec.rb
+++ b/spec/integration/git/commands/remote/set_url_delete_spec.rb
@@ -33,16 +33,6 @@ RSpec.describe Git::Commands::Remote::SetUrlDelete, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'deletes a push url when :push is given' do
-        repo.remote_add('origin', remote_repo.dir.to_s)
-        execution_context.command_capturing('remote', 'set-url', '--add', '--push', 'origin', extra_repo.dir.to_s,
-                                            raise_on_failure: false)
-
-        result = command.call('origin', extra_repo.dir.to_s, push: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/remote/set_url_spec.rb
+++ b/spec/integration/git/commands/remote/set_url_spec.rb
@@ -32,14 +32,6 @@ RSpec.describe Git::Commands::Remote::SetUrl, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
         expect(repo.remote('origin').url).to eq(replacement_repo.dir.to_s)
       end
-
-      it 'returns a CommandLineResult with :push option' do
-        repo.remote_add('origin', remote_repo.dir.to_s)
-
-        result = command.call('origin', replacement_repo.dir.to_s, push: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/repack_spec.rb
+++ b/spec/integration/git/commands/repack_spec.rb
@@ -16,13 +16,6 @@ RSpec.describe Git::Commands::Repack, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
         expect(result.status.exitstatus).to eq(0)
       end
-
-      it 'returns a CommandLineResult with :a and :d options' do
-        result = command.call(a: true, d: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.status.exitstatus).to eq(0)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/reset_spec.rb
+++ b/spec/integration/git/commands/reset_spec.rb
@@ -26,29 +26,6 @@ RSpec.describe Git::Commands::Reset, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns a result with exit status 0' do
-        result = command.call
-
-        expect(result.status.exitstatus).to eq(0)
-      end
-
-      it 'hard resets the index and working tree' do
-        result = command.call(hard: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.status.exitstatus).to eq(0)
-      end
-
-      it 'resets specific files via :pathspec' do
-        write_file('other.txt', "other\n")
-        repo.add('other.txt')
-
-        result = command.call(pathspec: ['file.txt'])
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.status.exitstatus).to eq(0)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/rev_parse_spec.rb
+++ b/spec/integration/git/commands/rev_parse_spec.rb
@@ -22,13 +22,6 @@ RSpec.describe Git::Commands::RevParse, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
-
-      it 'returns a CommandLineResult for --show-toplevel' do
-        result = command.call(show_toplevel: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.stdout).not_to be_empty
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/revert/quit_spec.rb
+++ b/spec/integration/git/commands/revert/quit_spec.rb
@@ -24,16 +24,6 @@ RSpec.describe Git::Commands::Revert::Quit, :integration do
 
   describe '#call' do
     context 'when the command succeeds' do
-      context 'when a revert is in progress' do
-        before do
-          # Start a conflicting revert to open a revert session
-          execution_context.command_capturing(
-            'revert', '--no-edit', 'HEAD~1',
-            chdir: repo_dir, raise_on_failure: false
-          )
-        end
-      end
-
       context 'when no revert is in progress' do
         it 'returns a CommandLineResult (no-op unlike --abort)' do
           result = command.call

--- a/spec/integration/git/commands/revert/quit_spec.rb
+++ b/spec/integration/git/commands/revert/quit_spec.rb
@@ -32,12 +32,6 @@ RSpec.describe Git::Commands::Revert::Quit, :integration do
             chdir: repo_dir, raise_on_failure: false
           )
         end
-
-        it 'returns a CommandLineResult' do
-          result = command.call
-
-          expect(result).to be_a(Git::CommandLine::Result)
-        end
       end
 
       context 'when no revert is in progress' do

--- a/spec/integration/git/commands/rm_spec.rb
+++ b/spec/integration/git/commands/rm_spec.rb
@@ -21,14 +21,6 @@ RSpec.describe Git::Commands::Rm, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      context 'with cached option' do
-        it 'returns a CommandLineResult' do
-          result = command.call('file.txt', cached: true)
-
-          expect(result).to be_a(Git::CommandLine::Result)
-        end
-      end
     end
 
     describe 'when the command fails' do

--- a/spec/integration/git/commands/show_ref/exclude_existing_spec.rb
+++ b/spec/integration/git/commands/show_ref/exclude_existing_spec.rb
@@ -21,25 +21,6 @@ RSpec.describe Git::Commands::ShowRef::ExcludeExisting, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns exit status 0' do
-        result = command.call
-
-        expect(result.status.exitstatus).to eq(0)
-      end
-
-      it 'returns exit status 0 with a mix of existing and nonexistent refs' do
-        result = command.call('refs/heads/main', 'refs/heads/nonexistent')
-
-        expect(result.status.exitstatus).to eq(0)
-      end
-
-      it 'echoes only refs that do not already exist locally' do
-        result = command.call('refs/heads/main', 'refs/heads/nonexistent')
-
-        stdout_refs = result.stdout.lines.map(&:chomp).reject(&:empty?)
-        expect(stdout_refs).to eq(['refs/heads/nonexistent'])
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/show_ref/exists_spec.rb
+++ b/spec/integration/git/commands/show_ref/exists_spec.rb
@@ -16,12 +16,6 @@ RSpec.describe Git::Commands::ShowRef::Exists, :integration, skip: unless_git('2
 
   describe '#call' do
     context 'when the command succeeds' do
-      it 'returns a CommandLineResult for an existing ref' do
-        result = command.call('refs/heads/main')
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
-
       it 'returns exit code 0 when the ref exists' do
         result = command.call('refs/heads/main')
 

--- a/spec/integration/git/commands/show_ref/list_spec.rb
+++ b/spec/integration/git/commands/show_ref/list_spec.rb
@@ -17,12 +17,6 @@ RSpec.describe Git::Commands::ShowRef::List, :integration do
 
   describe '#call' do
     context 'when the command succeeds' do
-      it 'returns a CommandLineResult' do
-        result = command.call
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
-
       it 'returns exit status 0 when refs are found' do
         result = command.call
 
@@ -33,39 +27,6 @@ RSpec.describe Git::Commands::ShowRef::List, :integration do
         result = command.call('nonexistent-ref-xyz')
 
         expect(result.status.exitstatus).to eq(1)
-      end
-
-      it 'returns exit status 0 with the :tags option' do
-        result = command.call(tags: true)
-
-        expect(result.status.exitstatus).to eq(0)
-      end
-
-      it 'returns exit status 0 with the :heads option' do
-        result = command.call(heads: true)
-
-        expect(result.status.exitstatus).to eq(0)
-      end
-
-      it 'returns exit status 0 with the :branches option',
-         skip: unless_git('2.46.0', 'git show-ref --branches') do
-        result = command.call(branches: true)
-
-        expect(result.status.exitstatus).to eq(0)
-      end
-
-      it 'returns exit status 0 with the :head option' do
-        result = command.call(head: true)
-
-        expect(result.status.exitstatus).to eq(0)
-      end
-
-      it 'returns exit status 0 with the :dereference option' do
-        repo.tag_add('v1.0-annotated', annotate: true, message: 'annotation')
-
-        result = command.call(dereference: true)
-
-        expect(result.status.exitstatus).to eq(0)
       end
     end
 

--- a/spec/integration/git/commands/show_ref/verify_spec.rb
+++ b/spec/integration/git/commands/show_ref/verify_spec.rb
@@ -21,25 +21,12 @@ RSpec.describe Git::Commands::ShowRef::Verify, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns exit status 0 for an existing ref' do
-        result = command.call('refs/heads/main')
-
-        expect(result.status.exitstatus).to eq(0)
-      end
     end
 
     context 'when the command fails' do
       it 'raises FailedError for a nonexistent ref' do
         expect { command.call('refs/heads/nonexistent') }
           .to raise_error(Git::FailedError, /nonexistent/)
-      end
-
-      it 'raises FailedError when not in a git repository' do
-        FileUtils.rm_rf(File.join(repo_dir, '.git'))
-
-        expect { command.call('refs/heads/main') }
-          .to raise_error(Git::FailedError, /git repository/)
       end
     end
   end

--- a/spec/integration/git/commands/show_spec.rb
+++ b/spec/integration/git/commands/show_spec.rb
@@ -23,14 +23,6 @@ RSpec.describe Git::Commands::Show, :integration do
         expect(result.status.success?).to be true
         expect(result.stdout).not_to be_empty
       end
-
-      it 'streams blob content into an IO object when out: is given' do
-        io = StringIO.new
-        result = command.call('HEAD:test.txt', out: io)
-
-        expect(io.string).to eq("Hello, World!\n")
-        expect(result.stdout).to eq('')
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/stash/branch_spec.rb
+++ b/spec/integration/git/commands/stash/branch_spec.rb
@@ -33,12 +33,6 @@ RSpec.describe Git::Commands::Stash::Branch, :integration do
       it 'raises FailedError with nonexistent stash' do
         expect { command.call('new-branch', 'stash@{99}') }.to raise_error(Git::FailedError)
       end
-
-      it 'raises FailedError with existing branch name' do
-        repo.branch('existing-branch').create
-
-        expect { command.call('existing-branch') }.to raise_error(Git::FailedError)
-      end
     end
   end
 end

--- a/spec/integration/git/commands/stash/create_spec.rb
+++ b/spec/integration/git/commands/stash/create_spec.rb
@@ -26,15 +26,6 @@ RSpec.describe Git::Commands::Stash::Create, :integration do
           expect(result.stdout.strip).not_to be_empty
         end
       end
-
-      context 'with no local changes' do
-        it 'returns a CommandLineResult with empty output' do
-          result = command.call
-
-          expect(result).to be_a(Git::CommandLine::Result)
-          expect(result.stdout.strip).to be_empty
-        end
-      end
     end
 
     describe 'when the command fails' do

--- a/spec/integration/git/commands/stash/list_spec.rb
+++ b/spec/integration/git/commands/stash/list_spec.rb
@@ -18,16 +18,6 @@ RSpec.describe Git::Commands::Stash::List, :integration do
 
   describe '#call' do
     describe 'when the command succeeds' do
-      context 'with no stashes' do
-        it 'returns CommandLineResult with empty output' do
-          result = command.call
-
-          expect(result).to be_a(Git::CommandLine::Result)
-          expect(result.status.exitstatus).to eq(0)
-          expect(result.stdout).to be_empty
-        end
-      end
-
       context 'with stashes' do
         before do
           write_file('file.txt', 'modified content')

--- a/spec/integration/git/commands/stash/push_spec.rb
+++ b/spec/integration/git/commands/stash/push_spec.rb
@@ -29,15 +29,6 @@ RSpec.describe Git::Commands::Stash::Push, :integration do
           expect(result.stdout).not_to be_empty
         end
       end
-
-      context 'with no changes' do
-        it 'returns a CommandLineResult' do
-          result = command.call
-
-          expect(result).to be_a(Git::CommandLine::Result)
-          expect(result.stdout).not_to be_empty
-        end
-      end
     end
 
     describe 'when the command fails' do

--- a/spec/integration/git/commands/stash/show_spec.rb
+++ b/spec/integration/git/commands/stash/show_spec.rb
@@ -25,20 +25,6 @@ RSpec.describe Git::Commands::Stash::Show, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
-
-      it 'returns a CommandLineResult with patch output' do
-        result = command.call(patch: true, numstat: true, shortstat: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.stdout).not_to be_empty
-      end
-
-      it 'returns a CommandLineResult with raw output' do
-        result = command.call(raw: true)
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.stdout).not_to be_empty
-      end
     end
 
     describe 'when the command fails' do

--- a/spec/integration/git/commands/status_spec.rb
+++ b/spec/integration/git/commands/status_spec.rb
@@ -21,12 +21,6 @@ RSpec.describe Git::Commands::Status, :integration do
 
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns a CommandLineResult with a path operand' do
-        result = command.call('file.txt')
-
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/symbolic_ref/read_spec.rb
+++ b/spec/integration/git/commands/symbolic_ref/read_spec.rb
@@ -17,12 +17,6 @@ RSpec.describe Git::Commands::SymbolicRef::Read, :integration do
         expect(result.stdout.strip).to eq('refs/heads/main')
       end
 
-      it 'returns the shortened ref name with :short' do
-        result = command.call('HEAD', short: true)
-
-        expect(result.stdout.strip).to eq('main')
-      end
-
       context 'when HEAD is detached' do
         before do
           write_file('initial.txt', 'content')

--- a/spec/integration/git/commands/symbolic_ref/update_spec.rb
+++ b/spec/integration/git/commands/symbolic_ref/update_spec.rb
@@ -19,15 +19,6 @@ RSpec.describe Git::Commands::SymbolicRef::Update, :integration do
         head_content = File.read(File.join(repo_dir, '.git', 'HEAD')).strip
         expect(head_content).to eq('ref: refs/heads/new-branch')
       end
-
-      it 'updates the symbolic ref with the :m option' do
-        result = command.call('HEAD', 'refs/heads/feature', m: 'switching to feature')
-
-        expect(result.status.exitstatus).to eq(0)
-
-        head_content = File.read(File.join(repo_dir, '.git', 'HEAD')).strip
-        expect(head_content).to eq('ref: refs/heads/feature')
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/tag/delete_spec.rb
+++ b/spec/integration/git/commands/tag/delete_spec.rb
@@ -24,12 +24,6 @@ RSpec.describe Git::Commands::Tag::Delete, :integration do
         expect(result.stdout).not_to be_empty
       end
 
-      it 'returns exit code 0 when all tags are deleted' do
-        result = command.call('v1.0.0')
-
-        expect(result.status.exitstatus).to eq(0)
-      end
-
       it 'returns exit code 1 for partial failure' do
         repo.tag_add('v2.0.0')
 

--- a/spec/integration/git/commands/tag/list_spec.rb
+++ b/spec/integration/git/commands/tag/list_spec.rb
@@ -21,13 +21,6 @@ RSpec.describe Git::Commands::Tag::List, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).not_to be_empty
       end
-
-      it 'returns empty stdout when there are no tags' do
-        result = command.call
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(result.stdout).to be_empty
-      end
     end
 
     describe 'when the command fails' do

--- a/spec/integration/git/commands/tag/verify_spec.rb
+++ b/spec/integration/git/commands/tag/verify_spec.rb
@@ -15,16 +15,7 @@ RSpec.describe Git::Commands::Tag::Verify, :integration do
       repo.commit('Initial commit')
     end
 
-    # Signed tag tests require GPG configuration which may not be available
-    # in all CI environments. These tests are skipped unless GPG is configured.
-    describe 'when the command succeeds', skip: 'Requires GPG configuration' do
-      # To run these tests locally:
-      # 1. Configure GPG: git config user.signingkey <your-gpg-key-id>
-      # 2. Enable signing: git config tag.gpgsign true
-      # 3. Create a signed tag: git tag -s v3.0.0 -m "Signed release"
-    end
-
-    describe 'when the command fails' do
+    context 'when the command fails' do
       it 'raises FailedError for a non-existent tag' do
         expect { command.call('nonexistent') }.to raise_error(Git::FailedError)
       end

--- a/spec/integration/git/commands/tag/verify_spec.rb
+++ b/spec/integration/git/commands/tag/verify_spec.rb
@@ -22,44 +22,11 @@ RSpec.describe Git::Commands::Tag::Verify, :integration do
       # 1. Configure GPG: git config user.signingkey <your-gpg-key-id>
       # 2. Enable signing: git config tag.gpgsign true
       # 3. Create a signed tag: git tag -s v3.0.0 -m "Signed release"
-
-      it 'verifies a signed tag successfully' do
-        # This would need:
-        # repo.tag_add('v3.0.0', sign: true, message: 'Signed release')
-        # result = command.call('v3.0.0')
-        # expect(result.stdout).to include('Good signature')
-      end
     end
 
     describe 'when the command fails' do
-      it 'raises FailedError for an unsigned lightweight tag' do
-        repo.tag_add('v1.0.0')
-
-        expect { command.call('v1.0.0') }.to raise_error(Git::FailedError)
-      end
-
-      it 'raises FailedError for an unsigned annotated tag' do
-        repo.tag_add('v2.0.0', annotate: true, message: 'Release version 2.0.0')
-
-        expect { command.call('v2.0.0') }.to raise_error(Git::FailedError)
-      end
-
       it 'raises FailedError for a non-existent tag' do
         expect { command.call('nonexistent') }.to raise_error(Git::FailedError)
-      end
-
-      it 'raises FailedError when any tag is unsigned' do
-        repo.tag_add('v1.0.0')
-        repo.tag_add('v2.0.0', annotate: true, message: 'Release 2.0')
-
-        expect { command.call('v1.0.0', 'v2.0.0') }.to raise_error(Git::FailedError)
-      end
-
-      it 'raises FailedError with format option on unsigned tag' do
-        repo.tag_add('v1.0.0')
-
-        # Format option is still passed through even when verification fails
-        expect { command.call('v1.0.0', format: '%(refname:short)') }.to raise_error(Git::FailedError)
       end
     end
   end

--- a/spec/integration/git/commands/update_ref/batch_spec.rb
+++ b/spec/integration/git/commands/update_ref/batch_spec.rb
@@ -28,37 +28,6 @@ RSpec.describe Git::Commands::UpdateRef::Batch, :integration do
         expect(repo.rev_parse('refs/heads/batch-a')).to eq(head_sha)
         expect(repo.rev_parse('refs/heads/batch-b')).to eq(head_sha)
       end
-
-      it 'atomically deletes refs via stdin' do
-        head_sha = repo.rev_parse('HEAD')
-        repo.branch('to-delete').create
-
-        result = command.call("delete refs/heads/to-delete #{head_sha}")
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect { repo.rev_parse('refs/heads/to-delete') }.to raise_error(Git::FailedError)
-      end
-
-      it 'atomically updates and deletes refs in one call' do
-        head_sha = repo.rev_parse('HEAD')
-        repo.branch('to-update').create
-        repo.branch('to-delete').create
-
-        # Create a new commit to update to
-        write_file('file.txt', "updated\n")
-        repo.add('file.txt')
-        repo.commit('Second commit')
-        new_sha = repo.rev_parse('HEAD')
-
-        result = command.call(
-          "update refs/heads/to-update #{new_sha} #{head_sha}",
-          "delete refs/heads/to-delete #{head_sha}"
-        )
-
-        expect(result).to be_a(Git::CommandLine::Result)
-        expect(repo.rev_parse('refs/heads/to-update')).to eq(new_sha)
-        expect { repo.rev_parse('refs/heads/to-delete') }.to raise_error(Git::FailedError)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/version_spec.rb
+++ b/spec/integration/git/commands/version_spec.rb
@@ -19,12 +19,5 @@ RSpec.describe Git::Commands::Version, :integration do
         expect(result.stderr).to be_empty
       end
     end
-
-    context 'with unsupported options' do
-      it 'raises ArgumentError for unsupported options' do
-        expect { command.call(unsupported: true) }
-          .to raise_error(ArgumentError, /Unsupported options/)
-      end
-    end
   end
 end

--- a/spec/integration/git/commands/worktree/add_spec.rb
+++ b/spec/integration/git/commands/worktree/add_spec.rb
@@ -26,28 +26,12 @@ RSpec.describe Git::Commands::Worktree::Add, :integration do
           result = command.call(worktree_path)
           expect(result).to be_a(Git::CommandLine::Result)
         end
-
-        it 'creates the worktree directory on disk' do
-          command.call(worktree_path)
-          expect(File.directory?(worktree_path)).to be(true)
-        end
-
-        it 'creates a .git file in the worktree' do
-          command.call(worktree_path)
-          expect(File.exist?(File.join(worktree_path, '.git'))).to be(true)
-        end
       end
 
       context 'with --detach' do
         let(:worktree_path) { File.join(repo_dir, '..', "worktree-detach-#{SecureRandom.hex(4)}") }
 
         after { FileUtils.rm_rf(worktree_path) }
-
-        it 'creates a detached HEAD worktree' do
-          result = command.call(worktree_path, detach: true)
-          expect(result).to be_a(Git::CommandLine::Result)
-          expect(File.directory?(worktree_path)).to be(true)
-        end
       end
     end
 

--- a/spec/integration/git/commands/worktree/add_spec.rb
+++ b/spec/integration/git/commands/worktree/add_spec.rb
@@ -27,12 +27,6 @@ RSpec.describe Git::Commands::Worktree::Add, :integration do
           expect(result).to be_a(Git::CommandLine::Result)
         end
       end
-
-      context 'with --detach' do
-        let(:worktree_path) { File.join(repo_dir, '..', "worktree-detach-#{SecureRandom.hex(4)}") }
-
-        after { FileUtils.rm_rf(worktree_path) }
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/worktree/list_spec.rb
+++ b/spec/integration/git/commands/worktree/list_spec.rb
@@ -20,29 +20,6 @@ RSpec.describe Git::Commands::Worktree::List, :integration do
         result = command.call
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns a CommandLineResult with the :porcelain option' do
-        result = command.call(porcelain: true)
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
-
-      it 'returns a CommandLineResult with the :verbose option',
-         skip: unless_git('2.33.0', 'git worktree list --verbose') do
-        result = command.call(verbose: true)
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
-
-      it 'returns a CommandLineResult with the :z option combined with :porcelain',
-         skip: unless_git('2.36.0', 'git worktree list --porcelain -z') do
-        result = command.call(porcelain: true, z: true)
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
-
-      it 'returns a CommandLineResult with the :expire option',
-         skip: unless_git('2.33.0', 'git worktree list --expire') do
-        result = command.call(expire: '2.weeks.ago')
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/worktree/lock_spec.rb
+++ b/spec/integration/git/commands/worktree/lock_spec.rb
@@ -27,11 +27,6 @@ RSpec.describe Git::Commands::Worktree::Lock, :integration do
         result = command.call(worktree_path)
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'locks the worktree with a reason' do
-        result = command.call(worktree_path, reason: 'on NFS share')
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/worktree/prune_spec.rb
+++ b/spec/integration/git/commands/worktree/prune_spec.rb
@@ -20,16 +20,6 @@ RSpec.describe Git::Commands::Worktree::Prune, :integration do
         result = command.call
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'returns a CommandLineResult with --dry-run' do
-        result = command.call(dry_run: true)
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
-
-      it 'returns a CommandLineResult with --verbose' do
-        result = command.call(verbose: true)
-        expect(result).to be_a(Git::CommandLine::Result)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/worktree/remove_spec.rb
+++ b/spec/integration/git/commands/worktree/remove_spec.rb
@@ -28,11 +28,6 @@ RSpec.describe Git::Commands::Worktree::Remove, :integration do
         result = command.call(worktree_path)
         expect(result).to be_a(Git::CommandLine::Result)
       end
-
-      it 'removes the worktree directory from disk' do
-        command.call(worktree_path)
-        expect(File.directory?(worktree_path)).to be(false)
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/commands/write_tree_spec.rb
+++ b/spec/integration/git/commands/write_tree_spec.rb
@@ -22,18 +22,6 @@ RSpec.describe Git::Commands::WriteTree, :integration do
         expect(result).to be_a(Git::CommandLine::Result)
         expect(result.stdout).to match(/\A[0-9a-f]{40}\z/)
       end
-
-      context 'with the :prefix option' do
-        it 'writes a tree object for a subdirectory' do
-          write_file('sub/file.txt', "content\n")
-          repo.add('sub/file.txt')
-
-          result = command.call(prefix: 'sub/')
-
-          expect(result).to be_a(Git::CommandLine::Result)
-          expect(result.stdout).to match(/\A[0-9a-f]{40}\z/)
-        end
-      end
     end
 
     context 'when the command fails' do

--- a/spec/integration/git/git_spec.rb
+++ b/spec/integration/git/git_spec.rb
@@ -18,10 +18,6 @@ RSpec.describe Git, :integration do
 
     let(:options) { {} }
 
-    it 'returns a Git::Repository' do
-      expect(repository).to be_a(Git::Repository)
-    end
-
     it 'exposes the working directory through #dir' do
       expect(repository.dir).to eq(Pathname.new(repo_dir).realpath)
     end
@@ -125,10 +121,6 @@ RSpec.describe Git, :integration do
 
     after { FileUtils.rm_rf(bare_dir) }
 
-    it 'returns a Git::Repository' do
-      expect(repository).to be_a(Git::Repository)
-    end
-
     it 'has no working directory' do
       expect(repository.dir).to be_nil
     end
@@ -161,10 +153,6 @@ RSpec.describe Git, :integration do
       FileUtils.rm_rf(parent_dir)
     end
 
-    it 'returns a Git::Repository' do
-      expect(repository).to be_a(Git::Repository)
-    end
-
     it 'sets #dir to the cloned working directory' do
       expect(repository.dir).to be_a(Pathname)
       expect(repository.dir.directory?).to be(true)
@@ -184,10 +172,6 @@ RSpec.describe Git, :integration do
 
       subject(:repository) { Git.clone(source_dir, bare_clone_dir, bare: true) }
 
-      it 'returns a Git::Repository' do
-        expect(repository).to be_a(Git::Repository)
-      end
-
       it 'has no working directory' do
         expect(repository.dir).to be_nil
       end
@@ -205,10 +189,6 @@ RSpec.describe Git, :integration do
 
       subject(:repository) { Git.clone(source_dir, 'my-clone', chdir: chdir_dir) }
 
-      it 'returns a Git::Repository' do
-        expect(repository).to be_a(Git::Repository)
-      end
-
       it 'sets #dir to the clone subdirectory within chdir' do
         expected_path = File.join(chdir_dir, 'my-clone')
         expect(repository.dir).to eq(Pathname.new(expected_path))
@@ -219,10 +199,6 @@ RSpec.describe Git, :integration do
       let(:custom_index) { File.join(parent_dir, 'custom.index') }
 
       subject(:repository) { Git.clone(source_dir, clone_dir, index: custom_index) }
-
-      it 'returns a Git::Repository' do
-        expect(repository).to be_a(Git::Repository)
-      end
 
       it 'uses the given index path' do
         expect(repository.index).to eq(Pathname.new(custom_index))
@@ -235,10 +211,6 @@ RSpec.describe Git, :integration do
       after { FileUtils.rm_rf(File.dirname(separate_git_dir)) }
 
       subject(:repository) { Git.clone(source_dir, clone_dir, repository: separate_git_dir) }
-
-      it 'returns a Git::Repository' do
-        expect(repository).to be_a(Git::Repository)
-      end
 
       it 'sets #repo to the separate git directory' do
         expect(repository.repo).to eq(Pathname.new(separate_git_dir).realpath)
@@ -259,10 +231,6 @@ RSpec.describe Git, :integration do
     let(:init_dir) { Dir.mktmpdir }
 
     after { FileUtils.rm_rf(init_dir) }
-
-    it 'returns a Git::Repository' do
-      expect(repository).to be_a(Git::Repository)
-    end
 
     it 'sets #dir to the initialized working directory' do
       expect(repository.dir).to be_a(Pathname)
@@ -285,10 +253,6 @@ RSpec.describe Git, :integration do
 
       subject(:repository) { Git.init(bare_dir, bare: true) }
 
-      it 'returns a Git::Repository' do
-        expect(repository).to be_a(Git::Repository)
-      end
-
       it 'has no working directory' do
         expect(repository.dir).to be_nil
       end
@@ -304,10 +268,6 @@ RSpec.describe Git, :integration do
 
       subject(:repository) { Git.init(init_dir, separate_git_dir: separate_git_dir) }
 
-      it 'returns a Git::Repository' do
-        expect(repository).to be_a(Git::Repository)
-      end
-
       it 'stores the .git data in the separate directory' do
         expect(repository.repo).to eq(Pathname.new(separate_git_dir))
       end
@@ -322,10 +282,6 @@ RSpec.describe Git, :integration do
 
     context 'with :initial_branch option' do
       subject(:repository) { Git.init(init_dir, initial_branch: 'trunk') }
-
-      it 'returns a Git::Repository' do
-        expect(repository).to be_a(Git::Repository)
-      end
 
       it 'initializes with the specified branch name' do
         head_content = File.read(File.join(repository.repo.to_s, 'HEAD'))

--- a/spec/integration/git/parsers/branch_spec.rb
+++ b/spec/integration/git/parsers/branch_spec.rb
@@ -27,56 +27,9 @@ RSpec.describe Git::Parsers::Branch, :integration do
       repo.add('file.txt')
       repo.commit('Initial commit')
     end
-
-    it 'uses pipe as field delimiter' do
-      output = git_branch_output
-      expect(output).to include(described_class::FIELD_DELIMITER)
-    end
-
-    it 'produces exactly 6 fields per line' do
-      output = git_branch_output
-      output.each_line do |line|
-        next if line.strip.empty?
-
-        # Split with -1 to keep trailing empty fields
-        fields = line.chomp.split(described_class::FIELD_DELIMITER, -1)
-        expect(fields.size).to eq(6), "Expected 6 fields but got #{fields.size}: #{line.inspect}"
-      end
-    end
-
-    it 'produces field order: refname, objectname, HEAD, worktreepath, symref, upstream' do
-      output = git_branch_output
-      line = output.lines.find { |l| l.include?('main') }
-      fields = line.chomp.split(described_class::FIELD_DELIMITER, -1)
-
-      # Field 0: refname - should contain 'main'
-      expect(fields[0]).to include('main')
-
-      # Field 1: objectname - should be 40-char hex SHA
-      expect(fields[1]).to match(/\A[0-9a-f]{40}\z/)
-
-      # Field 2: HEAD - should be '*' for current branch or empty
-      expect(fields[2]).to eq('*').or eq('')
-
-      # Field 3: worktreepath - should be empty or an absolute path (Unix: /path or Windows: C:/path)
-      expect(fields[3]).to match(%r{\A(|[A-Za-z]:/.*|/.+)\z})
-
-      # Field 4: symref - should be empty or a ref
-      expect(fields[4]).to match(%r{\A(|refs/.*)\z})
-
-      # Field 5: upstream - should be empty or a ref
-      expect(fields[5]).to match(%r{\A(|refs/.*)\z})
-    end
   end
 
   describe '.parse_list' do
-    context 'when there are no branches' do
-      it 'returns an empty array' do
-        result = described_class.parse_list('')
-        expect(result).to eq([])
-      end
-    end
-
     context 'with basic branches' do
       before do
         write_file('file.txt')
@@ -190,14 +143,6 @@ RSpec.describe Git::Parsers::Branch, :integration do
         expect(result.first.refname).to eq('main')
         expect(result.none? { |b| b.refname.include?('detached') }).to be true
       end
-    end
-  end
-
-  describe '.parse_deleted_branches' do
-    it 'parses deleted branch output' do
-      stdout = "Deleted branch feature (was abc1234).\nDeleted branch bugfix (was def5678).\n"
-      result = described_class.parse_deleted_branches(stdout)
-      expect(result).to contain_exactly('feature', 'bugfix')
     end
   end
 end

--- a/spec/integration/git/parsers/branch_spec.rb
+++ b/spec/integration/git/parsers/branch_spec.rb
@@ -20,15 +20,6 @@ RSpec.describe Git::Parsers::Branch, :integration do
     repo.execution_context.command_capturing('branch', '--list', format_arg, *args).stdout
   end
 
-  describe 'FORMAT_STRING validation' do
-    # These tests validate that real git output matches the format assumed by unit tests
-    before do
-      write_file('file.txt')
-      repo.add('file.txt')
-      repo.commit('Initial commit')
-    end
-  end
-
   describe '.parse_list' do
     context 'with basic branches' do
       before do

--- a/spec/integration/git/parsers/config_entry_spec.rb
+++ b/spec/integration/git/parsers/config_entry_spec.rb
@@ -130,15 +130,6 @@ RSpec.describe Git::Parsers::ConfigEntry, :integration do
         expect(user_name_entry.scope).to eq('local')
         expect(user_name_entry.origin).to match(%r{file:.*\.git[/\\]config})
       end
-
-      it 'correctly splits key and value at the embedded newline' do
-        result = described_class.parse_list(list_cmd.call(**list_opts).stdout)
-
-        result.each do |entry|
-          expect(entry.key).to match(/\A[a-z0-9]+(\.[^\0\n]+)+\z/i)
-          expect(entry.key).not_to include("\n")
-        end
-      end
     end
   end
 

--- a/spec/integration/git/parsers/fsck_spec.rb
+++ b/spec/integration/git/parsers/fsck_spec.rb
@@ -30,15 +30,6 @@ RSpec.describe Git::Parsers::Fsck, :integration do
         expect(result.empty?).to be true
         expect(result.any_issues?).to be false
       end
-
-      it 'returns FsckResult with all empty arrays' do
-        output = git_fsck_output
-        result = described_class.parse(output)
-        expect(result.dangling).to eq([])
-        expect(result.missing).to eq([])
-        expect(result.unreachable).to eq([])
-        expect(result.warnings).to eq([])
-      end
     end
 
     context 'with dangling objects' do
@@ -58,21 +49,6 @@ RSpec.describe Git::Parsers::Fsck, :integration do
         output = git_fsck_output
         result = described_class.parse(output)
         expect(result.dangling.any? { |obj| obj.type == :blob }).to be true
-      end
-
-      it 'returns FsckObject with the expected oid' do
-        output = git_fsck_output
-        result = described_class.parse(output)
-        dangling_blob = result.dangling.find { |obj| obj.type == :blob }
-        expect(dangling_blob.oid).to eq(expected_blob_oid)
-      end
-
-      it 'sets correct type on dangling objects' do
-        output = git_fsck_output
-        result = described_class.parse(output)
-        result.dangling.each do |obj|
-          expect(obj.type).to eq(:blob)
-        end
       end
     end
 
@@ -111,12 +87,6 @@ git commit --allow-empty -m "Another root" >/dev/null 2>&1`
         repo.tag_add('v1.0.0', annotate: true, message: 'Version 1.0.0')
       end
 
-      it 'reports tagged objects' do
-        output = git_fsck_output('--tags')
-        result = described_class.parse(output)
-        expect(result.tagged).not_to be_empty
-      end
-
       it 'returns tagged objects with tag name' do
         output = git_fsck_output('--tags')
         result = described_class.parse(output)
@@ -140,17 +110,6 @@ git commit --allow-empty -m "Another root" >/dev/null 2>&1`
         repo.add('orphan.txt')
         repo.reset('HEAD', hard: true)
       end
-
-      it 'matches OBJECT_PATTERN for dangling lines' do
-        output = git_fsck_output
-        dangling_lines = output.lines.select { |l| l.start_with?('dangling') }
-        expect(dangling_lines).not_to be_empty
-
-        dangling_lines.each do |line|
-          expect(line.strip).to match(described_class::OBJECT_PATTERN),
-                                "Expected line to match OBJECT_PATTERN: #{line.inspect}"
-        end
-      end
     end
 
     context 'with root commits' do
@@ -158,17 +117,6 @@ git commit --allow-empty -m "Another root" >/dev/null 2>&1`
         write_file('file.txt', 'content')
         repo.add('file.txt')
         repo.commit('Initial commit')
-      end
-
-      it 'matches ROOT_PATTERN for root lines' do
-        output = git_fsck_output('--root')
-        root_lines = output.lines.select { |l| l.start_with?('root') }
-        expect(root_lines).not_to be_empty
-
-        root_lines.each do |line|
-          expect(line.strip).to match(described_class::ROOT_PATTERN),
-                                "Expected line to match ROOT_PATTERN: #{line.inspect}"
-        end
       end
     end
 
@@ -178,17 +126,6 @@ git commit --allow-empty -m "Another root" >/dev/null 2>&1`
         repo.add('file.txt')
         repo.commit('Initial commit')
         repo.tag_add('v1.0.0', annotate: true, message: 'Version 1.0.0')
-      end
-
-      it 'matches TAGGED_PATTERN for tagged lines' do
-        output = git_fsck_output('--tags')
-        tagged_lines = output.lines.select { |l| l.start_with?('tagged') }
-        expect(tagged_lines).not_to be_empty
-
-        tagged_lines.each do |line|
-          expect(line.strip).to match(described_class::TAGGED_PATTERN),
-                                "Expected line to match TAGGED_PATTERN: #{line.inspect}"
-        end
       end
     end
   end

--- a/spec/integration/git/parsers/fsck_spec.rb
+++ b/spec/integration/git/parsers/fsck_spec.rb
@@ -96,37 +96,4 @@ git commit --allow-empty -m "Another root" >/dev/null 2>&1`
       end
     end
   end
-
-  describe 'output format validation' do
-    # These tests validate that fsck output patterns match the regex patterns
-    # used in unit test fixtures
-
-    context 'with dangling objects' do
-      before do
-        write_file('file.txt', 'original content')
-        repo.add('file.txt')
-        repo.commit('Initial commit')
-        write_file('orphan.txt', 'orphaned content')
-        repo.add('orphan.txt')
-        repo.reset('HEAD', hard: true)
-      end
-    end
-
-    context 'with root commits' do
-      before do
-        write_file('file.txt', 'content')
-        repo.add('file.txt')
-        repo.commit('Initial commit')
-      end
-    end
-
-    context 'with tagged objects' do
-      before do
-        write_file('file.txt', 'content')
-        repo.add('file.txt')
-        repo.commit('Initial commit')
-        repo.tag_add('v1.0.0', annotate: true, message: 'Version 1.0.0')
-      end
-    end
-  end
 end

--- a/spec/integration/git/parsers/stash_spec.rb
+++ b/spec/integration/git/parsers/stash_spec.rb
@@ -24,25 +24,10 @@ RSpec.describe Git::Parsers::Stash, :integration do
   end
 
   describe '.parse_list' do
-    context 'with no stashes' do
-      it 'returns an empty array' do
-        result = described_class.parse_list('')
-        expect(result).to eq([])
-      end
-    end
-
     context 'with a single stash' do
       before do
         write_file('file.txt', 'modified content')
         repo.stash_save('WIP on feature')
-      end
-
-      it 'returns an array with one StashInfo' do
-        output = git_stash_output
-        result = described_class.parse_list(output)
-
-        expect(result.size).to eq(1)
-        expect(result.first).to be_a(Git::StashInfo)
       end
 
       it 'parses the stash index correctly' do
@@ -135,14 +120,6 @@ RSpec.describe Git::Parsers::Stash, :integration do
         expect(messages[1]).to include('Second stash')
         expect(messages[2]).to include('First stash')
       end
-
-      it 'assigns unique OIDs to each stash' do
-        output = git_stash_output
-        result = described_class.parse_list(output)
-
-        oids = result.map(&:oid)
-        expect(oids.uniq.size).to eq(3)
-      end
     end
 
     context 'with custom message format (no branch prefix)' do
@@ -170,51 +147,6 @@ RSpec.describe Git::Parsers::Stash, :integration do
     before do
       write_file('file.txt', 'modified content')
       repo.stash_save('Test stash message')
-    end
-
-    it 'uses unit separator (0x1F) as field separator' do
-      output = git_stash_output
-      expect(output).to include(described_class::FIELD_SEPARATOR)
-    end
-
-    it 'produces exactly 10 fields per line' do
-      output = git_stash_output
-      output.each_line do |line|
-        fields = line.chomp.split(described_class::FIELD_SEPARATOR, -1)
-        expect(fields.size).to eq(described_class::FIELD_COUNT),
-                               "Expected #{described_class::FIELD_COUNT} fields but got #{fields.size}"
-      end
-    end
-
-    # rubocop:disable Layout/LineLength
-    it 'produces field order: oid, short_oid, reflog, message, author_name, author_email, author_date, committer_name, committer_email, committer_date' do
-      # rubocop:enable Layout/LineLength
-      output = git_stash_output
-      line = output.lines.first.chomp
-      fields = line.split(described_class::FIELD_SEPARATOR, -1)
-
-      # Field 0: %H - full SHA (40 hex chars)
-      expect(fields[0]).to match(/^[0-9a-f]{40}$/)
-      # Field 1: %h - short SHA (7+ hex chars)
-      expect(fields[1]).to match(/^[0-9a-f]{7,}$/)
-      # Field 2: %gd - reflog selector (stash@{n})
-      expect(fields[2]).to match(/^stash@\{\d+\}$/)
-      # Field 3: %gs - reflog subject (message)
-      expect(fields[3]).to include('Test stash message')
-      # Field 4: %an - author name
-      expect(fields[4]).to be_a(String)
-      expect(fields[4]).not_to be_empty
-      # Field 5: %ae - author email
-      expect(fields[5]).to match(/@/)
-      # Field 6: %aI - author date (ISO 8601)
-      expect(fields[6]).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
-      # Field 7: %cn - committer name
-      expect(fields[7]).to be_a(String)
-      expect(fields[7]).not_to be_empty
-      # Field 8: %ce - committer email
-      expect(fields[8]).to match(/@/)
-      # Field 9: %cI - committer date (ISO 8601)
-      expect(fields[9]).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
     end
   end
 end

--- a/spec/integration/git/parsers/stash_spec.rb
+++ b/spec/integration/git/parsers/stash_spec.rb
@@ -139,14 +139,4 @@ RSpec.describe Git::Parsers::Stash, :integration do
       end
     end
   end
-
-  describe 'STASH_FORMAT validation' do
-    # These tests validate that real git output matches the format assumptions
-    # used in unit test fixtures
-
-    before do
-      write_file('file.txt', 'modified content')
-      repo.stash_save('Test stash message')
-    end
-  end
 end

--- a/spec/integration/git/parsers/tag_spec.rb
+++ b/spec/integration/git/parsers/tag_spec.rb
@@ -179,16 +179,4 @@ RSpec.describe Git::Parsers::Tag, :integration do
       end
     end
   end
-
-  describe 'FORMAT_STRING validation' do
-    # These tests validate that real git output matches the format assumptions
-    # used in unit test fixtures
-
-    before do
-      write_file('file.txt', 'content')
-      repo.add('file.txt')
-      repo.commit('Initial commit')
-      repo.tag_add('v1.0.0', annotate: true, message: 'Release v1.0.0')
-    end
-  end
 end

--- a/spec/integration/git/parsers/tag_spec.rb
+++ b/spec/integration/git/parsers/tag_spec.rb
@@ -18,13 +18,6 @@ RSpec.describe Git::Parsers::Tag, :integration do
   end
 
   describe '.parse_list' do
-    context 'when there are no tags' do
-      it 'returns an empty array' do
-        result = described_class.parse_list('')
-        expect(result).to eq([])
-      end
-    end
-
     context 'with lightweight tags' do
       before do
         write_file('file.txt', 'content')
@@ -59,13 +52,6 @@ RSpec.describe Git::Parsers::Tag, :integration do
         expect(tag.tagger_email).to be_nil
         expect(tag.tagger_date).to be_nil
         expect(tag.message).to be_nil
-      end
-
-      it 'has target_oid pointing to the commit' do
-        output = git_tag_output
-        result = described_class.parse_list(output)
-        tag = result.first
-        expect(tag.target_oid).to match(/^[0-9a-f]{40}$/)
       end
     end
 
@@ -122,14 +108,6 @@ RSpec.describe Git::Parsers::Tag, :integration do
         result = described_class.parse_list(output)
         v1_tag = result.find { |t| t.name == 'v1.0.0' }
         expect(v1_tag.message).to eq(multiline_message)
-      end
-
-      it 'preserves newlines in message' do
-        output = git_tag_output
-        result = described_class.parse_list(output)
-        v1_tag = result.find { |t| t.name == 'v1.0.0' }
-        expect(v1_tag.message).to include("\n")
-        expect(v1_tag.message.lines.count).to eq(5)
       end
 
       it 'does not affect parsing of other tags' do
@@ -202,14 +180,6 @@ RSpec.describe Git::Parsers::Tag, :integration do
     end
   end
 
-  describe '.parse_deleted_tags' do
-    it 'parses deleted tag output' do
-      stdout = "Deleted tag 'v1.0.0' (was abc1234)\nDeleted tag 'v2.0.0' (was def5678)\n"
-      result = described_class.parse_deleted_tags(stdout)
-      expect(result).to contain_exactly('v1.0.0', 'v2.0.0')
-    end
-  end
-
   describe 'FORMAT_STRING validation' do
     # These tests validate that real git output matches the format assumptions
     # used in unit test fixtures
@@ -219,52 +189,6 @@ RSpec.describe Git::Parsers::Tag, :integration do
       repo.add('file.txt')
       repo.commit('Initial commit')
       repo.tag_add('v1.0.0', annotate: true, message: 'Release v1.0.0')
-    end
-
-    it 'uses unit separator (0x1F) as field delimiter' do
-      output = git_tag_output
-      expect(output).to include(described_class::FIELD_DELIMITER)
-    end
-
-    it 'uses record separator (0x1E) as record delimiter' do
-      output = git_tag_output
-      expect(output).to include(described_class::RECORD_DELIMITER)
-    end
-
-    it 'produces exactly 8 fields per record' do
-      output = git_tag_output
-      records = output.split(described_class::RECORD_DELIMITER).reject(&:empty?)
-      records.each do |record|
-        fields = record.split(described_class::FIELD_DELIMITER, -1)
-        expect(fields.size).to eq(described_class::FIELD_COUNT),
-                               "Expected #{described_class::FIELD_COUNT} fields but got #{fields.size}"
-      end
-    end
-
-    # rubocop:disable Layout/LineLength
-    it 'produces field order: refname, objectname, *objectname, objecttype, taggername, taggeremail, taggerdate, contents' do
-      # rubocop:enable Layout/LineLength
-      output = git_tag_output
-      records = output.split(described_class::RECORD_DELIMITER).reject(&:empty?)
-      record = records.first
-      fields = record.split(described_class::FIELD_DELIMITER, -1)
-
-      # Field 0: refname:short (tag name)
-      expect(fields[0]).to eq('v1.0.0')
-      # Field 1: objectname (SHA of tag object)
-      expect(fields[1]).to match(/^[0-9a-f]{40}$/)
-      # Field 2: *objectname (dereferenced SHA - commit ID)
-      expect(fields[2]).to match(/^[0-9a-f]{40}$/)
-      # Field 3: objecttype ('tag' for annotated)
-      expect(fields[3]).to eq('tag')
-      # Field 4: taggername
-      expect(fields[4]).to be_a(String)
-      # Field 5: taggeremail
-      expect(fields[5]).to match(/<.*>/) # e.g., <user@example.com>
-      # Field 6: taggerdate (ISO 8601)
-      expect(fields[6]).to match(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/)
-      # Field 7: contents (message)
-      expect(fields[7]).to include('Release v1.0.0')
     end
   end
 end

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -54,41 +54,6 @@ RSpec.describe Git::Repository::Branching, :integration do
     end
   end
 
-  describe '#checkout_file' do
-    before do
-      write_file('README.md', "# Modified\n")
-    end
-  end
-
-  describe '#checkout' do
-    context 'checking out an existing branch' do
-      before do
-        repo.branch('new-branch').create
-      end
-    end
-
-    context 'when the repository has no commits' do
-      let(:unborn_repo_dir) { Dir.mktmpdir('unborn_repo') }
-      let(:unborn_repo) do
-        r = Git.init(unborn_repo_dir, initial_branch: 'master')
-        r.config_set('user.email', 'test@example.com')
-        r.config_set('user.name', 'Test User')
-        r.config_set('commit.gpgsign', 'false')
-        r
-      end
-      let(:unborn_instance) { Git::Repository.new(execution_context: unborn_repo.execution_context) }
-
-      after { FileUtils.rm_rf(unborn_repo_dir) }
-    end
-  end
-
-  describe '#checkout_index' do
-    before do
-      write_file('indexed.txt', "indexed content\n")
-      repo.add('indexed.txt')
-    end
-  end
-
   describe '#local_branch?' do
     context 'when the branch exists locally' do
       it 'returns true' do
@@ -197,23 +162,6 @@ RSpec.describe Git::Repository::Branching, :integration do
   # ---------------------------------------------------------------------------
   # #branch_new
   # ---------------------------------------------------------------------------
-
-  describe '#branch_new' do
-    context 'with a start_point' do
-      # let! eagerly captures the SHA before the inner before block adds a second commit
-      let!(:initial_sha) { repo.log(1).execute.first.sha }
-
-      before do
-        write_file('CHANGES.md', "changes\n")
-        repo.add('CHANGES.md')
-        repo.commit('Second commit')
-      end
-    end
-
-    context 'when the branch already exists' do
-      before { described_instance.branch_new('duplicate') }
-    end
-  end
 
   # ---------------------------------------------------------------------------
   # #branch_delete
@@ -388,15 +336,6 @@ RSpec.describe Git::Repository::Branching, :integration do
   # ---------------------------------------------------------------------------
   # #update_ref
   # ---------------------------------------------------------------------------
-
-  describe '#update_ref' do
-    before do
-      repo.branch('feature').create
-      write_file('CHANGES.md', "changes\n")
-      repo.add('CHANGES.md')
-      repo.commit('Second commit')
-    end
-  end
 
   # ---------------------------------------------------------------------------
   # #branch (factory)

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -58,35 +58,12 @@ RSpec.describe Git::Repository::Branching, :integration do
     before do
       write_file('README.md', "# Modified\n")
     end
-
-    it 'restores the file to the HEAD version' do
-      described_instance.checkout_file('HEAD', 'README.md')
-      content = File.read(File.join(repo.dir.to_s, 'README.md'))
-      expect(content).to eq("# Hello\n")
-    end
-
-    it 'returns a String' do
-      result = described_instance.checkout_file('HEAD', 'README.md')
-      expect(result).to be_a(String)
-    end
   end
 
   describe '#checkout' do
     context 'checking out an existing branch' do
       before do
         repo.branch('new-branch').create
-      end
-
-      it 'switches to that branch' do
-        described_instance.checkout('new-branch')
-        expect(described_instance.current_branch).to eq('new-branch')
-      end
-    end
-
-    context 'creating and checking out a new branch' do
-      it 'creates and switches to the new branch' do
-        described_instance.checkout('feature', new_branch: true, start_point: 'HEAD')
-        expect(described_instance.current_branch).to eq('feature')
       end
     end
 
@@ -102,11 +79,6 @@ RSpec.describe Git::Repository::Branching, :integration do
       let(:unborn_instance) { Git::Repository.new(execution_context: unborn_repo.execution_context) }
 
       after { FileUtils.rm_rf(unborn_repo_dir) }
-
-      it 'raises Git::FailedError' do
-        expect { unborn_instance.checkout('master') }
-          .to raise_error(Git::FailedError, /master/)
-      end
     end
   end
 
@@ -114,20 +86,6 @@ RSpec.describe Git::Repository::Branching, :integration do
     before do
       write_file('indexed.txt', "indexed content\n")
       repo.add('indexed.txt')
-    end
-
-    context 'with all: true' do
-      it 'returns a String' do
-        result = described_instance.checkout_index(all: true, force: true)
-        expect(result).to be_a(String)
-      end
-    end
-
-    context 'with path_limiter' do
-      it 'returns a String' do
-        result = described_instance.checkout_index(path_limiter: 'indexed.txt', force: true)
-        expect(result).to be_a(String)
-      end
     end
   end
 
@@ -149,10 +107,6 @@ RSpec.describe Git::Repository::Branching, :integration do
     context 'when no remotes are configured' do
       it 'returns false for any branch name' do
         expect(described_instance.remote_branch?('main')).to be(false)
-      end
-
-      it 'returns false for a combined remote/branch name' do
-        expect(described_instance.remote_branch?('origin/main')).to be(false)
       end
     end
 
@@ -245,19 +199,6 @@ RSpec.describe Git::Repository::Branching, :integration do
   # ---------------------------------------------------------------------------
 
   describe '#branch_new' do
-    context 'without a start_point' do
-      it 'creates the branch from the current HEAD' do
-        head_sha = repo.revparse('HEAD')
-        described_instance.branch_new('new-feature')
-        expect(described_instance.local_branch?('new-feature')).to be(true)
-        expect(repo.revparse('new-feature')).to eq(head_sha)
-      end
-
-      it 'returns nil' do
-        expect(described_instance.branch_new('new-feature')).to be_nil
-      end
-    end
-
     context 'with a start_point' do
       # let! eagerly captures the SHA before the inner before block adds a second commit
       let!(:initial_sha) { repo.log(1).execute.first.sha }
@@ -267,20 +208,10 @@ RSpec.describe Git::Repository::Branching, :integration do
         repo.add('CHANGES.md')
         repo.commit('Second commit')
       end
-
-      it 'creates the branch at the given start_point' do
-        described_instance.branch_new('from-initial', initial_sha)
-        expect(described_instance.local_branch?('from-initial')).to be(true)
-        expect(repo.revparse('from-initial')).to eq(initial_sha)
-      end
     end
 
     context 'when the branch already exists' do
       before { described_instance.branch_new('duplicate') }
-
-      it 'raises Git::FailedError' do
-        expect { described_instance.branch_new('duplicate') }.to raise_error(Git::FailedError, /duplicate/)
-      end
     end
   end
 
@@ -332,15 +263,6 @@ RSpec.describe Git::Repository::Branching, :integration do
           .to raise_error(Git::Error, /nonexistent-branch/)
       end
     end
-
-    context 'when deleting multiple branches at once' do
-      it 'deletes all named branches and returns a String' do
-        result = described_instance.branch_delete('branch-1', 'branch-2')
-        expect(result).to be_a(String)
-        expect(result).to include('branch-1')
-        expect(result).to include('branch-2')
-      end
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -385,21 +307,6 @@ RSpec.describe Git::Repository::Branching, :integration do
 
   describe '#branch_contains' do
     let(:sha) { repo.revparse('HEAD') }
-
-    context 'when the commit is on the current branch' do
-      it 'returns a non-empty String' do
-        result = described_instance.branch_contains(sha)
-        expect(result).to be_a(String)
-        expect(result).not_to be_empty
-      end
-    end
-
-    context 'when a non-matching branch pattern is supplied' do
-      it 'returns an empty string' do
-        result = described_instance.branch_contains(sha, 'nonexistent-pattern')
-        expect(result).to eq('')
-      end
-    end
 
     context 'when branch_name is nil (treated as no pattern)' do
       it 'returns a non-empty String (same branches as omitting branch_name)' do
@@ -489,36 +396,11 @@ RSpec.describe Git::Repository::Branching, :integration do
       repo.add('CHANGES.md')
       repo.commit('Second commit')
     end
-
-    it 'points the branch ref at the given commit SHA' do
-      new_sha = repo.revparse('HEAD')
-      described_instance.update_ref('feature', new_sha)
-      expect(repo.revparse('refs/heads/feature')).to eq(new_sha)
-    end
-
-    it 'returns a Git::CommandLine::Result' do
-      result = described_instance.update_ref('feature', repo.revparse('HEAD'))
-      expect(result).to be_a(Git::CommandLine::Result)
-    end
   end
 
   # ---------------------------------------------------------------------------
   # #branch (factory)
   # ---------------------------------------------------------------------------
-
-  describe '#branch' do
-    it 'returns a Git::Branch for the given name' do
-      result = described_instance.branch('main')
-      expect(result).to be_a(Git::Branch)
-      expect(result.full).to eq('main')
-    end
-
-    it 'defaults to the current branch when no name is given' do
-      result = described_instance.branch
-      expect(result).to be_a(Git::Branch)
-      expect(result.full).to eq(described_instance.current_branch)
-    end
-  end
 
   # ---------------------------------------------------------------------------
   # #current_branch_state

--- a/spec/integration/git/repository/committing_spec.rb
+++ b/spec/integration/git/repository/committing_spec.rb
@@ -58,51 +58,9 @@ RSpec.describe Git::Repository::Committing, :integration do
     end
   end
 
-  describe '#commit' do
-    context 'with an empty message' do
-      it 'raises Git::FailedError' do
-        expect { described_instance.commit('', allow_empty: true) }
-          .to raise_error(Git::FailedError, /empty commit message|Aborting commit/i)
-      end
-    end
-
-    context 'with an empty message and allow_empty_message: true' do
-      it 'creates a commit and returns a String' do
-        result = described_instance.commit('', allow_empty: true, allow_empty_message: true)
-
-        expect(result).to be_a(String)
-        expect(repo.log.execute.to_a.size).to be >= 2
-      end
-    end
-  end
-
   describe '#set_index' do
     let(:custom_index_path) { File.join(repo_dir, 'custom_index') }
 
     after { FileUtils.rm_rf(custom_index_path) }
-
-    context 'with a programmatic commit workflow' do
-      it 'creates a new commit on a separate branch without touching the working tree' do
-        main_commit = repo.gcommit('main')
-
-        described_instance.set_index(custom_index_path, must_exist: false)
-        described_instance.read_tree(main_commit.gtree.sha)
-
-        new_tree_sha = described_instance.write_tree.strip
-        new_commit = described_instance.commit_tree(
-          new_tree_sha,
-          parents: [main_commit.sha],
-          message: 'Programmatic commit via custom index'
-        )
-
-        expect(new_commit.strip).to match(/\A[0-9a-f]{40}\z/)
-
-        repo.branch('feature-branch').update_ref(new_commit.strip)
-        feature_log = repo.log.object('feature-branch').execute
-
-        expect(feature_log.to_a.size).to eq(2)
-        expect(repo.log.object('main').execute.to_a.size).to eq(1)
-      end
-    end
   end
 end

--- a/spec/integration/git/repository/committing_spec.rb
+++ b/spec/integration/git/repository/committing_spec.rb
@@ -57,10 +57,4 @@ RSpec.describe Git::Repository::Committing, :integration do
       end
     end
   end
-
-  describe '#set_index' do
-    let(:custom_index_path) { File.join(repo_dir, 'custom_index') }
-
-    after { FileUtils.rm_rf(custom_index_path) }
-  end
 end

--- a/spec/integration/git/repository/configuring_spec.rb
+++ b/spec/integration/git/repository/configuring_spec.rb
@@ -65,14 +65,6 @@ RSpec.describe Git::Repository, :integration do
         expect(result['section.key']).to eq('value')
       end
     end
-
-    context 'when writing with a file: option then reading back' do
-      let(:config_file) { File.join(repo_dir, 'custom.config') }
-    end
-
-    context 'when include.path is set to chain a custom config file' do
-      let(:custom_config_path) { File.join(repo_dir, 'custom.config') }
-    end
   end
 
   describe '#global_config', skip: unless_git('2.32.0', 'GIT_CONFIG_GLOBAL isolation') do

--- a/spec/integration/git/repository/configuring_spec.rb
+++ b/spec/integration/git/repository/configuring_spec.rb
@@ -43,10 +43,6 @@ RSpec.describe Git::Repository, :integration do
     end
 
     context 'when called with a name only' do
-      it 'returns the config value as a String' do
-        expect(described_instance.config('user.name')).to eq('Test User')
-      end
-
       it 'raises Git::FailedError when the key does not exist' do
         expect { described_instance.config('ruby-git-rspec.nonexistent-key') }.to raise_error(Git::FailedError)
       end
@@ -72,23 +68,10 @@ RSpec.describe Git::Repository, :integration do
 
     context 'when writing with a file: option then reading back' do
       let(:config_file) { File.join(repo_dir, 'custom.config') }
-
-      it 'persists the value to the specified file' do
-        described_instance.config('section.key', 'file_value', file: config_file)
-        result = described_instance.config(file: config_file)
-        expect(result['section.key']).to eq('file_value')
-      end
     end
 
     context 'when include.path is set to chain a custom config file' do
       let(:custom_config_path) { File.join(repo_dir, 'custom.config') }
-
-      it 'makes settings from the included file visible via config' do
-        described_instance.config('user.name', 'bully', file: custom_config_path)
-        described_instance.config('include.path', custom_config_path)
-
-        expect(described_instance.config('user.name')).to eq('bully')
-      end
     end
   end
 
@@ -136,38 +119,6 @@ RSpec.describe Git::Repository, :integration do
       yield
     ensure
       saved.nil? ? ENV.delete('GIT_CONFIG_GLOBAL') : ENV['GIT_CONFIG_GLOBAL'] = saved
-    end
-  end
-
-  describe '#config_get' do
-    it 'returns a Git::ConfigEntryInfo for an existing key' do
-      entry = described_instance.config_get('user.name')
-
-      expect(entry).to be_a(Git::ConfigEntryInfo)
-      expect(entry.value).to eq('Test User')
-    end
-
-    it 'returns nil when the key does not exist' do
-      entry = described_instance.config_get('nonexistent.key', local: true)
-
-      expect(entry).to be_nil
-    end
-  end
-
-  describe '#config_list' do
-    it 'returns an Array of Git::ConfigEntryInfo objects' do
-      entries = described_instance.config_list
-
-      expect(entries).to be_an(Array)
-      expect(entries).to all(be_a(Git::ConfigEntryInfo))
-    end
-
-    it 'includes an entry for user.name from local config' do
-      entries = described_instance.config_list(local: true)
-
-      user_name_entry = entries.find { |e| e.key == 'user.name' }
-      expect(user_name_entry).not_to be_nil
-      expect(user_name_entry.value).to eq('Test User')
     end
   end
 end

--- a/spec/integration/git/repository/logging_spec.rb
+++ b/spec/integration/git/repository/logging_spec.rb
@@ -37,20 +37,6 @@ RSpec.describe Git::Repository::Logging, :integration do
         expect(result.first['message']).to eq("Add changelog\n")
         expect(result.first['parent']).to be_a(Array)
       end
-
-      it 'supports the between option' do
-        result = described_instance.full_log_commits(between: [first_sha, 'HEAD'])
-
-        expect(result.length).to eq(1)
-        expect(result.first['message']).to eq("Add changelog\n")
-      end
-
-      it 'supports the path_limiter option' do
-        result = described_instance.full_log_commits(path_limiter: 'README.md')
-
-        expect(result.length).to eq(1)
-        expect(result.first['message']).to eq("Initial commit\n")
-      end
     end
   end
 
@@ -79,13 +65,6 @@ RSpec.describe Git::Repository::Logging, :integration do
 
         expect(result.size).to eq(1)
         expect(result.first.message.strip).to eq('Add changelog')
-      end
-
-      it 'returns commits in reverse-chronological order' do
-        result = described_instance.log.execute
-
-        expect(result.first.message.strip).to eq('Add changelog')
-        expect(result.last.message.strip).to eq('Initial commit')
       end
     end
   end

--- a/spec/integration/git/repository/merging_spec.rb
+++ b/spec/integration/git/repository/merging_spec.rb
@@ -17,22 +17,6 @@ RSpec.describe Git::Repository::Merging, :integration do
   end
 
   # ---------------------------------------------------------------------------
-  # #merge — single branch
-  # ---------------------------------------------------------------------------
-
-  describe '#merge single branch' do
-    before do
-      # Create and populate a feature branch
-      repo.branch_new('feature')
-      repo.checkout('feature')
-      write_file('feature.txt', "feature content\n")
-      repo.add('feature.txt')
-      repo.commit('Add feature file')
-      repo.checkout('main')
-    end
-  end
-
-  # ---------------------------------------------------------------------------
   # #merge — Git::Branch object coercion
   # ---------------------------------------------------------------------------
 
@@ -54,43 +38,6 @@ RSpec.describe Git::Repository::Merging, :integration do
   end
 
   # ---------------------------------------------------------------------------
-  # #merge — Array of branches (octopus merge)
-  # ---------------------------------------------------------------------------
-
-  describe '#merge octopus (Array of branches)' do
-    before do
-      repo.branch_new('branch-a')
-      repo.checkout('branch-a')
-      write_file('file_a.txt', "content from branch-a\n")
-      repo.add('file_a.txt')
-      repo.commit('Add file_a.txt')
-      repo.checkout('main')
-
-      repo.branch_new('branch-b')
-      repo.checkout('branch-b')
-      write_file('file_b.txt', "content from branch-b\n")
-      repo.add('file_b.txt')
-      repo.commit('Add file_b.txt')
-      repo.checkout('main')
-    end
-  end
-
-  # ---------------------------------------------------------------------------
-  # #merge — no_ff: true with a commit message
-  # ---------------------------------------------------------------------------
-
-  describe '#merge with no_ff: true and a message' do
-    before do
-      repo.branch_new('feature')
-      repo.checkout('feature')
-      write_file('noff.txt', "no-ff content\n")
-      repo.add('noff.txt')
-      repo.commit('Add noff.txt')
-      repo.checkout('main')
-    end
-  end
-
-  # ---------------------------------------------------------------------------
   # #merge — fast-forward with message (git ignores -m on ff)
   # ---------------------------------------------------------------------------
 
@@ -108,32 +55,6 @@ RSpec.describe Git::Repository::Merging, :integration do
       described_instance.merge('feature', 'merge commit message')
       commits = repo.log.execute
       expect(commits.first.message).to eq('first commit message')
-    end
-  end
-
-  # ---------------------------------------------------------------------------
-  # #merge — no_commit: true (HEAD unchanged after merge)
-  #
-  # NOTE: git ignores --no-commit on fast-forward merges. The test therefore
-  # creates a divergent history (main has a commit that feature does not) so
-  # that a real three-way merge is required and --no-commit takes effect.
-  # ---------------------------------------------------------------------------
-
-  describe '#merge with no_commit: true' do
-    before do
-      # Branch feature off the initial commit
-      repo.branch_new('feature')
-      repo.checkout('feature')
-      write_file('staged.txt', "staged content\n")
-      repo.add('staged.txt')
-      repo.commit('Add staged.txt')
-      repo.checkout('main')
-
-      # Create a commit on main so that main and feature have diverged;
-      # this prevents a fast-forward and makes --no-commit effective.
-      write_file('main_only.txt', "main content\n")
-      repo.add('main_only.txt')
-      repo.commit('Add main_only.txt')
     end
   end
 

--- a/spec/integration/git/repository/merging_spec.rb
+++ b/spec/integration/git/repository/merging_spec.rb
@@ -30,23 +30,6 @@ RSpec.describe Git::Repository::Merging, :integration do
       repo.commit('Add feature file')
       repo.checkout('main')
     end
-
-    it 'returns a String' do
-      result = described_instance.merge('feature')
-      expect(result).to be_a(String)
-    end
-
-    it 'merges the feature branch into the current branch' do
-      described_instance.merge('feature')
-      expect(File.exist?(File.join(repo_dir, 'feature.txt'))).to be(true)
-    end
-
-    it 'makes the merged file visible in git status' do
-      described_instance.merge('feature')
-      # After a clean merge, status should show no untracked/modified files
-      expect(repo.status.added).to be_empty
-      expect(repo.status.changed).to be_empty
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -90,17 +73,6 @@ RSpec.describe Git::Repository::Merging, :integration do
       repo.commit('Add file_b.txt')
       repo.checkout('main')
     end
-
-    it 'merges all branches and all files appear in the working tree' do
-      described_instance.merge(%w[branch-a branch-b])
-      expect(File.exist?(File.join(repo_dir, 'file_a.txt'))).to be(true)
-      expect(File.exist?(File.join(repo_dir, 'file_b.txt'))).to be(true)
-    end
-
-    it 'returns a String' do
-      result = described_instance.merge(%w[branch-a branch-b])
-      expect(result).to be_a(String)
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -116,17 +88,6 @@ RSpec.describe Git::Repository::Merging, :integration do
       repo.commit('Add noff.txt')
       repo.checkout('main')
     end
-
-    it 'creates a merge commit whose message is the given string' do
-      described_instance.merge('feature', 'merge commit message', no_ff: true)
-      commits = repo.log.execute
-      expect(commits.first.message).to eq('merge commit message')
-    end
-
-    it 'makes the merged file visible in the working tree' do
-      described_instance.merge('feature', 'merge commit message', no_ff: true)
-      expect(File.exist?(File.join(repo_dir, 'noff.txt'))).to be(true)
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -141,16 +102,6 @@ RSpec.describe Git::Repository::Merging, :integration do
       repo.add('ff.txt')
       repo.commit('first commit message')
       repo.checkout('main')
-    end
-
-    it 'performs the merge successfully (returns a String)' do
-      result = described_instance.merge('feature', 'merge commit message')
-      expect(result).to be_a(String)
-    end
-
-    it 'merges the file into the working tree' do
-      described_instance.merge('feature', 'merge commit message')
-      expect(File.exist?(File.join(repo_dir, 'ff.txt'))).to be(true)
     end
 
     it 'does NOT set the commit message (git ignores -m on fast-forward merges)' do
@@ -184,20 +135,6 @@ RSpec.describe Git::Repository::Merging, :integration do
       repo.add('main_only.txt')
       repo.commit('Add main_only.txt')
     end
-
-    it 'leaves HEAD pointing at the pre-merge commit' do
-      head_before = repo.log(1).execute.first.sha
-      described_instance.merge('feature', nil, no_commit: true)
-      expect(repo.log(1).execute.first.sha).to eq(head_before)
-    end
-
-    it 'stages the merge result but does not create a commit' do
-      described_instance.merge('feature', nil, no_commit: true)
-      # The file is staged (type 'A') but no new commit was made
-      status = repo.status['staged.txt']
-      expect(status).not_to be_nil
-      expect(status.type).to eq('A')
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -221,16 +158,6 @@ RSpec.describe Git::Repository::Merging, :integration do
       write_file('main_extra.txt', "main extra\n")
       repo.add('main_extra.txt')
       repo.commit('Main extra commit')
-    end
-
-    it 'returns an Array' do
-      result = described_instance.merge_base('main', 'feature')
-      expect(result).to be_an(Array)
-    end
-
-    it 'returns an Array of String SHAs' do
-      result = described_instance.merge_base('main', 'feature')
-      expect(result).to all(be_a(String))
     end
 
     it 'returns the correct common ancestor SHA' do
@@ -284,11 +211,6 @@ RSpec.describe Git::Repository::Merging, :integration do
       result = described_instance.merge_base('new_branch_1', 'new_branch_2', all: true)
       expect(result.size).to be >= 2
     end
-
-    it 'returns Array<String> SHAs' do
-      result = described_instance.merge_base('new_branch_1', 'new_branch_2', all: true)
-      expect(result).to all(be_a(String))
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -325,10 +247,6 @@ RSpec.describe Git::Repository::Merging, :integration do
         rescue Git::FailedError
           # expected conflict
         end
-      end
-
-      it 'returns an Array' do
-        expect(described_instance.unmerged).to be_an(Array)
       end
 
       it 'returns the conflicting file path(s)' do
@@ -418,24 +336,6 @@ RSpec.describe Git::Repository::Merging, :integration do
     end
 
     let(:head_sha) { repo.log(1).execute.first.sha }
-
-    it 'returns a String' do
-      result = described_instance.revert(head_sha)
-      expect(result).to be_a(String)
-    end
-
-    it 'creates a new revert commit' do
-      sha = head_sha
-      log_before = repo.log(10_000).execute.count
-      described_instance.revert(sha)
-      expect(repo.log(10_000).execute.count).to eq(log_before + 1)
-    end
-
-    it 'undoes the file addition introduced by the reverted commit' do
-      sha = head_sha
-      described_instance.revert(sha)
-      expect(File.exist?(File.join(repo_dir, 'feature.txt'))).to be(false)
-    end
 
     it 'treats a nil commitish as HEAD and reverts HEAD' do
       log_before = repo.log(10_000).execute.count

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -16,23 +16,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
   end
 
   describe '#cat_file_contents' do
-    context 'with a blob via treeish path' do
-      it 'returns the raw content of the blob as a String' do
-        result = described_instance.cat_file_contents('HEAD:README.md')
-        expect(result).to be_a(String)
-        expect(result).to include('# Hello World')
-      end
-    end
-
-    context 'with a commit object' do
-      it 'returns the raw content of the commit as a String' do
-        result = described_instance.cat_file_contents('HEAD')
-        expect(result).to be_a(String)
-        expect(result).to include('tree ')
-        expect(result).to include('author ')
-      end
-    end
-
     context 'with a block' do
       it 'yields a File positioned at the start of the content' do
         yielded_content = nil
@@ -47,58 +30,13 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
         expect(result).to eq(:my_value)
       end
     end
-
-    context 'when object starts with a hyphen' do
-      it 'raises ArgumentError without calling git' do
-        expect { described_instance.cat_file_contents('--batch') }
-          .to raise_error(ArgumentError, "Invalid object: '--batch'")
-      end
-    end
-
-    context 'when the object does not exist' do
-      it 'raises Git::FailedError' do
-        expect { described_instance.cat_file_contents('0000000000000000000000000000000000000000') }
-          .to raise_error(Git::FailedError)
-      end
-    end
   end
 
   describe '#cat_file_size' do
-    context 'with a commit object' do
-      it 'returns the size of the commit as an Integer' do
-        result = described_instance.cat_file_size('HEAD')
-        expect(result).to be_a(Integer)
-        expect(result).to be_positive
-      end
-    end
-
     context 'with a blob via treeish path' do
       it 'returns the size of the blob' do
         result = described_instance.cat_file_size('HEAD:README.md')
         expect(result).to eq(File.read(File.join(repo.dir.to_s, 'README.md')).bytesize)
-      end
-    end
-
-    context 'with a tree object' do
-      it 'returns the size of the tree object as an Integer' do
-        tree_sha = repo.rev_parse('HEAD^{tree}')
-        result = described_instance.cat_file_size(tree_sha)
-        expect(result).to be_a(Integer)
-        expect(result).to be_positive
-      end
-    end
-
-    context 'when object starts with a hyphen' do
-      it 'raises ArgumentError without calling git' do
-        expect { described_instance.cat_file_size('--batch') }
-          .to raise_error(ArgumentError, "Invalid object: '--batch'")
-      end
-    end
-
-    context 'when the object does not exist' do
-      it 'raises Git::FailedError' do
-        expect { described_instance.cat_file_size('0000000000000000000000000000000000000000') }
-          .to raise_error(Git::FailedError)
       end
     end
   end
@@ -109,42 +47,11 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
         expect(described_instance.cat_file_type('HEAD')).to eq('commit')
       end
     end
-
-    context 'with a tree reference' do
-      it 'returns "tree"' do
-        tree_sha = repo.rev_parse('HEAD^{tree}')
-        expect(described_instance.cat_file_type(tree_sha)).to eq('tree')
-      end
-    end
-
-    context 'with a blob via treeish path' do
-      it 'returns "blob"' do
-        expect(described_instance.cat_file_type('HEAD:README.md')).to eq('blob')
-      end
-    end
-
-    context 'when object starts with a hyphen' do
-      it 'raises ArgumentError without calling git' do
-        expect { described_instance.cat_file_type('--batch') }
-          .to raise_error(ArgumentError, "Invalid object: '--batch'")
-      end
-    end
-
-    context 'when the object does not exist' do
-      it 'raises Git::FailedError' do
-        expect { described_instance.cat_file_type('0000000000000000000000000000000000000000') }
-          .to raise_error(Git::FailedError)
-      end
-    end
   end
 
   describe '#cat_file_commit' do
     context 'with HEAD' do
       subject(:result) { described_instance.cat_file_commit('HEAD') }
-
-      it 'returns a Hash' do
-        expect(result).to be_a(Hash)
-      end
 
       it 'sets sha to the requested object name' do
         expect(result['sha']).to eq('HEAD')
@@ -152,14 +59,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
       it 'includes tree, parent, author, committer, and message keys' do
         expect(result).to include('tree', 'parent', 'author', 'committer', 'message')
-      end
-
-      it 'sets parent to an Array' do
-        expect(result['parent']).to be_a(Array)
-      end
-
-      it 'sets message with a trailing newline' do
-        expect(result['message']).to end_with("\n")
       end
 
       it 'sets message to the commit message used when the commit was created' do
@@ -175,13 +74,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
       end
     end
 
-    context 'when the object does not exist' do
-      it 'raises Git::FailedError' do
-        expect { described_instance.cat_file_commit('0000000000000000000000000000000000000000') }
-          .to raise_error(Git::FailedError)
-      end
-    end
-
     context 'with a bare repository clone' do
       let(:clone_parent_dir) { Dir.mktmpdir }
       let(:bare_clone_dir) { File.join(clone_parent_dir, 'bare') }
@@ -190,15 +82,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
       after do
         FileUtils.rm_rf(clone_parent_dir)
-      end
-
-      it 'returns commit metadata including tree, author, committer, and parents' do
-        sha = bare_repo.rev_parse('HEAD')
-        result = bare_instance.cat_file_commit(sha)
-        expect(result).to include('tree', 'author', 'committer', 'message', 'parent')
-        expect(result['tree']).to match(/\A[0-9a-f]{40}\z/)
-        expect(result['author']).to be_a(String).and include('Test User', 'test@example.com')
-        expect(result['parent']).to be_an(Array)
       end
     end
 
@@ -235,10 +118,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     context 'with a valid annotated tag' do
       subject(:result) { described_instance.cat_file_tag('v1.0') }
 
-      it 'returns a Hash' do
-        expect(result).to be_a(Hash)
-      end
-
       it 'sets name to the tag name passed by the caller' do
         expect(result['name']).to eq('v1.0')
       end
@@ -247,34 +126,12 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
         expect(result).to include('name', 'object', 'type', 'tag', 'tagger', 'message')
       end
 
-      it 'sets type to "commit"' do
-        expect(result['type']).to eq('commit')
-      end
-
-      it 'sets tag to the tag name' do
-        expect(result['tag']).to eq('v1.0')
-      end
-
       it 'sets message to the tag message with a trailing newline' do
         expect(result['message']).to eq("Release v1.0\n")
       end
 
       it 'sets object to a 40-character SHA' do
         expect(result['object']).to match(/\A[0-9a-f]{40}\z/)
-      end
-    end
-
-    context 'when object starts with a hyphen' do
-      it 'raises ArgumentError without calling git' do
-        expect { described_instance.cat_file_tag('--all') }
-          .to raise_error(ArgumentError, "Invalid object: '--all'")
-      end
-    end
-
-    context 'when the object does not exist' do
-      it 'raises Git::FailedError' do
-        expect { described_instance.cat_file_tag('nonexistent_tag') }
-          .to raise_error(Git::FailedError)
       end
     end
 
@@ -294,41 +151,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     end
   end
 
-  describe '#rev_parse' do
-    context 'with HEAD' do
-      it 'returns a 40-character lowercase hex SHA' do
-        result = described_instance.rev_parse('HEAD')
-        expect(result).to match(/\A[0-9a-f]{40}\z/)
-      end
-
-      it 'returns a String' do
-        expect(described_instance.rev_parse('HEAD')).to be_a(String)
-      end
-    end
-
-    context 'with an abbreviated SHA' do
-      it 'expands the abbreviated SHA to the full 40-character SHA' do
-        full_sha = repo.rev_parse('HEAD')
-        abbreviated = full_sha[0, 7]
-        expect(described_instance.rev_parse(abbreviated)).to eq(full_sha)
-      end
-    end
-
-    context 'with a tree object via rev-parse syntax' do
-      it 'resolves the tree SHA' do
-        result = described_instance.rev_parse('HEAD^{tree}')
-        expect(result).to match(/\A[0-9a-f]{40}\z/)
-      end
-    end
-
-    context 'when the revision is unknown' do
-      it 'raises Git::FailedError' do
-        expect { described_instance.rev_parse('NOTFOUND') }
-          .to raise_error(Git::FailedError)
-      end
-    end
-  end
-
   describe '#tag_sha' do
     context 'when the tag exists' do
       before do
@@ -338,12 +160,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
       it 'returns the SHA of the tagged commit as a String' do
         result = described_instance.tag_sha('v1.0')
         expect(result.chomp).to match(/\A[0-9a-f]{40}\z/)
-      end
-
-      it 'returns the same SHA as rev_parse for the tag' do
-        expected = repo.rev_parse('v1.0')
-        result = described_instance.tag_sha('v1.0')
-        expect(result.chomp).to eq(expected.chomp)
       end
     end
 
@@ -356,38 +172,10 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
   describe '#full_tree' do
     context 'with the tree SHA for a commit containing one file' do
-      it 'returns an Array<String>' do
-        tree_sha = repo.rev_parse('HEAD^{tree}')
-        result = described_instance.full_tree(tree_sha)
-        expect(result).to be_a(Array)
-        expect(result).to all(be_a(String))
-      end
-
       it 'returns one entry per file in the tree' do
         tree_sha = repo.rev_parse('HEAD^{tree}')
         result = described_instance.full_tree(tree_sha)
         expect(result.size).to eq(1)
-      end
-
-      it 'returns entries in the git ls-tree format <mode> <type> <object>\\t<file>' do
-        tree_sha = repo.rev_parse('HEAD^{tree}')
-        result = described_instance.full_tree(tree_sha)
-        expect(result.first).to match(/\A\d{6} \w+ [0-9a-f]{40}\t\S+\z/)
-      end
-    end
-
-    context 'with a treeish specifier (HEAD^{tree})' do
-      it 'resolves and recurses into the tree' do
-        result = described_instance.full_tree('HEAD^{tree}')
-        expect(result).to be_a(Array)
-        expect(result).not_to be_empty
-      end
-    end
-
-    context 'when the sha does not exist' do
-      it 'raises Git::FailedError' do
-        expect { described_instance.full_tree('0000000000000000000000000000000000000000') }
-          .to raise_error(Git::FailedError)
       end
     end
   end
@@ -406,49 +194,14 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
         expect(result).to eq(1)
       end
     end
-
-    context 'with a treeish specifier (HEAD^{tree})' do
-      it 'returns a positive count' do
-        result = described_instance.tree_depth('HEAD^{tree}')
-        expect(result).to be_positive
-      end
-    end
-
-    context 'when the sha does not exist' do
-      it 'raises Git::FailedError' do
-        expect { described_instance.tree_depth('0000000000000000000000000000000000000000') }
-          .to raise_error(Git::FailedError)
-      end
-    end
   end
 
   describe '#name_rev' do
     context 'with a commit SHA that has a symbolic name' do
-      it 'returns a String' do
-        sha = repo.rev_parse('HEAD')
-        result = described_instance.name_rev(sha)
-        expect(result).to be_a(String)
-      end
-
       it 'returns the symbolic name without a trailing newline' do
         sha = repo.rev_parse('HEAD')
         result = described_instance.name_rev(sha)
         expect(result).not_to end_with("\n")
-      end
-    end
-
-    context 'with a branch ref that resolves to a commit' do
-      it 'returns a non-nil String' do
-        result = described_instance.name_rev('HEAD')
-        expect(result).to be_a(String)
-        expect(result).not_to be_empty
-      end
-    end
-
-    context 'when commit_ish starts with a hyphen' do
-      it 'raises ArgumentError without calling git' do
-        expect { described_instance.name_rev('--tags') }
-          .to raise_error(ArgumentError, "Invalid commit_ish: '--tags'")
       end
     end
   end
@@ -496,27 +249,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
         expect(result['tree']).not_to have_key('lib')
       end
     end
-
-    context 'with a path option' do
-      it 'limits the listing to entries under the given path' do
-        result = described_instance.ls_tree('HEAD', path: 'lib')
-        expect(result['tree']).to have_key('lib')
-        expect(result['blob']).not_to have_key('README.md')
-      end
-    end
-
-    context 'with an unsupported option' do
-      it 'raises ArgumentError' do
-        expect { described_instance.ls_tree('HEAD', bogus: true) }.to raise_error(ArgumentError)
-      end
-    end
-
-    context 'when the sha does not exist' do
-      it 'raises Git::FailedError' do
-        expect { described_instance.ls_tree('0000000000000000000000000000000000000000') }
-          .to raise_error(Git::FailedError)
-      end
-    end
   end
 
   describe '#archive' do
@@ -551,13 +283,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
         end
       end
 
-      context 'with a tar format' do
-        it 'writes a non-empty archive file' do
-          described_instance.archive('HEAD', tmpfile.path, format: 'tar')
-          expect(File.size(tmpfile.path)).to be_positive
-        end
-      end
-
       context 'with a tgz format' do
         it 'writes a gzip-compressed archive file' do
           described_instance.archive('HEAD', tmpfile.path, format: 'tgz')
@@ -567,25 +292,11 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
         end
       end
 
-      context 'with a prefix option' do
-        it 'writes a non-empty archive file' do
-          described_instance.archive('HEAD', tmpfile.path, format: 'tar', prefix: 'myproject/')
-          expect(File.size(tmpfile.path)).to be_positive
-        end
-      end
-
       context 'with add_gzip: true' do
         it 'writes a gzip-compressed archive file' do
           described_instance.archive('HEAD', tmpfile.path, format: 'tar', add_gzip: true)
           expect(File.size(tmpfile.path)).to be_positive
           Zlib::GzipReader.open(tmpfile.path, &:read)
-        end
-      end
-
-      context 'with an unknown option' do
-        it 'raises ArgumentError without calling git' do
-          expect { described_instance.archive('HEAD', tmpfile.path, bad_opt: true) }
-            .to raise_error(ArgumentError)
         end
       end
 
@@ -636,13 +347,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
           described_instance.archive('HEAD', link_path, format: 'zip')
           expect(File.size(link_target.path)).to eq(target_size_before)
         end
-      end
-    end
-
-    context 'with a directory path as file' do
-      it 'raises ArgumentError without creating an archive file' do
-        expect { described_instance.archive('HEAD', Dir.tmpdir) }
-          .to raise_error(ArgumentError, /is a directory/)
       end
     end
   end
@@ -749,20 +453,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
         expect(result).to eq({})
       end
     end
-
-    context 'with an unknown option' do
-      it 'raises ArgumentError without calling git' do
-        expect { described_instance.grep('TODO', nil, line_number: true) }
-          .to raise_error(ArgumentError, 'Unknown options: line_number')
-      end
-    end
-
-    context 'with an invalid object reference' do
-      it 'raises Git::FailedError' do
-        expect { described_instance.grep('TODO', nil, object: 'nonexistent_ref') }
-          .to raise_error(Git::FailedError)
-      end
-    end
   end
 
   # Integration tests for #gblob, #gcommit, #gtree, #tag, and #object are
@@ -775,24 +465,10 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
   # contract and argument forwarding.
 
   describe '#tags' do
-    context 'when the repository has no tags' do
-      it 'returns an empty array' do
-        expect(described_instance.tags).to eq([])
-      end
-    end
-
     context 'when the repository has tags' do
       before do
         described_instance.tag_add('v1.0.0')
         described_instance.tag_add('v2.0.0', annotate: true, message: 'Release 2.0.0')
-      end
-
-      it 'returns a Git::Object::Tag for every tag' do
-        expect(described_instance.tags).to all(be_a(Git::Object::Tag))
-      end
-
-      it 'returns every tag name' do
-        expect(described_instance.tags.map(&:name)).to contain_exactly('v1.0.0', 'v2.0.0')
       end
     end
   end
@@ -841,22 +517,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
   describe '#tag_delete' do
     context 'when the tag exists' do
       before { described_instance.tag_add('v1.0.0') }
-
-      it 'removes the tag' do
-        described_instance.tag_delete('v1.0.0')
-        expect(described_instance.tags.map(&:name)).not_to include('v1.0.0')
-      end
-
-      it 'returns git stdout confirming the deletion' do
-        expect(described_instance.tag_delete('v1.0.0')).to match(/Deleted tag 'v1.0.0'/)
-      end
-    end
-
-    context 'when the tag does not exist' do
-      it 'raises Git::FailedError naming the failed delete command' do
-        expect { described_instance.tag_delete('does-not-exist') }
-          .to raise_error(Git::FailedError, /does-not-exist/)
-      end
     end
   end
 end

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -74,17 +74,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
       end
     end
 
-    context 'with a bare repository clone' do
-      let(:clone_parent_dir) { Dir.mktmpdir }
-      let(:bare_clone_dir) { File.join(clone_parent_dir, 'bare') }
-      let(:bare_repo) { Git.clone(repo_dir, bare_clone_dir, bare: true) }
-      let(:bare_instance) { Git::Repository.new(execution_context: bare_repo.execution_context) }
-
-      after do
-        FileUtils.rm_rf(clone_parent_dir)
-      end
-    end
-
     context 'with a real SSH-signed commit',
             if: !Gem.win_platform?,
             skip: unless_git('2.34', 'SSH commit signing') || unless_command('ssh-keygen', 'SSH commit signing') do
@@ -464,15 +453,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
   # spec/unit/git/repository/object_operations_spec.rb verify the delegation
   # contract and argument forwarding.
 
-  describe '#tags' do
-    context 'when the repository has tags' do
-      before do
-        described_instance.tag_add('v1.0.0')
-        described_instance.tag_add('v2.0.0', annotate: true, message: 'Release 2.0.0')
-      end
-    end
-  end
-
   describe '#tag_add' do
     context 'with no target and no options' do
       it 'creates a lightweight tag on HEAD' do
@@ -511,12 +491,6 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
         expect(replaced.annotated?).to be(true)
         expect(replaced.message).to eq('replaced')
       end
-    end
-  end
-
-  describe '#tag_delete' do
-    context 'when the tag exists' do
-      before { described_instance.tag_add('v1.0.0') }
     end
   end
 end

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -39,55 +39,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   end
 
   # ---------------------------------------------------------------------------
-  # #push — basic invocations
-  # ---------------------------------------------------------------------------
-
-  describe '#push' do
-    context 'with tags: true' do
-      before do
-        repo.tag_add('v1.0')
-      end
-    end
-
-    context 'with no remote or branch arguments (tracking branch workflow)' do
-      let(:clone_parent_dir) { Dir.mktmpdir('clone_parent') }
-      let(:bare_origin_dir) { File.join(clone_parent_dir, 'origin.git') }
-      let(:clone_dir) { File.join(clone_parent_dir, 'clone') }
-
-      after { FileUtils.rm_rf(clone_parent_dir) }
-
-      context 'when the clone has a new commit to push' do
-        let(:clone_instance) do
-          Git.init(bare_origin_dir, bare: true)
-          git = Git.clone(bare_origin_dir, clone_dir)
-          git.config_set('user.email', 'test@example.com')
-          git.config_set('user.name', 'Test User')
-          git.config_set('commit.gpgsign', 'false')
-          File.write(File.join(clone_dir, 'file.txt'), 'content')
-          git.add('file.txt')
-          git.commit('First commit')
-          Git::Repository.new(execution_context: git.execution_context)
-        end
-      end
-
-      context 'when the clone has no commits to push' do
-        let(:clone_instance) do
-          Git.init(bare_origin_dir, bare: true)
-          git = Git.clone(bare_origin_dir, clone_dir)
-          git.config_set('user.email', 'test@example.com')
-          git.config_set('user.name', 'Test User')
-          git.config_set('commit.gpgsign', 'false')
-          Git::Repository.new(execution_context: git.execution_context)
-        end
-      end
-    end
-  end
-
-  # ---------------------------------------------------------------------------
-  # #pull — basic invocations
-  # ---------------------------------------------------------------------------
-
-  # ---------------------------------------------------------------------------
   # #remote_add — basic invocations
   # ---------------------------------------------------------------------------
 
@@ -99,7 +50,7 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
     end
 
     before do
-      Git.init(remote_dir, bare: true)
+      Git.init(remote_dir, bare: true, initial_branch: 'main')
     end
 
     it 'registers the remote so it appears in the repository config' do
@@ -140,10 +91,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   end
 
   # ---------------------------------------------------------------------------
-  # #remote (factory)
-  # ---------------------------------------------------------------------------
-
-  # ---------------------------------------------------------------------------
   # #remotes
   # ---------------------------------------------------------------------------
 
@@ -171,7 +118,7 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
 
     after { FileUtils.rm_rf(other_dir) }
 
-    before { Git.init(other_dir, bare: true) }
+    before { Git.init(other_dir, bare: true, initial_branch: 'main') }
 
     it 'updates the fetch URL for the named remote' do
       described_instance.remote_set_url('origin', other_dir)

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -30,32 +30,10 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   # ---------------------------------------------------------------------------
 
   describe '#fetch' do
-    it 'returns a String' do
-      result = described_instance.fetch('origin')
-      expect(result).to be_a(String)
-    end
-
-    it 'uses "origin" as the default remote' do
-      result = described_instance.fetch
-      expect(result).to be_a(String)
-    end
-
-    it 'raises Git::FailedError when the remote does not exist' do
-      expect { described_instance.fetch('nonexistent-remote') }
-        .to raise_error(Git::FailedError, /nonexistent-remote/)
-    end
-
     context 'when opts is passed as the first argument (Hash-only form)' do
       it 'returns a String when fetching without an explicit remote' do
         result = described_instance.fetch(prune: true)
         expect(result).to be_a(String)
-      end
-    end
-
-    context 'with an unknown option key' do
-      it 'raises ArgumentError before calling git' do
-        expect { described_instance.fetch('origin', unknown_key: true) }
-          .to raise_error(ArgumentError, /unknown_key/)
       end
     end
   end
@@ -65,38 +43,9 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   # ---------------------------------------------------------------------------
 
   describe '#push' do
-    it 'returns a String' do
-      result = described_instance.push('origin', 'main')
-      expect(result).to be_a(String)
-    end
-
-    it 'raises Git::FailedError when the remote does not exist' do
-      expect { described_instance.push('nonexistent-remote', 'main') }
-        .to raise_error(Git::FailedError, /nonexistent-remote/)
-    end
-
-    context 'when branch is specified without a remote' do
-      it 'raises ArgumentError' do
-        expect { described_instance.push(nil, 'main') }
-          .to raise_error(ArgumentError, /remote is required/)
-      end
-    end
-
-    context 'with an unknown option key' do
-      it 'raises ArgumentError before calling git' do
-        expect { described_instance.push('origin', 'main', unknown_key: true) }
-          .to raise_error(ArgumentError, /unknown_key/)
-      end
-    end
-
     context 'with tags: true' do
       before do
         repo.tag_add('v1.0')
-      end
-
-      it 'pushes refs and tags and returns a String' do
-        result = described_instance.push('origin', 'main', tags: true)
-        expect(result).to be_a(String)
       end
     end
 
@@ -119,10 +68,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
           git.commit('First commit')
           Git::Repository.new(execution_context: git.execution_context)
         end
-
-        it 'returns a String' do
-          expect(clone_instance.push).to be_a(String)
-        end
       end
 
       context 'when the clone has no commits to push' do
@@ -134,10 +79,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
           git.config_set('commit.gpgsign', 'false')
           Git::Repository.new(execution_context: git.execution_context)
         end
-
-        it 'raises Git::FailedError' do
-          expect { clone_instance.push }.to raise_error(Git::FailedError, /push/)
-        end
       end
     end
   end
@@ -145,28 +86,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   # ---------------------------------------------------------------------------
   # #pull — basic invocations
   # ---------------------------------------------------------------------------
-
-  describe '#pull' do
-    it 'returns a String' do
-      result = described_instance.pull('origin', 'main')
-      expect(result).to be_a(String)
-    end
-
-    it 'raises ArgumentError when a branch is given without a remote' do
-      expect { described_instance.pull(nil, 'main') }
-        .to raise_error(ArgumentError, /You must specify a remote if a branch is specified/)
-    end
-
-    it 'raises Git::FailedError when the remote does not exist' do
-      expect { described_instance.pull('nonexistent-remote', 'main') }
-        .to raise_error(Git::FailedError, /nonexistent-remote/)
-    end
-
-    it 'raises ArgumentError before calling git when an unknown option is given' do
-      expect { described_instance.pull('origin', 'main', unknown_opt: true) }
-        .to raise_error(ArgumentError, /unknown_opt/)
-    end
-  end
 
   # ---------------------------------------------------------------------------
   # #remote_add — basic invocations
@@ -183,40 +102,9 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       Git.init(remote_dir, bare: true)
     end
 
-    it 'returns Git::Remote' do
-      result = described_instance.remote_add('secondary', remote_dir)
-      expect(result).to be_a(Git::Remote)
-      expect(result.name).to eq('secondary')
-    end
-
     it 'registers the remote so it appears in the repository config' do
       described_instance.remote_add('secondary', remote_dir)
       expect(repo.remotes.map(&:name)).to include('secondary')
-    end
-
-    context 'with fetch: true' do
-      it 'does not raise an error' do
-        expect { described_instance.remote_add('secondary', remote_dir, fetch: true) }.not_to raise_error
-      end
-    end
-
-    context 'with track: "main"' do
-      it 'does not raise an error' do
-        expect { described_instance.remote_add('secondary', remote_dir, track: 'main') }.not_to raise_error
-      end
-    end
-
-    context 'with the deprecated :with_fetch alias' do
-      it 'does not raise an error' do
-        expect { described_instance.remote_add('secondary', remote_dir, with_fetch: true) }.not_to raise_error
-      end
-    end
-
-    context 'with an unknown option key' do
-      it 'raises ArgumentError before calling git' do
-        expect { described_instance.remote_add('secondary', remote_dir, unknown_key: true) }
-          .to raise_error(ArgumentError, /unknown_key/)
-      end
     end
   end
 
@@ -229,16 +117,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       described_instance.remote_remove('origin')
       expect(repo.remotes.map(&:name)).not_to include('origin')
     end
-
-    it 'returns a Git::CommandLine::Result' do
-      result = described_instance.remote_remove('origin')
-      expect(result).to be_a(Git::CommandLine::Result)
-    end
-
-    it 'raises Git::FailedError when the remote does not exist' do
-      expect { described_instance.remote_remove('nonexistent') }
-        .to raise_error(Git::FailedError, /nonexistent/)
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -246,10 +124,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   # ---------------------------------------------------------------------------
 
   describe '#config_remote' do
-    it 'returns a Hash' do
-      expect(described_instance.config_remote('origin')).to be_a(Hash)
-    end
-
     it 'includes the url key' do
       result = described_instance.config_remote('origin')
       expect(result).to have_key('url')
@@ -269,35 +143,11 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   # #remote (factory)
   # ---------------------------------------------------------------------------
 
-  describe '#remote' do
-    it 'returns a Git::Remote for the named remote' do
-      result = described_instance.remote('origin')
-      expect(result).to be_a(Git::Remote)
-      expect(result.name).to eq('origin')
-    end
-
-    it 'defaults to "origin" when no name is given' do
-      result = described_instance.remote
-      expect(result).to be_a(Git::Remote)
-      expect(result.name).to eq('origin')
-    end
-
-    it 'populates url from the remote configuration' do
-      result = described_instance.remote('origin')
-      expect(result.url).to eq(bare_dir)
-    end
-  end
-
   # ---------------------------------------------------------------------------
   # #remotes
   # ---------------------------------------------------------------------------
 
   describe '#remotes' do
-    it 'returns an Array of Git::Remote objects' do
-      result = described_instance.remotes
-      expect(result).to all(be_a(Git::Remote))
-    end
-
     it 'includes each configured remote by name' do
       described_instance.remote_add('upstream', bare_dir)
       expect(described_instance.remotes.map(&:name)).to contain_exactly('origin', 'upstream')
@@ -327,12 +177,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       described_instance.remote_set_url('origin', other_dir)
       expect(described_instance.config_remote('origin')['url']).to eq(other_dir)
     end
-
-    it 'returns a Git::Remote for the updated remote' do
-      result = described_instance.remote_set_url('origin', other_dir)
-      expect(result).to be_a(Git::Remote)
-      expect(result.name).to eq('origin')
-    end
   end
 
   # ---------------------------------------------------------------------------
@@ -340,10 +184,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   # ---------------------------------------------------------------------------
 
   describe '#remote_set_branches' do
-    it 'returns nil' do
-      expect(described_instance.remote_set_branches('origin', 'main')).to be_nil
-    end
-
     it 'replaces the tracked branches for the remote' do
       described_instance.remote_set_branches('origin', 'main')
       expect(described_instance.config_remote('origin')['fetch']).to include('main')
@@ -362,11 +202,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   # ---------------------------------------------------------------------------
 
   describe '#ls_remote' do
-    it 'returns a Hash' do
-      result = described_instance.ls_remote('origin')
-      expect(result).to be_a(Hash)
-    end
-
     it 'contains a "branches" key with at least one entry for the pushed branch' do
       result = described_instance.ls_remote('origin')
       expect(result).to have_key('branches')
@@ -376,13 +211,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
     it 'contains a "head" key' do
       result = described_instance.ls_remote('origin')
       expect(result).to have_key('head')
-    end
-
-    context 'with tags: true' do
-      it 'returns a Hash without raising' do
-        result = described_instance.ls_remote('origin', tags: true)
-        expect(result).to be_a(Hash)
-      end
     end
   end
 end

--- a/spec/integration/git/repository/staging_spec.rb
+++ b/spec/integration/git/repository/staging_spec.rb
@@ -79,10 +79,6 @@ RSpec.describe Git::Repository::Staging, :integration do
         described_instance.apply(patch_file)
         expect(read_file('hello.txt')).to eq("hello world\n")
       end
-
-      it 'returns a String' do
-        expect(described_instance.apply(patch_file)).to be_a(String)
-      end
     end
 
     context 'when the patch file does not exist' do
@@ -119,10 +115,6 @@ RSpec.describe Git::Repository::Staging, :integration do
         described_instance.apply_mail(mbox_file)
         expect(read_file('hello.txt')).to eq("hello world\n")
       end
-
-      it 'returns a String' do
-        expect(described_instance.apply_mail(mbox_file)).to be_a(String)
-      end
     end
 
     context 'when the mbox file does not exist' do
@@ -143,33 +135,6 @@ RSpec.describe Git::Repository::Staging, :integration do
       repo.add(all: true)
       repo.commit('Initial commit')
     end
-
-    it 'reads the tree into the index without error' do
-      expect { described_instance.read_tree('HEAD') }.not_to raise_error
-    end
-
-    it 'returns a String' do
-      expect(described_instance.read_tree('HEAD')).to be_a(String)
-    end
-
-    context 'with prefix option' do
-      it 'reads the tree under the given prefix without error' do
-        expect { described_instance.read_tree('HEAD', { prefix: 'sub/' }) }.not_to raise_error
-      end
-    end
-
-    context 'with an unknown option' do
-      it 'raises ArgumentError before calling git' do
-        expect { described_instance.read_tree('HEAD', { bogus: true }) }
-          .to raise_error(ArgumentError, /Unknown options: bogus/)
-      end
-    end
-
-    context 'legacy positional hash signature' do
-      it 'accepts opts as a positional hash' do
-        expect { described_instance.read_tree('HEAD', { prefix: 'sub/' }) }.not_to raise_error
-      end
-    end
   end
 
   describe '#rm' do
@@ -177,14 +142,6 @@ RSpec.describe Git::Repository::Staging, :integration do
       write_file('README.txt', 'hello world')
       repo.add('README.txt')
       repo.commit('Initial commit')
-    end
-
-    context 'when removing a tracked file with force: true' do
-      it 'removes the file from the working tree' do
-        described_instance.rm('README.txt', force: true)
-
-        expect(file_exist?('README.txt')).to be(false)
-      end
     end
   end
 end

--- a/spec/integration/git/repository/staging_spec.rb
+++ b/spec/integration/git/repository/staging_spec.rb
@@ -128,20 +128,4 @@ RSpec.describe Git::Repository::Staging, :integration do
       end
     end
   end
-
-  describe '#read_tree' do
-    before do
-      write_file('hello.txt', "hello\n")
-      repo.add(all: true)
-      repo.commit('Initial commit')
-    end
-  end
-
-  describe '#rm' do
-    before do
-      write_file('README.txt', 'hello world')
-      repo.add('README.txt')
-      repo.commit('Initial commit')
-    end
-  end
 end

--- a/spec/integration/git/repository/stashing_spec.rb
+++ b/spec/integration/git/repository/stashing_spec.rb
@@ -104,30 +104,4 @@ RSpec.describe Git::Repository::Stashing, :integration do
       expect(described_instance.stash_list).to include('WIP')
     end
   end
-
-  describe '#stash_save' do
-    context 'when the repository has no commits (unborn branch)' do
-      let(:unborn_repo_dir) { Dir.mktmpdir('unborn_repo') }
-      let(:unborn_repo) { init_test_repo(unborn_repo_dir) }
-      let(:unborn_instance) { Git::Repository.new(execution_context: unborn_repo.execution_context) }
-
-      before do
-        File.write(File.join(unborn_repo_dir, 'file.txt'), 'hello')
-        unborn_repo.add('file.txt')
-      end
-
-      after { FileUtils.rm_rf(unborn_repo_dir) }
-    end
-  end
-
-  describe '#stash_apply' do
-    context 'after saving a stash and resetting the working tree' do
-      before do
-        write_file('file.txt', 'modified content')
-        repo.add('file.txt')
-        described_instance.stash_save('testing')
-        repo.reset
-      end
-    end
-  end
 end

--- a/spec/integration/git/repository/stashing_spec.rb
+++ b/spec/integration/git/repository/stashing_spec.rb
@@ -27,12 +27,6 @@ RSpec.describe Git::Repository::Stashing, :integration do
         repo.stash_save('my feature work')
       end
 
-      it 'returns a single-element array with index 0' do
-        result = described_instance.stashes_all
-        expect(result.length).to eq(1)
-        expect(result.first.first).to eq(0)
-      end
-
       it 'strips the branch prefix from the message' do
         result = described_instance.stashes_all
         # Git prefixes the message: "On main: my feature work"
@@ -100,11 +94,6 @@ RSpec.describe Git::Repository::Stashing, :integration do
       described_instance.stash_list
     end
 
-    it 'returns a String' do
-      allow(Git::Deprecation).to receive(:warn)
-      expect(described_instance.stash_list).to be_a(String)
-    end
-
     it 'contains "stash@{0}"' do
       allow(Git::Deprecation).to receive(:warn)
       expect(described_instance.stash_list).to include('stash@{0}')
@@ -128,10 +117,6 @@ RSpec.describe Git::Repository::Stashing, :integration do
       end
 
       after { FileUtils.rm_rf(unborn_repo_dir) }
-
-      it 'raises Git::FailedError' do
-        expect { unborn_instance.stash_save('unborn stash') }.to raise_error(Git::FailedError, /stash/)
-      end
     end
   end
 
@@ -142,12 +127,6 @@ RSpec.describe Git::Repository::Stashing, :integration do
         repo.add('file.txt')
         described_instance.stash_save('testing')
         repo.reset
-      end
-
-      it 'restores the stashed changes to the working tree' do
-        described_instance.stash_apply
-
-        expect(repo.status.changed.keys).to include('file.txt')
       end
     end
   end

--- a/spec/integration/git/repository/status_operations_spec.rb
+++ b/spec/integration/git/repository/status_operations_spec.rb
@@ -91,10 +91,6 @@ RSpec.describe Git::Repository::StatusOperations, :integration do
         repo.commit('Initial commit')
       end
 
-      it 'returns a Git::Status instance' do
-        expect(described_instance.status).to be_a(Git::Status)
-      end
-
       context 'when an untracked file exists' do
         before { write_file('untracked.rb', 'content') }
 
@@ -174,10 +170,6 @@ RSpec.describe Git::Repository::StatusOperations, :integration do
       before do
         write_file('ignored.log', 'log content')
         write_file('.gitignore', "ignored.log\n")
-      end
-
-      it 'does not include the ignored file' do
-        expect(described_instance.untracked_files).not_to include('ignored.log')
       end
     end
   end

--- a/spec/integration/git/repository/status_operations_spec.rb
+++ b/spec/integration/git/repository/status_operations_spec.rb
@@ -165,12 +165,5 @@ RSpec.describe Git::Repository::StatusOperations, :integration do
         expect(described_instance.untracked_files).to contain_exactly('a.rb', 'lib/b.rb')
       end
     end
-
-    context 'when a file matches a .gitignore pattern' do
-      before do
-        write_file('ignored.log', 'log content')
-        write_file('.gitignore', "ignored.log\n")
-      end
-    end
   end
 end


### PR DESCRIPTION
## Summary

Removes the 328 integration tests identified in [`redesign/integration_test_analysis.md`](redesign/integration_test_analysis.md) that do not add meaningful signal beyond what unit tests already cover.

The **22 controversial removals** listed in that document are explicitly excluded and remain untouched pending a separate discussion.

## Tests removed (328)

| Reason | Count |
| ------ | ----- |
| Option variant (argument building verified by unit spec) | ~100 |
| Git state/output assertion (tests git's own behavior, not the Ruby layer) | ~60 |
| Duplicate invocation (no independent failure mode, Rule 24) | ~55 |
| Single-command delegator (covered by underlying command's integration spec) | ~40 |
| Pure-Ruby guard (`ArgumentError` raised before any git call) | ~25 |
| Type-only assertion (`be_a(X)`, Rule 24 violation) | ~30 |
| Structural detail / synthetic input (duplicates unit spec) | ~18 |

## Result

| Build | Before | After (measured) | Reduction | Target | Success |
| ----- | ------ | ---------------- | --------- | ------ | ------- |
| Sequential (local, macOS) | 3m 06s | 1m 54s | 38% | < 2m 00s | YES |
| Parallel (local, macOS) | 0m 31s | 0m 18s | 42% | < 0m 25s | YES |
| Parallel (Windows CI) | 4m 22s | 3m 11s | 35% | < 3m 00s | **NO** |
| Parallel (TruffleRuby CI) | 2m 04s | 1m 19s | 36% | < 1m 30s | YES |
| Serial (JRuby CI) | 1m 52s | 1m 20s | 29% | < 1m 20s | **NO** |
| Integration test count | 885 | 557 | 37% | 557 | YES |

## What was NOT removed

- The 22 controversial removals flagged in `redesign/integration_test_analysis.md`
- Any test not listed in the "Tests to remove" section of that document
