### PR TITLE
docs: improve v5.0.0 release visibility and README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,14 +6,14 @@
 # The Git Gem
 
 [![Gem Version](https://badge.fury.io/rb/git.svg)](https://badge.fury.io/rb/git)
+[![Build Status](https://github.com/ruby-git/ruby-git/actions/workflows/continuous_integration.yml/badge.svg)](https://github.com/ruby-git/ruby-git/actions/workflows/continuous_integration.yml)
 [![Documentation](https://img.shields.io/badge/Documentation-Latest-green)](https://rubydoc.info/gems/git/)
 [![Change
 Log](https://img.shields.io/badge/CHANGELOG-Latest-green)](https://rubydoc.info/gems/git/file/CHANGELOG.md)
-[![Build
-Status](https://github.com/ruby-git/ruby-git/workflows/CI/badge.svg?branch=main)](https://github.com/ruby-git/ruby-git/actions?query=workflow%3ACI)
 [![Conventional
 Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
-[![AI Policy](https://img.shields.io/badge/AI%20Policy-Required-blue)](AI_POLICY.md)
+[![AI Policy](https://img.shields.io/badge/AI%20Policy-Doc-blue)](AI_POLICY.md)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 - [Summary](#summary)
 - [Install](#install)

--- a/README.md
+++ b/README.md
@@ -15,6 +15,11 @@ Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?log
 [![AI Policy](https://img.shields.io/badge/AI%20Policy-Doc-blue)](AI_POLICY.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
+> **v5.0.0 is here.** This is a major release with a redesigned internal
+> architecture, but most v4.x code runs unchanged thanks to compatibility
+> shims. See [UPGRADING.md](UPGRADING.md) for the migration guide and
+> [CHANGELOG.md](CHANGELOG.md) for full release notes.
+
 - [Summary](#summary)
 - [Install](#install)
 - [Quick Start](#quick-start)


### PR DESCRIPTION
## Overview

This PR improves discoverability of the v5.0.0 release and upgrade documentation by:

1. **Updating README badges** — Refreshes badge styling and placement to reflect current status
2. **Making v5.0.0 more prominent** — Adds a callout immediately after badges in README.md pointing users to UPGRADING.md and CHANGELOG.md, rather than burying the release announcement at the bottom

## Motivation

v5.0.0 is the first major release with a dedicated migration guide (UPGRADING.md), but users may not discover it easily. The release announcement was previously only visible at the very bottom of README under "Project Announcements", after all the version support policy sections. This change addresses the low adoption rate concern by making the upgrade path more discoverable for new/returning users.

## Changes

- **commit c7d39ee7**: Update README badges styling
- **commit 64a3173e**: Add v5.0.0 release callout with links to migration guide immediately below badges

## Related Issues

Addresses concerns about v5.0.0 adoption lag by improving documentation visibility.