### PR TITLE
ci: remove vestigial experimental and java_version matrix dimensions

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -59,7 +59,6 @@ jobs:
       (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))
 
     runs-on: ${{ matrix.operating-system }}
-    continue-on-error: ${{ matrix.experimental == 'Yes' }}
     env: { JAVA_OPTS: -Djdk.io.File.enableADS=true }
 
     strategy:
@@ -69,24 +68,13 @@ jobs:
         #
         ruby: ["3.2", "4.0", "truffleruby-24.2.1", "jruby-10.0.0.1"]
         operating-system: [ubuntu-latest]
-        experimental: [No]
-        java_version: [""]
         include:
           - ruby: "3.2"
             operating-system: windows-latest
-            experimental: No
-            java_version: ""
 
     steps:
       - name: Checkout Code
         uses: actions/checkout@v6
-
-      - name: Setup Java
-        if: matrix.java_version != ''
-        uses: actions/setup-java@v5
-        with:
-          distribution: 'temurin'
-          java-version: ${{ matrix.java_version }}
 
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1


### PR DESCRIPTION
# Description

Remove the vestigial `experimental` and `java_version` dimensions from the
standard CI matrix, the always-false `continue-on-error`, and the never-run
`Setup Java` step.

The unconditional `JAVA_OPTS` remains unchanged. This is a behavior-preserving
workflow cleanup: the same five build jobs, plus the separate lint job, are
still generated.

Closes #1676

## Verification

Agent-run verification completed before this PR was opened:

- `BUNDLE_PATH=vendor/bundle bundle exec rake default` passed on both the
  unmodified baseline and the final branch.
- The final run completed 5,816 unit examples and 569 integration examples
  with no failures; unit coverage remained at 100% for lines and branches.
- `actionlint` v1.7.12 reported no errors for the changed workflow.
- A semantic matrix check confirmed the same five build combinations before
  and after the change.
- `git diff --check` passed.
- The submitter independently ran `BUNDLE_PATH=vendor/bundle bundle exec rake`
  on the published PR commit and confirmed it passed on 2026-08-08.

No product code, user-facing behavior, or documentation changed, so no tests or
documentation updates are needed.

Prepared with OpenAI Codex assistance. The submitter personally reviewed and
verified the final change in accordance with the project's AI Policy.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).
