### PR TITLE
feat(info): nest Git::AuthorInfo in Git::TagInfo and Git::StashInfo

### DIFF
--- a/lib/git/parsers/stash.rb
+++ b/lib/git/parsers/stash.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'time'
+
+require 'git/author_info'
 require 'git/stash_info'
 
 module Git
@@ -45,10 +48,10 @@ module Git
       # %gs = reflog subject (the stash message)
       # %an = author name
       # %ae = author email
-      # %aI = author date (ISO 8601 format)
+      # %aI = author date (ISO 8601 format, parsed into a Time)
       # %cn = committer name
       # %ce = committer email
-      # %cI = committer date (ISO 8601 format)
+      # %cI = committer date (ISO 8601 format, parsed into a Time)
       STASH_FORMAT = [
         '%H',  # 0: full SHA
         '%h',  # 1: short SHA
@@ -163,7 +166,7 @@ module Git
       # @return [Hash] attributes for StashInfo.new
       #
       def stash_info_attrs(parts, index)
-        core_attrs(parts, index).merge(author_attrs(parts)).merge(committer_attrs(parts))
+        core_attrs(parts, index).merge(author: author_info(parts), committer: committer_info(parts))
       end
 
       # Build core StashInfo attributes from parsed fields
@@ -182,30 +185,60 @@ module Git
         }
       end
 
-      # Build author-related StashInfo attributes from parsed fields
+      # Build the author identity from the parsed fields
       #
       # @param parts [Array<String>] the parsed format fields
       #
-      # @return [Hash<Symbol, String>] author attributes for StashInfo.new
+      # @return [Git::AuthorInfo] the stash author; its `date` is a `Time`
       #
-      def author_attrs(parts)
-        {
-          author_name: parts[Fields::AUTHOR_NAME], author_email: parts[Fields::AUTHOR_EMAIL],
-          author_date: parts[Fields::AUTHOR_DATE]
-        }
+      def author_info(parts)
+        build_author_info(parts[Fields::AUTHOR_NAME], parts[Fields::AUTHOR_EMAIL], parts[Fields::AUTHOR_DATE])
       end
 
-      # Build committer-related StashInfo attributes from parsed fields
+      # Build the committer identity from the parsed fields
       #
       # @param parts [Array<String>] the parsed format fields
       #
-      # @return [Hash<Symbol, String>] committer attributes for StashInfo.new
+      # @return [Git::AuthorInfo] the stash committer; its `date` is a `Time`
       #
-      def committer_attrs(parts)
-        {
-          committer_name: parts[Fields::COMMITTER_NAME], committer_email: parts[Fields::COMMITTER_EMAIL],
-          committer_date: parts[Fields::COMMITTER_DATE]
-        }
+      def committer_info(parts)
+        build_author_info(
+          parts[Fields::COMMITTER_NAME], parts[Fields::COMMITTER_EMAIL], parts[Fields::COMMITTER_DATE]
+        )
+      end
+
+      # Build a Git::AuthorInfo from identity fields
+      #
+      # The date is parsed with `Time.iso8601`, so the UTC offset git emits for
+      # `%aI` and `%cI` is preserved in the resulting `Time`.
+      #
+      # @param name [String] the `%an` or `%cn` field
+      #
+      # @param email [String] the `%ae` or `%ce` field
+      #
+      # @param date [String] the `%aI` or `%cI` field in ISO 8601 format
+      #
+      # @return [Git::AuthorInfo] the identity with `date` as a `Time`
+      #
+      # @raise [Git::UnexpectedResultError] if the date is not a valid ISO 8601 date
+      #
+      def build_author_info(name, email, date)
+        Git::AuthorInfo.new(name: name, email: email, date: parse_date(date))
+      end
+
+      # Parse a `%aI` or `%cI` field into a Time
+      #
+      # @param date [String] the date field in ISO 8601 format
+      #
+      # @return [Time] the parsed time, preserving the UTC offset
+      #
+      # @raise [Git::UnexpectedResultError] if the field is not a valid ISO 8601 date
+      #
+      def parse_date(date)
+        Time.iso8601(date)
+      rescue ArgumentError => e
+        raise Git::UnexpectedResultError,
+              "Unexpected date #{date.inspect} in output from `git stash list`: #{e.message}"
       end
 
       # Extract the stash index from a reflog selector

--- a/lib/git/parsers/tag.rb
+++ b/lib/git/parsers/tag.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'time'
+
+require 'git/author_info'
 require 'git/tag_info'
 require 'git/tag_delete_result'
 require 'git/tag_delete_failure'
@@ -114,7 +117,7 @@ module Git
       # where <FS> is the unit separator character ("\x1f").
       #
       # For lightweight tags, Git emits empty strings for the tagger fields and message;
-      # these are converted to nil by {#parse_optional_field} and {#parse_message}.
+      # these are converted to nil by {#parse_tagger} and {#parse_message}.
       #
       # @param record [String] a single tag record from git tag --format output
       #
@@ -183,19 +186,62 @@ module Git
       def build_tag_info_object(parts, oid, target_oid)
         Git::TagInfo.new(
           name: parts[0], oid: oid, target_oid: target_oid, objecttype: parts[3],
-          tagger_name: parse_optional_field(parts[4]), tagger_email: parse_optional_field(parts[5]),
-          tagger_date: parse_optional_field(parts[6]), message: parse_message(parts[3], parts[7])
+          tagger: parse_tagger(parts[4], parts[5], parts[6]), message: parse_message(parts[3], parts[7])
         )
       end
 
-      # Parse an optional field, returning nil if empty
+      # Build the tagger identity from the tagger name, email, and date fields
       #
-      # @param value [String] the field value
+      # Git emits empty strings for all three fields when there is no tag object
+      # (lightweight tags) or the tag object has no tagger header, in which case
+      # the tagger is nil. Otherwise the angle brackets git wraps around
+      # `%(taggeremail)` are stripped and the strict ISO 8601
+      # `%(taggerdate:iso8601-strict)` value is parsed into a `Time` that
+      # preserves the UTC offset. A partially populated identity (for example an
+      # empty name with an email and date) is kept as emitted rather than dropped,
+      # and an empty date becomes `nil`.
       #
-      # @return [String, nil] the value or nil if empty
+      # @example An annotated tag's tagger
+      #   parse_tagger('John Doe', '<john@example.com>', '2024-01-15T10:30:00-08:00')
+      #   #=> #<data Git::AuthorInfo name="John Doe", email="john@example.com", ...>
       #
