### PR TITLE
refactor(branch): redesign BranchInfo value object

### DIFF
--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -65,23 +65,6 @@ module Git
     #
     attr_accessor :name
 
-    # The upstream tracking branch info, or `nil` if none is configured
-    #
-    # Returns the {Git::BranchInfo} object for the configured upstream branch.
-    # Only populated when this branch was initialized from a full {Git::BranchInfo}
-    # (e.g. via {Git::Repository#branches} or {Git::Repository#branch}).
-    #
-    # @example Get the upstream remote name
-    #   git.branch('foo').upstream&.remote_name  #=> 'origin'
-    #
-    # @example Get the upstream branch short name
-    #   git.branch('foo').upstream&.short_name   #=> 'bar'
-    #
-    # @return [Git::BranchInfo, nil] the upstream branch info, or `nil` if no
-    #   upstream is configured or unavailable
-    #
-    attr_reader :upstream
-
     # Initialize a new Branch object
     #
     # @param base [Git::Repository] the git repository
@@ -398,25 +381,6 @@ module Git
       @full
     end
 
-    # Returns the {Git::Remote} for the configured upstream, or `nil`
-    #
-    # A convenience wrapper around {#upstream} for the common case where the
-    # caller only needs the remote object rather than the full upstream
-    # {Git::BranchInfo}.
-    #
-    # @example Get the upstream remote
-    #   git.branch('foo').upstream_remote  #=> #<Git::Remote 'origin'>
-    #
-    # @return [Git::Remote, nil] the remote associated with the upstream branch,
-    #   or `nil` if no upstream is configured or the upstream is not a
-    #   remote-tracking branch
-    #
-    def upstream_remote
-      return nil unless @upstream&.remote_name
-
-      Git::Remote.new(@base, @upstream.remote_name)
-    end
-
     # Regular expression for parsing branch refnames
     #
     # Matches full and short refnames, capturing an optional remote name and the
@@ -460,10 +424,9 @@ module Git
     # @return [nil]
     #
     def initialize_from_branch_info(branch_info)
-      @full = branch_info.refname
       @name = branch_info.short_name
       @remote = branch_info.remote_name ? Git::Remote.new(@base, branch_info.remote_name) : nil
-      @upstream = branch_info.upstream
+      @full = @remote ? "remotes/#{@remote.name}/#{@name}" : @name
     end
 
     # Initialize from a string name (legacy path for backward compatibility)
@@ -475,7 +438,6 @@ module Git
     def initialize_from_name(name)
       @full = name
       @remote, @name = parse_name(name)
-      @upstream = nil
     end
 
     # Parses a full branch name into remote and short branch name components

--- a/lib/git/branch_info.rb
+++ b/lib/git/branch_info.rb
@@ -9,14 +9,15 @@ module Git
   #
   # @example Parse branch refnames
   #   'main' => { remote_name: nil, branch_name: 'main' }
+  #   'refs/heads/main' => { remote_name: nil, branch_name: 'main' }
   #   'remotes/origin/main' => { remote_name: 'origin', branch_name: 'main' }
+  #   'refs/remotes/origin/main' => { remote_name: 'origin', branch_name: 'main' }
   #   'feature/foo' => { remote_name: nil, branch_name: 'feature/foo' }
   #   'remotes/origin/feature/bar' => { remote_name: 'origin', branch_name: 'feature/bar' }
   #
-  # @note This regex is similar to Git::Branch::BRANCH_NAME_REGEXP but uses \A/\z anchors
-  #   instead of ^/$ for stricter matching. As part of the architectural redesign,
-  #   Git::Branch will eventually be refactored to use BranchInfo internally, at which
-  #   point this will become the single source of truth for branch name parsing.
+  # @note This regex handles both raw full refs (e.g., `refs/heads/main`) as stored in
+  #   {Git::BranchInfo#refname} and normalized short-form refs (e.g., `main`,
+  #   `remotes/origin/main`) used elsewhere.
   #
   # @note This regex assumes remote names do not contain '/'. If a remote name
   #   contains '/', parsing will be incorrect. For example, 'remotes/team/upstream/main'
@@ -26,10 +27,11 @@ module Git
   #
   # @api private
   BRANCH_REFNAME_REGEXP = %r{
-    \A                              # start of string
-    (?:(?:refs/)?remotes/(?<remote_name>[^/]+)/)? # optional 'refs?/remotes/<remote_name>/'
-    (?<branch_name>.+)                   # branch name (everything else)
-    \z                              # end of string
+    \A                                            # start of string
+    (?:refs/heads/)?                              # optional refs/heads/ prefix (stripped)
+    (?:(?:refs/)?remotes/(?<remote_name>[^/]+)/)? # optional refs?/remotes/<remote_name>/
+    (?<branch_name>.+)                            # branch name (everything else)
+    \z                                            # end of string
   }x
 
   # Value object representing branch metadata from git branch output
@@ -38,50 +40,32 @@ module Git
   # commands. It contains only the data parsed from git output without any
   # repository context or operations.
   #
-  # @example Creating from git branch output
+  # @example Local branch with upstream tracking
   #   info = Git::BranchInfo.new(
-  #     refname: 'main',
+  #     refname: 'refs/heads/main',
   #     target_oid: 'abc123def456789012345678901234567890abcd',
   #     current: true,
-  #     worktree: false,
+  #     worktree_path: nil,
   #     symref: nil,
-  #     upstream: nil
+  #     upstream: 'refs/remotes/origin/main'
   #   )
   #   info.current?     #=> true
   #   info.remote?      #=> false
   #   info.short_name   #=> 'main'
+  #   info.upstream     #=> 'refs/remotes/origin/main'
   #
-  # @example Remote branch
+  # @example Remote-tracking branch
   #   info = Git::BranchInfo.new(
-  #     refname: 'remotes/origin/main',
+  #     refname: 'refs/remotes/origin/main',
   #     target_oid: 'abc123def456789012345678901234567890abcd',
   #     current: false,
-  #     worktree: false,
+  #     worktree_path: nil,
   #     symref: nil,
   #     upstream: nil
   #   )
   #   info.remote?      #=> true
   #   info.remote_name  #=> 'origin'
   #   info.short_name   #=> 'main'
-  #
-  # @example Local branch with upstream tracking
-  #   upstream_info = Git::BranchInfo.new(
-  #     refname: 'remotes/origin/main',
-  #     target_oid: 'abc123def456789012345678901234567890abcd',
-  #     current: false,
-  #     worktree: false,
-  #     symref: nil,
-  #     upstream: nil
-  #   )
-  #   info = Git::BranchInfo.new(
-  #     refname: 'main',
-  #     target_oid: 'abc123def456789012345678901234567890abcd',
-  #     current: true,
-  #     worktree: false,
-  #     symref: nil,
-  #     upstream: upstream_info
-  #   )
-  #   info.upstream.remote_name  #=> 'origin'
   #
   # @see Git::Branch for the full-featured branch object with operations
   #
@@ -93,13 +77,19 @@ module Git
   #
   #   The full reference name of the branch
   #
-  #   @return [String] the branch refname (e.g., 'main', 'remotes/origin/main')
+  #   Must be the full refname as returned by git (e.g., 'refs/heads/main',
+  #   'refs/remotes/origin/main') because the short name alone is not guaranteed to
+  #   be unique (e.g., 'main' could exist as both a local and remote branch).
+  #
+  #   @return [String] the branch refname (e.g., 'refs/heads/main',
+  #     'refs/remotes/origin/main')
   #
   # @!attribute [r] target_oid
   #
-  #   The commit object ID (SHA) that this branch points to
+  #   The commit object ID (SHA) that this branch points to (aka HEAD)
   #
-  #   @return [String, nil] the full 40-character object ID, or nil if unavailable
+  #   @return [String, nil] the full 40-character object ID, or nil if branch is
+  #   unborn (no commits yet)
   #
   # @!attribute [r] current
   #
@@ -107,11 +97,28 @@ module Git
   #
   #   @return [Boolean] true if this is the current branch
   #
-  # @!attribute [r] worktree
+  #   @note A branch can be current ({#current?} true) or in another worktree
+  #     ({#other_worktree?} true), but never both. A branch not checked out
+  #     anywhere has both false.
   #
-  #   Whether this branch is checked out in another linked worktree
+  # @!attribute [r] worktree_path
   #
-  #   @return [Boolean] true if checked out in a different worktree
+  #   The absolute path of the *other* linked worktree this branch is checked
+  #   out in, or nil.
+  #
+  #   This is nil in two distinct cases:
+  #   - The branch is the current branch in this worktree (use {#current?} to
+  #     distinguish that case)
+  #   - The branch is not checked out in any worktree
+  #
+  #   This path is suppressed for the current branch even though git reports it
+  #   via `%(worktreepath)`, because the current worktree's path is already
+  #   known from the repository object and storing it here would make
+  #   {#other_worktree?} incorrect.
+  #
+  #   @return [String, nil] the absolute path of the linked worktree root
+  #     directory (e.g., `'/home/user/projects/my-repo-hotfix'`), or nil if
+  #     the branch is not checked out in a different linked worktree
   #
   # @!attribute [r] symref
   #
@@ -121,27 +128,32 @@ module Git
   #
   # @!attribute [r] upstream
   #
-  #   The configured upstream/tracking branch
+  #   The configured upstream/tracking branch refname as reported by git
   #
-  #   @return [Git::BranchInfo, nil] the upstream branch info, or nil if no upstream is configured
+  #   @return [String, nil] the raw upstream refname from `%(upstream)`
+  #     (e.g., `'refs/remotes/origin/main'`), or nil if no upstream is configured
   #
-  #   @note Remote-tracking branches (e.g., 'origin/main') have upstream: nil
+  #   @note Remote-tracking branches (e.g., `'refs/remotes/origin/main'`) have upstream: nil
   #
-  #   @note When upstream exists but the remote-tracking branch hasn't been fetched,
-  #     the upstream's target_oid may be nil
+  #   @note This is the raw refname snapshot from when the branch list was read.
+  #     It does not reflect live git state after the snapshot was taken.
   #
