### PR TITLE
docs: make command-class policy self-contained in the skills

### DIFF
--- a/.github/skills/command-implementation/REFERENCE.md
+++ b/.github/skills/command-implementation/REFERENCE.md
@@ -411,12 +411,15 @@ adds no behavior and conflicts with the `@!method` directive.
 1. **Input validation the DSL cannot express** — per-argument validation parameters
    (`required:`, `type:`, `allow_nil:`, etc.) and operand format validation belong
    in `arguments do`. Cross-argument constraint methods are generally **not** declared;
-   git validates its own option semantics. The narrow exception is **arguments git
-   cannot observe in its argv**: if an argument is `skip_cli: true` and never
-   reaches git's argv, git cannot detect incompatibilities — use `conflicts` and/or
-   `requires_one_of` in the DSL (e.g., `cat-file --batch` uses both because
-   `:objects` is `skip_cli: true`). Do not raise `ArgumentError` manually for things
-   the DSL can express via a constraint declaration.
+   git validates its own option semantics. There are two narrow exceptions, both
+   defined in
+   [Project Context — Validation Boundaries](../project-context/SKILL.md#validation-boundaries).
+   The one you will actually meet is **arguments git cannot observe in its argv** —
+   `skip_cli: true` operands, `execution_option` entries, anything consumed entirely
+   on the Ruby side. Git cannot detect incompatibilities it never sees, so use
+   `conflicts` and/or `requires_one_of` in the DSL (e.g., `cat-file --batch` uses
+   both because `:object` is `skip_cli: true`). Do not raise `ArgumentError` manually
+   for things the DSL can express via a constraint declaration.
 2. **stdin feeding** — batch protocols (`--batch`, `--batch-check`) via
    `Base#with_stdin`
 3. **Non-trivial option routing** — build different argument sets based on
@@ -469,7 +472,7 @@ an explicit override.
 #   @raise [Git::FailedError] if git exits with a non-zero exit status
 def call(*objects, **options)
   bound = args_definition.bind(*objects, **options)
-  with_stdin(Array(bound.objects).map { |o| "#{o}\n" }.join) do |reader|
+  with_stdin(Array(bound.object).map { |o| "#{o}\n" }.join) do |reader|
     run_batch(bound, reader)
   end
 end
@@ -487,14 +490,27 @@ modeling that contract in the DSL:
 ```ruby
 arguments do
   literal 'cat-file'
-  literal '--batch-check'
+  flag_or_value_option :batch, inline: true
+  flag_or_value_option :batch_check, inline: true
+  flag_or_value_option :batch_command, inline: true
   flag_option :batch_all_objects
-  operand :objects, repeatable: true, skip_cli: true
+  operand :object, repeatable: true, skip_cli: true
 
-  conflicts :objects, :batch_all_objects
-  requires_one_of :objects, :batch_all_objects
+  conflicts :object, :batch_all_objects
+  requires_one_of :object, :batch_all_objects
 end
 ```
+
+All three batch modes live on the one class as `flag_or_value_option` entries, not as
+`literal '--batch-check'` or one subclass per mode — none of them selects the operation,
+so none qualifies as a `literal`. See
+[Do NOT split by output format / output mode](#do-not-split-by-output-format--output-mode).
+The caller picks the mode: `call('HEAD', batch_check: true)`. This mirrors
+`Git::Commands::CatFile::Batch`.
+
+Note which constraints are present. The mode options are git-visible, so "exactly one
+mode must be selected" is left to git; only the argv-invisible `:object` gets a
+constraint.
 
 ### Action-option-with-optional-value commands
 
@@ -583,7 +599,7 @@ Example — batch stdin protocol (as used by `git cat-file --batch`):
 ```ruby
 def call(*, **)
   bound = args_definition.bind(*, **)
-  with_stdin(Array(bound.objects).map { |object| "#{object}\n" }.join) do |stdin_r|
+  with_stdin(Array(bound.object).map { |object| "#{object}\n" }.join) do |stdin_r|
     run_batch(bound, stdin_r)
   end
 end
@@ -659,33 +675,33 @@ the expected inline form (`--option=value`). Check every `value_option` and
 **Constraint declarations are generally not used in command classes.** Do not add
 `conflicts`, `requires`, `requires_one_of`, `requires_exactly_one_of`,
 `forbid_values`, or `allowed_values` declarations to command classes. Git is the
-single source of truth for its own option semantics. There are two narrow exceptions:
+single source of truth for its own option semantics. See
+[Project Context — Validation Boundaries](../project-context/SKILL.md#validation-boundaries)
+for the policy this follows. There are two narrow exceptions:
 
-1. **`skip_cli: true` arguments** — the argument never reaches git's argv, so git
-   cannot detect incompatibilities and constraint declarations are appropriate (see
-   the `cat-file --batch` example above: `:objects` is `skip_cli: true`, so git never
-   sees it and cannot detect the conflict or the absent-both case).
+1. **Arguments with no argv representation** — `skip_cli: true` operands,
+   `execution_option` entries, and anything else consumed entirely on the Ruby side.
+   Git never sees a token for it, so it cannot detect incompatibilities and
+   constraint declarations are appropriate. Two shapes in the tree: the
+   `cat-file --batch` example above, where `:object` is `skip_cli: true`; and
+   `Git::Commands::Archive`, which declares `conflicts :output, :out` because `:out`
+   is an `execution_option` naming a Ruby IO object.
 2. **Git-visible arguments that cause silent data loss** — if a combination of
    git-visible arguments causes git to silently discard data (no error, wrong
    result), a `conflicts` declaration MAY be added with: a code comment explaining
    why, a reference to the git version(s) where the behavior was verified, and a
-   test. As of this writing, no such case has been identified.
-3. **Mode-scoped flags explicitly constrained by the git docs** — if the git
-   documentation explicitly states that a flag only applies to certain modes or
-   option combinations (e.g., `--allow-unknown-type` is documented as "Allow
-   `-s` or `-t` to query broken/corrupt objects of unknown type"), a
-   `requires_one_of :mode_a, :mode_b, when: :flag` declaration is appropriate. Add
-   a DSL comment noting the constraint and a unit test asserting the ArgumentError.
+   test.
 
-   ```ruby
-   # Allow -t and -s to query broken or corrupt objects of unknown type;
-   # rejected by git in any other mode — enforced by constraint below
-   flag_option :allow_unknown_type
-   # ...
-   requires_one_of :t, :s, when: :allow_unknown_type
-   ```
+**One existing deviation, which is not a third exception.**
+`Git::Commands::CatFile::Raw` declares `requires_one_of :t, :s, when: :allow_unknown_type`
+(`lib/git/commands/cat_file/raw.rb:78`). `:allow_unknown_type` is an ordinary
+`flag_option`, so it does reach git's argv and git does reject it in any other mode —
+which is exactly the case the policy above says to delegate. It predates the policy.
 
-See `redesign/3_architecture_implementation.md` Insight 6 for the full policy.
+Do not use it as a template, and do not add mode-scoped constraints for
+git-visible flags on the strength of it. Whether it should be removed is a
+behavior question, not a documentation one: dropping it changes an `ArgumentError`
+into a `Git::FailedError` for callers who pass the invalid combination.
 
 This step is required. A command class that only exposes the options that happen to
 be used today in the `Git::Repository::*` facade is incomplete — callers of the future API should not need

--- a/.github/skills/command-test-conventions/SKILL.md
+++ b/.github/skills/command-test-conventions/SKILL.md
@@ -99,12 +99,14 @@ Unit tests verify CLI argument building and command-layer behavior for each comm
   options, `required:` violations, `type:` mismatches, etc. Command classes generally
   do **not** declare cross-argument constraint methods (`conflicts`, `requires`,
   `requires_one_of`, `requires_exactly_one_of`, `forbid_values`, `allowed_values`,
-  etc.) — git validates its own option semantics. The narrow exception is **arguments
-  git cannot observe in its argv**: if an argument is `skip_cli: true`, it never
-  reaches git's argv and git cannot detect incompatibilities — constraint
-  declarations are appropriate and the resulting `ArgumentError` should be tested.
-  See the validation delegation policy in `redesign/3_architecture_implementation.md`
-  Insight 6.
+  etc.) — git validates its own option semantics. Two narrow exceptions allow a
+  constraint, and a declared constraint of either kind gets an `ArgumentError` test.
+  The first is **arguments git cannot observe in its argv** — `skip_cli: true`
+  operands, `execution_option` entries, anything consumed entirely on the Ruby side.
+  The second is **git-visible combinations that make git silently discard data**, for
+  which the policy requires a test as a condition of adding the constraint at all.
+  See [Project Context — Validation Boundaries](../project-context/SKILL.md#validation-boundaries)
+  for the full policy.
 
 #### Expectations for command invocation
 
@@ -134,10 +136,11 @@ Commands that use `Base#with_stdin` pass an `IO` pipe read end as `in:` to
 assert its content. Use a block form on the `expect` to intercept keyword arguments:
 
 ```ruby
-# Helper defined in the spec file:
-def expect_batch_command(*extra_args, stdin_content: nil, **extra_opts) # rubocop:disable Metrics/AbcSize
+# Helper defined in the spec file. The mode flag is an ordinary option on the class,
+# so it is passed in by the caller rather than baked into the helper:
+def expect_batch_command(*expected_cli_args, stdin_content: nil, **extra_opts)
   expect(execution_context).to receive(:command_capturing) do |*args, **kwargs|
-    expect(args).to eq(['cat-file', '--batch-check', *extra_args])
+    expect(args).to eq(['cat-file', *expected_cli_args])
     expect(kwargs).to include(raise_on_failure: false, **extra_opts)
     expect(kwargs[:in].read).to eq(stdin_content) if stdin_content
     command_result
@@ -146,26 +149,27 @@ end
 
 # Usage:
 it 'passes the object via stdin and runs --batch-check' do
-  expect_batch_command(stdin_content: "HEAD\n")
-  command.call('HEAD')
+  expect_batch_command('--batch-check', stdin_content: "HEAD\n")
+  command.call('HEAD', batch_check: true)
 end
 
 it 'writes each object on its own line to stdin' do
-  expect_batch_command(stdin_content: "HEAD\nv1.0\nabc123\n")
-  command.call('HEAD', 'v1.0', 'abc123')
+  expect_batch_command('--batch-check', stdin_content: "HEAD\nv1.0\nabc123\n")
+  command.call('HEAD', 'v1.0', 'abc123', batch_check: true)
 end
 
 it 'includes --batch-all-objects and writes nothing to stdin' do
-  expect_batch_command('--batch-all-objects', stdin_content: '')
-  command.call(batch_all_objects: true)
+  expect_batch_command('--batch-check', '--batch-all-objects', stdin_content: '')
+  command.call(batch_all_objects: true, batch_check: true)
 end
 
-# git-invisible argument exception: :objects is skip_cli: true, so git never sees
-# it in argv and cannot detect these incompatibilities. Ruby must enforce them.
+# argv-invisible argument exception: :object is skip_cli: true, so it reaches git
+# over stdin and never in argv. Git has no token to detect these incompatibilities
+# with, so Ruby must enforce them.
 # conflicts: can't pass objects AND bypass stdin; requires_one_of: must choose one.
 it 'raises when mutually exclusive DSL inputs are combined' do
-  expect { command.call('HEAD', batch_all_objects: true) }
-    .to raise_error(ArgumentError, /cannot specify :objects and :batch_all_objects/)
+  expect { command.call('HEAD', batch_all_objects: true, batch_check: true) }
+    .to raise_error(ArgumentError, /cannot specify :object and :batch_all_objects/)
 end
 ```
 
@@ -313,10 +317,15 @@ Unit tests are organized under `describe '#call'` with three sections:
    the range raise `FailedError`.
 3. **`context 'input validation'`** — only for commands with validation rules. Covers
    unsupported options and required arguments that raise `ArgumentError`.
-   Cross-argument constraints for git-visible arguments are not tested because
-   command classes do not declare them. The exception is constraints on `skip_cli:
-   true` arguments (e.g., `conflicts :objects, :batch_all_objects` and
-   `requires_one_of :objects, :batch_all_objects`), which should be tested.
+   Cross-argument constraints are usually absent, so there is usually nothing to
+   test here. Test whatever constraints a command *does* declare — both permitted
+   kinds require it:
+
+   - Arguments that never reach git's argv (e.g. `conflicts :object,
+     :batch_all_objects` and `requires_one_of :object, :batch_all_objects` in
+     `cat-file --batch`, or `conflicts :output, :out` in `archive`).
+   - Git-visible combinations that make git silently discard data, for which the
+     policy makes a test a precondition of adding the constraint at all.
 
 The exit code and input validation blocks are optional — include them only when the
 command has those behaviors. They always appear at the end of `#call`, in that order.

--- a/.github/skills/development-workflow/SKILL.md
+++ b/.github/skills/development-workflow/SKILL.md
@@ -304,16 +304,6 @@ based on what was learned during the current task.
   cases, or necessary refactorings, add them to the task list.
 - **Reprioritize if Needed:** Adjust task order if dependencies or priorities have
   changed.
-- **Sync Redesign Tracker (required for command migrations):** If the task adds,
-  migrates, or rewires any `Git::Commands::*` usage, update
-  `redesign/3_architecture_implementation.md` in the same task commit:
-  - mark migrated command checklist entries (`[ ]` → `[x]`)
-  - update Phase 2 migrated count in the Progress Tracker
-  - update "Next Task" to the next unchecked command in list order
-  - ensure command spec paths use `spec/unit/...` or `spec/integration/...` (never
-    stale `spec/git/...` paths)
-  - run a stale-doc sanity check by comparing unchecked `Git::Commands::*` entries
-    against files under `lib/git/commands/`; resolve any mismatches before moving on
 - **Report Progress:** Briefly summarize what was completed and what remains.
   **ALWAYS** print the updated task list with status (e.g., `[x] Task 1`, `[ ] Task
   2`).

--- a/.github/skills/facade-implementation/REFERENCE.md
+++ b/.github/skills/facade-implementation/REFERENCE.md
@@ -104,14 +104,16 @@ organization when more methods join it.
 
 ### Naming a new topic module
 
-Topic modules follow a **two-tier** convention (documented in
-[redesign/3_architecture_implementation.md §Facade module naming convention](../../../redesign/3_architecture_implementation.md#facade-module-naming-convention)):
+Topic modules follow a **three-tier** convention:
 
 - **Gerund** (`verb-ing`) when a single action word clearly names the whole module:
-  `Staging`, `Committing`, `Branching`, `Merging`, `Logging`, `Diffing`, `Stashing`.
+  `Staging`, `Committing`, `Branching`, `Merging`, `Logging`, `Diffing`, `Stashing`,
+  `Inspecting`.
 - **Noun + `Operations`** when the module groups a mixed bag of methods by git
   concept rather than a single action: `RemoteOperations`, `ObjectOperations`,
   `StatusOperations`, `WorktreeOperations`.
+- **Descriptive utility names** for cross-cutting helpers or housekeeping APIs that
+  are not domain-object names: `ContextHelpers`, `Maintenance`.
 
 Additional rules:
 
@@ -325,8 +327,8 @@ end
 
 ## The five facade responsibilities checklist
 
-From [redesign/2_architecture_redesign.md §2.1](../../../redesign/2_architecture_redesign.md).
-For each facade method, confirm whether each responsibility applies and is handled:
+These are the five responsibilities the facade layer is designed around. For each
+facade method, confirm whether each responsibility applies and is handled:
 
 - [ ] **Manage execution context** — calls `Git::Commands::*.new(@execution_context)`,
   never builds CLI argv directly and never bypasses the execution context.
@@ -552,26 +554,37 @@ end
 
 ### Naming rules
 
-**Topic modules** (those `include`d in `Git::Repository`) follow the two-tier
+**Topic modules** (those `include`d in `Git::Repository`) follow the three-tier
 naming convention in [Naming a new topic module](#naming-a-new-topic-module):
-gerund for single-action modules, `Noun + Operations` for mixed-bag modules.
+gerund for single-action modules, `Noun + Operations` for mixed-bag modules, and
+descriptive utility names for cross-cutting helpers and housekeeping APIs.
 
 **Internal helper modules** (those **not** `include`d) use descriptive nouns,
-never generic role-suffixes like `*Helpers`, `*Utils`, or `*Support`. The
-`*Operations` suffix is a topic-module convention — it is not a generic role
-suffix and is not prohibited here:
+never generic role-suffixes like `*Helpers`, `*Utils`, or `*Support`. That
+prohibition applies to internal helpers only — `Git::Repository::ContextHelpers`
+is an `include`d topic module in the third tier above, not a violation of this
+rule. The `*Operations` suffix is likewise a topic-module convention, not a
+generic role suffix, and is not prohibited here:
 
-| Module                                             | Distinguished by                                   |
-| -------------------------------------------------- | -------------------------------------------------- |
-| `Git::Repository::Staging`                         | `include`d, `@api public` (gerund topic module)    |
-| `Git::Repository::Branching`                       | `include`d, `@api public` (gerund topic module)    |
-| `Git::Repository::RemoteOperations`                | `include`d, `@api public` (`*Operations` topic module) |
-| `Git::Repository::SharedPrivate`                   | not `include`d, `@api private`, `private_constant` |
-| `Git::Repository::SharedPrivate::OptionValidation` | nested under `SharedPrivate`, `@api private`       |
+| Module                                             | Distinguished by                                       |
+| -------------------------------------------------- | ------------------------------------------------------ |
+| `Git::Repository::Staging`                         | `include`d (gerund topic module)                        |
+| `Git::Repository::Branching`                       | `include`d (gerund topic module)                        |
+| `Git::Repository::RemoteOperations`                | `include`d (`*Operations` topic module)                 |
+| `Git::Repository::ContextHelpers`                  | `include`d (utility-name topic module)                  |
+| `Git::Repository::SharedPrivate`                   | not `include`d, `private_constant`                      |
+| `Git::Repository::SharedPrivate::OptionValidation` | nested under `SharedPrivate` — hypothetical, see [Growth path](#growth-path) |
+
+**The `@api` tag does not distinguish these.** Every module under
+`lib/git/repository/` carries `@api private` at the module level, topic modules
+included — the namespace itself is not public API even when the methods it
+contributes to `Git::Repository` are. What separates a topic module from an
+internal helper is the `include` line in `lib/git/repository.rb`, and for
+`SharedPrivate` additionally `private_constant`.
 
 Reasons:
 
-- The location (`lib/git/repository/`) plus the `@api` tag and absence of an
+- The location (`lib/git/repository/`) plus the presence or absence of an
   `include` line in `lib/git/repository.rb` already convey API status. A
   `*Helpers` suffix is redundant signage.
 - Symmetry with topic modules keeps the directory listing readable.

--- a/.github/skills/facade-implementation/SKILL.md
+++ b/.github/skills/facade-implementation/SKILL.md
@@ -12,8 +12,8 @@ live in topic modules under `lib/git/repository/<topic>.rb` (e.g.
 A facade method is the public-API entry point that orchestrates one or more
 `Git::Commands::*` calls, optional argument pre-processing, and optional output
 parsing into rich Ruby return values. See
-[redesign/2_architecture_redesign.md §2.1](../../../redesign/2_architecture_redesign.md)
-for the five facade responsibilities this layer is designed around.
+[The five facade responsibilities checklist](REFERENCE.md#the-five-facade-responsibilities-checklist)
+for the responsibilities this layer is designed around.
 
 ## Contents
 
@@ -151,9 +151,11 @@ This skill supports three modes. Determine which mode applies before starting:
      would be awkward to place in any existing module. The deciding factor is
      topic fit, not method count; a single method that is genuinely distinct
      can start its own module.
-   - New module names follow the two-tier convention: gerund (`Staging`, `Logging`,
+   - New module names follow the three-tier convention: gerund (`Staging`, `Logging`,
      `Diffing`) for single-action modules; `Noun + Operations` (`RemoteOperations`,
-     `ObjectOperations`) for mixed-bag modules. See
+     `ObjectOperations`) for mixed-bag modules; descriptive utility names
+     (`ContextHelpers`, `Maintenance`) for cross-cutting helpers and housekeeping
+     APIs. See
      [REFERENCE.md §Naming a new topic module](REFERENCE.md#naming-a-new-topic-module).
 
 3. **For the facade method**, repeat steps 3a–3e:

--- a/.github/skills/pr-readiness-review/SKILL.md
+++ b/.github/skills/pr-readiness-review/SKILL.md
@@ -123,13 +123,8 @@ Execute and report results for:
 
 ## 6. Review Documentation
 
-- [ ] Architecture docs updated if new patterns introduced (redesign/*.md)
-- [ ] If command migration work is included, `redesign/3_architecture_implementation.md`
-  is synchronized (checklist status, Phase 2 count, and "Next Task")
-- [ ] Run a stale-doc audit for command migration docs by comparing unchecked
-  `Git::Commands::*` entries against files in `lib/git/commands/`
-- [ ] Verify command spec references in redesign docs point to `spec/unit/...` or
-  `spec/integration/...` as applicable (not `spec/git/...`)
+- [ ] If a new pattern was introduced, the skill that documents that pattern is
+  updated in the same PR (`.github/skills/`)
 - [ ] README.md updated if public API changed
 - [ ] Examples are clear and demonstrate common use cases
 - [ ] All `@param`, `@return`, `@raise` tags are accurate

--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -66,10 +66,8 @@ coding standard details, or implementation constraints.
 - `spec/unit/` — RSpec unit tests (mocked execution context)
 - `spec/integration/` — RSpec integration tests (real git repositories)
 - `spec/support/` — Shared test contexts and helpers
-- `redesign/` — Architecture redesign documentation
-  - `redesign/3_architecture_implementation.md` is a living migration tracker.
-    When command migrations land, keep checklist states, "Next Task", and Phase 2
-    progress counts synchronized with `lib/git/commands/` and current spec paths.
+- `redesign/` — Record of the completed v5.x architectural redesign. History, not
+  current policy; current standards live in `.github/skills/`
 
 ## Layer Responsibilities
 
@@ -122,14 +120,17 @@ The execution layer (`GIT_EDITOR='true'`) is an unconditional safety net.
 
 ### Validation Boundaries
 
+This section is the authority on what command classes validate and what they delegate
+to git. Skills that need the rule link here.
+
 Command classes use per-argument validation parameters (`required:`, `type:`,
 `allow_nil:`, etc.) and operand format validation. They generally do **not** declare
 cross-argument constraint methods (`conflicts`, `requires`, `requires_one_of`,
-`requires_exactly_one_of`, `forbid_values`, `allowed_values`) — git is the single source of truth for its
-own option semantics. The narrow exception is **arguments git cannot observe in
-its argv**: if an argument is `skip_cli: true`, git never sees it and cannot detect
-incompatibilities — `conflicts` and/or `requires_one_of` are appropriate. Example:
-`cat-file --batch` uses both because `:objects` is `skip_cli: true`:
+`requires_exactly_one_of`, `forbid_values`, `allowed_values`) — git is the single source
+of truth for its own option semantics. There are two narrow exceptions — **arguments
+git cannot observe in its argv**, and **git-visible combinations that make git silently
+discard data** — both spelled out under
+[Exception criteria for constraint declarations](#exception-criteria-for-constraint-declarations).
 
 | Validated by Commands | Mechanism |
 | --- | --- |
@@ -147,10 +148,78 @@ incompatibilities — `conflicts` and/or `requires_one_of` are appropriate. Exam
 | Forbidden value combinations | `Git::FailedError` |
 
 The constraint DSL infrastructure (`conflicts`, `requires`, `requires_one_of`,
-`requires_exactly_one_of`, `forbid_values`, `allowed_values`) remains available in `Git::Commands::Arguments`
-and is used only for `skip_cli: true` argument constraints, and in narrow documented cases for
-git-visible arguments whose combination causes silent data loss (no error, wrong result).
-See `redesign/3_architecture_implementation.md` Insight 6 for the full policy and exception criteria.
+`requires_exactly_one_of`, `forbid_values`, `allowed_values`) remains available in
+`Git::Commands::Arguments` and is kept intact, but command classes reach for it only
+under the exception criteria below.
+
+#### Exception criteria for constraint declarations
+
+The test: **does this argument appear in git's argv?**
+
+- **Yes** (normal `flag_option`, `value_option`, etc.) — git can observe it and report
+  the error, so do not declare a constraint.
+- **No** — the argument is consumed entirely on the Ruby side and has no argv
+  representation at all: `skip_cli: true` operands, `execution_option` entries, and
+  anything else that never becomes a token git can see. Git has no mechanism to detect
+  incompatibilities, so Ruby must enforce them with a constraint declaration.
+
+This is about *presence in argv*, not about transformation. Every DSL entry transforms
+something — `flag_option :force` turns `force: true` into `--force` — and those still
+belong to the **Yes** branch, because `--force` reaches git and git can object to it.
+
+The canonical case is `skip_cli: true` operands routed via stdin. `cat-file --batch`
+commands declare both `conflicts :object, :batch_all_objects` and
+`requires_one_of :object, :batch_all_objects`. `:object` is `skip_cli: true`, so it
+reaches git over stdin rather than in argv — git does receive the object names, but it
+has no argv token to reason about them with, and `--batch-all-objects` makes it discard
+stdin unread. Both failure modes are therefore silent:
+
+| Passed | What git does | Exit |
+| --- | --- | --- |
+| both | ignores stdin, dumps the entire object database | 0 |
+| neither | reads nothing from stdin, emits nothing | 0 |
+
+Neither is an error git can report, so Ruby must enforce those constraints.
+
+The distinction matters when reasoning about a new command: `skip_cli: true` means
+*absent from argv*, not *invisible to git*. A stdin-fed value git still reads is covered
+by this exception because git cannot correlate it with the argv flags, not because git
+never receives it.
+
+`Git::Commands::Archive` is the other shape: it declares `conflicts :output, :out`
+because `:out` is an `execution_option` naming a Ruby IO object to stream into. Only
+`--output` reaches argv, so git cannot see that both were requested.
+
+A secondary exception: if a combination of **git-visible** arguments causes git to
+**silently discard data** (no error, wrong result), a `conflicts` declaration MAY be
+added with a code comment explaining why, a reference to the git version(s) where the
+behavior was verified, and a test.
+
+One command deviates from the argv-visibility rule above (not from this secondary
+exception). `Git::Commands::CatFile::Raw` declares
+`requires_one_of :t, :s, when: :allow_unknown_type` on a git-visible `flag_option`
+that git already rejects in other modes. It predates this policy and is not a
+template — see the note in
+[Command Implementation](../command-implementation/REFERENCE.md#options-completeness--consult-the-latest-version-docs-first).
+
+#### Why the semantic checks are delegated
+
+1. **Git is the single source of truth.** Git validates its own option interactions and
+   reports clear errors via stderr, surfaced as `Git::FailedError`. Ruby-side constraints
+   duplicate that validation and risk going stale — potentially blocking valid usage when
+   git relaxes a restriction in a newer version.
+2. **Partial coverage is worse than none.** Inconsistent constraint coverage creates a
+   false promise of safety: users cannot tell whether the absence of an `ArgumentError`
+   means "this combination is valid" or "this command has no constraints."
+3. **Constraint violations are programming errors.** A developer who passes conflicting
+   options must stop and fix their code either way, so the cost difference between
+   `ArgumentError` and `Git::FailedError` is negligible.
+4. **Uniform error semantics.** Every *semantic* rejection in the delegated table
+   above surfaces the same way — `Git::FailedError` carrying git's actual message —
+   rather than as a mix of Ruby constraint errors and git rejections. The
+   per-argument checks in the first table still raise `ArgumentError`; the split is
+   between "this call is malformed" and "git says no", not between two arbitrary
+   error classes.
 
 ## Coding Standards
 

--- a/.github/skills/review-arguments-dsl/CHECKLIST.md
+++ b/.github/skills/review-arguments-dsl/CHECKLIST.md
@@ -110,7 +110,8 @@ When a parser requires specific output flags (e.g. `--pretty=raw`, `--numstat`),
 declare those flags in the DSL with `flag_option` or `value_option`, and pass them
 explicitly from the `Git::Repository::*` facade. Never hardcode them as `literal` entries inside the
 command class — that hides the parser contract and prevents the facade from choosing
-the format. See Insight 16 in `redesign/3_architecture_implementation.md`.
+the format. See
+[Command Implementation — Do NOT split by output format / output mode](../command-implementation/REFERENCE.md#do-not-split-by-output-format--output-mode).
 
 ## 2. Verify DSL method per option type
 
@@ -751,19 +752,28 @@ not flag the absence of `conflicts`, `requires`, `requires_one_of`,
 `requires_exactly_one_of`, `forbid_values`, or `allowed_values` as a completeness
 issue. Command classes use per-argument validation parameters (`required:`,
 `allow_nil:`, etc.) and operand format validation. Git validates its own option
-semantics. There are two narrow exceptions:
+semantics. The authority for this policy is
+[Project Context — Validation Boundaries](../project-context/SKILL.md#validation-boundaries);
+the summary below must not drift from it. There are two narrow exceptions:
 
 1. **Arguments git cannot observe in its argv** — the test is: does this argument
-   appear in git's argv? If no (e.g., `skip_cli: true` operands routed via stdin),
-   git cannot detect incompatibilities and constraint declarations are appropriate
-   and should not be flagged as policy violations. Example: `cat-file --batch`
-   declares `conflicts :objects, :batch_all_objects` and `requires_one_of :objects,
-   :batch_all_objects` because `:objects` is `skip_cli: true`.
+   appear in git's argv? If no — `skip_cli: true` operands, `execution_option`
+   entries, anything consumed entirely on the Ruby side — git cannot detect
+   incompatibilities and constraint declarations are appropriate and should not be
+   flagged as policy violations. Both shapes are in the tree: `cat-file --batch`
+   declares `conflicts :object, :batch_all_objects` and `requires_one_of :object,
+   :batch_all_objects` because `:object` is `skip_cli: true`; `archive` declares
+   `conflicts :output, :out` because `:out` is an `execution_option`.
 2. **Git-visible arguments that cause silent data loss** — if a combination of
    git-visible arguments causes git to silently discard data (no error, wrong
    result), a `conflicts` declaration MAY be added with: a code comment explaining
    why, a reference to the git version(s) where the behavior was verified, and a
-   test. As of this writing, no such case has been identified.
+   test.
+
+**Known deviation — do not flag it as new.** `Git::Commands::CatFile::Raw` declares
+`requires_one_of :t, :s, when: :allow_unknown_type` on a git-visible `flag_option`
+(`lib/git/commands/cat_file/raw.rb:78`). It predates the policy and is documented as
+such; report it only if the review is specifically about removing it.
 
 ## 7. Check class-level declarations
 

--- a/.github/skills/tdd-refactor-step/SKILL.md
+++ b/.github/skills/tdd-refactor-step/SKILL.md
@@ -88,7 +88,7 @@ the helper after **what** it does, not **how**:
 # Before
 def call(*, **)
   bound = args_definition.bind(*, **)
-  objects = Array(bound.objects).map { |o| "#{o}\n" }.join
+  objects = Array(bound.object).map { |o| "#{o}\n" }.join
   with_stdin(objects) { |r| run_batch(bound, r) }
 end
 
@@ -101,7 +101,7 @@ end
 private
 
 def stdin_content(bound)
-  Array(bound.objects).map { |o| "#{o}\n" }.join
+  Array(bound.object).map { |o| "#{o}\n" }.join
 end
 ```
 

--- a/lib/git/commands/base.rb
+++ b/lib/git/commands/base.rb
@@ -453,7 +453,7 @@ module Git
       #
       # @example Feed bound object names to a git batch command
       #   bound = args_definition.bind(*args, **kwargs)
-      #   stdin_content = Array(bound.objects).map { |object| "#{object}\n" }.join
+      #   stdin_content = Array(bound.object).map { |object| "#{object}\n" }.join
       #   with_stdin(stdin_content) do |reader|
       #     @execution_context.command_capturing('cat-file', '--batch-check', in: reader, raise_on_failure: false)
       #   end


### PR DESCRIPTION
First of four PRs retiring the `redesign/` directory. **Stacked** — merge in order; this one targets `main`.

## Why

Five skills cited `redesign/3_architecture_implementation.md` as *current policy*, using positional references into a plain ordered list with no anchors. "Insight 6" means the sixth `1.`-style item. Insert one item above it and three skills silently point at the wrong policy — and the validation policy is not even the subject of item 6, it sits in the body of an item titled "Use `flag_or_value_option ..., negatable: true`".

Filing that document under `archive/` while it is the authority for how to write a command class would be worse than leaving it alone. So the policy moves into the skills first. No files move in this PR.

## What changed

- **`project-context`** now carries the full validation delegation policy: the argv-visibility exception criteria (the `skip_cli: true` test, the `cat-file --batch` case, the silent-data-loss secondary exception) and the four-point design rationale. It is the single authority the other skills link to.
- **`facade-implementation`** inlines the facade module naming convention, corrected from two tiers to three — `ContextHelpers` and `Maintenance` are neither gerunds nor `*Operations`, and the skill did not say so. The five-responsibilities checklist drops its provenance link; the checklist itself was already complete.
- **`command-implementation`**, **`command-test-conventions`**, **`review-arguments-dsl`** link to the authoritative section instead of an unanchored list position.
- **`development-workflow`** loses the "Sync Redesign Tracker" REPLAN step and **`pr-readiness-review`** loses the four tracker-sync checklist lines. Phase 2 is 100% complete with every checklist item `[x]`; neither step can fire again.

## Four inaccuracies found while lifting the policy

Moving text meant checking it, and the source was wrong in four places. All are fixed here.

- **`:objects` does not exist.** The canonical `cat-file --batch` example named an argument that has been `operand :object` for some time ([cat_file/batch.rb:113](lib/git/commands/cat_file/batch.rb#L113)). It appeared 10 times across four skills, including in an error-message regex a reader would copy into a spec — the real message is `cannot specify :object and :batch_all_objects`. Fixed everywhere, not only in the section this PR makes authoritative.
- **The rationale contradicted its own table.** "All invalid-option errors surface as `Git::FailedError`" sat two paragraphs below a table that keeps unknown-option, required-option, and type failures on `ArgumentError`. Now scoped to the delegated semantic checks.
- **The `@api` column was wrong for every row.** The facade module identification table labeled topic modules `@api public`; every module under `lib/git/repository/` is `@api private` at the module level, `Staging` and `Branching` included. The tag distinguishes nothing — the `include` line in `repository.rb` does. The column is gone and the actual distinguisher is stated.
- **"Two narrow exceptions" listed three.** The third licensed constraints on git-visible flags, which is the exact case the policy delegates to git.

Three smaller ones in the same area:

- **`bound.objects` in two `#call` examples.** Renaming the DSL key was not enough — bound accessors follow the declared name, so both examples would raise `NoMethodError` if copied. The real command uses `bound.object` ([cat_file/batch.rb:323](lib/git/commands/cat_file/batch.rb#L323)).
- **The argv test's negative branch was too wide.** It read "arguments transformed before reaching argv," which describes every DSL entry — `flag_option :force` transforms `force: true` into `--force` — and so read as permission to constrain visible options. It now turns on whether the argument reaches argv at all, with an explicit note that transformation is not the criterion. `Git::Commands::Archive` joins `cat-file --batch` as an example: it constrains `:output` against `:out` because `:out` is an `execution_option` that never becomes a token.
- **`bound.objects` in two more files.** The same pattern is modeled in the `with_stdin` YARD example ([base.rb:456](lib/git/commands/base.rb#L456)) and the tdd-refactor-step skill. Both fixed — comment-only edits. `spec/unit/git/commands/arguments_spec.rb:654` is deliberately left: that example declares its own `operand :objects` inside the block under test, so the accessor is correct there.
- **The authority's own introduction claimed one exception** while the section below documented two. Now names both.
- **The local summary was narrower than the authority it links to.** After the argv test widened to cover every argument with no argv representation, `command-implementation` still scoped its first exception to `skip_cli: true` — which would lead an agent to reject the `conflicts :output, :out` that `Archive` already carries.
- **The review-arguments-dsl checklist restated the exceptions with no link to the authority** — the exact drift this PR exists to prevent. Linked, and it now names the deviation below so a reviewer does not file it as a fresh violation.

## Self-audit findings

Rather than wait for another review round, I audited every claim in the moved content against `lib/`.

**Enumerated all constraint declarations in the tree** to check the policy's claims. There are exactly four:

| Declaration | Classification |
| --- | --- |
| `archive.rb:51` `conflicts :output, :out` | argv-invisible (`:out` is an `execution_option`) |
| `cat_file/batch.rb:115-116` | argv-invisible (`:object` is `skip_cli: true`) |
| `cat_file/raw.rb:78` | the documented deviation |

So "no silent-data-loss case has been identified" holds, and the deviation is genuinely the only one.

**Three more restatements were still narrower than the authority.** After widening the argv test to cover every argument with no argv representation, `command-implementation:414`, `command-test-conventions:102`, and `review-arguments-dsl:759` all still said `skip_cli: true` only — each would lead an agent to reject `conflicts :output, :out`. Fixed, and two gained the missing link to the authority.

**The stdin DSL snippet declared `literal '--batch-check'`.** The real class models all three batch modes as `flag_or_value_option` entries on one class, and [Do NOT split by output format / output mode](.github/skills/command-implementation/REFERENCE.md) forbids literal mode flags a few sections earlier — so the example contradicted both the code and its own document. It now mirrors `Git::Commands::CatFile::Batch`.

**Two modules in the facade tables do not exist.** `Configuring` was listed as a gerund topic module, but `Git::Configuring` lives at `lib/git/configuring.rb`, not under `lib/git/repository/` — so it is not an example of that convention. `SharedPrivate::OptionValidation` is a hypothetical from the growth-path section and is now marked as one instead of sitting unmarked beside real modules.

Also verified and left alone: `validate_unsupported_options!` exists, option-like operand rejection is automatic pre-`--`, `execution_option` is confirmed absent from `to_ary`, and the `ArgumentError` message in the test example matches what the command actually raises.

## One real deviation in the code

That third exception is not only a prose error. [`cat_file/raw.rb:78`](lib/git/commands/cat_file/raw.rb#L78) declares `requires_one_of :t, :s, when: :allow_unknown_type` on an ordinary `flag_option` — git sees it and rejects it in other modes on its own, so the Ruby constraint duplicates git.

This PR documents it as predating the policy and explicitly not a template. It does **not** remove it: dropping the constraint turns an `ArgumentError` into a `Git::FailedError` for anyone passing the invalid combination, which is a behavior decision that does not belong in a docs PR.

## Verification

```
$ grep -rn "redesign/3_architecture_implementation" .github/
.github/skills-deprecated/extract-facade-from-base-lib/SKILL.md:292: ...
```

Only the deprecated-skill hit remains, which PR 4 clears.
