### PR TITLE
docs: fold borrowed skill practices into project skills and agent instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,9 +8,9 @@ A Ruby gem providing an interface to Git repositories by wrapping system calls t
 Read the "Project Context" skill (`.github/skills/project-context/SKILL.md`) for
 design philosophy, technical details, and compatibility requirements.
 
-Architectural decisions are recorded as ADRs in `docs/adr/`. Read the ADRs covering
-an area before changing it, and flag any contradiction between a change and an ADR
-rather than silently overriding the decision.
+Durable decisions (design, policy, process) are recorded as ADRs in `docs/adr/`.
+Read the ADRs covering an area before changing it, and flag any contradiction
+between a change and an ADR rather than silently overriding the decision.
 
 This project enforces Conventional Commits. See `.commitlintrc.yml` for allowed types
 and scopes. Never use `#` in the commit message body. Doing so will cause

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -8,6 +8,10 @@ A Ruby gem providing an interface to Git repositories by wrapping system calls t
 Read the "Project Context" skill (`.github/skills/project-context/SKILL.md`) for
 design philosophy, technical details, and compatibility requirements.
 
+Architectural decisions are recorded as ADRs in `docs/adr/`. Read the ADRs covering
+an area before changing it, and flag any contradiction between a change and an ADR
+rather than silently overriding the decision.
+
 This project enforces Conventional Commits. See `.commitlintrc.yml` for allowed types
 and scopes. Never use `#` in the commit message body. Doing so will cause
 commitlint to incorrectly parse the commit message body as a footer. If you need to

--- a/.github/skills/breaking-change-analysis/SKILL.md
+++ b/.github/skills/breaking-change-analysis/SKILL.md
@@ -116,6 +116,9 @@ proved it.
 **Project versioning policy:**
 - Breaking changes are batched for major releases
 - Use deprecation warnings in the current major series before removal in the next major release
+- Whether a specific removal may land in the next major is governed by the removal
+  gate in
+  [ADR-0006](../../../docs/adr/0006-removals-require-proven-safety-and-calendar-soak.md)
 
 **Deprecation approach:**
 

