### PR TITLE
docs: state each policy definition once and link everywhere else

### DIFF
--- a/.github/skills/command-implementation/REFERENCE.md
+++ b/.github/skills/command-implementation/REFERENCE.md
@@ -411,15 +411,15 @@ adds no behavior and conflicts with the `@!method` directive.
 1. **Input validation the DSL cannot express** — per-argument validation parameters
    (`required:`, `type:`, `allow_nil:`, etc.) and operand format validation belong
    in `arguments do`. Cross-argument constraint methods are generally **not** declared;
-   git validates its own option semantics. There are two narrow exceptions, both
-   defined in
-   [Project Context — Validation Boundaries](../project-context/SKILL.md#validation-boundaries).
-   The one you will actually meet is **arguments git cannot observe in its argv** —
-   `skip_cli: true` operands, `execution_option` entries, anything consumed entirely
-   on the Ruby side. Git cannot detect incompatibilities it never sees, so use
-   `conflicts` and/or `requires_one_of` in the DSL (e.g., `cat-file --batch` uses
-   both because `:object` is `skip_cli: true`). Do not raise `ArgumentError` manually
-   for things the DSL can express via a constraint declaration.
+   git validates its own option semantics. The two narrow exceptions are defined in
+   [Project Context — Exception criteria for constraint declarations](../project-context/SKILL.md#exception-criteria-for-constraint-declarations);
+   the one you will actually meet is the
+   [argv-invisible exception](../project-context/SKILL.md#the-argv-invisible-exception)
+   (e.g., `cat-file --batch` declares both `conflicts` and `requires_one_of` because
+   `:object` is `skip_cli: true`). When a constraint is warranted under the linked
+   criteria (each exception states whether it requires or merely permits one),
+   express it as a constraint declaration in the DSL — do not raise `ArgumentError`
+   manually for things the DSL can express via a constraint declaration.
 2. **stdin feeding** — batch protocols (`--batch`, `--batch-check`) via
    `Base#with_stdin`
 3. **Non-trivial option routing** — build different argument sets based on
@@ -611,6 +611,12 @@ end
 [Input](SKILL.md#git-documentation-for-the-git-command) phase and enumerate every
 option the latest-version docs describe.
 
+This section is the authority on the option-surface policy (the union of the
+supported git range). Because multiple skills depend on it by link, editing it
+changes their meaning without touching their files — after edits, rerun
+`bundle exec rake markdown:links` and audit the linking skills with the
+[Reviewing Skills](../reviewing-skills/SKILL.md) skill.
+
 ### `requires_git_version` convention
 
 `requires_git_version` is a **class-level** declaration only. Individual options do
@@ -698,35 +704,21 @@ the expected inline form (`--option=value`). Check every `value_option` and
 
 **Constraint declarations are generally not used in command classes.** Do not add
 `conflicts`, `requires`, `requires_one_of`, `requires_exactly_one_of`,
-`forbid_values`, or `allowed_values` declarations to command classes. Git is the
-single source of truth for its own option semantics. See
-[Project Context — Validation Boundaries](../project-context/SKILL.md#validation-boundaries)
-for the policy this follows. There are two narrow exceptions:
-
-1. **Arguments with no argv representation** — `skip_cli: true` operands,
-   `execution_option` entries, and anything else consumed entirely on the Ruby side.
-   Git never sees a token for it, so it cannot detect incompatibilities and
-   constraint declarations are appropriate. Two shapes in the tree: the
-   `cat-file --batch` example above, where `:object` is `skip_cli: true`; and
-   `Git::Commands::Archive`, which declares `conflicts :output, :out` because `:out`
-   is an `execution_option` naming a Ruby IO object.
-2. **Git-visible arguments that cause silent data loss or a wrong result** — if a combination of
-   git-visible arguments causes git to silently discard data or produce a wrong
-   result (no error, wrong answer), a constraint declaration MAY be added with: a
-   code comment explaining why, a reference to the git version(s) where the
-   behavior was verified, and a test.
-
-**A flag that is invalid in the selected mode is still not the second exception.**
-Whether git rejects the combination loudly (delegation's normal case — the caller
-gets `Git::FailedError` with git's message) or accepts the flag and silently
-ignores it (a no-op produces no wrong answer), no constraint is warranted, and
-guarding every such combination is the partial-coverage trap the delegation policy
-exists to avoid. `Git::Commands::CatFile::Raw` once declared
-`requires_one_of :t, :s, when: :allow_unknown_type`, duplicating a check git
-2.28-2.49 performs itself (`cat-file` dies with "use with -s or -t" in any other
-mode) and git 2.50 removed along with the whole unknown-type feature, leaving the
-flag an accepted no-op everywhere. The constraint was removed and the flag passes
-through. The decision record for the policy and its exceptions is
+`forbid_values`, or `allowed_values` declarations to command classes — git is the
+single source of truth for its own option semantics. The two narrow exceptions,
+and what claiming each of them requires, are defined in
+[Project Context — Exception criteria for constraint declarations](../project-context/SKILL.md#exception-criteria-for-constraint-declarations).
+The scaffolding consequences: whenever the DSL contains a `skip_cli: true` operand
+(like `:object` in the `cat-file --batch` example above) or an `execution_option`
+entry, consult the exception criteria before deciding the class needs no
+constraints — the
+[argv-invisible exception](../project-context/SKILL.md#the-argv-invisible-exception)
+is the usual reason one is warranted. Conversely, do **not** add a constraint for
+a flag that is merely invalid in the selected mode — whether git rejects the
+combination loudly or accepts the flag as an ignored no-op, delegate it; the
+[silent-wrong-result exception](../project-context/SKILL.md#the-silent-wrong-result-exception)
+does not cover it. The worked example of removing exactly such a constraint
+(`CatFile::Raw` and `--allow-unknown-type`) is in
 [ADR-0003](../../../docs/adr/0003-validation-of-git-semantics-is-delegated-to-git.md).
 
 This step is required. A command class that only exposes the options that happen to

--- a/.github/skills/command-implementation/SKILL.md
+++ b/.github/skills/command-implementation/SKILL.md
@@ -16,6 +16,7 @@ integration tests, and YARD docs.
   - [Command source code](#command-source-code)
   - [Command test code](#command-test-code)
   - [Git documentation for the git command](#git-documentation-for-the-git-command)
+  - [Policy authorities](#policy-authorities)
 - [Reference](#reference)
 - [Workflow](#workflow)
 - [Output](#output)
@@ -78,19 +79,31 @@ Skip this step when scaffolding a new command (the file does not exist yet).
   Read the **entire** official git documentation online man page for the command for
   the `Git::MINIMUM_GIT_VERSION` version of git. This serves two purposes:
   command-introduction and `requires_git_version` decisions, and option-surface
-  reconciliation — an option these docs describe that the latest-version docs no
-  longer do stays in the DSL with a version-split comment (see
-  [Options completeness](REFERENCE.md#options-completeness--consult-the-latest-version-docs-first)).
-  The diff only signals that the option's status changed. Before writing the
-  comment, establish when and how — newer git may reject the option, hide it from
-  the docs while still honoring it, or accept it as a no-op — from the versioned
-  docs at intermediate releases, the git release notes, or the upstream source.
+  reconciliation. Diff these docs against the latest-version docs; an option they
+  describe that the latest-version docs no longer describe stays in the DSL with a
+  version-split comment, and before writing that comment, establish its
+  when-and-how claims from the versioned docs at intermediate releases, the git
+  release notes, or the upstream source. What the endpoint diff can and cannot
+  establish is defined in
+  [Options completeness](REFERENCE.md#options-completeness--consult-the-latest-version-docs-first).
   Fetch this version from
   URL `https://git-scm.com/docs/git-{command}/{version}`.
 
 Do **not** scaffold from local `git <command> -h` output — the installed Git
 version is unknown and may differ from the latest supported version. Local help should
 NOT be used even as a supplemental check.
+
+### Policy authorities
+
+Read
+[Project Context — Validation Boundaries](../project-context/SKILL.md#validation-boundaries),
+including its
+[exception criteria for constraint declarations](../project-context/SKILL.md#exception-criteria-for-constraint-declarations),
+and
+[Options completeness — consult the latest-version docs first](REFERENCE.md#options-completeness--consult-the-latest-version-docs-first).
+The Input phase above and the workflow reference these policies by link; load
+both authorities now so option-surface reconciliation and constraint decisions
+are made with the criteria in context, not from memory.
 
 ## Reference
 

--- a/.github/skills/command-test-conventions/SKILL.md
+++ b/.github/skills/command-test-conventions/SKILL.md
@@ -99,15 +99,9 @@ Unit tests verify CLI argument building and command-layer behavior for each comm
   options, `required:` violations, `type:` mismatches, etc. Command classes generally
   do **not** declare cross-argument constraint methods (`conflicts`, `requires`,
   `requires_one_of`, `requires_exactly_one_of`, `forbid_values`, `allowed_values`,
-  etc.) — git validates its own option semantics. Two narrow exceptions allow a
-  constraint, and a declared constraint of either kind gets an `ArgumentError` test.
-  The first is **arguments git cannot observe in its argv** — `skip_cli: true`
-  operands, `execution_option` entries, anything consumed entirely on the Ruby side.
-  The second is **git-visible combinations that make git silently discard data or
-  produce a wrong result**, for which the policy requires a test as a condition of
-  adding the constraint at all.
-  See [Project Context — Validation Boundaries](../project-context/SKILL.md#validation-boundaries)
-  for the full policy.
+  etc.) — git validates its own option semantics. Every constraint a command *does*
+  declare gets an `ArgumentError` test. What makes a constraint permitted is defined in
+  [Project Context — Validation Boundaries](../project-context/SKILL.md#validation-boundaries).
 
 #### Expectations for command invocation
 
@@ -319,15 +313,11 @@ Unit tests are organized under `describe '#call'` with three sections:
 3. **`context 'input validation'`** — only for commands with validation rules. Covers
    unsupported options and required arguments that raise `ArgumentError`.
    Cross-argument constraints are usually absent, so there is usually nothing to
-   test here. Test whatever constraints a command *does* declare — both permitted
-   kinds require it:
-
-   - Arguments that never reach git's argv (e.g. `conflicts :object,
-     :batch_all_objects` and `requires_one_of :object, :batch_all_objects` in
-     `cat-file --batch`, or `conflicts :output, :out` in `archive`).
-   - Git-visible combinations that make git silently discard data or produce a
-     wrong result, for which the policy makes a test a precondition of adding the
-     constraint at all.
+   test here. Test whatever constraints a command *does* declare (e.g.
+   `conflicts :object, :batch_all_objects` and `requires_one_of :object,
+   :batch_all_objects` in `cat-file --batch`, or `conflicts :output, :out` in
+   `archive`) — what makes a constraint permitted is defined in
+   [Project Context — Validation Boundaries](../project-context/SKILL.md#validation-boundaries).
 
 The exit code and input validation blocks are optional — include them only when the
 command has those behaviors. They always appear at the end of `#call`, in that order.

--- a/.github/skills/make-skill-template/SKILL.md
+++ b/.github/skills/make-skill-template/SKILL.md
@@ -129,6 +129,15 @@ examples with consistent labels.
 Define named thresholds, modes, phases, or terms before first use, and keep one
 authoritative definition for each concept.
 
+State each policy definition (what the policy is, its exceptions, their criteria)
+once, in a single designated authority section, and link to that authority by
+anchor from every other skill or section that needs the policy. Keep role-specific
+operational instructions (what to do, flag, or test) inline in the document whose
+role they serve. Restated definitions silently rot when the authority changes,
+while a link cannot drift and an instruction stated in only one place cannot
+drift. A reader executing a workflow or checklist must never need the linked
+definition to perform an action — they follow the link only to understand why.
+
 Use real markdown headings for durable rule sections. Avoid bold paragraphs as
 pseudo-headings when the section may need a table-of-contents entry, deep link,
 or review reference.
@@ -207,6 +216,8 @@ my-awesome-skill/
 - [ ] Always-needed workflow and review rules remain in `SKILL.md`
 - [ ] Situational details are split into reference files with clear load conditions
 - [ ] Named thresholds, modes, phases, or terms are defined before first use
+- [ ] Policy definitions are stated once in a designated authority section and
+      linked from everywhere else; role-specific instructions stay inline
 - [ ] Standards/review rules are mandatory unless explicitly marked `Optional`
 - [ ] Deep links, TOC anchors, and referenced files resolve after heading changes
 - [ ] Bundled assets are under 5MB each

--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -123,15 +123,16 @@ The execution layer (`GIT_EDITOR='true'`) is an unconditional safety net.
 ### Validation Boundaries
 
 This section is the authority on what command classes validate and what they delegate
-to git. Skills that need the rule link here.
+to git. Skills that need the rule link here. Because multiple skills depend on this
+section by link, editing it changes their meaning without touching their files —
+after edits, rerun `bundle exec rake markdown:links` and audit the linking skills
+with the [Reviewing Skills](../reviewing-skills/SKILL.md) skill.
 
 Command classes use per-argument validation parameters (`required:`, `type:`,
 `allow_nil:`, etc.) and operand format validation. They generally do **not** declare
 cross-argument constraint methods (`conflicts`, `requires`, `requires_one_of`,
 `requires_exactly_one_of`, `forbid_values`, `allowed_values`) — git is the single source
-of truth for its own option semantics. There are two narrow exceptions — **arguments
-git cannot observe in its argv**, and **git-visible combinations that make git silently
-discard data or produce a wrong result** — both spelled out under
+of truth for its own option semantics, subject only to the two exceptions defined under
 [Exception criteria for constraint declarations](#exception-criteria-for-constraint-declarations).
 
 | Validated by Commands | Mechanism |
@@ -155,6 +156,13 @@ The constraint DSL infrastructure (`conflicts`, `requires`, `requires_one_of`,
 under the exception criteria below.
 
 #### Exception criteria for constraint declarations
+
+Two exceptions, each defined in its own subsection below, permit a constraint
+declaration: the [argv-invisible exception](#the-argv-invisible-exception) and the
+[silent-wrong-result exception](#the-silent-wrong-result-exception). Skills that
+reference an individual exception link to it by these names and anchors.
+
+##### The argv-invisible exception
 
 The test: **does this argument appear in git's argv?**
 
@@ -192,7 +200,9 @@ never receives it.
 because `:out` is an `execution_option` naming a Ruby IO object to stream into. Only
 `--output` reaches argv, so git cannot see that both were requested.
 
-A secondary exception: if a combination of **git-visible** arguments causes git to
+##### The silent-wrong-result exception
+
+If a combination of **git-visible** arguments causes git to
 **silently discard data or produce a wrong result** (no error, wrong answer), a
 constraint declaration MAY be added with a code comment explaining why, a reference
 to the git version(s) where the behavior was verified, and a test.

--- a/.github/skills/review-arguments-dsl/CHECKLIST.md
+++ b/.github/skills/review-arguments-dsl/CHECKLIST.md
@@ -625,18 +625,17 @@ The one exception is action-option-with-optional-value commands (see
 ### Option surface spans the supported git range
 
 The latest-version docs are the primary completeness authority, but not the whole
-surface. Per
-[ADR-0004](../../../docs/adr/0004-the-option-surface-is-the-union-of-the-supported-git-range.md),
-the DSL carries the union of the supported git range:
+surface. The option-surface rule, its scaffolding mechanics, and what the endpoint
+diff can and cannot establish are defined in
+[Options completeness — consult the latest-version docs first](../command-implementation/REFERENCE.md#options-completeness--consult-the-latest-version-docs-first).
+Review flags:
 
 - An option the `Git::MINIMUM_GIT_VERSION` docs describe that the latest docs no
-  longer do belongs in the DSL with a comment noting the version split — flag its
+  longer describe belongs in the DSL with a comment noting the version split — flag its
   absence from a newly scaffolded class, and flag any suggestion to delete it from
-  an existing class while the floor still honors it. Also flag a version-split
-  comment whose claims are not backed by the versioned docs, the git release
-  notes, or the upstream source — the endpoint diff shows that the option's status
-  changed, not when or how (newer git may reject it, hide it while still honoring
-  it, or accept it as a no-op).
+  an existing class while the floor still honors it.
+- Flag a version-split comment whose when-and-how claims are not backed by the
+  versioned docs, the git release notes, or the upstream source.
 - An option added after the floor needs no per-option version gating; an older git
   rejects it as an unknown option (see the
   [`requires_git_version` convention](../command-implementation/REFERENCE.md#requires_git_version-convention)).
@@ -771,27 +770,23 @@ constraint exists for that argument — omitting them is correct in that case.
 not flag the absence of `conflicts`, `requires`, `requires_one_of`,
 `requires_exactly_one_of`, `forbid_values`, or `allowed_values` as a completeness
 issue. Command classes use per-argument validation parameters (`required:`,
-`allow_nil:`, etc.) and operand format validation. Git validates its own option
-semantics. The authority for this policy is
-[Project Context — Validation Boundaries](../project-context/SKILL.md#validation-boundaries);
-the summary below must not drift from it. There are two narrow exceptions:
+`allow_nil:`, etc.) and operand format validation; git validates its own option
+semantics. The two narrow exceptions that permit a constraint, and the criteria for
+each, are defined in
+[Project Context — Exception criteria for constraint declarations](../project-context/SKILL.md#exception-criteria-for-constraint-declarations).
+Review flags:
 
-1. **Arguments git cannot observe in its argv** — the test is: does this argument
-   appear in git's argv? If no — `skip_cli: true` operands, `execution_option`
-   entries, anything consumed entirely on the Ruby side — git cannot detect
-   incompatibilities and constraint declarations are appropriate and should not be
-   flagged as policy violations. Both shapes are in the tree: `cat-file --batch`
-   declares `conflicts :object, :batch_all_objects` and `requires_one_of :object,
-   :batch_all_objects` because `:object` is `skip_cli: true`; `archive` declares
-   `conflicts :output, :out` because `:out` is an `execution_option`.
-2. **Git-visible arguments that cause silent data loss or a wrong result** — if a combination of
-   git-visible arguments causes git to silently discard data or produce a wrong
-   result (no error, wrong answer), a constraint declaration MAY be added with: a
-   code comment explaining why, a reference to the git version(s) where the
-   behavior was verified, and a test. A flag git accepts and silently ignores in an
-   inapplicable mode is neither silent data loss nor a wrong result — flag a
-   constraint that guards a merely ignored flag, and flag a constraint claiming
-   this exception without its code comment, verified git version, and spec.
+- Do **not** flag a constraint that meets the
+  [argv-invisible exception](../project-context/SKILL.md#the-argv-invisible-exception)
+  — such as one on `skip_cli: true` operands or `execution_option` entries — as a
+  policy violation.
+- Flag a constraint on git-visible arguments that does not meet the
+  [silent-wrong-result exception](../project-context/SKILL.md#the-silent-wrong-result-exception).
+- Flag a constraint claiming the
+  [silent-wrong-result exception](../project-context/SKILL.md#the-silent-wrong-result-exception)
+  without its code comment, verified git version(s), and spec.
+- Flag a constraint that guards a flag git accepts and silently ignores in an
+  inapplicable mode — the linked criteria exclude it.
 
 ## 7. Check class-level declarations
 

--- a/.github/skills/review-arguments-dsl/SKILL.md
+++ b/.github/skills/review-arguments-dsl/SKILL.md
@@ -17,6 +17,7 @@ methods and modifiers.
   - [Command source code](#command-source-code)
   - [Command test code](#command-test-code)
   - [Git documentation for the git command](#git-documentation-for-the-git-command)
+  - [Policy authorities](#policy-authorities)
 - [Reference](#reference)
   - [Architecture Context (Base Pattern)](#architecture-context-base-pattern)
   - [DSL to CLI Mapping](#dsl-to-cli-mapping)
@@ -64,19 +65,32 @@ argument → expected git CLI). Coverage completeness is assessed by the
   Read the **entire** official git documentation online man page for the command for
   the `Git::MINIMUM_GIT_VERSION` version of git. This serves two purposes:
   command-introduction and `requires_git_version` decisions, and option-surface
-  reconciliation — an option these docs describe that the latest-version docs no
-  longer do belongs in the DSL with a version-split comment (see
-  [Option surface spans the supported git range](CHECKLIST.md#option-surface-spans-the-supported-git-range)).
-  The diff only signals that the option's status changed. Before accepting the
-  comment's claims, confirm when and how — newer git may reject the option, hide
-  it from the docs while still honoring it, or accept it as a no-op — against the
-  versioned docs at intermediate releases, the git release notes, or the upstream
-  source. Fetch this version from
+  reconciliation. Diff these docs against the latest-version docs; an option they
+  describe that the latest-version docs no longer describe belongs in the DSL with a
+  version-split comment (the review flags are in
+  [Option surface spans the supported git range](CHECKLIST.md#option-surface-spans-the-supported-git-range)),
+  and before accepting that comment's when-and-how claims, confirm them against
+  the versioned docs at intermediate releases, the git release notes, or the
+  upstream source. What the endpoint diff can and cannot establish is defined in
+  [Options completeness](../command-implementation/REFERENCE.md#options-completeness--consult-the-latest-version-docs-first).
+  Fetch this version from
   URL `https://git-scm.com/docs/git-{command}/{version}`.
 
 Do **not** scaffold from local `git <command> -h` output alone — the installed Git
 version is unknown and may differ from the latest supported version. Local help should
 NOT be used even as a supplemental check.
+
+### Policy authorities
+
+Read
+[Project Context — Validation Boundaries](../project-context/SKILL.md#validation-boundaries),
+including its
+[exception criteria for constraint declarations](../project-context/SKILL.md#exception-criteria-for-constraint-declarations),
+and
+[Options completeness — consult the latest-version docs first](../command-implementation/REFERENCE.md#options-completeness--consult-the-latest-version-docs-first).
+The review flags in [CHECKLIST.md](CHECKLIST.md) reference these policies by
+link; load both authorities now so the flags are applied with the criteria in
+context, not from memory.
 
 ## Reference
 

--- a/.github/skills/reviewing-skills/SKILL.md
+++ b/.github/skills/reviewing-skills/SKILL.md
@@ -140,6 +140,19 @@ Match instruction specificity to task fragility:
 - [ ] Consistent terminology throughout (one term per concept, not synonyms)
 - [ ] Named thresholds, modes, phases, or terms are defined before first use and
       have one authoritative definition
+- [ ] Policy definitions (what a policy is, its exceptions, their criteria) are
+      stated only in their designated authority section; every other file or
+      section links to the authority by anchor instead of restating it. **A
+      policy definition restated outside its authority section is a defect —
+      flag it and point the restating file at the authority.** Restated
+      definitions silently rot when the authority changes (PR #1708 spent most
+      of seven review rounds on exactly this), while a link cannot drift and an
+      instruction stated in only one place cannot drift
+- [ ] Role-specific operational instructions (what to do, flag, or test) stay
+      inline in the document whose role they serve — do not flag them as
+      restatements, and flag consolidation that removes them. A reader executing
+      a checklist or workflow must never need the linked definition to perform
+      an action; they follow the link only to understand why
 - [ ] Examples are concrete, not abstract
 - [ ] Examples and domain facts are technically accurate; repo-specific skills
       use real project patterns where practical


### PR DESCRIPTION
## Summary

Implements issue 1710. Each policy definition now lives in exactly one authority section; every former restatement is a link plus that document's own role-specific instructions.

- **Validation delegation policy** — defined only in Project Context's `Validation Boundaries` / `Exception criteria for constraint declarations`. The section's intro no longer re-defines the two exceptions; the restatements in `command-implementation/REFERENCE.md` (both the constraint block and the `#call` override guidance), `command-test-conventions/SKILL.md` (both passages), and `review-arguments-dsl/CHECKLIST.md` are replaced with links. The CatFile::Raw worked example is now a one-line pointer to ADR-0003, where it is recorded.
- **Option-surface union rule** — defined only in Command Implementation's `Options completeness` section. The Input-phase bullets in `command-implementation/SKILL.md` and `review-arguments-dsl/SKILL.md` keep the workflow actions (fetch both doc versions, diff, establish/confirm the version-split comment's claims) and link the theory of what the endpoint diff can and cannot establish to the authority. The checklist's `Option surface spans the supported git range` section keeps all three flags and links the rule.
- **Enforcement guards** — `reviewing-skills` now flags a policy definition restated outside its authority section (with the compact why) and protects the other direction (role-specific instructions stay inline). `make-skill-template` states the rule where new skills are born.

## Hardening the link-based design

Four additions address the failure modes a link-everywhere design introduces:

1. **Named exceptions, not positional references.** The two exceptions are now named subsections with stable anchors — `The argv-invisible exception` and `The silent-wrong-result exception` — and every cross-file reference uses the name and deep link. A positional reference ("the second exception") would silently break if the authority reordered its criteria; a named anchor cannot.
2. **Authorities are required Input reading.** Both `command-implementation` and `review-arguments-dsl` gained a `Policy authorities` Input step that requires loading the linked authority sections before executing the workflow, so link-dependent review flags run with the criteria in context rather than from memory.
3. **The invalid-in-mode boundary keeps an imperative at the decision point.** One sentence in the REFERENCE.md constraint block (do not constrain a flag that is merely invalid in the selected mode; delegate it) guards the most likely scaffolding mistake inline, with the definition still only in the authority.
4. **Edit warnings on both authorities.** Each authority section notes that linking skills depend on it, and that edits should be followed by the link check and a reviewing-skills audit of the linkers.

No review flag or test requirement was weakened; ADRs are untouched.

## Verification

- `bundle exec rake default` passes (unit, integration, rubocop, markdown:links)
- The issue's inventory greps rerun clean: remaining hits are the authorities themselves, links, flags, or unrelated text

Closes: #1710

🤖 Generated with [Claude Code](https://claude.com/claude-code)