-      def parse_optional_field(value)
-        value.empty? ? nil : value
+      # @example A lightweight tag has no tagger
+      #   parse_tagger('', '', '') #=> nil
+      #
+      # @param name [String] the `%(taggername)` field
+      #
+      # @param email [String] the `%(taggeremail)` field, including angle brackets
+      #
+      # @param date [String] the `%(taggerdate:iso8601-strict)` field
+      #
+      # @return [Git::AuthorInfo, nil] the tagger, or nil when all three fields are empty
+      #
+      # @raise [Git::UnexpectedResultError] if a non-empty date is not a valid ISO 8601
+      #   date
+      #
+      def parse_tagger(name, email, date)
+        return nil if [name, email, date].all?(&:empty?)
+
+        Git::AuthorInfo.new(
+          name: name,
+          email: email.delete_prefix('<').delete_suffix('>'),
+          date: date.empty? ? nil : parse_date(date)
+        )
+      end
+
+      # Parse a `%(taggerdate:iso8601-strict)` field into a Time
+      #
+      # @param date [String] the date field in strict ISO 8601 format
+      #
+      # @return [Time] the parsed time, preserving the UTC offset
+      #
+      # @raise [Git::UnexpectedResultError] if the field is not a valid ISO 8601 date
+      #
+      def parse_date(date)
+        Time.iso8601(date)
+      rescue ArgumentError => e
+        raise Git::UnexpectedResultError,
+              "Unexpected tagger date #{date.inspect} in output from `git tag --list`: #{e.message}"
       end
 
       # Parse message field, returning nil for lightweight tags or empty messages

--- a/lib/git/stash_info.rb
+++ b/lib/git/stash_info.rb
@@ -1,13 +1,19 @@
 # frozen_string_literal: true
 
+require 'time'
+
+require 'git/author_info'
+
 module Git
   # Immutable value object representing stash entry information
   #
   # StashInfo encapsulates the parsed data from `git stash list` output.
   # Each entry contains comprehensive information about the stash including
-  # its index, reference name, commit SHA, branch, message, author/committer
-  # details, and timestamps.
+  # its index, reference name, commit SHA, branch, message, and the author and
+  # committer identities.
   #
+  # The author and committer are nested {Git::AuthorInfo} values. Their `date`
+  # is a `Time` parsed from git's ISO 8601 output, not an ISO 8601 string.
   #
   # @example Create a StashInfo from parsed stash list output
   #   info = Git::StashInfo.new(
@@ -17,12 +23,16 @@ module Git
   #     short_oid: 'abc123d',
   #     branch: 'main',
   #     message: 'WIP on main: abc123 Initial commit',
-  #     author_name: 'Jane Doe',
-  #     author_email: 'jane@example.com',
-  #     author_date: '2026-01-24T10:30:00-08:00',
-  #     committer_name: 'Jane Doe',
-  #     committer_email: 'jane@example.com',
-  #     committer_date: '2026-01-24T10:30:00-08:00'
+  #     author: Git::AuthorInfo.new(
+  #       name: 'Jane Doe',
+  #       email: 'jane@example.com',
+  #       date: Time.iso8601('2026-01-24T10:30:00-08:00')
+  #     ),
+  #     committer: Git::AuthorInfo.new(
+  #       name: 'Jane Doe',
+  #       email: 'jane@example.com',
+  #       date: Time.iso8601('2026-01-24T10:30:00-08:00')
+  #     )
   #   )
   #
   #   info.index           # => 0
@@ -31,12 +41,12 @@ module Git
   #   info.short_oid       # => 'abc123d'
   #   info.branch          # => 'main'
   #   info.message         # => 'WIP on main: abc123 Initial commit'
-  #   info.author_name     # => 'Jane Doe'
-  #   info.author_email    # => 'jane@example.com'
-  #   info.author_date     # => '2026-01-24T10:30:00-08:00'
-  #   info.committer_name  # => 'Jane Doe'
-  #   info.committer_email # => 'jane@example.com'
-  #   info.committer_date  # => '2026-01-24T10:30:00-08:00'
+  #   info.author.name     # => 'Jane Doe'
+  #   info.author.email    # => 'jane@example.com'
+  #   info.author.date     # => 2026-01-24 10:30:00 -0800
+  #   info.committer.name  # => 'Jane Doe'
+  #
+  # @see Git::AuthorInfo for the nested author and committer identities
   #
   # @api public
   #
@@ -59,23 +69,15 @@ module Git
   # @!attribute [r] message
   #   @return [String] the stash message (e.g., 'WIP on main: abc123 commit msg')
   #
-  # @!attribute [r] author_name
-  #   @return [String] the name of the stash author
+  # @!attribute [r] author
+  #   The identity of the stash author; the nested `date` is a `Time`.
   #
-  # @!attribute [r] author_email
-  #   @return [String] the email of the stash author
+  #   @return [Git::AuthorInfo] the author of the stash commit
   #
-  # @!attribute [r] author_date
-  #   @return [String] the author date in ISO 8601 format
+  # @!attribute [r] committer
+  #   The identity of the stash committer; the nested `date` is a `Time`.
   #
-  # @!attribute [r] committer_name
-  #   @return [String] the name of the stash committer
-  #
-  # @!attribute [r] committer_email
-  #   @return [String] the email of the stash committer
-  #
-  # @!attribute [r] committer_date
-  #   @return [String] the committer date in ISO 8601 format
+  #   @return [Git::AuthorInfo] the committer of the stash commit
   #
   StashInfo = Data.define(
     :index,
@@ -84,12 +86,8 @@ module Git
     :short_oid,
     :branch,
     :message,
-    :author_name,
-    :author_email,
-    :author_date,
-    :committer_name,
-    :committer_email,
-    :committer_date
+    :author,
+    :committer
   ) do
     # Returns the stash reference name
     #

--- a/lib/git/tag_info.rb
+++ b/lib/git/tag_info.rb
@@ -11,19 +11,25 @@ module Git
   # commands. It contains only the data parsed from git output without any
   # repository context or operations.
   #
+  # The tagger identity is a nested {Git::AuthorInfo}. Its `date` is a `Time`
+  # parsed from git's strict ISO 8601 output, not an ISO 8601 string.
+  #
   # @example Annotated tag
   #   info = Git::TagInfo.new(
   #     name: 'v1.0.0',
   #     oid: 'abc123def456',        # tag object's ID
   #     target_oid: 'def456abc789', # commit it points to
   #     objecttype: 'tag',
