### PR TITLE
docs: name maintainer and contributors in the LICENSE copyright notice

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License
 
-Copyright (c) 2008 Scott Chacon
+Copyright (c) 2008 Scott Chacon, 2020 James Couball, and the ruby-git contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Backport of #1735 to the 4.x branch. Updates the LICENSE copyright notice to:

    Copyright (c) 2008 Scott Chacon, 2020 James Couball, and the ruby-git contributors