### PR TITLE
refactor(remote): remote_add and remote_set_url return nil

### DIFF
--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -330,11 +330,11 @@ module Git
       # @option opts [String, nil] :track (nil) track only the given branch during
       #   fetch (`-t`)
       #
-      # @return [Git::Remote] the newly added remote
+      # @return [void]
       #
       # @raise [ArgumentError] when unsupported option keys are provided
       #
-      # @raise [Git::FailedError] when git exits with a non-zero status
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
       def remote_add(name, url, opts = {})
         url = url.repo.to_s if url.is_a?(Git::Repository)
@@ -342,7 +342,7 @@ module Git
         SharedPrivate.assert_valid_opts!(REMOTE_ADD_ALLOWED_OPTS, **opts)
         Git::Commands::Remote::Add.new(@execution_context).call(name, url, **opts)
 
-        Git::Remote.new(self, name)
+        nil
       end
 
       # @param name [String] the name for the new remote
@@ -367,7 +367,7 @@ module Git
       #
       # @raise [ArgumentError] when unsupported option keys are provided
       #
-      # @raise [Git::FailedError] when git exits with a non-zero status
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
       # @deprecated Use {#remote_add} instead
       #
@@ -377,6 +377,7 @@ module Git
           'Use Git::Repository#remote_add instead.'
         )
         remote_add(name, url, opts)
+        Git::Remote.new(self, name)
       end
 
       # Removes a remote from this repository
@@ -431,15 +432,15 @@ module Git
       #   A {Git::Repository} instance is accepted for local references and converted
       #   to `url.repo.to_s`.
       #
-      # @return [Git::Remote] the updated remote
+      # @return [void]
       #
-      # @raise [Git::FailedError] when git exits with a non-zero status
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
       def remote_set_url(name, url)
         url = url.repo.to_s if url.is_a?(Git::Repository)
         Git::Commands::Remote::SetUrl.new(@execution_context).call(name, url)
 
-        Git::Remote.new(self, name)
+        nil
       end
 
       # @param name [String] the name of the remote to update
@@ -451,7 +452,7 @@ module Git
       #
       # @return [Git::Remote] the updated remote
       #
-      # @raise [Git::FailedError] when git exits with a non-zero status
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
       # @deprecated Use {#remote_set_url} instead
       #
@@ -461,6 +462,7 @@ module Git
           'Use Git::Repository#remote_set_url instead.'
         )
         remote_set_url(name, url)
+        Git::Remote.new(self, name)
       end
 
       # Configures which branches are fetched for a remote

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -599,13 +599,11 @@ RSpec.describe Git::Repository::RemoteOperations do
   describe '#remote_add' do
     let(:remote_add_command) { instance_double(Git::Commands::Remote::Add) }
     let(:remote_add_result) { command_result('') }
-    let(:remote_object) { instance_double(Git::Remote) }
 
     before do
       allow(Git::Commands::Remote::Add)
         .to receive(:new).with(execution_context).and_return(remote_add_command)
       allow(remote_add_command).to receive(:call).and_return(remote_add_result)
-      allow(Git::Remote).to receive(:new).and_return(remote_object)
     end
 
     # --- Default invocation --------------------------------------------------
@@ -624,9 +622,8 @@ RSpec.describe Git::Repository::RemoteOperations do
         result
       end
 
-      it 'returns Git::Remote' do
-        expect(Git::Remote).to receive(:new).with(described_instance, 'upstream').and_return(remote_object)
-        expect(result).to eq(remote_object)
+      it 'returns nil' do
+        expect(result).to be_nil
       end
     end
 
@@ -706,8 +703,9 @@ RSpec.describe Git::Repository::RemoteOperations do
     let(:remote_object) { instance_double(Git::Remote) }
 
     before do
-      allow(described_instance).to receive(:remote_add).and_return(remote_object)
+      allow(described_instance).to receive(:remote_add).and_return(nil)
       allow(Git::Deprecation).to receive(:warn)
+      allow(Git::Remote).to receive(:new).with(described_instance, 'upstream').and_return(remote_object)
     end
 
     it 'emits a deprecation warning matching /add_remote is deprecated/' do
@@ -715,11 +713,15 @@ RSpec.describe Git::Repository::RemoteOperations do
       described_instance.add_remote('upstream', 'https://example.com/repo.git')
     end
 
-    it 'calls remote_add with all arguments forwarded and returns its return value' do
+    it 'calls remote_add with all arguments forwarded' do
       expect(described_instance)
         .to receive(:remote_add).with('upstream', 'https://example.com/repo.git', { fetch: true })
