### PR TITLE
Fix: drop unsupported -- separator from remote remove/rename commands

### DIFF
--- a/lib/git/commands/remote/remove.rb
+++ b/lib/git/commands/remote/remove.rb
@@ -13,9 +13,9 @@ module Git
       #   remove = Git::Commands::Remote::Remove.new(execution_context)
       #   remove.call('origin')
       #
-      # @example Remove a remote with a name that looks like a flag
-      #   remove = Git::Commands::Remote::Remove.new(execution_context)
-      #   remove.call('-weirdremote')
+      # @note No `end_of_options` boundary: `git remote remove` did not accept a `--`
+      #   separator until git 2.38.0, so a name that looks like a flag (e.g. `-weird`)
+      #   raises `ArgumentError` instead of being sent to git.
       #
       # @note `arguments` block audited against https://git-scm.com/docs/git-remote/2.53.0
       #
@@ -29,8 +29,6 @@ module Git
         arguments do
           literal 'remote'
           literal 'remove'
-
-          end_of_options
 
           operand :name, required: true
         end

--- a/lib/git/commands/remote/rename.rb
+++ b/lib/git/commands/remote/rename.rb
@@ -22,6 +22,13 @@ module Git
       #   rename = Git::Commands::Remote::Rename.new(execution_context)
       #   rename.call('origin', 'upstream', no_progress: true)
       #
+      # @note No `end_of_options` boundary despite `:progress` preceding the operands:
+      #   `git remote rename` did not accept a `--` separator until git 2.36.0. Since
+      #   the `old`/`new` operands are still validated (an operand is rejected as
+      #   option-like whenever no `--` boundary exists anywhere in the definition),
+      #   a name that looks like a flag (e.g. `-weird`) raises `ArgumentError` instead
+      #   of ever reaching git, so omitting the boundary introduces no ambiguity.
+      #
       # @note `arguments` block audited against https://git-scm.com/docs/git-remote/2.53.0
       #
       # @see Git::Commands::Remote
@@ -35,8 +42,6 @@ module Git
           literal 'remote'
           literal 'rename'
           flag_option :progress, negatable: true
-
-          end_of_options
 
           operand :old, required: true
           operand :new, required: true

--- a/spec/unit/git/commands/remote/remove_spec.rb
+++ b/spec/unit/git/commands/remote/remove_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::Remote::Remove do
     context 'with a remote name' do
       it 'passes the remote name' do
         expected_result = command_result
-        expect_command_capturing('remote', 'remove', '--', 'origin').and_return(expected_result)
+        expect_command_capturing('remote', 'remove', 'origin').and_return(expected_result)
 
         result = command.call('origin')
 
@@ -21,12 +21,10 @@ RSpec.describe Git::Commands::Remote::Remove do
       end
     end
 
-    context 'with end-of-options separator' do
-      it 'includes -- before the name operand' do
-        expect_command_capturing('remote', 'remove', '--', '-weirdremote')
-          .and_return(command_result)
-
-        command.call('-weirdremote')
+    context 'with a name that looks like a flag' do
+      it 'raises ArgumentError instead of sending it to git' do
+        expect { command.call('-weirdremote') }
+          .to raise_error(ArgumentError, /looks like a command-line option/)
       end
     end
 

--- a/spec/unit/git/commands/remote/rename_spec.rb
+++ b/spec/unit/git/commands/remote/rename_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::Remote::Rename do
     context 'with old and new names' do
       it 'passes both names' do
         expected_result = command_result
-        expect_command_capturing('remote', 'rename', '--', 'origin', 'upstream').and_return(expected_result)
+        expect_command_capturing('remote', 'rename', 'origin', 'upstream').and_return(expected_result)
 
         result = command.call('origin', 'upstream')
 
@@ -24,7 +24,7 @@ RSpec.describe Git::Commands::Remote::Rename do
     context 'with :progress option' do
       context 'when true' do
         it 'includes --progress flag' do
-          expect_command_capturing('remote', 'rename', '--progress', '--', 'origin',
+          expect_command_capturing('remote', 'rename', '--progress', 'origin',
                                    'upstream').and_return(command_result)
 
           command.call('origin', 'upstream', progress: true)
@@ -33,7 +33,7 @@ RSpec.describe Git::Commands::Remote::Rename do
 
       context 'when :no_progress is true' do
         it 'includes --no-progress flag' do
-          expect_command_capturing('remote', 'rename', '--no-progress', '--', 'origin',
+          expect_command_capturing('remote', 'rename', '--no-progress', 'origin',
                                    'upstream').and_return(command_result)
 
           command.call('origin', 'upstream', no_progress: true)


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository.

# Description

`Git::Commands::Remote::Remove` and `Git::Commands::Remote::Rename` always
emitted the `--` end-of-options separator (meant to safely pass remote names
that look like flags, e.g. `-weird`). Git only started accepting `--` for
`remote remove` in 2.38.0 and for `remote rename` in 2.36.0. On older git
versions (e.g. 2.37.7, discovered via `bin/test-git-versions --start
2.37.7`), this caused an obscure failure for *every* invocation, even normal
ones:

```
usage: git remote remove <name>
```

## Fix

Rather than gating the whole command behind `requires_git_version` (which
would make normal `remote_remove`/`remote_rename` calls fail outright on
still-supported git versions), this drops `end_of_options` from both command
classes.

The `Arguments` DSL already rejects operands that look like command-line
options (`ArgumentError`, client-side) when no `--` boundary is declared in
the definition. So:

- Normal remote names now work unconditionally on every supported git
  version (2.28.0+) — no version gate needed.
- Names that look like flags (e.g. `-weird`) now raise a clear
  `ArgumentError` up front instead of relying on a `--` separator that old
  git doesn't support anyway (where it would previously have been silently
  misparsed as an option, or, with `end_of_options`, only worked on newer
  git).

Verified against the git 2.37.7 binary in `git-versions/`: previously 6
integration failures, now 0 failures (pending count unchanged from before
this bug was introduced). Full `bundle exec rake` passes against the
currently installed git.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] Documentation updated where applicable (README and/or YARD).
