### PR TITLE
build: add fiddle as a Windows development dependency

### DIFF
--- a/git.gemspec
+++ b/git.gemspec
@@ -64,6 +64,13 @@ Gem::Specification.new do |spec|
 
   unless RUBY_PLATFORM == 'java' || RUBY_ENGINE == 'truffleruby'
     spec.add_development_dependency 'irb', '~> 1.16'
+
+    # Ruby 4.0.0 dropped fiddle from the default gems. On Windows, irb loads
+    # reline/io/windows.rb, which requires fiddle/import for the Win32 console API,
+    # so bin/console cannot start without fiddle in the bundle. Other platforms use
+    # reline's ANSI IO gate and never load it.
+    spec.add_development_dependency 'fiddle', '~> 1.1' if Gem.win_platform?
+
     spec.add_development_dependency 'redcarpet', '~> 3.6'
     spec.add_development_dependency 'yard', '~> 0.9', '>= 0.9.28'
     spec.add_development_dependency 'yard_example_test', '~> 0.2', '>= 0.2.1'


### PR DESCRIPTION
# Description

`bundle exec ruby bin/console` fails on Windows under Ruby 4.0:

```
reline-0.7.0/lib/reline/io/windows.rb:1: warning: fiddle/import is found in fiddle,
  which is not part of the default gems since Ruby 4.0.0.
cannot load such file -- fiddle/import (LoadError)
```

Ruby 4.0.0 removed `fiddle` from the default gems. On Windows, `irb` loads
`reline/io/windows.rb` for the Win32 console API, and its first line is
`require 'fiddle/import'`. `bin/console` calls `require 'bundler/setup'`, which
restricts the load path to the bundle, so a `fiddle` installed on the system is
invisible to it and the console cannot start.

`reline` picks that file by `RbConfig::CONFIG['host_os']`, so macOS and Linux take
the ANSI IO gate and never load it — this is Windows-only. The dispatch happens
before the tty checks, so Git Bash and mintty fail the same way.

CI never caught it because the Windows matrix entry runs specs and never starts
`irb`.

This adds `fiddle` as a development dependency guarded by `Gem.win_platform?`,
placed next to the `irb` dependency it exists to serve. The gemspec already uses
runtime conditionals in this style for `i18n`, `yard-lint`, and the JRuby and
TruffleRuby exclusions.

## Validation

- `bin/console` starts and evaluates `Git::VERSION` (`5.0.5`).
- `bundle exec rubocop` — 622 files inspected, no offenses.
- `bundle exec rake spec:unit` — 5825 examples, 0 failures; line coverage
  7329/7329 and branch coverage 1165/1165, both 100%.

No `lib/` code changes, so there is nothing for `spec/` to cover and the coverage
gate is unaffected.

## AI assistance

Per [AI_POLICY.md](../AI_POLICY.md) item 3: this contribution was substantially
AI-assisted (Claude Code), and the commit carries a `Co-Authored-By` trailer. The
validation output quoted above was produced by the agent, which per CONTRIBUTING.md
is explicitly *not* a substitute for the submitter's own local validation.

This branch has been rebased on `main` now that #1694 has merged, so the two
blockers that previously made `bundle exec rake` unpassable on Windows here — the
`Layout/EndOfLine` default and the symlink specs — are gone. The full default task
now completes on Windows with exit code 0:

```text
spec:unit          5825 examples, 0 failures, 2 pending
                   Line 7329/7329 (100.00%)  Branch 1165/1165 (100.00%)
spec:integration    583 examples, 0 failures, 12 pendings
rubocop             622 files inspected, no offenses detected
yard / yard:lint    100.00% documented, No offenses found
build               git 5.0.5 built to pkg/git-5.0.5.gem
```

## Checklist

- [ ] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [ ] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed. (Not applicable: build configuration only, no
  `lib/` change.)
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD). (Not applicable:
  no public API change.)
