### PR TITLE
test: avoid git-version-dependent all-zero SHA in stash store integration spec

### DIFF
--- a/spec/integration/git/commands/stash/store_spec.rb
+++ b/spec/integration/git/commands/stash/store_spec.rb
@@ -28,8 +28,10 @@ RSpec.describe Git::Commands::Stash::Store, :integration do
     end
 
     describe 'when the command fails' do
-      it 'raises FailedError with an invalid commit SHA' do
-        expect { command.call('0000000000000000000000000000000000000000') }.to raise_error(Git::FailedError)
+      it 'raises FailedError with a nonexistent commit SHA' do
+        expect do
+          command.call('deadbeefdeadbeefdeadbeefdeadbeefdeadbeef')
+        end.to raise_error(Git::FailedError)
       end
     end
   end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

The `Git::Commands::Stash::Store` "when the command fails" integration example passed `git stash store` the all-zero (null) SHA (`0000...0000`) to trigger a failure.

This is git-version-dependent:

- **Older git (e.g. 2.42.0)** accepts the all-zero SHA without validation and writes `refs/stash` to it, so `git stash store` succeeds and no error is raised — failing the test's `raise_error(Git::FailedError)` expectation.
- **Newer git (2.55.0)** added a "stash-like commit" validation that rejects the all-zero SHA with `fatal: '0000...0000' is not a stash-like commit`, so the test passed there but not on older git.

Fix: use a well-formed, non-zero, nonexistent SHA (`deadbeef...`) instead. That value is rejected by git's ref-update machinery ("nonexistent object") on both old and new git, since that guard is not specific to the all-zero sentinel value — confirmed empirically with `git update-ref` directly.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed. (spec-only fix)
- [ ] Documentation updated where applicable (README and/or YARD). (not applicable — test-only change)
