### PR TITLE
feat(repository): add in_branch and merge_into facade methods

### DIFF
--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -744,6 +744,11 @@ module Git
         # @param execution_context [Git::ExecutionContext::Repository] the
         #   execution context for git commands
         #
+        # The full `refs/heads/<name>` ref is verified rather than the bare name.
+        # A bare name follows the gitrevisions search order, in which
+        # `refs/tags/<name>` is tried before `refs/heads/<name>`, so an unborn
+        # branch that shares its name with a tag would be reported as `:active`.
+        #
         # @param branch_name [String] the branch name to verify
         #
         # @return [:active, :unborn] the branch ref state
@@ -754,7 +759,7 @@ module Git
         # @api private
         #
         def get_branch_state(execution_context, branch_name)
-          Git::Commands::RevParse.new(execution_context).call(branch_name, verify: true, quiet: true)
+          Git::Commands::RevParse.new(execution_context).call("refs/heads/#{branch_name}", verify: true, quiet: true)
           :active
         rescue Git::FailedError => e
           raise unless e.result.status.exitstatus == 1 && e.result.stderr.empty?

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -187,6 +187,73 @@ module Git
         Git::Commands::Checkout::Branch.new(@execution_context).call(target, **translated_opts).stdout
       end
 
+      # Run a block with the given branch checked out, then restore the original branch
+      #
+      # Records the current branch (or the current commit when HEAD is detached),
+      # checks out `branch`, and yields to the block. If the block returns a truthy
+      # value, all pending changes are committed with `message` (see
+      # {#commit_all}); if it returns a falsy value, the index and working tree are
+      # hard-reset instead (see {#reset}). The original branch or commit is then
+      # checked out again. The hard reset discards changes to tracked files only;
+      # untracked files created by the block are left in place.
+      #
+      # Unlike `Git::Branch#in_branch`, this method does not create `branch`. The
+      # branch must be an existing local branch. Unlike {#checkout}, a commit SHA,
+      # tag, or remote-tracking branch is rejected before any checkout happens:
+      # those detach HEAD, and a commit made there would be left dangling once the
+      # original branch is restored. HEAD must
+      # be on a branch with at least one commit, or detached: an unborn branch (no
+      # commits yet) cannot be checked out again by name, so it is rejected before
+      # any checkout happens.
+      #
+      # **Note:** the restore checkout is not wrapped in `ensure`. If the block,
+      # the commit, or the reset raises an exception, the repository is left
+      # checked out on `branch` rather than restored to the original branch.
+      #
+      # @example Commit a new file on a feature branch
+      #   repo.in_branch('feature', 'Add README') do
+      #     File.write('README.md', '# Hello')
+      #     repo.add('README.md')
+      #     true  # commit and return to the original branch
+      #   end
+      #
+      # @example Discard experimental changes to a tracked file
+      #   repo.in_branch('scratch') do
+      #     File.write('README.md', '# Try something')
+      #     false  # hard-reset and return to the original branch
+      #   end
+      #
+      # @param branch [String] the name of an existing local branch to check out
+      #
+      # @param message [String] the commit message used when the block returns a
+      #   truthy value
+      #
+      # @return [String] git's stdout from the final checkout back to the original
+      #   branch or commit
+      #
+      # @raise [ArgumentError] if `branch` is not an existing local branch
+      #
+      # @raise [Git::Error] if HEAD is on an unborn branch
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @yield executes the block with `branch` checked out
+      #
+      # @yieldreturn [Object] a truthy value to commit all changes, a falsy value to
+      #   hard-reset
+      #
+      def in_branch(branch, message = 'in branch work')
+        SharedPrivate.assert_local_branch!(self, branch)
+        restore_point = SharedPrivate.head_restore_point(self)
+        checkout(branch)
+        if yield
+          commit_all(message)
+        else
+          reset(nil, hard: true)
+        end
+        checkout(restore_point)
+      end
+
       # Populate the working tree from the index
       #
       # @example Check out all files from the index

--- a/lib/git/repository/merging.rb
+++ b/lib/git/repository/merging.rb
@@ -10,8 +10,8 @@ require 'git/repository/shared_private'
 
 module Git
   class Repository
-    # Facade methods for merge operations: merging branches into the current branch,
-    # and finding common ancestors between commits
+    # Facade methods for merge operations: merging branches into the current branch
+    # or into another branch, and finding common ancestors between commits
     #
     # Included by {Git::Repository}.
     #
@@ -95,6 +95,100 @@ module Git
 
         branches = Array(branch).map(&:to_s)
         Git::Commands::Merge::Start.new(@execution_context).call(*branches, no_edit: true, **opts).stdout
