### PR TITLE
feat: add upstream and upstream_remote to Git::Branch

### DIFF
--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -65,6 +65,23 @@ module Git
     #
     attr_accessor :name
 
+    # The upstream tracking branch info, or `nil` if none is configured
+    #
+    # Returns the {Git::BranchInfo} object for the configured upstream branch.
+    # Only populated when this branch was initialized from a full {Git::BranchInfo}
+    # (e.g. via {Git::Repository#branches} or {Git::Repository#branch}).
+    #
+    # @example Get the upstream remote name
+    #   git.branch('foo').upstream&.remote_name  #=> 'origin'
+    #
+    # @example Get the upstream branch short name
+    #   git.branch('foo').upstream&.short_name   #=> 'bar'
+    #
+    # @return [Git::BranchInfo, nil] the upstream branch info, or `nil` if no
+    #   upstream is configured or unavailable
+    #
+    attr_reader :upstream
+
     # Initialize a new Branch object
     #
     # @param base [Git::Repository] the git repository
@@ -381,6 +398,25 @@ module Git
       @full
     end
 
+    # Returns the {Git::Remote} for the configured upstream, or `nil`
+    #
+    # A convenience wrapper around {#upstream} for the common case where the
+    # caller only needs the remote object rather than the full upstream
+    # {Git::BranchInfo}.
+    #
+    # @example Get the upstream remote
+    #   git.branch('foo').upstream_remote  #=> #<Git::Remote 'origin'>
+    #
+    # @return [Git::Remote, nil] the remote associated with the upstream branch,
+    #   or `nil` if no upstream is configured or the upstream is not a
+    #   remote-tracking branch
+    #
+    def upstream_remote
+      return nil unless @upstream&.remote_name
+
+      Git::Remote.new(@base, @upstream.remote_name)
+    end
+
     # Regular expression for parsing branch refnames
     #
     # Matches full and short refnames, capturing an optional remote name and the
@@ -427,6 +463,7 @@ module Git
       @full = branch_info.refname
       @name = branch_info.short_name
       @remote = branch_info.remote_name ? Git::Remote.new(@base, branch_info.remote_name) : nil
+      @upstream = branch_info.upstream
     end
 
     # Initialize from a string name (legacy path for backward compatibility)
@@ -438,6 +475,7 @@ module Git
     def initialize_from_name(name)
       @full = name
       @remote, @name = parse_name(name)
+      @upstream = nil
     end
 
     # Parses a full branch name into remote and short branch name components

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -509,16 +509,26 @@ module Git
       # @example List only local branches
       #   repo.branches_all.reject(&:remote?)
       #
-      # @return [Array<Git::BranchInfo>] parsed branch information for every
-      #   local and remote-tracking branch
+      # @example Filter by short name pattern
+      #   repo.branches_all(pattern: ['foo'])
+      #   # => [#<data Git::BranchInfo refname="foo", ...>]
       #
-      #   Returns an empty array when the repository has no branches.
+      # @param pattern [Array<String>] optional shell wildcard patterns passed
+      #   directly to `git branch --list`; an empty array (the default) returns
+      #   all branches.  Pattern matching follows git's own rules; behavior may
+      #   differ between local and remote-tracking branches.
+      #
+      # @return [Array<Git::BranchInfo>] parsed branch information for every
+      #   local and remote-tracking branch matching the pattern
+      #
+      #   Returns an empty array when the repository has no branches or no branches
+      #   match the given pattern.
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
-      def branches_all
+      def branches_all(pattern: [])
         result = Git::Commands::Branch::List.new(@execution_context).call(
-          all: true, format: Git::Parsers::Branch::FORMAT_STRING
+          *pattern, all: true, format: Git::Parsers::Branch::FORMAT_STRING
         )
         Git::Parsers::Branch.parse_list(result.stdout)
       end
@@ -573,13 +583,11 @@ module Git
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
       def branch(branch_name = current_branch)
