### PR TITLE
docs: record the v4.x call-shape rule as adr 0005

### DIFF
--- a/.github/skills/facade-implementation/SKILL.md
+++ b/.github/skills/facade-implementation/SKILL.md
@@ -222,7 +222,8 @@ This skill supports three modes. Determine which mode applies before starting:
      internals
    - is explicitly classified as `legacy-contract` (legacy predecessor exists)
      or `5.x-native` (new facade API), and signature shape matches that
-     classification
+     classification (why the call shape is preserved:
+     [ADR-0005](../../../docs/adr/0005-the-facade-keeps-the-v4x-call-shape.md))
    - has tests that verify call-shape compatibility when classification is
      `legacy-contract` (positional hash and/or keyword-arg / `**opts` forms where required)
 

--- a/docs/adr/0005-the-facade-keeps-the-v4x-call-shape.md
+++ b/docs/adr/0005-the-facade-keeps-the-v4x-call-shape.md
@@ -1,0 +1,29 @@
+# The facade keeps the v4.x call shape
+
+A `Git::Repository` facade method whose predecessor was public API on `Git::Base` or
+`Git::Lib` copies the predecessor's signature verbatim. Most v4.x methods took options
+as a positional `opts = {}` hash — the intended convention — but a few drifted to a
+keyword splat (`add(paths = '.', **)`). The facade preserves the drift along with the
+convention: callers bind to the signature that shipped, not the one that was intended,
+so correcting an old inconsistency is as much a breaking change as modernizing a
+correct signature. Methods with no v4.x predecessor use `opts = {}`, so the public API
+stays uniform until the whole surface can move at once.
+
+The rejected alternative was rewriting the facade with keyword arguments, and it was
+not rejected on paper: six methods (`checkout`, `reset`, `commit`, `commit_all`,
+`commit_tree`, `write_and_commit_tree`) shipped with `**opts` signatures during the
+v5.x redesign and were rolled back. Ruby 3 no longer converts a trailing positional
+`Hash` into keywords, so a v4.x caller holding options in a variable —
+`opts = { force: true }; repo.reset('HEAD', opts)` — raises `ArgumentError` against
+a keyword-accepting signature. Keyword signatures type-checked as an upgrade and
+behaved as a silent breaking change for exactly the callers v5.0.0 promised to carry
+forward.
+
+The consequence worth recording is that these signatures contradict the project's own
+coding standard, which prefers keyword arguments for multi-parameter methods. A reader
+of `lib/git/repository/` will find dozens of `opts = {}` signatures and be tempted to
+modernize them. Do not: flipping any one of them is a breaking change for
+positional-hash callers, which is why the kwargs migration is deferred to a future
+major release where it can be applied uniformly and announced as such. `checkout`
+additionally guards `branch.is_a?(Hash)` because its v4.x form accepted the options
+hash in the first position.


### PR DESCRIPTION
### Summary

Adds ADR-0005, "The facade keeps the v4.x call shape," and links it from the facade-implementation skill's signature-classification check.

During the v5.x redesign, six facade methods (`checkout`, `reset`, `commit`, `commit_all`, `commit_tree`, `write_and_commit_tree`) shipped with `**opts` keyword signatures and were rolled back to the positional `opts = {}` forms of their `Git::Base` predecessors: Ruby 3 no longer converts a trailing positional `Hash` into keywords, so the kwargs rewrite silently broke exactly the v4.x callers v5.0.0 promised to carry. That reasoning survived only in the archived c1c2 audit (`archive/v5-redesign/c1c2_audit.md` §5) and the deprecated extraction skill — the active skills name the `legacy-contract` / `5.x-native` classification but never state the hazard behind it.

The ADR records the general rule the rollback illustrates: callers bind to the signature that shipped, not the one that was intended. The positional hash was v4.x's intended convention, but where v4.x drifted to `**` forms (`add`), the facade preserves the drift too — correcting an old inconsistency is as much a breaking change as modernizing a correct signature. The facade-wide kwargs migration is deferred to a future major release where it can land uniformly; a future ADR executing that deferral would supersede this one.

This matters because the shipped signatures contradict the project's keyword-arguments coding standard, so a reader of `lib/git/repository/` (26 `opts = {}` methods) will be tempted to "fix" them piecemeal. The ADR is the recorded reason not to.

### Changes

- `docs/adr/0005-the-facade-keeps-the-v4x-call-shape.md` — new ADR
- `.github/skills/facade-implementation/SKILL.md` — the signature-classification review check now cites the ADR for the rationale

🤖 Generated with [Claude Code](https://claude.com/claude-code)