### PR TITLE
feat(repository): deprecate Git::Repository#remotes in favor of #remote_list

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -19,6 +19,7 @@ to update your code when upgrading from the preceding major version.
     - [`Git` module mixin deprecations](#git-module-mixin-deprecations)
     - [`Git::Author` deprecated](#gitauthor-deprecated)
     - [`Git::Branch#stashes` deprecated](#gitbranchstashes-deprecated)
+    - [`Git::Repository#remotes` deprecated](#gitrepositoryremotes-deprecated)
 
 ## Upgrading to v5.x
 
@@ -242,7 +243,7 @@ shim cannot forward them). Update call sites directly:
 
 | v4.x call | Notes |
 |-----------|-------|
-| `g.lib.list_files(ref_dir)` | Walked `.git/refs/` directly. Use `g.branches`, `g.tags`, or `g.remotes` instead. |
+| `g.lib.list_files(ref_dir)` | Walked `.git/refs/` directly. Use `g.branches`, `g.tags`, or `g.remote_list` instead. |
 
 ##### Internal plumbing methods (no replacement)
 
@@ -417,5 +418,44 @@ conversion.
 | `g.branch(name).stashes.apply` | `g.stash_apply` |
 | `g.branch(name).stashes.apply(i)` (`0` = newest) | `g.stash_apply(i)` |
 | `g.branch(name).stashes.clear` | `g.stash_clear` |
+#### `Git::Repository#remotes` deprecated
+
+`Git::Repository#remotes` is deprecated in favor of `Git::Repository#remote_list`
+and is removed in v6.0.0. Calling `remotes` emits a deprecation warning; its
+return value is unchanged.
+
+> **Return type change:** `remotes` returns `Array<Git::Remote>` — mutable
+> objects with `name`, `url`, and `fetch_opts` accessors and `fetch`, `merge`,
+> `branch`, and `remove` operations. `remote_list` returns
+> `Array<Git::RemoteInfo>` — immutable value objects read from the repository's
+> git config, with fields such as `name`, `url`, `push_url`, `fetch`, and `push`.
+> Because a remote may carry more than one URL or refspec, `url`, `push_url`,
+> `fetch`, and `push` are always frozen `Array<String>`. When a remote has more
+> than one URL, git fetches from the first; the legacy `Git::Remote#url` returned
+> the last one configured, so use `r.url.last` to reproduce that exact value.
+> Likewise, `Git::Remote#fetch_opts` returned only the last configured fetch
+> refspec, while `fetch` holds all of them. Operations that lived on
+> `Git::Remote` are called on the repository with the remote name instead.
+>
+> **Order change:** `remotes` lists remotes in the order `git remote` prints
+> them, while `remote_list` keeps the order in which remotes first appear in the
+> config. When the legacy order matters, iterate `g.remote_names` (the same
+> `git remote` order) or sort `g.remote_list` explicitly.
+
+| Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
+|-----------------------------------------------------|-------------|
+| `g.remotes` | `g.remote_list` — returns `Array<Git::RemoteInfo>` |
+| `g.remotes.map(&:name)` | `g.remote_list.map(&:name)` or `g.remote_names` |
+| `g.remotes.map(&:to_s)` | `g.remote_list.map(&:name)` — `Git::RemoteInfo#to_s` is not the name |
+| `g.remotes.map(&:url)` | `g.remote_list.map { \|r\| r.url.first }` — `url` is an `Array<String>` |
+| `g.remotes.map(&:fetch_opts)` | `g.remote_list.map { \|r\| r.fetch.last }` — `fetch` holds every refspec |
+| `g.remotes.each(&:fetch)` | `g.remote_names.each { \|name\| g.fetch(name) }` — same order as `remotes` |
+| `remote.fetch` | `g.fetch(remote.name)` |
+| `remote.fetch(opts)` | `g.fetch(remote.name, opts)` — same options hash |
+| `remote.merge` | `g.merge("#{remote.name}/#{g.current_branch}")` |
+| `remote.merge(branch)` | `g.merge("#{remote.name}/#{branch}")` |
+| `remote.branch` | `g.branch("#{remote.name}/#{g.current_branch}")` |
+| `remote.branch(name)` | `g.branch("#{remote.name}/#{name}")` |
+| `remote.remove` | `g.remote_remove(remote.name)` |
 
 ---

--- a/lib/git/remote_info.rb
+++ b/lib/git/remote_info.rb
@@ -6,7 +6,11 @@ module Git
   # Each instance holds the parsed configuration for a single remote as read
   # from the repository's git config. Multi-value fields (`:url`, `:push_url`,
   # `:fetch`, `:push`) are always `Array<String>` (never `nil`; may be empty).
-  # All other fields are nilable except `:name`.
+  # Those arrays are frozen copies of the values given, so the set of URLs and
+  # refspecs cannot change after construction; use `with` to derive a modified
+  # copy. The immutability is shallow, as with any `Data` member: the strings
+  # inside those arrays and the scalar members are the objects the caller
+  # passed in, not copies. All other fields are nilable except `:name`.
   #
   # @example Minimal remote (fetch-only, one URL)
   #   info = Git::RemoteInfo.new(
@@ -88,13 +92,13 @@ module Git
     #
     # @param name [String] the name of the remote (required)
     #
-    # @param url [Array<String>] fetch URLs (default `[]`)
+    # @param url [Array<String>] fetch URLs (default `[]`); stored as a frozen copy
     #
-    # @param push_url [Array<String>] push URLs (default `[]`)
+    # @param push_url [Array<String>] push URLs (default `[]`); stored as a frozen copy
     #
-    # @param fetch [Array<String>] fetch refspecs (default `[]`)
+    # @param fetch [Array<String>] fetch refspecs (default `[]`); stored as a frozen copy
     #
-    # @param push [Array<String>] push refspecs (default `[]`)
+    # @param push [Array<String>] push refspecs (default `[]`); stored as a frozen copy
     #
     # @param mirror [Boolean, nil] mirror flag (default `nil`)
     #
@@ -118,7 +122,7 @@ module Git
     #
     # @return [Git::RemoteInfo]
     #
-    def initialize(
+    def initialize( # rubocop:disable Metrics/ParameterLists
       name:,
       url: [],
       push_url: [],
@@ -136,11 +140,64 @@ module Git
       vcs: nil
     )
       super(
-        name:, url: Array(url), push_url: Array(push_url), fetch: Array(fetch),
-        push: Array(push), mirror:, skip_default_update:, tag_opt:, prune:,
-        prune_tags:, receivepack:, uploadpack:, promisor:, partial_clone_filter:,
-        vcs:
+        name:, url: Array(url).dup.freeze, push_url: Array(push_url).dup.freeze,
+        fetch: Array(fetch).dup.freeze, push: Array(push).dup.freeze, mirror:,
+        skip_default_update:, tag_opt:, prune:, prune_tags:, receivepack:, uploadpack:,
+        promisor:, partial_clone_filter:, vcs:
       )
+    end
+
+    # Return a copy of this RemoteInfo with the given fields replaced
+    #
+    # Routes through {#initialize} so the multi-value fields of the copy are
+    # frozen copies, the same as on construction. `Data#with` bypasses
+    # `initialize` on Ruby 3.2, which would leave those arrays mutable.
+    #
+    # @example Replace the fetch URL
+    #   info.with(url: ['https://example.com/other.git']).url
+    #   # => ["https://example.com/other.git"]
+    #
+    # @param fields [Hash{Symbol => Object}] the fields to replace, keyed by
+    #   member name
+    #
+    # @option fields [String] :name the name of the remote
+    #
+    # @option fields [Array<String>] :url fetch URLs
+    #
+    # @option fields [Array<String>] :push_url push URLs
+    #
+    # @option fields [Array<String>] :fetch fetch refspecs
+    #
+    # @option fields [Array<String>] :push push refspecs
+    #
+    # @option fields [Boolean, nil] :mirror mirror flag
+    #
+    # @option fields [Boolean, nil] :skip_default_update skip-default-update flag
+    #
+    # @option fields [String, nil] :tag_opt tag-fetching option
+    #
+    # @option fields [Boolean, nil] :prune prune flag
+    #
+    # @option fields [Boolean, nil] :prune_tags prune-tags flag
+    #
+    # @option fields [String, nil] :receivepack receive-pack path
+    #
+    # @option fields [String, nil] :uploadpack upload-pack path
+    #
+    # @option fields [Boolean, nil] :promisor promisor flag
+    #
+    # @option fields [String, nil] :partial_clone_filter partial-clone filter
+    #
+    # @option fields [String, nil] :vcs VCS type
+    #
+    # @return [Git::RemoteInfo] a new instance; `self` when no fields are given
+    #
+    # @raise [ArgumentError] if a key is not a member of this Data class
+    #
+    def with(**fields)
+      return self if fields.empty?
+
+      self.class.new(**to_h, **fields)
     end
   end
 end

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -589,7 +589,20 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @deprecated Use {#remote_list} instead
+      #
+      #   {#remote_list} returns `Array<Git::RemoteInfo>` (immutable value
+      #   objects) rather than `Array<Git::Remote>`. Call the corresponding
+      #   {Git::Repository} method (e.g. {#fetch}, {#remote_remove}) for
+      #   operations on a remote.
+      #
+      # @see #remote_list
+      #
       def remotes
+        Git::Deprecation.warn(
+          'Git::Repository#remotes is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#remote_list instead.'
+        )
         result = Git::Commands::Remote::List.new(@execution_context).call
         result.stdout.split("\n").map { |name| Git::Remote.new(self, name) }
       end

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -128,7 +128,16 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   # ---------------------------------------------------------------------------
 
   describe '#remotes' do
+    it 'emits a deprecation warning' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#remotes is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#remote_list instead.'
+      )
+      described_instance.remotes
+    end
+
     it 'includes each configured remote by name' do
+      allow(Git::Deprecation).to receive(:warn)
       described_instance.remote_add('upstream', bare_dir)
       expect(described_instance.remotes.map(&:name)).to contain_exactly('origin', 'upstream')
     end
@@ -137,6 +146,7 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       before { described_instance.remote_remove('origin') }
 
       it 'returns an empty array' do
+        allow(Git::Deprecation).to receive(:warn)
         expect(described_instance.remotes).to eq([])
       end
     end

--- a/spec/unit/git/remote_info_spec.rb
+++ b/spec/unit/git/remote_info_spec.rb
@@ -169,5 +169,68 @@ RSpec.describe Git::RemoteInfo do
     it 'is frozen' do
       expect(info).to be_frozen
     end
+
+    context 'with array-valued fields' do
+      subject(:info) do
+        described_class.new(
+          name: 'origin',
+          url: ['https://example.com/repo.git'],
+          push_url: ['git@example.com:repo.git'],
+          fetch: ['+refs/heads/*:refs/remotes/origin/*'],
+          push: ['refs/heads/main:refs/heads/main']
+        )
+      end
+
+      it 'freezes url' do
+        expect(info.url).to be_frozen
+      end
+
+      it 'freezes push_url' do
+        expect(info.push_url).to be_frozen
+      end
+
+      it 'freezes fetch' do
+        expect(info.fetch).to be_frozen
+      end
+
+      it 'freezes push' do
+        expect(info.push).to be_frozen
+      end
+
+      it 'does not freeze the array passed by the caller' do
+        url = ['https://example.com/repo.git']
+        described_class.new(name: 'origin', url: url)
+        expect(url).not_to be_frozen
+      end
+    end
+  end
+
+  # ---------------------------------------------------------------------------
+  # #with
+  # ---------------------------------------------------------------------------
+
+  describe '#with' do
+    subject(:info) { described_class.new(name: 'origin', url: ['https://example.com/repo.git']) }
+
+    it 'returns a new instance with the given fields replaced' do
+      copy = info.with(url: ['https://example.com/other.git'])
+      expect(copy).to have_attributes(name: 'origin', url: ['https://example.com/other.git'])
+    end
+
+    it 'leaves the other fields unchanged' do
+      expect(info.with(prune: true)).to have_attributes(url: ['https://example.com/repo.git'], prune: true)
+    end
+
+    it 'freezes the array-valued fields of the copy' do
+      expect(info.with(url: ['https://example.com/other.git']).url).to be_frozen
+    end
+
+    it 'returns self when no fields are given' do
+      expect(info.with).to equal(info)
+    end
+
+    it 'raises ArgumentError for a field that is not a member' do
+      expect { info.with(bogus: 1) }.to raise_error(ArgumentError, /bogus/)
+    end
   end
 end

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -1127,6 +1127,15 @@ RSpec.describe Git::Repository::RemoteOperations do
         .to receive(:new).with(execution_context).and_return(list_command)
       allow(list_command).to receive(:call).and_return(command_result("origin\nupstream\n"))
       allow(Git::Remote).to receive(:new) { |_base, name| instance_double(Git::Remote, name: name) }
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#remotes is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#remote_list instead.'
+      )
+      described_instance.remotes
     end
 
     it 'delegates to Git::Commands::Remote::List.new with the execution_context' do


### PR DESCRIPTION
# Description

`Git::Repository#remotes` now emits a deprecation warning via `Git::Deprecation.warn` and points callers at `Git::Repository#remote_list`. Its return value is unchanged (`Array<Git::Remote>`), so existing callers keep working until the method is removed in v6.0.0.

The two methods differ in return type. `remotes` returns mutable `Git::Remote` objects with `fetch`, `merge`, `branch`, and `remove` operations. `remote_list` returns immutable `Git::RemoteInfo` value objects read from git config, whose `url`, `push_url`, `fetch`, and `push` fields are always `Array<String>`. The YARD `@deprecated` tag and a new "`Git::Repository#remotes` deprecated" section in UPGRADING.md document this difference and show the repository-level call that replaces each `Git::Remote` operation (`g.fetch(name)`, `g.remote_remove(name)`, and so on).

Scope is limited to `#remotes`. `#remote`, `Git::Remote`, and the `add_remote`/`set_remote_url` aliases are tracked separately in #1643.

`config_remote` is intentionally unchanged here. The open question on #1640 about its relationship to `remote_list` is decided: it is deprecated in favor of `remote_list.find { |r| r.name == name }`, and that deprecation is folded into #1643 because its only internal caller is `Git::Remote#initialize`, which #1643 reworks.

Changes:

- `lib/git/repository/remote_operations.rb`: add the warning, `@deprecated`, and `@see #remote_list` to `#remotes`
- `spec/unit/git/repository/remote_operations_spec.rb` and `spec/integration/git/repository/remote_operations_spec.rb`: assert the warning is emitted; stub it in the existing `#remotes` examples
- `UPGRADING.md`: add the migration section and point the `g.lib.list_files` note at `g.remote_list`

Closes #1640

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).

