### PR TITLE
fix: pin LC_ALL to a locale that exists on the host platform

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -301,7 +301,7 @@ The `git` gem is organized into three architectural layers:
 | --- | --- | --- |
 | **Facade** (`Git::Repository` and `Git`) | Public API | Normalizes Ruby arguments, sets safe defaults, calls one or more `Git::Commands::*` classes, and may parse output into public Ruby objects |
 | **Command** (`Git::Commands::*`) | Neutral git CLI interface | Declares CLI arguments via the [Arguments DSL](lib/git/commands/arguments.rb), builds the git argv and executes git via `#call`, and returns `Git::CommandLine::Result` |
-| **Execution** (`Git::ExecutionContext::*`) | Execution context and subprocess defaults | Carries execution settings such as working directory, environment, timeout, binary path, and logging; runs the git CLI with default global options (such as `-c color.ui=false`) and subprocess environment variables (such as `LC_ALL=en_US.UTF-8`) |
+| **Execution** (`Git::ExecutionContext::*`) | Execution context and subprocess defaults | Carries execution settings such as working directory, environment, timeout, binary path, and logging; runs the git CLI with default global options (such as `-c color.ui=false`) and subprocess environment variables (such as a platform-conditional `LC_ALL` — `en_US.UTF-8` on macOS, `C.UTF-8` elsewhere) |
 
 Command classes (`Git::Commands::*`) are **faithful, neutral representations of the
 git CLI**. Each command class does the following:

--- a/lib/git/execution_context.rb
+++ b/lib/git/execution_context.rb
@@ -453,7 +453,46 @@ module Git
         'GIT_INDEX_FILE' => git_index_file,
         'GIT_SSH' => git_ssh,
         'GIT_EDITOR' => 'true',
-        'LC_ALL' => 'en_US.UTF-8'
+        # Pin the locale so git's behavior does not depend on the user's environment.
+        # Added for issue #753, where a German user's `git branch` output
+        # ("* (HEAD losgelöst bei origin/25.1)") broke branch parsing.
+        #
+        # The pin has two halves, and the load-bearing one is not the obvious one:
+        #
+        # - Messages: keeps git's human-readable text in English. This is now only
+        #   defense-in-depth — lib/ reads `--format=%(refname:short)` rather than
+        #   git's prose, and matches no English git message.
+        # - Ctype: makes git's regex engine match *characters* rather than *bytes*.
+        #   This is the half that matters. Under a C ctype, `grep`, `log`, and the
+        #   `config` value regexes silently return wrong answers — with exit status
+        #   zero — for any pattern whose metacharacters span non-ASCII text.
+        #
+        # So do not "simplify" this to `C`: that yields English messages and a broken
+        # ctype, which is the worst of both. A pinned locale the host does not have
+        # degrades to that same C ctype, which is why each branch below has to name a
+        # locale that actually exists on the platform it applies to:
+        #
+        # - Non-Darwin: `C.UTF-8`. Stock Debian, Ubuntu, and RHEL images generate no
+        #   `en_US.UTF-8`, so pinning it there produced exactly the silent breakage
+        #   above. (musl ignores the locale name for ctype, so Alpine is UTF-8 either
+        #   way.)
+        # - Darwin: `en_US.UTF-8`, which every macOS release ships. `C.UTF-8` did not
+        #   arrive until macOS 15, so macOS 11–14 — including Intel Macs that are
+        #   hardware-capped below 15 — would break under it. Delete this branch once
+        #   macOS 14 and earlier are out of support.
+        #
+        # Windows takes the non-Darwin branch, where the value makes no difference:
+        # Git for Windows folds case and runs PCRE in UTF mode under every value, and
+        # matches bytes for `.` and POSIX classes under every value — measured on git
+        # 2.55.0 against `en_US.UTF-8`, `C.UTF-8`, `C`, and no pin at all.
+        #
+        # Test `RUBY_PLATFORM` plainly rather than sniffing the Darwin version:
+        # `RUBY_PLATFORM` records the version Ruby was *built* against, so a Ruby built
+        # on macOS 14 still reports `darwin23` when run on macOS 15.
+        #
+        # RHEL 7 (glibc 2.17) has neither locale and gets a C ctype whatever is pinned.
+        # It is EOL, and there is deliberately no public override for this value.
+        'LC_ALL' => RUBY_PLATFORM.include?('darwin') ? 'en_US.UTF-8' : 'C.UTF-8'
       }.merge(additional_overrides)
     end
 