+      end
+
+      # Option keys accepted by {#merge_into}
+      #
+      # The keys accepted by {#merge} except `:no_commit`. A merge stopped before
+      # its commit leaves `target_branch` unchanged, and the restore checkout would
+      # carry the staged merge result onto the original branch instead.
+      MERGE_INTO_ALLOWED_OPTS = %i[no_ff m message].freeze
+      private_constant :MERGE_INTO_ALLOWED_OPTS
+
+      # Merge one or more branches into another branch without leaving the current branch
+      #
+      # Records the current branch (or the current commit when HEAD is detached),
+      # checks out `target_branch`, merges `branch` into it with {#merge}, then
+      # checks out the original branch or commit again. Use {#merge} directly when
+      # the target is the currently checked-out branch.
+      #
+      # `target_branch` must be an existing local branch. Unlike {#checkout}, a
+      # commit SHA, tag, or remote-tracking branch is rejected before any checkout
+      # happens: those detach HEAD, and the merge commit made there would be left
+      # dangling once the original branch is restored while the named ref stayed
+      # unchanged.
+      #
+      # HEAD must be on a branch with at least one commit, or detached: an unborn
+      # branch (no commits yet) cannot be checked out again by name, so it is
+      # rejected before any checkout happens.
+      #
+      # Option keys, the source list, and `target_branch` are checked before any
+      # branch is checked out, so those failures never leave the repository on
+      # `target_branch`. Anything rejected later, such as an option value that is
+      # not accepted or a source ref that does not exist, surfaces inside {#merge}
+      # after the checkout and follows the Note below.
+      #
+      # The `:no_commit` option is not accepted: a merge stopped before its commit
+      # would leave `target_branch` unchanged and the restore checkout would carry
+      # the staged result onto the original branch. To merge without committing,
+      # call {#checkout} and {#merge} directly.
+      #
+      # **Note:** the restore checkout is not wrapped in `ensure`. If the merge
+      # fails (for example, on a conflict), the repository is left checked out on
+      # `target_branch` with the merge in progress rather than restored to the
+      # original branch.
+      #
+      # @example Merge a feature branch into main while staying on the current branch
+      #   repo.merge_into('main', 'feature')
+      #
+      # @example Merge with a no-fast-forward commit message
+      #   repo.merge_into('main', 'feature', 'Merge feature into main', no_ff: true)
+      #
+      # @example Octopus merge of multiple branches into main
+      #   repo.merge_into('main', %w[feature-a feature-b])
+      #
+      # @param target_branch [String] the name of an existing local branch to
+      #   merge into
+      #
+      # @param branch [#to_s, Array<#to_s>] the branch or branches to merge into
+      #   `target_branch`; accepts the same forms as {#merge}, but must name at
+      #   least one branch
+      #
+      # @param message [String, nil] optional commit message for the merge commit;
+      #   see {#merge} for how it interacts with the `:message` and `:m` options
+      #
+      # @param opts [Hash] additional options forwarded to {#merge}
+      #
+      # @option opts [Boolean, nil] :no_ff (nil) create a merge commit even when
+      #   fast-forward is possible (`--no-ff`)
+      #
+      # @option opts [String] :message (nil) commit message; prefer the `:m` option
+      #
+      # @option opts [String] :m (nil) commit message (`-m` flag)
+      #
+      # @return [String] git's stdout from the merge command
+      #
+      # @raise [ArgumentError] when unsupported options (including `:no_commit`)
+      #   are provided
+      #
+      # @raise [ArgumentError] when `branch` is `nil` or an empty Array
+      #
+      # @raise [ArgumentError] when `target_branch` is not an existing local branch
+      #
+      # @raise [Git::Error] when HEAD is on an unborn branch
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def merge_into(target_branch, branch, message = nil, opts = {})
+        SharedPrivate.assert_valid_opts!(MERGE_INTO_ALLOWED_OPTS, **opts)
+        raise ArgumentError, 'at least one branch to merge is required' if Array(branch).empty?
+
+        SharedPrivate.assert_local_branch!(self, target_branch)
+        restore_point = SharedPrivate.head_restore_point(self)
+        checkout(target_branch)
+        output = merge(branch, message, opts)
+        checkout(restore_point)
+        output
       end
 
       # Find common ancestor commit(s) for use in a merge

--- a/lib/git/repository/shared_private.rb
+++ b/lib/git/repository/shared_private.rb
@@ -46,6 +46,73 @@ module Git
 
         raise ArgumentError, "Unknown options: #{unknown.join(', ')}"
       end