-  #     tagger_name: 'John Doe',
-  #     tagger_email: '<john@example.com>',
-  #     tagger_date: '2024-01-15T10:30:00-08:00',
+  #     tagger: Git::AuthorInfo.new(
+  #       name: 'John Doe',
+  #       email: 'john@example.com',
+  #       date: Time.iso8601('2024-01-15T10:30:00-08:00')
+  #     ),
   #     message: 'Release version 1.0.0'
   #   )
   #   info.annotated?   #=> true
   #   info.tagger.name  #=> 'John Doe'
+  #   info.tagger.date  #=> 2024-01-15 10:30:00 -0800
   #
   # @example Lightweight tag
   #   info = Git::TagInfo.new(
@@ -31,9 +37,7 @@ module Git
   #     oid: nil,                   # no tag object exists
   #     target_oid: 'def456abc789', # commit ID
   #     objecttype: 'commit',
-  #     tagger_name: nil,
-  #     tagger_email: nil,
-  #     tagger_date: nil,
+  #     tagger: nil,
   #     message: nil
   #   )
   #   info.lightweight?  #=> true
@@ -42,6 +46,8 @@ module Git
   # @see Git::Tag for the full-featured tag object with operations
   #
   # @see Git::Commands::Tag::List for the command that produces these
+  #
+  # @see Git::AuthorInfo for the nested tagger identity
   #
   # @api public
   #
@@ -67,19 +73,18 @@ module Git
   # @!attribute [r] objecttype
   #   @return [String] 'tag' for annotated tags, 'commit' for lightweight tags
   #
-  # @!attribute [r] tagger_name
-  #   @return [String, nil] the tagger's name, or nil for lightweight tags
+  # @!attribute [r] tagger
+  #   The identity of the person who created the tag object.
   #
-  # @!attribute [r] tagger_email
-  #   @return [String, nil] the tagger's email, or nil for lightweight tags
+  #   Lightweight tags have no tag object and therefore no tagger. The nested
+  #   `email` has no angle brackets and the nested `date` is a `Time`.
   #
-  # @!attribute [r] tagger_date
-  #   @return [String, nil] the tag date in ISO 8601 format, or nil for lightweight tags
+  #   @return [Git::AuthorInfo, nil] the tagger, or nil for lightweight tags
   #
   # @!attribute [r] message
   #   @return [String, nil] the tag message, or nil for lightweight tags
   #
-  TagInfo = Data.define(:name, :oid, :target_oid, :objecttype, :tagger_name, :tagger_email, :tagger_date, :message) do
+  TagInfo = Data.define(:name, :oid, :target_oid, :objecttype, :tagger, :message) do
     # @return [Boolean] true if this is an annotated tag (oid is present)
     def annotated?
       !oid.nil?
@@ -88,19 +93,6 @@ module Git
     # @return [Boolean] true if this is a lightweight tag (oid is nil)
     def lightweight?
       oid.nil?
-    end
-
-    # Return the tagger as an immutable Git::AuthorInfo object
-    #
-    # @return [Git::AuthorInfo, nil] the tagger, or nil for lightweight tags
-    def tagger
-      return nil unless annotated? && tagger_name && tagger_email
-
-      Git::AuthorInfo.new(
-        name: tagger_name,
-        email: tagger_email.gsub(/\A<|>\z/, ''), # remove angle brackets if present
-        date: tagger_date && Time.iso8601(tagger_date)
-      )
     end
   end
 end

--- a/spec/integration/git/parsers/stash_spec.rb
+++ b/spec/integration/git/parsers/stash_spec.rb
@@ -59,24 +59,26 @@ RSpec.describe Git::Parsers::Stash, :integration do
         expect(result.first.message).to include('WIP on feature')
       end
 
-      it 'parses author information (verifies format string includes author)' do
+      it 'parses author information into a Git::AuthorInfo (verifies format string includes author)' do
         output = git_stash_output
         result = described_class.parse_list(output)
 
-        expect(result.first.author_name).to be_a(String)
-        expect(result.first.author_name).not_to be_empty
-        expect(result.first.author_email).to match(/@/)
-        expect(result.first.author_date).to be_a(String)
+        expect(result.first.author).to be_a(Git::AuthorInfo)
+        expect(result.first.author.name).to be_a(String)
+        expect(result.first.author.name).not_to be_empty
+        expect(result.first.author.email).to match(/@/)
+        expect(result.first.author.date).to be_a(Time)
       end
 
-      it 'parses committer information (verifies format string includes committer)' do
+      it 'parses committer information into a Git::AuthorInfo (verifies format string includes committer)' do
         output = git_stash_output
         result = described_class.parse_list(output)
 
-        expect(result.first.committer_name).to be_a(String)
-        expect(result.first.committer_name).not_to be_empty
-        expect(result.first.committer_email).to match(/@/)
-        expect(result.first.committer_date).to be_a(String)
+        expect(result.first.committer).to be_a(Git::AuthorInfo)
+        expect(result.first.committer.name).to be_a(String)
+        expect(result.first.committer.name).not_to be_empty
+        expect(result.first.committer.email).to match(/@/)
+        expect(result.first.committer.date).to be_a(Time)
       end
     end
 

--- a/spec/integration/git/parsers/tag_spec.rb
+++ b/spec/integration/git/parsers/tag_spec.rb
@@ -43,14 +43,12 @@ RSpec.describe Git::Parsers::Tag, :integration do
         expect(result.first.annotated?).to be false
       end
 
-      it 'has nil oid and tagger fields for lightweight tags' do
+      it 'has nil oid, tagger, and message for lightweight tags' do
         output = git_tag_output
         result = described_class.parse_list(output)
         tag = result.first
         expect(tag.oid).to be_nil
-        expect(tag.tagger_name).to be_nil
-        expect(tag.tagger_email).to be_nil
-        expect(tag.tagger_date).to be_nil
+        expect(tag.tagger).to be_nil
         expect(tag.message).to be_nil
       end
     end
@@ -81,14 +79,21 @@ RSpec.describe Git::Parsers::Tag, :integration do
         expect(result.first.lightweight?).to be false
       end
 
-      it 'has tagger fields populated for annotated tags' do
+      it 'has the tagger populated as a Git::AuthorInfo for annotated tags' do
         output = git_tag_output
         result = described_class.parse_list(output)
         tag = result.first
