### PR TITLE
test: bring spec:unit to 100% line and branch coverage

### DIFF
--- a/lib/git/parsers/diff.rb
+++ b/lib/git/parsers/diff.rb
@@ -593,11 +593,10 @@ module Git
           # @return [void]
           #
           def apply_file_mode(type, mode)
-            case type
-            when 'new'
+            if type == 'new'
               @current_file[:dst_mode] = mode
               @current_file[:src_path] = nil
-            when 'deleted'
+            else
               @current_file[:src_mode] = mode
               @current_file[:dst_path] = nil
             end

--- a/lib/git/parsers/grep.rb
+++ b/lib/git/parsers/grep.rb
@@ -32,7 +32,7 @@ module Git
       def parse(output)
         output.each_line.with_object(Hash.new { |h, k| h[k] = [] }) do |line, hsh|
           filename, line_num, text = line.chomp.split("\0", 3)
-          next unless text && line_num&.match?(/\A\d+\z/)
+          next unless text && line_num.match?(/\A\d+\z/)
 
           hsh[filename] << [line_num.to_i, text]
         end

--- a/spec/unit/git/branch_spec.rb
+++ b/spec/unit/git/branch_spec.rb
@@ -371,6 +371,35 @@ RSpec.describe Git::Branch do
   end
 
   # ---------------------------------------------------------------------------
+  # #stashes
+  # ---------------------------------------------------------------------------
+
+  describe '#stashes' do
+    subject(:branch) { described_class.new(base, branch_info) }
+
+    let(:branch_info) do
+      Git::BranchInfo.new(
+        refname: 'feature',
+        target_oid: nil,
+        current: false,
+        worktree_path: nil,
+        symref: nil,
+        upstream: nil
+      )
+    end
+
+    before { allow(base).to receive(:stashes_all).and_return([]) }
+
+    it 'returns a Git::Stashes for the branch repository' do
+      expect(branch.stashes).to be_a(Git::Stashes)
+    end
+
+    it 'memoizes the result' do
+      expect(branch.stashes).to be(branch.stashes)
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # #archive
   # ---------------------------------------------------------------------------
 

--- a/spec/unit/git/branch_spec.rb
+++ b/spec/unit/git/branch_spec.rb
@@ -252,6 +252,47 @@ RSpec.describe Git::Branch do
   end
 
   # ---------------------------------------------------------------------------
+  # #merge
+  # ---------------------------------------------------------------------------
+
+  describe '#merge' do
+    subject(:branch) { described_class.new(base, branch_info) }
+
+    let(:branch_info) do
+      Git::BranchInfo.new(
+        refname: 'feature',
+        target_oid: nil,
+        current: false,
+        worktree_path: nil,
+        symref: nil,
+        upstream: nil
+      )
+    end
+
+    context 'when a branch is given' do
+      before do
+        allow(base).to receive(:current_branch).and_return('main')
+        allow(base).to receive(:branch_new).with('feature').and_return(command_result(''))
+        allow(base).to receive(:checkout).and_return('')
+        allow(base).to receive(:reset).with(nil, hard: true).and_return(command_result(''))
+      end
+
+      it 'merges the given branch into this branch, then restores the original branch' do
+        expect(base).to receive(:merge).with('other-branch', 'my message').and_return('merged')
+        expect(base).to receive(:checkout).with('main').and_return('restored')
+        expect(branch.merge('other-branch', 'my message')).to eq('restored')
+      end
+    end
+
+    context 'when no branch is given' do
+      it 'merges this branch into the current branch' do
+        expect(base).to receive(:merge).with('feature').and_return('merged')
+        expect(branch.merge).to eq('merged')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # #update_ref
   # ---------------------------------------------------------------------------
 

--- a/spec/unit/git/command_line/capturing_spec.rb
+++ b/spec/unit/git/command_line/capturing_spec.rb
@@ -400,5 +400,25 @@ RSpec.describe Git::CommandLine::Capturing do
           end
       end
     end
+
+    context 'when ProcessExecuter raises Errno::ESRCH (timeout race)' do
+      let(:original_error) { Errno::ESRCH.new('No such process') }
+
+      before do
+        allow(ProcessExecuter).to receive(:run_with_capture).and_raise(original_error)
+      end
+
+      it 'translates to Git::ProcessIOError' do
+        expect { described_instance.run('version') }
+          .to raise_error(Git::ProcessIOError, /timeout race/)
+      end
+
+      it 'sets the Errno::ESRCH as the cause' do
+        expect { described_instance.run('version') }
+          .to raise_error(Git::ProcessIOError, /timeout race/) do |error|
+            expect(error.cause).to be(original_error)
+          end
+      end
+    end
   end
 end