+
+      # Raise unless `branch` names an existing local branch
+      #
+      # Used by facade methods that check out a branch, do work on it, and switch
+      # back. {Git::Repository#checkout} also accepts commit SHAs, tags, and
+      # remote-tracking branches, all of which detach HEAD; work committed there
+      # would be left dangling once the original branch is restored, and git has
+      # no way to report that.
+      #
+      # @example With an existing local branch
+      #   SharedPrivate.assert_local_branch!(repo, 'feature') #=> nil
+      #
+      # @example With a tag
+      #   SharedPrivate.assert_local_branch!(repo, 'v1.0.0')
+      #   #=> raises ArgumentError: 'v1.0.0' is not an existing local branch
+      #
+      # @param repository [Git::Repository] the repository to check
+      #
+      # @param branch [String] the branch name to verify
+      #
+      # @return [void]
+      #
+      # @raise [ArgumentError] when `branch` is not an existing local branch
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def assert_local_branch!(repository, branch)
+        return if repository.local_branch?(branch)
+
+        raise ArgumentError, "'#{branch}' is not an existing local branch"
+      end
+
+      # Returns a revision that restores the current HEAD after switching branches
+      #
+      # Used by facade methods that temporarily check out another branch and
+      # then switch back. On a branch, the branch name is enough. When HEAD is
+      # detached, {Git::Repository#current_branch} reports `'HEAD'`, which after
+      # a checkout resolves to the new branch rather than the original commit,
+      # so the commit SHA is captured instead. An unborn branch (one with no
+      # commits yet) has no ref to check out by name, so it is rejected here,
+      # before the caller switches away from it.
+      #
+      # @example On a branch
+      #   SharedPrivate.head_restore_point(repo) #=> "main"
+      #
+      # @example With a detached HEAD
+      #   SharedPrivate.head_restore_point(repo) #=> "9b9b31e704c0b85ffdd8d2af2ded85170a5af87d"
+      #
+      # @param repository [Git::Repository] the repository whose HEAD to record
+      #
+      # @return [String] the current branch name, or the full HEAD commit SHA
+      #   when HEAD is detached
+      #
+      # @raise [Git::Error] when HEAD is on an unborn branch
+      #
+      # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      def head_restore_point(repository)
+        head = repository.current_branch_state
+        case head.state
+        when :detached then repository.rev_parse('HEAD').strip
+        when :unborn
+          raise Git::Error, "HEAD is on the unborn branch '#{head.name}', which cannot be restored " \
+                            'after switching branches; make a commit on it first'
+        else head.name
+        end
+      end
     end
 
     private_constant :SharedPrivate

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -436,4 +436,110 @@ RSpec.describe Git::Repository::Branching, :integration do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #in_branch
+  # ---------------------------------------------------------------------------
+  #
+  # in_branch is a multi-command orchestration (checkout, yield, commit or reset,
+  # checkout back), so integration tests confirm the documented end state of the
+  # repository against real git: where HEAD ends up and what landed on the target
+  # branch.
+
+  describe '#in_branch' do
+    before do
+      repo.branch_new('feature')
+    end
+
+    context 'when the block returns a truthy value' do
+      it 'creates a commit on the target branch with the given message' do
+        described_instance.in_branch('feature', 'Add feature file') do
+          write_file('feature.txt', "feature content\n")
+          repo.add('feature.txt')
+          true
+        end
+
+        expect(repo.gcommit('feature').message).to eq('Add feature file')
+        expect(repo.revparse('feature')).not_to eq(repo.revparse('main'))
+      end
+
+      it 'leaves HEAD on the original branch' do
+        described_instance.in_branch('feature', 'Add feature file') do
+          write_file('feature.txt', "feature content\n")
+          repo.add('feature.txt')
+          true
+        end
+
+        expect(described_instance.current_branch).to eq('main')
+      end
+    end
+
+    context 'when the block returns a falsy value' do
+      it 'discards the working tree change' do
+        described_instance.in_branch('feature') do
+          write_file('README.md', "# Changed\n")
+          false
+        end
+
+        expect(read_file('README.md')).to eq("# Hello\n")
+      end
+
+      it 'does not create a commit on the target branch' do
+        described_instance.in_branch('feature') do
+          write_file('README.md', "# Changed\n")
+          false
+        end
+
+        expect(repo.revparse('feature')).to eq(repo.revparse('main'))
+      end
+
+      it 'leaves HEAD on the original branch' do
+        described_instance.in_branch('feature') do
+          write_file('README.md', "# Changed\n")
+          false
+        end
+
+        expect(described_instance.current_branch).to eq('main')
+      end
+    end
+
+    context 'when HEAD is detached' do
+      let!(:original_sha) { repo.revparse('HEAD') }
+
+      before do
+        repo.checkout(original_sha)
+      end
+
+      it 'restores the detached HEAD to the original commit' do
+        described_instance.in_branch('feature', 'Add feature file') do
+          write_file('feature.txt', "feature content\n")
+          repo.add('feature.txt')
+          true
+        end
+
+        expect(described_instance.current_branch).to eq('HEAD')
+        expect(repo.revparse('HEAD')).to eq(original_sha)
+      end
+    end
+
+    context 'when branch is a commit SHA rather than a local branch' do
+      it 'raises ArgumentError and leaves HEAD on the original branch' do
+        expect { described_instance.in_branch(repo.revparse('feature')) { true } }
+          .to raise_error(ArgumentError, /is not an existing local branch/)
+        expect(described_instance.current_branch).to eq('main')
+      end
+    end
+
+    context 'when HEAD is on an unborn branch' do
+      before do
+        repo.checkout('scratch', orphan: true)
+      end
+
+      it 'raises Git::Error and leaves HEAD on the unborn branch' do
+        expect { described_instance.in_branch('feature') { true } }
+          .to raise_error(Git::Error, /unborn branch 'scratch'/)
+        expect(described_instance.current_branch_state).to have_attributes(state: :unborn, name: 'scratch')
+      end
+    end
+  end
 end

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -415,6 +415,17 @@ RSpec.describe Git::Repository::Branching, :integration do
       end
     end
 
