### PR TITLE
fix: run the Git.open bootstrap commands without redirecting stdin

### DIFF
--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'logger'
-require 'open3'
 
 module Git
   # The main public interface for interacting with Git commands
@@ -41,21 +40,14 @@ module Git
     end
 
     def self.binary_version(binary_path)
-      result, status = execute_git_version(binary_path)
-
-      raise "Failed to get git version: #{status}\n#{result}" unless status.success?
-
-      parse_version_string(result)
+      parse_version_string(execute_git_version(binary_path))
     end
 
     private_class_method def self.execute_git_version(binary_path)
-      Open3.capture2e(
-        binary_path,
-        '-c', 'core.quotePath=true',
-        '-c', 'color.ui=false',
-        'version'
-      )
-    rescue Errno::ENOENT
+      bootstrap_command_line(binary_path).run('version', merge: true).stdout
+    rescue Git::CommandLineError => e
+      raise "Failed to get git version: #{e.result.status}\n#{e.result.stdout}"
+    rescue Errno::ENOENT, ProcessExecuter::SpawnError
       raise "Failed to get git version: #{binary_path} not found"
     end
 
@@ -98,26 +90,45 @@ module Git
     def self.root_of_worktree(working_dir)
       raise ArgumentError, "'#{working_dir}' does not exist" unless Dir.exist?(working_dir)
 
-      result, status = execute_rev_parse_toplevel(working_dir)
-      process_rev_parse_result(result, status, working_dir)
+      execute_rev_parse_toplevel(working_dir)
     end
 
     private_class_method def self.execute_rev_parse_toplevel(working_dir)
-      Open3.capture2e(
-        Git::Base.config.binary_path,
-        '-c', 'core.quotePath=true',
-        '-c', 'color.ui=false',
-        'rev-parse', '--show-toplevel',
-        chdir: File.expand_path(working_dir)
-      )
-    rescue Errno::ENOENT
+      bootstrap_command_line(Git::Base.config.binary_path).run(
+        'rev-parse', '--show-toplevel', chdir: File.expand_path(working_dir), merge: true, chomp: true
+      ).stdout
+    rescue Git::CommandLineError
+      raise ArgumentError, "'#{working_dir}' is not in a git working tree"
+    rescue Errno::ENOENT, ProcessExecuter::SpawnError
       raise ArgumentError, 'Failed to find the root of the worktree: git binary not found'
     end
 
-    private_class_method def self.process_rev_parse_result(result, status, working_dir)
-      raise ArgumentError, "'#{working_dir}' is not in a git working tree" unless status.success?
-
-      result.chomp
+    # A command line for the git commands that run before a repository is known
+    #
+    # `Open3` is deliberately not used here. Windows has no fork, so
+    # `Process.spawn` implements a redirect of the child's stdin by redirecting
+    # the *parent's* stdin and restoring it afterward, which replaces the
+    # process's stdin handle. That leaves a console REPL such as irb or pry
+    # unable to read input for the rest of the session. `Git::CommandLine`
+    # redirects only stdout and stderr, so stdin is never disturbed.
+    #
+    # @see https://github.com/ruby-git/ruby-git/issues/840 issue 840
+    #
+    # @param binary_path [String] the path to the git binary to run
+    #
+    # @return [Git::CommandLine] a command line that runs `binary_path` with
+    #   `-c core.quotePath=true -c color.ui=false`
+    #
+    #   Those are the options the `Open3` calls this replaced passed, kept as they were
+    #   so these two commands behave exactly as before. Neither `git version` nor
+    #   `git rev-parse --show-toplevel` emits colored output, so the remaining `color.*`
+    #   settings in {Git::Lib}'s `STATIC_GLOBAL_OPTS` are not needed here.
+    #
+    # @api private
+    #
+    private_class_method def self.bootstrap_command_line(binary_path)
+      Git::CommandLine.new({}, binary_path, ['-c', 'core.quotePath=true', '-c', 'color.ui=false'],
+                           Logger.new(nil))
     end
 
     # (see Git.open)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -11,7 +11,6 @@ require 'process_executer'
 require 'stringio'
 require 'tempfile'
 require 'zlib'
-require 'open3'
 
 module Git
   # Internal git operations


### PR DESCRIPTION
## Summary

Backports the v5.0.0 behavior that resolves issue 840. `Git.open` no longer redirects the
calling process's stdin.

`Git::Base.root_of_worktree` and `Git::Base.binary_version` were the only two places in
the gem that spawned git through `Open3`. `Open3` always redirects the child's stdin, and
Windows has no `fork`, so `Process.spawn` implements that redirect by pointing the
*calling* process's stdin at the pipe and restoring it afterward. The handle the process
held going in does not survive. irb and pry on reline before 0.7.0 cache
`GetStdHandle(STD_INPUT_HANDLE)` when they start and then poll it forever, so after
`Git.open` they poll a dead handle. `WaitForSingleObject` returns `WAIT_FAILED`, the poll
loop cannot tell that from an idle console, and the REPL never reads another keystroke.

Both commands now go through `Git::CommandLine`, which redirects only stdout and stderr,
the same as every other git command in the gem. This mirrors 276cf9cb and 02a75147 in
v5.0.0.

