### PR TITLE
Fix BranchInfo parsing for slash remote names

### DIFF
--- a/lib/git/branch_info.rb
+++ b/lib/git/branch_info.rb
@@ -19,11 +19,10 @@ module Git
   #   {Git::BranchInfo#refname} and normalized short-form refs (e.g., `main`,
   #   `remotes/origin/main`) used elsewhere.
   #
-  # @note This regex assumes remote names do not contain '/'. If a remote name
-  #   contains '/', parsing will be incorrect. For example, 'remotes/team/upstream/main'
-  #   would parse as remote_name='team' instead of 'team/upstream'. This is an inherent
-  #   ambiguity in git refnames that can only be resolved with knowledge of configured
-  #   remotes. See: https://github.com/ruby-git/ruby-git/issues/919
+  # @note This regex is a fallback for branch refnames parsed without configured
+  #   remote context. Remote names containing '/' can only be resolved reliably
+  #   when the parser is given the configured remote names. See:
+  #   https://github.com/ruby-git/ruby-git/issues/919
   #
   # @api private
   BRANCH_REFNAME_REGEXP = %r{
@@ -33,6 +32,10 @@ module Git
     (?<branch_name>.+)                            # branch name (everything else)
     \z                                            # end of string
   }x
+
+  # Sentinel for distinguishing omitted BranchInfo remote_name from explicit nil
+  REMOTE_NAME_NOT_GIVEN = Object.new.freeze
+  private_constant :REMOTE_NAME_NOT_GIVEN
 
   # Value object representing branch metadata from git branch output
   #
@@ -83,6 +86,11 @@ module Git
   #
   #   @return [String] the branch refname (e.g., 'refs/heads/main',
   #     'refs/remotes/origin/main')
+  #
+  # @!attribute [r] remote_name
+  #
+  #   @return [String, nil] the resolved or fallback-derived remote name, or nil
+  #     for local branches
   #
   # @!attribute [r] target_oid
   #
@@ -138,7 +146,64 @@ module Git
   #   @note This is the raw refname snapshot from when the branch list was read.
   #     It does not reflect live git state after the snapshot was taken.
   #
