### PR TITLE
fix: return the full ref path in the ls_remote :ref value

### DIFF
--- a/lib/git/parsers/ls_remote.rb
+++ b/lib/git/parsers/ls_remote.rb
@@ -47,12 +47,12 @@ module Git
         end
 
         sha, info = line.split("\t", 2)
-        ref, type, name = info.split('/', 3)
+        _, type, name = info.split('/', 3)
 
         type ||= 'head'
         type = 'branches' if type == 'heads'
 
-        value = { ref: ref, sha: sha }
+        value = { ref: info, sha: sha }
 
         [type, name, value]
       end

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -639,7 +639,7 @@ module Git
       # @example List all refs from the local repository
       #   repo.ls_remote
       #   # => {"head"=>{ref: "HEAD", sha: "abc123"},
-      #   #     "branches"=>{"main"=>{ref: "refs", sha: "abc123"}}}
+      #   #     "branches"=>{"main"=>{ref: "refs/heads/main", sha: "abc123"}}}
       #
       # @example List all refs from a named remote
       #   repo.ls_remote('origin')
@@ -647,7 +647,7 @@ module Git
       #
       # @example List only tags from a named remote
       #   repo.ls_remote('origin', tags: true)
-      #   # => {"tags"=>{"v1.0"=>{ref: "refs", sha: "def456"}}}
+      #   # => {"tags"=>{"v1.0"=>{ref: "refs/tags/v1.0", sha: "def456"}}}
       #
       # @param location [String, nil] the remote name or URL to query; defaults to
       #   `'.'` (the local repository) when nil
@@ -677,12 +677,6 @@ module Git
       # @raise [ArgumentError] if unsupported options are provided
       #
       # @raise [Git::FailedError] if git exits outside the allowed range (exit code > 2)
-      #
-      # @note The `:ref` value in each pair is only the **first path segment** of the
-      #   full git ref (e.g. `"refs"` for `refs/heads/main`), not the complete ref
-      #   path. This matches the behavior of 4.x. See
-      #   [issue 1416](https://github.com/ruby-git/ruby-git/issues/1416) for the
-      #   planned fix.
       #
       def ls_remote(location = nil, opts = {})
         SharedPrivate.assert_valid_opts!(LS_REMOTE_ALLOWED_OPTS, **opts)

--- a/spec/unit/git/git_remote_utilities_spec.rb
+++ b/spec/unit/git/git_remote_utilities_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Git do
 
       expect(described_class.ls_remote('.', tags: true)).to eq(
         'head' => { ref: 'HEAD', sha: 'abc123' },
-        'branches' => { 'main' => { ref: 'refs', sha: 'abc123' } }
+        'branches' => { 'main' => { ref: 'refs/heads/main', sha: 'abc123' } }
       )
     end
 

--- a/spec/unit/git/parsers/ls_remote_spec.rb
+++ b/spec/unit/git/parsers/ls_remote_spec.rb
@@ -15,6 +15,38 @@ RSpec.describe Git::Parsers::LsRemote do
       end
     end
 
+    context 'with a branch ref line' do
+      let(:line) { "abc123\trefs/heads/main" }
+
+      it 'returns the full ref path as the :ref value' do
+        expect(result).to eq(['branches', 'main', { ref: 'refs/heads/main', sha: 'abc123' }])
+      end
+    end
+
+    context 'with a tag ref line' do
+      let(:line) { "def456\trefs/tags/v1.0.0" }
+
+      it 'returns the full ref path as the :ref value' do
+        expect(result).to eq(['tags', 'v1.0.0', { ref: 'refs/tags/v1.0.0', sha: 'def456' }])
+      end
+    end
+
+    context 'with a branch name containing a slash' do
+      let(:line) { "abc123\trefs/heads/feature/nested" }
+
+      it 'keeps the whole ref path in :ref and the whole branch name as the name' do
+        expect(result).to eq(['branches', 'feature/nested', { ref: 'refs/heads/feature/nested', sha: 'abc123' }])
+      end
+    end
+
+    context 'with a peeled tag ref line' do
+      let(:line) { "def456\trefs/tags/v1.0.0^{}" }
+
+      it 'preserves the peeled suffix in :ref' do
+        expect(result).to eq(['tags', 'v1.0.0^{}', { ref: 'refs/tags/v1.0.0^{}', sha: 'def456' }])
+      end
+    end
+
     context 'with a symref ref: line (e.g. --symref output)' do
       let(:line) { "ref: refs/heads/main\tHEAD" }
 

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -1299,6 +1299,10 @@ RSpec.describe Git::Repository::RemoteOperations do
         expect(branches).to have_key('main')
         expect(branches['main'][:sha]).to eq('abc123')
       end