-  BranchInfo = Data.define(:refname, :target_oid, :current, :worktree, :symref, :upstream) do
+  BranchInfo = Data.define(:refname, :target_oid, :current, :worktree_path, :symref, :upstream) do
     # @return [Boolean] always false for BranchInfo (see DetachedHeadInfo for detached state)
     def detached? = false
 
     # @return [Boolean] true if this is an unborn branch (no commits yet)
     def unborn? = target_oid.nil?
 
+    # @return [String] the short branch name without any remote or heads prefix
+    #   (e.g., 'main' or 'feature/foo')
+    def short_name = refname.match(Git::BRANCH_REFNAME_REGEXP)[:branch_name]
+
     # @return [Boolean] true if this is the currently checked out branch
     def current? = current
 
-    # @return [Boolean] true if this branch is checked out in another worktree
-    def worktree? = worktree
+    # @return [Boolean] true if this branch is checked out in another linked worktree
+    def other_worktree? = !worktree_path.nil?
 
     # @return [Boolean] true if this is a symbolic reference
     def symref? = !symref.nil?
@@ -150,29 +162,9 @@ module Git
     def remote? = !remote_name.nil?
 
     # @return [String, nil] the name of the remote (e.g., 'origin'), or nil for local branches
-    def remote_name
-      parse_refname[:remote_name]
-    end
-
-    # @return [String] the branch name without remote prefix (e.g., 'main' or 'feature/foo')
-    def short_name
-      parse_refname[:branch_name]
-    end
+    def remote_name = refname.match(Git::BRANCH_REFNAME_REGEXP)[:remote_name]
 
     # @return [String] string representation (the full refname)
     def to_s = refname
-
-    private
-
-    # Parse the refname and return match data
-    #
-    # The regex is guaranteed to match any non-empty string due to the `.+` pattern,
-    # so we don't need nil checking. If refname is empty/nil, this would fail at
-    # object creation time since refname is a required attribute.
-    #
-    # @return [MatchData] the match result
-    def parse_refname
-      refname.match(Git::BRANCH_REFNAME_REGEXP)
-    end
   end
 end

--- a/lib/git/branches.rb
+++ b/lib/git/branches.rb
@@ -30,7 +30,7 @@ module Git
 
       @base = base
 
-      branch_repository.branches_all.each do |branch_info|
+      branch_repository.branch_list.each do |branch_info|
         branch = Git::Branch.new(base, branch_info)
 
         @branches[branch_info.refname] = branch

--- a/lib/git/parsers/branch.rb
+++ b/lib/git/parsers/branch.rb
@@ -38,18 +38,21 @@ module Git
     module Branch
       # Format string for git branch --format
       #
-      # Fields (pipe-delimited):
-      # 1. refname - full ref name (e.g., refs/heads/main, refs/remotes/origin/main)
-      # 2. objectname - full SHA of the commit the branch points to
-      # 3. HEAD - '*' if current branch, empty otherwise
+      # Fields (null-delimited):
+      # 1. refname      - full ref name (e.g., refs/heads/main, refs/remotes/origin/main)
+      # 2. objectname  - full SHA of the commit the branch points to
+      # 3. HEAD         - '*' if current branch, empty otherwise
       # 4. worktreepath - path if checked out in another worktree, empty otherwise
-      # 5. symref - target ref if symbolic reference, empty otherwise
-      # 6. upstream - full upstream ref (e.g., refs/remotes/origin/main), empty if none
+      # 5. symref       - target ref if symbolic reference, empty otherwise
+      # 6. upstream     - full upstream ref (e.g., refs/remotes/origin/main), empty if none
       #
-      FORMAT_STRING = '%(refname)|%(objectname)|%(HEAD)|%(worktreepath)|%(symref)|%(upstream)'
+      # Null bytes (%00) are used as field delimiters so that worktree paths
+      # containing special characters (including '|') parse correctly.
+      #
+      FORMAT_STRING = '%(refname)%00%(objectname)%00%(HEAD)%00%(worktreepath)%00%(symref)%00%(upstream)'
 
       # Delimiter used in format output
-      FIELD_DELIMITER = '|'
+      FIELD_DELIMITER = "\0"
 
       # Regex to parse successful deletion lines from stdout
       # Matches: Deleted branch branchname (was abc123).
@@ -65,9 +68,13 @@ module Git
 
       # Parse git branch --list output into BranchInfo objects
       #
-      # @example
-      #   Git::Parsers::Branch.parse_list("refs/heads/main|abc1234|*|||\nrefs/heads/feature|def5678||||\n")
-      #   # => [#<data Git::BranchInfo refname="main", ...>, #<data Git::BranchInfo refname="feature", ...>]
+      # @example Parse NUL-delimited branch list output
+      #   Git::Parsers::Branch.parse_list(
+      #     "refs/heads/main\0abc1234\0*\0\0\0\n" \
+      #     "refs/heads/feature\0def5678\0\0\0\0\n"
+      #   )
+      #   # => [#<data Git::BranchInfo refname="refs/heads/main", ...>,
+      #   #     #<data Git::BranchInfo refname="refs/heads/feature", ...>]
       #
       # @param stdout [String] output from git branch --list --format=...
       #
@@ -79,7 +86,7 @@ module Git
 
       # Parse a single formatted branch line
       #
-      # @param line [String] the line to parse (pipe-delimited fields)
+      # @param line [String] the line to parse (NUL-delimited fields)
       #
       # @return [Git::BranchInfo, nil] branch info object, or nil if line should be skipped
       #
@@ -93,19 +100,18 @@ module Git
 
       # Build a BranchInfo from parsed fields
       #
-      # @param fields [Array<String>] the parsed fields: [refname, objectname, head, worktreepath, symref, upstream]
+      # @param fields [Array<String>] the parsed fields:
+      #   [refname, objectname, head, worktreepath, symref, upstream]
       #
       # @return [Git::BranchInfo] the branch info object
       #
       def build_branch_info(fields)
         raw_refname, objectname, head, worktreepath, symref, upstream = fields
-        current = head == '*'
-
         Git::BranchInfo.new(
-          refname: normalize_refname(raw_refname),
+          refname: raw_refname,
           target_oid: presence(objectname),
-          current: current,
-          worktree: in_other_worktree?(worktreepath, current),
+          current: head == '*',
+          worktree_path: head == '*' ? nil : presence(worktreepath),
           symref: presence(symref),
           upstream: build_upstream_info(upstream)
         )
