### PR TITLE
test: require git 2.39.0 for maintenance register/unregister --config-file specs

### DIFF
--- a/spec/integration/git/commands/maintenance/register_spec.rb
+++ b/spec/integration/git/commands/maintenance/register_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 require 'git/commands/maintenance/register'
 
-# GIT_CONFIG_GLOBAL (used for global config isolation) requires git 2.32.0,
-# so these integration tests require 2.32.0 even though the command itself supports 2.30.0.
+# --config-file requires git 2.39.0, so these integration tests require 2.39.0
+# even though the command itself supports 2.30.0.
 RSpec.describe Git::Commands::Maintenance::Register, :integration,
-               skip: unless_git('2.32.0', 'git maintenance register') do
+               skip: unless_git('2.39.0', 'git maintenance register --config-file') do
   include_context 'in an empty repository'
 
   subject(:command) { described_class.new(execution_context) }

--- a/spec/integration/git/commands/maintenance/unregister_spec.rb
+++ b/spec/integration/git/commands/maintenance/unregister_spec.rb
@@ -3,10 +3,10 @@
 require 'spec_helper'
 require 'git/commands/maintenance/unregister'
 
-# GIT_CONFIG_GLOBAL (used for global config isolation) requires git 2.32.0,
-# so these integration tests require 2.32.0 even though the command itself supports 2.30.0.
+# --config-file requires git 2.39.0, so these integration tests require 2.39.0
+# even though the command itself supports 2.30.0.
 RSpec.describe Git::Commands::Maintenance::Unregister, :integration,
-               skip: unless_git('2.32.0', 'git maintenance unregister') do
+               skip: unless_git('2.39.0', 'git maintenance unregister --config-file') do
   include_context 'in an empty repository'
 
   subject(:command) { described_class.new(execution_context) }


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository.

# Description

`--config-file` for `git maintenance register`/`unregister` was added in git 2.39.0, not 2.32.0. The integration specs for `Git::Commands::Maintenance::Register` and `Git::Commands::Maintenance::Unregister` pass `config_file:` in every example, so they require 2.39.0, not the 2.32.0 previously declared for `GIT_CONFIG_GLOBAL` isolation alone.

This was causing spurious failures when testing against git 2.38.5:

```
Git::FailedError:
  ... stderr: "error: unknown option `config-file'\nusage: git maintenance unregister\n"
```

Fixed by raising the `skip: unless_git(...)` version requirement on both spec files from `2.32.0` to `2.39.0` and updating the explanatory comments. No production code changes — the command classes correctly keep `requires_git_version '2.30.0'` since option-level version gating is intentionally left to git's native CLI errors per project convention.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](https://github.com/ruby-git/ruby-git/blob/main/AI_POLICY.md). I understand and verify any AI-assisted changes included in this PR and ensured they meet quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see [Local development setup](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [ ] Documentation updated where applicable (README and/or YARD). N/A — no doc changes needed.