-        expect(tag.tagger_name).not_to be_nil
-        expect(tag.tagger_email).not_to be_nil
-        expect(tag.tagger_date).to match(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}([-+]\d{2}:\d{2}|Z)$/)
+        expect(tag.tagger).to be_a(Git::AuthorInfo)
+        expect(tag.tagger.name).to be_a(String)
+        expect(tag.tagger.name).not_to be_empty
+        expect(tag.tagger.date).to be_a(Time)
         expect(tag.message).to eq('Release version 2.0.0')
+      end
+
+      it 'strips the angle brackets git emits around the tagger email' do
+        output = git_tag_output
+        result = described_class.parse_list(output)
+        expect(result.first.tagger.email).to match(/\A[^<>\s]+@[^<>\s]+\z/)
       end
     end
 

--- a/spec/unit/git/parsers/stash_spec.rb
+++ b/spec/unit/git/parsers/stash_spec.rb
@@ -30,12 +30,31 @@ RSpec.describe Git::Parsers::Stash do
       expect(result[0].short_oid).to eq('abc123d')
       expect(result[0].branch).to eq('main')
       expect(result[0].message).to eq('WIP on main: def456 Initial commit')
-      expect(result[0].author_name).to eq('Jane Doe')
-      expect(result[0].author_email).to eq('jane@example.com')
-      expect(result[0].author_date).to eq('2026-01-24T10:30:00-08:00')
-      expect(result[0].committer_name).to eq('Jane Doe')
-      expect(result[0].committer_email).to eq('jane@example.com')
-      expect(result[0].committer_date).to eq('2026-01-24T10:30:00-08:00')
+      expect(result[0].author).to eq(
+        Git::AuthorInfo.new(
+          name: 'Jane Doe', email: 'jane@example.com', date: Time.iso8601('2026-01-24T10:30:00-08:00')
+        )
+      )
+      expect(result[0].committer).to eq(
+        Git::AuthorInfo.new(
+          name: 'Jane Doe', email: 'jane@example.com', date: Time.iso8601('2026-01-24T10:30:00-08:00')
+        )
+      )
+    end
+
+    it 'parses the author and committer dates into Time values that preserve the UTC offset' do
+      line = [
+        'abc123', 'abc', 'stash@{0}', 'WIP on main: msg',
+        'Jane', 'jane@ex.com', '2026-01-24T10:30:00-08:00',
+        'John', 'john@ex.com', '2026-01-24T19:30:00+01:00'
+      ].join(field_sep)
+
+      result = described_class.parse_list(line)
+
+      expect(result[0].author.date).to be_a(Time)
+      expect(result[0].author.date.utc_offset).to eq(-8 * 3600)
+      expect(result[0].committer.date).to be_a(Time)
+      expect(result[0].committer.date.utc_offset).to eq(3600)
     end
 
     it 'parses multiple stash entries' do
@@ -85,6 +104,18 @@ RSpec.describe Git::Parsers::Stash do
       expect do
         described_class.parse_list(malformed_line)
       end.to raise_error(Git::UnexpectedResultError, /Expected 10 fields/)
+    end
+
+    it 'raises UnexpectedResultError when a date field is not a valid ISO 8601 date' do
+      line = [
+        'abc123', 'abc', 'stash@{0}', 'WIP on main: msg',
+        'Jane', 'jane@ex.com', 'not-a-date',
+        'Jane', 'jane@ex.com', '2026-01-24T10:30:00Z'
+      ].join(field_sep)
+
+      expect do
+        described_class.parse_list(line)
+      end.to raise_error(Git::UnexpectedResultError, /not-a-date/)
     end
   end
 
@@ -152,12 +183,12 @@ RSpec.describe Git::Parsers::Stash do
       expect(result[:short_oid]).to eq('short')
       expect(result[:branch]).to eq('feature')
       expect(result[:message]).to eq('WIP on feature: msg')
-      expect(result[:author_name]).to eq('Author')
-      expect(result[:author_email]).to eq('author@ex.com')
-      expect(result[:author_date]).to eq('2026-01-24T10:00:00Z')
-      expect(result[:committer_name]).to eq('Committer')
-      expect(result[:committer_email]).to eq('committer@ex.com')
-      expect(result[:committer_date]).to eq('2026-01-24T11:00:00Z')
+      expect(result[:author]).to eq(
+        Git::AuthorInfo.new(name: 'Author', email: 'author@ex.com', date: Time.iso8601('2026-01-24T10:00:00Z'))
+      )
+      expect(result[:committer]).to eq(
+        Git::AuthorInfo.new(name: 'Committer', email: 'committer@ex.com', date: Time.iso8601('2026-01-24T11:00:00Z'))
+      )
     end
   end
 
@@ -217,23 +248,21 @@ RSpec.describe Git::Parsers::Stash do
     context 'with field separator in message' do
       it 'documents known limitation with \\x1f in stash message' do
         # This documents a known limitation: if a stash message contains the
-        # field separator (\x1f), parsing will produce incorrect field alignment
-        # because split() with a limit will keep exactly 10 parts, but the message
-        # gets split causing all subsequent fields to shift. This is extremely
-        # rare in practice since \x1f is a non-printable control character.
+        # field separator (\x1f), split() with a limit still keeps exactly 10
+        # parts, but the message gets split causing all subsequent fields to
+        # shift. The shifted author date field then holds the author email,
+        # which is not a valid ISO 8601 date, so parsing fails with the
+        # parser's usual error. This is extremely rare in practice since \x1f
+        # is a non-printable control character.
         field_sep = described_class::FIELD_SEPARATOR
         line = "abc123#{field_sep}abc#{field_sep}stash@{0}#{field_sep}" \
                "Message with #{field_sep} inside#{field_sep}" \
                "author#{field_sep}email@example.com#{field_sep}2024-01-15T10:00:00Z#{field_sep}" \
                "committer#{field_sep}cemail@example.com#{field_sep}2024-01-15T10:00:00Z"
 
-        # Parse succeeds but produces misaligned data
-        result = described_class.parse_stash_line(line, 0, [line])
-
-        # The message field gets split at the separator
-        expect(result.message).to eq('Message with ')
-        # Subsequent fields are shifted: 'inside' appears where author_name should be
-        expect(result.author_name).to eq(' inside')
+        expect do
+          described_class.parse_stash_line(line, 0, [line])
+        end.to raise_error(Git::UnexpectedResultError, /email@example\.com/)
       end
     end
   end

