### PR TITLE
test: disable coverage for spec:integration, add SPEC filtering, fix formatters

### DIFF
--- a/.github/skills/rspec-unit-testing-standards/SKILL.md
+++ b/.github/skills/rspec-unit-testing-standards/SKILL.md
@@ -68,9 +68,9 @@ Adoption and enforcement notes:
 - Apply these rules as hard requirements for new and modified unit specs.
 - Legacy specs may violate some rules; treat those as incremental cleanup work.
 - Branch and line coverage are both reported by SimpleCov in this repository.
-- `coverage_threshold: 100` is configured, but `fail_on_low_coverage` is currently
-  `false`; enforce Rule 21 during review by checking the coverage report until
-  strict failure is enabled.
+- `minimum_coverage: { line: 100, branch: 100 }` is configured, but `fail_on_low_coverage`
+  is currently `false`; enforce Rule 21 during review by checking the coverage report
+  until strict failure is enabled.
 
 ## Related skills
 

--- a/.rspec
+++ b/.rspec
@@ -1,3 +1,2 @@
 --require spec_helper
---format Fuubar
 --color

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -926,9 +926,14 @@ process.stdin.on('end', () =>
   local working copy.
 - Test runs are covered by SimpleCov by default. Set `COVERAGE=false` (or `0`/`no`/
   `off`) to skip coverage, e.g. `COVERAGE=false bundle exec rake spec`.
+  `rake spec:integration` always disables coverage, regardless of `COVERAGE`:
+  integration tests aren't meant to be exhaustive, so tracking their coverage would
+  misleadingly suggest that low integration coverage is a problem to fix.
 - `rake spec:integration` runs in parallel (via `parallel_tests`) on MRI. Set
   `PARALLEL_TESTS=false` (or `0`/`no`/`off`) to force serial execution, e.g.
   `PARALLEL_TESTS=false bundle exec rake spec:integration`.
+- Set `SPEC=<glob>` to run specific files instead of a task's whole directory, e.g.
+  `SPEC=spec/unit/git/version_spec.rb bundle exec rake spec:unit`.
 
 This project uses **RSpec** (`spec/`) as its sole test framework. Structure,
 naming, setup, stubbing, and coverage rules for unit specs are defined in the

--- a/git.gemspec
+++ b/git.gemspec
@@ -41,9 +41,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.3'
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'rubocop', '~> 1.82'
-  spec.add_development_dependency 'simplecov', '~> 0.22'
+  spec.add_development_dependency 'simplecov', '~> 1.0'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.9'
-  spec.add_development_dependency 'simplecov-rspec', '~> 0.4'
+  spec.add_development_dependency 'simplecov-rspec', '~> 1.0'
 
   if RUBY_ENGINE == 'truffleruby' && Gem::Version.new(RUBY_ENGINE_VERSION) < Gem::Version.new('34.0.0')
     # i18n 1.15+ uses Fiber.[] (Ruby 3.2 Fiber storage) which TruffleRuby < 34.0.0 does not implement

--- a/lib/git/commands/arguments.rb
+++ b/lib/git/commands/arguments.rb
@@ -2399,11 +2399,11 @@ module Git
           build_option(args, entry[:name], @option_definitions[entry[:name]], normalized_opts[entry[:name]])
         when :operand
           build_single_positional(args, entry[:name], allocated_positionals)
-        # :nocov: this case should be unreachable
+        # simplecov:disable this case should be unreachable
         else
           raise ArgumentError, "unknown entry kind: #{entry[:kind].inspect}"
         end
-        # :nocov:
+        # simplecov:enable
       end
 
       # Replace the END_OF_OPTIONS_MARKER with the stored `as:` value if any element

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,8 +29,24 @@ RSpec.configure do |config|
     expectations.syntax = :expect
   end
 
-  # Use the documentation formatter for detailed output
-  config.default_formatter = 'doc' if config.files_to_run.one?
+  # Choose the formatter here (rather than a static --format in .rspec), since Fuubar
+  # isn't the right choice for every case:
+  #
+  # - Single-file run (focused debugging) or JRuby (so a hang's last printed line
+  #   identifies the blocking test): plain per-example output is more useful than a
+  #   progress bar.
+  # - Under parallel_tests (ENV['TEST_ENV_NUMBER'] is set for every worker, including
+  #   the first): multiple worker processes redraw Fuubar's progress bar on the same
+  #   terminal line concurrently, corrupting the output. Plain dots don't redraw, so
+  #   they interleave safely.
+  config.default_formatter =
+    if (config.files_to_run.one? && !ENV['TEST_ENV_NUMBER']) || RUBY_ENGINE == 'jruby'
+      'documentation'
+    elsif ENV['TEST_ENV_NUMBER']
+      'progress'
+    else
+      'Fuubar'
+    end
 
   # Run specs in random order to surface order dependencies
   config.order = :random
@@ -173,9 +189,10 @@ if enable_coverage?
   SimpleCov.enable_coverage :branch
 
   SimpleCov::RSpec.start(
-    coverage_threshold: 100,
+    minimum_coverage: { line: 100, branch: 100 },
     fail_on_low_coverage: false,
-    list_uncovered_lines: false
+    list_uncovered: %i[branch line],
+    list_uncovered_detail: false
   ) do
     command_name "RSpec-#{ENV['TEST_ENV_NUMBER']}" if ENV['TEST_ENV_NUMBER']
   end

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rspec/core/rake_task'
-
 # Skip parallel test execution when the PARALLEL_TESTS environment variable is set to a falsy value
 def parallel_tests_disabled_via_env?
   parallel_tests_env = ENV.fetch('PARALLEL_TESTS', 'true').strip.downcase
@@ -16,36 +14,55 @@ def parallel_tests?
   RUBY_ENGINE == 'ruby' && !parallel_tests_disabled_via_env?
 end
 
-def define_parallel_spec_task(name, dir)
+# SPEC lets a developer target one or more specific files, e.g.
+# `SPEC=spec/unit/git/version_spec.rb rake spec:unit`, running just those files
+# instead of the whole directory. Both rspec and parallel_rspec recurse a bare
+# directory argument using their own default *_spec.rb pattern, so no explicit
+# --pattern flag is needed for the non-SPEC case.
+def spec_targets(dir)
+  spec_files = ENV.fetch('SPEC', nil)&.strip
+  return [dir] if spec_files.nil? || spec_files.empty?
+
+  targets = FileList[spec_files].sort
+  raise "SPEC=#{spec_files.inspect} did not match any files" if targets.empty?
+
+  targets
+end
+
+def define_parallel_spec_task(name, dir, env: {})
   task name do
-    sh 'bundle', 'exec', 'parallel_rspec', dir
+    sh env, 'bundle', 'exec', 'parallel_rspec', *spec_targets(dir)
   end
 end
 
-def define_serial_spec_task(name, dir)
-  RSpec::Core::RakeTask.new(name) do |t|
-    t.pattern = "#{dir}**/*_spec.rb"
-    # On JRuby, use 'documentation' formatter so each test name is printed before
-    # it runs. When the suite hangs, the last printed line identifies the blocking
-    # test.
-    t.rspec_opts = '--format documentation' if RUBY_ENGINE == 'jruby'
+def define_serial_spec_task(name, dir, env: {})
+  task name do
+    sh env, 'bundle', 'exec', 'rspec', *spec_targets(dir)
   end
 end
 
 # Define a spec task that runs in parallel (via parallel_tests) when parallel_tests? is
-# true, and serially (via RSpec::Core::RakeTask) otherwise.
-def define_spec_task(name, dir, desc_text)
+# true, and serially (via a direct `bundle exec rspec` call) otherwise. env, when given,
+# is passed to `sh` and scoped to just the spawned test subprocess(es).
+def define_spec_task(name, dir, desc_text, env: {})
   desc desc_text
-  parallel_tests? ? define_parallel_spec_task(name, dir) : define_serial_spec_task(name, dir)
+  parallel_tests? ? define_parallel_spec_task(name, dir, env: env) : define_serial_spec_task(name, dir, env: env)
 end
 
 # Run only unit specs. These run in a few seconds, so parallel_tests startup
 # overhead isn't worth it - always run serially.
-desc 'Run unit RSpec tests (mocked, fast)'
+desc 'Run unit RSpec tests (mocked, fast; SPEC=<glob> to run specific files)'
 define_serial_spec_task('spec:unit', 'spec/unit/')
 
-# Run only integration specs
-define_spec_task('spec:integration', 'spec/integration/', 'Run integration RSpec tests (real git, slower)')
+# Run only integration specs. Coverage is forced off (regardless of the COVERAGE
+# env var): integration tests intentionally aren't exhaustive, so tracking or
+# reporting coverage for them would misleadingly suggest that low integration
+# coverage is a problem to fix.
+define_spec_task(
+  'spec:integration', 'spec/integration/',
+  'Run integration RSpec tests (real git, slower; SPEC=<glob> to run specific files)',
+  env: { 'COVERAGE' => 'false' }
+)
 
 # Run all specs, keeping unit and integration output clearly separated
 desc 'Run unit and integration RSpec tests'


### PR DESCRIPTION
## Summary

- `rake spec:integration` now forces `COVERAGE=false` regardless of the `COVERAGE` env var. Integration tests aren't meant to be exhaustive, so tracking/reporting their coverage sent the wrong signal.
- `SPEC=<glob>` now works consistently on both the serial and parallel test execution paths (previously only worked when forced serial), via a shared `spec_targets` helper. This drops the `RSpec::Core::RakeTask` dependency, which couldn't invoke `parallel_rspec` or scope env vars per-subprocess. Blank/whitespace-only `SPEC` is treated as unset (falls back to the default directory), and a `SPEC` glob that matches no files now raises immediately instead of silently running the full default suite with no path args.
- Fixed formatter selection in `spec_helper.rb`: Fuubar's cursor-based progress bar corrupts output under parallel tests (12 concurrent workers redrawing the same terminal line produced a garbled ~600-character-wide bar). Parallel workers now use the plain `progress` (dot) formatter. Single-file runs and JRuby get `documentation` instead of Fuubar, so a hang's last printed line is unambiguous. Selection now sets `config.default_formatter` instead of `config.add_formatter`, so an explicit `--format` passed on the CLI or `.rspec` takes precedence instead of stacking with the auto-selected formatter, and the single-file special case is scoped to exclude `parallel_tests` workers.
- Documented `SPEC=` and the integration coverage behavior in `CONTRIBUTING.md`; fixed a stale `minimum_coverage` parameter reference in the `rspec-unit-testing-standards` skill.

## Test plan

- [x] `bundle exec rake default` (spec:unit, spec:integration, rubocop, yard, build) passes clean
- [x] `spec:integration` produces no `coverage/` output even with `COVERAGE=true` forced, on both the parallel and serial (`PARALLEL_TESTS=false`) paths
- [x] `SPEC=<glob>` verified on both serial and parallel paths, single-file and multi-file glob
- [x] `SPEC` unset, blank, and whitespace-only all fall back to running the default directory
- [x] `SPEC` glob with no matches raises immediately instead of running the full default suite
- [x] Single-file run shows `documentation` formatter output only (no Fuubar)
- [x] Full serial `spec:unit` run still shows Fuubar
- [x] Full parallel `spec:integration` run shows plain dots, zero garbled `Progress:` lines (previously many)
- [x] `--format <name>` on the CLI is honored instead of being overridden/stacked by the auto-selected formatter

🤖 Generated with [Claude Code](https://claude.com/claude-code)
