### PR TITLE
fix: detect Darwin under JRuby when pinning LC_ALL

### DIFF
--- a/lib/git/execution_context.rb
+++ b/lib/git/execution_context.rb
@@ -486,17 +486,34 @@ module Git
         # matches bytes for `.` and POSIX classes under every value — measured on git
         # 2.55.0 against `en_US.UTF-8`, `C.UTF-8`, `C`, and no pin at all.
         #
-        # Test `RUBY_PLATFORM` plainly rather than sniffing the Darwin version:
-        # `RUBY_PLATFORM` records the version Ruby was *built* against, so a Ruby built
-        # on macOS 14 still reports `darwin23` when run on macOS 15.
-        #
         # RHEL 7 (glibc 2.17) has neither locale and gets a C ctype whatever is pinned.
         # It is EOL, and there is deliberately no public override for this value.
-        'LC_ALL' => RUBY_PLATFORM.include?('darwin') ? 'en_US.UTF-8' : 'C.UTF-8'
+        'LC_ALL' => darwin_platform? ? 'en_US.UTF-8' : 'C.UTF-8'
       }.merge(additional_overrides)
     end
 
     private
+
+    # Whether this process is running on macOS
+    #
+    # Checks `RUBY_DESCRIPTION` as well as `RUBY_PLATFORM` because JRuby reports
+    # `RUBY_PLATFORM` as `"java"` on every host and records the real platform only in
+    # `RUBY_DESCRIPTION` (as, for example, `"... [arm64-darwin]"`). Testing
+    # `RUBY_PLATFORM` alone would put JRuby on macOS onto the non-Darwin branch of the
+    # `LC_ALL` pin, which is the one platform pairing that branch must never be given —
+    # see {#env_overrides}.
+    #
+    # Test the platform plainly rather than sniffing the Darwin version: `RUBY_PLATFORM`
+    # records the version Ruby was *built* against, so a Ruby built on macOS 14 still
+    # reports `darwin23` when run on macOS 15.
+    #
+    # @return [Boolean] true if this process is running on macOS
+    #
+    # @api private
+    #
+    def darwin_platform?
+      RUBY_PLATFORM.include?('darwin') || RUBY_DESCRIPTION.include?('darwin')
+    end
 
     # Returns the Array of git global option strings for this context
     #

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -151,12 +151,22 @@ def ci_build? = ENV.fetch('GITHUB_ACTIONS', 'false') == 'true'
 # Mirrors the platform-conditional pin in `Git::ExecutionContext#env_overrides` so
 # that specs which merely pass through the git environment can assert on it without
 # hardcoding a literal that is only correct on one platform family. Specs that are
-# *about* the pin stub `RUBY_PLATFORM` and assert literals instead, so both branches
-# stay covered on every host.
+# *about* the pin stub `RUBY_PLATFORM` and `RUBY_DESCRIPTION` and assert literals
+# instead, so every branch stays covered on every host.
 #
 # @return [String] the `LC_ALL` value expected on the current platform
 #
-def expected_lc_all = RUBY_PLATFORM.include?('darwin') ? 'en_US.UTF-8' : 'C.UTF-8'
+def expected_lc_all = darwin_platform? ? 'en_US.UTF-8' : 'C.UTF-8'
+
+# Whether these specs are running on macOS
+#
+# Checks `RUBY_DESCRIPTION` as well as `RUBY_PLATFORM` because JRuby reports
+# `RUBY_PLATFORM` as `"java"` on every host. Mirrors
+# `Git::ExecutionContext#darwin_platform?`.
+#
+# @return [Boolean] true if these specs are running on macOS
+#
+def darwin_platform? = RUBY_PLATFORM.include?('darwin') || RUBY_DESCRIPTION.include?('darwin')
 
 # Returns false when running on CI, or a skip-reason string when not on CI.
 # Use as the `skip:` metadata value for tests that modify shared OS state

--- a/spec/unit/git/execution_context_spec.rb
+++ b/spec/unit/git/execution_context_spec.rb
@@ -87,19 +87,61 @@ RSpec.describe Git::ExecutionContext do
       end
     end
 
-    context 'when running on Darwin' do
-      before { stub_const('RUBY_PLATFORM', 'arm64-darwin24') }
+    # The pinned locale has to name a locale that exists on the platform it applies to,
+    # or the git subprocess falls back to a C ctype and matches bytes rather than
+    # characters. Every branch is asserted on every host so none can rot on a platform
+    # CI does not run — there is no macOS job in the matrix.
+    #
+    # `RUBY_PLATFORM` and `RUBY_DESCRIPTION` are stubbed together because the platform
+    # is read from the latter when the former is `'java'`; stubbing only one would leave
+    # the host's real platform visible through the other.
+    describe 'the LC_ALL pin' do
+      context 'when running on Darwin' do
+        before do
+          stub_const('RUBY_PLATFORM', 'arm64-darwin24')
+          stub_const('RUBY_DESCRIPTION', 'ruby 3.4.1 (2024-12-25 revision abc1234) [arm64-darwin24]')
+        end
 