--- a/spec/integration/git/command_line_spec.rb
+++ b/spec/integration/git/command_line_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'CommandLine::Capturing#run raise_on_failure integration' do
   # bypasses that layer. Without an explicit locale here, the git subprocess inherits the
   # developer's, and the example fails on any non-English machine.
   let(:command_line) do
-    Git::CommandLine::Capturing.new({ 'LC_ALL' => 'en_US.UTF-8' }, 'git', [], Logger.new(nil))
+    Git::CommandLine::Capturing.new({ 'LC_ALL' => expected_lc_all }, 'git', [], Logger.new(nil))
   end
 
   describe 'raise_on_failure: false' do

--- a/spec/integration/git/non_ascii_regex_matching_spec.rb
+++ b/spec/integration/git/non_ascii_regex_matching_spec.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Integration coverage for the `LC_ALL` pin in `Git::ExecutionContext#env_overrides`.
+#
+# git's regex engine matches *characters* only when the pinned locale resolves to a
+# UTF-8 `LC_CTYPE` in the child process. When it does not — because the pinned value
+# names a locale the host has not generated — git matches *bytes* instead, and every
+# pattern whose metacharacters span non-ASCII text silently returns no match with
+# exit status zero. These examples drive the affected public surfaces against real
+# git so a wrong pinned value fails the build instead of returning empty results.
+#
+# Each surface carries a metacharacter-free positive control, which matches
+# byte-for-byte under any ctype. Without it, a rig that fails to deliver UTF-8 bytes
+# to git is indistinguishable from a genuine no-match.
+#
+# Do not gate these examples on whether the pinned locale actually loads. A spec that
+# skips itself wherever the locale is missing disappears in exactly the environments
+# where this defect lives, which is how the defect survived unreported for eighteen
+# months. Nor is there anything to gate on for Darwin: each branch of the pin names a
+# locale that exists on the platform it applies to.
+#
+# Windows is the one platform that does need a gate, and it is a statement about git
+# rather than about the locale — see {#skip_on_git_for_windows}.
+#
+RSpec.describe 'non-ASCII regex matching', :integration do
+  include_context 'in an empty repository'
+
+  # Non-ASCII text used as file content, commit message, and config value. `Ä` is two
+  # bytes in UTF-8 (C3 84), so a leading `.` matches it only under a UTF-8 ctype.
+  let(:text) { 'ÄPFEL sind gut' }
+
+  # Case-sensitive pattern whose only metacharacter has to match a multi-byte character
+  let(:metacharacter_pattern) { '^.PFEL' }
+
+  before do
+    write_file('w.txt', "#{text}\n")
+    repo.add('w.txt')
+    repo.commit(text)
+    repo.config_set('test.desc', text)
+  end
+
+  # Skips an example that needs a metacharacter to match a whole multi-byte character
+  #
+  # Git for Windows matches *bytes* for `.` and for POSIX classes over non-ASCII text
+  # no matter what `LC_ALL` says. Measured on windows-latest with git 2.55.0: the
+  # `^.PFEL` and `^[[:alpha:]]PFEL` probes fail identically under `en_US.UTF-8`,
+  # `C.UTF-8`, `C`, and no pin at all, while the literal controls, `-i` folding, and
+  # `-P` all succeed under every one of them. So this is a property of git's bundled
+  # regex on that platform, not of the pinned value, and predates the pin.
+  #
+  # This gate is therefore not the forbidden "skip when the pinned locale is missing"
+  # — it does not consult the locale at all. It does mean these examples have no
+  # discriminating power on Windows, which is accurate: neither does the pin.
+  #
+  def skip_on_git_for_windows
+    return unless Gem.win_platform?
+
+    skip 'Git for Windows matches bytes rather than characters for `.` and POSIX classes, ' \
+         'identically under every LC_ALL value including the one this gem pins'
+  end
+
+  describe 'Git::Repository#grep' do
+    it 'matches a literal non-ASCII pattern' do
+      expect(repo.grep(text)).to eq('HEAD:w.txt' => [[1, text]])
+    end
+
+    it 'matches a case-sensitive pattern whose metacharacter spans a non-ASCII character' do
+      skip_on_git_for_windows
+
+      expect(repo.grep(metacharacter_pattern)).to eq('HEAD:w.txt' => [[1, text]])
+    end
+
+    it 'folds case across non-ASCII characters when ignore_case is given' do
+      expect(repo.grep('äpfel sind gut', nil, ignore_case: true)).to eq('HEAD:w.txt' => [[1, text]])
+    end
+  end
+
+  describe 'Git::Repository#log' do
+    it 'matches a literal non-ASCII commit message pattern' do
+      expect(repo.log.grep(text).execute.size).to eq(1)
+    end
+
+    it 'matches a case-sensitive pattern whose metacharacter spans a non-ASCII character' do
+      skip_on_git_for_windows
+
+      expect(repo.log.grep(metacharacter_pattern).execute.size).to eq(1)
+    end
+  end
+
+  describe 'Git::Repository#config_get_all' do
+    it 'matches a literal non-ASCII value regex' do
+      expect(repo.config_get_all('test.desc', text).map(&:value)).to eq([text])
+    end
+
+    it 'matches a case-sensitive value regex whose metacharacter spans a non-ASCII character' do
+      skip_on_git_for_windows
+
+      expect(repo.config_get_all('test.desc', metacharacter_pattern).map(&:value)).to eq([text])
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -146,6 +146,18 @@ end
 
 def ci_build? = ENV.fetch('GITHUB_ACTIONS', 'false') == 'true'
 