+
+      it 'gives the branch entry the full ref path as its :ref' do
+        expect(result['branches']['main'][:ref]).to eq('refs/heads/main')
+      end
     end
 
     # --- Signature compatibility (legacy-contract) ---------------------------


### PR DESCRIPTION
# Description

Fixes #1416.

`Git::Parsers::LsRemote.parse_line` splits the ref path to derive the type and the
name, but stored only the first segment as `:ref`:

```ruby
sha, info = line.split("\t", 2)       # info = "refs/heads/main"
ref, type, name = info.split('/', 3)  # ref  = "refs"
value = { ref: ref, sha: sha }        # :ref is the constant "refs"
```

So every ref under `refs/` came back with the same uninformative `:ref`:

```ruby
repo.ls_remote('origin')
# before => {"branches"=>{"main"=>{ref: "refs", sha: "abc123"}}}
# after  => {"branches"=>{"main"=>{ref: "refs/heads/main", sha: "abc123"}}}
```

The fix is the one described in the issue: store `info` (the whole ref path). The
first element of the split is then unused, so it becomes `_`.

The `"head"` entry is unaffected. For a `"<sha>\tHEAD"` line, `info` is `"HEAD"` and
the split already yields `"HEAD"`, so its value is identical before and after.
`:sha` is untouched, and so is `parse_default_branch`, which matches the raw output
with its own regex rather than going through `parse_line`.

## Changes

- `lib/git/parsers/ls_remote.rb` — store the full ref path in `:ref`.
- `lib/git/repository/remote_operations.rb` — the two `@example` blocks showed
  `ref: "refs"`; the `@note` documented the truncation and pointed here as the
  planned fix. Both now describe the corrected behavior.
- `spec/unit/git/parsers/ls_remote_spec.rb` — four cases covering the shapes real
  `git ls-remote` emits: branch, tag, a branch name containing a slash, and a
  peeled tag. Each fails on `main` and passes with the fix.
- `spec/unit/git/repository/remote_operations_spec.rb` — assert `:ref` on the parsed
  branch entry; the existing example only asserted `:sha`.
- `spec/unit/git/git_remote_utilities_spec.rb` — one expectation pinned
  `ref: 'refs'`, i.e. the bug itself. Corrected to `'refs/heads/main'`; the test's
  own subject (the execution-context and command wiring) is unchanged.

## A note on versioning

The issue says the fix "will require a documented behavior change", so I want to
flag the release implication rather than decide it. I used a plain `fix:` commit
because 1416 is labeled `bug` and not `breaking-change`, which the repo does apply
to breaking work (issues 1635, 1639 and 1643) — so a plain `fix:` keeps this a
patch bump.
If you would rather it land as a hard break in v6.0.0, say so and I will amend to
`fix!:` with a `BREAKING CHANGE:` footer and add an UPGRADING.md entry. I left
UPGRADING.md alone for now since its sections are per major version.

## Testing

- `LC_ALL=en_US.UTF-8 bundle exec rake` — passes on this branch (exit 0):
  5816 unit examples 0 failures, 569 integration examples 0 failures, RuboCop 621
  files no offenses, yard-lint no offenses, yard example-test 0 failures.
- `bundle exec rake spec:unit` coverage: **100% line (7324/7324) and 100% branch
  (1163/1163)**.
- Same command on unmodified `main` first, for a baseline: exit 0, 5811 examples.
- The four new parser examples were confirmed red before the fix and green after
  (`git stash` on the parser only → 4 failures, all showing `ref: "refs"`).
- Also checked against real `git ls-remote` output through the public API, not just
  mocks: branch, tag and peeled-tag entries all return their full ref path.

One local detail, in case it is useful: I had to set `LC_ALL=en_US.UTF-8` because
`spec/integration/git/command_line_spec.rb:14` matches the English string
`unknown revision`, and git emits localized diagnostics on my machine. That
reproduces on unmodified `main` and is unrelated to this change.

Note: I used Claude Code while preparing this change, and I reviewed the final diff
and ran the listed checks locally.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).