### PR TITLE
fix: pin LC_ALL to a locale that exists on the host platform

### DIFF
--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -2075,7 +2075,7 @@ module Git
     # @example Unsetting an environment variable (used by worktree_command_line)
     #   env_overrides('GIT_INDEX_FILE' => nil)
     #   # => { 'GIT_DIR' => '/path/to/.git', 'GIT_WORK_TREE' => '/path/to/worktree',
-    #   #      'GIT_INDEX_FILE' => nil, 'GIT_SSH' => <git_ssh_value>, 'LC_ALL' => 'en_US.UTF-8' }
+    #   #      'GIT_INDEX_FILE' => nil, 'GIT_SSH' => <git_ssh_value>, 'LC_ALL' => <pinned_locale> }
     #   # When passed to Process.spawn, GIT_INDEX_FILE will be unset in the environment
     #
     # @see https://ruby-doc.org/core/Process.html#method-c-spawn Process.spawn
@@ -2088,8 +2088,65 @@ module Git
         'GIT_WORK_TREE' => @git_work_dir,
         'GIT_INDEX_FILE' => @git_index_file,
         'GIT_SSH' => resolved_git_ssh,
-        'LC_ALL' => 'en_US.UTF-8'
+        # Pin the locale so git's behavior does not depend on the user's environment.
+        # Added for issue #753, where a German user's `git branch` output
+        # ("* (HEAD losgelöst bei origin/25.1)") broke branch parsing.
+        #
+        # The pin has two halves, and both are load-bearing here:
+        #
+        # - Messages: keeps git's human-readable text in English. `BRANCH_LINE_REGEXP`
+        #   matches the literal English strings "(HEAD detached at ...)" and
+        #   "(not a branch)" in `git branch -a` output, which is the exact issue #753
+        #   failure mode.
+        # - Ctype: makes git's regex engine match *characters* rather than *bytes*.
+        #   Under a C ctype, `grep` and `log --grep` silently return wrong answers —
+        #   with exit status zero — for any pattern whose metacharacters span
+        #   non-ASCII text.
+        #
+        # So do not "simplify" this to `C`: that yields English messages and a broken
+        # ctype, which is the worst of both. A pinned locale the host does not have
+        # degrades to that same C ctype, which is why each branch below has to name a
+        # locale that actually exists on the platform it applies to:
+        #
+        # - Non-Darwin: `C.UTF-8`. Stock Debian, Ubuntu, and RHEL images generate no
+        #   `en_US.UTF-8`, so pinning it there produced exactly the silent breakage
+        #   above. (musl ignores the locale name for ctype, so Alpine is UTF-8 either
+        #   way.)
+        # - Darwin: `en_US.UTF-8`, which every macOS release ships. `C.UTF-8` did not
+        #   arrive until macOS 15, so macOS 11–14 — including Intel Macs that are
+        #   hardware-capped below 15 — would break under it. Delete this branch once
+        #   macOS 14 and earlier are out of support.
+        #
+        # Windows takes the non-Darwin branch, where the value makes no difference:
+        # Git for Windows folds case and runs PCRE in UTF mode under every value, and
+        # matches bytes for `.` and POSIX classes under every value — measured on git
+        # 2.55.0 against `en_US.UTF-8`, `C.UTF-8`, `C`, and no pin at all.
+        #
+        # RHEL 7 (glibc 2.17) has neither locale and gets a C ctype whatever is pinned.
+        # It is EOL, and there is deliberately no public override for this value.
+        'LC_ALL' => darwin_platform? ? 'en_US.UTF-8' : 'C.UTF-8'
       }.merge(additional_overrides)
+    end
+
+    # Whether this process is running on macOS
+    #
+    # Checks `RUBY_DESCRIPTION` as well as `RUBY_PLATFORM` because JRuby reports
+    # `RUBY_PLATFORM` as `"java"` on every host and records the real platform only in
+    # `RUBY_DESCRIPTION` (as, for example, `"... [arm64-darwin]"`). Testing
+    # `RUBY_PLATFORM` alone would put JRuby on macOS onto the non-Darwin branch, which is
+    # the one platform pairing that branch must not be given. This is the same detection
+    # the test suite uses for Windows, and for the same reason.
+    #
+    # Test the platform plainly rather than sniffing the Darwin version: `RUBY_PLATFORM`
+    # records the version Ruby was *built* against, so a Ruby built on macOS 14 still
+    # reports `darwin23` when run on macOS 15.
+    #
+    # @return [Boolean] true if this process is running on macOS
+    #
+    # @api private
+    #
+    def darwin_platform?
+      RUBY_PLATFORM.include?('darwin') || RUBY_DESCRIPTION.include?('darwin')
     end
 
     # Resolve the git_ssh value to use for this instance