--- a/spec/unit/git/command_line/streaming_spec.rb
+++ b/spec/unit/git/command_line/streaming_spec.rb
@@ -304,5 +304,25 @@ RSpec.describe Git::CommandLine::Streaming do
           end
       end
     end
+
+    context 'when ProcessExecuter raises Errno::ESRCH (timeout race)' do
+      let(:original_error) { Errno::ESRCH.new('No such process') }
+
+      before do
+        allow(ProcessExecuter).to receive(:run).and_raise(original_error)
+      end
+
+      it 'translates to Git::ProcessIOError' do
+        expect { described_instance.run('status') }
+          .to raise_error(Git::ProcessIOError, /timeout race/)
+      end
+
+      it 'sets the Errno::ESRCH as the cause' do
+        expect { described_instance.run('status') }
+          .to raise_error(Git::ProcessIOError, /timeout race/) do |error|
+            expect(error.cause).to be(original_error)
+          end
+      end
+    end
   end
 end

--- a/spec/unit/git/command_line_result_spec.rb
+++ b/spec/unit/git/command_line_result_spec.rb
@@ -11,13 +11,21 @@ RSpec.describe 'Git::CommandLineResult (deprecated)' do
     Git.send(:remove_const, :CommandLineResult) if Git.const_defined?(:CommandLineResult, false)
   end
 
-  it 'resolves to Git::CommandLine::Result' do
-    allow(Git::Deprecation).to receive(:warn)
-    expect(Git::CommandLineResult).to be(Git::CommandLine::Result)
+  context 'when accessing Git::CommandLineResult' do
+    it 'resolves to Git::CommandLine::Result' do
+      allow(Git::Deprecation).to receive(:warn)
+      expect(Git::CommandLineResult).to be(Git::CommandLine::Result)
+    end
+
+    it 'emits a deprecation warning when accessed' do
+      expect(Git::Deprecation).to receive(:warn).with(/Git::CommandLineResult is deprecated/)
+      Git::CommandLineResult
+    end
   end
 
-  it 'emits a deprecation warning when accessed' do
-    expect(Git::Deprecation).to receive(:warn).with(/Git::CommandLineResult is deprecated/)
-    Git::CommandLineResult
+  context 'when accessing an unrelated missing constant' do
+    it 'raises NameError instead of resolving it' do
+      expect { Git::NotARealConstant }.to raise_error(NameError, /uninitialized constant Git::NotARealConstant/)
+    end
   end
 end

--- a/spec/unit/git/diff_file_patch_info_spec.rb
+++ b/spec/unit/git/diff_file_patch_info_spec.rb
@@ -34,6 +34,21 @@ RSpec.describe Git::DiffFilePatchInfo do
 
       expect(patch.path).to eq('deleted.rb')
     end
+
+    it 'returns nil when both src and dst are nil' do
+      patch = described_class.new(
+        src: nil,
+        dst: nil,
+        patch: 'diff text',
+        status: :modified,
+        similarity: nil,
+        binary: false,
+        insertions: 0,
+        deletions: 0
+      )
+
+      expect(patch.path).to be_nil
+    end
   end
 
   describe '#src_path' do

--- a/spec/unit/git/diff_file_raw_info_spec.rb
+++ b/spec/unit/git/diff_file_raw_info_spec.rb
@@ -122,6 +122,20 @@ RSpec.describe Git::DiffFileRawInfo do
 
       expect(info.path).to eq('deleted.rb')
     end
+
+    it 'returns nil when both src and dst are nil' do
+      info = described_class.new(
+        src: nil,
+        dst: nil,
+        status: :modified,
+        similarity: nil,
+        insertions: 0,
+        deletions: 0,
+        binary: false
+      )
+
+      expect(info.path).to be_nil
+    end
   end
 
   describe '#src_path' do

--- a/spec/unit/git/diff_spec.rb
+++ b/spec/unit/git/diff_spec.rb
@@ -151,6 +151,19 @@ RSpec.describe Git::Diff do
     end
   end
 
