### PR TITLE
chore: fix rubocop offenses on the 4.x branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ node_modules
 package-lock.json
 ai-prompt.erb
 rubocop-report.json
+git-versions/

--- a/lib/git/base.rb
+++ b/lib/git/base.rb
@@ -306,6 +306,7 @@ module Git
       branch_names.include?(branch)
     end
 
+    # @deprecated Use {#local_branch?} instead
     def is_local_branch?(branch) # rubocop:disable Naming/PredicatePrefix
       Git::Deprecation.warn(
         'Git::Base#is_local_branch? is deprecated and will be removed in a future version. ' \
@@ -320,6 +321,7 @@ module Git
       branch_names.include?(branch)
     end
 
+    # @deprecated Use {#remote_branch?} instead
     def is_remote_branch?(branch) # rubocop:disable Naming/PredicatePrefix
       Git::Deprecation.warn(
         'Git::Base#is_remote_branch? is deprecated and will be removed in a future version. ' \
@@ -334,6 +336,7 @@ module Git
       branch_names.include?(branch)
     end
 
+    # @deprecated Use {#branch?} instead
     def is_branch?(branch) # rubocop:disable Naming/PredicatePrefix
       Git::Deprecation.warn(
         'Git::Base#is_branch? is deprecated and will be removed in a future version. ' \
@@ -710,11 +713,9 @@ module Git
     #   @example Check specific objects
     #     result = git.fsck('abc1234', 'def5678')
     #
-    # rubocop:disable Style/ArgumentsForwarding
-    def fsck(*objects, **opts)
-      lib.fsck(*objects, **opts)
+    def fsck(*objects, **opts) # rubocop:disable Style/ArgumentsForwarding
+      lib.fsck(*objects, **opts) # rubocop:disable Style/ArgumentsForwarding
     end
-    # rubocop:enable Style/ArgumentsForwarding
 
     def apply(file)
       return unless File.exist?(file)

--- a/lib/git/lib.rb
+++ b/lib/git/lib.rb
@@ -798,7 +798,7 @@ module Git
     end
 
     def branch_contains(commit, branch_name = '')
-      command('branch',  branch_name, '--contains', commit)
+      command('branch', branch_name, '--contains', commit)
     end
 
     GREP_OPTION_MAP = [


### PR DESCRIPTION
A newer RuboCop release flags two offenses on the 4.x branch. This PR fixes both; `bundle exec rubocop` now reports no offenses.

* **Style/ArgumentsForwarding** in `Git::Base#fsck`: move the disables inline onto the offending lines. A directive comment above the `def` (either a disable/enable pair or `disable-next`) is contiguous with the doc comment, so YARD renders it as part of the docstring.
* **Layout/ExtraSpacing** in `Git::Lib#branch_contains`: remove a stray extra space in the `command` call.

Also adds `@deprecated` docstrings to `is_branch?`, `is_local_branch?`, and `is_remote_branch?`. These undocumented methods had inline rubocop directives on the `def` line, which YARD falls back to as the docstring — the generated docs showed "rubocop:disable Naming/PredicatePrefix" as their summary. With a real docstring, the directive no longer appears outside the source listing.

All changes are non-functional (comments and whitespace).