+# The value ruby-git pins `LC_ALL` to on this host
+#
+# Mirrors the platform-conditional pin in `Git::ExecutionContext#env_overrides` so
+# that specs which merely pass through the git environment can assert on it without
+# hardcoding a literal that is only correct on one platform family. Specs that are
+# *about* the pin stub `RUBY_PLATFORM` and assert literals instead, so both branches
+# stay covered on every host.
+#
+# @return [String] the `LC_ALL` value expected on the current platform
+#
+def expected_lc_all = RUBY_PLATFORM.include?('darwin') ? 'en_US.UTF-8' : 'C.UTF-8'
+
 # Returns false when running on CI, or a skip-reason string when not on CI.
 # Use as the `skip:` metadata value for tests that modify shared OS state
 # (e.g. launchctl/systemd scheduler entries) and must only run on CI where

--- a/spec/unit/git/execution_context/global_spec.rb
+++ b/spec/unit/git/execution_context/global_spec.rb
@@ -94,10 +94,10 @@ RSpec.describe Git::ExecutionContext::Global do
         allow(command_line_double).to receive(:run).and_return(result)
       end
 
-      it 'passes GIT_EDITOR=true and LC_ALL=en_US.UTF-8 in the env hash' do
+      it 'passes GIT_EDITOR=true and the platform pinned LC_ALL in the env hash' do
         context.command_capturing('version')
         expect(Git::CommandLine::Capturing).to have_received(:new).with(
-          hash_including('GIT_EDITOR' => 'true', 'LC_ALL' => 'en_US.UTF-8'),
+          hash_including('GIT_EDITOR' => 'true', 'LC_ALL' => expected_lc_all),
           anything, anything, anything
         )
       end

--- a/spec/unit/git/execution_context/repository_spec.rb
+++ b/spec/unit/git/execution_context/repository_spec.rb
@@ -261,10 +261,10 @@ RSpec.describe Git::ExecutionContext::Repository do
         )
       end
 
-      it 'passes GIT_EDITOR=true and LC_ALL=en_US.UTF-8 in the env hash' do
+      it 'passes GIT_EDITOR=true and the platform pinned LC_ALL in the env hash' do
         context.command_capturing('version')
         expect(Git::CommandLine::Capturing).to have_received(:new).with(
-          hash_including('GIT_EDITOR' => 'true', 'LC_ALL' => 'en_US.UTF-8'),
+          hash_including('GIT_EDITOR' => 'true', 'LC_ALL' => expected_lc_all),
           anything, anything, anything
         )
       end

