### PR TITLE
feat(remote): add Git::Repository#remote_list facade method

### DIFF
--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -7,6 +7,7 @@ require 'git/commands/pull'
 require 'git/commands/push'
 require 'git/commands/remote'
 require 'git/parsers/ls_remote'
+require 'git/parsers/remote'
 require 'git/remote'
 
 require 'git/repository/shared_private'
@@ -529,6 +530,34 @@ module Git
         Private.config_list(@execution_context).each_with_object({}) do |(key, value), hsh|
           hsh[key.delete_prefix(prefix)] = value if key.start_with?(prefix)
         end
+      end
+
+      # List all configured remotes as {Git::RemoteInfo} objects
+      #
+      # Reads the repository configuration via {Git::Configuring#config_list} and
+      # returns one {Git::RemoteInfo} per configured remote, preserving the order
+      # in which remotes appear in the config. Multi-value fields (`:url`,
+      # `:push_url`, `:fetch`, `:push`) are always `Array<String>` (never `nil`).
+      #
+      # @example List all remotes
+      #   repo.remote_list
+      #   # => [#<data Git::RemoteInfo name="origin" ...>,
+      #   #      #<data Git::RemoteInfo name="upstream" ...>]
+      #
+      # @example Get fetch URLs for all remotes
+      #   repo.remote_list.map { |r| [r.name, r.url] }.to_h
+      #
+      # @return [Array<Git::RemoteInfo>] one entry per configured remote
+      #
+      #   Returns an empty array when no remotes are configured.
+      #
+      # @raise [ArgumentError] if a `remote.*` config entry carries an
+      #   unrecognized boolean value (e.g. `remote.origin.prune=maybe`)
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      def remote_list
+        Git::Parsers::Remote.parse_list(config_list)
       end
 
       # Returns a {Git::Remote} object for the named remote

--- a/spec/integration/git/commands/remote/add_spec.rb
+++ b/spec/integration/git/commands/remote/add_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Git::Commands::Remote::Add, :integration do
         result = command.call('origin', remote_repo.dir.to_s)
 
         expect(result).to be_a(Git::CommandLine::Result)
-        expect(repo.remotes.map(&:name)).to include('origin')
+        expect(repo.remote_list.map(&:name)).to include('origin')
       end
     end
 

--- a/spec/integration/git/commands/remote/remove_spec.rb
+++ b/spec/integration/git/commands/remote/remove_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Git::Commands::Remote::Remove, :integration do
         result = command.call('origin')
 
         expect(result).to be_a(Git::CommandLine::Result)
-        expect(repo.remotes.map(&:name)).not_to include('origin')
+        expect(repo.remote_list.map(&:name)).not_to include('origin')
       end
     end
 

--- a/spec/integration/git/commands/remote/rename_spec.rb
+++ b/spec/integration/git/commands/remote/rename_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe Git::Commands::Remote::Rename, :integration do
         result = command.call('origin', 'upstream')
 
         expect(result).to be_a(Git::CommandLine::Result)
-        expect(repo.remotes.map(&:name)).to include('upstream')
-        expect(repo.remotes.map(&:name)).not_to include('origin')
+        expect(repo.remote_list.map(&:name)).to include('upstream')
+        expect(repo.remote_list.map(&:name)).not_to include('origin')
       end
     end
 

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -55,7 +55,7 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
 
     it 'registers the remote so it appears in the repository config' do
       described_instance.remote_add('secondary', remote_dir)
-      expect(repo.remotes.map(&:name)).to include('secondary')
+      expect(described_instance.remote_list.map(&:name)).to include('secondary')
     end
   end
 
@@ -66,7 +66,7 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   describe '#remote_remove' do
     it 'removes the named remote' do
       described_instance.remote_remove('origin')
-      expect(repo.remotes.map(&:name)).not_to include('origin')
+      expect(described_instance.remote_list.map(&:name)).not_to include('origin')
     end
   end
 
@@ -87,6 +87,39 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
 
     it 'returns an empty hash for an unknown remote name' do
       expect(described_instance.config_remote('nonexistent-remote')).to eq({})
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #remote_list
+  # ---------------------------------------------------------------------------
+
+  describe '#remote_list' do
+    it 'returns one RemoteInfo per configured remote' do
+      described_instance.remote_add('upstream', bare_dir)
+      expect(described_instance.remote_list.map(&:name)).to contain_exactly('origin', 'upstream')
+    end
+
+    it 'returns RemoteInfo objects' do
+      expect(described_instance.remote_list).to contain_exactly(be_a(Git::RemoteInfo))
+    end
+
+    it 'includes the fetch URL for the remote' do
+      result = described_instance.remote_list.find { |r| r.name == 'origin' }
+      expect(result.url).to contain_exactly(bare_dir)
+    end
+
+    it 'includes at least one fetch refspec for the remote' do
+      result = described_instance.remote_list.find { |r| r.name == 'origin' }
+      expect(result.fetch).not_to be_empty
+    end
+
+    context 'when no remotes are configured' do
+      before { described_instance.remote_remove('origin') }
+
+      it 'returns an empty array' do
+        expect(described_instance.remote_list).to eq([])
+      end
     end
   end
 

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -1041,6 +1041,71 @@ RSpec.describe Git::Repository::RemoteOperations do
   end
 
   # ---------------------------------------------------------------------------