--- a/tests/test_helper.rb
+++ b/tests/test_helper.rb
@@ -193,6 +193,60 @@ module Test
         RUBY_PLATFORM == 'java'
       end
 
+      # The value this gem pins `LC_ALL` to on this host
+      #
+      # Mirrors the platform-conditional pin in `Git::Lib#env_overrides` so that tests
+      # which merely pass the git environment through can assert on it without
+      # hardcoding a literal that is only correct on one platform family. Tests that
+      # are *about* the pin use {#with_ruby_platform} and assert literals instead, so
+      # every branch stays covered on every host.
+      #
+      # @return [String] the `LC_ALL` value expected on the current platform
+      #
+      def expected_lc_all
+        darwin_platform? ? 'en_US.UTF-8' : 'C.UTF-8'
+      end
+
+      # Whether these tests are running on macOS
+      #
+      # Checks `RUBY_DESCRIPTION` as well as `RUBY_PLATFORM` for the same reason
+      # {#windows_platform?} does: JRuby reports `RUBY_PLATFORM` as `"java"` on every
+      # host. Mirrors `Git::Lib#darwin_platform?`.
+      #
+      def darwin_platform?
+        RUBY_PLATFORM.include?('darwin') || RUBY_DESCRIPTION.include?('darwin')
+      end
+
+      # Run the given block with `RUBY_PLATFORM` and `RUBY_DESCRIPTION` replaced
+      #
+      # Both have to be replaced together: the platform is read from `RUBY_DESCRIPTION`
+      # when `RUBY_PLATFORM` is `"java"`, so replacing only the latter would leave the
+      # host's real platform visible through the former. They are ordinary constants on
+      # `Object`, so they are removed and redefined rather than stubbed, and the
+      # original values are always restored.
+      #
+      # @param platform [String] the value `RUBY_PLATFORM` should report in the block
+      # @param description [String] the value `RUBY_DESCRIPTION` should report
+      #
+      # @yield [] the block to run with the replaced constants
+      #
+      # @return [Object] the value returned by the block
+      #
+      def with_ruby_platform(platform, description)
+        originals = { RUBY_PLATFORM: RUBY_PLATFORM, RUBY_DESCRIPTION: RUBY_DESCRIPTION }
+        replacements = { RUBY_PLATFORM: platform, RUBY_DESCRIPTION: description }
+
+        replacements.each { |name, value| redefine_object_const(name, value) }
+        yield
+      ensure
+        originals.each { |name, value| redefine_object_const(name, value) }
+      end
+
+      def redefine_object_const(name, value)
+        Object.send(:remove_const, name)
+        Object.const_set(name, value)
+      end
+
       # Run a command and return the status including stdout and stderr output
       #
       # @example

--- a/tests/units/test_command_line_env_overrides.rb
+++ b/tests/units/test_command_line_env_overrides.rb
@@ -17,7 +17,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
           'GIT_INDEX_FILE' => git.lib.git_index_file,
           'GIT_SSH' => 'ssh -i /path/to/key',
           'GIT_WORK_TREE' => git.lib.git_work_dir,
-          'LC_ALL' => 'en_US.UTF-8'
+          'LC_ALL' => expected_lc_all
         }
         expected_command_line = [expected_env, 'checkout', {}]
 
@@ -37,9 +37,49 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
       assert_equal git.lib.git_dir, env['GIT_DIR']
       assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
       assert_equal git.lib.git_index_file, env['GIT_INDEX_FILE']
-      assert_equal 'en_US.UTF-8', env['LC_ALL']
+      assert_equal expected_lc_all, env['LC_ALL']
       assert_equal Git::Base.config.git_ssh, env['GIT_SSH']
     end