+  describe '#name_status' do
+    subject(:result) { described_instance.name_status }
+
+    let(:name_status_hash) { { 'lib/foo.rb' => 'M', 'README.md' => 'A' } }
+
+    it 'returns the path-to-status hash from DiffPathStatus' do
+      allow(repository_base).to receive(:diff_name_status)
+        .with('HEAD~1', 'HEAD', path_limiter: nil)
+        .and_return(name_status_hash)
+      expect(result).to eq(name_status_hash)
+    end
+  end
+
   describe '#lines' do
     subject(:lines) { described_instance.lines }
 

--- a/spec/unit/git/encoding_utils_spec.rb
+++ b/spec/unit/git/encoding_utils_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/encoding_utils'
+
+RSpec.describe Git::EncodingUtils do
+  describe '.default_encoding' do
+    it "returns this source file's encoding name" do
+      expect(described_class.default_encoding).to eq(__ENCODING__.name)
+    end
+  end
+
+  describe '.best_guess_encoding' do
+    it 'returns UTF-8' do
+      expect(described_class.best_guess_encoding).to eq('UTF-8')
+    end
+  end
+
+  describe '.detected_encoding' do
+    subject(:detected) { described_class.detected_encoding(str) }
+
+    let(:str) { "caf\xE9".dup.force_encoding(Encoding::BINARY) }
+
+    context 'when CharDet detects an encoding' do
+      before { allow(CharDet).to receive(:detect).with(str).and_return({ 'encoding' => 'ISO-8859-1' }) }
+
+      it 'returns the detected encoding name' do
+        expect(detected).to eq('ISO-8859-1')
+      end
+    end
+
+    context 'when CharDet cannot detect an encoding' do
+      before { allow(CharDet).to receive(:detect).with(str).and_return({ 'encoding' => nil }) }
+
+      it 'falls back to best_guess_encoding' do
+        expect(detected).to eq('UTF-8')
+      end
+    end
+  end
+
+  describe '.encoding_options' do
+    it 'replaces invalid and undefined bytes' do
+      expect(described_class.encoding_options).to eq(invalid: :replace, undef: :replace)
+    end
+  end
+
+  describe '.normalize_encoding' do
+    subject(:normalized) { described_class.normalize_encoding(str) }
+
+    context 'when the string is already in the default encoding' do
+      let(:str) { 'already utf-8'.dup.force_encoding(described_class.default_encoding) }
+
+      it 'returns the same string object unchanged' do
+        expect(normalized).to be(str)
+      end
+    end
+
+    context 'when the string has a valid but different encoding' do
+      let(:str) { 'café'.encode(Encoding::ISO_8859_1) }
+
+      it 'transcodes it to the default encoding without detection' do
+        expect(CharDet).not_to receive(:detect)
+        expect(normalized).to eq('café')
+        expect(normalized.encoding.name).to eq(described_class.default_encoding)
+      end
+    end
+
+    context 'when the string has an invalid encoding' do
+      let(:str) { "caf\xE9".dup.force_encoding(Encoding::UTF_8) }
+
+      before { allow(CharDet).to receive(:detect).with(str).and_return({ 'encoding' => 'ISO-8859-1' }) }
+
+      it 'detects the encoding and transcodes it to the default encoding' do
+        expect(normalized).to eq('café')
+        expect(normalized.encoding.name).to eq(described_class.default_encoding)
+      end
+    end
+  end
+end

--- a/spec/unit/git/factories_spec.rb
+++ b/spec/unit/git/factories_spec.rb
@@ -508,6 +508,26 @@ RSpec.describe Git::Factories do
       end
     end
 
+    context 'when :index option is given' do
+      let(:options) { { index: '/custom/index' } }
+      let(:resolved_custom_index_paths) do
+        { working_directory: '/new-repo', repository: '/new-repo/.git', index: '/custom/index' }
+      end
+
+      before do
+        allow(Git::PathResolver).to receive(:resolve_paths)
+          .with(working_directory: directory, repository: nil, index: '/custom/index')
+          .and_return(resolved_custom_index_paths)
+      end
+
+      it 'passes the custom index path through to Git.open' do
+        repository
+        expect(Git::PathResolver).to(
+          have_received(:resolve_paths).with(working_directory: directory, repository: nil, index: '/custom/index')
+        )
+      end
+    end
+
     context 'when :separate_git_dir option is given' do
       let(:options) { { separate_git_dir: '/custom/git' } }
       let(:resolved_custom_paths) do

--- a/spec/unit/git/factories_spec.rb
+++ b/spec/unit/git/factories_spec.rb
@@ -188,6 +188,14 @@ RSpec.describe Git::Factories do
       )
     end
 