-        branch_info = Git::BranchInfo.new(
-          refname: branch_name,
-          target_oid: nil,
-          current: false,
-          worktree: false,
-          symref: nil,
-          upstream: nil
+        short_name = branch_name.match(Git::BRANCH_REFNAME_REGEXP)[:branch_name]
+        branch_info = branches_all(pattern: [short_name]).find { |b| b.refname == branch_name }
+        branch_info ||= Git::BranchInfo.new(
+          refname: branch_name, target_oid: nil, current: false,
+          worktree: false, symref: nil, upstream: nil
         )
         Git::Branch.new(self, branch_info)
       end

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -341,9 +341,63 @@ RSpec.describe Git::Repository::Branching, :integration do
   # #branch (factory)
   # ---------------------------------------------------------------------------
 
-  # ---------------------------------------------------------------------------
-  # #current_branch_state
-  # ---------------------------------------------------------------------------
+  describe '#branch' do
+    context 'when the local branch has an upstream tracking branch on a remote' do
+      let(:bare_dir) { Dir.mktmpdir('bare_repo') }
+      let(:branch) { described_instance.branch('foo') }
+
+      after { FileUtils.rm_rf(bare_dir) }
+
+      # Reproduces the user scenario from issue #1270:
+      # local branch 'foo' tracking remote 'origin' branch 'bar'
+      # (deliberately different names to verify upstream.short_name)
+      before do
+        Git.init(bare_dir, bare: true)
+        repo.remote_add('origin', bare_dir)
+        # Create foo, push it to origin as 'bar', then configure tracking
+        repo.branch('foo').create
+        repo.checkout('foo')
+        repo.push('origin', 'foo:bar')
+        repo.config_set('branch.foo.remote', 'origin')
+        repo.config_set('branch.foo.merge', 'refs/heads/bar')
+      end
+
+      it 'returns a Branch whose upstream is the upstream BranchInfo' do
+        expect(branch.upstream).to be_a(Git::BranchInfo)
+      end
+
+      it 'returns a Branch whose upstream remote_name is origin' do
+        expect(branch.upstream.remote_name).to eq('origin')
+      end
+
+      it 'returns a Branch whose upstream short_name is the remote branch name' do
+        expect(branch.upstream.short_name).to eq('bar')
+      end
+
+      it 'returns a Branch whose upstream_remote is a Git::Remote for origin' do
+        expect(branch.upstream_remote).to be_a(Git::Remote)
+        expect(branch.upstream_remote.name).to eq('origin')
+      end
+    end
+
+    context 'when the local branch has no upstream' do
+      it 'returns a Branch with nil upstream' do
+        branch = described_instance.branch('main')
+        expect(branch.upstream).to be_nil
+      end
+
+      it 'returns a Branch with nil upstream_remote' do
+        branch = described_instance.branch('main')
+        expect(branch.upstream_remote).to be_nil
+      end
+    end
+
+    # The bare BranchInfo fallback for non-existent branch names (the ||=
+    # assignment in Branching#branch) is pure-Ruby logic covered by unit
+    # tests. branches_all is still called first and runs git, but the
+    # fallback path itself adds no new git behavior worth integration-testing.
+  end
+
   #
   # current_branch_state calls both ShowCurrent and RevParse, so integration
   # tests confirm the multi-command orchestration produces the correct HeadState

--- a/spec/unit/git/branch_spec.rb
+++ b/spec/unit/git/branch_spec.rb
@@ -505,4 +505,164 @@ RSpec.describe Git::Branch do
       expect(branch.to_s).to eq('feature')
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #upstream
+  # ---------------------------------------------------------------------------
+
+  describe '#upstream' do
+    subject(:upstream) { described_class.new(base, branch_info).upstream }
+
+    context 'when upstream is configured (BranchInfo path)' do
+      let(:upstream_info) do
+        Git::BranchInfo.new(
+          refname: 'remotes/origin/bar',
+          target_oid: nil,
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      let(:branch_info) do
+        Git::BranchInfo.new(
+          refname: 'foo',
+          target_oid: 'abc123',
+          current: true,
+          worktree: false,
+          symref: nil,
+          upstream: upstream_info
+        )
+      end
+
+      it 'returns the upstream BranchInfo' do
+        expect(upstream).to eq(upstream_info)
+      end
+
+      it 'exposes the upstream remote name' do
+        expect(upstream.remote_name).to eq('origin')
+      end
+
+      it 'exposes the upstream short name' do
+        expect(upstream.short_name).to eq('bar')
+      end
+    end
+
+    context 'when no upstream is configured (BranchInfo path)' do
+      let(:branch_info) do
+        Git::BranchInfo.new(
+          refname: 'foo',
+          target_oid: 'abc123',
+          current: true,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      it 'returns nil' do
+        expect(upstream).to be_nil
+      end
+    end
+
+    context 'when initialized from a String (legacy path)' do
+      let(:branch_info) { 'foo' }
+
+      it 'returns nil' do
+        expect(upstream).to be_nil
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #upstream_remote
+  # ---------------------------------------------------------------------------
+
+  describe '#upstream_remote' do
+    subject(:upstream_remote) { described_class.new(base, branch_info).upstream_remote }
+
+    context 'when upstream is a remote-tracking branch' do
+      let(:upstream_info) do
+        Git::BranchInfo.new(
+          refname: 'remotes/origin/bar',
+          target_oid: nil,
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      let(:branch_info) do
+        Git::BranchInfo.new(
+          refname: 'foo',
+          target_oid: 'abc123',
+          current: true,
+          worktree: false,
+          symref: nil,
+          upstream: upstream_info
+        )
+      end
+
+      let(:remote_config) { { 'url' => 'https://github.com/test/repo.git' } }
+
+      before do
+        allow(base).to receive(:config_remote).with('origin').and_return(remote_config)
+      end
+
+      it 'returns a Git::Remote for the upstream remote' do
+        expect(upstream_remote).to be_a(Git::Remote)
+      end
+
+      it 'returns a remote with the correct name' do
+        expect(upstream_remote.name).to eq('origin')
+      end
+    end
+
+    context 'when upstream is a local branch (no remote_name)' do
+      let(:upstream_info) do
+        Git::BranchInfo.new(
+          refname: 'main',
+          target_oid: nil,
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      let(:branch_info) do
+        Git::BranchInfo.new(
+          refname: 'foo',
+          target_oid: 'abc123',
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: upstream_info
+        )
+      end
+
+      it 'returns nil' do
+        expect(upstream_remote).to be_nil
+      end
+    end
+
+    context 'when no upstream is configured' do
+      let(:branch_info) do
+        Git::BranchInfo.new(
+          refname: 'foo',
+          target_oid: 'abc123',
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      it 'returns nil' do
+        expect(upstream_remote).to be_nil
+      end
+    end
+  end
 end

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -864,7 +864,8 @@ RSpec.describe Git::Repository::Branching do
   # ---------------------------------------------------------------------------
 
   describe '#branches_all' do
-    subject(:result) { described_instance.branches_all }
+    subject(:result) { described_instance.branches_all(**options) }
+    let(:options) { {} }
 
     let(:branch_list_command) { instance_double(Git::Commands::Branch::List) }
     let(:branch_list_result) do
@@ -917,6 +918,26 @@ RSpec.describe Git::Repository::Branching do
             .ordered
         )
         expect(result).to eq([])
+      end
+    end
+
+    context 'when a pattern is given' do
+      let(:options) { { pattern: ['foo'] } }
+
+      it 'passes the pattern as a positional argument to Branch::List#call' do
+        expect(branch_list_command).to(
+          receive(:call)
+            .with('foo', all: true, format: Git::Parsers::Branch::FORMAT_STRING)
+            .and_return(branch_list_result)
+            .ordered
+        )
+        expect(Git::Parsers::Branch).to(
+          receive(:parse_list)
+            .with(branch_list_result.stdout)
+            .and_return(parsed_branches)
+            .ordered
+        )
+        expect(result).to eq(parsed_branches)
       end
     end
   end
@@ -994,6 +1015,12 @@ RSpec.describe Git::Repository::Branching do
     context 'with an explicit branch name' do
       subject(:result) { described_instance.branch('feature') }
 
+      before do
+        allow(described_instance).to receive(:branches_all)
+          .with(pattern: ['feature'])
+          .and_return([])
+      end
+
       it 'returns a Git::Branch for the given name' do
         expect(result).to be_a(Git::Branch)
       end
@@ -1018,11 +1045,101 @@ RSpec.describe Git::Repository::Branching do
 
       before do
         allow(show_current_command).to receive(:call).and_return(show_current_result)
+        allow(described_instance).to receive(:branches_all)
+          .with(pattern: ['main'])
+          .and_return([])
       end
 
       it 'returns a Git::Branch for the current branch name' do
         expect(result).to be_a(Git::Branch)
         expect(result.full).to eq('main')
+      end
+    end
+
+    context 'when the branch exists in git with upstream tracking' do
+      subject(:result) { described_instance.branch('foo') }
+
+      let(:upstream_info) do
+        Git::BranchInfo.new(
+          refname: 'remotes/origin/bar',
+          target_oid: nil,
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      let(:branch_info) do
+        Git::BranchInfo.new(
+          refname: 'foo',
+          target_oid: 'abc123',
+          current: true,
+          worktree: false,
+          symref: nil,
+          upstream: upstream_info
+        )
+      end
+
+      before do
+        allow(described_instance).to receive(:branches_all)
+          .with(pattern: ['foo'])
+          .and_return([branch_info])
+        allow(described_instance).to receive(:config_remote).with('origin').and_return({})
+      end
+
+      it 'returns a Branch with upstream populated from BranchInfo' do
+        expect(result.upstream).to eq(upstream_info)
+      end
+
+      it 'returns a Branch whose upstream_remote has the correct name' do
+        expect(result.upstream_remote.name).to eq('origin')
+      end
+    end
+
+    context 'when the branch does not exist in git (fallback to bare BranchInfo)' do
+      subject(:result) { described_instance.branch('nonexistent') }
+
+      before do
+        allow(described_instance).to receive(:branches_all)
+          .with(pattern: ['nonexistent'])
+          .and_return([])
+      end
+
+      it 'returns a Git::Branch with the given name' do
+        expect(result).to be_a(Git::Branch)
+        expect(result.full).to eq('nonexistent')
+      end
+
+      it 'has nil upstream' do
+        expect(result.upstream).to be_nil
+      end
+    end
+
+    context 'when the branch name is a remote-tracking refname' do
+      subject(:result) { described_instance.branch('remotes/origin/foo') }
+
+      let(:remote_branch_info) do
+        Git::BranchInfo.new(
+          refname: 'remotes/origin/foo',
+          target_oid: 'abc123',
+          current: false,
+          worktree: false,
+          symref: nil,
+          upstream: nil
+        )
+      end
+
+      before do
+        allow(described_instance).to receive(:branches_all)
+          .with(pattern: ['foo'])
+          .and_return([remote_branch_info])
+        allow(described_instance).to receive(:config_remote).with('origin').and_return({})
+      end
+
+      it 'returns the remote-tracking Branch' do
+        expect(result.full).to eq('remotes/origin/foo')
+        expect(result.remote.name).to eq('origin')
       end
     end
   end


### PR DESCRIPTION
# Description

Closes #1270.

Local branches with a configured upstream now expose that upstream info
via two new methods on `Git::Branch`:

- `#upstream` — returns the upstream `Git::BranchInfo` (with `remote_name`
  and `short_name`), or `nil` when no upstream is configured
- `#upstream_remote` — returns `Git::Remote` for the upstream remote, or
  `nil` when the upstream is not a remote-tracking branch

`Branching#branch` now calls `branches_all(pattern: [short_name])` to look
up the real `BranchInfo` so that `git.branch('foo').upstream` is populated
when the branch is accessed by name — not only when iterating via
`git.branches`.

`Branching#branches_all` gains an optional `pattern:` keyword arg that
forwards patterns as positional args to `Commands::Branch::List#call`.

**Before:**
```ruby
git = Git.open('.')
git.branch(git.current_branch).remote  # => nil, even with tracking configured
```

**After:**
```ruby
git = Git.open('.')
branch = git.branch(git.current_branch)
branch.upstream.remote_name   # => 'origin'
branch.upstream.short_name    # => 'bar'
branch.upstream_remote.name   # => 'origin'
```

## Key decisions

- `#upstream` returns `Git::BranchInfo` (not `Git::Branch`) per maintainer
  comment in #1270 — gives access to `remote_name` and `short_name` without
  additional git invocations
- `#upstream_remote` returns `Git::Remote` as a convenience wrapper
- `git.branch('nonexistent')` still falls back to a bare `Branch` (no behavior
  regression for non-existent branch names)
- Legacy `initialize_from_name` path sets `@upstream = nil` explicitly
- The extra subprocess per `git.branch(name)` call is accepted as the cost of
  having upstream data available regardless of how the branch is accessed; the
  fallback preserves backward compatibility

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
