### PR TITLE
ci: warm bundler caches at default-branch scope on push to main

### DIFF
--- a/.github/workflows/warm_bundler_caches.yml
+++ b/.github/workflows/warm_bundler_caches.yml
@@ -1,0 +1,82 @@
+name: Warm Bundler Caches
+
+# GitHub Actions scopes every cache to the ref that wrote it, and only caches
+# written at *default-branch* scope are readable from other refs. The CI workflow runs
+# on `pull_request`, where github.ref is refs/pull/<n>/merge, so the caches it writes
+# are visible to that one PR and nothing else. The result is that nearly every PR paid
+# a cold `bundle install` on nearly every job. See issue #1674 for the measurements.
+#
+# This workflow exists solely to write those caches from refs/heads/main so that a
+# PR's *first* run can read them. It does no checkout-and-test work beyond what
+# `bundler-cache: true` needs: no specs, no RuboCop, no YARD.
+#
+# The matrix below must stay in sync with continuous_integration.yml: setup-ruby's
+# cache key embeds the runner OS, the resolved Ruby version, and the Gemfile.lock hash,
+# so a pair that is not warmed here still starts cold in CI. That includes the lint
+# job's Ruby 3.4 and the Windows 3.2 job, neither of which appears in CI's main matrix
+# list. The head rubies from experimental_continuous_integration.yml are deliberately
+# absent: that workflow already runs on `push: [main]` and warms its own caches.
+#
+# Only `main` is listed below. A run's readable caches are its own ref, its base ref,
+# and the default branch, so warming 4.x would need this file backported to the 4.x
+# branch with that branch's own matrix -- the copy on main is never what runs for a
+# push to 4.x.
+on:
+  push:
+    branches: [main]
+
+  workflow_dispatch:
+
+# Deliberately NOT cancel-in-progress. Two merges landing close together would
+# otherwise cancel the first one's warming mid-save, which is the opposite of the
+# point; queueing them costs a couple of runner-minutes and always leaves a warm cache
+# behind. This group is also distinct from CI's because github.workflow differs.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  warm:
+    name: Warm Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
+
+    runs-on: ${{ matrix.operating-system }}
+    timeout-minutes: 15
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - ruby: "3.2"
+            operating-system: ubuntu-latest
+
+          - # Hosts the lint job in continuous_integration.yml
+            ruby: "3.4"
+            operating-system: ubuntu-latest
+
+          - ruby: "4.0"
+            operating-system: ubuntu-latest
+
+          - ruby: "truffleruby-24.2.1"
+            operating-system: ubuntu-latest
+
+          - ruby: "jruby-10.0.0.1"
+            operating-system: ubuntu-latest
+
+          - ruby: "3.2"
+            operating-system: windows-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      # No bundler-* inputs here on purpose. setup-ruby folds its `bundler`, `with`,
+      # `without`, and `only` inputs into the cache key, so any option set here and not
+      # in continuous_integration.yml would warm a key CI never looks up.
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically


### PR DESCRIPTION
Closes #1674.

## Problem

GitHub Actions scopes every cache to the ref that wrote it, and a run may only read
caches from its own ref, its base ref, or the default branch. `continuous_integration.yml`
triggers only on `pull_request`, where `github.ref` is `refs/pull/<n>/merge` — so every
bundler cache CI writes is readable by exactly one PR and then abandoned.

Nothing wrote a bundler cache at `refs/heads/main` scope for the versions CI actually
uses, so nearly every PR paid a cold `bundle install` on nearly every job. `gh cache list`
before this change had only three `refs/heads/main` entries, none of them a CI matrix
pair:

| Key | Written by |
| --- | --- |
| `ubuntu-24.04-x64-ruby-head` | `experimental_continuous_integration.yml` |
| `windows-2025-x64-jruby-head` | `experimental_continuous_integration.yml` |
| `ubuntu-24.04-x64-ruby-4.0.6` | `release.yml`, whose `ruby-version: ruby` happens to resolve to 4.0.6 |

The 4.0.6 entry is the one accident that gave the Ruby 4.0 job a cache hit.

## Approach

Option 1 from the issue: a dedicated workflow on `push: [main]` that checks out the repo
and runs `ruby/setup-ruby` with `bundler-cache: true` for each `(os, ruby)` pair — and
nothing else. No specs, no RuboCop, no YARD. Option 2 (adding `push: branches: [main]` to
CI) would warm the same caches but re-run the whole matrix on every merge, spending much
of the savings it creates.

Details worth calling out:

- **`cancel-in-progress: false`.** Per the issue's implementation note. Two merges landing
  close together would otherwise cancel the first one's warming mid-save.
- **The matrix covers six pairs, not four.** setup-ruby's cache key embeds the runner OS,
  resolved Ruby version, and `Gemfile.lock` hash, so the lint job's Ruby 3.4 and the
  Windows 3.2 job both need warming even though neither appears in CI's main matrix list.
- **No `bundler-*` inputs.** setup-ruby folds its `bundler`/`with`/`without`/`only` inputs
  into the cache key, so any option set here and not in CI would warm a key CI never looks up.
- **Head rubies excluded.** `experimental_continuous_integration.yml` already runs on
  `push: [main]` and warms those itself.
- **`main` only.** A run reads caches from its own ref, its base ref, or the default
  branch, so warming `4.x` requires backporting this file to that branch with that
  branch's own matrix — the copy on `main` is never what runs for a push to `4.x`.

