### PR TITLE
feat(branch): deprecate Git::Branch#stashes in favor of Git::Repository#stashes_all

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -18,6 +18,7 @@ to update your code when upgrading from the preceding major version.
     - [v4.x-style configuration methods](#v4x-style-configuration-methods)
     - [`Git` module mixin deprecations](#git-module-mixin-deprecations)
     - [`Git::Author` deprecated](#gitauthor-deprecated)
+    - [`Git::Branch#stashes` deprecated](#gitbranchstashes-deprecated)
 
 ## Upgrading to v5.x
 
@@ -383,5 +384,38 @@ Constructing `Git::Author` directly emits a deprecation warning naming
 |-----------------|-------------|
 | `Git::Author.new('Name <email> 1627849923 +0200')` | `Git::AuthorInfo.parse('Name <email> 1627849923 +0200')` |
 | `author.name = 'New Name'` | `author = author.with(name: 'New Name')` (returns a new object) |
+
+#### `Git::Branch#stashes` deprecated
+
+`Git::Branch#stashes` ignores the branch it is called on and returns every stash
+in the repository, so `g.branch('feature').stashes` and `g.branch('main').stashes`
+return the same entries. Call `Git::Repository#stashes_all` instead; it is the
+query `Git::Branch#stashes` was already running.
+
+> **Return type change:** `Git::Branch#stashes` returns a `Git::Stashes`
+> collection of `Git::Stash` objects, newest first. `g.stashes_all` returns an
+> array of `[index, message]` pairs, oldest first. Code that read `stash.message`
+> from each entry should read the second element of each pair instead. Code that
+> iterated or indexed the collection must reverse the order first, because
+> `Git::Stashes` yields and indexes newest first while `g.stashes_all` is oldest
+> first.
+
+`Git::Stashes` also exposes `save`, `apply`, and `clear`. Those map to the
+repository's `stash_save`, `stash_apply`, and `stash_clear`, which are not
+deprecated. `Git::Stashes#apply(i)` already passed `i` to git as `stash@{i}`
+(`0` = newest), and `g.stash_apply(i)` does the same, so that index needs no
+conversion.
+
+| Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
+|-----------------------------------------------------|-------------|
+| `g.branch(name).stashes` | `g.stashes_all` — returns `[[index, message], ...]` |
+| `g.branch(name).stashes.each { \|s\| puts s.message }` | `g.stashes_all.reverse_each { \|_index, message\| puts message }` |
+| `g.branch(name).stashes.all` | `g.stashes_all` |
+| `g.branch(name).stashes.size` | `g.stashes_all.size` |
+| `g.branch(name).stashes[i].message` (`0` = newest, `i` coerced with `to_i`) | `g.stashes_all.reverse[i.to_i][1]` |
+| `g.branch(name).stashes.save(message)` | `g.stash_save(message)` |
+| `g.branch(name).stashes.apply` | `g.stash_apply` |
+| `g.branch(name).stashes.apply(i)` (`0` = newest) | `g.stash_apply(i)` |
+| `g.branch(name).stashes.clear` | `g.stash_clear` |
 
 ---

--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -101,6 +101,11 @@ module Git
 
     # Returns the stash list for this repository
     #
+    # This method ignores the branch receiver and returns every stash in the
+    # repository, so `git.branch('feature').stashes` and
+    # `git.branch('main').stashes` return the same entries. It is deprecated and
+    # will be removed in v6.0.0.
+    #
     # The result is memoized after the first call.
     #
     # @example Iterate over stash entries
@@ -108,7 +113,16 @@ module Git
     #
     # @return [Git::Stashes] the stash list
     #
+    # @deprecated Use {Git::Repository#stashes_all} instead
+    #
+    # @see Git::Repository#stashes_all
+    #
     def stashes
+      Git::Deprecation.warn(
+        'Git::Branch#stashes is deprecated and will be removed in v6.0.0. ' \
+        'It ignores the branch and returns all repository stashes. ' \
+        'Use Git::Repository#stashes_all instead.'
+      )
       @stashes ||= Git::Stashes.new(branch_repository)
     end
 

--- a/spec/unit/git/branch_spec.rb
+++ b/spec/unit/git/branch_spec.rb
@@ -431,6 +431,11 @@ RSpec.describe Git::Branch do
 
     before { allow(base).to receive(:stashes_all).and_return([]) }
 
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      expect(Git::Deprecation).to receive(:warn).with(a_string_including('Git::Branch#stashes'))
+      branch.stashes
+    end
+
     it 'returns a Git::Stashes for the branch repository' do
       expect(branch.stashes).to be_a(Git::Stashes)
     end

--- a/spec/unit/git/branch_spec.rb
+++ b/spec/unit/git/branch_spec.rb
@@ -437,11 +437,19 @@ RSpec.describe Git::Branch do
     end
 
     it 'returns a Git::Stashes for the branch repository' do
+      allow(Git::Deprecation).to receive(:warn)
       expect(branch.stashes).to be_a(Git::Stashes)
     end
 
     it 'memoizes the result' do
+      allow(Git::Deprecation).to receive(:warn)
       expect(branch.stashes).to be(branch.stashes)
+    end
+
+    it 'emits the deprecation warning on every call, including memoized calls' do
+      expect(Git::Deprecation).to receive(:warn).with(a_string_including('Git::Branch#stashes')).twice
+      branch.stashes
+      branch.stashes
     end
   end
 


### PR DESCRIPTION
# Description

Deprecates `Git::Branch#stashes` in favor of `Git::Repository#stashes_all`.

`Git::Branch#stashes` ignores its branch receiver and returns every stash in the repository, so `g.branch('feature').stashes` and `g.branch('main').stashes` give the same answer. There is no branch-scoped behavior to preserve (see ADR-0001), so the method is deprecated rather than reimplemented. Behavior is unchanged: it still returns the memoized repo-wide `Git::Stashes`, but now calls `Git::Deprecation.warn` on every call, before the memoization, following the `Git::Repository#stash_list` pattern.

**Removal horizon.** The warning says "removed in v6.0.0" rather than the issue's "a future version" wording. The v6.0.0 roadmap (#1725) pins this removal to v6.0.0, and every other deprecation message in the codebase names v6.0.0.

**Return shape.** UPGRADING.md gains a `Git::Branch#stashes` subsection under "Deprecated methods" that shows the replacement and notes the return-shape difference: `#stashes` returns a `Git::Stashes` collection of `Git::Stash` objects, while `stashes_all` returns `[[index, message], ...]` pairs, oldest first.

The YARD docs gain a `@deprecated` tag explaining that the branch receiver is ignored and a `@see Git::Repository#stashes_all`. README.md has no `branch(...).stashes` example, so nothing changed there. CHANGELOG.md is generated from commits and was not edited.

Two commits: the first adds the failing unit test for the deprecation warning, the second adds the deprecation and docs.

Closes #1637

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).