-      it 'pins LC_ALL to en_US.UTF-8' do
-        expect(env).to include('LC_ALL' => 'en_US.UTF-8')
+        it 'pins LC_ALL to en_US.UTF-8' do
+          expect(env).to include('LC_ALL' => 'en_US.UTF-8')
+        end
       end
-    end
 
-    context 'when running on a platform other than Darwin' do
-      before { stub_const('RUBY_PLATFORM', 'x86_64-linux') }
+      context 'when running on a platform other than Darwin' do
+        before do
+          stub_const('RUBY_PLATFORM', 'x86_64-linux')
+          stub_const('RUBY_DESCRIPTION', 'ruby 3.4.1 (2024-12-25 revision abc1234) [x86_64-linux]')
+        end
 
-      it 'pins LC_ALL to C.UTF-8' do
-        expect(env).to include('LC_ALL' => 'C.UTF-8')
+        it 'pins LC_ALL to C.UTF-8' do
+          expect(env).to include('LC_ALL' => 'C.UTF-8')
+        end
+      end
+
+      # JRuby reports RUBY_PLATFORM as 'java' on every host and records the real
+      # platform only in RUBY_DESCRIPTION. A Darwin check that consults only
+      # RUBY_PLATFORM would put JRuby on macOS onto the non-Darwin branch — the one
+      # pairing that branch exists to prevent, since macOS 11-14 have no C.UTF-8.
+      context 'when running under JRuby on Darwin' do
+        before do
+          stub_const('RUBY_PLATFORM', 'java')
+          stub_const('RUBY_DESCRIPTION', 'jruby 10.0.0.1 (3.4.2) OpenJDK 64-Bit Server VM [arm64-darwin]')
+        end
+
+        it 'pins LC_ALL to en_US.UTF-8' do
+          expect(env).to include('LC_ALL' => 'en_US.UTF-8')
+        end
+      end
+
+      context 'when running under JRuby on a platform other than Darwin' do
+        before do
+          stub_const('RUBY_PLATFORM', 'java')
+          stub_const('RUBY_DESCRIPTION', 'jruby 10.0.0.1 (3.4.2) OpenJDK 64-Bit Server VM [x86_64-linux]')
+        end
+
+        it 'pins LC_ALL to C.UTF-8' do
+          expect(env).to include('LC_ALL' => 'C.UTF-8')
+        end
       end
     end
 


### PR DESCRIPTION
Follow-up to #1681 and #1682, both merged. Found while backporting the `LC_ALL` fix to
`4.x`, where #1682 already carries this correction.

## The defect

`Git::ExecutionContext#env_overrides` pins `LC_ALL` per platform family so that each branch
names a locale known to exist there:

```ruby
'LC_ALL' => RUBY_PLATFORM.include?('darwin') ? 'en_US.UTF-8' : 'C.UTF-8'
```

**JRuby reports `RUBY_PLATFORM` as `"java"` on every host.** The real platform appears only
in `RUBY_DESCRIPTION`:

```text
jruby 10.0.0.1 (3.4.2) 2025-05-27 OpenJDK 64-Bit Server VM ... [arm64-darwin]
```

So JRuby on macOS takes the **non-Darwin** branch — the single platform pairing that branch
exists to prevent. `C.UTF-8` did not arrive until macOS 15, so on macOS 11–14 the pin names
a locale the host does not have, the child process falls back to a C ctype, and git's regex
engine matches bytes instead of characters. That reintroduces exactly the silently-wrong
`grep`, `log`, and `config` value-regex results that #1681 changed the pin to fix, on the
platform the Darwin branch was added to protect.

This is a supported combination: `jruby-10.0.0.1` is in the CI matrix and the gemspec sets
no macOS floor. And **no CI job would ever have caught it** — there is no macOS job on either
branch, and JRuby runs only on `ubuntu-latest`. The same blind spot #1669 documents for the
Darwin branch generally.

## The change

```ruby
def darwin_platform?
  RUBY_PLATFORM.include?('darwin') || RUBY_DESCRIPTION.include?('darwin')
end
```

The predicate is extracted rather than inlined because the reasoning needs somewhere to live
— the YARD comment records why `RUBY_DESCRIPTION` is consulted, so the next contributor does
not "simplify" it back. Nothing changes on CRuby or TruffleRuby, which both report the real
platform in `RUBY_PLATFORM`; the `||` only ever fires where `RUBY_PLATFORM` is `"java"`.

This is the same detection `4.x` already uses for Windows in its test helper
(`windows_platform?`), and for the same reason.

## Tests

The two specs that stub `RUBY_PLATFORM` now stub `RUBY_DESCRIPTION` alongside it — stubbing
only one would leave the host's real platform visible through the other, so the non-Darwin
example would fail on a macOS checkout. Two new examples cover both branches under JRuby, and
all four are grouped under a `describe 'the LC_ALL pin'` block carrying the reasoning.

Verified discriminating: restoring the `RUBY_PLATFORM`-only form fails the new
"under JRuby on Darwin" example and nothing else.

## Verification

`bundle exec rake default` passes: 5820 unit examples, 576 integration examples, 622 files
RuboCop-clean, YARD 100% documented with no lint offenses.