+  end
+
+  # The pinned locale has to name a locale that exists on the platform it applies to, or
+  # the git subprocess falls back to a C ctype and matches bytes rather than characters.
+  # Both branches are asserted on every host so neither can rot on a platform CI does not
+  # run (there is no macOS job in the matrix).
+  #
+  # JRuby is covered explicitly because it reports RUBY_PLATFORM as "java" everywhere, so
+  # a Darwin check that consults only RUBY_PLATFORM would put JRuby on macOS onto the
+  # non-Darwin branch — the one pairing that branch must never be given.
+
+  CRUBY_DARWIN = ['arm64-darwin24', 'ruby 3.4.1 (2024-12-25 revision abc1234) [arm64-darwin24]'].freeze
+  CRUBY_LINUX = ['x86_64-linux', 'ruby 3.4.1 (2024-12-25 revision abc1234) [x86_64-linux]'].freeze
+  JRUBY_DARWIN = ['java', 'jruby 10.0.0.1 (3.4.2) 2025-05-27 OpenJDK 64-Bit Server VM on 21 [arm64-darwin]'].freeze
+  JRUBY_LINUX = ['java', 'jruby 10.0.0.1 (3.4.2) 2025-05-27 OpenJDK 64-Bit Server VM on 21 [x86_64-linux]'].freeze
+
+  def assert_lc_all_pinned_to(expected, platform)
+    in_temp_dir do |_path|
+      git = Git.init('test_project')
+
+      env = with_ruby_platform(*platform) { git.lib.send(:env_overrides) }
+
+      assert_equal expected, env['LC_ALL']
+    end
+  end
+
+  test 'env_overrides should pin LC_ALL to en_US.UTF-8 on Darwin' do
+    assert_lc_all_pinned_to('en_US.UTF-8', CRUBY_DARWIN)
+  end
+
+  test 'env_overrides should pin LC_ALL to C.UTF-8 on platforms other than Darwin' do
+    assert_lc_all_pinned_to('C.UTF-8', CRUBY_LINUX)
+  end
+
+  test 'env_overrides should pin LC_ALL to en_US.UTF-8 on Darwin under JRuby' do
+    assert_lc_all_pinned_to('en_US.UTF-8', JRUBY_DARWIN)
+  end
+
+  test 'env_overrides should pin LC_ALL to C.UTF-8 on platforms other than Darwin under JRuby' do
+    assert_lc_all_pinned_to('C.UTF-8', JRUBY_LINUX)
   end
 
   test 'env_overrides should allow adding additional environment variables' do
@@ -88,7 +128,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
       # Other variables should remain unchanged
       assert_equal git.lib.git_dir, env['GIT_DIR']
       assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
-      assert_equal 'en_US.UTF-8', env['LC_ALL']
+      assert_equal expected_lc_all, env['LC_ALL']
     end
   end
 
@@ -108,7 +148,7 @@ class TestCommandLineEnvOverrides < Test::Unit::TestCase
       # Other environment variables should still be present
       assert_equal git.lib.git_dir, env['GIT_DIR']
       assert_equal git.lib.git_work_dir, env['GIT_WORK_TREE']
-      assert_equal 'en_US.UTF-8', env['LC_ALL']
+      assert_equal expected_lc_all, env['LC_ALL']
     end
   end
 