-        .and_return(remote_object)
-      result = described_instance.add_remote('upstream', 'https://example.com/repo.git', fetch: true)
+      described_instance.add_remote('upstream', 'https://example.com/repo.git', fetch: true)
+    end
+
+    it 'returns a Git::Remote for the named remote' do
+      expect(Git::Remote).to receive(:new).with(described_instance, 'upstream').and_return(remote_object)
+      result = described_instance.add_remote('upstream', 'https://example.com/repo.git')
       expect(result).to be(remote_object)
     end
   end
@@ -888,13 +890,11 @@ RSpec.describe Git::Repository::RemoteOperations do
   describe '#remote_set_url' do
     let(:set_url_command) { instance_double(Git::Commands::Remote::SetUrl) }
     let(:set_url_result) { command_result('') }
-    let(:remote_object) { instance_double(Git::Remote) }
 
     before do
       allow(Git::Commands::Remote::SetUrl)
         .to receive(:new).with(execution_context).and_return(set_url_command)
       allow(set_url_command).to receive(:call).and_return(set_url_result)
-      allow(Git::Remote).to receive(:new).and_return(remote_object)
     end
 
     context 'with a string url' do
@@ -912,9 +912,8 @@ RSpec.describe Git::Repository::RemoteOperations do
         result
       end
 
-      it 'returns the Git::Remote for the updated name' do
-        expect(Git::Remote).to receive(:new).with(described_instance, 'origin').and_return(remote_object)
-        expect(result).to eq(remote_object)
+      it 'returns nil' do
+        expect(result).to be_nil
       end
     end
 
@@ -945,8 +944,9 @@ RSpec.describe Git::Repository::RemoteOperations do
     let(:remote_object) { instance_double(Git::Remote) }
 
     before do
-      allow(described_instance).to receive(:remote_set_url).and_return(remote_object)
+      allow(described_instance).to receive(:remote_set_url).and_return(nil)
       allow(Git::Deprecation).to receive(:warn)
+      allow(Git::Remote).to receive(:new).with(described_instance, 'origin').and_return(remote_object)
     end
 
     it 'emits a deprecation warning matching /set_remote_url is deprecated/' do
@@ -954,10 +954,14 @@ RSpec.describe Git::Repository::RemoteOperations do
       described_instance.set_remote_url('origin', 'https://example.com/repo.git')
     end
 
-    it 'calls remote_set_url with all arguments forwarded and returns its return value' do
+    it 'calls remote_set_url with all arguments forwarded' do
       expect(described_instance)
         .to receive(:remote_set_url).with('origin', 'https://example.com/repo.git')
-        .and_return(remote_object)
+      described_instance.set_remote_url('origin', 'https://example.com/repo.git')
+    end
+
+    it 'returns a Git::Remote for the named remote' do
+      expect(Git::Remote).to receive(:new).with(described_instance, 'origin').and_return(remote_object)
       result = described_instance.set_remote_url('origin', 'https://example.com/repo.git')
       expect(result).to be(remote_object)
     end


### PR DESCRIPTION
## Description

Part of the RemoteInfo + RemoteOperations API modernization plan (`redesign/remote_refactor_plan.md`), **PR 1 of 3** (independent, smallest).

`remote_add` and `remote_set_url` previously returned a `Git::Remote` object. This is a breaking change that cleans up the return values: these mutation methods now return `nil`, consistent with other void-return facade methods like `remote_set_branches`.

The deprecated wrappers (`add_remote`, `set_remote_url`) are updated to still return a `Git::Remote` for backward compatibility by constructing it themselves after calling the underlying method.

### Changes

- **`remote_add`** — removes `Git::Remote.new(self, name)` return; explicitly returns `nil`
- **`remote_set_url`** — same change
- **`add_remote`** (deprecated wrapper) — calls `remote_add(...)` then constructs and returns `Git::Remote.new(self, name)`
- **`set_remote_url`** (deprecated wrapper) — same pattern
- **YARD docs** — `@return` tags on `remote_add` and `remote_set_url` updated to `@return [void]`
- **Specs** — updated to assert the new `nil` return for `remote_add`/`remote_set_url`, and that the deprecated wrappers still return a `Git::Remote`

### Files changed

- `lib/git/repository/remote_operations.rb`
- `spec/unit/git/repository/remote_operations_spec.rb`

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed.
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
