### PR TITLE
feat(cat-file): deprecate the allow_unknown_type option of Git::Commands::CatFile::Raw

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -21,6 +21,7 @@ to update your code when upgrading from the preceding major version.
     - [`Git::Branch#stashes` deprecated](#gitbranchstashes-deprecated)
     - [`Git::Repository#remotes` deprecated](#gitrepositoryremotes-deprecated)
     - [`Git::Remote` deprecated](#gitremote-deprecated)
+    - [`Git::Commands::CatFile::Raw` `allow_unknown_type` option deprecated](#gitcommandscatfileraw-allow_unknown_type-option-deprecated)
 
 ## Upgrading to v5.x
 
@@ -508,5 +509,25 @@ In the table, `name` is the remote name (`g.remote` defaults it to `'origin'`).
 | `remote.branch` | `g.branch_list("#{name}/#{g.current_branch}").first` — returns a `Git::BranchInfo` |
 | `remote.branch(branch)` | `g.branch_list("#{name}/#{branch}").first` — returns a `Git::BranchInfo` |
 | `remote.remove` | `g.remote_remove(name)` |
+
+#### `Git::Commands::CatFile::Raw` `allow_unknown_type` option deprecated
+
+The `allow_unknown_type:` option of `Git::Commands::CatFile::Raw` is deprecated
+and is removed in v6.0.0. Passing it emits a deprecation warning; the
+`--allow-unknown-type` flag still reaches git unchanged until the option is
+removed.
+
+There is no replacement. Git 2.50 removed the unknown-type feature, so on git
+2.50 and later `--allow-unknown-type` is an accepted no-op and the option has no
+effect. On git 2.28 through 2.49 the flag still lets `t: true` and `s: true`
+report the type and size of an object whose type git does not recognize, but
+that behavior is dropped together with the option. The class is internal
+(`@api private`) and no `Git::Repository` method passes the option, so only code
+that constructs the command class directly is affected.
+
+| Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
+|-----------------------------------------------------|-------------|
+| `Git::Commands::CatFile::Raw.new(ctx).call(sha, t: true, allow_unknown_type: true)` | `Git::Commands::CatFile::Raw.new(ctx).call(sha, t: true)` |
+| `Git::Commands::CatFile::Raw.new(ctx).call(sha, s: true, allow_unknown_type: true)` | `Git::Commands::CatFile::Raw.new(ctx).call(sha, s: true)` |
 
 ---

--- a/docs/adr/0004-the-option-surface-is-the-union-of-the-supported-git-range.md
+++ b/docs/adr/0004-the-option-surface-is-the-union-of-the-supported-git-range.md
@@ -30,7 +30,11 @@ that major, remove them in the next.
 
 The case that prompted the rule: git 2.50 retired `--allow-unknown-type`, leaving the
 `allow_unknown_type:` option of `Git::Commands::CatFile::Raw` meaningful only below
-2.50. It stays because the floor is 2.28.0. Issue #1709 holds its deprecation trigger.
+2.50. It stays because the floor is 2.28.0. Issue #1709 then deprecated it in v5.3.0,
+ahead of the floor, as an exception the rule allows only because the option is
+private (it lives on an `@api private` command class, reachable only by constructing
+that class directly) and proven unused (the safety proof on issue #1718 found no call
+site in any dependent gem or on GitHub); the floor rule stands for public options.
 
 The scaffolding and audit mechanics live in
 [Command Implementation - Options completeness](../../.github/skills/command-implementation/REFERENCE.md#options-completeness--consult-the-latest-version-docs-first).

--- a/lib/git/commands/cat_file/raw.rb
+++ b/lib/git/commands/cat_file/raw.rb
@@ -50,8 +50,10 @@ module Git
           flag_option :s
 
           # Allow -t and -s to query broken or corrupt objects of unknown type.
-          # Git 2.28-2.49 rejects this flag in other modes; git 2.50+ accepts and
-          # ignores it everywhere (the unknown-type feature was removed; see issue 1709).
+          # Deprecated and removed in v6.0.0 (see issue 1709); passing it emits a
+          # deprecation warning. Git 2.28-2.49 honors it with -t and -s and rejects
+          # it in other modes; git 2.50+ accepts and ignores it everywhere (the
+          # unknown-type feature was removed).
           # See https://git-scm.com/docs/git-cat-file/2.49.0#Documentation/git-cat-file.txt---allow-unknown-type
           flag_option :allow_unknown_type
 
@@ -91,6 +93,13 @@ module Git
         #
         #   @param options [Hash] command options
         #
+        #   @option options [Boolean, nil] :allow_unknown_type (nil) pass `--allow-unknown-type` through to git,
+        #     which rejects it in this mode on git 2.28-2.49 and accepts it as a no-op
+        #     on git 2.50 and later
+        #
+        #     Deprecated and removed in v6.0.0; passing it emits a deprecation
+        #     warning.
+        #
         #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #
         #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
@@ -113,8 +122,11 @@ module Git
         #   @param options [Hash] command options
         #
         #   @option options [Boolean, nil] :allow_unknown_type (nil) allow querying broken or corrupt objects of
-        #     unknown type on git 2.28-2.49; git 2.50 removed the unknown-type feature
-        #     and accepts this flag as a no-op
+        #     unknown type on git 2.28-2.49
+        #
+        #     Deprecated and removed in v6.0.0; passing it emits a deprecation
+        #     warning. Git 2.50 removed the unknown-type feature and accepts this
+        #     flag as a no-op.
         #
         #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #
@@ -138,8 +150,11 @@ module Git
         #   @param options [Hash] command options
         #
         #   @option options [Boolean, nil] :allow_unknown_type (nil) allow querying broken or corrupt objects of
-        #     unknown type on git 2.28-2.49; git 2.50 removed the unknown-type feature
-        #     and accepts this flag as a no-op
+        #     unknown type on git 2.28-2.49
+        #
+        #     Deprecated and removed in v6.0.0; passing it emits a deprecation
+        #     warning. Git 2.50 removed the unknown-type feature and accepts this
+        #     flag as a no-op.
         #
         #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #
@@ -162,6 +177,13 @@ module Git
         #
         #   @param options [Hash] command options
         #
+        #   @option options [Boolean, nil] :allow_unknown_type (nil) pass `--allow-unknown-type` through to git,
+        #     which rejects it in this mode on git 2.28-2.49 and accepts it as a no-op
+        #     on git 2.50 and later
+        #
+        #     Deprecated and removed in v6.0.0; passing it emits a deprecation
+        #     warning.
+        #
         #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #
         #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
@@ -183,6 +205,13 @@ module Git
         #
         #   @param options [Hash] command options
         #
+        #   @option options [Boolean, nil] :allow_unknown_type (nil) pass `--allow-unknown-type` through to git,
+        #     which rejects it in this mode on git 2.28-2.49 and accepts it as a no-op
+        #     on git 2.50 and later
+        #
+        #     Deprecated and removed in v6.0.0; passing it emits a deprecation
+        #     warning.
+        #
         #   @option options [Boolean, nil] :use_mailmap (nil) remap identities via mailmap (`--use-mailmap`)
         #
         #   @option options [Boolean, nil] :no_use_mailmap (nil) suppress mailmap remapping (`--no-use-mailmap`)
@@ -199,6 +228,7 @@ module Git
         #   @option options [Numeric, nil] :timeout (nil) abort the command after this many seconds
         #
         def call(*, **)
+          warn_allow_unknown_type_deprecated(**)
           bound = args_definition.bind(*, **)
           validate_version!(bound.execution_options)
           result = execute_command(bound)
@@ -210,6 +240,30 @@ module Git
           raise Git::FailedError, result unless allowed
 
           result
+        end
+
+        private
+
+        # Emit the deprecation warning when the `allow_unknown_type` keyword is passed
+        #
+        # Keys on the keyword being present, whatever its value: `false` and `nil`
+        # suppress the flag but still name a deprecated option.
+        #
+        # @param options [Hash] the keyword arguments passed to {#call}
+        #
+        # @option options [Boolean, nil] :allow_unknown_type the deprecated option;
+        #   any value, including `false` and `nil`, triggers the warning
+        #
+        # @return [void]
+        #
+        def warn_allow_unknown_type_deprecated(**options)
+          return unless options.key?(:allow_unknown_type)
+
+          Git::Deprecation.warn(
+            'The allow_unknown_type option of Git::Commands::CatFile::Raw is deprecated ' \
+            'and will be removed in v6.0.0. Git 2.50 removed the unknown-type feature ' \
+            'and accepts --allow-unknown-type as a no-op.'
+          )
         end
       end
     end

--- a/spec/unit/git/commands/cat_file/raw_spec.rb
+++ b/spec/unit/git/commands/cat_file/raw_spec.rb
@@ -76,6 +76,7 @@ RSpec.describe Git::Commands::CatFile::Raw do
 
     context 'with :allow_unknown_type option' do
       it 'passes --allow-unknown-type' do
+        allow(Git::Deprecation).to receive(:warn)
         expect_command_capturing('cat-file', '-t', '--allow-unknown-type', '--', 'HEAD')
           .and_return(command_result('commit'))
 
@@ -83,10 +84,39 @@ RSpec.describe Git::Commands::CatFile::Raw do
       end
 
       it 'passes --allow-unknown-type through in other modes and lets git respond' do
+        allow(Git::Deprecation).to receive(:warn)
         expect_command_capturing('cat-file', '-e', '--allow-unknown-type', '--', 'HEAD')
           .and_return(command_result(''))
 
         command.call('HEAD', e: true, allow_unknown_type: true)
+      end
+
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        allow(execution_context).to receive(:command_capturing).and_return(command_result('commit'))
+        expect(Git::Deprecation).to receive(:warn).with(a_string_including('allow_unknown_type'))
+
+        command.call('HEAD', t: true, allow_unknown_type: true)
+      end
+
+      it 'does not emit a deprecation warning when the option is not passed' do
+        allow(execution_context).to receive(:command_capturing).and_return(command_result('commit'))
+        expect(Git::Deprecation).not_to receive(:warn)
+
+        command.call('HEAD', t: true)
+      end
+
+      it 'emits a deprecation warning when the option is passed as false' do
+        allow(execution_context).to receive(:command_capturing).and_return(command_result('commit'))
+        expect(Git::Deprecation).to receive(:warn).with(a_string_including('allow_unknown_type'))
+
+        command.call('HEAD', t: true, allow_unknown_type: false)
+      end
+
+      it 'emits a deprecation warning when the option is passed as nil' do
+        allow(execution_context).to receive(:command_capturing).and_return(command_result('commit'))
+        expect(Git::Deprecation).to receive(:warn).with(a_string_including('allow_unknown_type'))
+
+        command.call('HEAD', t: true, allow_unknown_type: nil)
       end
     end
 


### PR DESCRIPTION
## Summary

Deprecates the `allow_unknown_type:` option of `Git::Commands::CatFile::Raw`. Passing the option now calls `Git::Deprecation.warn`. The check is on key presence, so `allow_unknown_type: false` and `allow_unknown_type: nil` warn too; a caller has to drop the keyword to silence it. The `--allow-unknown-type` flag still passes through to git unchanged. The option is removed in v6.0.0 with no replacement.

Git 2.50 removed the unknown-type feature and turned `--allow-unknown-type` into an accepted no-op. On git 2.28 through 2.49 the flag still works with `-t` and `-s`, and that behavior is dropped together with the option.

## Decision

ADR-0004 says a retired option stays until a `Git::MINIMUM_GIT_VERSION` raise leaves it meaningless across the whole supported range. This option is deprecated in v5.3.0 ahead of that trigger, per the v6.0.0 roadmap (issue #1717, decision 7) and the safety proof on issue #1718: the option lives on an `@api private` command class, is reachable only by constructing that class directly, and the proof found zero call sites in any dependent gem or on GitHub. The paragraph in ADR-0004 that names issue #1709 now records that exception; the floor rule stands for public options.

## Changes

- `lib/git/commands/cat_file/raw.rb`: warn in `#call` when the `allow_unknown_type` keyword is passed, whatever its value; the DSL comment and an `@option` tag in every overload say the option is deprecated and removed in v6.0.0. The `-e`, `-p`, and positional-type tags say git rejects the flag in that mode before 2.50 and accepts it as a no-op from 2.50 on, since the DSL accepts the keyword for every call shape.
- `spec/unit/git/commands/cat_file/raw_spec.rb`: examples asserting the warning is emitted for `true`, `false`, and `nil` and not when the keyword is absent; existing examples stub the warning.
- `UPGRADING.md`: new subsection under "Deprecated methods" with the call shown with and without the option.
- `docs/adr/0004-...md`: final sentence of the paragraph naming issue #1709 updated as described above.

The text at `.github/skills/project-context/SKILL.md` line 213 describes the removed `requires_one_of` constraint and remains accurate, so it is unchanged. CHANGELOG.md is generated by release-please.

## Verification

| Check | Result |
| --- | --- |
| `bundle exec rake default` | every suite 0 failures (unit: 5888 examples); line coverage 7397/7397 (100.00%), branch coverage 1190/1190 (100.00%) |
| `bundle exec rubocop` | 626 files inspected, no offenses detected |
| `bundle exec rake yard` | 100.00% documented, yard-lint no offenses, example tests 88 runs, 0 failures |
| `bundle exec rake markdown:links` | 1615 total, 1250 OK, 0 errors |

The branch is a single commit; the three warning examples (`true`, `false`, `nil`) fail against `main` because `warn` is received 0 times before the fix.

Closes #1709