+    context 'when the clone stderr cannot be parsed' do
+      let(:clone_stderr) { "fatal: repository 'bogus' does not exist\n" }
+
+      it 'raises Git::UnexpectedResultError' do
+        expect { repository }.to raise_error(Git::UnexpectedResultError, /Unable to determine clone directory/)
+      end
+    end
+
     context 'when cloning a bare repository via :bare option' do
       let(:options) { { bare: true } }
       let(:clone_stderr) { "Cloning into bare repository 'ruby-git.git'...\n" }

--- a/spec/unit/git/parsers/cat_file_spec.rb
+++ b/spec/unit/git/parsers/cat_file_spec.rb
@@ -170,4 +170,15 @@ RSpec.describe Git::Parsers::CatFile do
       end
     end
   end
+
+  describe '.each_header' do
+    it 'stops cleanly when a header line is the last line (no trailing separator)' do
+      lines = ['type commit']
+
+      headers = {}
+      described_class.each_header(lines) { |key, value| headers[key] = value }
+
+      expect(headers).to eq('type' => 'commit')
+    end
+  end
 end

--- a/spec/unit/git/parsers/diff_spec.rb
+++ b/spec/unit/git/parsers/diff_spec.rb
@@ -31,6 +31,13 @@ RSpec.describe Git::Parsers::Diff do
 
       expect(result).to eq(files_changed: 0, insertions: 0, deletions: 0)
     end
+
+    it 'returns 0 for files_changed when the file count is missing' do
+      line = ' 10 insertions(+), 5 deletions(-)'
+      result = described_class.parse_shortstat(line)
+
+      expect(result).to eq(files_changed: 0, insertions: 10, deletions: 5)
+    end
   end
 
   describe '.parse_dirstat' do
@@ -54,6 +61,14 @@ RSpec.describe Git::Parsers::Diff do
       result = described_class.parse_dirstat([])
 
       expect(result.entries).to be_empty
+    end
+
+    it 'skips lines that do not match the percentage pattern' do
+      lines = ['  50.0% lib/', 'not a dirstat line']
+      result = described_class.parse_dirstat(lines)
+
+      expect(result.entries.size).to eq(1)
+      expect(result.entries[0].directory).to eq('lib/')
     end
   end
 
@@ -316,6 +331,21 @@ RSpec.describe Git::Parsers::Diff::Raw do
       expect(file.deletions).to eq(5)
     end
 
+    it 'includes dirstat when requested' do
+      output = <<~OUTPUT
+        :100644 100644 abc1234 def5678 M\tlib/file.rb
+        10\t5\tlib/file.rb
+         1 file changed, 10 insertions(+), 5 deletions(-)
+        100.0% lib/
+      OUTPUT
+
+      result = described_class.parse(output, include_dirstat: true)
+
+      expect(result.dirstat).not_to be_nil
+      expect(result.dirstat.entries.size).to eq(1)
+      expect(result.dirstat.entries[0].percentage).to eq(100.0)
+    end
+
     it 'parses renamed files' do
       output = <<~OUTPUT
         :100644 100644 abc1234 def5678 R075\told.rb\tnew.rb
@@ -486,6 +516,16 @@ RSpec.describe Git::Parsers::Diff::Patch do
       expect(result.files_changed).to eq(0)
     end
 
+    it 'ignores a diff header line that starts with "diff --git" but does not match the full pattern' do
+      # The line is located by a loose `start_with?('diff --git')` check, but
+      # DIFF_HEADER_PATTERN requires the full "a/<path> b/<path>" shape to match.
+      output = "diff --git malformed header line\n"
+
+      result = described_class.parse(output)
+
+      expect(result.files).to be_empty
+    end
+
     it 'parses patch output with numstat and shortstat' do
       output = <<~OUTPUT
         10\t5\tlib/file.rb
@@ -512,6 +552,48 @@ RSpec.describe Git::Parsers::Diff::Patch do
       expect(file.deletions).to eq(5)
       expect(file.patch).to include('diff --git')
       expect(file.patch).to include('+new line')
