### PR TITLE
refactor: express development dependency conditions as named predicates

### DIFF
--- a/git.gemspec
+++ b/git.gemspec
@@ -46,38 +46,59 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'process_executer', '~> 4.0'
   spec.add_dependency 'rchardet', '~> 1.9'
 
+  # Not every development dependency is installed on every runtime. Each predicate
+  # below names one reason for holding a gem back, which keeps the dependency list
+  # itself a flat, readable list. Deriving one predicate from another also keeps
+  # coupled gems from drifting apart when a condition changes.
+  #
+  # These are local variables rather than methods deliberately. The Gemfile uses
+  # `gemspec`, so Bundler evaluates this file on every `bundle exec`, and a top-level
+  # `def` -- including one written inside this block, since a block is not a definition
+  # scope -- would define a private method on Object in every one of those processes.
+
+  # JRuby (which reports RUBY_PLATFORM as 'java') and TruffleRuby build no C extensions
+  # and do not run the docs build.
+  mri = !(RUBY_PLATFORM == 'java' || RUBY_ENGINE == 'truffleruby')
+
+  # irb stopped being a default gem in Ruby 3.4. JRuby and TruffleRuby ship their own.
+  install_irb = mri
+
+  # Ruby 4.0.0 dropped fiddle from the default gems. On Windows, irb loads
+  # reline/io/windows.rb, which requires fiddle/import for the Win32 console API, so
+  # bin/console cannot start without it; every other platform takes reline's ANSI IO
+  # gate and never loads that file. Derived from install_irb because fiddle exists only
+  # to serve irb and, being a C extension, could not install where irb is not.
+  install_fiddle = install_irb && Gem.win_platform?
+
+  # The docs toolchain is supported on MRI only. redcarpet, YARD's Markdown renderer,
+  # is also a C extension and so could not install on JRuby regardless.
+  install_docs = mri
+
+  # yard-lint requires Ruby >= 3.3.
+  install_yard_lint = install_docs && Gem.ruby_version >= Gem::Version.new('3.3.0')
+
+  # i18n 1.15+ uses Fiber.[] (Ruby 3.2 Fiber storage), which TruffleRuby < 34.0.0 does
+  # not implement, so those runtimes hold at the last release that works there.
+  pin_old_i18n = RUBY_ENGINE == 'truffleruby' &&
+                 Gem::Version.new(RUBY_ENGINE_VERSION) < Gem::Version.new('34.0.0')
+
   spec.add_development_dependency 'create_github_release', '~> 2.1'
+  spec.add_development_dependency 'fiddle', '~> 1.1' if install_fiddle
   spec.add_development_dependency 'fuubar', '~> 2.5'
+  spec.add_development_dependency 'i18n', '< 1.15' if pin_old_i18n
+  spec.add_development_dependency 'irb', '~> 1.16' if install_irb
   spec.add_development_dependency 'main_branch_shared_rubocop_config', '~> 0.1'
   spec.add_development_dependency 'parallel_tests', '~> 5.6'
   spec.add_development_dependency 'rake', '~> 13.3'
+  spec.add_development_dependency 'redcarpet', '~> 3.6' if install_docs
   spec.add_development_dependency 'rspec', '~> 3.13'
   spec.add_development_dependency 'rubocop', '~> 1.82'
   spec.add_development_dependency 'simplecov', '~> 1.0'
   spec.add_development_dependency 'simplecov-lcov', '~> 0.9'
   spec.add_development_dependency 'simplecov-rspec', '~> 1.1'
-
-  if RUBY_ENGINE == 'truffleruby' && Gem::Version.new(RUBY_ENGINE_VERSION) < Gem::Version.new('34.0.0')
-    # i18n 1.15+ uses Fiber.[] (Ruby 3.2 Fiber storage) which TruffleRuby < 34.0.0 does not implement
-    spec.add_development_dependency 'i18n', '< 1.15'
-  end
-
-  unless RUBY_PLATFORM == 'java' || RUBY_ENGINE == 'truffleruby'
-    spec.add_development_dependency 'irb', '~> 1.16'
-
-    # Ruby 4.0.0 dropped fiddle from the default gems. On Windows, irb loads
-    # reline/io/windows.rb, which requires fiddle/import for the Win32 console API,
-    # so bin/console cannot start without fiddle in the bundle. Other platforms use
-    # reline's ANSI IO gate and never load it.
-    spec.add_development_dependency 'fiddle', '~> 1.1' if Gem.win_platform?
-
-    spec.add_development_dependency 'redcarpet', '~> 3.6'
-    spec.add_development_dependency 'yard', '~> 0.9', '>= 0.9.28'
-    spec.add_development_dependency 'yard_example_test', '~> 0.2', '>= 0.2.1'
-
-    # yard-lint requires Ruby >= 3.3, so it is only installed on Ruby 3.3+.
-    spec.add_development_dependency 'yard-lint', '~> 1.8' if Gem.ruby_version >= Gem::Version.new('3.3.0')
-  end
+  spec.add_development_dependency 'yard', '~> 0.9', '>= 0.9.28' if install_docs
+  spec.add_development_dependency 'yard_example_test', '~> 0.2', '>= 0.2.1' if install_docs
+  spec.add_development_dependency 'yard-lint', '~> 1.8' if install_yard_lint
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
> **Stacked on #1693.** This targets `build/fiddle-for-windows-console` rather than
> `main`, because the refactor expresses `install_fiddle` in terms of `install_irb`
> and that dependency only exists on #1693. GitHub will retarget this to `main`
> automatically when #1693 merges. Review #1693 first.