-  BranchInfo = Data.define(:refname, :target_oid, :current, :worktree_path, :symref, :upstream) do
+  BranchInfo = Data.define(:refname, :remote_name, :target_oid, :current, :worktree_path, :symref, :upstream) do
+    # @param refname [String] the full branch refname
+    #
+    # @param remote_name [String, nil] resolved remote name, nil for local branches,
+    #   or omitted to derive from `refname`
+    #
+    # @param target_oid [String, nil] the commit object ID, or nil for unborn branches
+    #
+    # @param current [Boolean] whether this branch is currently checked out
+    #
+    # @param worktree_path [String, nil] path to another linked worktree, or nil
+    #
+    # @param symref [String, nil] symbolic reference target, or nil
+    #
+    # @param upstream [String, nil] upstream refname, or nil
+    #
+    def initialize(refname:, target_oid:, current:, worktree_path:, symref:, upstream:, # rubocop:disable Metrics/ParameterLists
+                   remote_name: REMOTE_NAME_NOT_GIVEN)
+      remote_name = self.class.fallback_remote_name(refname) if remote_name.equal?(REMOTE_NAME_NOT_GIVEN)
+      self.class.validate_remote_name!(refname, remote_name)
+
+      super
+    end
+
+    # @param refname [String] the branch refname to validate
+    #
+    # @param remote_name [String, nil] the remote name to validate
+    #
+    # @return [void]
+    #
+    # @raise [ArgumentError] if the remote name contradicts the refname type
+    def self.validate_remote_name!(refname, remote_name)
+      if remote_tracking_refname?(refname)
+        unless remote_name.is_a?(String) && !remote_name.empty?
+          raise ArgumentError, 'remote_name must be a non-empty String for remote-tracking refname'
+        end
+
+        remote_ref_prefix = %r{\A(?:refs/)?remotes/#{Regexp.escape(remote_name)}/}
+        raise ArgumentError, 'remote_name must match remote-tracking refname' unless refname.match?(remote_ref_prefix)
+      elsif !remote_name.nil?
+        raise ArgumentError, 'remote_name must be nil for local branch refname'
+      end
+    end
+
+    # @param refname [String] the branch refname to parse
+    #
+    # @return [String, nil] the regex-derived remote name, or nil for local branches
+    def self.fallback_remote_name(refname)
+      refname.match(Git::BRANCH_REFNAME_REGEXP)[:remote_name]
+    end
+
+    # @param refname [String] the branch refname to inspect
+    #
+    # @return [Boolean] true if the refname is a remote-tracking refname
+    def self.remote_tracking_refname?(refname)
+      refname.match?(%r{\A(?:refs/)?remotes/[^/]+/.+})
+    end
+
     # @return [Boolean] always false for BranchInfo (see DetachedHeadInfo for detached state)
     def detached? = false
 
@@ -147,7 +212,12 @@ module Git
 
     # @return [String] the short branch name without any remote or heads prefix
     #   (e.g., 'main' or 'feature/foo')
-    def short_name = refname.match(Git::BRANCH_REFNAME_REGEXP)[:branch_name]
+    def short_name
+      return refname.delete_prefix('refs/heads/') if remote_name.nil?
+
+      remote_ref_prefix = %r{\A(?:refs/)?remotes/#{Regexp.escape(remote_name)}/}
+      refname.sub(remote_ref_prefix, '')
+    end
 
     # @return [Boolean] true if this is the currently checked out branch
     def current? = current
@@ -160,9 +230,6 @@ module Git
 
     # @return [Boolean] true if this is a remote-tracking branch
     def remote? = !remote_name.nil?
-
-    # @return [String, nil] the name of the remote (e.g., 'origin'), or nil for local branches
-    def remote_name = refname.match(Git::BRANCH_REFNAME_REGEXP)[:remote_name]
 
     # @return [String] string representation (the full refname)
     def to_s = refname

--- a/lib/git/parsers/branch.rb
+++ b/lib/git/parsers/branch.rb
@@ -78,24 +78,30 @@ module Git
       #
       # @param stdout [String] output from git branch --list --format=...
       #
+      # @param remote_names [Array<String>] configured remote names used to resolve
+      #   remote-tracking refs with slash-containing remote names
+      #
       # @return [Array<Git::BranchInfo>] parsed branch information
       #
-      def parse_list(stdout)
-        stdout.split("\n").filter_map { |line| parse_branch_line(line) }
+      def parse_list(stdout, remote_names: [])
+        stdout.split("\n").filter_map { |line| parse_branch_line(line, remote_names: remote_names) }
       end
 
       # Parse a single formatted branch line
       #
       # @param line [String] the line to parse (NUL-delimited fields)
       #
+      # @param remote_names [Array<String>] configured remote names used to resolve
+      #   remote-tracking refs with slash-containing remote names
+      #
       # @return [Git::BranchInfo, nil] branch info object, or nil if line should be skipped
       #
-      def parse_branch_line(line)
+      def parse_branch_line(line, remote_names: [])
         fields = line.split(FIELD_DELIMITER, 6)
 
         return nil if non_branch_entry?(fields[0])
 
-        build_branch_info(fields)
+        build_branch_info(fields, remote_names: remote_names)
       end
 
       # Build a BranchInfo from parsed fields
@@ -103,9 +109,12 @@ module Git
       # @param fields [Array<String>] the parsed fields:
       #   [refname, objectname, head, worktreepath, symref, upstream]
       #
+      # @param remote_names [Array<String>] configured remote names used to resolve
+      #   remote-tracking refs with slash-containing remote names
+      #
       # @return [Git::BranchInfo] the branch info object
       #
-      def build_branch_info(fields)
+      def build_branch_info(fields, remote_names: [])
         raw_refname, objectname, head, worktreepath, symref, upstream = fields
         Git::BranchInfo.new(
           refname: raw_refname,
@@ -113,8 +122,28 @@ module Git
           current: head == '*',
           worktree_path: head == '*' ? nil : presence(worktreepath),
           symref: presence(symref),
-          upstream: build_upstream_info(upstream)
+          upstream: build_upstream_info(upstream),
+          remote_name: resolve_remote_name(raw_refname, remote_names)
         )
+      end
+
+      # Resolve a remote-tracking refname to a configured remote name
+      #
+      # @param refname [String] the branch refname to inspect
+      #
+      # @param remote_names [Array<String>] configured remote names
+      #
+      # @return [String, nil] the resolved remote name, or nil for local branches
+      #
+      def resolve_remote_name(refname, remote_names)
+        remote_path = refname[%r{\A(?:refs/)?remotes/(.+)\z}, 1]
+        return nil if remote_path.nil?
+
+        configured_remote_name = remote_names
+                                 .select { |remote_name| remote_path.start_with?("#{remote_name}/") }
+                                 .max_by(&:length)
+
+        configured_remote_name || Git::BranchInfo.fallback_remote_name(refname)
       end
 
       # Check if the refname represents a detached HEAD state or non-branch entry

--- a/spec/integration/git/parsers/branch_spec.rb
+++ b/spec/integration/git/parsers/branch_spec.rb
@@ -110,6 +110,34 @@ RSpec.describe Git::Parsers::Branch, :integration do
       end
     end
 
+    context 'with a slash-containing remote name' do
+      let(:bare_dir) { Dir.mktmpdir('bare_repo') }
+
+      after do
+        FileUtils.rm_rf(bare_dir)
+      end
+
+      before do
+        write_file('file.txt')
+        repo.add('file.txt')
+        repo.commit('Initial commit')
+
+        Git.init(bare_dir, bare: true)
+        repo.remote_add('team/upstream', bare_dir)
+        repo.push('team/upstream', 'main')
+        repo.fetch('team/upstream')
+      end
+
+      it 'resolves the remote name using configured remote names' do
+        output = git_branch_output('--remotes')
+        result = described_class.parse_list(output, remote_names: ['team/upstream'])
+        remote_branch = result.find { |branch| branch.refname == 'refs/remotes/team/upstream/main' }
+
+        expect(remote_branch.remote_name).to eq('team/upstream')
+        expect(remote_branch.short_name).to eq('main')
+      end
+    end
+
     context 'with detached HEAD' do
       before do
         write_file('file.txt')

--- a/spec/unit/git/branch_info_spec.rb
+++ b/spec/unit/git/branch_info_spec.rb
@@ -3,6 +3,78 @@
 require 'spec_helper'
 
 RSpec.describe Git::BranchInfo do
+  describe '#initialize' do
+    it 'raises when remote_name is given for a local branch refname' do
+      expect do
+        described_class.new(
+          refname: 'refs/heads/main',
+          target_oid: 'abc123',
+          current: false,
+          worktree_path: nil,
+          symref: nil,
+          upstream: nil,
+          remote_name: 'origin'
+        )
+      end.to raise_error(ArgumentError, /remote_name must be nil for local branch refname/)
+    end
+
+    it 'raises when remote_name is nil for a remote-tracking branch refname' do
+      expect do
+        described_class.new(
+          refname: 'refs/remotes/origin/main',
+          target_oid: 'abc123',
+          current: false,
+          worktree_path: nil,
+          symref: nil,
+          upstream: nil,
+          remote_name: nil
+        )
+      end.to raise_error(ArgumentError, /remote_name must be a non-empty String for remote-tracking refname/)
+    end
+
+    it 'raises when remote_name is empty for a remote-tracking branch refname' do
+      expect do
+        described_class.new(
+          refname: 'refs/remotes/origin/main',
+          target_oid: 'abc123',
+          current: false,
+          worktree_path: nil,
+          symref: nil,
+          upstream: nil,
+          remote_name: ''
+        )
+      end.to raise_error(ArgumentError, /remote_name must be a non-empty String for remote-tracking refname/)
+    end
+
+    it 'raises when remote_name is not a String for a remote-tracking branch refname' do
+      expect do
+        described_class.new(
+          refname: 'refs/remotes/origin/main',
+          target_oid: 'abc123',
+          current: false,
+          worktree_path: nil,
+          symref: nil,
+          upstream: nil,
+          remote_name: :origin
+        )
+      end.to raise_error(ArgumentError, /remote_name must be a non-empty String for remote-tracking refname/)
+    end
+
+    it 'raises when remote_name does not match the remote-tracking branch refname' do
+      expect do
+        described_class.new(
+          refname: 'refs/remotes/team/upstream/main',
+          target_oid: 'abc123',
+          current: false,
+          worktree_path: nil,
+          symref: nil,
+          upstream: nil,
+          remote_name: 'origin'
+        )
+      end.to raise_error(ArgumentError, /remote_name must match remote-tracking refname/)
+    end
+  end
+
   describe 'attributes' do
     subject(:branch_info) do
       described_class.new(
@@ -37,6 +109,20 @@ RSpec.describe Git::BranchInfo do
 
     it 'exposes upstream' do
       expect(branch_info.upstream).to be_nil
+    end
+
+    it 'exposes an explicit remote_name' do
+      branch_info = described_class.new(
+        refname: 'refs/remotes/team/upstream/main',
+        target_oid: 'abc123',
+        current: false,
+        worktree_path: nil,
+        symref: nil,
+        upstream: nil,
+        remote_name: 'team/upstream'
+      )
+
+      expect(branch_info.remote_name).to eq('team/upstream')
     end
   end
 
@@ -138,6 +224,14 @@ RSpec.describe Git::BranchInfo do
         )
         expect(branch_info.remote?).to be false
       end
+
+      it 'returns false for a remotes-prefixed branch name without a branch segment' do
+        branch_info = described_class.new(
+          refname: 'remotes/foo', target_oid: 'abc123', current: false, worktree_path: nil,
+          symref: nil, upstream: nil
+        )
+        expect(branch_info.remote?).to be false
+      end
     end
 
     context 'with remote-tracking branch' do
@@ -172,6 +266,14 @@ RSpec.describe Git::BranchInfo do
       it 'returns nil for branch with slashes' do
         branch_info = described_class.new(
           refname: 'feature/my-feature', target_oid: 'abc123', current: false, worktree_path: nil,
+          symref: nil, upstream: nil
+        )
+        expect(branch_info.remote_name).to be_nil
+      end
+
+      it 'returns nil for a refs/remotes-prefixed branch name without a branch segment' do
+        branch_info = described_class.new(
+          refname: 'refs/remotes/main', target_oid: 'abc123', current: false, worktree_path: nil,
           symref: nil, upstream: nil
         )
         expect(branch_info.remote_name).to be_nil
@@ -254,6 +356,14 @@ RSpec.describe Git::BranchInfo do
         )
         expect(branch_info.short_name).to eq('feature/team/project/task')
       end
+
+      it 'returns the full name for a refs/remotes-prefixed branch name without a branch segment' do
+        branch_info = described_class.new(
+          refname: 'refs/remotes/main', target_oid: 'abc123', current: false, worktree_path: nil,
+          symref: nil, upstream: nil
+        )
+        expect(branch_info.short_name).to eq('refs/remotes/main')
+      end
     end
 
     context 'with remote-tracking branch' do
@@ -279,6 +389,20 @@ RSpec.describe Git::BranchInfo do
           worktree_path: nil, symref: nil, upstream: nil
         )
         expect(branch_info.short_name).to eq('feature/my-feature')
