### PR TITLE
feat(checkout): support the :orphan option in Repository#checkout

### DIFF
--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -41,7 +41,7 @@ module Git
 
       # Option keys accepted by {#checkout}
       #
-      CHECKOUT_ALLOWED_OPTS = %i[force f new_branch b start_point].freeze
+      CHECKOUT_ALLOWED_OPTS = %i[force f new_branch b start_point orphan].freeze
       private_constant :CHECKOUT_ALLOWED_OPTS
 
       # Option keys accepted by {#checkout_index}
@@ -130,6 +130,9 @@ module Git
       # @example Create a new branch with a name different from the start point
       #   repo.checkout('main', new_branch: 'new-feature')
       #
+      # @example Create and check out an unborn branch with no history
+      #   repo.checkout('gh-pages', orphan: true)
+      #
       # @example Force checkout discarding local changes
       #   repo.checkout('main', force: true)
       #
@@ -151,12 +154,24 @@ module Git
       #
       # @option opts [Boolean, nil] :f (nil) alias for `:force`
       #
+      # @option opts [Boolean, String, nil] :orphan (nil) when `true`, creates a
+      #   new unborn branch named `branch` whose first commit has no parents
+      #
+      #   When a `String`, creates an unborn branch with that name, using
+      #   `branch` as the start point for the working tree and index.
+      #
+      #   `false` and `nil` are both treated as unset. A blank branch name is
+      #   rejected rather than ignored.
+      #
       # @option opts [String, nil] :start_point (nil) the commit or branch to
-      #   start the new branch from; used together with `new_branch: true`
+      #   start the new branch from; used together with `new_branch: true` or
+      #   `orphan: true`
       #
       # @return [String] git's stdout from the checkout
       #
       # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [ArgumentError] if `:orphan` is given a blank or missing branch name
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
@@ -680,19 +695,24 @@ module Git
           :unborn
         end
 
-        # Translates legacy checkout options to the new command interface
+        # Translates {#checkout} options to the new command interface
         #
         # Legacy callers passed combinations like:
         #   checkout('branch', new_branch: true, start_point: 'main')
         # which should map to:
         #   checkout('main', b: 'branch')
         #
+        # `orphan: true` follows the same shape, naming the unborn branch:
+        #   checkout('branch', orphan: true, start_point: 'main')
+        # maps to:
+        #   checkout('main', orphan: 'branch')
+        #
         # @param branch [String, nil] the branch argument passed to {#checkout}
         #
         # @param checkout_options [Hash] the raw options passed to {#checkout}
         #
-        # @return [Array] a two-element tuple `[target, options]` containing the
-        #   translated checkout arguments
+        # @return [Array((String, nil), Hash)] a two-element tuple
+        #   `[target, options]` containing the translated checkout arguments
         #
         #   `target` (`String` or `nil`) is the branch or commit to check out.
         #   `options` is a `Hash` of keyword arguments for
@@ -701,13 +721,67 @@ module Git
         # @api private
         #
         def translate_checkout_opts(branch, checkout_options)
+          checkout_options = normalize_orphan_option(checkout_options)
+
           if checkout_options[:new_branch] == true || checkout_options[:b] == true
             [checkout_options[:start_point], checkout_options.except(:new_branch, :b, :start_point).merge(b: branch)]
           elsif checkout_options[:new_branch].is_a?(String)
             [branch, checkout_options.except(:new_branch).merge(b: checkout_options[:new_branch])]
+          elsif checkout_options[:orphan] == true
+            translate_orphan_opts(branch, checkout_options)
           else
             [branch, checkout_options]
           end
+        end
+
+        # Normalizes the `:orphan` option, rejecting names that git would never see
+        #
+        # `:orphan` is a value option on the underlying command, so a literal
+        # `false` would be emitted as `--orphan false` and create a branch named
+        # "false". Flag options such as `:force` already ignore `false`; this
+        # gives `:orphan` the same behavior.
+        #
+        # A blank name is rejected rather than dropped: the argument DSL omits
+        # empty values, so `orphan: ''` would otherwise degrade silently into a
+        # plain checkout.
+        #
+        # @param checkout_options [Hash] the raw options passed to {#checkout}
+        #
+        # @return [Hash] the options with a `false` `:orphan` key removed
+        #
+        # @raise [ArgumentError] if `:orphan` is given a blank branch name
+        #
+        # @api private
+        #
+        def normalize_orphan_option(checkout_options)
+          orphan = checkout_options[:orphan]
+          return checkout_options.except(:orphan) if orphan == false
+          raise ArgumentError, 'orphan requires a non-empty branch name' if orphan.is_a?(String) && orphan.strip.empty?
+
+          checkout_options
+        end
+
+        # Translates `orphan: true` into the command's `:orphan` value option
+        #
+        # `orphan: true` names the unborn branch from the positional argument and
+        # takes its start point from `:start_point`, mirroring `new_branch: true`.
+        #
+        # @param branch [String, nil] the branch argument passed to {#checkout}
+        #
+        # @param checkout_options [Hash] the raw options passed to {#checkout}
+        #
+        # @return [Array((String, nil), Hash)] a two-element tuple
+        #   `[target, options]` containing the translated checkout arguments
+        #
+        # @raise [ArgumentError] if `branch` is blank (`nil`, empty, or whitespace
+        #   only), since the unborn branch would otherwise have no name
+        #
+        # @api private
+        #
+        def translate_orphan_opts(branch, checkout_options)
+          raise ArgumentError, 'orphan: true requires a branch name' if branch.to_s.strip.empty?
+
+          [checkout_options[:start_point], checkout_options.except(:start_point).merge(orphan: branch)]
         end
 
         # Normalizes path specifications for Git commands

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -270,6 +270,74 @@ RSpec.describe Git::Repository::Branching do
       end
     end
 
