### PR TITLE
feat: expose perl_regexp on the grep and log facades

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?log
 - [Errors Raised by This Gem](#errors-raised-by-this-gem)
 - [Specifying and Handling Timeouts](#specifying-and-handling-timeouts)
 - [Deprecations](#deprecations)
+- [Platform Limitations](#platform-limitations)
+  - [Regex Metacharacters on Git for Windows](#regex-metacharacters-on-git-for-windows)
 - [Project Policies](#project-policies)
   - [Ruby Version Support Policy](#ruby-version-support-policy)
   - [Git Version Support Policy](#git-version-support-policy)
@@ -301,6 +303,71 @@ needed for the upgrade.
 
 For the full list of deprecated methods and their replacements, see
 [UPGRADING.md](UPGRADING.md).
+
+## Platform Limitations
+
+### Regex Metacharacters on Git for Windows
+
+On Git for Windows, git's regex engine matches **bytes** rather than characters. A
+metacharacter such as `.`, or a POSIX character class such as `[[:alpha:]]`, therefore
+never matches a whole multi-byte character. The same call matches on Linux and macOS.
+
+The failure is silent — nothing raises, and the result is indistinguishable from a
+pattern that genuinely does not occur:
+
+```ruby
+# File content, commit message, and config value are all 'ÄPFEL sind gut'.
+# 'Ä' is two bytes in UTF-8 (C3 84), so '.' has to match both to match the character.
+
+repo.grep('^.PFEL')                              # => {} on Windows, matches elsewhere
+repo.log.grep('^.PFEL').execute.size             # =>  0 on Windows, 1 elsewhere
+repo.config_get_all('test.desc', '^.PFEL')       # => [] on Windows, matches elsewhere
+```
+
+This is a property of the regex engine git bundles on that platform, not something the
+gem sets. It is unaffected by the locale: the behavior is identical under `en_US.UTF-8`,
+`C.UTF-8`, `C`, and with no `LC_ALL` set at all. Literal (metacharacter-free) patterns
+and case-insensitive matching are unaffected on every platform.
+
+**Workaround.** Perl-compatible regular expressions do match characters on Git for
+Windows, so the surfaces that can reach a PCRE engine accept an opt-in selector:
+
+```ruby
+repo.grep('^.PFEL', nil, perl_regexp: true)      # matches on every platform
+repo.log.perl_regexp.grep('^.PFEL').execute      # matches on every platform
+repo.full_log_commits(grep: '^.PFEL', perl_regexp: true)
+```
+
+Two caveats:
+
+- **PCRE is a different dialect** than git's default POSIX basic/extended regular
+  expressions. Selecting it is a deliberate choice by the caller, so the gem does not
+  substitute it automatically based on the host.
+- **PCRE must be compiled in.** Git for Windows and the mainstream Linux and macOS
+  packages ship it, but git built without `USE_LIBPCRE` fails with `cannot use
+  Perl-compatible regexes...`.
+
+**There is no workaround for `git config` value patterns.** They are POSIX extended
+regular expressions with no PCRE mode, so `config_get`, `config_get_all`,
+`config_get_regexp`, `config_replace_all`, `config_unset`, and `config_unset_all` cannot
+match a metacharacter against a non-ASCII character on Git for Windows. Match on ASCII
+text or an exact value instead.
+
+`config_replace_all` deserves particular care, because there the failure is not merely an
+empty result. When the value pattern selects nothing, `git config --replace-all` *adds*
+the new value as an additional entry rather than replacing one, and exits zero:
+
+```ruby
+# Existing value of test.desc is 'ÄPFEL sind gut'
+repo.config_replace_all('test.desc', 'NEW', '^.PFEL')
+
+repo.config_get_all('test.desc').map(&:value)
+# => ["NEW"]                     elsewhere — replaced, as intended
+# => ["ÄPFEL sind gut", "NEW"]   on Windows — original kept, duplicate added
+```
+
+So a replace can silently leave the original value in place and add a second entry beside
+it. Confirm with `config_get_all` when the key must end up single-valued.
 
 ## Project Policies
 

--- a/lib/git/configuring.rb
+++ b/lib/git/configuring.rb
@@ -88,6 +88,14 @@ module Git
     #
     # @raise [Git::FailedError] if git exits with an unexpected non-zero status
     #
+    # @note On Git for Windows, git's default regex engine matches *bytes* rather than
+    #   characters, so a metacharacter such as `.` or a POSIX class such as
+    #   `[[:alpha:]]` in `value_regex` never matches a whole multi-byte character. The
+    #   failure is silent: nothing raises, and the outcome is indistinguishable from a
+    #   `value_regex` that genuinely matches nothing. `git config` value patterns are
+    #   POSIX extended regular expressions with no PCRE mode, so unlike
+    #   {Git::Repository#grep} there is no alternate regex engine to select here.
+    #
     def config_get(name, value_regex = nil, **options)
       Private.assert_valid_opts!(CONFIG_GET_ALLOWED_OPTS, **options)
       assert_valid_scope!(**options)
@@ -138,6 +146,14 @@ module Git
     # @raise [ArgumentError] if unsupported options are provided
     #
     # @raise [Git::FailedError] if git exits with an unexpected non-zero status
+    #
+    # @note On Git for Windows, git's default regex engine matches *bytes* rather than
+    #   characters, so a metacharacter such as `.` or a POSIX class such as
+    #   `[[:alpha:]]` in `value_regex` never matches a whole multi-byte character. The
+    #   failure is silent: nothing raises, and the outcome is indistinguishable from a
+    #   `value_regex` that genuinely matches nothing. `git config` value patterns are
+    #   POSIX extended regular expressions with no PCRE mode, so unlike
+    #   {Git::Repository#grep} there is no alternate regex engine to select here.
     #
     def config_get_all(name, value_regex = nil, **options)
       Private.assert_valid_opts!(CONFIG_GET_ALL_ALLOWED_OPTS, **options)
@@ -237,6 +253,14 @@ module Git
     # @raise [ArgumentError] if unsupported options are provided
     #
     # @raise [Git::FailedError] if git exits with an unexpected non-zero status
+    #
+    # @note On Git for Windows, git's default regex engine matches *bytes* rather than
+    #   characters, so a metacharacter such as `.` or a POSIX class such as
+    #   `[[:alpha:]]` in `value_regex` never matches a whole multi-byte character. The
+    #   failure is silent: nothing raises, and the outcome is indistinguishable from a
+    #   `value_regex` that genuinely matches nothing. `git config` value patterns are
+    #   POSIX extended regular expressions with no PCRE mode, so unlike
+    #   {Git::Repository#grep} there is no alternate regex engine to select here.
     #
     def config_get_regexp(name_regex, value_regex = nil, **options)
       Private.assert_valid_opts!(CONFIG_GET_REGEXP_ALLOWED_OPTS, **options)
@@ -529,6 +553,22 @@ module Git
     #
     #   @raise [Git::FailedError] if git exits with a non-zero exit status
     #
+    # @note On Git for Windows, git's default regex engine matches *bytes* rather than
+    #   characters, so a metacharacter such as `.` or a POSIX class such as
+    #   `[[:alpha:]]` in `value_regex` never matches a whole multi-byte character. The
+    #   failure is silent: nothing raises, and the outcome is indistinguishable from a
+    #   `value_regex` that genuinely matches nothing. `git config` value patterns are
+    #   POSIX extended regular expressions with no PCRE mode, so unlike
+    #   {Git::Repository#grep} there is no alternate regex engine to select here.
+    #
+    # @note A `value_regex` that selects nothing does not make this method a no-op.
+    #   `git config --replace-all` *adds* `value` as an additional entry when no
+    #   existing value matches, and exits zero. On Git for Windows, a `value_regex`
+    #   whose metacharacters span non-ASCII text therefore leaves the value it was
+    #   meant to replace in place and silently creates a duplicate entry beside it.
+    #   Confirm the result with {#config_get_all}, or match on ASCII text, when the
+    #   key must end up single-valued.
+    #
     def config_replace_all(name, value, value_regex = nil, **)
       Private.assert_valid_opts!(CONFIG_REPLACE_ALL_ALLOWED_OPTS, **)
       assert_valid_scope!(**)
@@ -621,6 +661,14 @@ module Git
     #
     #   @raise [Git::FailedError] if git exits with a non-zero exit status
     #
+    # @note On Git for Windows, git's default regex engine matches *bytes* rather than
+    #   characters, so a metacharacter such as `.` or a POSIX class such as
+    #   `[[:alpha:]]` in `value_regex` never matches a whole multi-byte character. The
+    #   failure is silent: nothing raises, and the outcome is indistinguishable from a
+    #   `value_regex` that genuinely matches nothing. `git config` value patterns are
+    #   POSIX extended regular expressions with no PCRE mode, so unlike
+    #   {Git::Repository#grep} there is no alternate regex engine to select here.
+    #
     def config_unset(name, value_regex = nil, **)
       Private.assert_valid_opts!(CONFIG_UNSET_ALLOWED_OPTS, **)
       assert_valid_scope!(**)
@@ -665,6 +713,14 @@ module Git
     #   @raise [ArgumentError] if unsupported options are provided
     #
     #   @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    # @note On Git for Windows, git's default regex engine matches *bytes* rather than
+    #   characters, so a metacharacter such as `.` or a POSIX class such as
+    #   `[[:alpha:]]` in `value_regex` never matches a whole multi-byte character. The
+    #   failure is silent: nothing raises, and the outcome is indistinguishable from a
+    #   `value_regex` that genuinely matches nothing. `git config` value patterns are
+    #   POSIX extended regular expressions with no PCRE mode, so unlike
+    #   {Git::Repository#grep} there is no alternate regex engine to select here.
     #
     def config_unset_all(name, value_regex = nil, **)
       Private.assert_valid_opts!(CONFIG_UNSET_ALL_ALLOWED_OPTS, **)

--- a/lib/git/log.rb
+++ b/lib/git/log.rb
@@ -142,6 +142,25 @@ module Git
     #
     def grep(regex)         = set_option(:grep, regex)
 
+    # Interprets {#grep} and {#author} patterns as Perl-compatible regular expressions
+    #
+    # Selects PCRE instead of git's default POSIX basic regular expressions for
+    # every pattern in the query. Requires a git built with PCRE support.
+    #
+    # @example Match a metacharacter against a non-ASCII character on Git for Windows
+    #   repo.log.perl_regexp.grep('^.PFEL').execute
+    #
+    # @return [Git::Log] the current query builder
+    #
+    # @note On Git for Windows, git's default regex engine matches *bytes* rather
+    #   than characters, so a metacharacter such as `.` or a POSIX class such as
+    #   `[[:alpha:]]` never matches a whole multi-byte character. The match fails
+    #   silently: git exits zero and the result is empty. PCRE does match characters
+    #   on that platform, but it is a different dialect than git's default, so
+    #   selecting it is a deliberate choice by the caller.
+    #
+    def perl_regexp         = set_option(:perl_regexp, true)
+
     # Limits commits to those that touch the given path or paths
     #
     # @param path [String, Pathname, Array<String, Pathname>] path limiter input

--- a/lib/git/repository/logging.rb
+++ b/lib/git/repository/logging.rb
@@ -18,7 +18,7 @@ module Git
       # @return [Array<Symbol>] the supported option keys
       #
       FULL_LOG_COMMITS_ALLOWED_OPTS = %i[
-        count all cherry since until grep author between object path_limiter skip merges
+        count all cherry since until grep author between object path_limiter skip merges perl_regexp
       ].freeze
       private_constant :FULL_LOG_COMMITS_ALLOWED_OPTS
 
@@ -68,6 +68,13 @@ module Git
       #
       # @option opts [Boolean, nil] :merges (nil) include only merge commits
       #
+      # @option opts [Boolean, nil] :perl_regexp (nil) interpret the `:grep` and
+      #   `:author` patterns as Perl-compatible regular expressions (PCRE) instead of
+      #   git's default POSIX basic regular expressions
+      #
+      #   Requires a git built with PCRE support; git otherwise fails with
+      #   "cannot use Perl-compatible regexes...".
+      #
       # @return [Array<Hash>] the parsed raw log output for each commit
       #
       # @raise [ArgumentError] if unsupported options are provided
@@ -75,6 +82,14 @@ module Git
       # @raise [ArgumentError] if `:count` is not an Integer
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @note On Git for Windows, git's default regex engine matches *bytes* rather
+      #   than characters, so a metacharacter such as `.` or a POSIX class such as
+      #   `[[:alpha:]]` never matches a whole multi-byte character in a `:grep` or
+      #   `:author` pattern. The match fails silently: git exits zero and the result
+      #   is empty. Pass `perl_regexp: true` to select PCRE, which does match
+      #   characters. PCRE is a different dialect than git's default, so this is a
+      #   deliberate choice by the caller rather than a transparent substitution.
       #
       # @see https://git-scm.com/docs/git-log git-log
       #
@@ -112,6 +127,14 @@ module Git
       #
       module Private
         module_function
+
+        # Log option keys forwarded to {Git::Commands::Log#call} under the same name
+        #
+        # The remaining options are renamed or reshaped by {#log_base_call_options}.
+        #
+        # @return [Array<Symbol>] the pass-through option keys
+        #
+        PASSTHROUGH_LOG_OPTS = %i[all cherry since until grep author perl_regexp].freeze
 
         # Validates the :count log option
         #
@@ -195,6 +218,9 @@ module Git
         # @option opts [String, nil] :author (nil) only include commits whose author
         #   matches this pattern
         #
+        # @option opts [Boolean, nil] :perl_regexp (nil) interpret the `:grep` and
+        #   `:author` patterns as Perl-compatible regular expressions
+        #
         # @option opts [Integer, nil] :count (nil) maximum number of commits to return
         #
         # @option opts [String, Pathname, Array<String, Pathname>, nil] :path_limiter (nil)
@@ -207,16 +233,14 @@ module Git
         # @return [Hash] keyword options for {Git::Commands::Log#call}
         #
         def log_base_call_options(opts, extra = {})
-          {
-            all: opts[:all],
-            cherry: opts[:cherry],
-            since: opts[:since],
-            until: opts[:until],
-            grep: opts[:grep],
-            author: opts[:author],
-            max_count: opts[:count],
-            path: opts[:path_limiter] ? Array(opts[:path_limiter]) : nil
-          }.merge(extra).compact
+          opts
+            .slice(*PASSTHROUGH_LOG_OPTS)
+            .merge(
+              max_count: opts[:count],
+              path: opts[:path_limiter] ? Array(opts[:path_limiter]) : nil
+            )
+            .merge(extra)
+            .compact
         end
 
         # Executes git log and parses the raw output

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -454,7 +454,7 @@ module Git
       end
 
       # Option keys accepted by {#grep}
-      GREP_ALLOWED_OPTS = %i[ignore_case i invert_match v extended_regexp E object].freeze
+      GREP_ALLOWED_OPTS = %i[ignore_case i invert_match v extended_regexp E perl_regexp P object].freeze
       private_constant :GREP_ALLOWED_OPTS
 
       # Search tracked file contents in a git tree for a pattern
@@ -474,6 +474,9 @@ module Git
       #
       # @example Case-insensitive search
       #   repo.grep('todo', nil, ignore_case: true)
+      #
+      # @example Match a metacharacter against a non-ASCII character on Git for Windows
+      #   repo.grep('^.PFEL', nil, perl_regexp: true)
       #
       # @param pattern [String] the pattern to search for
       #
@@ -499,6 +502,14 @@ module Git
       #
       #   Alias: :E
       #
+      # @option opts [Boolean, nil] :perl_regexp (nil) use Perl-compatible regular
+      #   expressions (PCRE) for the pattern
+      #
+      #   Requires a git built with PCRE support; git otherwise fails with
+      #   "cannot use Perl-compatible regexes...".
+      #
+      #   Alias: :P
+      #
       # @return [Hash<String, Array<Array(Integer, String)>>] a hash mapping
       #   each `"treeish:filename"` key to an array of `[line_number, text]`
       #   pairs; returns an empty hash when no lines match
@@ -507,6 +518,16 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero status and
       #   stderr is non-empty (e.g. bad object reference)
+      #
+      # @note On Git for Windows, git's default regex engine matches *bytes* rather
+      #   than characters, so a metacharacter such as `.` or a POSIX class such as
+      #   `[[:alpha:]]` never matches a whole multi-byte character. The failure is
+      #   silent: nothing raises, and the empty hash returned is indistinguishable
+      #   from a pattern that genuinely does not occur in the tree. Pass
+      #   `perl_regexp: true` to select PCRE, which does match characters. PCRE is a
+      #   different dialect than git's default POSIX basic/extended regular
+      #   expressions, so this is a deliberate choice by the caller rather than a
+      #   transparent substitution, and it requires a git built with PCRE support.
       #
       # @see https://git-scm.com/docs/git-grep git-grep documentation
       #

--- a/spec/integration/git/non_ascii_regex_matching_spec.rb
+++ b/spec/integration/git/non_ascii_regex_matching_spec.rb
@@ -24,6 +24,12 @@ require 'spec_helper'
 # Windows is the one platform that does need a gate, and it is a statement about git
 # rather than about the locale — see {#skip_on_git_for_windows}.
 #
+# The `with perl_regexp` groups cover the supported workaround for that platform and
+# are deliberately *not* gated on Windows: PCRE matches characters everywhere, which is
+# the whole reason those surfaces expose the selector. They are gated on whether git was
+# built with PCRE at all. `config` has no such group because `git config` value patterns
+# are POSIX extended regular expressions with no PCRE mode — there is nothing to select.
+#
 RSpec.describe 'non-ASCII regex matching', :integration do
   include_context 'in an empty repository'
 
@@ -75,6 +81,12 @@ RSpec.describe 'non-ASCII regex matching', :integration do
     it 'folds case across non-ASCII characters when ignore_case is given' do
       expect(repo.grep('äpfel sind gut', nil, ignore_case: true)).to eq('HEAD:w.txt' => [[1, text]])
     end
+
+    context 'with perl_regexp', skip: unless_pcre('Git::Repository#grep with perl_regexp') do
+      it 'matches a metacharacter against a non-ASCII character on every platform' do
+        expect(repo.grep(metacharacter_pattern, nil, perl_regexp: true)).to eq('HEAD:w.txt' => [[1, text]])
+      end
+    end
   end
 
   describe 'Git::Repository#log' do
@@ -86,6 +98,12 @@ RSpec.describe 'non-ASCII regex matching', :integration do
       skip_on_git_for_windows
 
       expect(repo.log.grep(metacharacter_pattern).execute.size).to eq(1)
+    end
+
+    context 'with perl_regexp', skip: unless_pcre('Git::Log#perl_regexp') do
+      it 'matches a metacharacter against a non-ASCII character on every platform' do
+        expect(repo.log.perl_regexp.grep(metacharacter_pattern).execute.size).to eq(1)
+      end
     end
   end
 

--- a/spec/integration/git/repository/logging_spec.rb
+++ b/spec/integration/git/repository/logging_spec.rb
@@ -37,6 +37,18 @@ RSpec.describe Git::Repository::Logging, :integration do
         expect(result.first['message']).to eq("Add changelog\n")
         expect(result.first['parent']).to be_a(Array)
       end
+
+      context 'with :perl_regexp', skip: unless_pcre('full_log_commits with perl_regexp') do
+        it 'matches a grep pattern using Perl-compatible regular expressions' do
+          result = described_instance.full_log_commits(grep: 'Add(?= changelog)', perl_regexp: true)
+
+          expect(result.map { |c| c['message'] }).to eq(["Add changelog\n"])
+        end
+
+        it 'treats a PCRE-only construct as a literal without the option' do
+          expect(described_instance.full_log_commits(grep: 'Add(?= changelog)')).to be_empty
+        end
+      end
     end
   end
 
@@ -65,6 +77,18 @@ RSpec.describe Git::Repository::Logging, :integration do
 
         expect(result.size).to eq(1)
         expect(result.first.message.strip).to eq('Add changelog')
+      end
+
+      context 'with #perl_regexp', skip: unless_pcre('Git::Log#perl_regexp') do
+        it 'matches a grep pattern using Perl-compatible regular expressions' do
+          result = described_instance.log.perl_regexp.grep('Add(?= changelog)').execute
+
+          expect(result.map { |c| c.message.strip }).to eq(['Add changelog'])
+        end
+
+        it 'treats a PCRE-only construct as a literal without the selector' do
+          expect(described_instance.log.grep('Add(?= changelog)').execute.size).to eq(0)
+        end
       end
     end
   end

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -428,6 +428,17 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
       end
     end
 
+    context 'with :perl_regexp option', skip: unless_pcre('Git::Repository#grep with perl_regexp') do
+      it 'matches using Perl-compatible regular expressions' do
+        result = described_instance.grep('TODO(?=: fix)', nil, perl_regexp: true)
+        expect(result.keys).to contain_exactly('HEAD:src/foo.rb')
+      end
+
+      it 'treats a PCRE-only construct as a literal without the option' do
+        expect(described_instance.grep('TODO(?=: fix)')).to be_empty
+      end
+    end
+
     context 'with :object option pointing to a specific commit' do
       it 'searches in that commit instead of HEAD' do
         sha = repo.rev_parse('HEAD')

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,6 +10,9 @@ $stderr.sync = true
 # before the first RSpec example produces no output at all.
 warn "[spec_helper] JRuby #{RUBY_VERSION}: beginning spec_helper load" if RUBY_ENGINE == 'jruby'
 
+require 'English'
+require 'tmpdir'
+
 # Load support files
 Dir[File.join(__dir__, 'support', '**', '*.rb')].each do |f|
   warn "[spec_helper] requiring #{f}" if RUBY_ENGINE == 'jruby'
@@ -145,6 +148,99 @@ def unless_command(command, feature)
 end
 
 def ci_build? = ENV.fetch('GITHUB_ACTIONS', 'false') == 'true'
+
+# Returns `false` if the installed git was built with PCRE, otherwise a skip-reason
+# string. Use as the `skip:` metadata value for tests that pass `--perl-regexp` to
+# git.
+#
+# `--perl-regexp` is not universally available: git only accepts it when compiled
+# with `USE_LIBPCRE`, and fails with "cannot use Perl-compatible regexes..." when it
+# was not. Git for Windows and the mainstream Linux and macOS packages all ship it,
+# but a self-built git may not.
+#
+# The probe runs `git grep --perl-regexp` with `--no-index` in an empty temporary
+# directory, so it needs no repository and has no files to scan. A git that accepted
+# the flag reports a normal grep status: 0 (matched) or 1 (did not match). Every other
+# status means the flag was not honored — 128 for the fatal "cannot use
+# Perl-compatible regexes" error, 127 when the binary could not be executed at all —
+# and is treated as unsupported so the affected examples skip rather than fail.
+#
+# @param feature [String] the feature name to include in the skip reason
+#
+# @return [false, String] `false` if git supports `--perl-regexp`; otherwise a
+#   human-readable skip reason string
+#
+# @example Skip an example group when git lacks PCRE support
+#   RSpec.describe MyFeature, skip: unless_pcre('PCRE grep') do
+#     it 'works' do
+#       # ...
+#     end
+#   end
+#
+def unless_pcre(feature)
+  return false if git_supports_pcre?
+
+  "#{feature} requires a git built with PCRE support (USE_LIBPCRE), which this git lacks"
+end
+
+# Whether the installed git accepts `--perl-regexp`
+#
+# Memoized because the probe shells out and every `unless_pcre` call site would
+# otherwise pay for it again.
+#
+# @return [Boolean] true if git was built with PCRE support
+#
+def git_supports_pcre? = GitPcreProbe.supported?
+
+# Runs and caches the one-off probe behind {#git_supports_pcre?}
+#
+# @api private
+#
+module GitPcreProbe
+  # Exit statuses that prove git ran the probe and honored `--perl-regexp`
+  #
+  # These are `git grep`'s normal "matched" and "did not match" statuses. Anything
+  # else — the 128 fatal for a git without PCRE, the 127 from a binary that could not
+  # be executed, a usage error — means the flag was not honored.
+  #
+  ACCEPTED_EXIT_STATUSES = [0, 1].freeze
+
+  # Whether the installed git accepts `--perl-regexp`, running the probe at most once
+  #
+  # @return [Boolean] true if git was built with PCRE support
+  #
+  def self.supported?
+    return @supported unless @supported.nil?
+
+    @supported = probe
+  end
+
+  # Runs `git grep --perl-regexp` where there is nothing to match and reads the status
+  #
+  # @return [Boolean] true if git accepted the flag
+  #
+  def self.probe
+    Dir.mktmpdir do |dir|
+      # Only an accepted status counts, so every ambiguous outcome — including a git
+      # that could not be executed — reports unsupported and skips rather than fails.
+      ACCEPTED_EXIT_STATUSES.include?(run_probe(dir)&.exitstatus)
+    end
+  end
+
+  # Invokes the probe command in the given directory, discarding its output
+  #
+  # @param dir [String] an empty directory to run in, so there are no files to scan
+  #
+  # @return [Process::Status, nil] the probe's exit status, or nil if git did not run
+  #
+  def self.run_probe(dir)
+    system(
+      Git.config.binary_path, 'grep', '--perl-regexp', '--no-index', '--quiet', '-e', 'x', '--', '.',
+      chdir: dir, out: File::NULL, err: File::NULL
+    )
+    $CHILD_STATUS
+  end
+end
 
 # The value ruby-git pins `LC_ALL` to on this host
 #

--- a/spec/unit/git/log_spec.rb
+++ b/spec/unit/git/log_spec.rb
@@ -184,6 +184,19 @@ RSpec.describe Git::Log do
     end
   end
 
+  describe '#perl_regexp' do
+    before { allow(repository).to receive(:full_log_commits).and_return([]) }
+
+    it 'forwards perl_regexp to full_log_commits' do
+      expect(repository).to receive(:full_log_commits).with(hash_including(perl_regexp: true)).and_return([])
+      described_instance.perl_regexp.execute
+    end
+
+    it 'returns the query builder so it can be chained' do
+      expect(described_instance.perl_regexp).to be(described_instance)
+    end
+  end
+
   describe '#cherry' do
     before { allow(repository).to receive(:full_log_commits).and_return([]) }
 

--- a/spec/unit/git/repository/logging_spec.rb
+++ b/spec/unit/git/repository/logging_spec.rb
@@ -152,7 +152,8 @@ RSpec.describe Git::Repository::Logging do
           between: %w[v1.0.0 HEAD],
           path_limiter: Pathname('README.md'),
           skip: 1,
-          merges: true
+          merges: true,
+          perl_regexp: true
         }
       end
 
@@ -167,10 +168,23 @@ RSpec.describe Git::Repository::Logging do
           until: '2024-01-31',
           grep: 'fix',
           author: 'Jane',
+          perl_regexp: true,
           max_count: 2,
           path: [Pathname('README.md')],
           skip: 1,
           merges: true
+        ).and_return(command_result(''))
+
+        expect(result).to eq([])
+      end
+    end
+
+    context 'with a :perl_regexp option' do
+      let(:opts) { { grep: '^.PFEL', perl_regexp: true } }
+
+      it 'forwards perl_regexp to the command' do
+        expect(log_command).to receive(:call).with(
+          no_color: true, pretty: 'raw', grep: '^.PFEL', perl_regexp: true
         ).and_return(command_result(''))
 
         expect(result).to eq([])

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -1157,6 +1157,28 @@ RSpec.describe Git::Repository::ObjectOperations do
       end
     end
 
+    context 'with :perl_regexp option' do
+      subject(:result) { described_instance.grep('^.PFEL', nil, perl_regexp: true) }
+
+      it 'forwards perl_regexp to the command' do
+        expect(grep_command).to receive(:call)
+          .with('HEAD', pattern: '^.PFEL', perl_regexp: true, no_color: true, line_number: true, null: true)
+          .and_return(command_result(''))
+        result
+      end
+    end
+
+    context 'with :P alias' do
+      subject(:result) { described_instance.grep('^.PFEL', nil, P: true) }
+
+      it 'forwards :P to the command' do
+        expect(grep_command).to receive(:call)
+          .with('HEAD', pattern: '^.PFEL', P: true, no_color: true, line_number: true, null: true)
+          .and_return(command_result(''))
+        result
+      end
+    end
+
     context 'when no lines match (exit status 1, empty stderr)' do
       subject(:result) { described_instance.grep('NOMATCH') }
 


### PR DESCRIPTION
## Summary

Adds `perl_regexp` to the `grep` and `log` facades, so callers can select PCRE for pattern
matching, and documents the platform limitation that motivates it.

```ruby
repo.grep('^.PFEL', nil, perl_regexp: true)              # alias: P:
repo.log.perl_regexp.grep('^.PFEL').execute
repo.full_log_commits(grep: '^.PFEL', perl_regexp: true)
```

`Git::Commands::Grep` and `Git::Commands::Log` have both defined this flag all along — only
the facade allowlists (`GREP_ALLOWED_OPTS`, `FULL_LOG_COMMITS_ALLOWED_OPTS`) withheld it, so
there was no supported way to reach PCRE from the public API.

## This is not a ruby-git defect

Worth stating plainly, because #1686 is labeled `bug` and this PR closes it:

**Nothing in this gem was misbehaving, and nothing here fixes git's behavior.** On Git for
Windows, git's bundled regex engine matches *bytes* rather than characters, so `.` or
`[[:alpha:]]` never matches a whole multi-byte character. The gem hands patterns to git
faithfully; git returns an empty result with exit status 0. That is a property of the
platform's git build, unrelated to the `LC_ALL` pin — the issue measured it as identical
under `en_US.UTF-8`, `C.UTF-8`, `C`, and no pin at all.

After this PR, Git for Windows still matches bytes with the default engine. What changes is
that callers who need character semantics now have a supported way to ask for it, and the
failure mode is documented instead of being discovered as a silent empty result.

The issue itself framed it this way — *"it is a platform property the gem cannot fix"* — and
offered three options. This PR does 1 and 2. Option 3 (silently switching to `-P` on Windows)
is deliberately **not** implemented; the issue rejected it, since changing regex dialect based
on the host is the opposite of what a thin, predictable CLI wrapper should do.

## What's included

**Feature — `perl_regexp` where a PCRE engine is reachable**

- **grep** — `:perl_regexp` / `:P` added to `GREP_ALLOWED_OPTS`.
- **log** — `:perl_regexp` added to `FULL_LOG_COMMITS_ALLOWED_OPTS`, plus a
  `Git::Log#perl_regexp` selector. One flag covers both `#grep` and `#author`, since
  `--perl-regexp` applies to all of git log's pattern options.
- **config** — nothing, deliberately. `git config` value patterns are POSIX extended regular
  expressions with no PCRE mode, so there is no alternate engine to select. This surface has
  no workaround and the docs say so.

**Documentation**

- A **Platform Limitations** section in `README.md`: the silent empty result, the workaround,
  and its two caveats — PCRE is a different dialect than git's default, and it requires a git
  built with `USE_LIBPCRE`.
- `@note` tags on `Git::Repository#grep`, `#full_log_commits`, `Git::Log#perl_regexp`, and all
  six `Configuring` methods that accept a `value_regex`.

### The `config_replace_all` hazard is the sharpest practical consequence

Worth calling out for review, because it is the one place where this limitation can *change
state* rather than merely return nothing.

When a value pattern selects no existing value, `git config --replace-all` **adds** the new
value as an additional entry instead of replacing one, and exits zero. Measured:

```console
before:  test.desc = 'ÄPFEL sind gut'                        (1 entry)
$ git config --replace-all test.desc NEW '<non-matching>'    → exit 0
after:   test.desc = 'ÄPFEL sind gut'
         test.desc = 'NEW'                                   (2 entries)
```

So on Git for Windows, `repo.config_replace_all('test.desc', 'NEW', '^.PFEL')` can leave the
value it was meant to replace in place and silently create a duplicate beside it. Both the
README and the `config_replace_all` `@note` now warn about this specifically and point at
`config_get_all` for verification, rather than lumping it in with the read methods that just
return empty.

### A note on exit statuses

An earlier revision of these docs claimed the failure means "git exits zero." That is true
only for `git log`. Measured no-match statuses: `git grep` → 1, `git config --get` /
`--get-all` / `--get-regexp` → 1, `git config --unset` / `--unset-all` → 5, `git log` → 0.
The gem returns empty/`nil` without raising because the wrappers set `allow_exit_status 0..1`
(and `0..5` for the unsetters) — so the *observable* behavior was described correctly, but the
mechanism was not. The notes now describe the API result instead of asserting an exit status.

## Testing

Unit and integration coverage for every new option, plus a new `unless_pcre` capability gate
in `spec_helper` following the existing `unless_git` / `unless_command` convention. It probes
`git grep --perl-regexp --no-index` in an empty tmpdir and accepts only git grep's normal 0
and 1 exit statuses, so any ambiguous outcome — 128 for a git without PCRE, 127 for a binary
that cannot be executed — skips rather than claiming the capability.

The `perl_regexp` examples added to `spec/integration/git/non_ascii_regex_matching_spec.rb`
are deliberately **not** Windows-gated. That platform is the entire reason the selector
exists, so Windows CI is where they earn their keep.

Per the issue's non-goals, the existing `Gem.win_platform?` skips on the default-engine
examples are unchanged, and the `LC_ALL` pin is untouched.

`bundle exec rake` is clean at every commit in this branch, not just the tip. No linter
offenses were suppressed.

## Notes for the reviewer

1. **One existing test modified.** The `'with all documented options'` context in
   `spec/unit/git/repository/logging_spec.rb` gained `perl_regexp: true`. Additive, but its
   name would otherwise have become false.

2. **An unplanned refactor.** Adding a key pushed `log_base_call_options` to 11 lines, over
   `Metrics/MethodLength`. Rather than suppress the cop, I extracted `PASSTHROUGH_LOG_OPTS`
   and rewrote the method as `slice`/`merge`. Verified behavior-preserving: the two
   implementations produce identical option hashes across a range of inputs, and emitted CLI
   argument order comes from the DSL's `@ordered_definitions`, not from caller hash order.

3. **The issue's open question is still open.** It asks whether newer Git for Windows builds
   still match bytes, and whether upstream considers it a defect. That is not verified here —
   the measurement in the issue is against git 2.55.0, which is still current. Windows CI
   running the new ungated examples is what will confirm the workaround holds there. The
   `perl_regexp` selectors are worth having regardless of how upstream rules on it.

4. **Scope of the log selector.** Only `perl_regexp` is exposed, not a general flavor selector
   (`basic_regexp`, `extended_regexp`, `fixed_strings`). PCRE is the only flavor that gives
   character semantics on the affected platform; the rest would be scope growth.

Closes #1686

🤖 Generated with [Claude Code](https://claude.com/claude-code)

