### PR TITLE
test(fsck): build the second root commit through the public API

### DIFF
--- a/spec/integration/git/parsers/fsck_spec.rb
+++ b/spec/integration/git/parsers/fsck_spec.rb
@@ -59,8 +59,8 @@ RSpec.describe Git::Parsers::Fsck, :integration do
         repo.commit('First root commit')
 
         repo.branch('orphan-branch').checkout
-        `cd #{repo_dir} && git checkout --orphan another-root >/dev/null 2>&1 && \
-git commit --allow-empty -m "Another root" >/dev/null 2>&1`
+        repo.checkout('another-root', orphan: true)
+        repo.commit('Another root', allow_empty: true)
       end
 
       it 'reports root commits' do


### PR DESCRIPTION
# Description

Running the fsck parser integration specs on Windows printed a stray error twice:

```
Git::Parsers::Fsck
  .parse
    with root commits
The system cannot find the path specified.
      reports root commits
The system cannot find the path specified.
      returns root commits as FsckObject with :commit type
```

The `with root commits` setup shelled out with backticks:

```ruby
`cd #{repo_dir} && git checkout --orphan another-root >/dev/null 2>&1 && \
git commit --allow-empty -m "Another root" >/dev/null 2>&1`
```

On Windows those backticks run through `cmd.exe`, which has no `/dev/null`. It treats
it as a path, fails to create it, and writes `The system cannot find the path
specified.` to stderr. The message appeared once per example because `before` runs per
example.

The more interesting consequence: the failed redirect short-circuits the `&&` chain,
so **the orphan commit was never created on Windows at all**. The examples passed
anyway because `git fsck --root` still reports the *first* root commit, so the
assertions were satisfied without the scenario they describe ever being set up.

## Changes

```ruby
repo.checkout('another-root', orphan: true)
repo.commit('Another root', allow_empty: true)
```

No shell is involved, so there is nothing to redirect: the execution context spawns
git directly and captures stdout and stderr internally. `:orphan` is the option added
in #1697 (merged); `repo.commit` already accepted `allow_empty:`.

## Testing

`bundle exec rspec spec/integration/git/parsers/fsck_spec.rb` passes with no stray
output on Windows. The setup now actually produces two root commits on every platform,
confirmed with `git rev-list --max-parents=0 --all`, so the two examples in that
context exercise the scenario they were written for.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).

