### PR TITLE
feat(remote): deprecate Git::Remote and Git::Repository#remote in favor of #remote_list

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -20,6 +20,7 @@ to update your code when upgrading from the preceding major version.
     - [`Git::Author` deprecated](#gitauthor-deprecated)
     - [`Git::Branch#stashes` deprecated](#gitbranchstashes-deprecated)
     - [`Git::Repository#remotes` deprecated](#gitrepositoryremotes-deprecated)
+    - [`Git::Remote` deprecated](#gitremote-deprecated)
 
 ## Upgrading to v5.x
 
@@ -421,8 +422,10 @@ conversion.
 #### `Git::Repository#remotes` deprecated
 
 `Git::Repository#remotes` is deprecated in favor of `Git::Repository#remote_list`
-and is removed in v6.0.0. Calling `remotes` emits a deprecation warning; its
-return value is unchanged.
+and is removed in v6.0.0. Its return value is unchanged. Calling `remotes` emits
+one deprecation warning for itself plus one `Git::Remote` constructor warning for
+each remote it returns (see the `Git::Remote` deprecation below), so a repository
+with N remotes produces N + 1 warnings per call.
 
 > **Return type change:** `remotes` returns `Array<Git::Remote>` — mutable
 > objects with `name`, `url`, and `fetch_opts` accessors and `fetch`, `merge`,
@@ -454,8 +457,56 @@ return value is unchanged.
 | `remote.fetch(opts)` | `g.fetch(remote.name, opts)` — same options hash |
 | `remote.merge` | `g.merge("#{remote.name}/#{g.current_branch}")` |
 | `remote.merge(branch)` | `g.merge("#{remote.name}/#{branch}")` |
-| `remote.branch` | `g.branch("#{remote.name}/#{g.current_branch}")` |
-| `remote.branch(name)` | `g.branch("#{remote.name}/#{name}")` |
+| `remote.branch` | `g.branch_list("#{remote.name}/#{g.current_branch}").first` — returns a `Git::BranchInfo` |
+| `remote.branch(name)` | `g.branch_list("#{remote.name}/#{name}").first` — returns a `Git::BranchInfo` |
 | `remote.remove` | `g.remote_remove(remote.name)` |
+
+#### `Git::Remote` deprecated
+
+`Git::Remote`, `Git::Repository#remote`, and `Git::Repository#config_remote` are
+deprecated and are removed in v6.0.0. Read a remote's configuration through
+`Git::Repository#remote_list`, which returns one `Git::RemoteInfo` value object per
+remote, and call the repository-level operations (`fetch`, `merge`, `branch_list`,
+`remote_remove`) with the remote name. Return values are unchanged. Constructing a
+`Git::Remote` directly emits one deprecation warning, and so does calling
+`g.config_remote`. Calling `g.remote` emits two: one for `Git::Repository#remote`
+and one for the `Git::Remote` it constructs. Likewise `g.remotes` emits one warning
+for itself plus one per `Git::Remote` it returns (N + 1 for N remotes). The extra
+warnings from `g.remote` and `g.remotes` are expected, not a bug.
+
+> **Return type changes:** `Git::RemoteInfo#url` and `Git::RemoteInfo#fetch` are
+> frozen `Array<String>` because a remote may carry more than one URL or fetch
+> refspec. The legacy `Git::Remote#url` and `Git::Remote#fetch_opts` returned only
+> the last configured value, so `r.url.last` and `r.fetch.last` reproduce them
+> exactly; `r.url.first` is the URL git actually fetches from.
+> `config_remote` returned a flat `Hash{String => String}` in which a repeated
+> `url` or `fetch` key overwrote the earlier value, so it could not report every
+> configured URL or refspec; `remote_list` keeps all of them. In the other
+> direction, `Git::RemoteInfo` models only the remote variables git defines and
+> drops any other `remote.<name>.*` key, while `config_remote` returned every key.
+> Code that reads custom keys should filter `g.config_list` instead (see the
+> table); that yields the same `Hash{String => String}` as `config_remote`.
+> `Git::Remote#branch` returned a `Git::Branch`. Its replacement,
+> `g.branch_list("#{name}/#{branch}").first`, returns a `Git::BranchInfo` value
+> object, or `nil` when the remote-tracking branch does not exist.
+
+In the table, `name` is the remote name (`g.remote` defaults it to `'origin'`).
+
+| Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
+|-----------------------------------------------------|-------------|
+| `g.remote` | `g.remote_list.find { \|r\| r.name == 'origin' }` — returns a `Git::RemoteInfo`; the deprecated call emits two warnings |
+| `g.remote(name)` | `g.remote_list.find { \|r\| r.name == name }` — returns a `Git::RemoteInfo`; the deprecated call emits two warnings |
+| `g.config_remote(name)` for `url`, `fetch`, and the other modeled fields | `g.remote_list.find { \|r\| r.name == name }` — a `Git::RemoteInfo`, not a `Hash` |
+| `g.config_remote(name)` for every key, including custom ones | `g.config_list.select { \|e\| e.key.start_with?("remote.#{name}.") }.to_h { \|e\| [e.key.delete_prefix("remote.#{name}."), e.value] }` — the same `Hash{String => String}` |
+| `remote.name`, `remote.to_s` | `g.remote_list.find { \|r\| r.name == name }.name` or `g.remote_names` |
+| `remote.url` | `g.remote_list.find { \|r\| r.name == name }.url` — `Array<String>`; `.first` for the single-URL case |
+| `remote.fetch_opts` | `g.remote_list.find { \|r\| r.name == name }.fetch` — `Array<String>` of refspecs |
+| `remote.fetch` | `g.fetch(name)` |
+| `remote.fetch(opts)` | `g.fetch(name, opts)` — same option keys |
+| `remote.merge` | `g.merge("#{name}/#{g.current_branch}")` |
+| `remote.merge(branch)` | `g.merge("#{name}/#{branch}")` |
+| `remote.branch` | `g.branch_list("#{name}/#{g.current_branch}").first` — returns a `Git::BranchInfo` |
+| `remote.branch(branch)` | `g.branch_list("#{name}/#{branch}").first` — returns a `Git::BranchInfo` |
+| `remote.remove` | `g.remote_remove(name)` |
 
 ---

--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -443,7 +443,9 @@ module Git
     #
     def initialize_from_branch_info(branch_info)
       @name = branch_info.short_name
-      @remote = branch_info.remote_name ? Git::Remote.new(@base, branch_info.remote_name) : nil
+      remote_name = branch_info.remote_name
+      # Silenced because Git::Branch is not deprecated until issue 1639
+      @remote = remote_name ? Git::Deprecation.silence { Git::Remote.new(@base, remote_name) } : nil
       @full = @remote ? "remotes/#{@remote.name}/#{@name}" : @name
     end
 
@@ -482,7 +484,9 @@ module Git
     def parse_name(name)
       # Expect this will always match
       match = name.match(BRANCH_NAME_REGEXP)
-      remote = match[:remote_name] ? Git::Remote.new(@base, match[:remote_name]) : nil
+      remote_name = match[:remote_name]
+      # Silenced because Git::Branch is not deprecated until issue 1639
+      remote = remote_name ? Git::Deprecation.silence { Git::Remote.new(@base, remote_name) } : nil
       branch_name = match[:branch_name]
       [remote, branch_name]
     end

--- a/lib/git/remote.rb
+++ b/lib/git/remote.rb
@@ -7,13 +7,26 @@ module Git
   # A remote in a Git repository
   #
   # Remote objects provide access to remote metadata and operations like fetch,
-  # merge, and remove. They should be obtained via `Git::Repository#remote`,
-  # not constructed directly.
+  # merge, and remove. This class and `Git::Repository#remote`, which returns
+  # it, are both deprecated: read remote configuration through
+  # {Git::Repository::RemoteOperations#remote_list} and call the
+  # repository-level operations with the remote name instead.
   #
-  # @example Getting a remote
+  # @example Reading a remote and fetching from it without Git::Remote
   #   git = Git.open('.')
-  #   remote = git.remote('origin')
-  #   remote.fetch
+  #   origin = git.remote_list.find { |r| r.name == 'origin' }  #=> Git::RemoteInfo
+  #   origin.url.first
+  #   git.fetch(origin.name)
+  #
+  # @deprecated Use {Git::Repository::RemoteOperations#remote_list} and the
+  #   repository-level remote operations instead
+  #
+  #   {Git::Repository::RemoteOperations#remote_list} returns immutable
+  #   {Git::RemoteInfo} value objects. Operations that lived on this class are
+  #   called on the repository with the remote name instead (for example
+  #   {Git::Repository::RemoteOperations#fetch} and
+  #   {Git::Repository::RemoteOperations#remote_remove}). Constructing a
+  #   `Git::Remote` emits a deprecation warning.
   #
   # @api public
   #
@@ -42,13 +55,20 @@ module Git
     #
     # @param name [String] the remote name (e.g. `'origin'`)
     #
-    # @note Use `Git::Repository#remote` instead of constructing directly
+    # @note Do not construct directly. `Git::Repository#remote` is deprecated as
+    #   well; use {Git::Repository::RemoteOperations#remote_list} and the
+    #   repository-level remote operations instead.
     #
     # @api private
     #
     def initialize(base, name)
+      Git::Deprecation.warn(
+        'Git::Remote is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#remote_list and the repository-level remote operations instead.'
+      )
       @base = base
-      config = remote_repository.config_remote(name)
+      # config_remote is deprecated too; silence it so one Git::Remote.new emits one warning
+      config = Git::Deprecation.silence { remote_repository.config_remote(name) }
       @name = name
       @url = config['url']
       @fetch_opts = config['fetch']
@@ -118,6 +138,16 @@ module Git
     # @param branch [String] the branch name on this remote (defaults to current branch)
     #
     # @return [Git::Branch] a branch object representing `<remote>/<branch>`
+    #
+    # @deprecated Use
+    #   `Git::Repository#branch_list("#{name}/#{branch || current_branch}").first`
+    #   instead
+    #
+    #   With no argument this method falls back to the current branch, so the
+    #   replacement has to supply `Git::Repository#current_branch` itself. The
+    #   replacement returns a {Git::BranchInfo} value object rather than a
+    #   {Git::Branch}, and returns `nil` when the remote-tracking branch does
+    #   not exist.
     #
     def branch(branch = nil)
       branch ||= remote_repository.current_branch

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -525,7 +525,37 @@ module Git
       #
       # @raise [Git::FailedError] when git exits with a non-zero status
       #
+      # @deprecated Use `remote_list.find { |r| r.name == name }` for the fields
+      #   {Git::RemoteInfo} models, or filter {Git::Configuring#config_list} on
+      #   the `remote.<name>.` key prefix to keep every entry
+      #
+      #   {#remote_list} returns a {Git::RemoteInfo} per remote. Its `url` and
+      #   `fetch` members hold every configured value as `Array<String>`,
+      #   whereas this method returns a flat hash in which a repeated `url` or
+      #   `fetch` key overwrites the earlier value.
+      #
+      #   {Git::RemoteInfo} models only the remote variables git defines and
+      #   drops any other `remote.<name>.*` entry, whereas this method returns
+      #   every entry. Callers that read custom keys should filter
+      #   {Git::Configuring#config_list} instead, which returns the same hash
+      #   (shown here for the `origin` remote):
+      #
+      #     prefix = 'remote.origin.'
+      #     repo.config_list
+      #         .select { |entry| entry.key.start_with?(prefix) }
+      #         .to_h { |entry| [entry.key.delete_prefix(prefix), entry.value] }
+      #
+      # @see #remote_list
+      #
+      # @see Git::Configuring#config_list
+      #
       def config_remote(name)
+        Git::Deprecation.warn(
+          'Git::Repository#config_remote is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#remote_list.find { |r| r.name == name } for the fields ' \
+          'Git::RemoteInfo models, or filter Git::Repository#config_list on the ' \
+          '"remote.<name>." key prefix to keep every entry.'
+        )
         prefix = "remote.#{name}."
         Private.config_list(@execution_context).each_with_object({}) do |(key, value), hsh|
           hsh[key.delete_prefix(prefix)] = value if key.start_with?(prefix)
@@ -574,7 +604,19 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @deprecated Use `remote_list.find { |r| r.name == name }` instead
+      #
+      #   {#remote_list} returns immutable {Git::RemoteInfo} value objects
+      #   rather than {Git::Remote}. Call the corresponding {Git::Repository}
+      #   method (e.g. {#fetch}, {#remote_remove}) for operations on a remote.
+      #
+      # @see #remote_list
+      #
       def remote(name = 'origin')
+        Git::Deprecation.warn(
+          'Git::Repository#remote is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#remote_list.find { |r| r.name == name } instead.'
+        )
         Git::Remote.new(self, name)
       end
 
@@ -594,7 +636,9 @@ module Git
       #   {#remote_list} returns `Array<Git::RemoteInfo>` (immutable value
       #   objects) rather than `Array<Git::Remote>`. Call the corresponding
       #   {Git::Repository} method (e.g. {#fetch}, {#remote_remove}) for
-      #   operations on a remote.
+      #   operations on a remote. Each {Git::Remote} this method constructs
+      #   emits its own deprecation warning, so a call produces one warning
+      #   for this method plus one per remote returned.
       #
       # @see #remote_list
       #

--- a/spec/integration/git/commands/remote/set_url_spec.rb
+++ b/spec/integration/git/commands/remote/set_url_spec.rb
@@ -30,7 +30,8 @@ RSpec.describe Git::Commands::Remote::SetUrl, :integration do
         result = command.call('origin', replacement_repo.dir.to_s)
 
         expect(result).to be_a(Git::CommandLine::Result)
-        expect(repo.remote('origin').url).to eq(replacement_repo.dir.to_s)
+        origin = repo.remote_list.find { |r| r.name == 'origin' }
+        expect(origin.url).to eq([replacement_repo.dir.to_s])
       end
     end
 

--- a/spec/integration/git/repository/remote_operations_spec.rb
+++ b/spec/integration/git/repository/remote_operations_spec.rb
@@ -76,17 +76,18 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
 
   describe '#config_remote' do
     it 'includes the url key' do
-      result = described_instance.config_remote('origin')
+      result = Git::Deprecation.silence { described_instance.config_remote('origin') }
       expect(result).to have_key('url')
     end
 
     it 'includes the fetch key' do
-      result = described_instance.config_remote('origin')
+      result = Git::Deprecation.silence { described_instance.config_remote('origin') }
       expect(result).to have_key('fetch')
     end
 
     it 'returns an empty hash for an unknown remote name' do
-      expect(described_instance.config_remote('nonexistent-remote')).to eq({})
+      result = Git::Deprecation.silence { described_instance.config_remote('nonexistent-remote') }
+      expect(result).to eq({})
     end
   end
 
@@ -128,6 +129,9 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   # ---------------------------------------------------------------------------
 
   describe '#remotes' do
+    # Each Git::Remote that #remotes builds emits its own deprecation warning
+    before { allow(Git::Deprecation).to receive(:warn) }
+
     it 'emits a deprecation warning' do
       expect(Git::Deprecation).to receive(:warn).with(
         'Git::Repository#remotes is deprecated and will be removed in v6.0.0. ' \
@@ -137,7 +141,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
     end
 
     it 'includes each configured remote by name' do
-      allow(Git::Deprecation).to receive(:warn)
       described_instance.remote_add('upstream', bare_dir)
       expect(described_instance.remotes.map(&:name)).to contain_exactly('origin', 'upstream')
     end
@@ -146,7 +149,6 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
       before { described_instance.remote_remove('origin') }
 
       it 'returns an empty array' do
-        allow(Git::Deprecation).to receive(:warn)
         expect(described_instance.remotes).to eq([])
       end
     end
@@ -199,7 +201,8 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
 
     it 'updates the fetch URL for the named remote' do
       described_instance.remote_set_url('origin', other_dir)
-      expect(described_instance.config_remote('origin')['url']).to eq(other_dir)
+      origin = described_instance.remote_list.find { |r| r.name == 'origin' }
+      expect(origin.url).to eq([other_dir])
     end
   end
 
@@ -210,7 +213,8 @@ RSpec.describe Git::Repository::RemoteOperations, :integration do
   describe '#remote_set_branches' do
     it 'replaces the tracked branches for the remote' do
       described_instance.remote_set_branches('origin', 'main')
-      expect(described_instance.config_remote('origin')['fetch']).to include('main')
+      origin = described_instance.remote_list.find { |r| r.name == 'origin' }
+      expect(origin.fetch).to include(a_string_including('main'))
     end
 
     it 'appends tracked branches when add: true' do

--- a/spec/unit/git/remote_spec.rb
+++ b/spec/unit/git/remote_spec.rb
@@ -12,6 +12,7 @@ RSpec.describe Git::Remote do
 
   before do
     allow(base).to receive(:config_remote).with('origin').and_return(remote_config)
+    allow(Git::Deprecation).to receive(:warn)
   end
 
   let(:described_instance) { described_class.new(base, 'origin') }
@@ -23,6 +24,14 @@ RSpec.describe Git::Remote do
   describe '#initialize' do
     context 'when base is a Git::Repository' do
       subject(:remote) { described_instance }
+
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Remote is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#remote_list and the repository-level remote operations instead.'
+        )
+        remote
+      end
 
       it 'sets the name' do
         expect(remote.name).to eq('origin')
@@ -39,6 +48,35 @@ RSpec.describe Git::Remote do
       it 'calls config_remote on the repository' do
         expect(base).to receive(:config_remote).with('origin').and_return(remote_config)
         remote
+      end
+    end
+
+    context 'when config_remote itself emits a deprecation warning' do
+      subject(:remote) { described_instance }
+
+      let(:messages) { [] }
+
+      # Route real warnings to a collector so the silence in #initialize is
+      # exercised instead of bypassed by the stubbed Git::Deprecation.warn
+      around do |example|
+        original_behavior = Git::Deprecation.behavior
+        Git::Deprecation.behavior = ->(message, *) { messages << message }
+        example.run
+      ensure
+        Git::Deprecation.behavior = original_behavior
+      end
+
+      before do
+        allow(Git::Deprecation).to receive(:warn).and_call_original
+        allow(base).to receive(:config_remote).with('origin') do
+          Git::Deprecation.warn('Git::Repository#config_remote is deprecated')
+          remote_config
+        end
+      end
+
+      it 'lets only the Git::Remote warning escape' do
+        remote
+        expect(messages).to contain_exactly(a_string_including('Git::Remote is deprecated'))
       end
     end
   end

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -806,6 +806,7 @@ RSpec.describe Git::Repository::RemoteOperations do
       allow(Git::Commands::ConfigOptionSyntax::List)
         .to receive(:new).with(execution_context).and_return(list_command)
       allow(list_command).to receive(:call).and_return(list_result)
+      allow(Git::Deprecation).to receive(:warn)
     end
 
     context 'when the remote has entries in git config' do
@@ -817,6 +818,16 @@ RSpec.describe Git::Repository::RemoteOperations do
           "core.bare=false\n"
       end
       let(:list_result) { command_result(config_stdout) }
+
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Repository#config_remote is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#remote_list.find { |r| r.name == name } for the fields ' \
+          'Git::RemoteInfo models, or filter Git::Repository#config_list on the ' \
+          '"remote.<name>." key prefix to keep every entry.'
+        )
+        result
+      end
 
       it 'returns a Hash' do
         expect(result).to be_a(Hash)
@@ -878,10 +889,19 @@ RSpec.describe Git::Repository::RemoteOperations do
       allow(Git::Commands::ConfigOptionSyntax::List)
         .to receive(:new).with(execution_context).and_return(config_list_command)
       allow(config_list_command).to receive(:call).and_return(command_result(config_stdout))
+      allow(Git::Deprecation).to receive(:warn)
     end
 
     context 'with an explicit remote name' do
       subject(:result) { described_instance.remote('upstream') }
+
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Repository#remote is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#remote_list.find { |r| r.name == name } instead.'
+        )
+        result
+      end
 
       it 'returns a Git::Remote for the given name' do
         expect(result).to be_a(Git::Remote)


### PR DESCRIPTION
# Description

Deprecates `Git::Remote`, `Git::Repository#remote`, and `Git::Repository#config_remote` in favor of `Git::Repository#remote_list` and the name-based remote operations, per the audit on #1643. Every `Git::Remote` member has a facade replacement (`fetch(name)`, `merge("#{name}/#{branch}")`, `branch_list("#{name}/#{branch}").first`, `remote_remove(name)`), and `remote_list.find { |r| r.name == name }` replaces both `remote(name)` and `config_remote(name)`. Behavior and return values are unchanged until removal in v6.0.0.

The branch has two commits: the failing warning specs, then the deprecation itself.

**Where the warnings fire.** `Git::Remote#initialize` warns first, following the `Git::Author` precedent, and wraps its `config_remote` lookup in `Git::Deprecation.silence` so one construction emits exactly one warning. `#remote` and `#config_remote` warn at the facade entry point, following the `stash_list` precedent. `#remote` therefore emits two warnings (its own plus the constructor's); the same double warning now comes from the already-deprecated `remotes`, `add_remote`, and `set_remote_url` wrappers, which hand back a deprecated object. The audit comment on #1643 accepts this. `remote_add` and `remote_set_url` return `nil`, so no non-deprecated method returns a `Git::Remote`.

**`Git::Branch` is not deprecated yet.** `Git::Branch` builds a `Git::Remote` for remote-tracking branches, and it stays undeprecated until #1639, so the two constructor calls in `lib/git/branch.rb` are wrapped in `Git::Deprecation.silence`. `Git::Branch#remote` still returns a `Git::Remote`.

**Return shape.** UPGRADING.md gains a "`Git::Remote` deprecated" subsection with the member-by-member replacement table and a callout on the differences: `Git::RemoteInfo#url` and `#fetch` are frozen `Array<String>` (the legacy accessors returned the last configured value, so `.last` reproduces them), `config_remote` returned a lossy flat hash, and `remote.branch` maps to `branch_list(...).first`, which returns a `Git::BranchInfo` or `nil`. The two `remote.branch` rows in the existing `remotes` table now point at `branch_list` instead of `g.branch`, which #1639 is about to deprecate.

**YARD.** The class-level `@deprecated` tag links through `Git::Repository::RemoteOperations#remote_list`. A class-level `{Git::Repository#remote_list}` link does not resolve through the mixin (method-level tags do), and the fully qualified form builds with no warnings.

**Specs.** Integration specs that only needed a URL or refspec now assert against `remote_list`; the remaining callers of the deprecated methods silence the warning or stub `Git::Deprecation.warn` in a `before` hook, matching the existing `#remotes` block.

Closes #1643