## Before vs. after

Measured on this PR's own CI run, [`31219539800`](https://github.com/ruby-git/ruby-git/actions/runs/31219539800).

**Methodology.** The warming workflow cannot write a `refs/heads/main` cache until this PR
merges, so the "after" column is the same run re-run: attempt 1 started cold and saved its
caches to `refs/pull/1677/merge`; attempt 2 then restored all six. The keys, the payloads,
and the restore path are identical to what a warmed `refs/heads/main` cache gives a PR's
*first* run — only the scope the entry is filed under differs. Same commit, same runner
images, same matrix in both attempts.

### `Setup Ruby` step, per job

| Job | Before | After | Δ |
| --- | ---: | ---: | ---: |
| Ruby 3.2 on windows-latest | 121s (miss) | 39s (hit) | −82s |
| Ruby jruby-10.0.0.1 on ubuntu-latest | 58s (miss) | 33s (hit) | −25s |
| Lint and Docs (Ruby 3.4) | 45s (miss) | 6s (hit) | −39s |
| Ruby 3.2 on ubuntu-latest | 44s (miss) | 6s (hit) | −38s |
| Ruby truffleruby-24.2.1 on ubuntu-latest | 42s (miss) | 20s (hit) | −22s |
| Ruby 4.0 on ubuntu-latest | 8s (hit) | 7s (hit) | −1s |
| **Total** | **318s** | **111s** | **−207s (−65%)** |

Ruby 4.0 was already hitting before this change — that is the `release.yml` accident
described above, and it is the only row that does not move.

### Run totals

| Metric | Before | After | Δ |
| --- | ---: | ---: | ---: |
| Wall clock | 340s | 255s | −85s (−25%) |
| Billable job-seconds | 972s | 755s | −217s (−22%) |

Wall clock is set by the Windows job, which is the critical path in both attempts
(338s → 249s).

### Where the Windows saving comes from

Windows is both the biggest winner and the only job whose improvement shortens anyone's
wait, so it is worth breaking its `Setup Ruby` step down by sub-step:

| Sub-step | Cold | Warm | Δ |
| --- | ---: | ---: | ---: |
| Download msys2 build tools | 1.2s | 2.8s | +1.6s |
| Extract msys2 build tools | 18.0s | 22.0s | +4.0s |
| Set up ridk environment | 0.8s | 0.6s | −0.2s |
| Print Ruby version | 0.1s | 0.1s | — |
| Install Bundler | 4.4s | 3.7s | −0.7s |
| `bundle install` | 96.5s | 9.3s | **−87.2s** |
| **Step total** | **121s** | **39s** | **−82s** |

The targeted part — `bundle install` — falls from 96.5s to 9.3s, of which the cache restore
itself is 2.6s (17 MB at ~41 MB/s, then untarred). The 39s that remains is almost entirely
msys2 build-tool setup, a toolchain `bundler-cache` neither writes nor reads; it got 5.6s
*slower* between attempts, which is runner noise rather than a regression.

The same split explains the alternative runtimes: what is left in their `Setup Ruby` steps
after warming is uncached toolchain installation, not gem installation.

### Confirmation on a fresh run

Run [`31220370424`](https://github.com/ruby-git/ruby-git/actions/runs/31220370424) — pushed
after a comment-only amend, so a genuinely new run rather than a re-run — restored all six
caches on its first attempt and finished in **253s wall / 798 job-seconds**, matching
attempt 2's wall clock.

Its `Setup Ruby` total was 171s rather than 111s, entirely because the TruffleRuby job's
step took 87s instead of 20s despite a confirmed cache hit. That is worth being explicit
about: `Setup Ruby` installs the Ruby toolchain *and* restores the bundler cache, and only
the second half is what this workflow addresses. Downloading the TruffleRuby build itself
is uncached and varies run to run, so expect the per-step savings to fluctuate on the
alternative runtimes even when every cache hits.

The −207s `Setup Ruby` figure is the number actually attributable to caching; the −217s
job-seconds figure includes spec-runtime noise between attempts (individual spec steps
moved by −24s to +8s in both directions), so treat it as −207s ± noise rather than as an
additional saving. Against issue #1674's estimate of ~240s of job-seconds and ~100s of
critical path, the result lands slightly under: a warm restore is not free, and on the
slower runtimes it still costs 20–39s rather than the 9s the Ruby 4.0 job set as the
benchmark.

### What the warming workflow costs

It is not free either. Extrapolating from attempt 1's cold `Setup Ruby` times plus
checkout and runner overhead, warming should cost roughly **420–450 job-seconds and
~2.5 minutes of wall clock per push to `main`**, dominated by Windows. That is an estimate,
not a measurement — the first post-merge run will give the real number. It pays for itself
as long as `main` receives fewer pushes than the CI runs it accelerates, which is the case
here: a single PR usually triggers several runs.

## Known limitation

`Gemfile.lock` is gitignored, so setup-ruby runs `bundle lock` on each run and hashes the
result into the cache key. When any dependency publishes a new version the key changes and
every ref goes cold again until the next push to `main` re-warms it. This is already
visible in the cache list — `ubuntu-24.04-x64-ruby-4.0.6` has three distinct main-scoped
hashes from the last week. Two follow-ups would close that gap, neither in scope here:
commit `Gemfile.lock`, or add a `schedule:` trigger to this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