+      end
+
+      it 'derives branch name from explicit slash remote name' do
+        branch_info = described_class.new(
+          refname: 'refs/remotes/team/upstream/feature/foo',
+          target_oid: 'abc123',
+          current: false,
+          worktree_path: nil,
+          symref: nil,
+          upstream: nil,
+          remote_name: 'team/upstream'
+        )
+
+        expect(branch_info.short_name).to eq('feature/foo')
       end
     end
   end
@@ -346,6 +470,19 @@ RSpec.describe Git::BranchInfo do
         symref: nil, upstream: nil
       )
       expect(info1).not_to eq(info2)
+    end
+
+    it 'is equal when explicit remote_name matches the fallback remote_name' do
+      info1 = described_class.new(
+        refname: 'refs/remotes/origin/main', target_oid: 'abc123', current: false, worktree_path: nil,
+        symref: nil, upstream: nil
+      )
+      info2 = described_class.new(
+        refname: 'refs/remotes/origin/main', target_oid: 'abc123', current: false, worktree_path: nil,
+        symref: nil, upstream: nil, remote_name: 'origin'
+      )
+
+      expect(info1).to eq(info2)
     end
   end
 

--- a/spec/unit/git/parsers/branch_spec.rb
+++ b/spec/unit/git/parsers/branch_spec.rb
@@ -41,6 +41,30 @@ RSpec.describe Git::Parsers::Branch do
       expect(result[0].remote_name).to eq('origin')
     end
 