--- a/spec/unit/git/execution_context_spec.rb
+++ b/spec/unit/git/execution_context_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Git::ExecutionContext do
           'GIT_INDEX_FILE' => '/fake/repo/.git/index',
           'GIT_SSH' => '/configured/ssh',
           'GIT_EDITOR' => 'true',
-          'LC_ALL' => 'en_US.UTF-8'
+          'LC_ALL' => expected_lc_all
         )
       end
 
@@ -84,6 +84,22 @@ RSpec.describe Git::ExecutionContext do
         allow(Git::Config.instance).to receive(:git_ssh).and_return('/first/ssh', '/second/ssh')
         expect(context.env_overrides['GIT_SSH']).to eq('/first/ssh')
         expect(context.env_overrides['GIT_SSH']).to eq('/second/ssh')
+      end
+    end
+
+    context 'when running on Darwin' do
+      before { stub_const('RUBY_PLATFORM', 'arm64-darwin24') }
+
+      it 'pins LC_ALL to en_US.UTF-8' do
+        expect(env).to include('LC_ALL' => 'en_US.UTF-8')
+      end
+    end
+
+    context 'when running on a platform other than Darwin' do
+      before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
+
+      it 'pins LC_ALL to C.UTF-8' do
+        expect(env).to include('LC_ALL' => 'C.UTF-8')
       end
     end
 
@@ -141,7 +157,7 @@ RSpec.describe Git::ExecutionContext do
           'GIT_SSH' => nil,
           'GIT_DIR' => '/fake/repo/.git',
           'GIT_WORK_TREE' => '/fake/repo',
-          'LC_ALL' => 'en_US.UTF-8'
+          'LC_ALL' => expected_lc_all
         )
       end
     end
@@ -229,10 +245,10 @@ RSpec.describe Git::ExecutionContext do
         allow(command_line_double).to receive(:run).and_return(result)
       end
 
-      it 'passes GIT_EDITOR=true and LC_ALL=en_US.UTF-8 in the env hash' do
+      it 'passes GIT_EDITOR=true and the platform pinned LC_ALL in the env hash' do
         context.command_capturing('version')
         expect(Git::CommandLine::Capturing).to have_received(:new).with(
-          hash_including('GIT_EDITOR' => 'true', 'LC_ALL' => 'en_US.UTF-8'),
+          hash_including('GIT_EDITOR' => 'true', 'LC_ALL' => expected_lc_all),
           anything, anything, anything
         )
       end
@@ -290,7 +306,7 @@ RSpec.describe Git::ExecutionContext do
         context.command_streaming('version')
 
         expect(Git::CommandLine::Streaming).to have_received(:new).with(
-          hash_including('GIT_EDITOR' => 'true', 'LC_ALL' => 'en_US.UTF-8'),
+          hash_including('GIT_EDITOR' => 'true', 'LC_ALL' => expected_lc_all),
           context.binary_path,
           anything,
           anything


### PR DESCRIPTION
Part 1 of #1669 — the fix on `main`. Parts 2 (the `4.x` backport) and 3 (the `LOCPATH`
regression guard) follow as separate PRs, so this leaves the issue open.

## The defect

`Git::ExecutionContext#env_overrides` pinned `LC_ALL` to `en_US.UTF-8` for every git
command. Stock Debian, Ubuntu, and RHEL images do not generate that locale, so on those
hosts the pin silently failed and the child process fell back to a C ctype. Under a C
ctype git's regex engine matches **bytes instead of characters**, so every locale-sensitive
regex surface returned wrong answers with exit status 0:

```ruby
# ruby:3.4-slim, en_US.UTF-8 not generated; pin as shipped
repo.config_get_all('test.desc', 'ÄPFEL')  # control
#=> [#<data Git::ConfigEntryInfo ... value="ÄPFEL sind gut">]
repo.config_get_all('test.desc', '^.PFEL')
#=> []
repo.grep('äpfel', nil, ignore_case: true)
#=> {}
```

An empty result, no exception, no warning. The measured blast radius is `grep`, `log`, and
the six `Configuring` methods that take a `value_regex`, plus the diff pickaxe and
word-diff options as their whitelists widen.