@@ -125,53 +131,16 @@ module Git
         refname.match?(/^\(HEAD detached/) || refname.match?(/^\(not a branch\)/)
       end
 
-      # Normalize a full refname to the expected format
-      #
-      # Converts:
-      # - refs/heads/main -> main
-      # - refs/remotes/origin/main -> remotes/origin/main
-      #
-      # @param refname [String] the full refname from git
-      #
-      # @return [String] normalized refname
-      #
-      def normalize_refname(refname)
-        refname.sub(%r{^refs/heads/}, '').sub(%r{^refs/}, '')
-      end
-
-      # Check if the branch is checked out in another worktree
-      #
-      # worktree is true when the branch is checked out in ANOTHER worktree
-      # (worktreepath is non-empty AND it's not the current branch)
-      #
-      # @param worktreepath [String, nil] the worktree path from git output
-      #
-      # @param current [Boolean] whether this is the current branch
-      #
-      # @return [Boolean] true if checked out in another worktree
-      #
-      def in_other_worktree?(worktreepath, current)
-        has_worktree = !worktreepath.nil? && !worktreepath.empty?
-        has_worktree && !current
-      end
-
-      # Build upstream BranchInfo from upstream refname
+      # Return the raw upstream refname string, or nil if empty
       #
       # @param upstream_ref [String, nil] the upstream ref (e.g., 'refs/remotes/origin/main')
       #
-      # @return [Git::BranchInfo, nil] upstream branch info or nil
+      # @return [String, nil] the raw upstream refname, or nil
       #
       def build_upstream_info(upstream_ref)
         return nil if upstream_ref.nil? || upstream_ref.empty?
 
-        Git::BranchInfo.new(
-          refname: normalize_refname(upstream_ref),
-          target_oid: nil, # We don't have upstream's OID from this format
-          current: false,
-          worktree: false,
-          symref: nil,
-          upstream: nil # Upstream branches don't have their own upstream in this context
-        )
+        upstream_ref
       end
 
       # Return value if non-empty, nil otherwise

--- a/lib/git/remote.rb
+++ b/lib/git/remote.rb
@@ -121,9 +121,7 @@ module Git
     #
     def branch(branch = nil)
       branch ||= remote_repository.current_branch
-      remote_tracking_branch = "#{@name}/#{branch}"
-      branch_info = build_branch_info(remote_tracking_branch)
-      Git::Branch.new(@base, branch_info)
+      Git::Branch.new(@base, "#{@name}/#{branch}")
     end
 
     # Removes this remote from the repository
@@ -158,25 +156,6 @@ module Git
     #
     def remote_repository
       @base
-    end
-
-    # Builds branch metadata for a remote-tracking branch
-    #
-    # @param refname [String] remote-tracking branch name (for example,
-    #   `'origin/main'`)
-    #
-    # @return [Git::BranchInfo] minimal branch metadata for constructing
-    #   {Git::Branch}
-    #
-    def build_branch_info(refname)
-      Git::BranchInfo.new(
-        refname: refname,
-        target_oid: nil,
-        current: false,
-        worktree: false,
-        symref: nil,
-        upstream: nil
-      )
     end
   end
 end

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -499,23 +499,25 @@ module Git
       # Returns all local and remote-tracking branches as structured objects
       #
       # @example List all branches
-      #   repo.branches_all
-      #   # => [#<data Git::BranchInfo refname="main", current=true, ...>,
-      #   #     #<data Git::BranchInfo refname="remotes/origin/main", current=false, ...>]
+      #   repo.branch_list
+      #   # => [#<data Git::BranchInfo refname="refs/heads/main", current=true, ...>,
+      #   #     #<data Git::BranchInfo refname="refs/remotes/origin/main", current=false, ...>]
       #
       # @example Find the currently checked-out branch
-      #   repo.branches_all.find(&:current)
+      #   repo.branch_list.find(&:current)
       #
       # @example List only local branches
-      #   repo.branches_all.reject(&:remote?)
+      #   repo.branch_list.reject(&:remote?)
       #
-      # @example Filter by short name pattern
-      #   repo.branches_all(pattern: ['foo'])
-      #   # => [#<data Git::BranchInfo refname="foo", ...>]
+      # @example Filter to an exact branch name
+      #   repo.branch_list('feature/auth')
       #
-      # @param pattern [Array<String>] optional shell wildcard patterns passed
-      #   directly to `git branch --list`; an empty array (the default) returns
-      #   all branches.  Pattern matching follows git's own rules; behavior may
+      # @example Filter using glob patterns
+      #   repo.branch_list('feature/*', 'hotfix/*')
+      #
+      # @param patterns [Array<String>] optional shell wildcard patterns passed
+      #   directly to `git branch --list`; when empty (the default) all branches
+      #   are returned. Pattern matching follows git's own rules; behavior may
       #   differ between local and remote-tracking branches.
       #
       # @return [Array<Git::BranchInfo>] parsed branch information for every
@@ -526,11 +528,35 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
-      def branches_all(pattern: [])
+      def branch_list(*patterns)
         result = Git::Commands::Branch::List.new(@execution_context).call(
-          *pattern, all: true, format: Git::Parsers::Branch::FORMAT_STRING
+          *patterns, all: true, format: Git::Parsers::Branch::FORMAT_STRING
         )
         Git::Parsers::Branch.parse_list(result.stdout)
+      end
+
+      # Returns all local and remote-tracking branches in the 4.x-compatible format
+      #
+      # Each entry is a 4-element array: `[refname, current, worktree, symref]`.
+      # The `refname` uses the short form (`main`, `remotes/origin/main`) to
+      # match the output of the legacy `Git::Lib#branches_all` method.
+      #
+      # @return [Array<Array>] array of `[refname, current, worktree, symref]` tuples
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @deprecated Use {#branch_list} instead, which returns richer
+      #   {Git::BranchInfo} objects.
+      #
+      def branches_all
+        Git::Deprecation.warn(
+          'Git::Repository#branches_all is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#branch_list instead.'
+        )
+        branch_list.map do |info|
+          refname = info.remote? ? "remotes/#{info.remote_name}/#{info.short_name}" : info.short_name
+          [refname, info.current, info.other_worktree?, info.symref]
+        end
       end
 
       # Update a branch ref to point to a new commit
@@ -583,13 +609,7 @@ module Git
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
       def branch(branch_name = current_branch)
-        short_name = branch_name.match(Git::BRANCH_REFNAME_REGEXP)[:branch_name]
-        branch_info = branches_all(pattern: [short_name]).find { |b| b.refname == branch_name }
-        branch_info ||= Git::BranchInfo.new(
-          refname: branch_name, target_oid: nil, current: false,
-          worktree: false, symref: nil, upstream: nil
-        )
-        Git::Branch.new(self, branch_info)
+        Git::Branch.new(self, branch_name)
       end
 
       # Returns a {Git::Branches} collection of all branches in the repository

--- a/spec/integration/git/parsers/branch_spec.rb
+++ b/spec/integration/git/parsers/branch_spec.rb
@@ -32,29 +32,29 @@ RSpec.describe Git::Parsers::Branch, :integration do
       it 'parses all branches' do
         output = git_branch_output
         result = described_class.parse_list(output)
-        expect(result.map(&:refname)).to contain_exactly('main', 'feature-branch')
+        expect(result.map(&:short_name)).to contain_exactly('main', 'feature-branch')
       end
 
       it 'identifies the current branch' do
         output = git_branch_output
         result = described_class.parse_list(output)
-        expect(result.find(&:current).refname).to eq('main')
+        expect(result.find(&:current).short_name).to eq('main')
       end
 
       it 'returns BranchInfo objects with all expected attributes' do
         output = git_branch_output
         result = described_class.parse_list(output)
-        main_branch = result.find { |b| b.refname == 'main' }
+        main_branch = result.find { |b| b.short_name == 'main' }
 
         expect(main_branch).to respond_to(:refname)
         expect(main_branch).to respond_to(:target_oid)
         expect(main_branch).to respond_to(:current)
-        expect(main_branch).to respond_to(:worktree)
+        expect(main_branch).to respond_to(:worktree_path)
         expect(main_branch).to respond_to(:symref)
         expect(main_branch).to respond_to(:upstream)
 
         expect(main_branch.current).to be true
-        expect(main_branch.worktree).to be false
+        expect(main_branch.worktree_path).to be_nil
         expect(main_branch.symref).to be_nil
         expect(main_branch.target_oid).to match(/\A[0-9a-f]{40}\z/)
         expect(main_branch.upstream).to be_nil
@@ -73,13 +73,13 @@ RSpec.describe Git::Parsers::Branch, :integration do
       it 'parses branch names with slashes' do
         output = git_branch_output
         result = described_class.parse_list(output)
-        expect(result.map(&:refname)).to include('feature/with-slash')
+        expect(result.map(&:short_name)).to include('feature/with-slash')
       end
 
       it 'parses branch names with unicode' do
         output = git_branch_output
         result = described_class.parse_list(output)
-        expect(result.map(&:refname)).to include('feature/日本語')
+        expect(result.map(&:short_name)).to include('feature/日本語')
       end
     end
 
@@ -101,16 +101,12 @@ RSpec.describe Git::Parsers::Branch, :integration do
         repo.execution_context.command_capturing('branch', '-u', 'origin/main', 'main')
       end
 
-      it 'populates upstream as BranchInfo with refname' do
+      it 'populates upstream as the raw upstream refname string' do
         output = git_branch_output
         result = described_class.parse_list(output)
-        main_branch = result.find { |b| b.refname == 'main' }
+        main_branch = result.find { |b| b.short_name == 'main' }
 
-        expect(main_branch.upstream).to be_a(Git::BranchInfo)
-        expect(main_branch.upstream.refname).to eq('remotes/origin/main')
-        expect(main_branch.upstream.target_oid).to be_nil
-        expect(main_branch.upstream.current).to be false
-        expect(main_branch.upstream.worktree).to be false
+        expect(main_branch.upstream).to eq('refs/remotes/origin/main')
       end
     end
 
@@ -131,7 +127,7 @@ RSpec.describe Git::Parsers::Branch, :integration do
         result = described_class.parse_list(output)
 
         expect(result.size).to eq(1)
-        expect(result.first.refname).to eq('main')
+        expect(result.first.short_name).to eq('main')
         expect(result.none? { |b| b.refname.include?('detached') }).to be true
       end
     end

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -266,29 +266,29 @@ RSpec.describe Git::Repository::Branching, :integration do
   end
 
   # ---------------------------------------------------------------------------
-  # #branches_all
+  # #branch_list
   # ---------------------------------------------------------------------------
   #
-  # branches_all delegates parsing to Git::Parsers::Branch.parse_list, which
+  # branch_list delegates parsing to Git::Parsers::Branch.parse_list, which
   # means the integration tests verify the end-to-end Ruby return value against
   # real git output.
 
-  describe '#branches_all' do
+  describe '#branch_list' do
     context 'when only a local branch exists' do
       it 'returns an Array of Git::BranchInfo' do
-        result = described_instance.branches_all
+        result = described_instance.branch_list
         expect(result).to be_an(Array)
         expect(result).to all(be_a(Git::BranchInfo))
       end
 
       it 'includes the current branch' do
         current = described_instance.current_branch
-        refnames = described_instance.branches_all.map(&:refname)
-        expect(refnames).to include(current)
+        short_names = described_instance.branch_list.map(&:short_name)
+        expect(short_names).to include(current)
       end
 
       it 'marks exactly one branch as current' do
-        result = described_instance.branches_all
+        result = described_instance.branch_list
         current_branches = result.select(&:current)
         expect(current_branches.length).to eq(1)
       end
@@ -306,16 +306,16 @@ RSpec.describe Git::Repository::Branching, :integration do
       end
 
       it 'returns an Array of Git::BranchInfo that includes the remote-tracking branch' do
-        result = described_instance.branches_all
+        result = described_instance.branch_list
         expect(result).to be_an(Array)
         expect(result).to all(be_a(Git::BranchInfo))
         expect(result.any?(&:remote?)).to be(true)
       end
 
       it 'includes both local and remote-tracking branches' do
-        refnames = described_instance.branches_all.map(&:refname)
-        expect(refnames).to include('main')
-        expect(refnames.any? { |r| r.start_with?('remotes/origin/') }).to be(true)
+        branches = described_instance.branch_list
+        expect(branches.map(&:short_name)).to include('main')
+        expect(branches.any?(&:remote?)).to be(true)
       end
     end
 
@@ -326,9 +326,30 @@ RSpec.describe Git::Repository::Branching, :integration do
       end
 
       it 'returns an Array of Git::BranchInfo' do
-        result = described_instance.branches_all
+        result = described_instance.branch_list
         expect(result).to be_an(Array)
         expect(result).to all(be_a(Git::BranchInfo))
+      end
+    end
+
+    context 'when a local branch has a configured upstream (issue #1270)' do
+      let(:bare_dir) { Dir.mktmpdir('bare_repo') }
+
+      after { FileUtils.rm_rf(bare_dir) }
+
+      before do
+        Git.init(bare_dir, bare: true)
+        repo.remote_add('origin', bare_dir)
+        repo.branch('foo').create
+        repo.checkout('foo')
+        repo.push('origin', 'foo:bar')
+        repo.config_set('branch.foo.remote', 'origin')
+        repo.config_set('branch.foo.merge', 'refs/heads/bar')
+      end
+
+      it 'returns a BranchInfo whose upstream is the raw upstream refname string' do
+        foo = described_instance.branch_list.find { |b| b.short_name == 'foo' }
+        expect(foo.upstream).to eq('refs/remotes/origin/bar')
       end
     end
   end
@@ -338,65 +359,9 @@ RSpec.describe Git::Repository::Branching, :integration do
   # ---------------------------------------------------------------------------
 
   # ---------------------------------------------------------------------------
-  # #branch (factory)
+  # #branch (factory): upstream data is not populated by git.branch(name) —
+  # use git.branch_list to obtain BranchInfo with upstream tracking data.
   # ---------------------------------------------------------------------------
-
-  describe '#branch' do
-    context 'when the local branch has an upstream tracking branch on a remote' do
-      let(:bare_dir) { Dir.mktmpdir('bare_repo') }
-      let(:branch) { described_instance.branch('foo') }
-
-      after { FileUtils.rm_rf(bare_dir) }
-
-      # Reproduces the user scenario from issue #1270:
-      # local branch 'foo' tracking remote 'origin' branch 'bar'
-      # (deliberately different names to verify upstream.short_name)
-      before do
-        Git.init(bare_dir, bare: true)
-        repo.remote_add('origin', bare_dir)
-        # Create foo, push it to origin as 'bar', then configure tracking
-        repo.branch('foo').create
-        repo.checkout('foo')
-        repo.push('origin', 'foo:bar')
-        repo.config_set('branch.foo.remote', 'origin')
-        repo.config_set('branch.foo.merge', 'refs/heads/bar')
-      end
-
-      it 'returns a Branch whose upstream is the upstream BranchInfo' do
-        expect(branch.upstream).to be_a(Git::BranchInfo)
-      end
-
-      it 'returns a Branch whose upstream remote_name is origin' do
-        expect(branch.upstream.remote_name).to eq('origin')
-      end
-
-      it 'returns a Branch whose upstream short_name is the remote branch name' do
-        expect(branch.upstream.short_name).to eq('bar')
-      end
-
-      it 'returns a Branch whose upstream_remote is a Git::Remote for origin' do
-        expect(branch.upstream_remote).to be_a(Git::Remote)
-        expect(branch.upstream_remote.name).to eq('origin')
-      end
-    end
-
-    context 'when the local branch has no upstream' do
-      it 'returns a Branch with nil upstream' do
-        branch = described_instance.branch('main')
-        expect(branch.upstream).to be_nil
-      end
-
-      it 'returns a Branch with nil upstream_remote' do
-        branch = described_instance.branch('main')
-        expect(branch.upstream_remote).to be_nil
-      end
-    end
-
-    # The bare BranchInfo fallback for non-existent branch names (the ||=
-    # assignment in Branching#branch) is pure-Ruby logic covered by unit
-    # tests. branches_all is still called first and runs git, but the
-    # fallback path itself adds no new git behavior worth integration-testing.
-  end
 
   #
   # current_branch_state calls both ShowCurrent and RevParse, so integration

--- a/spec/unit/git/branch_info_spec.rb
+++ b/spec/unit/git/branch_info_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Git::BranchInfo do
         refname: 'main',
         target_oid: 'abc123def456789012345678901234567890abcd',
         current: true,
-        worktree: false,
+        worktree_path: nil,
         symref: nil,
         upstream: nil
       )
@@ -23,8 +23,8 @@ RSpec.describe Git::BranchInfo do
       expect(branch_info.current).to be true
     end
 
-    it 'exposes worktree' do
-      expect(branch_info.worktree).to be false
+    it 'exposes worktree_path' do
+      expect(branch_info.worktree_path).to be_nil
     end
 
     it 'exposes symref' do
@@ -43,39 +43,43 @@ RSpec.describe Git::BranchInfo do
   describe '#current?' do
     it 'returns true when current is true' do
       branch_info = described_class.new(
-        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+        refname: 'main', target_oid: 'abc123', current: true, worktree_path: nil,
+        symref: nil, upstream: nil
       )
       expect(branch_info.current?).to be true
     end
 
     it 'returns false when current is false' do
       branch_info = described_class.new(
-        refname: 'main', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+        refname: 'main', target_oid: 'abc123', current: false, worktree_path: nil,
+        symref: nil, upstream: nil
       )
       expect(branch_info.current?).to be false
     end
   end
 
-  describe '#worktree?' do
-    it 'returns true when worktree is true' do
+  describe '#other_worktree?' do
+    it 'returns true when worktree_path is non-nil' do
       branch_info = described_class.new(
-        refname: 'feature', target_oid: 'abc123', current: false, worktree: true, symref: nil, upstream: nil
+        refname: 'feature', target_oid: 'abc123', current: false, worktree_path: '/path/to/worktree',
+        symref: nil, upstream: nil
       )
-      expect(branch_info.worktree?).to be true
+      expect(branch_info.other_worktree?).to be true
     end
 
-    it 'returns false when worktree is false' do
+    it 'returns false when worktree_path is nil' do
       branch_info = described_class.new(
-        refname: 'feature', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+        refname: 'feature', target_oid: 'abc123', current: false, worktree_path: nil,
+        symref: nil, upstream: nil
       )
-      expect(branch_info.worktree?).to be false
+      expect(branch_info.other_worktree?).to be false
     end
   end
 
   describe '#symref?' do
     it 'returns true when symref is present' do
       branch_info = described_class.new(
-        refname: 'HEAD', target_oid: 'abc123', current: false, worktree: false,
+        refname: 'HEAD', target_oid: 'abc123', current: false, worktree_path: nil,
         symref: 'refs/heads/main', upstream: nil
       )
       expect(branch_info.symref?).to be true
@@ -83,7 +87,8 @@ RSpec.describe Git::BranchInfo do
 
     it 'returns false when symref is nil' do
       branch_info = described_class.new(
-        refname: 'main', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+        refname: 'main', target_oid: 'abc123', current: false, worktree_path: nil,
+        symref: nil, upstream: nil
       )
       expect(branch_info.symref?).to be false
     end
@@ -92,7 +97,8 @@ RSpec.describe Git::BranchInfo do
   describe '#detached?' do
     it 'always returns false' do
       branch_info = described_class.new(
-        refname: 'main', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+        refname: 'main', target_oid: 'abc123', current: false, worktree_path: nil,
+        symref: nil, upstream: nil
       )
       expect(branch_info.detached?).to be false
     end
@@ -101,14 +107,15 @@ RSpec.describe Git::BranchInfo do
   describe '#unborn?' do
     it 'returns true when target_oid is nil' do
       branch_info = described_class.new(
-        refname: 'main', target_oid: nil, current: true, worktree: false, symref: nil, upstream: nil
+        refname: 'main', target_oid: nil, current: true, worktree_path: nil, symref: nil, upstream: nil
       )
       expect(branch_info.unborn?).to be true
     end
 
     it 'returns false when target_oid is present' do
       branch_info = described_class.new(
-        refname: 'main', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+        refname: 'main', target_oid: 'abc123', current: false, worktree_path: nil,
+        symref: nil, upstream: nil
       )
       expect(branch_info.unborn?).to be false
     end
@@ -118,14 +125,15 @@ RSpec.describe Git::BranchInfo do
     context 'with local branch' do
       it 'returns false for simple branch name' do
         branch_info = described_class.new(
-          refname: 'main', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+          refname: 'main', target_oid: 'abc123', current: false, worktree_path: nil,
+          symref: nil, upstream: nil
         )
         expect(branch_info.remote?).to be false
       end
 
       it 'returns false for branch with slashes' do
         branch_info = described_class.new(
-          refname: 'feature/my-feature', target_oid: 'abc123', current: false, worktree: false,
+          refname: 'feature/my-feature', target_oid: 'abc123', current: false, worktree_path: nil,
           symref: nil, upstream: nil
         )
         expect(branch_info.remote?).to be false
@@ -135,7 +143,7 @@ RSpec.describe Git::BranchInfo do
     context 'with remote-tracking branch' do
       it 'returns true for remotes/origin/main' do
         branch_info = described_class.new(
-          refname: 'remotes/origin/main', target_oid: 'abc123', current: false, worktree: false,
+          refname: 'remotes/origin/main', target_oid: 'abc123', current: false, worktree_path: nil,
           symref: nil, upstream: nil
         )
         expect(branch_info.remote?).to be true
@@ -143,7 +151,7 @@ RSpec.describe Git::BranchInfo do
 
       it 'returns true for refs/remotes/origin/main' do
         branch_info = described_class.new(
-          refname: 'refs/remotes/origin/main', target_oid: 'abc123', current: false, worktree: false,
+          refname: 'refs/remotes/origin/main', target_oid: 'abc123', current: false, worktree_path: nil,
           symref: nil, upstream: nil
         )
         expect(branch_info.remote?).to be true
@@ -155,14 +163,15 @@ RSpec.describe Git::BranchInfo do
     context 'with local branch' do
       it 'returns nil for simple branch name' do
         branch_info = described_class.new(
-          refname: 'main', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+          refname: 'main', target_oid: 'abc123', current: false, worktree_path: nil,
+          symref: nil, upstream: nil
         )
         expect(branch_info.remote_name).to be_nil
       end
 
       it 'returns nil for branch with slashes' do
         branch_info = described_class.new(
-          refname: 'feature/my-feature', target_oid: 'abc123', current: false, worktree: false,
+          refname: 'feature/my-feature', target_oid: 'abc123', current: false, worktree_path: nil,
           symref: nil, upstream: nil
         )
         expect(branch_info.remote_name).to be_nil
@@ -172,7 +181,7 @@ RSpec.describe Git::BranchInfo do
     context 'with remote-tracking branch' do
       it 'extracts remote name from remotes/origin/main' do
         branch_info = described_class.new(
-          refname: 'remotes/origin/main', target_oid: 'abc123', current: false, worktree: false,
+          refname: 'remotes/origin/main', target_oid: 'abc123', current: false, worktree_path: nil,
           symref: nil, upstream: nil
         )
         expect(branch_info.remote_name).to eq('origin')
@@ -180,7 +189,7 @@ RSpec.describe Git::BranchInfo do
 
       it 'extracts remote name from refs/remotes/origin/main' do
         branch_info = described_class.new(
-          refname: 'refs/remotes/origin/main', target_oid: 'abc123', current: false, worktree: false,
+          refname: 'refs/remotes/origin/main', target_oid: 'abc123', current: false, worktree_path: nil,
           symref: nil, upstream: nil
         )
         expect(branch_info.remote_name).to eq('origin')
@@ -188,7 +197,7 @@ RSpec.describe Git::BranchInfo do
 
       it 'extracts remote name from remotes/upstream/feature' do
         branch_info = described_class.new(
-          refname: 'remotes/upstream/feature', target_oid: 'abc123', current: false, worktree: false,
+          refname: 'remotes/upstream/feature', target_oid: 'abc123', current: false, worktree_path: nil,
           symref: nil, upstream: nil
         )
         expect(branch_info.remote_name).to eq('upstream')
@@ -200,14 +209,39 @@ RSpec.describe Git::BranchInfo do
     context 'with local branch' do
       it 'returns the branch name for simple branch' do
         branch_info = described_class.new(
-          refname: 'main', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+          refname: 'main', target_oid: 'abc123', current: false, worktree_path: nil,
+          symref: nil, upstream: nil
         )
         expect(branch_info.short_name).to eq('main')
       end
 
+      it 'returns the branch name for refs/heads/ prefixed refname' do
+        branch_info = described_class.new(
+          refname: 'refs/heads/main', target_oid: 'abc123', current: false, worktree_path: nil,
+          symref: nil, upstream: nil
+        )
+        expect(branch_info.short_name).to eq('main')
+      end
+
+      it 'returns nil for remote_name for refs/heads/ prefixed refname' do
+        branch_info = described_class.new(
+          refname: 'refs/heads/main', target_oid: 'abc123', current: false, worktree_path: nil,
+          symref: nil, upstream: nil
+        )
+        expect(branch_info.remote_name).to be_nil
+      end
+
+      it 'returns false for remote? for refs/heads/ prefixed refname' do
+        branch_info = described_class.new(
+          refname: 'refs/heads/main', target_oid: 'abc123', current: false, worktree_path: nil,
+          symref: nil, upstream: nil
+        )
+        expect(branch_info.remote?).to be false
+      end
+
       it 'returns the full name for branch with slashes' do
         branch_info = described_class.new(
-          refname: 'feature/my-feature', target_oid: 'abc123', current: false, worktree: false,
+          refname: 'feature/my-feature', target_oid: 'abc123', current: false, worktree_path: nil,
           symref: nil, upstream: nil
         )
         expect(branch_info.short_name).to eq('feature/my-feature')
@@ -215,7 +249,7 @@ RSpec.describe Git::BranchInfo do
 
       it 'returns the full name for deeply nested branch' do
         branch_info = described_class.new(
-          refname: 'feature/team/project/task', target_oid: 'abc123', current: false, worktree: false,
+          refname: 'feature/team/project/task', target_oid: 'abc123', current: false, worktree_path: nil,
           symref: nil, upstream: nil
         )
         expect(branch_info.short_name).to eq('feature/team/project/task')
@@ -225,7 +259,7 @@ RSpec.describe Git::BranchInfo do
     context 'with remote-tracking branch' do
       it 'extracts branch name from remotes/origin/main' do
         branch_info = described_class.new(
-          refname: 'remotes/origin/main', target_oid: 'abc123', current: false, worktree: false,
+          refname: 'remotes/origin/main', target_oid: 'abc123', current: false, worktree_path: nil,
           symref: nil, upstream: nil
         )
         expect(branch_info.short_name).to eq('main')
@@ -233,7 +267,7 @@ RSpec.describe Git::BranchInfo do
 
       it 'extracts branch name from refs/remotes/origin/main' do
         branch_info = described_class.new(
-          refname: 'refs/remotes/origin/main', target_oid: 'abc123', current: false, worktree: false,
+          refname: 'refs/remotes/origin/main', target_oid: 'abc123', current: false, worktree_path: nil,
           symref: nil, upstream: nil
         )
         expect(branch_info.short_name).to eq('main')
@@ -242,7 +276,7 @@ RSpec.describe Git::BranchInfo do
       it 'preserves slashes in remote branch name' do
         branch_info = described_class.new(
           refname: 'remotes/origin/feature/my-feature', target_oid: 'abc123', current: false,
-          worktree: false, symref: nil, upstream: nil
+          worktree_path: nil, symref: nil, upstream: nil
         )
         expect(branch_info.short_name).to eq('feature/my-feature')
       end
@@ -252,14 +286,15 @@ RSpec.describe Git::BranchInfo do
   describe '#to_s' do
     it 'returns the refname' do
       branch_info = described_class.new(
-        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+        refname: 'main', target_oid: 'abc123', current: true, worktree_path: nil,
+        symref: nil, upstream: nil
       )
       expect(branch_info.to_s).to eq('main')
     end
 
     it 'returns full refname for remote branches' do
       branch_info = described_class.new(
-        refname: 'remotes/origin/main', target_oid: 'abc123', current: false, worktree: false,
+        refname: 'remotes/origin/main', target_oid: 'abc123', current: false, worktree_path: nil,
         symref: nil, upstream: nil
       )
       expect(branch_info.to_s).to eq('remotes/origin/main')
@@ -269,7 +304,8 @@ RSpec.describe Git::BranchInfo do
   describe 'immutability' do
     it 'is frozen' do
       branch_info = described_class.new(
-        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+        refname: 'main', target_oid: 'abc123', current: true, worktree_path: nil,
+        symref: nil, upstream: nil
       )
       expect(branch_info).to be_frozen
     end
@@ -278,30 +314,36 @@ RSpec.describe Git::BranchInfo do
   describe 'equality' do
     it 'is equal to another BranchInfo with same attributes' do
       info1 = described_class.new(
-        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+        refname: 'main', target_oid: 'abc123', current: true, worktree_path: nil,
+        symref: nil, upstream: nil
       )
       info2 = described_class.new(
-        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+        refname: 'main', target_oid: 'abc123', current: true, worktree_path: nil,
+        symref: nil, upstream: nil
       )
       expect(info1).to eq(info2)
     end
 
     it 'is not equal when refname differs' do
       info1 = described_class.new(
-        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+        refname: 'main', target_oid: 'abc123', current: true, worktree_path: nil,
+        symref: nil, upstream: nil
       )
       info2 = described_class.new(
-        refname: 'develop', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+        refname: 'develop', target_oid: 'abc123', current: true, worktree_path: nil,
+        symref: nil, upstream: nil
       )
       expect(info1).not_to eq(info2)
     end
 
     it 'is not equal when current differs' do
       info1 = described_class.new(
-        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+        refname: 'main', target_oid: 'abc123', current: true, worktree_path: nil,
+        symref: nil, upstream: nil
       )
       info2 = described_class.new(
-        refname: 'main', target_oid: 'abc123', current: false, worktree: false, symref: nil, upstream: nil
+        refname: 'main', target_oid: 'abc123', current: false, worktree_path: nil,
+        symref: nil, upstream: nil
       )
       expect(info1).not_to eq(info2)
     end
@@ -310,7 +352,8 @@ RSpec.describe Git::BranchInfo do
   describe 'pattern matching' do
     it 'supports pattern matching on attributes' do
       branch_info = described_class.new(
-        refname: 'main', target_oid: 'abc123', current: true, worktree: false, symref: nil, upstream: nil
+        refname: 'main', target_oid: 'abc123', current: true, worktree_path: nil,
+        symref: nil, upstream: nil
       )
 
       result = case branch_info
@@ -326,25 +369,14 @@ RSpec.describe Git::BranchInfo do
 
   describe 'upstream tracking' do
     context 'local branch tracking a remote-tracking branch' do
-      let(:upstream_info) do
-        described_class.new(
-          refname: 'remotes/origin/main',
-          target_oid: 'abc123def456789012345678901234567890abcd',
-          current: false,
-          worktree: false,
-          symref: nil,
-          upstream: nil
-        )
-      end
-
       subject(:branch_info) do
         described_class.new(
-          refname: 'main',
+          refname: 'refs/heads/main',
           target_oid: 'abc123def456789012345678901234567890abcd',
           current: true,
-          worktree: false,
+          worktree_path: nil,
           symref: nil,
-          upstream: upstream_info
+          upstream: 'refs/remotes/origin/main'
         )
       end
 
@@ -352,49 +384,29 @@ RSpec.describe Git::BranchInfo do
         expect(branch_info.upstream).not_to be_nil
       end
 
-      it 'upstream is a BranchInfo' do
-        expect(branch_info.upstream).to be_a(Git::BranchInfo)
+      it 'upstream is the raw upstream refname String' do
+        expect(branch_info.upstream).to be_a(String)
       end
 
-      it 'upstream has no upstream of its own' do
-        expect(branch_info.upstream.upstream).to be_nil
-      end
-
-      it 'allows accessing upstream properties' do
-        expect(branch_info.upstream.remote_name).to eq('origin')
-        expect(branch_info.upstream.short_name).to eq('main')
+      it 'upstream equals the raw upstream refname' do
+        expect(branch_info.upstream).to eq('refs/remotes/origin/main')
       end
     end
 
     context 'local branch tracking another local branch' do
-      let(:upstream_local) do
-        described_class.new(
-          refname: 'main',
-          target_oid: 'abc123def456789012345678901234567890abcd',
-          current: false,
-          worktree: false,
-          symref: nil,
-          upstream: nil
-        )
-      end
-
       subject(:branch_info) do
         described_class.new(
-          refname: 'feature',
+          refname: 'refs/heads/feature',
           target_oid: 'def456789012345678901234567890abcdef12',
           current: false,
-          worktree: false,
+          worktree_path: nil,
           symref: nil,
-          upstream: upstream_local
+          upstream: 'refs/heads/main'
         )
       end
 
-      it 'has a local branch as upstream' do
-        expect(branch_info.upstream.remote?).to be false
-      end
-
-      it 'upstream refname is the local branch name' do
-        expect(branch_info.upstream.refname).to eq('main')
+      it 'upstream is the raw upstream refname String' do
+        expect(branch_info.upstream).to eq('refs/heads/main')
       end
     end
 
@@ -404,7 +416,7 @@ RSpec.describe Git::BranchInfo do
           refname: 'orphan-branch',
           target_oid: 'ghi789012345678901234567890abcdef123456',
           current: false,
-          worktree: false,
+          worktree_path: nil,
           symref: nil,
           upstream: nil
         )
