### PR TITLE
test(merge): fix incorrect version-gated failure expectation in quit_spec

### DIFF
--- a/spec/integration/git/commands/merge/quit_spec.rb
+++ b/spec/integration/git/commands/merge/quit_spec.rb
@@ -37,13 +37,13 @@ RSpec.describe Git::Commands::Merge::Quit, :integration do
           expect(result).to be_a(Git::CommandLine::Result)
         end
       end
-    end
 
-    describe 'when the command fails' do
-      it 'raises FailedError when no merge is in progress' do
-        skip 'requires git < 2.35.0' unless Git.git_version < Git::Version.new(2, 35, 0)
+      context 'when no merge is in progress' do
+        it 'returns a CommandLineResult' do
+          result = command.call
 
-        expect { command.call }.to raise_error(Git::FailedError)
+          expect(result).to be_a(Git::CommandLine::Result)
+        end
       end
     end
   end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

`spec/integration/git/commands/merge/quit_spec.rb` had a test asserting that
`git merge --quit` raises `Git::FailedError` when no merge is in progress, but
only for git versions below 2.35.0 (`skip 'requires git < 2.35.0' unless
Git.git_version < Git::Version.new(2, 35, 0)`).

This assumption was never actually true. Verified directly against the
`git-versions/` binaries in this repo (2.28.0 through 2.55.0): `git merge
--quit` is a no-op that always exits `0` when no merge is in progress,
regardless of git version. This broke `bin/test-git-versions` runs against
older git binaries (e.g. 2.34.8), which correctly executed the test (since it
wasn't skipped) and hit a real failure because the command didn't raise.

For contrast, `git merge --abort` *does* fail with exit 128 when no merge is
in progress — that's a separate, correctly-tested code path in
`abort_spec.rb`.

## Fix

Replaced the bogus version-gated `FailedError` expectation with an assertion
that `Quit#call` returns a `Git::CommandLine::Result` when no merge is in
progress, matching real git behavior across all supported versions.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [ ] Documentation updated where applicable (README and/or YARD). (not applicable — test-only fix)
