### PR TITLE
chore(deps): update process_executer to ~> 4.1

### DIFF
--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -324,10 +324,12 @@ swallow exceptions silently.
 
 ### Dependencies
 
-- `activesupport` (≥ 5.0) — utilities and deprecation handling
-- `addressable` (~> 2.8) — URI parsing
-- `process_executer` (~> 4.0) — subprocess execution with timeout
-- `rchardet` (~> 1.9) — character encoding detection
+Version constraints live in `git.gemspec`; do not restate them here.
+
+- `activesupport` — utilities and deprecation handling
+- `addressable` — URI parsing
+- `process_executer` — subprocess execution with timeout
+- `rchardet` — character encoding detection
 
 ## Compatibility
 

--- a/git.gemspec
+++ b/git.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'activesupport', '>= 5.0'
   spec.add_dependency 'addressable', '~> 2.8'
-  spec.add_dependency 'process_executer', '~> 4.0'
+  spec.add_dependency 'process_executer', '~> 4.1'
   spec.add_dependency 'rchardet', '~> 1.9'
 
   # Not every development dependency is installed on every runtime. Each predicate


### PR DESCRIPTION
Raises the process_executer dependency constraint from ~> 4.0 to ~> 4.1. The full test suite passes with process_executer 4.1.0.