@@ -423,7 +435,7 @@ RSpec.describe Git::BranchInfo do
           refname: 'main',
           target_oid: 'abc123def456789012345678901234567890abcd',
           current: true,
-          worktree: false,
+          worktree_path: nil,
           symref: nil,
           upstream: nil
         )
@@ -440,7 +452,7 @@ RSpec.describe Git::BranchInfo do
           refname: 'unborn',
           target_oid: nil,
           current: false,
-          worktree: false,
+          worktree_path: nil,
           symref: nil,
           upstream: nil
         )

--- a/spec/unit/git/branch_spec.rb
+++ b/spec/unit/git/branch_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Git::Branch do
           refname: 'feature/my-feature',
           target_oid: 'abc123',
           current: true,
-          worktree: false,
+          worktree_path: nil,
           symref: nil,
           upstream: nil
         )
@@ -42,7 +42,7 @@ RSpec.describe Git::Branch do
           refname: 'remotes/origin/main',
           target_oid: 'abc123',
           current: false,
-          worktree: false,
+          worktree_path: nil,
           symref: nil,
           upstream: nil
         )
@@ -100,7 +100,7 @@ RSpec.describe Git::Branch do
           refname: refname,
           target_oid: 'abc123',
           current: false,
-          worktree: false,
+          worktree_path: nil,
           symref: nil,
           upstream: nil
         )