+    context 'on an unborn branch that shares its name with a tag' do
+      before do
+        repo.tag_add('scratch')
+        repo.checkout('scratch', orphan: true)
+      end
+
+      it 'returns HeadState with state :unborn (the tag does not stand in for the branch)' do
+        expect(described_instance.current_branch_state).to have_attributes(state: :unborn, name: 'scratch')
+      end
+    end
+
     context 'on an unborn branch (repository initialized with no commits)' do
       let(:unborn_repo_dir) { Dir.mktmpdir('unborn_repo') }
       let(:unborn_repo) { Git.init(unborn_repo_dir) }
@@ -532,6 +543,19 @@ RSpec.describe Git::Repository::Branching, :integration do
 
     context 'when HEAD is on an unborn branch' do
       before do
+        repo.checkout('scratch', orphan: true)
+      end
+
+      it 'raises Git::Error and leaves HEAD on the unborn branch' do
+        expect { described_instance.in_branch('feature') { true } }
+          .to raise_error(Git::Error, /unborn branch 'scratch'/)
+        expect(described_instance.current_branch_state).to have_attributes(state: :unborn, name: 'scratch')
+      end
+    end
+
+    context 'when HEAD is on an unborn branch that shares its name with a tag' do
+      before do
+        repo.tag_add('scratch')
         repo.checkout('scratch', orphan: true)
       end
 

--- a/spec/integration/git/repository/merging_spec.rb
+++ b/spec/integration/git/repository/merging_spec.rb
@@ -143,6 +143,19 @@ RSpec.describe Git::Repository::Merging, :integration do
         expect(described_instance.current_branch_state).to have_attributes(state: :unborn, name: 'scratch')
       end
     end
+
+    context 'when HEAD is on an unborn branch that shares its name with a tag' do
+      before do
+        repo.tag_add('scratch')
+        repo.checkout('scratch', orphan: true)
+      end
+
+      it 'raises Git::Error and leaves HEAD on the unborn branch' do
+        expect { described_instance.merge_into('main', 'feature') }
+          .to raise_error(Git::Error, /unborn branch 'scratch'/)
+        expect(described_instance.current_branch_state).to have_attributes(state: :unborn, name: 'scratch')
+      end
+    end
   end
 
   # ---------------------------------------------------------------------------

--- a/spec/integration/git/repository/merging_spec.rb
+++ b/spec/integration/git/repository/merging_spec.rb
@@ -54,6 +54,98 @@ RSpec.describe Git::Repository::Merging, :integration do
   end
 
   # ---------------------------------------------------------------------------