--- a/.github/skills/breaking-change-analysis/SKILL.md
+++ b/.github/skills/breaking-change-analysis/SKILL.md
@@ -16,6 +16,7 @@ or modifying default behavior.
 - [Step 1: Identify the Change Scope](#step-1-identify-the-change-scope)
 - [Step 2: Find All Usages](#step-2-find-all-usages)
 - [Step 3: Assess and Document Impact](#step-3-assess-and-document-impact)
+  - [Prove the safety claim](#prove-the-safety-claim)
 - [Step 4: Plan Migration Path](#step-4-plan-migration-path)
 
 ## How to use this skill
@@ -91,9 +92,24 @@ Produce an impact assessment:
 - Severity: [High/Medium/Low]
 - Migration difficulty: [Easy/Medium/Hard]
 
+### Safety Proof
+[The single fact each "safe" verdict rests on, and the code that was run to prove it]
+
 ### Migration Path
 [How users should update their code]
 ```
+
+### Prove the safety claim
+
+Every "this looks risky but is actually safe" verdict in the assessment rests on some
+single fact — an option no caller passes, output no parser depends on, behavior
+identical across the supported git range. Isolate that fact, then prove it by running
+real code: a spec exercising the old and new behavior, a console session against a
+fixture repository, or a query against the RubyGems dump showing no dependent gem is
+affected. Record the fact and its proof in the **Safety Proof** section of the
+assessment. A safety claim backed only by reasoning is an open question, not a
+finding — the step is complete when every such claim names its fact and the code that
+proved it.
 
 ## Step 4: Plan Migration Path
 

--- a/.github/skills/development-workflow/SKILL.md
+++ b/.github/skills/development-workflow/SKILL.md
@@ -164,7 +164,12 @@ clean baseline, and create a clear implementation plan before writing any code.
 4. **Verify Clean Baseline:** Ensure that all existing tests and linters pass by
    running `bundle exec rake default`.
 5. **Analyze and Plan:** Understand the requirements, identify edge cases and
-   potential challenges, and break the work into small, isolated tasks. Consider what
+   potential challenges, and break the work into small, isolated tasks. Each task
+   must end in a verifiable state: tests passing, linters clean, its behavior
+   demonstrable on its own. Order the tasks so the sequence proves itself to a
+   reviewer — each commit builds only on work already verified before it. When an
+   effort spans multiple PRs, apply the same rule one level up: slice it into
+   independently releasable PRs, each leaving the gem shippable. Consider what
    tests will be needed and in what order they should be written.
 6. **Consider Refactoring:** Look for ways to make the implementation of the feature
    or bug fix easier by performing one or more refactorings. If any are found,

--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -69,7 +69,7 @@ coding standard details, or implementation constraints.
 - `archive/` — Frozen records of completed projects, such as
   `archive/v5-redesign/`. History, not current policy; current standards live in
   `.github/skills/`
-- `docs/adr/` — Architecture decision records: why something was decided
+- `docs/adr/` — decision records (ADRs): why something was decided
 
 ## Layer Responsibilities
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,19 @@ imported below. Edit that file so all agents stay in sync. Reserve this file for
 guidance that applies *only* to Claude Code.
 
 @.github/copilot-instructions.md
+
+## Agent skills
+
+Configuration for the mattpocock engineering skills (`/to-tickets`, `/to-spec`,
+`/wayfinder`), which run only in Claude Code. Guidance that applies to all agents
+stays in `.github/copilot-instructions.md`.
+
+### Issue tracker
+
+Work is tracked in this repo's GitHub Issues via the `gh` CLI. See
+`docs/agents/issue-tracker.md`.
+
+### Domain docs
+
+Single-context: the Project Context skill serves as the domain reference and ADRs
+live in `docs/adr/` (no root `CONTEXT.md`). See `docs/agents/domain.md`.

--- a/docs/adr/0006-removals-require-proven-safety-and-calendar-soak.md
+++ b/docs/adr/0006-removals-require-proven-safety-and-calendar-soak.md
@@ -1,0 +1,26 @@
+# Removals require proven safety and calendar soak
+
+A major release deletes a deprecated API only when two conditions both hold. First, a
+Safety Proof per the breaking-change-analysis skill: the single fact the removal is
+safe because of, proven by running real code — reverse-dependency evidence, not
+reasoning. Second, soak, scaled by what the proof finds: when the proof shows external
+usage, the deprecation must have shipped in a released minor at least six months
+before the major that removes it; when it shows none, in at least one released minor
+before the final minor of the series. An API that fails either condition ships in the
+major still deprecated and is removed in the following major. The first application is
+v6.0.0, gating the removals deprecated by issues 1637, 1639, 1640, 1643, and 1709.
+
+The rejected alternative was measuring soak in releases rather than calendar time,
+and it fails on this project's own numbers: seven releases shipped in the three weeks
+around v5.0.0, so "deprecated for two minors" could mean nine days. A warning only
+does its job for a caller who upgrades into it, exercises the code path, and acts
+before the removal ships, and callers move on their own dependency-update rhythm —
+typically weeks to months — not on this gem's release cadence. Calendar time is the
+honest proxy for warning reach; release count is not.
+
+Two consequences are worth recording. The soak clock, not the implementation work,
+sets the earliest date of a removing major: deprecations must ship early in the
+preceding series, and a major wanted sooner simply carries more APIs forward as
+deprecated. And soak only protects adopters of the deprecating series — users who
+jump from an older major straight to the new one never see the warnings, which no
+soak length can fix; UPGRADING.md is the instrument for them.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,4 +1,4 @@
-# Architecture decision records
+# Decision records (ADRs)
 
 Each file here records one decision and the reason for it. A plan says what we intend to
 do next, and goes stale the moment reality diverges from it. A decision stays true even

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,29 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **The Project Context skill** (`.github/skills/project-context/SKILL.md`) — this
+  repo's domain reference: architecture, design philosophy, layered
+  command/parser/facade structure, and compatibility requirements. This repo uses
+  it in place of a root `CONTEXT.md`; do not create a `CONTEXT.md`.
+- **`docs/adr/`** — read the ADRs that touch the area you're about to work in.
+  `docs/adr/README.md` states when a decision earns an ADR and what belongs on the
+  issue tracker instead.
+
+## Use the project's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a
+hypothesis, a test name), use the term as the Project Context skill defines it —
+command class, parser, facade, topic module, Info object. Don't drift to synonyms.
+
+If the concept you need isn't defined there, that's a signal — either you're
+inventing language the project doesn't use (reconsider) or there's a real gap
+(note it so the skill can be extended).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0003 (validation is delegated to git) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and specs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments` for a readable view. When labels or comment filtering are needed, use `gh issue view <number> --json title,body,labels,comments --jq '...'` instead.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins. In the GitHub UI, `is:open -is:blocked` in the issues search bar renders the unblocked set directly (verified against this repo).
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.


### PR DESCRIPTION
## Summary

Folds two practices from third-party skill libraries into this project's own skills,
and points agents at the ADR directory. These are the "borrow, do not install"
outcomes of the skills-adoption review: the conventions are worth having, the source
plugins are not worth installing, so the text lands where this repository already
records how work is done.

- **`.github/copilot-instructions.md`** — agents are now told that architectural
  decisions live in `docs/adr/`, to read the ADRs covering an area before changing
  it, and to flag contradictions rather than silently overriding a recorded
  decision. The ADR convention was adopted with ADRs 0001–0005 but the agent
  instructions never mentioned it.
- **`breaking-change-analysis`** — a safety verdict must now name the single fact it
  rests on and prove that fact by running real code (a spec, a fixture-repo session,
  or a RubyGems dump query), recorded in a new **Safety Proof** section of the
  impact assessment. Reasoning alone no longer closes the assessment step.
- **`development-workflow`** — the PREPARE planning step now states the sequencing
  rule the project already follows by instinct: each task ends in a verifiable
  state, the task order proves itself to a reviewer, and multi-PR efforts slice
  into independently releasable PRs.

## Verification

- `lychee` link check passes on all three edited files, including the new
  table-of-contents anchor.
- Skill edits audited against the `reviewing-skills` checklist: descriptions still
  accurate, additions are inline workflow rules (no restated policy), no
  time-sensitive content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