@@ -136,7 +136,7 @@ RSpec.describe Git::Branch do
           refname: 'feature',
           target_oid: 'abc123',
           current: false,
-          worktree: false,
+          worktree_path: nil,
           symref: nil,
           upstream: nil
         )
@@ -157,7 +157,7 @@ RSpec.describe Git::Branch do
           refname: 'remotes/origin/feature',
           target_oid: 'abc123',
           current: false,
-          worktree: false,
+          worktree_path: nil,
           symref: nil,
           upstream: nil
         )
@@ -189,7 +189,7 @@ RSpec.describe Git::Branch do
         refname: 'feature',
         target_oid: nil,
         current: false,
-        worktree: false,
+        worktree_path: nil,
         symref: nil,
         upstream: nil
       )
@@ -228,7 +228,7 @@ RSpec.describe Git::Branch do
         refname: 'feature',
         target_oid: nil,
         current: false,
-        worktree: false,
+        worktree_path: nil,
         symref: nil,
         upstream: nil
       )
@@ -264,7 +264,7 @@ RSpec.describe Git::Branch do
           refname: 'feature',
           target_oid: nil,
           current: false,
-          worktree: false,
+          worktree_path: nil,
           symref: nil,
           upstream: nil
         )
@@ -285,7 +285,7 @@ RSpec.describe Git::Branch do
           refname: 'remotes/origin/feature',
           target_oid: nil,
           current: false,
