### PR TITLE
chore: fix a broken doc link and bound the locale job's apt step

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -207,10 +207,25 @@ jobs:
       # `update-locale` is deliberately not run: it edits /etc/default/locale, which is
       # only consulted for logins that do not already set LANG and LC_ALL, and this job
       # sets both explicitly.
+      #
+      # The two apt settings below exist because this step reaches out to the Ubuntu
+      # archive, which is the only part of this job that can fail for reasons that have
+      # nothing to do with the code under test:
+      #
+      #   * `Acquire::Retries` retries an individual download that fails outright,
+      #     rather than failing the job on one unlucky mirror.
+      #   * `timeout-minutes` bounds a mirror that accepts the connection and then
+      #     stops responding, which retries cannot help with. Without it the step
+      #     inherits the 6 hour job default: run 32087601711 sat here for 12 minutes
+      #     before it was cancelled by hand, and would otherwise have held a runner
+      #     for the rest of the day. The whole job normally finishes in 53-118
+      #     seconds, so 5 minutes is generous while still failing the same morning.
+      #
       - name: Install the German locale and message catalogs
+        timeout-minutes: 5
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y --no-install-recommends language-pack-de
+          sudo apt-get -o Acquire::Retries=3 update -qq
+          sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends language-pack-de
           sudo locale-gen de_DE.UTF-8
 
       # Ruby 3.4 to share the bundler cache the lint job already warms. Nothing about

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,7 +194,7 @@ Before moving a pull request out of draft or requesting a review, confirm:
 - [ ] `bundle exec rake` passes locally on your branch (see
   [Local development setup](#local-development-setup)).
 - [ ] New or changed code has accompanying tests under `spec/`
-  (see [Unit tests](#unit-tests)).
+  (see [Unit tests vs Integration tests](#unit-tests-vs-integration-tests)).
 - [ ] Every commit message follows [Conventional Commits](#commit-message-guidelines).
 - [ ] User-facing changes are documented in `README.md` and/or YARD as appropriate.
 


### PR DESCRIPTION
# Description

Two small, unrelated cleanups left over from the Windows development-environment
work in #1693, #1694, and #1695. Grouped into one PR only because each is a
handful of lines; they are separate atomic commits and could be split if you'd
rather review them apart.

**1. `docs: fix a broken section link in the pre-review checklist`**

The "Before requesting review" checklist linked to `#unit-tests`, an anchor no
heading generates. The section it means is "Unit tests vs Integration tests",
which the table of contents already links correctly — the checklist was the only
place pointing at a fragment that silently goes nowhere.

**2. `ci: bound the locale job's apt step so a stalled mirror fails fast`**

Installing `language-pack-de` is the only step in the Non-English Locale job that
reaches the Ubuntu archive, which makes it the only step that can fail for reasons
unrelated to the code under test. It had no timeout, so it inherited the 6 hour
job default.

Run [32087601711](https://github.com/ruby-git/ruby-git/actions/runs/32087601711)
hit exactly that while #1694 was in review: apt accepted the connection and then
stopped responding, and the job sat on step 3 of 7 for 12 minutes before being
cancelled by hand. Left alone it would have held a runner for the rest of the day
and blocked the PR behind a required check that was never going to report — the
same "required check that never reports" failure mode the workflow already
documents in its `all_specs_passed` comment.

For scale, that job on the seven preceding runs:

```text
32084593324  success   54s
32079107463  success  118s
32079105868  success   53s
32069391503  success   53s
32066789035  success   55s
32043608213  success  103s
```

So `timeout-minutes: 5` is generous against a 53-118 second norm while still
failing within the same morning. `Acquire::Retries=3` covers the other half:
retries do nothing for a mirror that hangs, but they do recover a download that
fails outright, which is the more common flavor of archive flake.

Neither setting changes what the job proves. The locale is still generated, the
catalogs still installed, and the "Verify the Locale Took Effect" guard still
diffs localized output against `LC_ALL=C` to prove translation is active rather
than the env vars being inert.

## Validation

- The workflow YAML parses, and the step round-trips with `timeout-minutes: 5`
  and both `Acquire::Retries` flags intact.
- The corrected anchor now matches the same fragment the table of contents uses
  for that heading.
- No `lib/` or `spec/` changes, so the test suite and coverage gate are untouched.

The CI change is self-testing: this PR's own Non-English Locale job exercises the
modified step.

## AI assistance

Per [AI_POLICY.md](../AI_POLICY.md) item 3: this contribution was substantially
AI-assisted (Claude Code), and both commits carry a `Co-Authored-By` trailer.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed. (Not applicable: documentation and CI
  configuration only.)
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)). Unchanged — no
  `lib/` or `spec/` files are touched.
- [x] Documentation updated where applicable (README and/or YARD).
