### PR TITLE
test: pin the locale for the CommandLine::Capturing integration spec

### DIFF
--- a/spec/integration/git/command_line_spec.rb
+++ b/spec/integration/git/command_line_spec.rb
@@ -6,8 +6,14 @@ require 'tempfile'
 RSpec.describe 'CommandLine::Capturing#run raise_on_failure integration' do
   include_context 'in an empty repository'
 
+  # The env below is required, not incidental: git translates its diagnostics when the
+  # environment selects a non-English locale, and the example on raise_on_failure: false
+  # matches the English text "unknown revision". Git::ExecutionContext pins the locale for
+  # every command it runs, but this spec drives Git::CommandLine::Capturing directly and so
+  # bypasses that layer. Without an explicit locale here, the git subprocess inherits the
+  # developer's, and the example fails on any non-English machine.
   let(:command_line) do
-    Git::CommandLine::Capturing.new({}, 'git', [], Logger.new(nil))
+    Git::CommandLine::Capturing.new({ 'LC_ALL' => 'en_US.UTF-8' }, 'git', [], Logger.new(nil))
   end
 
   describe 'raise_on_failure: false' do


### PR DESCRIPTION
# Description

Test-only change. No library code is touched.

`spec/integration/git/command_line_spec.rb` builds `Git::CommandLine::Capturing` with an
empty env and then asserts on the English string `unknown revision` in git's stderr:

```ruby
let(:command_line) do
  Git::CommandLine::Capturing.new({}, 'git', [], Logger.new(nil))
end
...
expect(result.stderr).to include('unknown revision')
```

git translates its diagnostics when the environment selects a non-English locale.
`Git::ExecutionContext` pins `LC_ALL` for every command it runs — precisely so that
parsers never see translated output — but this spec drives the `CommandLine` layer
directly and so bypasses that layer. The git subprocess therefore inherits the
developer's own locale, and the example fails on any non-English machine:

```text
fatal: mehrdeutiges Argument 'nonexistent-ref': unbekannter Commit oder Pfad
existiert nicht im Arbeitsverzeichnis
```

This surfaced while preparing PR 1667, whose author worked around it by exporting
`LC_ALL=en_US.UTF-8` for the whole suite. Setting the locale through the spec's own env
is the narrower fix: `env` is `Capturing`'s constructor parameter, so passing it exercises
the plumbing that is the entire point of that layer rather than papering over it from the
outside.

## Changes

- `spec/integration/git/command_line_spec.rb` — pass `{ 'LC_ALL' => 'en_US.UTF-8' }` when
  constructing `Capturing`, with a comment recording why the env is required rather than
  incidental, so it is not later removed as redundant.

The second `describe` block in the same file is deliberately left alone: it runs a Ruby
fixture script rather than git, so no locale applies. This is the only spec in the suite
that constructs the `CommandLine` layer against a real git binary.

## Testing

- Confirmed red before and green after, under `LC_ALL=de_DE.UTF-8` and
  `LC_ALL=ko_KR.UTF-8`. Before: `7 examples, 1 failure`. After: `7 examples, 0 failures`
  under both, and under the ambient locale.
- `bundle exec rake` passes on this branch, exit 0: 5811 unit examples 0 failures, 569
  integration examples 0 failures (4 pending, all pre-existing), RuboCop 621 files no
  offenses, yard-lint no offenses, yard example-test 88 runs 0 failures.
- `bundle exec rake spec:unit` coverage unchanged at 100% line (7324/7324) and 100% branch
  (1163/1163).

## Follow-ups

Two related issues will be filed separately and are not addressed here:

- Whether the pinned locale should move from `en_US.UTF-8` to `C.UTF-8`. Note that plain
  `C` is not a safe choice — it disables non-ASCII case folding, so `git grep -i "äpfel"`
  silently stops matching `ÄPFEL`.
- Adding a CI job that runs the suite under a non-English locale, which would catch this
  class of problem before it reaches a contributor's machine. It is blocked by this PR,
  since the spec above is a known failure under such a job.

## Note on AI assistance

Prepared with Claude Code. The diff is two lines plus a comment; I reviewed it and ran the
checks listed above.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).