--- a/spec/unit/git/parsers/tag_spec.rb
+++ b/spec/unit/git/parsers/tag_spec.rb
@@ -27,11 +27,35 @@ RSpec.describe Git::Parsers::Tag do
       expect(result[0].oid).to eq('abc123def456789012345678901234567890abcdef')
       expect(result[0].target_oid).to eq('def456789012345678901234567890abcdef012345')
       expect(result[0].objecttype).to eq('tag')
-      expect(result[0].tagger_name).to eq('John Doe')
-      expect(result[0].tagger_email).to eq('<john@example.com>')
-      expect(result[0].tagger_date).to eq('2024-01-15T10:30:00-08:00')
+      expect(result[0].tagger).to eq(
+        Git::AuthorInfo.new(
+          name: 'John Doe', email: 'john@example.com', date: Time.iso8601('2024-01-15T10:30:00-08:00')
+        )
+      )
       expect(result[0].message).to eq('Release version 1.0.0')
       expect(result[0].annotated?).to be true
+    end
+
+    it 'strips the angle brackets git emits around the tagger email' do
+      record = [
+        'v1.0.0', 'abc123', 'def456', 'tag', 'John Doe', '<john@example.com>', '2024-01-15T10:30:00-08:00', 'Msg'
+      ].join(field_sep) + record_sep
+
+      result = described_class.parse_list(record)
+
+      expect(result[0].tagger.email).to eq('john@example.com')
+    end
+
+    it 'parses the tagger date into a Time that preserves the UTC offset' do
+      record = [
+        'v1.0.0', 'abc123', 'def456', 'tag', 'John Doe', '<john@example.com>', '2024-01-15T10:30:00-08:00', 'Msg'
+      ].join(field_sep) + record_sep
+
+      result = described_class.parse_list(record)
+
+      expect(result[0].tagger.date).to be_a(Time)
+      expect(result[0].tagger.date).to eq(Time.iso8601('2024-01-15T10:30:00-08:00'))
+      expect(result[0].tagger.date.utc_offset).to eq(-8 * 3600)
     end
 
     it 'parses a lightweight tag' do
@@ -53,9 +77,7 @@ RSpec.describe Git::Parsers::Tag do
       expect(result[0].oid).to be_nil
       expect(result[0].target_oid).to eq('abc123def456789012345678901234567890abcdef')
       expect(result[0].objecttype).to eq('commit')
-      expect(result[0].tagger_name).to be_nil
-      expect(result[0].tagger_email).to be_nil
-      expect(result[0].tagger_date).to be_nil
+      expect(result[0].tagger).to be_nil
       expect(result[0].message).to be_nil
       expect(result[0].lightweight?).to be true
     end
@@ -91,7 +113,7 @@ RSpec.describe Git::Parsers::Tag do
     end
 
     it 'handles leading whitespace from previous records' do
-      tag_fields = ['v1.0.0', 'abc', 'def', 'tag', 'J', '<j@e.com>', '2024-01-15', 'Msg']
+      tag_fields = ['v1.0.0', 'abc', 'def', 'tag', 'J', '<j@e.com>', '2024-01-15T10:30:00Z', 'Msg']
       records = "\n#{tag_fields.join(field_sep)}#{record_sep}"
       result = described_class.parse_list(records)
 
@@ -106,11 +128,55 @@ RSpec.describe Git::Parsers::Tag do
         described_class.parse_list(malformed_record)
       end.to raise_error(Git::UnexpectedResultError, /Expected 8 fields/)
     end
+
+    it 'raises UnexpectedResultError when the tagger date is not a valid ISO 8601 date' do
+      record = [
+        'v1.0.0', 'abc123', 'def456', 'tag', 'John Doe', '<john@example.com>', 'not-a-date', 'Msg'
+      ].join(field_sep) + record_sep
+
+      expect do
+        described_class.parse_list(record)
+      end.to raise_error(Git::UnexpectedResultError, /not-a-date/)
+    end
+
+    it 'builds the tagger from the remaining fields when only the tagger name is empty' do
+      record = [
+        'v1.0.0', 'abc123', 'def456', 'tag', '', '<john@example.com>', '2024-01-15T10:30:00Z', 'Msg'
+      ].join(field_sep) + record_sep
+
+      result = described_class.parse_list(record)
+
+      expect(result[0].tagger).to eq(
+        Git::AuthorInfo.new(name: '', email: 'john@example.com', date: Time.iso8601('2024-01-15T10:30:00Z'))
+      )
+    end
+
+    it 'preserves an empty tagger date as nil when the name or email is present' do
+      record = [
+        'v1.0.0', 'abc123', 'def456', 'tag', 'John Doe', '<john@example.com>', '', 'Msg'
+      ].join(field_sep) + record_sep
+
+      result = described_class.parse_list(record)
+
+      expect(result[0].tagger).to eq(Git::AuthorInfo.new(name: 'John Doe', email: 'john@example.com', date: nil))
+    end
+
+    it 'raises UnexpectedResultError when the tagger name is empty and the date is invalid' do
+      record = [
+        'v1.0.0', 'abc123', 'def456', 'tag', '', '<john@example.com>', 'not-a-date', 'Msg'
+      ].join(field_sep) + record_sep
+
+      expect do
+        described_class.parse_list(record)
+      end.to raise_error(Git::UnexpectedResultError, /not-a-date/)
+    end
   end
 
   describe '.parse_tag_record' do
     it 'parses annotated tag record' do
-      record = ['v1.0.0', 'abc123', 'def456', 'tag', 'John', '<john@ex.com>', '2024-01-15', 'Msg'].join(field_sep)
+      record = [
+        'v1.0.0', 'abc123', 'def456', 'tag', 'John', '<john@ex.com>', '2024-01-15T10:30:00Z', 'Msg'
+      ].join(field_sep)
       result = described_class.parse_tag_record(record, 0, [record])
 
       expect(result.name).to eq('v1.0.0')
@@ -130,13 +196,15 @@ RSpec.describe Git::Parsers::Tag do
 
   describe '.build_tag_info' do
     it 'builds TagInfo for annotated tag' do
