### PR TITLE
docs: name maintainer and contributors in the LICENSE copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2008 Scott Chacon
+Copyright (c) 2008 Scott Chacon, 2020 James Couball, and the ruby-git contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
The LICENSE copyright notice named only the original 2008 author. This adds the current maintainer and the collective ruby-git contributors:

    Copyright (c) 2008 Scott Chacon, 2020 James Couball, and the ruby-git contributors

The notice is informational (each contributor already holds copyright in their own contributions); this just makes it accurate. The same change is being applied to the 4.x branch in a separate PR.