## The change

```ruby
'LC_ALL' => RUBY_PLATFORM.include?('darwin') ? 'en_US.UTF-8' : 'C.UTF-8'
```

Each branch names a locale known to exist on the platform it applies to. A flat `C.UTF-8`
would have fixed glibc while introducing the identical defect on macOS 11–14, which have
`en_US.UTF-8` but not `C.UTF-8` — including Intel Macs hardware-capped below macOS 15. The
Darwin branch pins the value macOS already uses, so **macOS, Windows, and Alpine are
unaffected**; this is strictly a fix on glibc hosts that lack `en_US.UTF-8`.

`RUBY_PLATFORM` is tested plainly rather than by Darwin version, because it records the
version Ruby was *built* against — a Ruby built on macOS 14 still reports `darwin23` when
run on macOS 15.

The call site now carries the reasoning that was never recorded: why the pin exists
(#753), that the **ctype** half is the load-bearing half now that `branching.rb` reads
`--format=%(refname:short)`, why plain `C` is not an acceptable "simplification", why the
Darwin branch exists and when it can be deleted, and that RHEL 7 has neither value.

## Tests

Ten existing assertions hardcoded the literal value across four spec files. They can no
longer do that — they would pass on Linux and fail on macOS — so they derive the value
through a new `expected_lc_all` spec helper, and two new examples stub `RUBY_PLATFORM` so
**both branches are covered on every host**.

New in `spec/integration/git/non_ascii_regex_matching_spec.rb`: coverage that non-ASCII
regex matching works through every affected public surface — `Git::Repository#grep` (both
a case-sensitive metacharacter pattern `^.PFEL` and `ignore_case`), the `log` path, and a
`Configuring` `value_regex` method — against real git. Each surface carries a
metacharacter-free positive control, so a rig that fails to deliver UTF-8 bytes to git is
distinguishable from a genuine no-match.

Verified discriminating: forcing the pin to `C` fails the four metacharacter/`ignore_case`
examples on macOS while all three controls still pass.

### Windows

The first push turned `windows-latest` red on the three metacharacter examples. Probed on
that runner (git 2.55.0, `x64-mingw-ucrt`) rather than assumed:

```text
LC_ALL           grep ctl  grep ^.  grep [:a:]  grep -i  grep -P  log ctl  log ^.  cfg ctl  cfg ^.
en_US.UTF-8            1        0           0        1        1        1       0        1       0
C.UTF-8                1        0           0        1        1        1       0        1       0
C                      1        0           0        1        1        1       0        1       0
<unset>                1        0           0        1        1        1       0        1       0
```

Identical under every value, including the `en_US.UTF-8` shipped today and no pin at all —
so this is **not a regression from `C.UTF-8`**. Git for Windows matches bytes for `.` and
POSIX classes over non-ASCII text regardless of locale, while folding and `-P` work
regardless of locale. Those three examples are therefore skipped via `Gem.win_platform?`,
with the measurement recorded at the skip site. The gate consults the platform and never
the locale, so it is not the forbidden "skip when the pinned locale is missing".

Posted as a correction on #1669, whose "Windows is unaffected" row was measured with a
folding probe and does not generalize to metacharacters.

### On gating

These examples are deliberately **not** gated on whether the pinned locale loads. A spec
that skips itself wherever the locale is missing disappears in exactly the environments
where the defect lives — which is how this survived since February 2025. Note that on
`ubuntu-latest` both locales exist, so the run is not yet discriminating there; that is
what Part 3's `LOCPATH` guard is for.

## Also updated

`CONTRIBUTING.md` — the architecture table cited the literal `LC_ALL=en_US.UTF-8`.

## No CHANGELOG diff

The issue lists "add a CHANGELOG entry" as a Part 1 deliverable. `CHANGELOG.md` is
generated from conventional commits in this repo, so the entry is the commit message on
this branch — it describes the effect as non-ASCII regex matching in `grep`, `log`, and
`config` value regexes, per the issue's wording guidance. Nothing to hand-edit.

## Verification

`bundle exec rake default` passes: 5818 unit examples, 576 integration examples, 622 files
RuboCop-clean, YARD 100% documented with no lint offenses.