-      parts = ['v1.0.0', 'abc123', 'def456', 'tag', 'John', '<john@ex.com>', '2024-01-15', 'Message']
+      parts = ['v1.0.0', 'abc123', 'def456', 'tag', 'John', '<john@ex.com>', '2024-01-15T10:30:00Z', 'Message']
       result = described_class.build_tag_info(parts)
 
       expect(result.name).to eq('v1.0.0')
       expect(result.oid).to eq('abc123')
       expect(result.target_oid).to eq('def456')
-      expect(result.tagger_name).to eq('John')
+      expect(result.tagger).to eq(
+        Git::AuthorInfo.new(name: 'John', email: 'john@ex.com', date: Time.iso8601('2024-01-15T10:30:00Z'))
+      )
     end
 
     it 'builds TagInfo for lightweight tag' do
@@ -145,7 +213,7 @@ RSpec.describe Git::Parsers::Tag do
 
       expect(result.oid).to be_nil
       expect(result.target_oid).to eq('abc123')
-      expect(result.tagger_name).to be_nil
+      expect(result.tagger).to be_nil
     end
   end
 
@@ -255,9 +323,7 @@ RSpec.describe Git::Parsers::Tag do
         oid: 'abc123',
         target_oid: 'def456',
         objecttype: 'tag',
-        tagger_name: 'John',
-        tagger_email: '<john@ex.com>',
-        tagger_date: '2024-01-15',
+        tagger: Git::AuthorInfo.new(name: 'John', email: 'john@ex.com', date: Time.iso8601('2024-01-15T10:30:00Z')),
         message: 'Release'
       )
     end

--- a/spec/unit/git/parsers/tag_spec.rb
+++ b/spec/unit/git/parsers/tag_spec.rb
@@ -217,16 +217,6 @@ RSpec.describe Git::Parsers::Tag do
     end
   end
 
-  describe '.parse_optional_field' do
-    it 'returns value for non-empty string' do
-      expect(described_class.parse_optional_field('John Doe')).to eq('John Doe')
-    end
-
-    it 'returns nil for empty string' do
-      expect(described_class.parse_optional_field('')).to be_nil
-    end
-  end
-
   describe '.parse_message' do
     it 'returns message for annotated tag' do
       expect(described_class.parse_message('tag', 'Release notes')).to eq('Release notes')

--- a/spec/unit/git/stash_info_spec.rb
+++ b/spec/unit/git/stash_info_spec.rb
@@ -4,6 +4,22 @@ require 'spec_helper'
 require 'git/stash_info'
 
 RSpec.describe Git::StashInfo do
+  let(:author) do
+    Git::AuthorInfo.new(
+      name: 'Test Author',
+      email: 'author@test.com',
+      date: Time.iso8601('2026-01-24T10:00:00-08:00')
+    )
+  end
+
+  let(:committer) do
+    Git::AuthorInfo.new(
+      name: 'Test Committer',
+      email: 'committer@test.com',
+      date: Time.iso8601('2026-01-24T11:00:00-08:00')
+    )
+  end
+
   # Default attributes for creating test StashInfo objects
   let(:default_attrs) do
     {
@@ -13,31 +29,23 @@ RSpec.describe Git::StashInfo do
       short_oid: 'abc1234',
       branch: 'main',
       message: 'WIP on main: abc123 Initial commit',
-      author_name: 'Test Author',
-      author_email: 'author@test.com',
-      author_date: '2026-01-24T10:00:00-08:00',
-      committer_name: 'Test Committer',
-      committer_email: 'committer@test.com',
-      committer_date: '2026-01-24T10:00:00-08:00'
+      author: author,
+      committer: committer
     }
   end
 
-  describe '.new' do
-    it 'creates a stash info with all attributes' do
-      info = described_class.new(**default_attrs)
+  describe '#initialize' do
+    subject(:info) { described_class.new(**default_attrs) }
 
-      expect(info.index).to eq(0)
-      expect(info.name).to eq('stash@{0}')
-      expect(info.oid).to eq('abc1234567890abcdef1234567890abcdef123456')
-      expect(info.short_oid).to eq('abc1234')
-      expect(info.branch).to eq('main')
-      expect(info.message).to eq('WIP on main: abc123 Initial commit')
-      expect(info.author_name).to eq('Test Author')
-      expect(info.author_email).to eq('author@test.com')
-      expect(info.author_date).to eq('2026-01-24T10:00:00-08:00')
-      expect(info.committer_name).to eq('Test Committer')
-      expect(info.committer_email).to eq('committer@test.com')
-      expect(info.committer_date).to eq('2026-01-24T10:00:00-08:00')
+    it 'stores all members' do
+      expect(info).to have_attributes(**default_attrs)
+    end
+
+    it 'exposes the author and committer as Git::AuthorInfo values whose dates are Time' do
+      expect(info.author).to be_a(Git::AuthorInfo)
+      expect(info.author.date).to be_a(Time)
+      expect(info.committer).to be_a(Git::AuthorInfo)
+      expect(info.committer.date).to be_a(Time)
     end
   end
 
@@ -82,10 +90,12 @@ RSpec.describe Git::StashInfo do
     it 'returns all attributes for pattern matching' do
       # Data.define provides #deconstruct that returns all attribute values
       values = info.deconstruct
-      expect(values.length).to eq(12)
+      expect(values.length).to eq(8)
       expect(values[0]).to eq(0) # index
       expect(values[1]).to eq('stash@{0}') # name
       expect(values[5]).to eq('WIP on main: abc123 Initial commit') # message
+      expect(values[6]).to eq(author)
+      expect(values[7]).to eq(committer)
     end
 
     it 'supports Ruby pattern matching with all attributes' do
@@ -97,7 +107,7 @@ RSpec.describe Git::StashInfo do
         expect(short_oid).to eq('abc1234')
         expect(branch).to eq('main')
         expect(message).to eq('WIP on main: abc123 Initial commit')
-        expect(rest.length).to eq(6) # remaining author/committer fields
+        expect(rest).to eq([author, committer])
       end
     end
   end

--- a/spec/unit/git/tag_delete_result_spec.rb
+++ b/spec/unit/git/tag_delete_result_spec.rb
@@ -8,14 +8,12 @@ require 'git/tag_info'
 RSpec.describe Git::TagDeleteResult do
   let(:tag_v1) do
     Git::TagInfo.new(
-      name: 'v1.0.0', oid: nil, target_oid: 'abc123', objecttype: 'commit',
-      tagger_name: nil, tagger_email: nil, tagger_date: nil, message: nil
+      name: 'v1.0.0', oid: nil, target_oid: 'abc123', objecttype: 'commit', tagger: nil, message: nil
     )
   end
   let(:tag_v2) do
     Git::TagInfo.new(
-      name: 'v2.0.0', oid: nil, target_oid: 'def456', objecttype: 'commit',
-      tagger_name: nil, tagger_email: nil, tagger_date: nil, message: nil
+      name: 'v2.0.0', oid: nil, target_oid: 'def456', objecttype: 'commit', tagger: nil, message: nil
     )
   end
   let(:failure1) { Git::TagDeleteFailure.new(name: 'nonexistent', error_message: "tag 'nonexistent' not found.") }