-          worktree: false,
+          worktree_path: nil,
           symref: nil,
           upstream: nil
         )
@@ -314,7 +314,7 @@ RSpec.describe Git::Branch do
         refname: 'new-feature',
         target_oid: nil,
         current: false,
-        worktree: false,
+        worktree_path: nil,
         symref: nil,
         upstream: nil
       )
@@ -350,7 +350,7 @@ RSpec.describe Git::Branch do
         refname: 'feature',
         target_oid: 'abc123',
         current: false,
-        worktree: false,
+        worktree_path: nil,
         symref: nil,
         upstream: nil
       )
@@ -382,7 +382,7 @@ RSpec.describe Git::Branch do
         refname: 'feature',
         target_oid: nil,
         current: false,
-        worktree: false,
+        worktree_path: nil,
         symref: nil,
         upstream: nil
       )
@@ -406,7 +406,7 @@ RSpec.describe Git::Branch do
         refname: 'feature',
         target_oid: nil,
         current: false,
-        worktree: false,
+        worktree_path: nil,
         symref: nil,
         upstream: nil
       )
@@ -431,7 +431,7 @@ RSpec.describe Git::Branch do
         refname: 'feature',
         target_oid: nil,
         current: false,
-        worktree: false,
+        worktree_path: nil,
         symref: nil,
         upstream: nil
       )
@@ -472,7 +472,7 @@ RSpec.describe Git::Branch do
         refname: 'feature',
         target_oid: nil,
         current: false,
-        worktree: false,
+        worktree_path: nil,
         symref: nil,
         upstream: nil
       )
@@ -495,7 +495,7 @@ RSpec.describe Git::Branch do
         refname: 'feature',
         target_oid: nil,
         current: false,
-        worktree: false,
+        worktree_path: nil,
         symref: nil,
         upstream: nil
       )
@@ -503,166 +503,6 @@ RSpec.describe Git::Branch do
 
     it 'returns the full refname as a string' do
       expect(branch.to_s).to eq('feature')
-    end
-  end
-
-  # ---------------------------------------------------------------------------
-  # #upstream
-  # ---------------------------------------------------------------------------
-
-  describe '#upstream' do
-    subject(:upstream) { described_class.new(base, branch_info).upstream }
-
-    context 'when upstream is configured (BranchInfo path)' do
-      let(:upstream_info) do
-        Git::BranchInfo.new(
-          refname: 'remotes/origin/bar',
-          target_oid: nil,
-          current: false,
-          worktree: false,
-          symref: nil,
-          upstream: nil
-        )
-      end
-
-      let(:branch_info) do
-        Git::BranchInfo.new(
-          refname: 'foo',
-          target_oid: 'abc123',
-          current: true,
-          worktree: false,
-          symref: nil,
-          upstream: upstream_info
-        )
-      end
-
-      it 'returns the upstream BranchInfo' do
-        expect(upstream).to eq(upstream_info)
-      end
-
-      it 'exposes the upstream remote name' do
-        expect(upstream.remote_name).to eq('origin')
-      end
-
-      it 'exposes the upstream short name' do
-        expect(upstream.short_name).to eq('bar')
-      end
-    end
-
-    context 'when no upstream is configured (BranchInfo path)' do
-      let(:branch_info) do
-        Git::BranchInfo.new(
-          refname: 'foo',
-          target_oid: 'abc123',
-          current: true,
-          worktree: false,
-          symref: nil,
-          upstream: nil
-        )
-      end
-
-      it 'returns nil' do
-        expect(upstream).to be_nil
-      end
-    end
-
-    context 'when initialized from a String (legacy path)' do
-      let(:branch_info) { 'foo' }
-
-      it 'returns nil' do
-        expect(upstream).to be_nil
-      end
-    end
-  end
-
-  # ---------------------------------------------------------------------------
-  # #upstream_remote
-  # ---------------------------------------------------------------------------
-
-  describe '#upstream_remote' do
-    subject(:upstream_remote) { described_class.new(base, branch_info).upstream_remote }
-
-    context 'when upstream is a remote-tracking branch' do
-      let(:upstream_info) do
-        Git::BranchInfo.new(
-          refname: 'remotes/origin/bar',
-          target_oid: nil,
-          current: false,
-          worktree: false,
-          symref: nil,
-          upstream: nil
-        )
-      end
-
-      let(:branch_info) do
-        Git::BranchInfo.new(
-          refname: 'foo',
-          target_oid: 'abc123',
-          current: true,
-          worktree: false,
-          symref: nil,
-          upstream: upstream_info
-        )
-      end
-
-      let(:remote_config) { { 'url' => 'https://github.com/test/repo.git' } }
-
-      before do
-        allow(base).to receive(:config_remote).with('origin').and_return(remote_config)
-      end
-
-      it 'returns a Git::Remote for the upstream remote' do
-        expect(upstream_remote).to be_a(Git::Remote)
-      end
-
-      it 'returns a remote with the correct name' do
-        expect(upstream_remote.name).to eq('origin')
-      end
-    end
-
-    context 'when upstream is a local branch (no remote_name)' do
-      let(:upstream_info) do
-        Git::BranchInfo.new(
-          refname: 'main',
-          target_oid: nil,
-          current: false,
-          worktree: false,
-          symref: nil,
-          upstream: nil
-        )
-      end
-
-      let(:branch_info) do
-        Git::BranchInfo.new(
-          refname: 'foo',
-          target_oid: 'abc123',
-          current: false,
-          worktree: false,
-          symref: nil,
-          upstream: upstream_info
-        )
-      end
-
-      it 'returns nil' do
-        expect(upstream_remote).to be_nil
-      end
-    end
-
-    context 'when no upstream is configured' do
-      let(:branch_info) do
-        Git::BranchInfo.new(
-          refname: 'foo',
-          target_oid: 'abc123',
-          current: false,
-          worktree: false,
-          symref: nil,
-          upstream: nil
-        )
-      end
-
-      it 'returns nil' do
-        expect(upstream_remote).to be_nil
-      end
     end
   end
 end

--- a/spec/unit/git/branches_spec.rb
+++ b/spec/unit/git/branches_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Git::Branches do
       refname: refname,
       target_oid: nil,
       current: current,
-      worktree: false,
+      worktree_path: nil,
       symref: nil,
       upstream: nil
     )
@@ -37,13 +37,13 @@ RSpec.describe Git::Branches do
       let(:base) { instance_double(Git::Repository) }
 
       before do
-        allow(base).to receive(:branches_all).and_return([local_info, remote_info])
+        allow(base).to receive(:branch_list).and_return([local_info, remote_info])
         allow(Git::Branch).to receive(:new).with(base, local_info).and_return(local_branch)
         allow(Git::Branch).to receive(:new).with(base, remote_info).and_return(remote_branch)
       end
 
