### PR TITLE
fix: remove the cat-file raw constraint that duplicated a git check

### DIFF
--- a/.github/skills/command-implementation/REFERENCE.md
+++ b/.github/skills/command-implementation/REFERENCE.md
@@ -629,6 +629,30 @@ on an older git installation, git itself will produce its native "unknown option
 error. This is acceptable and expected; the ruby-git library does not gate individual
 options by version.
 
+The same rule applies at the other edge. An option git has retired — whether removed
+outright or kept as an accepted no-op, like `--allow-unknown-type` on git 2.50+ —
+stays in the DSL while any git version in the supported range still honors it; newer
+git reports or ignores it, and the option's comment documents the version split.
+Scaffolding reconciles both endpoints of the range: the latest-version docs are the
+primary authority, and the `Git::MINIMUM_GIT_VERSION` docs (already fetched during
+the [Input](SKILL.md#git-documentation-for-the-git-command) phase) are diffed against
+them — an option the floor docs describe that the latest docs no longer do is
+included with a version-split comment, not omitted. The diff detects the status
+change only; the comment's when-and-how (rejected, hidden but honored, or reduced
+to a no-op, and from which version) must come from the versioned docs, the git
+release notes, or the upstream source. Establishing the `--allow-unknown-type`
+split took `builtin/cat-file.c` and the 2.50 release notes. One case escapes
+the endpoint diff: an option both introduced and retired strictly between the two
+endpoints appears in neither document, and is added when a caller on an affected git
+version reports the gap. When git retires an option out from under an already-shipped
+class, keep it under this rule rather than deleting it. Support is removed
+only when a `Git::MINIMUM_GIT_VERSION` raise leaves the option meaningless across the
+whole range — a floor raise carries an audit for exactly that, and removal follows
+the normal deprecation cadence (deprecate in that major, remove in the next). Both
+edges are one decision: the option surface is the union of the supported git range,
+recorded in
+[ADR-0004](../../../docs/adr/0004-the-option-surface-is-the-union-of-the-supported-git-range.md).
+
 For each option, make one of three decisions:
 
 | Decision | Reason | Action |
@@ -686,7 +710,7 @@ for the policy this follows. There are two narrow exceptions:
    `cat-file --batch` example above, where `:object` is `skip_cli: true`; and
    `Git::Commands::Archive`, which declares `conflicts :output, :out` because `:out`
    is an `execution_option` naming a Ruby IO object.
-2. **Git-visible arguments that cause silent data loss** — if a combination of
+2. **Git-visible arguments that cause silent data loss or a wrong result** — if a combination of
    git-visible arguments causes git to silently discard data or produce a wrong
    result (no error, wrong answer), a constraint declaration MAY be added with: a
    code comment explaining why, a reference to the git version(s) where the

--- a/.github/skills/command-implementation/REFERENCE.md
+++ b/.github/skills/command-implementation/REFERENCE.md
@@ -692,15 +692,18 @@ for the policy this follows. There are two narrow exceptions:
    code comment explaining why, a reference to the git version(s) where the
    behavior was verified, and a test.
 
-**Git accepting a flag and silently ignoring it is NOT the second exception.**
-Git's option parsing is deliberately lenient: mode-scoped flags are accepted in
-every mode and consulted only where they apply, and git even retires flags by
-turning them into accepted no-ops (`--allow-unknown-type` does nothing anywhere on
-git 2.50+). A no-op flag produces no wrong answer, and guarding every ignored
-combination is the partial-coverage trap the delegation policy exists to avoid.
-Delegate it. `Git::Commands::CatFile::Raw` once declared
-`requires_one_of :t, :s, when: :allow_unknown_type` on exactly this basis; the
-constraint was removed and the flag passes through.
+**A flag that is invalid in the selected mode is still not the second exception.**
+Whether git rejects the combination loudly (delegation's normal case — the caller
+gets `Git::FailedError` with git's message) or accepts the flag and silently
+ignores it (a no-op produces no wrong answer), no constraint is warranted, and
+guarding every such combination is the partial-coverage trap the delegation policy
+exists to avoid. `Git::Commands::CatFile::Raw` once declared
+`requires_one_of :t, :s, when: :allow_unknown_type`, duplicating a check git
+2.28-2.49 performs itself (`cat-file` dies with "use with -s or -t" in any other
+mode) and git 2.50 removed along with the whole unknown-type feature, leaving the
+flag an accepted no-op everywhere. The constraint was removed and the flag passes
+through. The decision record for the policy and its exceptions is
+[ADR-0003](../../../docs/adr/0003-validation-of-git-semantics-is-delegated-to-git.md).
 
 This step is required. A command class that only exposes the options that happen to
 be used today in the `Git::Repository::*` facade is incomplete — callers of the future API should not need

--- a/.github/skills/command-implementation/REFERENCE.md
+++ b/.github/skills/command-implementation/REFERENCE.md
@@ -687,21 +687,20 @@ for the policy this follows. There are two narrow exceptions:
    `Git::Commands::Archive`, which declares `conflicts :output, :out` because `:out`
    is an `execution_option` naming a Ruby IO object.
 2. **Git-visible arguments that cause silent data loss** — if a combination of
-   git-visible arguments causes git to silently discard data (no error, wrong
-   result), a `conflicts` declaration MAY be added with: a code comment explaining
-   why, a reference to the git version(s) where the behavior was verified, and a
-   test.
+   git-visible arguments causes git to silently discard data or produce a wrong
+   result (no error, wrong answer), a constraint declaration MAY be added with: a
+   code comment explaining why, a reference to the git version(s) where the
+   behavior was verified, and a test.
 
-**One existing deviation, which is not a third exception.**
-`Git::Commands::CatFile::Raw` declares `requires_one_of :t, :s, when: :allow_unknown_type`
-(`lib/git/commands/cat_file/raw.rb:78`). `:allow_unknown_type` is an ordinary
-`flag_option`, so it does reach git's argv and git does reject it in any other mode —
-which is exactly the case the policy above says to delegate. It predates the policy.
-
-Do not use it as a template, and do not add mode-scoped constraints for
-git-visible flags on the strength of it. Whether it should be removed is a
-behavior question, not a documentation one: dropping it changes an `ArgumentError`
-into a `Git::FailedError` for callers who pass the invalid combination.
+**Git accepting a flag and silently ignoring it is NOT the second exception.**
+Git's option parsing is deliberately lenient: mode-scoped flags are accepted in
+every mode and consulted only where they apply, and git even retires flags by
+turning them into accepted no-ops (`--allow-unknown-type` does nothing anywhere on
+git 2.50+). A no-op flag produces no wrong answer, and guarding every ignored
+combination is the partial-coverage trap the delegation policy exists to avoid.
+Delegate it. `Git::Commands::CatFile::Raw` once declared
+`requires_one_of :t, :s, when: :allow_unknown_type` on exactly this basis; the
+constraint was removed and the flag passes through.
 
 This step is required. A command class that only exposes the options that happen to
 be used today in the `Git::Repository::*` facade is incomplete — callers of the future API should not need

--- a/.github/skills/command-implementation/SKILL.md
+++ b/.github/skills/command-implementation/SKILL.md
@@ -76,8 +76,16 @@ Skip this step when scaffolding a new command (the file does not exist yet).
 - **Minimum-version online command documentation**
 
   Read the **entire** official git documentation online man page for the command for
-  the `Git::MINIMUM_GIT_VERSION` version of git. This will be used only for
-  command-introduction and `requires_git_version` decisions. Fetch this version from
+  the `Git::MINIMUM_GIT_VERSION` version of git. This serves two purposes:
+  command-introduction and `requires_git_version` decisions, and option-surface
+  reconciliation — an option these docs describe that the latest-version docs no
+  longer do stays in the DSL with a version-split comment (see
+  [Options completeness](REFERENCE.md#options-completeness--consult-the-latest-version-docs-first)).
+  The diff only signals that the option's status changed. Before writing the
+  comment, establish when and how — newer git may reject the option, hide it from
+  the docs while still honoring it, or accept it as a no-op — from the versioned
+  docs at intermediate releases, the git release notes, or the upstream source.
+  Fetch this version from
   URL `https://git-scm.com/docs/git-{command}/{version}`.
 
 Do **not** scaffold from local `git <command> -h` output — the installed Git

--- a/.github/skills/command-test-conventions/SKILL.md
+++ b/.github/skills/command-test-conventions/SKILL.md
@@ -103,8 +103,9 @@ Unit tests verify CLI argument building and command-layer behavior for each comm
   constraint, and a declared constraint of either kind gets an `ArgumentError` test.
   The first is **arguments git cannot observe in its argv** — `skip_cli: true`
   operands, `execution_option` entries, anything consumed entirely on the Ruby side.
-  The second is **git-visible combinations that make git silently discard data**, for
-  which the policy requires a test as a condition of adding the constraint at all.
+  The second is **git-visible combinations that make git silently discard data or
+  produce a wrong result**, for which the policy requires a test as a condition of
+  adding the constraint at all.
   See [Project Context — Validation Boundaries](../project-context/SKILL.md#validation-boundaries)
   for the full policy.
 
@@ -324,8 +325,9 @@ Unit tests are organized under `describe '#call'` with three sections:
    - Arguments that never reach git's argv (e.g. `conflicts :object,
      :batch_all_objects` and `requires_one_of :object, :batch_all_objects` in
      `cat-file --batch`, or `conflicts :output, :out` in `archive`).
-   - Git-visible combinations that make git silently discard data, for which the
-     policy makes a test a precondition of adding the constraint at all.
+   - Git-visible combinations that make git silently discard data or produce a
+     wrong result, for which the policy makes a test a precondition of adding the
+     constraint at all.
 
 The exit code and input validation blocks are optional — include them only when the
 command has those behaviors. They always appear at the end of `#call`, in that order.

--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -193,15 +193,15 @@ because `:out` is an `execution_option` naming a Ruby IO object to stream into. 
 `--output` reaches argv, so git cannot see that both were requested.
 
 A secondary exception: if a combination of **git-visible** arguments causes git to
-**silently discard data** (no error, wrong result), a `conflicts` declaration MAY be
-added with a code comment explaining why, a reference to the git version(s) where the
-behavior was verified, and a test.
+**silently discard data** or produce a wrong result (no error, wrong answer), a
+constraint declaration MAY be added with a code comment explaining why, a reference
+to the git version(s) where the behavior was verified, and a test.
 
-One command deviates from the argv-visibility rule above (not from this secondary
-exception). `Git::Commands::CatFile::Raw` declares
-`requires_one_of :t, :s, when: :allow_unknown_type` on a git-visible `flag_option`
-that git already rejects in other modes. It predates this policy and is not a
-template — see the note in
+Git accepting a flag and silently ignoring it in a mode where it does not apply is
+not this exception — that leniency is deliberate git behavior, and a no-op flag
+produces no wrong answer. Delegate it. `Git::Commands::CatFile::Raw` once declared
+`requires_one_of :t, :s, when: :allow_unknown_type` on that basis; the constraint
+was removed and the flag now passes through — see the note in
 [Command Implementation](../command-implementation/REFERENCE.md#options-completeness--consult-the-latest-version-docs-first).
 
 #### Why the semantic checks are delegated

--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -131,7 +131,7 @@ cross-argument constraint methods (`conflicts`, `requires`, `requires_one_of`,
 `requires_exactly_one_of`, `forbid_values`, `allowed_values`) — git is the single source
 of truth for its own option semantics. There are two narrow exceptions — **arguments
 git cannot observe in its argv**, and **git-visible combinations that make git silently
-discard data** — both spelled out under
+discard data or produce a wrong result** — both spelled out under
 [Exception criteria for constraint declarations](#exception-criteria-for-constraint-declarations).
 
 | Validated by Commands | Mechanism |
@@ -193,35 +193,34 @@ because `:out` is an `execution_option` naming a Ruby IO object to stream into. 
 `--output` reaches argv, so git cannot see that both were requested.
 
 A secondary exception: if a combination of **git-visible** arguments causes git to
-**silently discard data** or produce a wrong result (no error, wrong answer), a
+**silently discard data or produce a wrong result** (no error, wrong answer), a
 constraint declaration MAY be added with a code comment explaining why, a reference
 to the git version(s) where the behavior was verified, and a test.
 
-Git accepting a flag and silently ignoring it in a mode where it does not apply is
-not this exception — that leniency is deliberate git behavior, and a no-op flag
-produces no wrong answer. Delegate it. `Git::Commands::CatFile::Raw` once declared
-`requires_one_of :t, :s, when: :allow_unknown_type` on that basis; the constraint
-was removed and the flag now passes through — see the note in
+A flag that is invalid in the selected mode is still not this exception, whether
+git rejects the combination loudly (delegation's normal case) or accepts the flag
+and silently ignores it (a no-op produces no wrong answer). Delegate both.
+`Git::Commands::CatFile::Raw` once declared
+`requires_one_of :t, :s, when: :allow_unknown_type`, duplicating a check git
+2.28-2.49 performs itself and git 2.50 removed along with the unknown-type
+feature; the constraint was removed and the flag now passes through — see the note
+in
 [Command Implementation](../command-implementation/REFERENCE.md#options-completeness--consult-the-latest-version-docs-first).
 
 #### Why the semantic checks are delegated
 
-1. **Git is the single source of truth.** Git validates its own option interactions and
-   reports clear errors via stderr, surfaced as `Git::FailedError`. Ruby-side constraints
-   duplicate that validation and risk going stale — potentially blocking valid usage when
-   git relaxes a restriction in a newer version.
-2. **Partial coverage is worse than none.** Inconsistent constraint coverage creates a
-   false promise of safety: users cannot tell whether the absence of an `ArgumentError`
-   means "this combination is valid" or "this command has no constraints."
-3. **Constraint violations are programming errors.** A developer who passes conflicting
-   options must stop and fix their code either way, so the cost difference between
-   `ArgumentError` and `Git::FailedError` is negligible.
-4. **Uniform error semantics.** Every *semantic* rejection in the delegated table
-   above surfaces the same way — `Git::FailedError` carrying git's actual message —
-   rather than as a mix of Ruby constraint errors and git rejections. The
-   per-argument checks in the first table still raise `ArgumentError`; the split is
-   between "this call is malformed" and "git says no", not between two arbitrary
-   error classes.
+The decision and its rationale are recorded in
+[ADR-0003](../../../docs/adr/0003-validation-of-git-semantics-is-delegated-to-git.md):
+duplicated rules go stale under git's moving semantics, partial coverage creates a
+false promise of safety, and a constraint violation is a programming error the
+developer must fix whichever exception reports it.
+
+The operational consequence: every *semantic* rejection in the delegated table
+above surfaces the same way — `Git::FailedError` carrying git's actual message —
+rather than as a mix of Ruby constraint errors and git rejections. The
+per-argument checks in the first table still raise `ArgumentError`; the split is
+between "this call is malformed" and "git says no", not between two arbitrary
+error classes.
 
 ## Coding Standards
 

--- a/.github/skills/review-arguments-dsl/CHECKLIST.md
+++ b/.github/skills/review-arguments-dsl/CHECKLIST.md
@@ -23,6 +23,7 @@
 - [5. Verify modifiers](#5-verify-modifiers)
   - [`execution_option` usage](#execution_option-usage)
 - [6. Check completeness](#6-check-completeness)
+  - [Option surface spans the supported git range](#option-surface-spans-the-supported-git-range)
   - [YARD documentation ↔ DSL parity](#yard-documentation--dsl-parity)
   - [Repeatable boolean flags](#repeatable-boolean-flags)
   - [Operand naming](#operand-naming)
@@ -621,6 +622,25 @@ The one exception is action-option-with-optional-value commands (see
 
 ## 6. Check completeness
 
+### Option surface spans the supported git range
+
+The latest-version docs are the primary completeness authority, but not the whole
+surface. Per
+[ADR-0004](../../../docs/adr/0004-the-option-surface-is-the-union-of-the-supported-git-range.md),
+the DSL carries the union of the supported git range:
+
+- An option the `Git::MINIMUM_GIT_VERSION` docs describe that the latest docs no
+  longer do belongs in the DSL with a comment noting the version split — flag its
+  absence from a newly scaffolded class, and flag any suggestion to delete it from
+  an existing class while the floor still honors it. Also flag a version-split
+  comment whose claims are not backed by the versioned docs, the git release
+  notes, or the upstream source — the endpoint diff shows that the option's status
+  changed, not when or how (newer git may reject it, hide it while still honoring
+  it, or accept it as a no-op).
+- An option added after the floor needs no per-option version gating; an older git
+  rejects it as an unknown option (see the
+  [`requires_git_version` convention](../command-implementation/REFERENCE.md#requires_git_version-convention)).
+
 ### YARD documentation ↔ DSL parity
 
 Every keyword/positional parameter documented for `call` must correspond to a DSL
@@ -764,16 +784,14 @@ the summary below must not drift from it. There are two narrow exceptions:
    declares `conflicts :object, :batch_all_objects` and `requires_one_of :object,
    :batch_all_objects` because `:object` is `skip_cli: true`; `archive` declares
    `conflicts :output, :out` because `:out` is an `execution_option`.
-2. **Git-visible arguments that cause silent data loss** — if a combination of
-   git-visible arguments causes git to silently discard data (no error, wrong
-   result), a `conflicts` declaration MAY be added with: a code comment explaining
-   why, a reference to the git version(s) where the behavior was verified, and a
-   test.
-
-**Known deviation — do not flag it as new.** `Git::Commands::CatFile::Raw` declares
-`requires_one_of :t, :s, when: :allow_unknown_type` on a git-visible `flag_option`
-(`lib/git/commands/cat_file/raw.rb:78`). It predates the policy and is documented as
-such; report it only if the review is specifically about removing it.
+2. **Git-visible arguments that cause silent data loss or a wrong result** — if a combination of
+   git-visible arguments causes git to silently discard data or produce a wrong
+   result (no error, wrong answer), a constraint declaration MAY be added with: a
+   code comment explaining why, a reference to the git version(s) where the
+   behavior was verified, and a test. A flag git accepts and silently ignores in an
+   inapplicable mode is neither silent data loss nor a wrong result — flag a
+   constraint that guards a merely ignored flag, and flag a constraint claiming
+   this exception without its code comment, verified git version, and spec.
 
 ## 7. Check class-level declarations
 

--- a/.github/skills/review-arguments-dsl/SKILL.md
+++ b/.github/skills/review-arguments-dsl/SKILL.md
@@ -62,8 +62,16 @@ argument → expected git CLI). Coverage completeness is assessed by the
 - **Minimum-version online command documentation**
 
   Read the **entire** official git documentation online man page for the command for
-  the `Git::MINIMUM_GIT_VERSION` version of git. This will be used only for
-  command-introduction and `requires_git_version` decisions. Fetch this version from
+  the `Git::MINIMUM_GIT_VERSION` version of git. This serves two purposes:
+  command-introduction and `requires_git_version` decisions, and option-surface
+  reconciliation — an option these docs describe that the latest-version docs no
+  longer do belongs in the DSL with a version-split comment (see
+  [Option surface spans the supported git range](CHECKLIST.md#option-surface-spans-the-supported-git-range)).
+  The diff only signals that the option's status changed. Before accepting the
+  comment's claims, confirm when and how — newer git may reject the option, hide
+  it from the docs while still honoring it, or accept it as a no-op — against the
+  versioned docs at intermediate releases, the git release notes, or the upstream
+  source. Fetch this version from
   URL `https://git-scm.com/docs/git-{command}/{version}`.
 
 Do **not** scaffold from local `git <command> -h` output alone — the installed Git

--- a/docs/adr/0003-validation-of-git-semantics-is-delegated-to-git.md
+++ b/docs/adr/0003-validation-of-git-semantics-is-delegated-to-git.md
@@ -1,0 +1,36 @@
+# Validation of git semantics is delegated to git
+
+Command classes translate the caller's arguments into argv and run git. They do not
+check whether a combination of git-visible arguments makes sense together. Git answers
+that, and its rejections surface as `Git::FailedError` carrying git's own message.
+
+The rejected alternative was Ruby-side constraint declarations raising `ArgumentError`
+before git runs. The arguments DSL supports them (`conflicts`, `requires_one_of`, and
+the rest), and the earlier, clearer error is a real benefit. It loses to three costs.
+
+Duplicated rules go stale. Git's semantics move under a constraint that snapshots them.
+The case that proved it: `Git::Commands::CatFile::Raw` constrained `--allow-unknown-type`
+to the `-t` and `-s` modes, duplicating a check git 2.28-2.49 performs itself
+(`cat-file` dies with "use with -s or -t" in any other mode). Git 2.50 then retired the
+unknown-type feature, dropped its own check, and kept the flag as an accepted no-op in
+every mode, so the constraint was enforcing a distinction git had erased. PR #1708
+removed it.
+
+Partial coverage is a false promise. Git has more option interactions than any wrapper
+will encode, so a gem that validates some of them teaches callers that the absence of
+an `ArgumentError` means a combination is valid.
+
+A constraint violation is a programming error either way. The developer has to fix the
+call whichever exception reports it, so the earlier error buys little.
+
+Two narrow exceptions exist, both for errors git cannot report. Arguments with no argv
+representation (`skip_cli: true` operands, `execution_option` entries) leave git no
+token to object to, so Ruby must enforce their interactions. And a combination git
+accepts while silently discarding data or producing a wrong answer may be constrained,
+with proof. A flag git accepts and silently ignores is neither exception: that leniency
+is deliberate, git can retire a flag by turning it into a no-op, and guarding ignored
+flags walks straight back into the staleness cost above.
+
+The operational rules, the argv-presence test, and the burden of proof for the second
+exception are normative policy in
+[Project Context - Validation Boundaries](../../.github/skills/project-context/SKILL.md#validation-boundaries).

--- a/docs/adr/0004-the-option-surface-is-the-union-of-the-supported-git-range.md
+++ b/docs/adr/0004-the-option-surface-is-the-union-of-the-supported-git-range.md
@@ -1,0 +1,36 @@
+# The option surface is the union of the supported git range
+
+A command class exposes every option that does something on at least one git version in
+the supported range, from `Git::MINIMUM_GIT_VERSION` to the latest release. Options
+introduced after the floor are included, and options git has retired stay while any
+git in the range still honors them.
+
+Three narrower surfaces were rejected.
+
+Tracking only the latest docs drops options that still work at the floor, abandoning
+callers pinned to an older git inside the range the gem claims to support. Tracking
+only the floor withholds new git features from every caller running a current git. And
+gating individual options with Ruby-side version checks duplicates git's own knowledge
+of its options, which goes stale exactly the way constraints do (ADR-0003). Version
+gating stops at command granularity: `requires_git_version` marks a whole class whose
+command does not exist at the floor, and below that, git speaks for itself.
+
+Delegation is what makes the union rule cheap. At both edges git handles the mismatch:
+a git older than an option rejects it as an unknown option, and a git newer than a
+retired option rejects it or accepts it as a no-op. No Ruby-side version table exists
+to maintain or to trust.
+
+Removal is triggered by the floor, not by git's latest. An option stays while any
+supported git honors it, because a caller pinned to an older git inside the range is
+exactly who the range promise serves. When a major release raises
+`Git::MINIMUM_GIT_VERSION` to or past the version where git retired an option, the
+option is dead across the whole range and enters the normal deprecation cadence. A floor raise
+therefore carries an audit: list the options the new floor kills, deprecate them in
+that major, remove them in the next.
+
+The case that prompted the rule: git 2.50 retired `--allow-unknown-type`, leaving the
+`allow_unknown_type:` option of `Git::Commands::CatFile::Raw` meaningful only below
+2.50. It stays because the floor is 2.28.0. Issue #1709 holds its deprecation trigger.
+
+The scaffolding and audit mechanics live in
+[Command Implementation - Options completeness](../../.github/skills/command-implementation/REFERENCE.md#options-completeness--consult-the-latest-version-docs-first).

--- a/lib/git/commands/cat_file/raw.rb
+++ b/lib/git/commands/cat_file/raw.rb
@@ -49,9 +49,10 @@ module Git
           # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt--s
           flag_option :s
 
-          # Allow -t and -s to query broken or corrupt objects of unknown type;
-          # rejected by git in any other mode — enforced by constraint below
-          # See https://git-scm.com/docs/git-cat-file#Documentation/git-cat-file.txt---allow-unknown-type
+          # Allow -t and -s to query broken or corrupt objects of unknown type.
+          # Git 2.28-2.49 rejects this flag in other modes; git 2.50+ accepts and
+          # ignores it everywhere (the unknown-type feature was removed; see issue 1709).
+          # See https://git-scm.com/docs/git-cat-file/2.49.0#Documentation/git-cat-file.txt---allow-unknown-type
           flag_option :allow_unknown_type
 
           # Map committer/author identities through the mailmap before reporting size
@@ -74,8 +75,6 @@ module Git
 
           # Object name: SHA, ref, `HEAD`, treeish path reference, etc.
           operand :object, required: true
-
-          requires_one_of :t, :s, when: :allow_unknown_type
         end
 
         # Execute `git cat-file` for a single object.
@@ -114,7 +113,8 @@ module Git
         #   @param options [Hash] command options
         #
         #   @option options [Boolean, nil] :allow_unknown_type (nil) allow querying broken or corrupt objects of
-        #     unknown type
+        #     unknown type on git 2.28-2.49; git 2.50 removed the unknown-type feature
+        #     and accepts this flag as a no-op
         #
         #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #
@@ -138,7 +138,8 @@ module Git
         #   @param options [Hash] command options
         #
         #   @option options [Boolean, nil] :allow_unknown_type (nil) allow querying broken or corrupt objects of
-        #     unknown type
+        #     unknown type on git 2.28-2.49; git 2.50 removed the unknown-type feature
+        #     and accepts this flag as a no-op
         #
         #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #

--- a/spec/unit/git/commands/cat_file/raw_spec.rb
+++ b/spec/unit/git/commands/cat_file/raw_spec.rb
@@ -81,6 +81,13 @@ RSpec.describe Git::Commands::CatFile::Raw do
 
         command.call('HEAD', t: true, allow_unknown_type: true)
       end
+
+      it 'passes --allow-unknown-type through in other modes and lets git respond' do
+        expect_command_capturing('cat-file', '-e', '--allow-unknown-type', '--', 'HEAD')
+          .and_return(command_result(''))
+
+        command.call('HEAD', e: true, allow_unknown_type: true)
+      end
     end
 
     context 'with out: execution option (streaming)' do
@@ -138,11 +145,6 @@ RSpec.describe Git::Commands::CatFile::Raw do
 
       it 'raises ArgumentError when the required object argument is missing' do
         expect { command.call }.to raise_error(ArgumentError, /object is required/)
-      end
-
-      it 'raises ArgumentError when allow_unknown_type is used without -t or -s' do
-        expect { command.call('HEAD', e: true, allow_unknown_type: true) }
-          .to raise_error(ArgumentError, /:allow_unknown_type requires/)
       end
     end
   end


### PR DESCRIPTION
## Summary

Resolves the open question from the PR 1704 review rounds: whether the `requires_one_of :t, :s, when: :allow_unknown_type` constraint in `Git::Commands::CatFile::Raw` should be removed as a violation of the validation delegation policy. Answer: remove it. It duplicated a check git performs itself, then outlived that check.

## The finding

Verified against upstream `builtin/cat-file.c` at v2.49.0 and empirically on git 2.55.0 (including against a hand-written unknown-type loose object):

| Git version | `--allow-unknown-type` outside `-t`/`-s` | With `-t`/`-s` |
| --- | --- | --- |
| 2.28–2.49 | rejected loudly: `die("git cat-file --allow-unknown-type: use with -s or -t")` | works as documented |
| 2.50+ | accepted, silently ignored | also ignored — [git 2.50 retired the unknown-type feature](https://github.blog/open-source/git/highlights-from-git-2-50/); the flag is an accepted no-op everywhere and gone from the man page |

So on the older supported range the constraint duplicated git's own validation — the textbook case the delegation policy exists for — and on modern git it enforced a mode distinction git has erased. No combination in either era produces a silently wrong answer.

## The change

- **The constraint is removed and the flag passes through.** On git 2.28–2.49 the invalid combination fails loudly as `Git::FailedError` carrying git's message; on git 2.50+ it succeeds and the flag does nothing, matching git. Calls that raised `ArgumentError` no longer do — a relaxation, not a break. The spec that asserted the `ArgumentError` now asserts pass-through, and the flag's comment documents the version split.
- **The policy's second exception stays scoped to silent data loss and wrong results.** The skills that state the policy (`project-context` is the authority) now record the boundary this settled: a flag that is invalid in the selected mode earns no constraint whether git rejects it loudly or silently ignores it. The review checklist flags any future constraint that guards a merely ignored flag.
- With this, no command class deviates from the validation delegation policy.
- **ADR-0003 records the delegation policy's rationale** (second commit). The why previously lived only inside the `project-context` skill and was rewritten twice in one day as this question was argued out; per the repo's artifact boundaries a why that is decided once belongs in `docs/adr/`, with the cat-file constraint's rise and fall as the worked example. The skill keeps the operational rules and cites the ADR.

- **ADR-0004 records the option surface rule** (third commit), which the review of this change surfaced: a command class exposes the union of options meaningful anywhere in the supported git range. The options-completeness skill already stated the newer-than-floor edge; it now states the retired-option edge, the floor-raise removal trigger, and cites the ADR.

The option's longer-term future — git retired the feature it maps to — is deliberately out of scope here and tracked in #1709, which now states its own removal trigger per ADR-0004.

## Verification

- `bundle exec rspec spec/unit/git/commands/cat_file/raw_spec.rb`: 17 examples, 0 failures; RuboCop clean; full unit suite green with 100% line and branch coverage.
- `bundle exec rake markdown:links`: 0 errors, including the new ADR cross-references in both directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