--- a/tests/units/test_non_ascii_regex_matching.rb
+++ b/tests/units/test_non_ascii_regex_matching.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Coverage for the `LC_ALL` pin in `Git::Lib#env_overrides`.
+#
+# git's regex engine matches *characters* only when the pinned locale resolves to a
+# UTF-8 `LC_CTYPE` in the child process. When it does not — because the pinned value
+# names a locale the host has not generated — git matches *bytes* instead, and every
+# pattern whose metacharacters span non-ASCII text silently returns no match with exit
+# status zero. These tests drive the affected public surfaces against real git so a
+# wrong pinned value fails the build instead of returning empty results.
+#
+# Each surface carries a metacharacter-free positive control, which matches
+# byte-for-byte under any ctype. Without it, a rig that fails to deliver UTF-8 bytes to
+# git is indistinguishable from a genuine no-match.
+#
+# Do not gate these tests on whether the pinned locale actually loads. A test that
+# omits itself wherever the locale is missing disappears in exactly the environments
+# where this defect lives, which is how the defect survived unreported for eighteen
+# months. Nor is there anything to gate on for Darwin: each branch of the pin names a
+# locale that exists on the platform it applies to.
+#
+# Windows is the one platform that does need a gate, and it is a statement about git
+# rather than about the locale — see {#omit_on_git_for_windows}.
+#
+class TestNonAsciiRegexMatching < Test::Unit::TestCase
+  # Non-ASCII text used as both file content and commit message. `Ä` is two bytes in
+  # UTF-8 (C3 84), so a leading `.` matches it only under a UTF-8 ctype.
+  TEXT = 'ÄPFEL sind gut'
+
+  # Case-sensitive pattern whose only metacharacter has to match a multi-byte character
+  METACHARACTER_PATTERN = '^.PFEL'
+
+  # Omits a test that needs a metacharacter to match a whole multi-byte character
+  #
+  # Git for Windows matches *bytes* for `.` and for POSIX classes over non-ASCII text
+  # no matter what `LC_ALL` says. Measured on windows-latest with git 2.55.0: the
+  # `^.PFEL` and `^[[:alpha:]]PFEL` probes fail identically under `en_US.UTF-8`,
+  # `C.UTF-8`, `C`, and no pin at all, while the literal controls, `-i` folding, and
+  # `-P` all succeed under every one of them. So this is a property of git's bundled
+  # regex on that platform, not of the pinned value, and predates the pin.
+  #
+  # This gate is therefore not the forbidden "omit when the pinned locale is missing" —
+  # it does not consult the locale at all. It does mean these tests have no
+  # discriminating power on Windows, which is accurate: neither does the pin.
+  #
+  def omit_on_git_for_windows
+    return unless windows_platform?
+
+    omit 'Git for Windows matches bytes rather than characters for `.` and POSIX classes, ' \
+         'identically under every LC_ALL value including the one this gem pins'
+  end
+
+  # Yields a repository with TEXT as both the content of w.txt and the commit message
+  def in_repo_with_non_ascii_content
+    in_temp_dir do |_path|
+      git = Git.init('test_project')
+      Dir.chdir('test_project') do
+        git.config('user.name', 'Test User')
+        git.config('user.email', 'test@email.com')
+        File.binwrite('w.txt', "#{TEXT}\n")
+        git.add('w.txt')
+        git.commit(TEXT)
+
+        yield git
+      end
+    end
+  end
+
+  # The grep result is keyed by "<tree-ish>:<path>", and Git::Base#grep resolves
+  # 'HEAD' to its sha before calling git
+  def expected_grep_result(git)
+    { "#{git.object('HEAD').sha}:w.txt" => [[1, TEXT]] }
+  end
+
+  test 'grep should match a literal non-ASCII pattern' do
+    in_repo_with_non_ascii_content do |git|
+      assert_equal expected_grep_result(git), git.grep(TEXT)
+    end
+  end
+
+  test 'grep should match a case-sensitive pattern whose metacharacter spans a non-ASCII character' do
+    omit_on_git_for_windows
+
+    in_repo_with_non_ascii_content do |git|
+      assert_equal expected_grep_result(git), git.grep(METACHARACTER_PATTERN)
+    end
+  end
+
+  test 'grep should fold case across non-ASCII characters when ignore_case is given' do
+    in_repo_with_non_ascii_content do |git|
+      assert_equal expected_grep_result(git), git.grep('äpfel sind gut', nil, ignore_case: true)
+    end
+  end
+
+  test 'log should match a literal non-ASCII commit message pattern' do
+    in_repo_with_non_ascii_content do |git|
+      assert_equal 1, git.log.grep(TEXT).execute.size
+    end
+  end
+
+  test 'log should match a case-sensitive pattern whose metacharacter spans a non-ASCII character' do
+    omit_on_git_for_windows
+
+    in_repo_with_non_ascii_content do |git|
+      assert_equal 1, git.log.grep(METACHARACTER_PATTERN).execute.size
+    end
+  end
+end


### PR DESCRIPTION
Part 2 of #1669 — the `4.x` backport of the `main` fix shipped in #1681. Part 3 (the
`LOCPATH` regression guard) follows separately, so this leaves the issue open.

## The defect

`Git::Lib#env_overrides` pinned `LC_ALL` to `en_US.UTF-8` for every git command. Stock
Debian, Ubuntu, and RHEL images do not generate that locale, so on those hosts the pin
silently failed and the child process fell back to a C ctype. Under a C ctype git's regex
engine matches **bytes instead of characters**, so every locale-sensitive regex surface
returned wrong answers with exit status 0 — an empty result, no exception, no warning.

v5.0.0 is twelve days old, so effectively the entire installed base is on `4.x` — this is
the branch where those silently wrong answers are actually being returned.

## The change

```ruby
'LC_ALL' => RUBY_PLATFORM.include?('darwin') ? 'en_US.UTF-8' : 'C.UTF-8'
```

```ruby
'LC_ALL' => darwin_platform? ? 'en_US.UTF-8' : 'C.UTF-8'
```

Same value as `main`. Each branch names a locale known to exist on the platform it applies
to, so **macOS, Windows, and Alpine are unaffected**; this is strictly a fix on glibc hosts
that lack `en_US.UTF-8`. The platform is tested plainly rather than by Darwin version,
because it records the version Ruby was *built* against.

## A JRuby gap found while backporting — `main` has it too