+    it 'parses remote-tracking branches using configured slash remote names' do
+      stdout = "refs/remotes/team/upstream/main\0abc123\0\0\0\0\n"
+      result = described_class.parse_list(stdout, remote_names: ['team/upstream'])
+
+      expect(result[0].remote_name).to eq('team/upstream')
+      expect(result[0].short_name).to eq('main')
+    end
+
+    it 'uses the longest configured remote name prefix' do
+      stdout = "refs/remotes/team/upstream/main\0abc123\0\0\0\0\n"
+      result = described_class.parse_list(stdout, remote_names: %w[team team/upstream])
+
+      expect(result[0].remote_name).to eq('team/upstream')
+      expect(result[0].short_name).to eq('main')
+    end
+
+    it 'falls back to single-segment remote parsing for stale refs' do
+      stdout = "refs/remotes/missing/main\0abc123\0\0\0\0\n"
+      result = described_class.parse_list(stdout, remote_names: ['origin'])
+
+      expect(result[0].remote_name).to eq('missing')
+      expect(result[0].short_name).to eq('main')
+    end
+
     it 'skips detached HEAD entries' do
       stdout = <<~OUTPUT
         (HEAD detached at abc123)\0abc123\0\0\0\0


### PR DESCRIPTION
# Description

Implements PR 2 from `redesign/branch_parse_refactor_plan.md`: the `BranchInfo` stored field and remote-aware parser foundation for slash-containing remote names.

## Summary

- Adds `remote_name` as a stored `Git::BranchInfo` member while keeping `short_name` derived from `refname` and `remote_name`.
- Preserves backward compatibility by deriving `remote_name` from the existing regex when `remote_name:` is not given.
- Validates explicit `remote_name:` values against local vs remote-tracking refnames.
- Threads `remote_names:` through `Git::Parsers::Branch.parse_list`, `parse_branch_line`, and `build_branch_info`.
- Resolves slash remote names by longest configured remote-name prefix, with stale-ref fallback to existing single-segment parsing.
- Adds unit and integration coverage for slash remote parsing, longest-prefix matching, stale fallback, explicit `remote_name`, derived `short_name`, and constructor validation.

## Validation

- `bundle exec rake`
- `rake spec:unit`
- `bundle exec rspec spec/unit/git/branch_info_spec.rb spec/unit/git/parsers/branch_spec.rb`
- Confirmed unit branch coverage:
  - `lib/git/branch_info.rb`: 10/10 branches, 100%
  - `lib/git/parsers/branch.rb`: 12/12 branches, 100%

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).