-      it 'calls branches_all directly on the base' do
-        expect(base).to receive(:branches_all).and_return([local_info, remote_info])
+      it 'calls branch_list directly on the base' do
+        expect(base).to receive(:branch_list).and_return([local_info, remote_info])
         described_class.new(base)
       end
 
@@ -64,7 +64,7 @@ RSpec.describe Git::Branches do
   let(:described_instance) { described_class.new(repo_base) }
 
   before do
-    allow(repo_base).to receive(:branches_all).and_return(branch_infos)
+    allow(repo_base).to receive(:branch_list).and_return(branch_infos)
     allow(Git::Branch).to receive(:new).with(repo_base, local_info).and_return(local_branch)
     allow(Git::Branch).to receive(:new).with(repo_base, remote_info).and_return(remote_branch)
   end

--- a/spec/unit/git/parsers/branch_spec.rb
+++ b/spec/unit/git/parsers/branch_spec.rb
@@ -6,62 +6,61 @@ require 'git/parsers/branch'
 RSpec.describe Git::Parsers::Branch do
   describe '.parse_list' do
     it 'parses a single local branch' do
-      stdout = "main|abc123def456789012345678901234567890abcdef|*||||\n"
+      stdout = "refs/heads/main\0abc123def456789012345678901234567890abcdef\0*\0\0\0\n"
       result = described_class.parse_list(stdout)
 
       expect(result.size).to eq(1)
-      expect(result[0].refname).to eq('main')
+      expect(result[0].refname).to eq('refs/heads/main')
       expect(result[0].target_oid).to eq('abc123def456789012345678901234567890abcdef')
       expect(result[0].current?).to be true
-      expect(result[0].worktree?).to be false
+      expect(result[0].other_worktree?).to be false
     end
 
     it 'parses multiple branches' do
       stdout = <<~OUTPUT
-        refs/heads/main|abc123|*|||refs/remotes/origin/main
-        refs/heads/feature|def456||||
+        refs/heads/main\0abc123\0*\0\0\0refs/remotes/origin/main
+        refs/heads/feature\0def456\0\0\0\0
       OUTPUT
       result = described_class.parse_list(stdout)
 
       expect(result.size).to eq(2)
-      expect(result[0].refname).to eq('main')
+      expect(result[0].refname).to eq('refs/heads/main')
       expect(result[0].current?).to be true
-      expect(result[0].upstream).not_to be_nil
-      expect(result[0].upstream.refname).to eq('remotes/origin/main')
-      expect(result[1].refname).to eq('feature')
+      expect(result[0].upstream).to eq('refs/remotes/origin/main')
+      expect(result[1].refname).to eq('refs/heads/feature')
       expect(result[1].current?).to be false
     end
 
     it 'parses remote-tracking branches' do
-      stdout = "refs/remotes/origin/main|abc123||||\n"
+      stdout = "refs/remotes/origin/main\0abc123\0\0\0\0\n"
       result = described_class.parse_list(stdout)
 
       expect(result.size).to eq(1)
-      expect(result[0].refname).to eq('remotes/origin/main')
+      expect(result[0].refname).to eq('refs/remotes/origin/main')
       expect(result[0].remote?).to be true
       expect(result[0].remote_name).to eq('origin')
     end
 
     it 'skips detached HEAD entries' do
       stdout = <<~OUTPUT
-        (HEAD detached at abc123)|abc123||||
-        main|def456||||
+        (HEAD detached at abc123)\0abc123\0\0\0\0
+        refs/heads/main\0def456\0\0\0\0
       OUTPUT
       result = described_class.parse_list(stdout)
 
       expect(result.size).to eq(1)
-      expect(result[0].refname).to eq('main')
+      expect(result[0].refname).to eq('refs/heads/main')
     end
 
     it 'skips non-branch entries' do
       stdout = <<~OUTPUT
-        (not a branch)|||||
-        main|abc123||||
+        (not a branch)\0\0\0\0\0
+        refs/heads/main\0abc123\0\0\0\0
       OUTPUT
       result = described_class.parse_list(stdout)
 
       expect(result.size).to eq(1)
-      expect(result[0].refname).to eq('main')
+      expect(result[0].refname).to eq('refs/heads/main')
     end
 
     it 'returns empty array for empty input' do
@@ -71,22 +70,23 @@ RSpec.describe Git::Parsers::Branch do
     end
 
     it 'parses branch checked out in another worktree' do
-      stdout = "refs/heads/feature|abc123||/path/to/worktree||\n"
+      stdout = "refs/heads/feature\0abc123\0\0/path/to/worktree\0\0\n"
       result = described_class.parse_list(stdout)
 
-      expect(result[0].worktree?).to be true
+      expect(result[0].other_worktree?).to be true
+      expect(result[0].worktree_path).to eq('/path/to/worktree')
     end
 
     it 'does not mark current branch as worktree even with worktree path' do
-      stdout = "refs/heads/main|abc123|*|/path/to/main||\n"
+      stdout = "refs/heads/main\0abc123\0*\0/path/to/main\0\0\n"
       result = described_class.parse_list(stdout)
 
       expect(result[0].current?).to be true
-      expect(result[0].worktree?).to be false
+      expect(result[0].other_worktree?).to be false
     end
 
     it 'parses symbolic reference' do
-      stdout = "refs/heads/HEAD|abc123|||refs/heads/main|\n"
+      stdout = "refs/heads/HEAD\0abc123\0\0\0refs/heads/main\0\n"
       result = described_class.parse_list(stdout)
 
       expect(result[0].symref?).to be true
@@ -96,25 +96,25 @@ RSpec.describe Git::Parsers::Branch do
 
   describe '.parse_branch_line' do
     it 'returns nil for detached HEAD' do
-      line = '(HEAD detached at abc123)|abc123||||'
+      line = "(HEAD detached at abc123)\0abc123\0\0\0\0"
       result = described_class.parse_branch_line(line)
 
       expect(result).to be_nil
     end
 
     it 'returns nil for (not a branch) entries' do
-      line = '(not a branch)|||||'
+      line = "(not a branch)\0\0\0\0\0"
       result = described_class.parse_branch_line(line)
 
       expect(result).to be_nil
     end
 
     it 'parses a valid branch line' do
-      line = 'main|abc123|*|||'
+      line = "refs/heads/main\0abc123\0*\0\0\0"
       result = described_class.parse_branch_line(line)
 
       expect(result).to be_a(Git::BranchInfo)
-      expect(result.refname).to eq('main')
+      expect(result.refname).to eq('refs/heads/main')
     end
   end
 
@@ -123,17 +123,17 @@ RSpec.describe Git::Parsers::Branch do
       fields = ['refs/heads/main', 'abc123', '*', '', '', 'refs/remotes/origin/main']
       result = described_class.build_branch_info(fields)
 
-      expect(result.refname).to eq('main')
+      expect(result.refname).to eq('refs/heads/main')
       expect(result.target_oid).to eq('abc123')
       expect(result.current?).to be true
-      expect(result.upstream.refname).to eq('remotes/origin/main')
+      expect(result.upstream).to eq('refs/remotes/origin/main')
     end
 
     it 'handles nil/empty optional fields' do
       fields = ['refs/heads/feature', '', '', '', '', '']
       result = described_class.build_branch_info(fields)
 
-      expect(result.refname).to eq('feature')
+      expect(result.refname).to eq('refs/heads/feature')
       expect(result.target_oid).to be_nil
       expect(result.current?).to be false
       expect(result.symref).to be_nil
@@ -157,47 +157,9 @@ RSpec.describe Git::Parsers::Branch do
     end
   end
 
-  describe '.normalize_refname' do
-    it 'strips refs/heads/ prefix' do
-      expect(described_class.normalize_refname('refs/heads/main')).to eq('main')
-    end
-
-    it 'converts refs/remotes/ to remotes/' do
-      expect(described_class.normalize_refname('refs/remotes/origin/main')).to eq('remotes/origin/main')
-    end
-
-    it 'preserves already-normalized names' do
-      expect(described_class.normalize_refname('main')).to eq('main')
-      expect(described_class.normalize_refname('remotes/origin/main')).to eq('remotes/origin/main')
-    end
-  end
-
-  describe '.in_other_worktree?' do
-    it 'returns true when worktree path present and not current' do
-      expect(described_class.in_other_worktree?('/path/to/worktree', false)).to be true
-    end
-
-    it 'returns false when worktree path present but is current' do
-      expect(described_class.in_other_worktree?('/path/to/worktree', true)).to be false
-    end
-
-    it 'returns false when worktree path is empty' do
-      expect(described_class.in_other_worktree?('', false)).to be false
-    end
-
-    it 'returns false when worktree path is nil' do
-      expect(described_class.in_other_worktree?(nil, false)).to be false
-    end
-  end
-
   describe '.build_upstream_info' do
-    it 'builds BranchInfo for valid upstream ref' do
-      result = described_class.build_upstream_info('refs/remotes/origin/main')
-
-      expect(result).to be_a(Git::BranchInfo)
-      expect(result.refname).to eq('remotes/origin/main')
-      expect(result.target_oid).to be_nil
-      expect(result.current?).to be false
+    it 'returns the raw upstream refname string for a valid upstream ref' do
+      expect(described_class.build_upstream_info('refs/remotes/origin/main')).to eq('refs/remotes/origin/main')
     end
 
     it 'returns nil for empty upstream ref' do
@@ -324,7 +286,7 @@ RSpec.describe Git::Parsers::Branch do
         refname: 'feature',
         target_oid: 'abc123',
         current: false,
-        worktree: false,
+        worktree_path: nil,
         symref: nil,
         upstream: nil
       )

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -860,12 +860,12 @@ RSpec.describe Git::Repository::Branching do
   end
 
   # ---------------------------------------------------------------------------
-  # #branches_all
+  # #branch_list
   # ---------------------------------------------------------------------------
 
