### PR TITLE
feat(author): add immutable Git::AuthorInfo and deprecate Git::Author

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,6 +17,7 @@ to update your code when upgrading from the preceding major version.
     - [Facade method renames](#facade-method-renames)
     - [v4.x-style configuration methods](#v4x-style-configuration-methods)
     - [`Git` module mixin deprecations](#git-module-mixin-deprecations)
+    - [`Git::Author` deprecated](#gitauthor-deprecated)
 
 ## Upgrading to v5.x
 
@@ -361,5 +362,26 @@ as bare methods is deprecated:
 | `include Git; global_config(name)` | `Git.config_get(name, global: true)` |
 | `include Git; global_config(name, value)` | `Git.config_set(name, value, global: true)` |
 | `include Git; global_config` | `Git.config_list(global: true)` |
+
+#### `Git::Author` deprecated
+
+Starting in v5.3.0, methods that return author, committer, or tagger data —
+`Git::Object::Commit#author`, `Git::Object::Commit#committer`,
+`Git::Object::Tag#tagger`, and `Git::TagInfo#tagger` — return an immutable
+`Git::AuthorInfo` value object instead of the mutable `Git::Author`.
+
+`Git::AuthorInfo` exposes the same `name`, `email`, and `date` readers, so code
+that only reads these attributes needs no changes. Code that mutated a
+`Git::Author` (via `name=`, `email=`, or `date=`) must be updated:
+`Git::AuthorInfo` is frozen, and `#with` returns a modified copy rather than
+updating in place (e.g. `info = info.with(name: 'New Name')`).
+
+Constructing `Git::Author` directly emits a deprecation warning naming
+`Git::AuthorInfo` as the replacement. The class is removed in v6.0.0.
+
+| Deprecated usage | Replacement |
+|-----------------|-------------|
+| `Git::Author.new('Name <email> 1627849923 +0200')` | `Git::AuthorInfo.parse('Name <email> 1627849923 +0200')` |
+| `author.name = 'New Name'` | `author = author.with(name: 'New Name')` (returns a new object) |
 
 ---

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -46,6 +46,7 @@ module Git
 end
 
 require 'git/author'
+require 'git/author_info'
 require 'git/branch'
 require 'git/branch_info'
 require 'git/branches'

--- a/lib/git/author.rb
+++ b/lib/git/author.rb
@@ -3,6 +3,9 @@
 module Git
   # An author in a Git commit
   #
+  # @deprecated Use {Git::AuthorInfo} instead; this mutable class will be
+  #   removed in v6.0.0
+  #
   # @api public
   #
   class Author
@@ -24,7 +27,15 @@ module Git
     #
     # @return [void]
     #
+    # @deprecated Use {Git::AuthorInfo.parse} instead
+    #
     def initialize(author_string)
+      if defined?(Git::Deprecation)
+        Git::Deprecation.warn(
+          'Git::Author is deprecated and will be removed in v6.0.0. Use Git::AuthorInfo instead.'
+        )
+      end
+
       return unless (m = /(.*?) <(.*?)> (\d+) (.*)/.match(author_string))
 
       @name = m[1]

--- a/lib/git/author_info.rb
+++ b/lib/git/author_info.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+module Git
+  # Immutable value object representing an author or committer identity
+  #
+  # This is a lightweight, immutable data structure holding the identity data
+  # git records for commit authors, committers, and taggers. It replaces the
+  # mutable {Git::Author}, which is deprecated.
+  #
+  # @example Construct from individual values
+  #   info = Git::AuthorInfo.new(
+  #     name: 'John Doe',
+  #     email: 'john.doe@example.com',
+  #     date: Time.at(1627849923)
+  #   )
+  #   info.name  #=> 'John Doe'
+  #
+  # @example Parse from a raw git author string
+  #   info = Git::AuthorInfo.parse('John Doe <john.doe@example.com> 1627849923 +0200')
+  #   info.email     #=> 'john.doe@example.com'
+  #   info.date.to_i #=> 1627849923
+  #
+  # @see Git::Object::Commit#author
+  #
+  # @see Git::Object::Commit#committer
+  #
+  # @api public
+  #
+  # @!attribute [r] name
+  #   @return [String, nil] the person's name, or `nil` if not available
+  #
+  # @!attribute [r] email
+  #   @return [String, nil] the person's email address, or `nil` if not available
+  #
+  # @!attribute [r] date
+  #   @return [Time, nil] the timestamp of the change, or `nil` if not available
+  #
+  AuthorInfo = Data.define(:name, :email, :date) do
+    # Parses a raw git identity string into a Git::AuthorInfo
+    #
+    # The expected format is `"Name <email> timestamp offset"` as emitted by
+    # `git cat-file` for the `author`, `committer`, and `tagger` headers. The
+    # timestamp is interpreted as seconds since the Unix epoch; the timezone
+    # offset is not preserved in the resulting `date`.
+    #
+    # @example Parse a well-formed identity string
+    #   Git::AuthorInfo.parse('John Doe <john.doe@example.com> 1627849923 +0200')
+    #   #=> #<data Git::AuthorInfo name="John Doe", email="john.doe@example.com", ...>
+    #
+    # @example A string that does not match the expected format
+    #   Git::AuthorInfo.parse('garbage')
+    #   #=> #<data Git::AuthorInfo name=nil, email=nil, date=nil>
+    #
+    # @param author_string [String] the raw identity string to parse
+    #
+    # @return [Git::AuthorInfo] the parsed identity; all attributes are `nil`
+    #   when the string does not match the expected format
+    #
+    def self.parse(author_string)
+      match = /(.*?) <(.*?)> (\d+) (.*)/.match(author_string)
+      return new(name: nil, email: nil, date: nil) unless match
+
+      new(name: match[1], email: match[2], date: Time.at(match[3].to_i))
+    end
+  end
+end

--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require 'git/author'
+require 'git/author_info'
 require 'git/diff'
 require 'git/errors'
 require 'git/log'
@@ -438,7 +438,10 @@ module Git
         @parents
       end
 
-      # git author
+      # Returns the commit author identity
+      #
+      # @return [Git::AuthorInfo] the author name, email, and author date
+      #
       def author
         check_commit
         @author
@@ -452,7 +455,10 @@ module Git
         author.date
       end
 
-      # git author
+      # Returns the commit committer identity
+      #
+      # @return [Git::AuthorInfo] the committer name, email, and commit date
+      #
       def committer
         check_commit
         @committer
@@ -499,8 +505,8 @@ module Git
       #
       def from_data(data)
         @sha ||= data['sha']
-        @committer = Git::Author.new(data['committer'])
-        @author = Git::Author.new(data['author'])
+        @committer = Git::AuthorInfo.parse(data['committer'])
+        @author = Git::AuthorInfo.parse(data['author'])
         @tree = Git::Object::Tree.new(@base, data['tree'])
         @parents = data['parent'].map { |sha| Git::Object::Commit.new(@base, sha) }
         @message = data['message'].chomp
@@ -593,7 +599,7 @@ module Git
 
       # Returns the tagger identity
       #
-      # @return [Git::Author, nil] the tagger for an annotated tag, or `nil`
+      # @return [Git::AuthorInfo, nil] the tagger for an annotated tag, or `nil`
       #   for a lightweight tag
       #
       def tagger
@@ -613,7 +619,7 @@ module Git
         if annotated?
           tdata = object_repository.cat_file_tag(@name)
           @message = tdata['message'].chomp
-          @tagger = Git::Author.new(tdata['tagger'])
+          @tagger = Git::AuthorInfo.parse(tdata['tagger'])
         else
           @message = @tagger = nil
         end

--- a/lib/git/tag_info.rb
+++ b/lib/git/tag_info.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
-require 'git/author'
+require 'time'
+
+require 'git/author_info'
 
 module Git
   # Value object representing tag metadata from git tag output
@@ -88,19 +90,17 @@ module Git
       oid.nil?
     end
 
-    # Return the tagger as an Author object
+    # Return the tagger as an immutable Git::AuthorInfo object
     #
-    # @return [Git::Author, nil] the tagger as an Author object, or nil for lightweight tags
+    # @return [Git::AuthorInfo, nil] the tagger, or nil for lightweight tags
     def tagger
       return nil unless annotated? && tagger_name && tagger_email
 
-      # Git::Author expects format "Name <email> timestamp timezone"
-      # We construct a minimal format that will parse correctly
-      author = Git::Author.new('')
-      author.name = tagger_name
-      # Remove angle brackets if present
-      author.email = tagger_email.gsub(/\A<|>\z/, '')
-      author
+      Git::AuthorInfo.new(
+        name: tagger_name,
+        email: tagger_email.gsub(/\A<|>\z/, ''), # remove angle brackets if present
+        date: tagger_date && Time.iso8601(tagger_date)
+      )
     end
   end
 end

--- a/spec/unit/git/author_info_spec.rb
+++ b/spec/unit/git/author_info_spec.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::AuthorInfo do
+  describe '#initialize' do
+    subject(:instance) { described_class.new(name: name, email: email, date: date) }
+
+    let(:name) { 'John Doe' }
+    let(:email) { 'john.doe@example.com' }
+    let(:date) { Time.at(1_627_849_923) }
+
+    it 'stores all constructor arguments' do
+      expect(instance).to have_attributes(name: name, email: email, date: date)
+    end
+
+    it 'creates an immutable object' do
+      expect(instance).to be_frozen
+      expect { instance.name = 'Jane Doe' }.to raise_error(NoMethodError, /name=/)
+    end
+
+    it 'compares equal to another instance with the same values' do
+      expect(instance).to eq(described_class.new(name: name, email: email, date: date))
+    end
+  end
+
+  describe '.parse' do
+    subject(:result) { described_class.parse(author_string) }
+
+    let(:author_string) { 'John Doe <john.doe@example.com> 1627849923 +0200' }
+
+    context 'with a well-formed author string' do
+      it 'returns a Git::AuthorInfo with the parsed name, email, and date' do
+        expect(result).to be_a(described_class)
+        expect(result).to have_attributes(
+          name: 'John Doe',
+          email: 'john.doe@example.com',
+          date: Time.at(1_627_849_923)
+        )
+      end
+    end
+
+    context 'with a string that does not match the author format' do
+      let(:author_string) { 'not an author string' }
+
+      it 'returns a Git::AuthorInfo with nil name, email, and date' do
+        expect(result).to be_a(described_class)
+        expect(result).to have_attributes(name: nil, email: nil, date: nil)
+      end
+    end
+  end
+end

--- a/spec/unit/git/author_info_spec.rb
+++ b/spec/unit/git/author_info_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'git/author_info'
 
 RSpec.describe Git::AuthorInfo do
   describe '#initialize' do

--- a/spec/unit/git/author_spec.rb
+++ b/spec/unit/git/author_spec.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/author'
+
+RSpec.describe Git::Author do
+  describe '#initialize' do
+    subject(:instance) { described_class.new(author_string) }
+
+    let(:author_string) { 'John Doe <john.doe@example.com> 1627849923 +0200' }
+
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    context 'with a well-formed author string' do
+      it 'emits a deprecation warning naming Git::AuthorInfo and still parses the string' do
+        expect(instance).to have_attributes(
+          name: 'John Doe',
+          email: 'john.doe@example.com',
+          date: Time.at(1_627_849_923)
+        )
+        expect(Git::Deprecation).to have_received(:warn).with(a_string_including('Git::AuthorInfo'))
+      end
+    end
+
+    context 'with a string that does not match the author format' do
+      let(:author_string) { 'not an author string' }
+
+      it 'emits a deprecation warning naming Git::AuthorInfo and leaves the attributes nil' do
+        expect(instance).to have_attributes(name: nil, email: nil, date: nil)
+        expect(Git::Deprecation).to have_received(:warn).with(a_string_including('Git::AuthorInfo'))
+      end
+    end
+
+    context 'when Git::Deprecation is unavailable (partial require)' do
+      before { hide_const('Git::Deprecation') }
+
+      it 'still parses the author string without raising' do
+        expect(instance).to have_attributes(
+          name: 'John Doe',
+          email: 'john.doe@example.com',
+          date: Time.at(1_627_849_923)
+        )
+      end
+    end
+  end
+end

--- a/spec/unit/git/object_spec.rb
+++ b/spec/unit/git/object_spec.rb
@@ -525,6 +525,10 @@ RSpec.describe Git::Object::Commit do
     it 'returns the commit author with correct name and email' do
       expect(result).to have_attributes(name: 'A U Thor', email: 'author@example.com')
     end
+
+    it 'returns an immutable Git::AuthorInfo' do
+      expect(result).to be_a(Git::AuthorInfo)
+    end
   end
 
   describe '#author_date' do
@@ -540,6 +544,10 @@ RSpec.describe Git::Object::Commit do
 
     it 'returns the committer with correct name and email' do
       expect(result).to have_attributes(name: 'A U Thor', email: 'author@example.com')
+    end
+
+    it 'returns an immutable Git::AuthorInfo' do
+      expect(result).to be_a(Git::AuthorInfo)
     end
   end
 
@@ -770,6 +778,10 @@ RSpec.describe Git::Object::Tag do
 
       it 'returns the tag creator with correct name and email' do
         expect(result).to have_attributes(name: 'A U Thor', email: 'author@example.com')
+      end
+
+      it 'returns an immutable Git::AuthorInfo' do
+        expect(result).to be_a(Git::AuthorInfo)
       end
     end
   end

--- a/spec/unit/git/tag_info_spec.rb
+++ b/spec/unit/git/tag_info_spec.rb
@@ -171,8 +171,8 @@ RSpec.describe Git::TagInfo do
         )
       end
 
-      it 'returns a Git::Author object' do
-        expect(tag_info.tagger).to be_a(Git::Author)
+      it 'returns an immutable Git::AuthorInfo object' do
+        expect(tag_info.tagger).to be_a(Git::AuthorInfo)
       end
 
       it 'has the correct name' do
@@ -181,6 +181,29 @@ RSpec.describe Git::TagInfo do
 
       it 'has the correct email' do
         expect(tag_info.tagger.email).to eq('john@example.com')
+      end
+
+      it 'carries the tag date parsed from tagger_date' do
+        expect(tag_info.tagger.date).to eq(Time.iso8601('2024-01-15T10:30:00-08:00'))
+      end
+
+      context 'when tagger_date is nil' do
+        subject(:tag_info) do
+          described_class.new(
+            name: 'v1.0.0',
+            oid: 'abc123',
+            target_oid: 'def456',
+            objecttype: 'tag',
+            tagger_name: 'John Doe',
+            tagger_email: '<john@example.com>',
+            tagger_date: nil,
+            message: 'Release'
+          )
+        end
+
+        it 'has a nil date' do
+          expect(tag_info.tagger.date).to be_nil
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

Makes author/committer/tagger data an immutable value object and deprecates the
mutable `Git::Author`.

- Adds `Git::AuthorInfo`, an immutable `Data.define(:name, :email, :date)` value
  object with a `.parse` class method for the raw `"Name <email> timestamp offset"`
  string previously handled by `Git::Author#initialize`.
- `Git::Object::Commit#author`, `Git::Object::Commit#committer`,
  `Git::Object::Tag#tagger`, and `Git::TagInfo#tagger` now return
  `Git::AuthorInfo`.
- Constructing `Git::Author` emits `Git::Deprecation.warn` naming
  `Git::AuthorInfo` as the replacement. The class is removed in v6.0.0.
- UPGRADING.md documents the deprecation and migration.

The change is non-breaking and targets a 5.x minor release: `Git::AuthorInfo`
exposes the same `name`, `email`, and `date` readers, so read-only callers keep
working unchanged. This starts the ADR-0006 soak clock for this candidate.

## Commits

1. `test(author)` — the failing tests specifying `Git::AuthorInfo`, the new
   return types, and the deprecation warning.
2. `feat(author)` — the implementation and docs that make those tests pass.

## Verification

- Ruby (MRI) 4.0.6: full `bundle exec rake` passes locally.
- JRuby 10.0.6.0: full `bundle exec rake` passes locally.
- TruffleRuby 24.2.1: `bundle exec rake spec` passes locally (5847 + 584
  examples, 0 failures). The full `rake` fails there only because RuboCop
  1.90.0 crashes internally on TruffleRuby on files this branch does not
  touch — pre-existing, and CI runs only `rake spec` on the engine matrix
  for this reason.
- Windows MRI verification is pending and will be run by the maintainer.

Closes: #1721