+    end
+
+    it 'includes dirstat when requested' do
+      output = <<~OUTPUT
+        10\t5\tlib/file.rb
+         1 file changed, 10 insertions(+), 5 deletions(-)
+        100.0% lib/
+        diff --git a/lib/file.rb b/lib/file.rb
+        index abc1234..def5678 100644
+        --- a/lib/file.rb
+        +++ b/lib/file.rb
+        @@ -1,5 +1,10 @@
+        +new line
+         existing line
+      OUTPUT
+
+      result = described_class.parse(output, include_dirstat: true)
+
+      expect(result.dirstat).not_to be_nil
+      expect(result.dirstat.entries.size).to eq(1)
+      expect(result.dirstat.entries[0].percentage).to eq(100.0)
+    end
+
+    it 'defaults to zeroed shortstat totals when the shortstat line is missing' do
+      output = <<~OUTPUT
+        10\t5\tlib/file.rb
+        diff --git a/lib/file.rb b/lib/file.rb
+        index abc1234..def5678 100644
+        --- a/lib/file.rb
+        +++ b/lib/file.rb
+        @@ -1,5 +1,10 @@
+        +new line
+         existing line
+      OUTPUT
+
+      result = described_class.parse(output)
+
+      expect(result.files_changed).to eq(0)
+      expect(result.total_insertions).to eq(0)
+      expect(result.total_deletions).to eq(0)
+      expect(result.files[0].insertions).to eq(10)
+      expect(result.files[0].deletions).to eq(5)
     end
 
     it 'parses new files' do
@@ -554,6 +636,28 @@ RSpec.describe Git::Parsers::Diff::Patch do
       expect(file.status).to eq(:deleted)
       expect(file.src.path).to eq('old_file.rb')
       expect(file.dst).to be_nil
+    end
+
+    it 'parses a mode change combined with content changes' do
+      # When both the mode and content change, the index line carries a mode
+      # suffix, but old/new mode lines (processed first) already set src_mode
+      # and dst_mode, so the index line's mode must not overwrite them.
+      output = <<~OUTPUT
+        0\t0\tfile.sh
+         1 file changed, 0 insertions(+), 0 deletions(-)
+        diff --git a/file.sh b/file.sh
+        old mode 100644
+        new mode 100755
+        index abc1234..def5678 100755
+        --- a/file.sh
+        +++ b/file.sh
+      OUTPUT
+
+      result = described_class.parse(output)
+      file = result.files[0]
+
+      expect(file.src.mode).to eq('100644')
+      expect(file.dst.mode).to eq('100755')
     end
 
     it 'parses renamed files with similarity' do

--- a/spec/unit/git/parsers/ls_tree_spec.rb
+++ b/spec/unit/git/parsers/ls_tree_spec.rb
@@ -78,6 +78,18 @@ RSpec.describe Git::Parsers::LsTree do
       end
     end
 
+    context 'with a line that has no tab-separated filename' do
+      subject(:result) do
+        described_class.parse('100644 blob e69de29bb2d1d6434b8b29ae775ad8c2e48c5391')
+      end
+
+      it 'still parses mode, type, and sha, keying the entry by a nil filename' do
+        expect(result['blob']).to eq(
+          { nil => { mode: '100644', sha: 'e69de29bb2d1d6434b8b29ae775ad8c2e48c5391' } }
+        )
+      end
+    end
+
     context 'with empty output' do
       subject(:result) { described_class.parse('') }
 

--- a/spec/unit/git/parsers/remote_spec.rb
+++ b/spec/unit/git/parsers/remote_spec.rb
@@ -346,5 +346,19 @@ RSpec.describe Git::Parsers::Remote do
         expect(result[0].vcs).to eq('svn')
       end
     end
+
+    context 'with an unrecognized config variable' do
+      subject(:result) do
+        entries = [
+          entry('origin', 'url', 'https://github.com/ruby-git/ruby-git.git'),
+          entry('origin', 'somefuturevariable', 'unknown-value')
+        ]
+        described_class.parse_list(entries)
+      end
+
+      it 'silently ignores the unrecognized variable' do
+        expect(result[0].url).to eq(['https://github.com/ruby-git/ruby-git.git'])
+      end
+    end
   end
 end

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -159,6 +159,16 @@ RSpec.describe Git::Repository::RemoteOperations do
       end
     end
 
+    context 'with a String option key' do
+      subject(:result) { described_instance.fetch('origin', 'force' => true) }
+
+      it 'normalizes the String key to a Symbol before validating options' do
+        expect(fetch_command)
+          .to receive(:call).with('origin', force: true, merge: true).and_return(fetch_result)
+        result
+      end
+    end
+
     # --- Option whitelisting -------------------------------------------------
 
     context 'with an unknown option key' do

--- a/spec/unit/git/stashes_spec.rb
+++ b/spec/unit/git/stashes_spec.rb
@@ -68,6 +68,40 @@ RSpec.describe Git::Stashes do
     end
   end
 