--- a/spec/unit/git/tag_info_spec.rb
+++ b/spec/unit/git/tag_info_spec.rb
@@ -4,226 +4,106 @@ require 'spec_helper'
 require 'git/tag_info'
 
 RSpec.describe Git::TagInfo do
-  describe 'attributes' do
-    context 'for annotated tags' do
-      subject(:tag_info) do
-        described_class.new(
+  let(:tagger) do
+    Git::AuthorInfo.new(
+      name: 'John Doe',
+      email: 'john@example.com',
+      date: Time.iso8601('2024-01-15T10:30:00-08:00')
+    )
+  end
+
+  let(:annotated_tag) do
+    described_class.new(
+      name: 'v1.0.0',
+      oid: 'abc123def456',
+      target_oid: 'def456abc789',
+      objecttype: 'tag',
+      tagger: tagger,
+      message: 'Release version 1.0.0'
+    )
+  end
+
+  let(:lightweight_tag) do
+    described_class.new(
+      name: 'v1.0.0-beta',
+      oid: nil,
+      target_oid: 'def456abc789',
+      objecttype: 'commit',
+      tagger: nil,
+      message: nil
+    )
+  end
+
+  describe '#initialize' do
+    context 'with an annotated tag' do
+      subject(:tag_info) { annotated_tag }
+
+      it 'stores all members' do
+        expect(tag_info).to have_attributes(
           name: 'v1.0.0',
           oid: 'abc123def456',
           target_oid: 'def456abc789',
           objecttype: 'tag',
-          tagger_name: 'John Doe',
-          tagger_email: '<john@example.com>',
-          tagger_date: '2024-01-15T10:30:00-08:00',
+          tagger: tagger,
           message: 'Release version 1.0.0'
         )
       end
 
-      it 'has a name' do
-        expect(tag_info.name).to eq('v1.0.0')
+      it 'exposes the tagger as a Git::AuthorInfo whose date is a Time' do
+        expect(tag_info.tagger).to be_a(Git::AuthorInfo)
+        expect(tag_info.tagger.date).to be_a(Time)
       end
 
-      it 'has an oid (tag object ID)' do
-        expect(tag_info.oid).to eq('abc123def456')
-      end
-
-      it 'has a target_oid (commit ID)' do
-        expect(tag_info.target_oid).to eq('def456abc789')
-      end
-
-      it 'has an objecttype' do
-        expect(tag_info.objecttype).to eq('tag')
-      end
-
-      it 'has tagger_name' do
-        expect(tag_info.tagger_name).to eq('John Doe')
-      end
-
-      it 'has tagger_email' do
-        expect(tag_info.tagger_email).to eq('<john@example.com>')
-      end
-
-      it 'has tagger_date' do
-        expect(tag_info.tagger_date).to eq('2024-01-15T10:30:00-08:00')
-      end
-
-      it 'has a message' do
-        expect(tag_info.message).to eq('Release version 1.0.0')
+      it 'creates an immutable object' do
+        expect(tag_info).to be_frozen
       end
     end
 
-    context 'for lightweight tags' do
-      subject(:tag_info) do
-        described_class.new(
+    context 'with a lightweight tag' do
+      subject(:tag_info) { lightweight_tag }
+
+      it 'stores nil for the oid, tagger, and message' do
+        expect(tag_info).to have_attributes(
           name: 'v1.0.0-beta',
           oid: nil,
           target_oid: 'def456abc789',
           objecttype: 'commit',
-          tagger_name: nil,
-          tagger_email: nil,
-          tagger_date: nil,
+          tagger: nil,
           message: nil
         )
-      end
-
-      it 'has nil oid' do
-        expect(tag_info.oid).to be_nil
-      end
-
-      it 'has a target_oid (commit ID)' do
-        expect(tag_info.target_oid).to eq('def456abc789')
       end
     end
   end
 
   describe '#annotated?' do
-    context 'when oid is present (annotated tag)' do
-      subject(:tag_info) do
-        described_class.new(
-          name: 'v1.0.0',
-          oid: 'abc123',
-          target_oid: 'def456',
-          objecttype: 'tag',
-          tagger_name: 'John Doe',
-          tagger_email: '<john@example.com>',
-          tagger_date: '2024-01-15T10:30:00-08:00',
-          message: 'Release'
-        )
-      end
+    subject(:result) { tag_info.annotated? }
 
-      it 'returns true' do
-        expect(tag_info.annotated?).to be true
-      end
+    context 'when oid is present (annotated tag)' do
+      let(:tag_info) { annotated_tag }
+
+      it { is_expected.to be true }
     end
 
     context 'when oid is nil (lightweight tag)' do
-      subject(:tag_info) do
-        described_class.new(
-          name: 'v1.0.0',
-          oid: nil,
-          target_oid: 'def456',
-          objecttype: 'commit',
-          tagger_name: nil,
-          tagger_email: nil,
-          tagger_date: nil,
-          message: nil
-        )
-      end
+      let(:tag_info) { lightweight_tag }
 
-      it 'returns false' do
-        expect(tag_info.annotated?).to be false
-      end
+      it { is_expected.to be false }
     end
   end
 
   describe '#lightweight?' do
-    context 'when oid is nil (lightweight tag)' do
-      subject(:tag_info) do
-        described_class.new(
-          name: 'v1.0.0',
-          oid: nil,
-          target_oid: 'def456',
-          objecttype: 'commit',
-          tagger_name: nil,
-          tagger_email: nil,
-          tagger_date: nil,
-          message: nil
-        )
-      end
+    subject(:result) { tag_info.lightweight? }
 
-      it 'returns true' do
-        expect(tag_info.lightweight?).to be true
-      end
+    context 'when oid is nil (lightweight tag)' do
+      let(:tag_info) { lightweight_tag }
+
+      it { is_expected.to be true }
     end
 
     context 'when oid is present (annotated tag)' do
-      subject(:tag_info) do
-        described_class.new(
-          name: 'v1.0.0',
-          oid: 'abc123',
-          target_oid: 'def456',
-          objecttype: 'tag',
-          tagger_name: 'John Doe',
-          tagger_email: '<john@example.com>',
-          tagger_date: '2024-01-15T10:30:00-08:00',
-          message: 'Release'
-        )
-      end
+      let(:tag_info) { annotated_tag }
 
-      it 'returns false' do
-        expect(tag_info.lightweight?).to be false
-      end
-    end
-  end
-
-  describe '#tagger' do
-    context 'for annotated tags' do
-      subject(:tag_info) do
-        described_class.new(
-          name: 'v1.0.0',
-          oid: 'abc123',
-          target_oid: 'def456',
-          objecttype: 'tag',
-          tagger_name: 'John Doe',
-          tagger_email: '<john@example.com>',
-          tagger_date: '2024-01-15T10:30:00-08:00',
-          message: 'Release'
-        )
-      end
-
-      it 'returns an immutable Git::AuthorInfo object' do
-        expect(tag_info.tagger).to be_a(Git::AuthorInfo)
-      end
-
-      it 'has the correct name' do
-        expect(tag_info.tagger.name).to eq('John Doe')
-      end
-
-      it 'has the correct email' do
-        expect(tag_info.tagger.email).to eq('john@example.com')
-      end
-
-      it 'carries the tag date parsed from tagger_date' do
-        expect(tag_info.tagger.date).to eq(Time.iso8601('2024-01-15T10:30:00-08:00'))
-      end
-
-      context 'when tagger_date is nil' do
-        subject(:tag_info) do
-          described_class.new(
-            name: 'v1.0.0',
-            oid: 'abc123',
-            target_oid: 'def456',
-            objecttype: 'tag',
-            tagger_name: 'John Doe',
-            tagger_email: '<john@example.com>',
-            tagger_date: nil,
-            message: 'Release'
-          )
-        end
-
-        it 'has a nil date' do
-          expect(tag_info.tagger.date).to be_nil
-        end
-      end
-    end
-
-    context 'for lightweight tags' do
-      subject(:tag_info) do
-        described_class.new(
-          name: 'v1.0.0',
-          oid: nil,
-          target_oid: 'def456',
-          objecttype: 'commit',
-          tagger_name: nil,
-          tagger_email: nil,
-          tagger_date: nil,
-          message: nil
-        )
-      end
-
-      it 'returns nil' do
-        expect(tag_info.tagger).to be_nil
-      end
+      it { is_expected.to be false }
     end
   end
 end


### PR DESCRIPTION
# Description

Implements #1745: `Git::TagInfo` and `Git::StashInfo` now carry nested `Git::AuthorInfo`
members instead of flat identity strings, matching `Git::Object::Commit#author` and
`#committer`.

## Proof disposition

The ADR-0006 safety proof was run on 2026-09-02 against the restored RubyGems.org dump
and GitHub code search and is recorded on the issue. It found no published gem that can
resolve to git 5.3.0 constructing either value object or reading the flat members, so the
issue's route table selects the **hard change in the 5.3.0 minor** with no deprecation
shims and no UPGRADING.md entry. The commits deliberately do not use `feat!` or a
`BREAKING CHANGE:` footer so release-please cuts v5.3.0, not v6.0.0.

## Removed members and their replacements

| Removed | Replacement |
| --- | --- |
| `Git::TagInfo#tagger_name`, `#tagger_email`, `#tagger_date` | `Git::TagInfo#tagger` (`Git::AuthorInfo`, or `nil` for lightweight tags) |
| `Git::StashInfo#author_name`, `#author_email`, `#author_date` | `Git::StashInfo#author` (`Git::AuthorInfo`) |
| `Git::StashInfo#committer_name`, `#committer_email`, `#committer_date` | `Git::StashInfo#committer` (`Git::AuthorInfo`) |

The nested `date` values are `Time` objects, not ISO 8601 strings. `Git::Parsers::Tag`
strips the angle brackets git emits in `%(taggeremail)` and parses
`%(taggerdate:iso8601-strict)` with `Time.iso8601`; `Git::Parsers::Stash` parses `%aI`
and `%cI` the same way, so the UTC offset is preserved. The derived `TagInfo#tagger`
method is gone (the member replaces it), and the tag parser's now-unused
`parse_optional_field` helper is removed with its spec.

## Commit structure

Two commits, in TDD order:

1. `test(info): add failing tests for nested Git::AuthorInfo on TagInfo and StashInfo`
   updates the value-object, parser, and integration specs to the new shape. Against
   the previous code they fail with missing-keyword `ArgumentError`s at every
   construction site and `NoMethodError` for `author`/`committer` on `Git::StashInfo`.
   The tag parser and tag integration specs' nested assertions passed already because
   the derived `TagInfo#tagger` produced the same value; they failed only where a
   `TagInfo` is constructed.
2. `feat(info): nest Git::AuthorInfo in Git::TagInfo and Git::StashInfo` makes them
   pass and updates the class docs.

## Verification

`bundle exec rake` was run on macOS with three engines (asdf):

| Engine | spec:unit | spec:integration | rubocop | markdown:links | yard | build |
| --- | --- | --- | --- | --- | --- | --- |
| MRI 4.0.6 | 5840 examples, 0 failures, 100% line and branch coverage | 585 examples, 0 failures, 4 pending | 626 files, no offenses | 0 errors | build + lint clean, 88 example runs | passed |
| JRuby 10.0.6.0 | 5840 examples, 0 failures | 585 examples, 0 failures, 4 pending | 626 files, no offenses | passed | skipped by the rake task on JRuby | passed |
| TruffleRuby 24.2.1 | 5840 examples, 0 failures, 2 pending | 585 examples, 0 failures, 5 pending | **failed: pre-existing** (see below) | not reached | skipped by the rake task on TruffleRuby | not reached |

The TruffleRuby `rake rubocop` stage aborts with 106 RuboCop internal errors
("An error occurred while ... cop was inspecting ...", RuboCop 1.90.0 on truffleruby
3.3.7) in files this PR does not touch. The identical failure reproduces on a clean
`origin/main` worktree with the same engine, so it is pre-existing and left alone here.
Because rake stops at that stage, `markdown:links` and `build` did not run on
TruffleRuby; both passed on MRI and JRuby.

Windows MRI was not run here.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).
