### PR TITLE
ci: skip the All Specs Passed gate on release PRs

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -112,20 +112,39 @@ jobs:
   # five expanded names never report at all. Required checks that never report block a PR
   # indefinitely rather than passing, which is what stranded the v5.0.5 release PR.
   #
-  # So the ruleset requires this job instead: one stable name, no matrix, no `if:` guard
-  # on the name's existence. It also decouples the required-check list from the matrix, so
-  # adding or dropping a Ruby version no longer needs a matching ruleset edit.
+  # So the ruleset requires this job instead: one stable name, no matrix, no template to
+  # expand. It also decouples the required-check list from the matrix, so adding or
+  # dropping a Ruby version no longer needs a matching ruleset edit.
   #
-  # `always()` rather than `!cancelled()` because a skipped job reports a skipped
-  # conclusion, which rulesets treat as passing -- so skipping this gate on a cancelled
-  # run would report success for a build that never finished. Running it and inspecting
-  # `needs.build.result` fails closed instead: only success (the matrix passed) and
-  # skipped (a release PR, where the matrix was never meant to run) are accepted.
+  # This job carries the same release-PR guard as every job above, so that a release PR
+  # reports it as skipped rather than as a success for specs that never ran. Skipping is
+  # safe here and was not safe for `build`: this job's name is a literal string, so the
+  # check run exists and reports a skipped conclusion whether or not the job runs, and
+  # rulesets treat skipped as passing. A matrix job's name does not exist at all until the
+  # matrix is evaluated, which is the whole reason this job exists.
+  #
+  # `always()` is load-bearing and must stay. Without a status check function a job-level
+  # `if:` implies `success()`, so a failing matrix would skip this job -- and a skipped
+  # required check counts as passing, meaning a red build would merge. `always()` forces a
+  # real verdict on every run that is not a release PR. `!cancelled()` is not a substitute:
+  # a cancelled run would then skip the gate and report success for a build that never
+  # finished.
+  #
+  # The case below accepts `success` only. `build` and this job now carry identical guards,
+  # so this job runs exactly when `build` ran; a `skipped` result would mean the two guards
+  # have drifted apart, and failing closed on it turns that into a loud failure rather than
+  # a silent pass.
   build-complete:
     name: All Specs Passed
 
     needs: [build]
-    if: always()
+
+    # Report a verdict on every non-release PR regardless of the matrix result, and skip
+    # on release PRs, where the matrix was never meant to run.
+    if: >-
+      always() &&
+      (github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--')))
 
     runs-on: ubuntu-latest
 
@@ -133,7 +152,7 @@ jobs:
       - name: Check the result of the build job
         run: |
           case "${{ needs.build.result }}" in
-            success | skipped)
+            success)
               echo "build: ${{ needs.build.result }}"
               ;;
             *)


### PR DESCRIPTION
## Problem

Every other job in `continuous_integration.yml` is guarded off release PRs. `build-complete` was not, so on a release PR it ran, saw `needs.build.result == 'skipped'`, accepted it, and reported **success** — a green check named `All Specs Passed` for a run in which no spec executed.

That is misleading to anyone reading the checks list. The check names an outcome that did not happen.

## Change

Give the gate the same guard the other jobs carry, so it reports `skipped` instead:

```yaml
if: >-
  always() &&
  (github.event_name == 'workflow_dispatch' ||
  (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--')))
```

Rulesets treat a `skipped` conclusion as passing, so release PRs stay mergeable and no ruleset edit is needed.

**Skipping is safe for this job and was not safe for the matrix it aggregates.** This job's name is a literal string, so its check run exists and reports a conclusion whether or not the job runs — exactly how `Lint and Docs` and `Non-English Locale` behaved on #1673. A matrix job's name does not exist until the matrix is evaluated, which is what stranded the v5.0.5 release PR and why this job was added.

## Two things worth reviewing closely

**`always()` is now load-bearing in a subtler way.** A job-level `if:` without a status check function implies `success()`. Dropping `always()` from this expression would skip the job whenever the matrix failed — and a skipped required check counts as passing, so a red build would merge. The comment above the job says so explicitly, because the expression is no longer self-evidently safe the way a bare `if: always()` was.

**The accepted results are tightened from `success | skipped` to `success` alone.** This is a judgment call beyond the literal ask, so flag it if you disagree. The rationale: the `skipped` arm existed *only* to accept a release PR, which the guard now handles earlier. `build` and this job carry identical guards, so this job runs exactly when `build` ran — meaning a `skipped` result is now unreachable except if the two guards drift apart in a future edit. Failing closed on it makes that drift a loud failure instead of a silent pass.

## Verification

On this PR: matrix green, `All Specs Passed` a real `success`. The skip path is exercised on the next release PR, which should show `All Specs Passed — skipped` and still be mergeable.

A companion PR makes the same change on `4.x`.

Refs: #1675

🤖 Generated with [Claude Code](https://claude.com/claude-code)