### PR TITLE
fix: exclude the .claude/skills symlink and other dev files from the gem

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,7 @@
   - [Testing guidelines](#testing-guidelines)
     - [Test coverage policy](#test-coverage-policy)
     - [Unit tests vs Integration tests](#unit-tests-vs-integration-tests)
+  - [What ships in the gem](#what-ships-in-the-gem)
 - [Building a specific version of the Git command-line](#building-a-specific-version-of-the-git-command-line)
   - [Install pre-requisites](#install-pre-requisites)
   - [Obtain Git source code](#obtain-git-source-code)
@@ -250,6 +251,9 @@ materializes symlinks when `core.symlinks` is enabled (which requires Developer 
 or an elevated shell). Without it, Windows contributors get a plain text file there
 and Claude Code silently loads no skills; either enable symlinks or point your agent
 at [`.github/skills/`](.github/skills/) directly. Copilot is unaffected.
+
+The symlink stays out of the published gem, so it never reaches users — see
+[What ships in the gem](#what-ships-in-the-gem).
 
 ### Agent skills
 
@@ -1136,6 +1140,32 @@ $ bundle exec rspec spec/unit/git/commands/add_spec.rb
 # Run tests with a different version of the git command line:
 $ GIT_PATH=/Users/james/Downloads/git-2.30.2/bin-wrappers bundle exec rake spec
 ```
+
+### What ships in the gem
+
+`spec.files` in [`git.gemspec`](git.gemspec) is an **allowlist**: the released gem
+contains `lib/`, the documents [`.yardopts`](.yardopts) names as extra files, plus
+`UPGRADING.md` and the gemspec itself. Nothing else in the repository is published.
+
+It used to be a denylist, which meant every new path was published by default. That
+shipped `.github/`, `redesign/`, and the Husky hooks to users, and — the reason it
+changed — the `.claude/skills` symlink. Extracting a symlink requires a privilege
+Windows grants only under Developer Mode or an elevated shell, so `gem install git`
+either failed there or, on RubyGems new enough to fall back to a copy, quietly
+duplicated the whole skills tree into the installed gem.
+
+What this means when you add a file:
+
+- **Under `lib/`** — nothing to do; it ships automatically.
+- **A new top-level document** — add it to `doc_files` in the gemspec if users should
+  get it, and to `.yardopts` if rubydoc.info should render it. The two lists are
+  checked against each other, so a file in `.yardopts` but not the gem fails the
+  suite rather than becoming a broken documentation link.
+- **Anything else** — it stays out of the gem, which is almost always what you want.
+
+[`spec/unit/gemspec_spec.rb`](spec/unit/gemspec_spec.rb) enforces all of this: every
+tracked file under `lib/` is present, no symlink is, and nothing outside `lib/` and
+the project root is.
 
 ## Building a specific version of the Git command-line
 

--- a/git.gemspec
+++ b/git.gemspec
@@ -101,8 +101,40 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'yard-lint', '~> 1.8' if install_yard_lint
 
   # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
+  #
+  # This is an allowlist rather than a denylist. A denylist admitted every new
+  # development-only path by default, so the gem shipped `.github/`, `redesign/`, the
+  # husky hooks, and -- the reason this became an allowlist -- the `.claude/skills`
+  # symlink. Extracting a symlink needs a privilege that Windows grants only under
+  # Developer Mode or an elevated shell, so installing the gem there either failed
+  # outright or, on RubyGems new enough to fall back to a copy, silently duplicated
+  # the whole skills tree into the installed gem.
+  #
+  # spec/unit/gemspec_spec.rb guards both directions: nothing in the list may be a
+  # symlink, and every tracked file under lib/ must be present, so the allowlist
+  # cannot quietly drop runtime code.
+  #
+  # doc_files must stay in sync with the extra files named in .yardopts -- those are
+  # what rubydoc.info renders for the published documentation, so a file listed there
+  # but absent from the gem becomes a broken link.
+  doc_files = %w[
+    AI_POLICY.md
+    CHANGELOG.md
+    CODE_OF_CONDUCT.md
+    CONTRIBUTING.md
+    GOVERNANCE.md
+    LICENSE
+    MAINTAINERS.md
+    README.md
+    UPGRADING.md
+  ]
+
+  # .yardopts drives the rubydoc.info build; the gemspec is included by convention.
+  build_files = %w[.yardopts git.gemspec]
+
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(tests|spec|features|bin)/}) }
+    `git ls-files -z`.split("\x0").select do |f|
+      f.start_with?('lib/') || doc_files.include?(f) || build_files.include?(f)
+    end
   end
 end

--- a/spec/unit/gemspec_spec.rb
+++ b/spec/unit/gemspec_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Guards the contents of `spec.files` in git.gemspec.
+#
+# `spec.files` is an allowlist, which trades one failure mode for another: it can no
+# longer admit development-only files by accident, but it can silently omit files the
+# gem needs. These examples cover both sides.
+RSpec.describe 'git.gemspec' do
+  subject(:gemspec) { Gem::Specification.load(File.join(project_root, 'git.gemspec')) }
+
+  let(:project_root) { File.expand_path('../..', __dir__) }
+
+  it 'ships no symlinks' do
+    # Extracting a symlink requires a privilege Windows withholds outside Developer
+    # Mode or an elevated shell, so a symlink in the gem breaks `gem install` there.
+    #
+    # Read the index rather than the working tree: Git for Windows checks symlinks out
+    # as plain text files unless core.symlinks is enabled, so a File.symlink? test
+    # would pass vacuously on the very platform this protects. Each `git ls-files -s`
+    # record is "<mode> <sha> <stage>\t<path>".
+    symlinks = Dir.chdir(project_root) do
+      `git ls-files -s -z`.split("\x0").filter_map do |record|
+        fields, path = record.split("\t", 2)
+        path if fields.split.first == '120000'
+      end
+    end
+
+    expect(symlinks).not_to be_empty, 'expected the repository to contain a symlink to test against'
+    expect(gemspec.files & symlinks).to be_empty
+  end
+
+  it 'ships every tracked file under lib/' do
+    lib_files = Dir.chdir(project_root) { `git ls-files -z -- lib`.split("\x0") }
+
+    expect(lib_files).not_to be_empty
+    expect(gemspec.files).to include(*lib_files)
+  end
+
+  it 'ships every extra file named in .yardopts' do
+    # rubydoc.info renders these from the installed gem, so one missing here is a
+    # broken link in the published documentation. In .yardopts a lone "-" separates
+    # the YARD options from the list of extra files.
+    extra_files = File.readlines(File.join(project_root, '.yardopts'), chomp: true)
+                      .drop_while { |line| line != '-' }
+                      .drop(1)
+                      .reject(&:empty?)
+
+    expect(extra_files).not_to be_empty
+    expect(gemspec.files).to include(*extra_files)
+  end
+
+  it 'ships nothing outside lib/ and the project root' do
+    expect(gemspec.files.reject { |f| f.start_with?('lib/') }).to all(satisfy { |f| !f.include?('/') })
+  end
+end


### PR DESCRIPTION
# Description

`spec.files` in `git.gemspec` rejected only `tests|spec|features|bin`, so every other
tracked path was published by default. That shipped `.claude/skills` — a symlink to
`.github/skills`.

Extracting a symlink requires a privilege Windows grants only under Developer Mode or
an elevated shell, so `gem install git` either failed there or, on RubyGems new enough
to have the `Errno::EACCES` → `FileUtils.cp_r` fallback in
`Gem::Package#create_symlink`, silently duplicated the whole skills tree into the
installed gem.

Note that releases build on `ubuntu-latest`, so only the published gem carries a real
symlink. A gem built on Windows (where `core.symlinks` is typically off) stores it as a
plain 17-byte file and does not reproduce the failure.

## Changes

**`git.gemspec`** — `spec.files` is now an allowlist rather than a denylist: `lib/`,
the documents `.yardopts` names as extra files, `UPGRADING.md`, and the gemspec. Along
with the symlink this drops `.github/`, `redesign/`, the husky hooks, `docker/`,
`tasks/`, `Gemfile`, and `Rakefile`, taking the built gem from **663.5 KB to
346.5 KB** — a 47.8% reduction.

**`spec/unit/gemspec_spec.rb`** (new) — guards both directions of the allowlist, since
an allowlist trades "admits dev files by accident" for "omits needed files silently":

- no file in `spec.files` is a symlink
- every tracked file under `lib/` is present
- every extra file named in `.yardopts` is present, so rubydoc.info does not get broken
  links
- nothing outside `lib/` and the project root ships

The symlink check reads the git index (`mode 120000`) rather than the working tree.
Git for Windows checks symlinks out as plain text files unless `core.symlinks` is
enabled, so a `File.symlink?` test would pass vacuously on the very platform this
protects.

Verified the spec catches the regression: restoring the old denylist fails two examples
and names `.claude/skills` explicitly.

**`CONTRIBUTING.md`** — new "What ships in the gem" section covering what to do when
adding a file under `lib/` versus a new top-level document, plus a TOC entry and a
pointer from the existing `.claude/skills` caveat in "Agent configuration".

The repository layout is unchanged — the symlink stays committed, so contributors and
agents work exactly as before. Only what gets packaged changes.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