+  # #remote_list
+  # ---------------------------------------------------------------------------
+
+  describe '#remote_list' do
+    let(:origin_entry) do
+      Git::ConfigEntryInfo.new(
+        scope: 'local', origin: 'file:.git/config',
+        key: 'remote.origin.url', value: 'https://github.com/user/repo.git'
+      )
+    end
+    let(:upstream_entry) do
+      Git::ConfigEntryInfo.new(
+        scope: 'local', origin: 'file:.git/config',
+        key: 'remote.upstream.url', value: 'https://github.com/upstream/repo.git'
+      )
+    end
+    let(:config_entries) { [origin_entry, upstream_entry] }
+    let(:origin_info) do
+      Git::RemoteInfo.new(
+        name: 'origin',
+        url: ['https://github.com/user/repo.git'],
+        push_url: [], fetch: [], push: []
+      )
+    end
+    let(:upstream_info) do
+      Git::RemoteInfo.new(
+        name: 'upstream',
+        url: ['https://github.com/upstream/repo.git'],
+        push_url: [], fetch: [], push: []
+      )
+    end
+    let(:parsed_remotes) { [origin_info, upstream_info] }
+
+    before do
+      allow(described_instance).to receive(:config_list).and_return(config_entries)
+      allow(Git::Parsers::Remote).to receive(:parse_list).and_return(parsed_remotes)
+    end
+
+    it 'calls config_list on the repository to retrieve all config entries' do
+      expect(described_instance).to receive(:config_list).and_return(config_entries)
+      described_instance.remote_list
+    end
+
+    it 'passes the config entries to Git::Parsers::Remote.parse_list' do
+      expect(Git::Parsers::Remote).to receive(:parse_list).with(config_entries).and_return(parsed_remotes)
+      described_instance.remote_list
+    end
+
+    it 'returns the result from Git::Parsers::Remote.parse_list' do
+      expect(described_instance.remote_list).to eq(parsed_remotes)
+    end
+
+    context 'when no config entries exist' do
+      before do
+        allow(described_instance).to receive(:config_list).and_return([])
+        allow(Git::Parsers::Remote).to receive(:parse_list).with([]).and_return([])
+      end
+
+      it 'returns an empty array' do
+        expect(described_instance.remote_list).to eq([])
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # #remotes
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements **PR 3** from [`redesign/remote_refactor_plan.md`](redesign/remote_refactor_plan.md):
the `remote_list` facade method that surfaces `Git::RemoteInfo` objects to callers.

## Dependencies

Depends on PR 2 — [feat(remote): add Git::RemoteInfo value object and Parsers::Remote #1627](https://github.com/ruby-git/ruby-git/pull/1627).

## Changes

### `Git::Repository::RemoteOperations#remote_list` (new)

Returns `Array<Git::RemoteInfo>` for all configured remotes.

- Calls `config_list` (the `Git::Configuring` instance method already mixed into
  `Git::Repository`) to obtain `Array<Git::ConfigEntryInfo>`
- Passes the result directly to `Git::Parsers::Remote.parse_list`
- Returns an empty array when no remotes are configured
- `#remotes` is **not** deprecated — consistent with `#branches`, which coexists
  with `#branch_list` without a deprecation warning

### Test updates

- **Unit tests** — 7 new examples for `#remote_list` (delegation to `config_list`,
  delegation to `Parsers::Remote.parse_list`, return value, empty-array case)
- **Integration tests** — 5 new examples for `#remote_list` proving end-to-end
  post-processing against real git output (names, `RemoteInfo` type, fetch URL,
  fetch refspecs, empty-repository case)
- **Command integration tests** (`add`, `remove`, `rename`) — updated
  post-command assertions to use `remote_list` instead of `remotes`

## Files changed

| File | Change |
|---|---|
| `lib/git/repository/remote_operations.rb` | add `#remote_list`; add `require 'git/parsers/remote'` |
| `spec/unit/git/repository/remote_operations_spec.rb` | 7 new examples |
| `spec/integration/git/repository/remote_operations_spec.rb` | 5 new examples |
| `spec/integration/git/commands/remote/add_spec.rb` | use `remote_list` |
| `spec/integration/git/commands/remote/remove_spec.rb` | use `remote_list` |
| `spec/integration/git/commands/remote/rename_spec.rb` | use `remote_list` |
