### PR TITLE
test: guard checkout-index nonexistent-path spec for git < 2.30.0

### DIFF
--- a/spec/integration/git/commands/checkout_index_spec.rb
+++ b/spec/integration/git/commands/checkout_index_spec.rb
@@ -24,7 +24,10 @@ RSpec.describe Git::Commands::CheckoutIndex, :integration do
     end
 
     describe 'when the command fails' do
-      it 'raises FailedError for a nonexistent file path' do
+      # git checkout-index only exits non-zero for a missing path starting in 2.30.0; on
+      # 2.28.0-2.29.x it warns on stderr but exits 0.
+      it 'raises FailedError for a nonexistent file path',
+         skip: unless_git('2.30.0', 'git checkout-index exit status for a nonexistent path') do
         expect { command.call('nonexistent.txt') }.to raise_error(Git::FailedError)
       end
     end


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

`git checkout-index <path-not-in-index>` only exits non-zero starting in git
2.30.0. On git 2.28.0–2.29.x it prints "is not in the cache" to stderr but
exits 0, so the `Git::FailedError` expectation in
`spec/integration/git/commands/checkout_index_spec.rb` only held on 2.30.0+
and failed `bin/test-git-versions` runs against older binaries (e.g.
2.29.3).

Fixed by skipping the test on git < 2.30.0 using the existing `unless_git`
guard pattern, matching how other version-dependent specs (e.g.
`maintenance`) already handle this. No production code changes.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [ ] Documentation updated where applicable (README and/or YARD). (not applicable — test-only change)
