### PR TITLE
ci: correct two imprecise claims in the build-complete comment

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -127,13 +127,13 @@ jobs:
   # `if:` implies `success()`, so a failing matrix would skip this job -- and a skipped
   # required check counts as passing, meaning a red build would merge. `always()` forces a
   # real verdict on every run that is not a release PR. `!cancelled()` is not a substitute:
-  # a cancelled run would then skip the gate and report success for a build that never
-  # finished.
+  # a cancelled run would then skip the gate, and a skipped conclusion is one rulesets treat
+  # as passing -- so a build that never finished would stop blocking the merge.
   #
-  # The case below accepts `success` only. `build` and this job now carry identical guards,
-  # so this job runs exactly when `build` ran; a `skipped` result would mean the two guards
-  # have drifted apart, and failing closed on it turns that into a loud failure rather than
-  # a silent pass.
+  # The case below accepts `success` only. `build` and this job now carry the same release-PR
+  # guard, so this job runs exactly when `build` ran; a `skipped` result would mean the two
+  # guards have drifted apart, and failing closed on it turns that into a loud failure rather
+  # than a silent pass.
   build-complete:
     name: All Specs Passed
 


### PR DESCRIPTION
Follow-up to #1688, which merged before Copilot's review of its `4.x` companion (#1689) came back. Copilot flagged two imprecise sentences in the comment block that #1688 introduced; the same text landed here verbatim.

**Comment-only. No job behavior changes** — `name`, `if:`, and the accepted results all parse identically before and after.

## 1. `!cancelled()` "would report success"

It would report a **`skipped`** conclusion, which rulesets then *treat* as passing. That distinction is the entire subject of the paragraph the sentence sits in, so blurring it there undercut the explanation around it. The wording this block replaced actually had the distinction, and the rewrite in #1688 dropped it.

```diff
-# a cancelled run would then skip the gate and report success for a build that never
-# finished.
+# a cancelled run would then skip the gate, and a skipped conclusion is one rulesets treat
+# as passing -- so a build that never finished would stop blocking the merge.
```

## 2. "identical guards"

The full `if:` expressions are not identical — `build-complete` prefixes `always() &&`. Only the release-PR portion matches, which is all the drift-detection argument ever depended on.

```diff
-# The case below accepts `success` only. `build` and this job now carry identical guards,
-# so this job runs exactly when `build` ran; a `skipped` result would mean the two guards
-# have drifted apart, and failing closed on it turns that into a loud failure rather than
-# a silent pass.
+# The case below accepts `success` only. `build` and this job now carry the same release-PR
+# guard, so this job runs exactly when `build` ran; a `skipped` result would mean the two
+# guards have drifted apart, and failing closed on it turns that into a loud failure rather
+# than a silent pass.
```

## Parity

After this merges, the `build-complete` comment block is byte-identical on `main` and `4.x` (verified against the head of #1689). Worth keeping that way — this block explains the least obvious part of the gating design, and the two branches having subtly different explanations of it is how the next person gets misled.

Refs: #1675

🤖 Generated with [Claude Code](https://claude.com/claude-code)