+  describe '#save' do
+    subject(:stashes) { described_class.new(repository) }
+
+    before do
+      allow(Git::Stash).to receive(:new).and_return(double('Stash', saved?: true))
+    end
+
+    context 'when there are changes to stash' do
+      let(:new_stash) { double('Stash', saved?: true) }
+
+      before do
+        allow(Git::Stash).to receive(:new).with(repository, 'WIP').and_return(new_stash)
+      end
+
+      it 'adds the new stash to the collection' do
+        stashes.save('WIP')
+        expect(stashes.size).to eq(3)
+      end
+    end
+
+    context 'when there are no changes to stash' do
+      let(:new_stash) { double('Stash', saved?: false) }
+
+      before do
+        allow(Git::Stash).to receive(:new).with(repository, 'WIP').and_return(new_stash)
+      end
+
+      it 'does not add anything to the collection' do
+        stashes.save('WIP')
+        expect(stashes.size).to eq(2)
+      end
+    end
+  end
+
   describe '#each' do
     subject(:stashes) { described_class.new(repository) }
 

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -48,4 +48,55 @@ RSpec.describe Git do
       end
     end
   end
+
+  describe '.export' do
+    subject(:result) { described_class.export(repository_url, directory, options) }
+
+    let(:repository_url) { 'https://example.com/repo.git' }
+    let(:directory) { '/tmp/example' }
+    let(:options) { {} }
+    let(:repo) { instance_double(Git::Repository, dir: Pathname.new(directory)) }
+
+    before do
+      allow(described_class).to receive(:clone).and_return(repo)
+      allow(FileUtils).to receive(:rm_r)
+    end
+
+    it 'clones the repository with depth: 1 merged into the given options' do
+      expect(described_class).to receive(:clone).with(repository_url, directory, { depth: 1 }).and_return(repo)
+      result
+    end
+
+    it 'removes the .git directory from the cloned repository' do
+      expect(FileUtils).to receive(:rm_r).with(File.join(directory, '.git'))
+      result
+    end
+
+    context 'when options include :remote' do
+      let(:options) { { remote: 'upstream' } }
+
+      it 'removes :remote before passing options to clone' do
+        expect(described_class).to receive(:clone).with(repository_url, directory, { depth: 1 }).and_return(repo)
+        result
+      end
+    end
+
+    context 'when options include :branch' do
+      let(:options) { { branch: 'develop' } }
+
+      before { allow(repo).to receive(:checkout) }
+
+      it 'checks out the origin branch on the cloned repository' do
+        expect(repo).to receive(:checkout).with('origin/develop')
+        result
+      end
+    end
+
+    context 'when options do not include :branch' do
+      it 'does not check out a branch' do
+        expect(repo).not_to receive(:checkout)
+        result
+      end
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Brings `spec:unit` to 100% line and 100% branch coverage, working through
the previously-uncovered lines/branches in small, reviewable batches — one
method or concern per commit.

- Adds unit tests for previously-uncovered branches across `Git.export`,
  `Git.const_missing`, `Git::Branch#stashes`/`#merge`, `Git::Stashes#save`,
  `Git::Diff#name_status`, the `Errno::ESRCH` timeout-race rescue in
  `Git::CommandLine::Base`, `Git::Parsers::Diff` edge cases, the `#path`
  fallback shared by `Git::DiffFilePatchInfo`/`Git::DiffFileRawInfo`,
  `Git::Factories` (`parse_clone_stderr`, the `:index` open option), and
  `Git::Parsers::CatFile`/`LsTree`/`Remote` plus
  `Git::Repository::RemoteOperations#normalize_fetch_keys`.
- Adds a new unit spec file for `Git::EncodingUtils`, which previously had
  no dedicated coverage.
- Two small `fix:` commits remove structurally unreachable branches
  (a `case` arm in `Git::Parsers::Diff::Patch#apply_file_mode` and a dead
  `&.` safe-navigation in `Git::Parsers::Grep.parse`) rather than adding
  tests that would require reaching into private internals to hit them.

No production behavior changes except the two `fix:` commits, both of
which are pure simplifications with no observable behavior change
(verified by the full test suite passing before and after).

## Test plan

- [x] `bundle exec rake spec:unit` — 5811 examples, 0 failures, 100.00%
      line coverage, 100.00% branch coverage
- [x] `bundle exec rake` (full task: unit + integration specs, RuboCop,
      yard-lint, yard docs, yard:example-test, build) — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)