### PR TITLE
test: skip get-urlmatch scope spec on git < 2.42.0

### DIFF
--- a/spec/integration/git/parsers/config_entry_spec.rb
+++ b/spec/integration/git/parsers/config_entry_spec.rb
@@ -142,7 +142,8 @@ RSpec.describe Git::Parsers::ConfigEntry, :integration do
         set_cmd.call('http.https://example.com.proxy', 'http://proxy.example.com', local: true)
       end
 
-      it 'returns a ConfigEntryInfo with scope, key, and value populated' do
+      it 'returns a ConfigEntryInfo with scope, key, and value populated',
+         skip: unless_git('2.42.0', 'git config --get-urlmatch --show-scope reporting the correct scope') do
         raw = urlmatch_cmd.call('http.proxy', 'https://example.com', local: true, show_scope: true, null: true).stdout
 
         result = described_class.parse_urlmatch(raw)


### PR DESCRIPTION
# Description

`git config --get-urlmatch --show-scope` reports the config scope as `unknown`
instead of the actual scope (e.g. `local`) on git versions before 2.42.0.

Confirmed this by running against several installed `bin/test-git-versions`
binaries:

```
2.41.0: unknown
2.41.1: unknown
2.41.2: unknown
2.41.3: unknown
2.42.0: local
2.42.4: local
2.43.0+: local
```

This was a bug in git itself, not in this project's parsing code. It was
fixed upstream by commit
[26b669324bb3ef8fd15387815bc020f08d0b4e7b](https://github.com/git/git/commit/26b669324bb3ef8fd15387815bc020f08d0b4e7b)
("config.c: pass ctx with CLI config", merged for Git 2.42.0). That commit's
message explicitly calls out this exact behavior:

> "git config --get-urlmatch --show-scope" iterates config to collect
> values, but then attempts to display the scope after config iteration,
> causing the "unknown" scope to be shown instead of the config file's
> scope... It was most likely a mistake that we allowed "--show-scope" to
> sneak through.

The fix copies the `key_value_info` during the collection phase in
`builtin/config.c` so the correct scope can be read back later, instead of
relying on stale state after iteration finished.

## Changes

- Skip the affected example in
  `spec/integration/git/parsers/config_entry_spec.rb` on git < 2.42.0 using
  the existing `unless_git` helper, consistent with other version-gated
  integration specs in the suite.

## Checklist

- [x] I reviewed and applied the project's AI Policy. I understand and
  verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed.
- [x] Tests added/updated as needed.
- [ ] Documentation updated where applicable (README and/or YARD). (N/A — test-only change)