## Changes

`lib/git/base.rb` replaces both `Open3.capture2e` calls with a private
`bootstrap_command_line` helper. The helper builds a `Git::CommandLine` carrying the two
global options the `Open3` calls passed, `-c core.quotePath=true -c color.ui=false`.
`process_rev_parse_result` is gone, because `run(merge: true, chomp: true)` does what it
did. Both rescue clauses now catch `ProcessExecuter::SpawnError` alongside
`Errno::ENOENT`, since that is what ProcessExecuter raises where `Open3` raised
`Errno::ENOENT` directly.

`lib/git/lib.rb` drops the now-unused `require 'open3'`.

That is the whole diff. Two files, 38 insertions, 28 deletions.

Public behavior does not change. Checked by hand on Windows:

- a subdirectory resolves to the worktree root
- a repository path containing spaces still works, which is the issue 757 regression
- a non-repository directory and a missing directory both raise `ArgumentError` with the
  previous messages
- a bogus binary path raises `RuntimeError` with the previous message
- a non-zero `git version` exit still produces
  `Failed to get git version: pid NNNN exit 3\nboom`

## Verification

I reproduced the freeze and confirmed the fix on Ruby 3.4.2 with reline 0.6.0 and irb
1.14.3, which is the reporter's environment. The harness drives irb in a real console and
injects keystrokes with `WriteConsoleInputW`. Each injected line appends to a trace file,
so a frozen REPL shows up as a missing trace entry.

| irb session | Trace |
| --- | --- |
| control, no git call | `BEFORE`, `AFTER` |
| `Git.open`, released v4.4.1 | `BEFORE`, then frozen |
| `Git.open`, this branch with the fix reverted | `BEFORE`, then frozen |
| `Git.open`, this branch | `BEFORE`, version line, `AFTER` |
| `Git.open`, v5.1.0 | `BEFORE`, version line, `AFTER` |

The third row is the one that matters. Same source tree, only this patch differs.

The full suite on Windows with Ruby 4.0.6 runs 551 tests with 2 failures,
`test_conflicts` and `test_do_not_chomp_contents`. Both fail the same way on unmodified
`4.x`, from CRLF handling. RuboCop is clean on both changed files.

## No new regression test, on purpose

Existing tests already cover the refactor on both platforms.
`test_git_binary_version` runs on Windows and Linux and covers success, a binary path
with spaces, and a missing binary, so it exercises `execute_git_version` including the new
`SpawnError` rescue. `test_git_base_root_of_worktree` covers success, spaces, a
non-repository directory, and a missing directory on Linux.

What a new test could add is a guard against someone reintroducing a stdin redirect, and
that guard is now structural. `Git::CommandLine#run` has no `in:` option, `RUN_ARGS`
would reject one, and after this change no `in:` appears anywhere in `lib/`. Bringing the
bug back would mean adding raw `Open3` or `Process.spawn` to a maintenance-only branch,
which is a conspicuous diff, and the comment on `bootstrap_command_line` says why not to.
The alternative costs a Windows-only test built on fiddle plus a C extension development
dependency, and it asserts Ruby's spawn behavior rather than this gem's contract.

## Limitations

1. This fixes the gem's exposure, not the underlying interaction. A bare
   `Process.spawn('git', 'version', in: File::NULL)` freezes the same REPL with no
   ruby-git involved. The hazard belongs to Ruby's Windows spawn implementation and to
   reline caching the console handle. All this PR does is stop `Git.open` from redirecting
   stdin when it has nothing to send.
2. reline 0.7.0 and later are already immune, because reline duplicates its cached handles
   there. Users on newer reline see no change from this PR. The ones it helps are users on
   older reline, which includes everyone on Ruby 3.4.x, since that ships reline 0.6.0.
3. `ProcessExecuter::SpawnError` now appears in a rescue clause in `Git::Base`. If a
   future ProcessExecuter major version renames or moves that class, these two rescues go
   stale and a missing binary raises `SpawnError` instead of the documented `RuntimeError`
   or `ArgumentError`. The gemspec allows `~> 4.0`, and v5 rescues the same class in
   `Git::CommandLine::Base`, so this is no worse than main.
4. Not addressed here. `ProcessExecuter.run_with_capture` hangs on Windows when `chdir:`
   points at a nonexistent directory, observed with 4.0.4. `root_of_worktree` guards with
   `Dir.exist?` before spawning, and v5's `PathResolver` guards the same way, so nothing
   in the gem reaches it. It sits next to the code this PR touches, so it is worth knowing
   about.
5. v5.x still has three stdin-feeding commands, `Git::Commands::CatFile::Batch`,
   `Git::Commands::UpdateRef::Batch`, and `Git::Commands::ShowRef::ExcludeExisting`. All
   three freeze a REPL on reline older than 0.7.0 when called directly. I checked. They
   are `@api private` and unreachable from the public facade today, but they are meant to
   be exposed. For those commands stdin is the protocol, so the redirect cannot come out.
   That is a v5.x design question, not something this branch can address.

Refs: #840

🤖 Generated with [Claude Code](https://claude.com/claude-code)
