### PR TITLE
ci: add a markdown link checker

### DIFF
--- a/.github/skills-deprecated/extract-command-from-lib/SKILL.md
+++ b/.github/skills-deprecated/extract-command-from-lib/SKILL.md
@@ -17,11 +17,11 @@ class. The git subcommand is determined by the first (or first few) arguments to
 - [Input](#input)
 - [Workflow](#workflow)
   - [Branch setup](#branch-setup)
-  - [Step 1 — Identify the `#command` call](#step-1-identify-the-command-call)
-  - [Step 2 — Plan the migration and get approval](#step-2-plan-the-migration-and-get-approval)
-  - [Step 3 — Ensure adequate legacy tests](#step-3-ensure-adequate-legacy-tests)
-  - [Step 4 — Ensure the `Git::Commands::*` class exists](#step-4-ensure-the-gitcommands-class-exists)
-  - [Step 5 — Update `Git::Lib` to delegate to the command class](#step-5-update-gitlib-to-delegate-to-the-command-class)
+  - [Step 1 — Identify the `#command` call](#step-1--identify-the-command-call)
+  - [Step 2 — Plan the migration and get approval](#step-2--plan-the-migration-and-get-approval)
+  - [Step 3 — Ensure adequate legacy tests](#step-3--ensure-adequate-legacy-tests)
+  - [Step 4 — Ensure the `Git::Commands::*` class exists](#step-4--ensure-the-gitcommands-class-exists)
+  - [Step 5 — Update `Git::Lib` to delegate to the command class](#step-5--update-gitlib-to-delegate-to-the-command-class)
 - [Commit discipline](#commit-discipline)
 - [Create a pull request](#create-a-pull-request)
 - [Quality gates (run at every step)](#quality-gates-run-at-every-step)
@@ -70,7 +70,7 @@ Run or reference these skills during the workflow:
 - [Command Test Conventions](../../skills/command-test-conventions/SKILL.md) — unit/integration test conventions for command classes
 - [Command YARD Documentation](../../skills/command-yard-documentation/SKILL.md) — documentation completeness for command classes
 - [Review Cross-Command Consistency](../../skills/review-cross-command-consistency/SKILL.md) — sibling consistency within a command family
-- [Review Backward Compatibility](../../skills/review-backward-compatibility/SKILL.md) — preserving `Git::Lib` return-value contracts
+- [Review Backward Compatibility](../review-backward-compatibility/SKILL.md) — preserving `Git::Lib` return-value contracts
 - [Extract Facade from Base/Lib](../extract-facade-from-base-lib/SKILL.md) — the
   follow-on extraction that moves the public method from `Git::Base` /
   `Git::Lib` into a `Git::Repository::*` facade method (Phase 4 deletes both

--- a/.github/skills-deprecated/extract-facade-from-base-lib/SKILL.md
+++ b/.github/skills-deprecated/extract-facade-from-base-lib/SKILL.md
@@ -290,7 +290,7 @@ Also state:
   When extracting one method at a time, scan `Git::Base` / `Git::Lib` for
   siblings on the same git topic and check
   `redesign/3_architecture_implementation.md` before deciding — see
-  [One-at-a-time extraction](../../skills/facade-implementation/REFERENCE.md#one-at-a-time-extraction-from-gitbase--gitlib).
+  [Choosing a module for a new facade method](../../skills/facade-implementation/REFERENCE.md#choosing-a-module-for-a-new-facade-method).
 - The delegation strategy for `Git::Base` and/or `Git::Lib` (Step 6) — both
   remain in place during the migration window and delegate to the new facade.
 - For Pattern B: explicit note that `g.lib.foo` callers will need to migrate

--- a/.github/skills-deprecated/review-backward-compatibility/SKILL.md
+++ b/.github/skills-deprecated/review-backward-compatibility/SKILL.md
@@ -46,9 +46,9 @@ Replace `branch` with the specific git command(s) you want to audit (e.g.,
 
 ## Related skills
 
-- [Refactor Command to CommandLineResult](../refactor-command-to-commandlineresult/SKILL.md) — migrating command classes to Base;
+- [Refactor Command to CommandLineResult](../../skills/refactor-command-to-commandlineresult/SKILL.md) — migrating command classes to Base;
   the counterpart to this skill's `Git::Lib` facade focus
-- [Command Implementation](../command-implementation/SKILL.md) — class structure, phased rollout gates, and
+- [Command Implementation](../../skills/command-implementation/SKILL.md) — class structure, phased rollout gates, and
   internal compatibility contracts
 
 ## Objective

--- a/.github/skills/development-workflow/SKILL.md
+++ b/.github/skills/development-workflow/SKILL.md
@@ -372,7 +372,7 @@ commit and complete the feature or bug fix.
      works on all platforms)
    - Then run in the terminal: `git push origin <branch>`
    - Then run in the terminal: `gh pr create --title "<title>" --base <target-branch> --body-file ./pr_body.md`
-     (choose `main` or `4.x` per the [branch strategy](/CONTRIBUTING.md))
+     (choose `main` or `4.x` per the [branch strategy](../../../CONTRIBUTING.md))
 
    After creating the PR, verify the stored body with
    `gh pr view <number> --json body --jq '.body'`. If it is garbled, rewrite

--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -265,7 +265,7 @@ template — see the note in
 
 ## Design Philosophy
 
-See [CONTRIBUTING.md](../../CONTRIBUTING.md) for authoritative, complete guidelines.
+See [CONTRIBUTING.md](../../../CONTRIBUTING.md) for authoritative, complete guidelines.
 
 **Summary:**
 

--- a/.github/skills/pull-request-review/SKILL.md
+++ b/.github/skills/pull-request-review/SKILL.md
@@ -33,7 +33,7 @@ confirms.
    before formal review
 - [CI/CD Troubleshooting](../ci-cd-troubleshooting/SKILL.md) — investigate failed
    checks discovered during review
-- [Review Backward Compatibility](../review-backward-compatibility/SKILL.md) —
+- [Review Backward Compatibility](../../skills-deprecated/review-backward-compatibility/SKILL.md) —
    deeper audit when API compatibility concerns surface
 
 ## Step 1: Fetch the PR

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -50,6 +50,49 @@ jobs:
         run: bundle exec rake rubocop yard
         timeout-minutes: 15
 
+  # Ensure that local links in markdown docs are valid.
+  #
+  # The checker is configured in .lychee.toml. Run the same check locally with:
+  #
+  #     rake markdown:links
+  #
+  links:
+    name: Markdown Links
+
+    # Skip this job if triggered by a release PR
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' && !startsWith(github.event.pull_request.head.ref, 'release-please--'))
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v6
+
+      # Track the newest lychee release rather than pinning one. Without this the
+      # action installs whatever version its own default names, which moves when the
+      # `@v2` tag moves -- pinned, but pinned by someone else and bumped without a
+      # commit here. `latest` at least makes the choice ours and keeps the checker
+      # current. The action accepts `latest`, `nightly`, or an exact tag; there is no
+      # major-version form, and lychee is 0.x, so a "compatible range" is not on offer.
+      #
+      # This can break the build on a release nobody here asked for. .lychee.toml is
+      # coupled to the lychee version -- `include_fragments` took a bare boolean before
+      # 0.24 and an enum string from 0.24 on -- and a future release is free to change
+      # a key again. That trade is deliberate: an occasional known-cause failure is
+      # cheaper than a checker that silently ages.
+      #
+      # When it does break, read the parse error, fix .lychee.toml against the current
+      # lychee docs, and commit that. Pin `lycheeVersion` to the last good tag only to
+      # unblock an unrelated PR, and open an issue to unpin.
+      - name: Check Markdown Links
+        uses: lycheeverse/lychee-action@v2
+        with:
+          lycheeVersion: latest
+          args: --config .lychee.toml .
+          fail: true
+
   build:
     name: Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}
 

--- a/.lychee.toml
+++ b/.lychee.toml
@@ -1,0 +1,29 @@
+# Configuration for lychee, the markdown link checker. See https://lychee.cli.rs.
+
+# Check only what this repository controls. Every link in these files is either a
+# relative path into the repository or an anchor within one of its documents, and
+# both break silently when a file moves or a heading is renamed -- which is exactly
+# what this checker exists to catch.
+#
+# External URLs are deliberately not requested. They fail for reasons that have
+# nothing to do with the commit under test: rate limits, redirects behind a login,
+# and sites that reject datacenter IPs. A gate that goes red on someone else's outage
+# gets ignored, and an ignored gate stops catching the internal breakage it was added
+# for.
+offline = true
+
+# Verify heading anchors, not just file paths. Half the links this repository writes
+# point at a section rather than a whole file, so path-only checking would still let
+# a renamed heading rot unnoticed.
+#
+# This key is version-sensitive: it took a bare boolean before lychee 0.24 and takes
+# one of none/anchor-only/text-only/full from 0.24 on. If this file stops parsing,
+# check the current lychee docs for the accepted form before changing anything else.
+include_fragments = "anchor-only"
+
+no_progress = true
+
+# Include .github, where the agent skills live. Generated and vendored trees --
+# doc/, coverage/, pkg/, node_modules/, tmp/ -- need no exclusions here: lychee honors
+# .gitignore, and every one of them is listed there.
+hidden = true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,6 +98,7 @@ prerequisite is missing.
 | Bundler | Any 2.x or 4.x | Install with `gem install bundler`. |
 | git | `>= 2.28.0` (matches `git.gemspec` `requirements`) | Older git versions are not supported and the test suite will not pass against them. |
 | Node.js / npm | Optional | Required only to install the local Conventional Commit `commit-msg` hook (Husky + commitlint). If npm is missing, `bin/setup` will warn and continue — CI will still validate commit messages. |
+| [lychee](https://lychee.cli.rs) | `>= 0.24.0` | Runs the markdown link check (`rake markdown:links`), which is part of the default task. The floor comes from [`.lychee.toml`](.lychee.toml): older releases cannot parse the enum form of `include_fragments`. Install with `brew install lychee` (macOS), `snap install lychee` (Ubuntu), `pacman -S lychee` (Arch), `winget install --id lycheeverse.lychee` (Windows), or see the [install docs](https://github.com/lycheeverse/lychee#installation). |
 
 #### A note for Windows contributors
 
@@ -130,6 +131,12 @@ bin/setup
    protected branches (`main`, `4.x`).
 4. Verify the toolchain by running `bundle exec rake --tasks`.
 
+`bin/setup` checks for [lychee](https://lychee.cli.rs) alongside Ruby, git, and
+Bundler, and exits non-zero when it is missing or too old. lychee is a Rust binary
+rather than a gem, so `bundle install` cannot supply it and `bin/setup` cannot
+install it for you — but every platform this project supports has a packaged
+build, and the error message names the command for yours.
+
 ### Verify the toolchain
 
 Once `bin/setup` succeeds, confirm the full test and lint suite passes locally:
@@ -138,8 +145,16 @@ Once `bin/setup` succeeds, confirm the full test and lint suite passes locally:
 bundle exec rake
 ```
 
-This is the same default task that runs in CI and is the canonical way to
-validate a change before requesting review.
+This runs everything CI checks — specs, RuboCop, the markdown link check, YARD,
+and the gem build — and is the canonical way to validate a change before
+requesting review.
+
+One caveat on the `links` task: passing locally does not guarantee the CI job
+passes, and the gap is the environment rather than the tool. A link whose
+capitalization is wrong resolves on a case-insensitive filesystem such as macOS and
+404s on the Linux runner, so `](docs/README.MD)` against a file named `README.md`
+looks fine locally and fails in CI. [`tasks/markdown.rake`](tasks/markdown.rake) lists
+this and the other differences. CI remains the authoritative link check.
 
 ### Contributor validation policy
 

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'rake/clean'
 # Load all .rake files from tasks and its subdirectories.
 Dir.glob('tasks/**/*.rake').each { |r| load r }
 
-default_tasks = %i[spec:unit spec:integration rubocop]
+default_tasks = %i[spec:unit spec:integration rubocop markdown:links]
 default_tasks << :yard if Rake::Task.task_defined?(:yard)
 default_tasks << :build
 

--- a/bin/setup
+++ b/bin/setup
@@ -7,6 +7,7 @@
 #   * installs Ruby gem dependencies via Bundler
 #   * installs the optional Node.js tooling used for the Conventional Commit
 #     commit-msg hook (Husky + commitlint)
+#   * verifies that the lychee link checker is installed and new enough
 #   * verifies the toolchain by listing the available rake tasks
 #
 # Run this from the project root after cloning the repository.
@@ -126,6 +127,44 @@ install_npm_tooling() {
   fi
 }
 
+# The minimum lychee version is set by .lychee.toml rather than by this project:
+# `include_fragments` takes an enum string from 0.24 on and took a bare boolean before
+# that, so an older binary cannot parse the config. Checking here turns a confusing TOML
+# parse error during `rake markdown:links` into a clear message. Keep this in sync with
+# the note on `include_fragments` in .lychee.toml.
+REQUIRED_LYCHEE_VERSION="0.24.0"
+
+# lychee is a Rust binary rather than a gem, so bundler cannot supply it and this script
+# cannot install it. It is still required: `rake markdown:links` is part of the default
+# task, and a link check that silently no-ops would make a green `bundle exec rake` mean
+# less than it says. Every platform this project supports has a packaged lychee.
+check_lychee() {
+  local required="$1"
+  if ! command -v lychee >/dev/null 2>&1; then
+    red "ERROR: lychee is not installed or not on PATH."
+    red "       ruby-git requires lychee >= ${required} for 'rake markdown:links',"
+    red "       which runs as part of the default task."
+    red "       Install with one of:"
+    red "         macOS    brew install lychee"
+    red "         Ubuntu   snap install lychee"
+    red "         Arch     pacman -S lychee"
+    red "         Windows  winget install --id lycheeverse.lychee"
+    red "       Others: https://github.com/lycheeverse/lychee#installation"
+    exit 1
+  fi
+
+  local lychee_version
+  # `lychee --version` prints e.g. "lychee 0.24.2".
+  lychee_version=$(lychee --version | awk '{print $2}')
+  if ! version_ge "${lychee_version}" "${required}"; then
+    red "ERROR: lychee ${lychee_version} is too old."
+    red "       ruby-git requires lychee >= ${required}: .lychee.toml uses the enum form"
+    red "       of 'include_fragments', which older releases cannot parse."
+    exit 1
+  fi
+  green "✓ lychee ${lychee_version} (>= ${required})"
+}
+
 verify_toolchain() {
   info ""
   info "Verifying the toolchain (bundle exec rake --tasks)..."
@@ -145,10 +184,11 @@ fi
 REQUIRED_RUBY_VERSION=$(required_ruby_version)
 REQUIRED_GIT_VERSION=$(required_git_version)
 
-info "Checking prerequisites (minimums read from ${GEMSPEC})..."
+info "Checking prerequisites (Ruby and git minimums read from ${GEMSPEC})..."
 check_ruby "${REQUIRED_RUBY_VERSION}"
 check_git "${REQUIRED_GIT_VERSION}"
 check_bundler
+check_lychee "${REQUIRED_LYCHEE_VERSION}"
 
 install_gems
 install_npm_tooling

--- a/redesign/info_object_migration_plan.md
+++ b/redesign/info_object_migration_plan.md
@@ -18,7 +18,7 @@ detailed design for its area.
 - [Issue index](#issue-index)
 - [Versioning and sequencing](#versioning-and-sequencing)
 - [Key decisions](#key-decisions)
-- [Open threads / not yet tracked](#open-threads--not-yet-tracked)
+- [Open threads](#open-threads)
 
 ## Motivation
 

--- a/tasks/markdown.rake
+++ b/tasks/markdown.rake
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+# Markdown link checking with lychee.
+#
+# lychee is a Rust binary rather than a gem, so `bundle install` cannot supply it. It is
+# a required prerequisite all the same -- bin/setup verifies it, and this task fails
+# rather than skipping when it is missing, because `markdown:links` runs as part of the
+# default task and a check that silently no-ops would make a successful
+# `bundle exec rake` mean less than it says. Every platform this project supports has a
+# packaged lychee; see the prerequisites table in CONTRIBUTING.md.
+#
+# A successful run here still does not guarantee a successful CI job, and the gap is
+# the environment rather than the tool:
+#
+#   * Case-sensitive filenames. macOS is case-insensitive by default, Linux is not, so
+#     `](docs/README.MD)` against a file named README.md resolves here and 404s in CI.
+#     Nothing lychee does can close this; the filesystem answers before lychee sees it.
+#     It is also invisible in review, because the link looks correct.
+#   * Empty results. The action sets failIfEmpty, so a .lychee.toml broken badly enough
+#     to match no files fails the job. lychee itself exits 0 in that case, so this task
+#     reports success.
+#   * Untracked files. lychee honors .gitignore, but a file that is merely untracked is
+#     still scanned here, while CI only ever sees what is committed. This is the one
+#     difference that errs toward noise rather than a missed failure.
+
+namespace :markdown do
+  desc 'Check markdown links and heading anchors with lychee'
+  task :links do
+    unless system('command -v lychee > /dev/null 2>&1')
+      abort <<~MESSAGE
+        lychee is not installed or not on PATH, and `rake markdown:links` requires it.
+        Install with one of:
+          macOS    brew install lychee
+          Ubuntu   snap install lychee
+          Arch     pacman -S lychee
+          Windows  winget install --id lycheeverse.lychee
+        Others: https://github.com/lycheeverse/lychee#installation
+        Then re-run `bin/setup` to confirm the version, or `rake markdown:links` directly.
+      MESSAGE
+    end
+
+    abort 'rake markdown:links failed' unless system('lychee', '--config', '.lychee.toml', '.')
+  end
+end


### PR DESCRIPTION
Second of four. **Stacked on #1704** — base is `docs-self-contained-command-policy`, so review only the top commit.

## Why

Nothing in the build reads documentation links. RuboCop reads Ruby, YARD reads doc comments, the specs read code. A relative path into a file that has since moved, and an anchor into a heading that has since been reworded, both stay green forever.

That is not hypothetical. An audit this month found a README section announcing a shipped release in the future tense, stale document paths, and a mis-slugged anchor, some over a year old. PR 4 in this stack rewrites roughly ten inbound references plus six internal links, and I would rather that be verified mechanically than by hand.

## What changed

A `Markdown Links` job running [lychee](https://lychee.cli.rs), configured by `.lychee.toml`. It is a separate job rather than another step in `lint` because it needs no Ruby and no bundle — a broken link should report as a broken link, not as a failure of the job that gates RuboCop.

**It runs offline.** Every link this repository controls is either a relative path or an in-document anchor. External URLs fail for reasons that have nothing to do with the commit under test: rate limits, redirects behind a login, sites that reject datacenter IPs. A gate that goes red on someone else's outage gets ignored, and an ignored gate catches nothing.

Fragments are checked, not just paths — half the links here point at a section, so path-only checking would still let a renamed heading rot.

## The twelve broken links this found

Fixed here so the gate starts green (1203 links checked, 0 errors):

- **5** contents entries in `extract-command-from-lib` that slugged an em-dash heading with one hyphen where GitHub emits two — `#step-1-identify-...` should be `#step-1--identify-...`
- **4** paths into skills that moved between `skills/` and `skills-deprecated/`
- **1** anchor into a `facade-implementation` section that no longer exists
- **1** root-relative `/CONTRIBUTING.md`, which resolves against the site root on GitHub and against nothing at all locally
- **1** contents entry in `redesign/info_object_migration_plan.md` pointing at an anchor for a heading since shortened to "Open threads"

## Running it locally

```bash
brew install lychee   # or: cargo install lychee
lychee --config .lychee.toml .
```