+  # #merge_into
+  # ---------------------------------------------------------------------------
+  #
+  # merge_into is a multi-command orchestration (checkout, merge, checkout back),
+  # so integration tests confirm the documented end state against real git: the
+  # target branch receives the merge and HEAD is restored to the original branch.
+
+  describe '#merge_into' do
+    before do
+      # A commit on feature that main does not have
+      repo.branch_new('feature')
+      repo.checkout('feature')
+      write_file('feature.txt', "feature content\n")
+      repo.add('feature.txt')
+      repo.commit('Add feature.txt')
+
+      # Do the merge from a third branch so the restore is observable
+      repo.checkout('main')
+      repo.branch_new('work')
+      repo.checkout('work')
+    end
+
+    it 'merges the source branch into the target branch' do
+      described_instance.merge_into('main', 'feature')
+
+      expect(repo.revparse('main')).to eq(repo.revparse('feature'))
+    end
+
+    it 'leaves the original branch checked out' do
+      described_instance.merge_into('main', 'feature')
+
+      expect(described_instance.current_branch).to eq('work')
+    end
+
+    it 'does not bring the merged content into the original branch' do
+      described_instance.merge_into('main', 'feature')
+
+      expect(file_exist?('feature.txt')).to be(false)
+    end
+
+    it "returns git's stdout from the merge" do
+      expect(described_instance.merge_into('main', 'feature')).to be_a(String)
+    end
+
+    context 'with a message and no_ff: true' do
+      it 'records a merge commit with the message on the target branch' do
+        described_instance.merge_into('main', 'feature', 'Merge feature into main', no_ff: true)
+
+        expect(repo.gcommit('main').message).to eq('Merge feature into main')
+      end
+    end
+
+    context 'when HEAD is detached' do
+      let!(:original_sha) { repo.revparse('HEAD') }
+
+      before do
+        repo.checkout(original_sha)
+      end
+
+      it 'merges into the target and restores the detached HEAD to the original commit' do
+        described_instance.merge_into('main', 'feature')
+
+        expect(repo.revparse('main')).to eq(repo.revparse('feature'))
+        expect(described_instance.current_branch).to eq('HEAD')
+        expect(repo.revparse('HEAD')).to eq(original_sha)
+      end
+    end
+
+    context 'when target_branch is a commit SHA rather than a local branch' do
+      it 'raises ArgumentError, leaves the target unchanged, and stays on the original branch' do
+        main_sha = repo.revparse('main')
+        expect { described_instance.merge_into(main_sha, 'feature') }
+          .to raise_error(ArgumentError, /is not an existing local branch/)
+        expect(repo.revparse('main')).to eq(main_sha)
+        expect(described_instance.current_branch).to eq('work')
+      end
+    end
+
+    context 'when HEAD is on an unborn branch' do
+      before do
+        repo.checkout('scratch', orphan: true)
+      end
+
+      it 'raises Git::Error and leaves HEAD on the unborn branch' do
+        expect { described_instance.merge_into('main', 'feature') }
+          .to raise_error(Git::Error, /unborn branch 'scratch'/)
+        expect(described_instance.current_branch_state).to have_attributes(state: :unborn, name: 'scratch')
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # #merge_base — basic ancestor lookup
   # ---------------------------------------------------------------------------
 

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -1382,4 +1382,154 @@ RSpec.describe Git::Repository::Branching do
       end
     end
   end
