### PR TITLE
ci: add a matrix-free All Specs Passed gate to 4.x

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -53,3 +53,49 @@ jobs:
 
       - name: Test Gem
         run: bundle exec rake test:gem
+
+  # The branch ruleset cannot require the matrix job above directly. A required status
+  # check is matched by name, and `build`'s name is a template -- GitHub only expands it
+  # into "Ruby 3.2 on ubuntu-latest" and friends when it evaluates the matrix. The
+  # job-level `if:` short-circuits before that happens, so a release PR reports one check
+  # named literally "Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}" and the
+  # six expanded names never report at all. Required checks that never report block a PR
+  # indefinitely rather than passing, which is what stranded the v5.0.5 release PR on
+  # main and the v4.4.1 release PR here.
+  #
+  # So the ruleset requires this job instead: one stable name, no matrix, no `if:` guard
+  # on the name's existence. It also decouples the required-check list from the matrix, so
+  # adding or dropping a Ruby version no longer needs a matching ruleset edit.
+  #
+  # Unlike main, this branch has no separate lint job: `rake default` runs RuboCop and
+  # YARD inside every matrix leg, so this one check covers everything CI does here.
+  #
+  # `always()` rather than `!cancelled()` because a skipped job reports a skipped
+  # conclusion, which rulesets treat as passing -- so skipping this gate on a cancelled
+  # run would report success for a build that never finished. Running it and inspecting
+  # `needs.build.result` fails closed instead: only success (the matrix passed) and
+  # skipped (a release PR, where the matrix was never meant to run) are accepted.
+  #
+  # Note that a matrix leg marked `experimental: Yes` carries continue-on-error, and a
+  # continue-on-error failure does not fail the job as a whole -- so it does not fail this
+  # gate either. That is what `experimental` is for; no leg currently sets it.
+  build-complete:
+    name: All Specs Passed
+
+    needs: [build]
+    if: always()
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check the result of the build job
+        run: |
+          case "${{ needs.build.result }}" in
+            success | skipped)
+              echo "build: ${{ needs.build.result }}"
+              ;;
+            *)
+              echo "::error::build: ${{ needs.build.result }}"
+              exit 1
+              ;;
+          esac


### PR DESCRIPTION
## Problem

The `Release Branch` ruleset (id `11716425`) covers `~DEFAULT_BRANCH` and `refs/heads/4.x` with **one shared list of required status checks** — but the two branches do not run the same jobs. Four of the five required contexts (`Lint and Docs`, `All Specs Passed`, `Non-English Locale`, `Missing en_US.UTF-8 Locale`) exist only on `main`.

On a `4.x` pull request those four never report at all — not skipped, not failed, simply absent. A required check that never reports blocks a PR indefinitely rather than failing visibly, so `4.x` currently has no working gate, only a deadlock.

Live on #1683 (`chore: release v4.4.1`):

```
mergeStateStatus: BLOCKED   rollup state: SUCCESS
reported: "Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}"  skipped
          "Verify Conventional Commits"                                skipped
```

Nothing is failing.

## Why not just require the matrix job

A required check is matched by name, and `build`'s name is a template. GitHub expands it into `Ruby 3.2 on ubuntu-latest` and friends only when it evaluates the matrix — and the job-level release-please guard short-circuits before that happens. So a release PR reports one check named literally `Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}` and the six expanded names never exist on the commit.

This is the same failure mode that stranded the v5.0.5 release PR on `main`. It was fixed there in #1680 by the aggregator this PR backports.

## Change

One job, `build-complete` / `All Specs Passed`: `needs: [build]`, `if: always()`, accepting only `success` (matrix passed) and `skipped` (release PR, matrix never meant to run). `always()` rather than `!cancelled()` so a cancelled run fails the gate instead of reporting a tolerated `skipped`.

Two things differ from `main`:

- **No separate lint job to require here.** `4.x`'s matrix runs `bundle exec rake default`, which includes RuboCop and YARD, so this single check covers everything CI does on this branch.
- **The two locale jobs are not backported.** They gate a defect class on `main`; `4.x` takes only security and backward-compatible bug fixes. Worth revisiting if a locale-sensitive fix is ever backported.

## This PR alone changes no merge behavior

The ruleset edit is a deliberate second step, once this job has reported at least once:

| Branch | Required contexts |
| --- | --- |
| `main` | `Verify Conventional Commits`, `Lint and Docs`, `All Specs Passed`, `Non-English Locale`, `Missing en_US.UTF-8 Locale` |
| `4.x` | `Verify Conventional Commits`, `All Specs Passed` |

Backporting before splitting is intentional: splitting first would leave `4.x` unguarded during the gap. The cost is that #1683 stays blocked until the new job reports on it, which needs a fresh run — release-please regenerating its branch after this merges is usually enough, and a close/reopen or `workflow_dispatch` forces it otherwise.

## Verification

`All Specs Passed` should report `success` on this PR itself, with the six matrix legs green.

Refs: #1675

🤖 Generated with [Claude Code](https://claude.com/claude-code)