`main` inlines the test as `RUBY_PLATFORM.include?('darwin')`. **JRuby reports
`RUBY_PLATFORM` as `"java"` on every host** and records the real platform only in
`RUBY_DESCRIPTION` (`"... [arm64-darwin]"`), so that test puts JRuby on macOS onto the
non-Darwin branch — the single platform pairing the Darwin branch exists to prevent. On
macOS 11–14 under JRuby, `C.UTF-8` does not exist, the pin degrades to a C ctype, and the
gem reintroduces exactly the defect this issue is about.

Both branches ship JRuby in the CI matrix (`jruby-10.0.0.1`) and the gemspec has no macOS
floor, so this is a supported combination. This branch therefore tests both constants:

```ruby
RUBY_PLATFORM.include?('darwin') || RUBY_DESCRIPTION.include?('darwin')
```

That is the same detection `windows_platform?` already uses in this repo's test helper, and
for the same reason. It is a deliberate divergence from #1681, which is a bug — **`main`
needs the same change**, and there is no CI job that would catch it (no macOS job on either
branch, and JRuby only runs on ubuntu).

Verified discriminating: reverting `darwin_platform?` to the `RUBY_PLATFORM`-only form fails
the new "en_US.UTF-8 on Darwin under JRuby" test and nothing else.

## One deliberate difference from #1681

The call-site comment on `main` says the **ctype** half of the pin is the load-bearing half,
because `lib/git/repository/branching.rb` there reads `--format=%(refname:short)` rather
than git's prose. **That is not true on `4.x`**, so the comment says something different
here: `Git::Lib::BRANCH_LINE_REGEXP` still matches the literal English strings
`(HEAD detached at ...)` and `(not a branch)` in `git branch -a` output, which is the exact
#753 failure mode. On this branch **both halves are load-bearing**, and the comment says so.

Everything else in the comment is carried over verbatim: why the pin exists (#753), why
plain `C` is not an acceptable "simplification", why the Darwin branch exists and when it
can be deleted, that the value makes no difference on Windows, and that RHEL 7 has neither
value.

## Blast radius on 4.x is narrower than on main

The public affected surfaces here are `Git::Base#grep` and the `log --grep` path. The six
`Configuring` `value_regex` methods that #1681 also had to cover **do not exist on `4.x`** —
`Git::Lib#config_get` takes a name only, and there is no `config_get_all` /
`config_get_regexp`. So the new coverage stops at `grep` and `log`, which is complete for
this branch rather than a reduction in scope.

## Tests

Four existing assertions hardcoded the literal value in
`tests/units/test_command_line_env_overrides.rb`. They can no longer do that — they would
pass on Linux and fail on macOS — so they derive the value through a new `expected_lc_all`
test helper. Four new tests use a new `with_ruby_platform` helper to replace `RUBY_PLATFORM`
and `RUBY_DESCRIPTION` together (both are plain constants, so they are removed and redefined
rather than stubbed, and always restored), covering **both branches on every host under both
CRuby and JRuby**. There is no macOS job in the `4.x` matrix either.

New in `tests/units/test_non_ascii_regex_matching.rb`: coverage that non-ASCII regex matching
works through both affected public surfaces — `Git::Base#grep` (a case-sensitive
metacharacter pattern `^.PFEL`, and `ignore_case`) and `git.log.grep` — against real git.
Each surface carries a metacharacter-free positive control, so a rig that fails to deliver
UTF-8 bytes to git is distinguishable from a genuine no-match.

Verified discriminating: forcing the pin to `C` fails 3 of the 5 tests on macOS while both
controls still pass.

### Windows

The two metacharacter tests are omitted on Windows, matching #1681. Measured there on git
2.55.0, Git for Windows matches bytes for `.` and POSIX classes over non-ASCII text
identically under `en_US.UTF-8`, `C.UTF-8`, `C`, and no pin at all — so this is not a
regression from `C.UTF-8`. The gate consults the platform and never the locale, so it is not
the forbidden "skip when the pinned locale is missing".

### On gating

These tests are deliberately **not** gated on whether the pinned locale loads. A test that
omits itself wherever the locale is missing disappears in exactly the environments where the
defect lives — which is how this survived since February 2025.

## No CHANGELOG diff

`CHANGELOG.md` is generated from conventional commits on this branch, so the entry is the
commit message. Nothing to hand-edit.

## Not applicable on this branch

`CONTRIBUTING.md` on `4.x` does not mention `LC_ALL` — that reference was added by the v5
architecture section, so there is nothing to update here.

## Verification

`bundle exec rake` passes: 550 tests, 1851 assertions, 0 failures, 0 errors, 1 pre-existing
omission; 119 files RuboCop-clean; YARD coverage 73.4% against a 50% threshold.