+
+  # ---------------------------------------------------------------------------
+  # #in_branch
+  # ---------------------------------------------------------------------------
+  #
+  # in_branch orchestrates sibling facade methods (current_branch_state,
+  # rev_parse, checkout, commit_all, reset) rather than a command class
+  # directly, so the sibling methods are stubbed on the repository instance (a
+  # verified partial double) and the contract asserted is the sequence and
+  # arguments of those calls.
+
+  describe '#in_branch' do
+    subject(:result) { described_instance.in_branch(*in_branch_args, &in_branch_block) }
+
+    let(:in_branch_args) { ['feature', 'my message'] }
+    let(:in_branch_block) { proc { true } }
+    let(:head_state) { Git::Repository::Branching::HeadState.new(state: :active, name: 'main') }
+    let(:restore_stdout) { "Switched to branch 'main'\n" }
+
+    before do
+      allow(described_instance).to receive(:local_branch?).with('feature').and_return(true)
+      allow(described_instance).to receive(:current_branch_state).and_return(head_state)
+      allow(described_instance).to receive(:checkout).and_return('')
+      allow(described_instance).to receive(:checkout).with('main').and_return(restore_stdout)
+      allow(described_instance).to receive(:commit_all).and_return('')
+      allow(described_instance).to receive(:reset).and_return('')
+    end
+
+    context 'when the block returns a truthy value' do
+      it 'commits all changes with the given message' do
+        expect(described_instance).to receive(:commit_all).with('my message').and_return('')
+        result
+      end
+
+      it 'does not reset the working tree' do
+        expect(described_instance).not_to receive(:reset)
+        result
+      end
+
+      context 'when the commit fails' do
+        let(:commit_error) { Git::FailedError.new(command_result('', stderr: 'fatal: commit failed', exitstatus: 1)) }
+
+        before do
+          allow(described_instance).to receive(:commit_all).and_raise(commit_error)
+        end
+
+        it 'propagates the error without restoring the original branch' do
+          expect(described_instance).not_to receive(:checkout).with('main')
+          expect { result }.to raise_error(Git::FailedError, /commit failed/)
+        end
+      end
+    end
+
+    context 'when the block returns a falsy value' do
+      let(:in_branch_block) { proc { false } }
+
+      it 'hard-resets the working tree' do
+        expect(described_instance).to receive(:reset).with(nil, hard: true).and_return('')
+        result
+      end
+
+      it 'does not commit' do
+        expect(described_instance).not_to receive(:commit_all)
+        result
+      end
+
+      context 'when the reset fails' do
+        let(:reset_error) { Git::FailedError.new(command_result('', stderr: 'fatal: reset failed', exitstatus: 1)) }
+
+        before do
+          allow(described_instance).to receive(:reset).and_raise(reset_error)
+        end
+
+        it 'propagates the error without restoring the original branch' do
+          expect(described_instance).not_to receive(:checkout).with('main')
+          expect { result }.to raise_error(Git::FailedError, /reset failed/)
+        end
+      end
+    end
+
+    context 'when the block raises' do
+      let(:in_branch_block) { proc { raise 'block failed' } }
+
+      it 'propagates the error without committing, resetting, or restoring the original branch' do
+        expect(described_instance).not_to receive(:commit_all)
+        expect(described_instance).not_to receive(:reset)
+        expect(described_instance).not_to receive(:checkout).with('main')
+        expect { result }.to raise_error(RuntimeError, /block failed/)
+      end
+    end
+
+    context 'with no message argument' do
+      let(:in_branch_args) { ['feature'] }
+
+      it "commits with the default message 'in branch work'" do
+        expect(described_instance).to receive(:commit_all).with('in branch work').and_return('')
+        result
+      end
+    end
+
+    it 'verifies the branch exists, checks it out, yields, then restores the original branch' do
+      expect(described_instance).to receive(:local_branch?).with('feature').and_return(true).ordered
+      expect(described_instance).to receive(:checkout).with('feature').and_return('').ordered
+      expect(described_instance).to receive(:commit_all).with('my message').and_return('').ordered
+      expect(described_instance).to receive(:checkout).with('main').and_return(restore_stdout).ordered
+      result
+    end
+
+    it 'yields control to the block once' do
+      expect { |b| described_instance.in_branch('feature', 'my message', &b) }.to yield_control.once
+    end
+
+    it "returns git's stdout from the checkout back to the original branch" do
+      expect(result).to eq(restore_stdout)
+    end
+
+    context 'when HEAD is detached' do
+      let(:head_state) { Git::Repository::Branching::HeadState.new(state: :detached, name: 'HEAD') }
+
+      before do
+        allow(described_instance).to receive(:rev_parse).with('HEAD').and_return("abc123\n")
+      end
+
+      it 'restores the original commit by SHA rather than by branch name' do
+        expect(described_instance).to receive(:checkout).with('feature').and_return('').ordered
+        expect(described_instance).to receive(:checkout).with('abc123').and_return('').ordered
+        result
+      end
+    end
+
+    context 'when HEAD is on an unborn branch' do
+      let(:head_state) { Git::Repository::Branching::HeadState.new(state: :unborn, name: 'main') }
+
+      it 'raises Git::Error without checking out the target branch' do
+        expect(described_instance).not_to receive(:checkout)
+        expect { result }.to raise_error(Git::Error, /unborn branch 'main'/)
+      end
+    end
+
+    context 'when the branch is not an existing local branch' do
+      before do
+        allow(described_instance).to receive(:local_branch?).with('feature').and_return(false)
+      end
+
+      it 'raises ArgumentError without checking anything out' do
+        expect(described_instance).not_to receive(:checkout)
+        expect { result }.to raise_error(ArgumentError, /'feature' is not an existing local branch/)
+      end
+    end
+  end
 end

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -95,7 +95,7 @@ RSpec.describe Git::Repository::Branching do
       before do
         allow(show_current_command).to receive(:call).and_return(command_result("main\n"))
         allow(rev_parse_command)
-          .to receive(:call).with('main', verify: true, quiet: true)
+          .to receive(:call).with('refs/heads/main', verify: true, quiet: true)
           .and_return(command_result('abc123'))
       end
 
@@ -112,7 +112,7 @@ RSpec.describe Git::Repository::Branching do
       before do
         allow(show_current_command).to receive(:call).and_return(command_result("main\n"))
         allow(rev_parse_command)
-          .to receive(:call).with('main', verify: true, quiet: true)
+          .to receive(:call).with('refs/heads/main', verify: true, quiet: true)
           .and_raise(Git::FailedError.new(unborn_result))
       end
 
@@ -146,7 +146,7 @@ RSpec.describe Git::Repository::Branching do
       before do
         allow(show_current_command).to receive(:call).and_return(command_result("main\n"))
         allow(rev_parse_command)
-          .to receive(:call).with('main', verify: true, quiet: true)
+          .to receive(:call).with('refs/heads/main', verify: true, quiet: true)
           .and_raise(Git::FailedError.new(error_result))
       end
 

--- a/spec/unit/git/repository/merging_spec.rb
+++ b/spec/unit/git/repository/merging_spec.rb
@@ -244,6 +244,150 @@ RSpec.describe Git::Repository::Merging do
   end
 
   # ---------------------------------------------------------------------------
