### PR TITLE
refactor: consolidate parallel and serial spec rake tasks

### DIFF
--- a/.github/skills/command-implementation/REFERENCE.md
+++ b/.github/skills/command-implementation/REFERENCE.md
@@ -908,7 +908,7 @@ For migration PRs, verify process constraints:
 - each slice is independently revertible
 - refactor-only changes are not mixed with unrelated behavior changes
 - quality gates pass for the slice — discover tasks via
-  `bundle exec ruby -e "require 'rake'; load 'Rakefile'; puts Rake::Task['default:parallel'].prerequisites"`
+  `bundle exec ruby -e "require 'rake'; load 'Rakefile'; puts Rake::Task['default'].prerequisites"`
   and run each individually via `bundle exec rake <task>`, fixing failures before
   advancing
 

--- a/.github/skills/command-implementation/SKILL.md
+++ b/.github/skills/command-implementation/SKILL.md
@@ -188,11 +188,11 @@ This skill supports three modes. Determine which mode applies before starting:
      requirements](REFERENCE.md#phased-rollout-requirements).
 
 5. **Run quality gates** — discover the prerequisite tasks for
-   `default:parallel` and run them sequentially, fixing failures before
+   `default` and run them sequentially, fixing failures before
    advancing:
 
    ```bash
-   bundle exec ruby -e "require 'rake'; load 'Rakefile'; puts Rake::Task['default:parallel'].prerequisites"
+   bundle exec ruby -e "require 'rake'; load 'Rakefile'; puts Rake::Task['default'].prerequisites"
    ```
 
    Run each listed task **individually** in order via `bundle exec rake <task>`

--- a/.github/skills/facade-implementation/SKILL.md
+++ b/.github/skills/facade-implementation/SKILL.md
@@ -224,11 +224,11 @@ This skill supports three modes. Determine which mode applies before starting:
    - has tests that verify call-shape compatibility when classification is
      `legacy-contract` (positional hash and/or keyword-arg / `**opts` forms where required)
 
-5. **Run quality gates** — discover the prerequisite tasks for `default:parallel`
+5. **Run quality gates** — discover the prerequisite tasks for `default`
    and run them sequentially, fixing failures before advancing:
 
    ```bash
-   bundle exec ruby -e "require 'rake'; load 'Rakefile'; puts Rake::Task['default:parallel'].prerequisites"
+   bundle exec ruby -e "require 'rake'; load 'Rakefile'; puts Rake::Task['default'].prerequisites"
    ```
 
    Run each listed task **individually** in order via `bundle exec rake <task>`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -926,6 +926,9 @@ process.stdin.on('end', () =>
   local working copy.
 - Test runs are covered by SimpleCov by default. Set `COVERAGE=false` (or `0`/`no`/
   `off`) to skip coverage, e.g. `COVERAGE=false bundle exec rake spec`.
+- `rake spec:integration` runs in parallel (via `parallel_tests`) on MRI. Set
+  `PARALLEL_TESTS=false` (or `0`/`no`/`off`) to force serial execution, e.g.
+  `PARALLEL_TESTS=false bundle exec rake spec:integration`.
 
 This project uses **RSpec** (`spec/`) as its sole test framework. Structure,
 naming, setup, stubbing, and coverage rules for unit specs are defined in the

--- a/Rakefile
+++ b/Rakefile
@@ -9,19 +9,8 @@ default_tasks = %i[spec:unit spec:integration rubocop]
 default_tasks << :yard if Rake::Task.task_defined?(:yard)
 default_tasks << :build
 
-default_tasks_parallel = %w[spec:unit:parallel spec:integration:parallel rubocop]
-default_tasks_parallel << :yard if Rake::Task.task_defined?(:yard)
-default_tasks_parallel << :build
-
-# Use parallel test execution for MRI where it cuts build times by 30-48%.
-# JRuby and TruffleRuby are slower with parallel_tests because each worker
-# process pays JVM/Truffle startup and warm-up overhead independently,
-# resulting in 18-28% slower builds vs. serial execution.
-parallel_supported = RUBY_ENGINE == 'ruby'
-task default: parallel_supported ? default_tasks_parallel : default_tasks
-
-desc 'Same as default but runs tests in parallel'
-task 'default:parallel': default_tasks_parallel
+desc 'Run all CI tasks (tests, linters, yard, and build)'
+task default: default_tasks
 
 module Rake
   # Overload Rake::Task to add logging

--- a/bin/test-git-versions
+++ b/bin/test-git-versions
@@ -7,7 +7,7 @@
 # For each version directory found under <base-dir>/<version>/bin/git, this
 # script runs:
 #
-#   GIT_PATH=<absolute path to base-dir/version/bin> bundle exec rake spec:integration:parallel
+#   GIT_PATH=<absolute path to base-dir/version/bin> bundle exec rake spec:integration
 #
 # Versions are run newest-first (sorted semantically, e.g. 2.53.0 after
 # 2.5.0). Test output for each version is written to a temporary log file;
@@ -115,10 +115,10 @@ end
 def run_version_tests(base_dir, version)
   git_path = git_path_for(base_dir, version)
   log_file = File.join(Dir.tmpdir, "test-git-versions-#{version}-#{SecureRandom.hex(8)}.log")
-  command = "GIT_PATH=#{git_path} bundle exec rake spec:integration:parallel"
+  command = "GIT_PATH=#{git_path} bundle exec rake spec:integration"
 
   success = File.open(log_file, 'w') do |log|
-    system({ 'GIT_PATH' => git_path }, 'bundle', 'exec', 'rake', 'spec:integration:parallel', out: log, err: log)
+    system({ 'GIT_PATH' => git_path }, 'bundle', 'exec', 'rake', 'spec:integration', out: log, err: log)
   end
 
   { success: success, log_file: log_file, command: command }

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -2,46 +2,54 @@
 
 require 'rspec/core/rake_task'
 
-# Run all specs
-RSpec::Core::RakeTask.new(:spec) do |t|
-  t.pattern = 'spec/**/*_spec.rb'
+# Skip parallel test execution when the PARALLEL_TESTS environment variable is set to a falsy value
+def parallel_tests_disabled_via_env?
+  parallel_tests_env = ENV.fetch('PARALLEL_TESTS', 'true').strip.downcase
+  %w[false 0 no off].include?(parallel_tests_env)
 end
 
-# Run only unit specs (mocked, fast)
-RSpec::Core::RakeTask.new('spec:unit') do |t|
-  t.pattern = 'spec/unit/**/*_spec.rb'
-  # On JRuby, use 'documentation' formatter so each test name is printed before
-  # it runs. When the suite hangs, the last printed line identifies the blocking
-  # test. Mirrors the same diagnostic added to spec:integration in PR #1274.
-  t.rspec_opts = '--format documentation' if RUBY_ENGINE == 'jruby'
+# Use parallel test execution for MRI where it cuts build times by 30-48%.
+# JRuby and TruffleRuby are slower with parallel_tests because each worker
+# process pays JVM/Truffle startup and warm-up overhead independently,
+# resulting in 18-28% slower builds vs. serial execution.
+def parallel_tests?
+  RUBY_ENGINE == 'ruby' && !parallel_tests_disabled_via_env?
 end
 
-# Run only integration specs (real git, slower)
-RSpec::Core::RakeTask.new('spec:integration') do |t|
-  t.pattern = 'spec/integration/**/*_spec.rb'
-  # On JRuby, override the default Fuubar formatter with 'documentation' so that
-  # each test name is printed before it runs. This makes CI logs useful when the
-  # suite hangs: the last printed test is the one that caused the hang.
-  t.rspec_opts = '--format documentation' if RUBY_ENGINE == 'jruby'
+def define_parallel_spec_task(name, dir)
+  task name do
+    sh 'bundle', 'exec', 'parallel_rspec', dir
+  end
 end
 
-# Run all specs in parallel
-desc 'Run all specs in parallel'
-task 'spec:parallel' do
-  sh 'bundle exec parallel_rspec spec/'
+def define_serial_spec_task(name, dir)
+  RSpec::Core::RakeTask.new(name) do |t|
+    t.pattern = "#{dir}**/*_spec.rb"
+    # On JRuby, use 'documentation' formatter so each test name is printed before
+    # it runs. When the suite hangs, the last printed line identifies the blocking
+    # test.
+    t.rspec_opts = '--format documentation' if RUBY_ENGINE == 'jruby'
+  end
 end
 
-# Run only unit specs in parallel
-desc 'Run unit specs in parallel'
-task 'spec:unit:parallel' do
-  sh 'bundle exec parallel_rspec spec/unit/'
+# Define a spec task that runs in parallel (via parallel_tests) when parallel_tests? is
+# true, and serially (via RSpec::Core::RakeTask) otherwise.
+def define_spec_task(name, dir, desc_text)
+  desc desc_text
+  parallel_tests? ? define_parallel_spec_task(name, dir) : define_serial_spec_task(name, dir)
 end
 
-# Run only integration specs in parallel
-desc 'Run integration specs in parallel'
-task 'spec:integration:parallel' do
-  sh 'bundle exec parallel_rspec spec/integration/'
-end
+# Run only unit specs. These run in a few seconds, so parallel_tests startup
+# overhead isn't worth it - always run serially.
+desc 'Run unit RSpec tests (mocked, fast)'
+define_serial_spec_task('spec:unit', 'spec/unit/')
+
+# Run only integration specs
+define_spec_task('spec:integration', 'spec/integration/', 'Run integration RSpec tests (real git, slower)')
+
+# Run all specs, keeping unit and integration output clearly separated
+desc 'Run unit and integration RSpec tests'
+task spec: %w[spec:unit spec:integration]
 
 CLEAN << 'coverage'
 CLEAN << '.rspec_status'


### PR DESCRIPTION
## Summary

`tasks/rspec.rake` used to define six separate rake tasks - a serial and a
parallel variant for each of `spec`, `spec:unit`, and `spec:integration` - plus
a matching `default` / `default:parallel` split in the `Rakefile`. This PR
collapses that into three spec tasks that pick the right execution mode
themselves:

| Task | Behavior |
| --- | --- |
| `spec:unit` | Always serial. The full unit suite runs in a few seconds, so `parallel_tests` worker startup would cost more than it saves. |
| `spec:integration` | Parallel on MRI (30-48% faster), serial on JRuby/TruffleRuby (where parallel worker startup/warm-up actually costs 18-28% *more*). Override with `PARALLEL_TESTS=false`. |
| `spec` | Depends on both of the above, so `rake spec` output stays clearly separated into a boxed `spec:unit` section and a boxed `spec:integration` section instead of one merged run. |

`spec:parallel`, `spec:unit:parallel`, `spec:integration:parallel`, and
`default:parallel` are removed - there's now one task name per suite, and it
does the right thing by default.

## Why

Fewer task names to remember, and both humans and AI agents get the faster
path automatically instead of having to know to reach for the `:parallel`
variant.

## Other changes swept up

Removing `spec:integration:parallel` and `default:parallel` broke a few other
things that referenced them by name:

- `bin/test-git-versions` shelled out to `rake spec:integration:parallel`
  directly - updated to `spec:integration`.
- `.github/skills/command-implementation/{SKILL,REFERENCE}.md` and
  `.github/skills/facade-implementation/SKILL.md` looked up quality-gate
  prerequisites via `Rake::Task['default:parallel']` - updated to `'default'`.
- `CONTRIBUTING.md` now documents the new `PARALLEL_TESTS` env var (accepting
  `false`/`0`/`no`/`off`, same convention as the existing `COVERAGE` var)
  right next to where `COVERAGE` is already documented.

(A handful of references in `redesign/*.md` and one deprecated skill under
`.github/skills-deprecated/` still mention the old task names; those are
historical/inactive records and were left as-is.)

## Test plan

- [x] `bundle exec rake spec:unit` runs serially regardless of engine/env var
- [x] `bundle exec rake spec:integration` runs parallel by default on MRI
- [x] `PARALLEL_TESTS=false bundle exec rake spec:integration` forces serial
- [x] `bundle exec rake spec` runs both with separated boxed output, all passing
- [x] `bundle exec rake -T` shows the expected task names and descriptions
- [x] `bundle exec rubocop` clean on all changed files
- [x] `ruby -c bin/test-git-versions` syntax-checks clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)