### PR TITLE
test: guard worktree repair spec for git < 2.29.0

### DIFF
--- a/spec/integration/git/commands/worktree/repair_spec.rb
+++ b/spec/integration/git/commands/worktree/repair_spec.rb
@@ -3,7 +3,8 @@
 require 'spec_helper'
 require 'git/commands/worktree/repair'
 
-RSpec.describe Git::Commands::Worktree::Repair, :integration do
+RSpec.describe Git::Commands::Worktree::Repair, :integration,
+               skip: unless_git('2.29.0', 'git worktree repair') do
   include_context 'in an empty repository'
 
   subject(:command) { described_class.new(execution_context) }


### PR DESCRIPTION
Review our [guidelines for contributing](https://github.com/ruby-git/ruby-git/blob/main/CONTRIBUTING.md) to this repository. A good start is to:

- Write tests for your changes
- Run `rake` before pushing
- Include / update docs in the README.md and in YARD documentation

# Description

`Git::Commands::Worktree::Repair` declares `requires_git_version '2.29.0'`
since `git worktree repair` was introduced in that version. The integration
spec ran unconditionally on all supported git versions, so on git < 2.29.0
(e.g. 2.28.1) `Base#call` raises `Git::VersionError` before git even runs,
breaking both the success-path and failure-path expectations and failing
`bin/test-git-versions` runs against older binaries.

Fixed by skipping the whole `describe` block on git < 2.29.0 via the
existing `unless_git` guard pattern, consistent with other version-gated
specs (e.g. `maintenance`, `checkout-index`). No production code changes.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [ ] Documentation updated where applicable (README and/or YARD). (not applicable — test-only change)