+    context 'with orphan: true' do
+      subject(:result) { described_instance.checkout('gh-pages', orphan: true) }
+
+      it 'translates to call(nil, orphan: branch)' do
+        expect(checkout_branch_command)
+          .to receive(:call).with(nil, orphan: 'gh-pages').and_return(checkout_branch_result)
+        result
+      end
+    end
+
+    context 'with orphan: true and start_point option' do
+      subject(:result) { described_instance.checkout('gh-pages', orphan: true, start_point: 'main') }
+
+      it 'translates to call(start_point, orphan: branch)' do
+        expect(checkout_branch_command)
+          .to receive(:call).with('main', orphan: 'gh-pages').and_return(checkout_branch_result)
+        result
+      end
+    end
+
+    context 'with orphan: String option' do
+      subject(:result) { described_instance.checkout('main', orphan: 'gh-pages') }
+
+      it 'translates to call(branch, orphan: orphan_branch_name)' do
+        expect(checkout_branch_command)
+          .to receive(:call).with('main', orphan: 'gh-pages').and_return(checkout_branch_result)
+        result
+      end
+    end
+
+    context 'with orphan: false' do
+      subject(:result) { described_instance.checkout('gh-pages', orphan: false) }
+
+      it 'treats the option as unset rather than passing it to the command' do
+        expect(checkout_branch_command).to receive(:call).with('gh-pages').and_return(checkout_branch_result)
+        result
+      end
+    end
+
+    context 'with orphan: true and no branch name' do
+      subject(:result) { described_instance.checkout(orphan: true) }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /orphan: true requires a branch name/)
+      end
+
+      it 'does not call the command' do
+        expect(checkout_branch_command).not_to receive(:call)
+        expect { result }.to raise_error(ArgumentError, /orphan: true requires a branch name/)
+      end
+    end
+
+    context 'with orphan: true and an empty branch name' do
+      subject(:result) { described_instance.checkout('', orphan: true) }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /orphan: true requires a branch name/)
+      end
+    end
+
+    context 'with orphan: an empty String' do
+      subject(:result) { described_instance.checkout('main', orphan: '') }
+
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /orphan requires a non-empty branch name/)
+      end
+    end
+
     context 'with options passed as the first argument' do
       it 'treats the hash as options and delegates without a branch' do
         expect(checkout_branch_command)


### PR DESCRIPTION
# Description

`git checkout --orphan` was already implemented by `Git::Commands::Checkout::Branch`
(`value_option :orphan`), but `Git::Repository#checkout` rejected the `:orphan` key
because it was missing from `CHECKOUT_ALLOWED_OPTS`. Callers who wanted an unborn
branch had to drop down to the execution context:

```ruby
repo.execution_context.command_capturing('checkout', '--orphan', 'gh-pages')
```

This PR exposes the option on the public facade. The shape mirrors the existing
`:new_branch` option, so there is nothing new to learn:

```ruby
repo.checkout('gh-pages', orphan: true)                      # git checkout --orphan gh-pages
repo.checkout('gh-pages', orphan: true, start_point: 'main') # git checkout --orphan gh-pages main
repo.checkout('main', orphan: 'gh-pages')                    # git checkout --orphan gh-pages main
```

As with `new_branch: true`, `orphan: true` names the branch from the positional
argument and takes its start point from `:start_point`; the `String` form names the
branch explicitly and treats the positional argument as the start point.

## Changes

- `CHECKOUT_ALLOWED_OPTS` now includes `:orphan`.
- `Private.translate_checkout_opts` translates `orphan: true` into
  `call(start_point, orphan: branch)`. The `String` form needs no translation and
  falls through to the existing pass-through path.
- `Private.normalize_orphan_option` treats `orphan: false` as unset. `:orphan` is a
  value option, so a literal `false` would otherwise reach git as `--orphan false`
  and create a branch named "false"; flag options such as `:force` already ignore
  `false`, and this gives `:orphan` the same behavior.
- `Private.translate_orphan_opts` raises `ArgumentError` when `orphan: true` is given
  without a branch name, rather than silently degrading to a bare `git checkout`.
- YARD docs for `#checkout` gained an `@option` for `:orphan`, a matching `@example`,
  a note on `:start_point` that it applies to `orphan: true` as well, and an
  `@raise` for the new validation.

## Testing

Three unit tests were added to `spec/unit/git/repository/branching_spec.rb`, one per
call shape, asserting the translated arguments reaching
`Git::Commands::Checkout::Branch#call`.

Integration tests are intentionally omitted per the [Facade Test
Conventions](../.github/skills/facade-test-conventions/SKILL.md) skill: the change is
pure argument pre-processing, and the resulting argv is already covered end-to-end by
the `Checkout::Branch` command specs. The behavior was verified manually against real
git — a repository with an orphan branch reports two root commits under
`git fsck --root` and `git rev-list --max-parents=0 --all`.

A follow-up PR uses this option to replace a `cmd.exe`-incompatible shell-out in
`spec/integration/git/parsers/fsck_spec.rb`.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).