+  # #merge_into
+  # ---------------------------------------------------------------------------
+  #
+  # merge_into orchestrates sibling facade methods (current_branch_state,
+  # rev_parse, checkout, merge) rather than a command class directly, so the
+  # sibling methods are stubbed on the repository instance (a verified partial
+  # double) and the contract asserted is the sequence and arguments of those
+  # calls. merge_into validates its own options (a stricter whitelist than
+  # #merge) before any checkout, and that validation is covered below.
+
+  describe '#merge_into' do
+    subject(:result) { described_instance.merge_into(*merge_into_args) }
+
+    let(:merge_into_args) { %w[main feature] }
+    let(:head_state) { Git::Repository::Branching::HeadState.new(state: :active, name: 'work') }
+    let(:merge_stdout) { "Merge made by the 'ort' strategy.\n" }
+
+    before do
+      allow(described_instance).to receive(:local_branch?).with('main').and_return(true)
+      allow(described_instance).to receive(:current_branch_state).and_return(head_state)
+      allow(described_instance).to receive(:checkout).and_return('')
+      allow(described_instance).to receive(:merge).and_return(merge_stdout)
+    end
+
+    it 'verifies the target exists, checks it out, merges, then restores the original branch' do
+      expect(described_instance).to receive(:local_branch?).with('main').and_return(true).ordered
+      expect(described_instance).to receive(:checkout).with('main').and_return('').ordered
+      expect(described_instance).to receive(:merge).with('feature', nil, {}).and_return(merge_stdout).ordered
+      expect(described_instance).to receive(:checkout).with('work').and_return('').ordered
+      result
+    end
+
+    context 'with a message and options' do
+      let(:merge_into_args) { ['main', 'feature', 'Merge feature into main', { no_ff: true }] }
+
+      it 'forwards the message and options to #merge' do
+        expect(described_instance)
+          .to receive(:merge).with('feature', 'Merge feature into main', { no_ff: true }).and_return(merge_stdout)
+        result
+      end
+    end
+
+    context 'with an Array of branches' do
+      let(:merge_into_args) { ['main', %w[feature-a feature-b]] }
+
+      it 'forwards the Array unchanged to #merge' do
+        expect(described_instance).to receive(:merge).with(%w[feature-a feature-b], nil, {}).and_return(merge_stdout)
+        result
+      end
+    end
+
+    it "returns git's stdout from the merge" do
+      expect(result).to eq(merge_stdout)
+    end
+
+    context 'when HEAD is detached' do
+      let(:head_state) { Git::Repository::Branching::HeadState.new(state: :detached, name: 'HEAD') }
+
+      before do
+        allow(described_instance).to receive(:rev_parse).with('HEAD').and_return("abc123\n")
+      end
+
+      it 'restores the original commit by SHA rather than by branch name' do
+        expect(described_instance).to receive(:checkout).with('main').and_return('').ordered
+        expect(described_instance).to receive(:merge).and_return(merge_stdout).ordered
+        expect(described_instance).to receive(:checkout).with('abc123').and_return('').ordered
+        result
+      end
+    end
+
+    context 'when HEAD is on an unborn branch' do
+      let(:head_state) { Git::Repository::Branching::HeadState.new(state: :unborn, name: 'work') }
+
+      it 'raises Git::Error without checking out the target branch' do
+        expect(described_instance).not_to receive(:checkout)
+        expect { result }.to raise_error(Git::Error, /unborn branch 'work'/)
+      end
+    end
+
+    context 'when the merge fails' do
+      let(:merge_error) { Git::FailedError.new(command_result('', stderr: 'CONFLICT (content)', exitstatus: 1)) }
+
+      before do
+        allow(described_instance).to receive(:merge).and_raise(merge_error)
+      end
+
+      it 'propagates the error without restoring the original branch' do
+        expect(described_instance).not_to receive(:checkout).with('work')
+        expect { result }.to raise_error(Git::FailedError, /CONFLICT/)
+      end
+    end
+
+    context 'with an empty Array of branches' do
+      let(:merge_into_args) { ['main', []] }
+
+      it 'raises ArgumentError without checking anything out or merging' do
+        expect(described_instance).not_to receive(:checkout)
+        expect(described_instance).not_to receive(:merge)
+        expect { result }.to raise_error(ArgumentError, /at least one branch to merge is required/)
+      end
+    end
+
+    context 'with a nil branch' do
+      let(:merge_into_args) { ['main', nil] }
+
+      it 'raises ArgumentError without checking anything out or merging' do
+        expect(described_instance).not_to receive(:checkout)
+        expect(described_instance).not_to receive(:merge)
+        expect { result }.to raise_error(ArgumentError, /at least one branch to merge is required/)
+      end
+    end
+
+    context 'when target_branch is not an existing local branch' do
+      before do
+        allow(described_instance).to receive(:local_branch?).with('main').and_return(false)
+      end
+
+      it 'raises ArgumentError without checking anything out or merging' do
+        expect(described_instance).not_to receive(:checkout)
+        expect(described_instance).not_to receive(:merge)
+        expect { result }.to raise_error(ArgumentError, /'main' is not an existing local branch/)
+      end
+    end
+
+    context 'with an unknown option' do
+      let(:merge_into_args) { ['main', 'feature', nil, { bogus: true }] }
+
+      it 'raises ArgumentError without checking out the target branch' do
+        expect(described_instance).not_to receive(:checkout)
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+
+    context 'with no_commit: true' do
+      let(:merge_into_args) { ['main', 'feature', nil, { no_commit: true }] }
+
+      it 'raises ArgumentError without checking out the target branch' do
+        expect(described_instance).not_to receive(:checkout)
+        expect { result }.to raise_error(ArgumentError, /Unknown options: no_commit/)
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
   # #merge_base
   # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