# Description

The conditional development dependencies were grouped by whichever condition was
convenient rather than by *why* each gem is held back. One block —

```ruby
unless RUBY_PLATFORM == 'java' || RUBY_ENGINE == 'truffleruby'
```

— covered three unrelated rationales:

| gem | native ext? | actual reason |
| --- | --- | --- |
| `redcarpet` | yes | *cannot install* — JRuby builds no C extensions |
| `fiddle` | yes | *cannot install*, same |
| `yard`, `yard_example_test` | no | install fine; docs build is MRI-only |
| `irb` | no | installs fine; JRuby and TruffleRuby ship their own |

Nothing in the file said which applied to a given entry, so adding a dependency
meant guessing which rationale you were inheriting.

This names each reason as a local predicate and lets the dependency list go flat —
one gem per line, alphabetical, the same shape as the unconditional entries above
it. The `unless` block and the separate `if` block for `i18n` both disappear.

Deriving predicates from one another also encodes coupling that was previously
only a comment:

```ruby
install_fiddle = install_irb && Gem.win_platform?
```

fiddle exists solely to serve irb, so it can never be installed where irb is not,
and the two cannot drift apart if either condition changes later.

### Why locals and not methods

The Gemfile uses `gemspec`, so Bundler evaluates this file on every `bundle exec`.
A top-level `def` — including one written inside the `Gem::Specification.new`
block, since a block is not a definition scope — would define a private method on
`Object` in every one of those processes, including the test suite. Locals scoped
to the block cost nothing and leak nothing.

## Validation

This is behavior-preserving, verified two ways:

1. **Resolved dependency set.** Loading the gemspec from `HEAD` and from this
   branch and diffing `spec.dependencies` gives an identical 20-entry set on this
   runtime (MRI 4.0.6, Windows).
2. **Logic equivalence across runtimes.** I have no JRuby or TruffleRuby available
   locally, and CI runs JRuby on Linux only, so a single-runtime check proves
   little. I ran the old and new decision logic side by side over 144 combinations
   of `RUBY_PLATFORM`, `RUBY_ENGINE`, engine version, `Gem.win_platform?`, and Ruby
   version: **0 mismatches**.

Also `bundle install` resolves unchanged (17 Gemfile dependencies, 65 gems), and
`bundle exec rubocop git.gemspec` is clean apart from the pre-existing
`Layout/EndOfLine` offense that #1694 fixes.

`Gemspec/OrderedDependencies` wants `yard_example_test` before `yard-lint`, which
is why the flat list is in that order rather than plain ASCII order.

## AI assistance

Per [AI_POLICY.md](../AI_POLICY.md) item 3: this contribution was substantially
AI-assisted (Claude Code), and the commit carries a `Co-Authored-By` trailer. The
equivalence checks quoted above were produced by the agent, which per CONTRIBUTING.md
is explicitly *not* a substitute for the submitter's own local validation.

This one deserves particular scrutiny despite being behavior-preserving on paper:
the 144-combination check exercises a *reimplementation* of the old and new logic
side by side, not the gemspec itself, so it proves the two decision procedures agree
— not that the reimplementation faithfully mirrors the file. The `spec.dependencies`
diff covers the gemspec directly, but only on one runtime.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
  On Windows it does not, for two reasons this branch does not carry: the
  `Layout/EndOfLine` default and the symlink specs, both fixed in #1694.
- [x] Tests added/updated as needed. (Not applicable: gemspec metadata only, no
  `lib/` change.)
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD). (Not applicable:
  no public API change; the rationale is documented in the gemspec itself.)