-  describe '#branches_all' do
-    subject(:result) { described_instance.branches_all(**options) }
-    let(:options) { {} }
+  describe '#branch_list' do
+    subject(:result) { described_instance.branch_list(*patterns) }
+    let(:patterns) { [] }
 
     let(:branch_list_command) { instance_double(Git::Commands::Branch::List) }
     let(:branch_list_result) do
@@ -922,7 +922,7 @@ RSpec.describe Git::Repository::Branching do
     end
 
     context 'when a pattern is given' do
-      let(:options) { { pattern: ['foo'] } }
+      let(:patterns) { ['foo'] }
 
       it 'passes the pattern as a positional argument to Branch::List#call' do
         expect(branch_list_command).to(
@@ -938,6 +938,47 @@ RSpec.describe Git::Repository::Branching do
             .ordered
         )
         expect(result).to eq(parsed_branches)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #branches_all (deprecated)
+  # ---------------------------------------------------------------------------
+
+  describe '#branches_all' do
+    subject(:result) { described_instance.branches_all }
+
+    let(:branch_list_command) { instance_double(Git::Commands::Branch::List) }
+    let(:branch_list_result) { command_result("refs/heads/main\0abc1234\0*\0\0\0\n") }
+
+    before do
+      allow(Git::Commands::Branch::List)
+        .to receive(:new).with(execution_context).and_return(branch_list_command)
+      allow(branch_list_command)
+        .to receive(:call)
+        .with(all: true, format: Git::Parsers::Branch::FORMAT_STRING)
+        .and_return(branch_list_result)
+    end
+
+    it 'emits a deprecation warning' do
+      expect(Git::Deprecation).to receive(:warn).with(/branches_all.*deprecated.*branch_list/i)
+      result
+    end
+
+    it 'returns an array of 4-element arrays [refname, current, worktree, symref]' do
+      allow(Git::Deprecation).to receive(:warn)
+      expect(result).to eq([['main', true, false, nil]])
+    end
+
+    context 'with a remote-tracking branch' do
+      let(:branch_list_result) do
+        command_result("refs/remotes/origin/main\0abc1234\0\0\0\0\n")
+      end
+
+      it 'formats the refname as remotes/<remote>/<branch>' do
+        allow(Git::Deprecation).to receive(:warn)
+        expect(result).to eq([['remotes/origin/main', false, false, nil]])
       end
     end
   end
@@ -1015,12 +1056,6 @@ RSpec.describe Git::Repository::Branching do
     context 'with an explicit branch name' do
       subject(:result) { described_instance.branch('feature') }
 
-      before do
-        allow(described_instance).to receive(:branches_all)
-          .with(pattern: ['feature'])
-          .and_return([])
-      end
-
       it 'returns a Git::Branch for the given name' do
         expect(result).to be_a(Git::Branch)
       end
@@ -1045,101 +1080,11 @@ RSpec.describe Git::Repository::Branching do
 
       before do
         allow(show_current_command).to receive(:call).and_return(show_current_result)
-        allow(described_instance).to receive(:branches_all)
-          .with(pattern: ['main'])
-          .and_return([])
       end
 
       it 'returns a Git::Branch for the current branch name' do
         expect(result).to be_a(Git::Branch)
         expect(result.full).to eq('main')
-      end
-    end
-
-    context 'when the branch exists in git with upstream tracking' do
-      subject(:result) { described_instance.branch('foo') }
-
-      let(:upstream_info) do
-        Git::BranchInfo.new(
-          refname: 'remotes/origin/bar',
-          target_oid: nil,
-          current: false,
-          worktree: false,
-          symref: nil,
-          upstream: nil
-        )
-      end
-
-      let(:branch_info) do
-        Git::BranchInfo.new(
-          refname: 'foo',
-          target_oid: 'abc123',
-          current: true,
-          worktree: false,
-          symref: nil,
-          upstream: upstream_info
-        )
-      end
-
-      before do
-        allow(described_instance).to receive(:branches_all)
-          .with(pattern: ['foo'])
-          .and_return([branch_info])
-        allow(described_instance).to receive(:config_remote).with('origin').and_return({})
-      end
-
-      it 'returns a Branch with upstream populated from BranchInfo' do
-        expect(result.upstream).to eq(upstream_info)
-      end
-
-      it 'returns a Branch whose upstream_remote has the correct name' do
-        expect(result.upstream_remote.name).to eq('origin')
-      end
-    end
-
-    context 'when the branch does not exist in git (fallback to bare BranchInfo)' do
-      subject(:result) { described_instance.branch('nonexistent') }
-
-      before do
-        allow(described_instance).to receive(:branches_all)
-          .with(pattern: ['nonexistent'])
-          .and_return([])
-      end
-
-      it 'returns a Git::Branch with the given name' do
-        expect(result).to be_a(Git::Branch)
-        expect(result.full).to eq('nonexistent')
-      end
-
-      it 'has nil upstream' do
-        expect(result.upstream).to be_nil
-      end
-    end
-
-    context 'when the branch name is a remote-tracking refname' do
-      subject(:result) { described_instance.branch('remotes/origin/foo') }
-
-      let(:remote_branch_info) do
-        Git::BranchInfo.new(
-          refname: 'remotes/origin/foo',
-          target_oid: 'abc123',
-          current: false,
-          worktree: false,
-          symref: nil,
-          upstream: nil
-        )
-      end
-
-      before do
-        allow(described_instance).to receive(:branches_all)
-          .with(pattern: ['foo'])
-          .and_return([remote_branch_info])
-        allow(described_instance).to receive(:config_remote).with('origin').and_return({})
-      end
-
-      it 'returns the remote-tracking Branch' do
-        expect(result.full).to eq('remotes/origin/foo')
-        expect(result.remote.name).to eq('origin')
       end
     end
   end


### PR DESCRIPTION
# Description

Follow-up to #1623, redesigning `BranchInfo` into a clean raw-data value object
and cleaning up several related design issues surfaced during review.

## Changes

### `BranchInfo` is now a pure raw-data snapshot

`BranchInfo` stores exactly what git reports — no normalization inside the class.

**`#refname` stores the full raw ref from git**

The field holds the full ref name as git outputs it (e.g. `refs/heads/main`,
`refs/remotes/origin/main`). `BRANCH_REFNAME_REGEXP` handles the `refs/heads/`
prefix so `short_name` and `remote_name` still derive correctly.

**`#upstream` stores the raw upstream refname from `%(upstream)`**

Previously the parser built a nested `BranchInfo` object for upstream. It now
stores the raw string directly (e.g. `refs/remotes/origin/bar`), keeping
`BranchInfo` flat.

```ruby
info = git.branch_list.find { |b| b.short_name == 'foo' }
info.upstream  # => 'refs/remotes/origin/bar'
```

**`#short_name` is a computed method**

`short_name` is derived from `refname` via `BRANCH_REFNAME_REGEXP` on every
access rather than being stored. This eliminates a constructor argument and
makes it impossible for `short_name` to be out of sync with `refname`.
`%(refname:short)` was removed from `FORMAT_STRING` and the `short_name_from`
parser helper was deleted.

**`:worktree` boolean replaced by `:worktree_path`**

The old boolean `:worktree` attribute is replaced by `:worktree_path`
(`String | nil`):

- `nil` when the branch is the current branch or not checked out anywhere
- An absolute path string when the branch is checked out in another linked
  worktree (e.g. `'/home/user/projects/my-repo-hotfix'`)

`worktree?` is renamed to `other_worktree?` and is derived as
`!worktree_path.nil?`. The current branch's worktree path is intentionally
suppressed — it is already available via `repo.dir` and storing it here would
make `other_worktree?` incorrect.

### Parser improvements

- `FORMAT_STRING` uses **NUL bytes (`%00`)** as field delimiters instead of `|`,
  so worktree paths containing `|` parse correctly.
- `%(refname:short)` removed from `FORMAT_STRING` (now 6 fields instead of 7).
- `build_upstream_info` returns the raw `%(upstream)` string.
- `in_other_worktree?` and `normalize_refname` helpers removed; both were dead
  code after the redesign.

### Revert Phase B — `Branching#branch` is pure Ruby

`branch(name)` is now simply `Git::Branch.new(self, name)` with no subprocess.
Upstream data is available via `repo.branch_list` (the correct new-API path).
The previous subprocess was introduced to support `git.branch('foo').upstream`,
but given that `Git::Branch` is planned for deprecation the added cost is
unjustified.

### Remove `Git::Branch#upstream` and `Git::Branch#upstream_remote`

Both methods were unreleased additions to a class slated for deprecation. Adding
more surface area to a deprecated class creates unnecessary migration burden.
Callers who need upstream information should use `branch_list` and work with
`BranchInfo` directly.

### Remove shell `BranchInfo` constructions

`Remote#branch` and the old `Branching#branch` both constructed bare
`BranchInfo` objects (all fields nil/false) purely to hand to `Git::Branch.new`.
Since `Git::Branch` already accepts a `String` via the legacy `initialize_from_name`
path, these intermediate objects were unnecessary. Both now pass the refname
string directly.

### `branch_list(*patterns)` added; `branches_all` deprecated

`Branching#branch_list` lists all local and remote-tracking branches, returning
`Array<Git::BranchInfo>`. Zero or more shell wildcard patterns can be passed to
filter results:

```ruby
repo.branch_list                           # all branches
repo.branch_list('feature/auth')           # exact name match
repo.branch_list('feature/*', 'hotfix/*')  # glob patterns
```

`branches_all` is retained as a deprecated wrapper that returns the 4.x-compatible
`[[refname, current, worktree, symref], ...]` format and emits a deprecation
warning pointing to `branch_list`.

## Design context

`BranchInfo` and similar `*Info` classes are value objects — immutable snapshots
of git state at the time they were read, with no repository reference.
`Git::Branch`, `Git::Branches`, and `Git::Remote` are active-record-style classes
that will be deprecated in 5.x (after 5.0.0 ships) and removed in 6.0.0.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