# Description

Adds the two `Git::Repository` facade methods requested in #1641. They replace the
only two `Git::Branch` conveniences that had no facade equivalent and are
preconditions for the branch deprecation in #1639. `Git::Branch`, `Git::Branches`,
and existing deprecation warnings are not changed here.

The branch has two commits, each with its own tests, so they are independently
releasable:

1. `feat(repository): add in_branch and merge_into facade methods`
2. `fix(branching): verify refs/heads when classifying the HEAD state`

## `Git::Repository#in_branch(branch, message = 'in branch work') { ... }`

In `Git::Repository::Branching`. Records where HEAD is, checks out `branch`, yields,
then commits all changes with `message` when the block returns a truthy value or
hard-resets when it returns a falsy value, and checks the original branch out
again. Returns git's stdout from that final checkout. The hard reset discards
changes to tracked files only; untracked files created by the block are left in
place.

Unlike `Git::Branch#in_branch`, the branch is not created. It must be an existing
local branch: a commit SHA, tag, or remote-tracking branch is rejected with
`ArgumentError` before any checkout, because work committed on a detached HEAD
would be left dangling once the original branch is restored.

## `Git::Repository#merge_into(target_branch, branch, message = nil, opts = {})`

In `Git::Repository::Merging`. Validates its arguments, records where HEAD is,
checks out `target_branch`, calls `merge(branch, message, opts)`, then checks the
original branch out again. Returns the merge's stdout. `branch` accepts the same
shapes `merge` does (String, `#to_s` object such as `Git::BranchInfo`, or an Array
for an octopus merge) but must name at least one branch.

`merge_into` has its own option whitelist: the `merge` options minus `:no_commit`.
A merge stopped before its commit leaves the target unchanged and the restore
checkout would carry the staged result onto the original branch, so `:no_commit`
raises `ArgumentError`. Option keys, the source list, and `target_branch` are all
checked before any checkout so a bad call never leaves the repository on the
target. Callers who want `--no-commit` use `checkout` and `merge` directly.

## Restore point and preconditions shared by both methods

Two `SharedPrivate` helpers back both methods:

- `head_restore_point` returns the branch name when on a branch, or the HEAD
  commit SHA when HEAD is detached. Recording `current_branch` alone would yield
  the literal `'HEAD'`, which after switching resolves to the target branch and
  cannot restore the original commit (`Git::Branch#in_branch` has this defect).
  An unborn HEAD (a branch with no commits yet) has no ref to check out by name,
  so the helper raises `Git::Error` before any checkout.
- `assert_local_branch!` raises `ArgumentError` unless the name is an existing
  local branch.

In both methods the restore checkout is deliberately not wrapped in `ensure`,
matching `Git::Branch#in_branch`. If the block, commit, reset, or merge raises,
the repository is left on the target branch (mid-merge for `merge_into`). Each
method documents this in a bold Note, and unit examples pin the contract so a
future `ensure` refactor cannot change it silently.

Both signatures use a positional `opts = {}` per ADR-0005 rather than keyword
arguments.

## Fix to `Git::Repository#current_branch_state`

`current_branch_state` classified a branch as `:active` or `:unborn` by running
`rev-parse --verify` on the bare branch name. A bare name follows the gitrevisions
search order, which tries `refs/tags/<name>` before `refs/heads/<name>`, so an
unborn branch that shared its name with a tag was reported as `:active`. It now
verifies `refs/heads/<name>`. Branch refs are shared by every linked worktree
through the common git dir, so the lookup behaves the same from any worktree.
This is a user-visible behavior change to an existing public method, limited to
the shadowed-unborn case.

## Checklist

- [ ] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).

Refs: #1641
