### PR TITLE
feat(branch): deprecate Git::Branch and Git::Branches in favor of Git::Repository#branch_list

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -22,6 +22,7 @@ to update your code when upgrading from the preceding major version.
     - [`Git::Repository#remotes` deprecated](#gitrepositoryremotes-deprecated)
     - [`Git::Remote` deprecated](#gitremote-deprecated)
     - [`Git::Commands::CatFile::Raw` `allow_unknown_type` option deprecated](#gitcommandscatfileraw-allow_unknown_type-option-deprecated)
+    - [`Git::Branch` and `Git::Branches` deprecated](#gitbranch-and-gitbranches-deprecated)
 
 ## Upgrading to v5.x
 
@@ -245,7 +246,7 @@ shim cannot forward them). Update call sites directly:
 
 | v4.x call | Notes |
 |-----------|-------|
-| `g.lib.list_files(ref_dir)` | Walked `.git/refs/` directly. Use `g.branches`, `g.tags`, or `g.remote_list` instead. |
+| `g.lib.list_files(ref_dir)` | Walked `.git/refs/` directly. Use `g.branch_list`, `g.tags`, or `g.remote_list` instead. |
 
 ##### Internal plumbing methods (no replacement)
 
@@ -529,5 +530,102 @@ that constructs the command class directly is affected.
 |-----------------------------------------------------|-------------|
 | `Git::Commands::CatFile::Raw.new(ctx).call(sha, t: true, allow_unknown_type: true)` | `Git::Commands::CatFile::Raw.new(ctx).call(sha, t: true)` |
 | `Git::Commands::CatFile::Raw.new(ctx).call(sha, s: true, allow_unknown_type: true)` | `Git::Commands::CatFile::Raw.new(ctx).call(sha, s: true)` |
+
+#### `Git::Branch` and `Git::Branches` deprecated
+
+`Git::Branch`, `Git::Branches`, `Git::Repository#branch`, and
+`Git::Repository#branches` are deprecated and are removed in v6.0.0. Read branch
+data through `Git::Repository#branch_list`, which returns one `Git::BranchInfo`
+value object per local and remote-tracking branch, and call the repository-level
+operations (`checkout`, `branch_new`, `branch_delete`, `merge`, `merge_into`,
+`in_branch`, and so on) with the branch name. Calling `g.branch` or `g.branches`,
+constructing a `Git::Branches`, and calling any operation on a `Git::Branch` each
+emit a deprecation warning; their return values are unchanged. The `full`,
+`name`, `remote`, `to_s`, and `to_a` readers on `Git::Branch` do not warn.
+
+> **Return shape change:** `Git::Branch` exposes `full` (`main` or
+> `remotes/origin/main`), `name`, and `remote` (a `Git::Remote`, or `nil`).
+> `Git::BranchInfo` exposes `refname` (always the full ref: `refs/heads/main` or
+> `refs/remotes/origin/main`), `short_name` (`main` for both), `remote_name` (a
+> `String`, or `nil`), `remote?`, `current?`, `target_oid`, `upstream`,
+> `worktree_path`, and `symref`. `Git::BranchInfo#to_s` is the full ref, not the
+> `remotes/origin/main` form `Git::Branch#to_s` returned. `branch_list` takes
+> `git branch --list` patterns: `'main'` matches the local branch and
+> `'origin/main'` matches the remote-tracking branch. The `remotes/origin/main`
+> and `refs/...` forms that `g.branches[...]` accepted match nothing.
+>
+> **`checkout` no longer creates the branch:** `g.branch('x').checkout` created
+> `x` when it did not exist, ignoring any error from that attempt, and then
+> checked it out. `g.checkout('x')` does not create a missing local branch,
+> with one exception that is git's own: when exactly one remote has a branch
+> named `x`, git creates a local tracking branch from it (its default guess
+> behavior). Otherwise the checkout fails. To reproduce create-or-checkout,
+> call `g.branch_new('x') unless g.local_branch?('x')` and then
+> `g.checkout('x')`. Use `g.checkout('x', new_branch: true)` only when `x` is
+> known not to exist; like `g.branch_new('x')`, it fails when `x` already
+> exists. Likewise `g.branch('x').create` ignored every error, while
+> `g.branch_new('x')` raises `Git::FailedError` when `x` already exists.
+>
+> **`in_branch` and `merge_into` differences:**
+>
+> 1. **Branch creation.** `g.branch('x').in_branch { ... }` created `x` if it did
+>    not exist. `g.in_branch('x') { ... }` raises `ArgumentError` unless `x` is an
+>    existing local branch, so call `g.branch_new('x')` first. A commit SHA, tag,
+>    or remote-tracking name is also rejected before any checkout.
+> 2. **Detached HEAD.** `Git::Branch#in_branch` recorded the literal `HEAD` and
+>    could not restore a detached HEAD to its original commit. `g.in_branch` and
+>    `g.merge_into` record the SHA and restore it.
+> 3. **Unborn HEAD.** Both new methods raise `Git::Error` before checking anything
+>    out when HEAD is on a branch with no commits. The old methods failed later,
+>    mid-flow.
+> 4. **Merge overload.** `g.branch('main').merge('feature')` returned stdout from
+>    the final restore checkout and ran a hard reset after the merge.
+>    `g.merge_into('main', 'feature')` returns the merge's stdout and does no
+>    reset. It also rejects the `:no_commit` option; callers who need
+>    `--no-commit` use `checkout` and `merge` directly.
+> 5. **Remote-tracking receivers.** Called on a remote-tracking `Git::Branch`,
+>    `in_branch` and `merge(branch)` checked out the remote-tracking ref,
+>    detaching HEAD, and any commit made there was left dangling. `g.in_branch`
+>    and `g.merge_into` take an existing local branch only. Create one from the
+>    remote-tracking ref first, with
+>    `g.branch_new(name, "remotes/#{remote}/#{name}")`, and pass that branch.
+
+In the table, `name` is the branch name (`g.branch` defaults it to the current
+branch), `remote` is the remote name of a remote-tracking branch, `b` is a
+`Git::Branch`, and `info` is the `Git::BranchInfo` that replaces it. Where a
+row says to pass `info.refname` for a remote-tracking branch, `b.full` (the
+`remotes/<remote>/<name>` form) works too; the shorter `"#{remote}/#{name}"`
+can resolve a local branch of that name and is only used where git expects it
+(`branch_delete` with `remotes: true`).
+
+| Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
+|-----------------------------------------------------|-------------|
+| `g.branch(name)` | `g.branch_list(name).first` for a local branch, or `g.branch_list("#{remote}/#{name}").find(&:remote?)` for a remote-tracking one — a `Git::BranchInfo`, or `nil` when the branch does not exist; the `remotes/` and `refs/` forms match nothing |
+| `g.branch` | `g.branch_list(g.current_branch).first` — `nil` when HEAD is detached or unborn; use `g.current_branch_state` there |
+| `g.branches` | `g.branch_list` — returns `Array<Git::BranchInfo>` |
+| `g.branches[name]` | `g.branch_list(name).first`, or `g.branch_list("#{remote}/#{name}").find(&:remote?)` for a remote-tracking branch |
+| `g.branches.local` | `g.branch_list.reject(&:remote?)` |
+| `g.branches.remote` | `g.branch_list.select(&:remote?)` |
+| `g.branches.size` | `g.branch_list.size` |
+| `g.branches.each { \|b\| ... }` | `g.branch_list.each { \|info\| ... }` |
+| `g.branches.to_s` | `g.branch_list.map { \|i\| "#{i.current? ? '* ' : '  '}#{i.refname}\n" }.join` — full refs, not `remotes/...` |
+| `b.full`, `b.to_s` | `info.refname` — `refs/remotes/origin/main` rather than `remotes/origin/main` |
+| `b.to_a` | `[info.refname]` |
+| `b.name` | `info.short_name` |
+| `b.remote` | `info.remote_name` — a `String`, or `nil` for a local branch |
+| `b.gcommit` | `g.gcommit(name)` — pass `info.refname` for a remote-tracking branch |
+| `b.checkout` | `g.checkout(name)` — does not create the branch (see above); pass `info.refname` for a remote-tracking branch |
+| `b.create` | `g.branch_new(name)` — raises when the branch already exists |
+| `b.delete` (local) | `g.branch_delete(name)` |
+| `b.delete` (remote-tracking) | `g.branch_delete("#{remote}/#{name}", remotes: true)` |
+| `b.current` | `g.current_branch == name` |
+| `b.contains?(commit)` | `!g.branch_contains(commit, name).empty?` |
+| `b.merge` | `g.merge(name)` |
+| `b.merge(branch, message)` | `g.merge_into(name, branch, message)` — local `b` only; see the differences above |
+| `b.update_ref(commit)` (local) | `g.update_ref(name, commit)` |
+| `b.update_ref(commit)` (remote-tracking) | `g.update_ref("remotes/#{remote}/#{name}", commit)` |
+| `b.archive(file, opts)` | `g.archive(name, file, opts)` — pass `info.refname` for a remote-tracking branch |
+| `b.in_branch(message) { ... }` | `g.in_branch(name, message) { ... }` — local `b` only; see the differences above |
+| `b.stashes` | `g.stashes_all` — see [`Git::Branch#stashes` deprecated](#gitbranchstashes-deprecated) |
 
 ---

--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -17,6 +17,17 @@ module Git
   # @example Listing branches
   #   git.branches.each { |b| puts b.name }
   #
+  # @deprecated Use {Git::Repository::Branching#branch_list} and the
+  #   name-based branch operations on {Git::Repository} instead
+  #
+  #   {Git::Repository::Branching#branch_list} returns immutable
+  #   {Git::BranchInfo} value objects. Operations that lived on this class are
+  #   called on the repository with the branch name instead (for example
+  #   {Git::Repository::Branching#checkout} and
+  #   {Git::Repository::Branching#branch_delete}). Every operation on a
+  #   `Git::Branch` emits a deprecation warning; the `full`, `name`, `remote`,
+  #   `to_s`, and `to_a` readers do not.
+  #
   # @api public
   #
   class Branch
@@ -94,7 +105,20 @@ module Git
     #
     # @return [Git::Object] the commit at the tip of this branch
     #
+    # @deprecated Use {Git::Repository::ObjectOperations#gcommit} with the branch name instead
+    #
+    #   Pass the branch name for a local branch, or `"remotes/#{remote}/#{name}"`
+    #   (the value of {#full}) for a remote-tracking branch; the shorter
+    #   `"#{remote}/#{name}"` can resolve a local branch of that name.
+    #
+    # @see Git::Repository::ObjectOperations#gcommit
+    #
     def gcommit
+      Git::Deprecation.warn(
+        'Git::Branch#gcommit is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#gcommit(name) or, for a remote-tracking branch, ' \
+        'Git::Repository#gcommit("remotes/remote/name") instead.'
+      )
       @gcommit ||= branch_repository.gcommit(@full)
       @gcommit
     end
@@ -145,7 +169,30 @@ module Git
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
+    # @deprecated Use {Git::Repository::Branching#checkout} with the branch name instead
+    #
+    #   {Git::Repository::Branching#checkout} does not create a missing local
+    #   branch, apart from the guess git makes on its own: with no `:no_guess`
+    #   option, git creates a tracking branch when exactly one remote has a
+    #   branch of that name. To reproduce the create-or-checkout behavior of
+    #   this method, call {Git::Repository::Branching#branch_new} when
+    #   {Git::Repository::Branching#local_branch?} is false, then
+    #   {Git::Repository::Branching#checkout}. Pass `"remotes/#{remote}/#{name}"`
+    #   (the value of {#full}) for a remote-tracking branch; the shorter
+    #   `"#{remote}/#{name}"` can resolve a local branch of that name.
+    #
+    # @see Git::Repository::Branching#checkout
+    #
+    # @see Git::Repository::Branching#branch_new
+    #
     def checkout
+      Git::Deprecation.warn(
+        'Git::Branch#checkout is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#checkout(name) or, for a remote-tracking branch, ' \
+        'Git::Repository#checkout("remotes/remote/name") instead. Git::Repository#checkout does not ' \
+        'create a missing local branch (beyond the guess git makes from a unique remote-tracking ' \
+        'branch); call Git::Repository#branch_new first unless Git::Repository#local_branch? is true.'
+      )
       check_if_create
       branch_repository.checkout(@full)
     end
@@ -186,7 +233,20 @@ module Git
     #
     # @raise [Git::FailedError] if `git archive` fails
     #
+    # @deprecated Use {Git::Repository::ObjectOperations#archive} with the branch name instead
+    #
+    #   Pass the branch name for a local branch, or `"remotes/#{remote}/#{name}"`
+    #   (the value of {#full}) for a remote-tracking branch; the shorter
+    #   `"#{remote}/#{name}"` can resolve a local branch of that name.
+    #
+    # @see Git::Repository::ObjectOperations#archive
+    #
     def archive(file, opts = {})
+      Git::Deprecation.warn(
+        'Git::Branch#archive is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#archive(name, file, opts) or, for a remote-tracking branch, ' \
+        'Git::Repository#archive("remotes/remote/name", file, opts) instead.'
+      )
       branch_repository.archive(@full, file, opts)
     end
 
@@ -217,14 +277,27 @@ module Git
     #
     # @yieldreturn [Object] return a truthy value to commit all changes, a falsy value to hard-reset
     #
+    # @deprecated Use {Git::Repository::Branching#in_branch} with the branch name instead
+    #
+    #   {Git::Repository::Branching#in_branch} does not create the branch and
+    #   restores a detached HEAD to its original commit.
+    #   It takes an existing local branch, so a remote-tracking `Git::Branch` has
+    #   no direct replacement: this method checked out the remote-tracking ref,
+    #   detaching HEAD. Create a local branch from that ref with
+    #   {Git::Repository::Branching#branch_new} first.
+    #
+    # @see Git::Repository::Branching#in_branch
+    #
     def in_branch(message = 'in branch work')
+      Git::Deprecation.warn(
+        'Git::Branch#in_branch is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#in_branch(name, message) instead. It takes an existing local ' \
+        'branch; for a remote-tracking branch, create a local branch from it first.'
+      )
       old_current = branch_repository.current_branch
-      checkout
-      if yield
-        branch_repository.commit_all(message)
-      else
-        branch_repository.reset(nil, hard: true)
-      end
+      # checkout is deprecated too; silence it so one in_branch call emits one warning
+      Git::Deprecation.silence { checkout }
+      yield ? branch_repository.commit_all(message) : branch_repository.reset(nil, hard: true)
       branch_repository.checkout(old_current)
     end
 
@@ -238,7 +311,18 @@ module Git
     #
     # @return [nil]
     #
+    # @deprecated Use {Git::Repository::Branching#branch_new} instead
+    #
+    #   {Git::Repository::Branching#branch_new} raises {Git::FailedError} when
+    #   the branch already exists rather than ignoring the error.
+    #
+    # @see Git::Repository::Branching#branch_new
+    #
     def create
+      Git::Deprecation.warn(
+        'Git::Branch#create is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#branch_new instead.'
+      )
       check_if_create
     end
 
@@ -254,7 +338,19 @@ module Git
     #
     # @raise [Git::Error] if the branch cannot be deleted
     #
+    # @deprecated Use {Git::Repository::Branching#branch_delete} instead
+    #
+    #   Pass the branch name for a local branch, or `"#{remote}/#{name}"` with
+    #   `remotes: true` for a remote-tracking branch.
+    #
+    # @see Git::Repository::Branching#branch_delete
+    #
     def delete
+      Git::Deprecation.warn(
+        'Git::Branch#delete is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#branch_delete(name) or, for a remote-tracking branch, ' \
+        'Git::Repository#branch_delete("remote/name", remotes: true) instead.'
+      )
       if @remote
         branch_repository.branch_delete("#{@remote.name}/#{@name}", remotes: true)
       else
@@ -277,7 +373,16 @@ module Git
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
+    # @deprecated Compare {Git::Repository::Branching#current_branch} with the
+    #   branch name instead
+    #
+    # @see Git::Repository::Branching#current_branch
+    #
     def current # rubocop:disable Naming/PredicateMethod
+      Git::Deprecation.warn(
+        'Git::Branch#current is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#current_branch == name instead.'
+      )
       branch_repository.current_branch == @name
     end
 
@@ -297,7 +402,19 @@ module Git
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
+    # @deprecated Use {Git::Repository::Branching#branch_contains} with the
+    #   commit and branch name instead
+    #
+    #   {Git::Repository::Branching#branch_contains} returns the matching
+    #   branch names as a String; test it with `empty?`.
+    #
+    # @see Git::Repository::Branching#branch_contains
+    #
     def contains?(commit)
+      Git::Deprecation.warn(
+        'Git::Branch#contains? is deprecated and will be removed in v6.0.0. ' \
+        'Use !Git::Repository#branch_contains(commit, name).empty? instead.'
+      )
       !branch_repository.branch_contains(commit, name).empty?
     end
 
@@ -332,16 +449,27 @@ module Git
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
+    # @deprecated Use {Git::Repository::Merging#merge_into} in place of
+    #   `merge(branch)` and {Git::Repository::Merging#merge} with the branch
+    #   name in place of `merge()`
+    #
+    #   {Git::Repository::Merging#merge_into} returns the merge's stdout, does
+    #   not hard-reset after the merge, and restores a detached HEAD to its
+    #   original commit.
+    #   It takes an existing local branch, so a remote-tracking `Git::Branch` has
+    #   no direct replacement: `merge(branch)` checked out the remote-tracking ref,
+    #   detaching HEAD. Create a local branch from that ref with
+    #   {Git::Repository::Branching#branch_new} first.
+    #
+    # @see Git::Repository::Merging#merge_into
+    #
+    # @see Git::Repository::Merging#merge
+    #
     def merge(branch = nil, message = nil)
       if branch
-        in_branch do
-          branch_repository.merge(branch, message)
-          false
-        end
-        # merge a branch into this one
+        merge_into_this_branch(branch, message)
       else
-        # merge this branch into the current one
-        branch_repository.merge(@name)
+        merge_into_current_branch
       end
     end
 
@@ -365,7 +493,19 @@ module Git
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
+    # @deprecated Use {Git::Repository::Branching#update_ref} instead
+    #
+    #   Pass the branch name for a local branch, or
+    #   `"remotes/#{remote}/#{name}"` for a remote-tracking branch.
+    #
+    # @see Git::Repository::Branching#update_ref
+    #
     def update_ref(commit)
+      Git::Deprecation.warn(
+        'Git::Branch#update_ref is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#update_ref(name, commit) or, for a remote-tracking branch, ' \
+        'Git::Repository#update_ref("remotes/remote/name", commit) instead.'
+      )
       if @remote
         branch_repository.update_ref("remotes/#{@remote.name}/#{@name}", commit)
       else
@@ -444,7 +584,7 @@ module Git
     def initialize_from_branch_info(branch_info)
       @name = branch_info.short_name
       remote_name = branch_info.remote_name
-      # Silenced because Git::Branch is not deprecated until issue 1639
+      # Git::Remote is deprecated too; silence it so one Git::Branch call emits one warning
       @remote = remote_name ? Git::Deprecation.silence { Git::Remote.new(@base, remote_name) } : nil
       @full = @remote ? "remotes/#{@remote.name}/#{@name}" : @name
     end
@@ -485,10 +625,47 @@ module Git
       # Expect this will always match
       match = name.match(BRANCH_NAME_REGEXP)
       remote_name = match[:remote_name]
-      # Silenced because Git::Branch is not deprecated until issue 1639
+      # Git::Remote is deprecated too; silence it so one Git::Branch call emits one warning
       remote = remote_name ? Git::Deprecation.silence { Git::Remote.new(@base, remote_name) } : nil
       branch_name = match[:branch_name]
       [remote, branch_name]
+    end
+
+    # Merges the given branch into this branch, then restores the original branch
+    #
+    # @param branch [String] the name of the branch to merge into this one
+    #
+    # @param message [String, nil] commit message for the merge commit
+    #
+    # @return [String] git's stdout from the final checkout back to the original branch
+    #
+    # @api private
+    #
+    def merge_into_this_branch(branch, message)
+      Git::Deprecation.warn(
+        'Git::Branch#merge(branch) is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#merge_into(name, branch, message) instead. It takes an existing ' \
+        'local branch; for a remote-tracking branch, create a local branch from it first.'
+      )
+      # in_branch is deprecated too; silence it so one merge call emits one warning.
+      # The falsy block value makes in_branch hard-reset instead of committing.
+      Git::Deprecation.silence do
+        in_branch { branch_repository.merge(branch, message) && false }
+      end
+    end
+
+    # Merges this branch into the currently checked-out branch
+    #
+    # @return [String] git's stdout from the merge command
+    #
+    # @api private
+    #
+    def merge_into_current_branch
+      Git::Deprecation.warn(
+        'Git::Branch#merge with no arguments is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#merge(name) instead.'
+      )
+      branch_repository.merge(@name)
     end
 
     # Creates the branch if it does not already exist, ignoring errors

--- a/lib/git/branch_info.rb
+++ b/lib/git/branch_info.rb
@@ -70,7 +70,7 @@ module Git
   #   info.remote_name  #=> 'origin'
   #   info.short_name   #=> 'main'
   #
-  # @see Git::Branch for the full-featured branch object with operations
+  # @see Git::Repository::Branching#branch_list for the repository method that returns these
   #
   # @see Git::Commands::Branch::List for the command that produces these
   #

--- a/lib/git/branches.rb
+++ b/lib/git/branches.rb
@@ -10,6 +10,14 @@ module Git
   #   branches = repo.branches
   #   branches.each { |b| puts b.name }
   #
+  # @deprecated Use {Git::Repository::Branching#branch_list} instead
+  #
+  #   {Git::Repository::Branching#branch_list} returns `Array<Git::BranchInfo>`
+  #   (immutable value objects). Filter it with `select(&:remote?)` or
+  #   `reject(&:remote?)` in place of {#remote} and {#local}, and look a
+  #   branch up by name with `branch_list(name).first` in place of {#[]}.
+  #   Constructing a `Git::Branches` emits a deprecation warning.
+  #
   # @api public
   #
   class Branches
@@ -24,18 +32,21 @@ module Git
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
+    # @deprecated Use {Git::Repository::Branching#branch_list} instead
+    #
+    # @see Git::Repository::Branching#branch_list
+    #
     def initialize(base)
+      Git::Deprecation.warn(
+        'Git::Branches is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#branch_list instead.'
+      )
       @branches = {}
       @lookup = {}
 
       @base = base
 
-      branch_repository.branch_list.each do |branch_info|
-        branch = Git::Branch.new(base, branch_info)
-
-        @branches[branch_info.refname] = branch
-        index_branch_lookup(branch, refname: branch_info.refname)
-      end
+      load_branches
     end
 
     # Returns all local (non-remote-tracking) branches
@@ -127,12 +138,29 @@ module Git
     def to_s
       out = +''
       @branches.each_value do |b|
-        out << (b.current ? '* ' : '  ') << b.to_s << "\n"
+        # Git::Branch#current is deprecated too; silence it so one to_s call emits one warning
+        current = Git::Deprecation.silence { b.current }
+        out << (current ? '* ' : '  ') << b.to_s << "\n"
       end
       out
     end
 
     private
+
+    # Builds a Git::Branch for every branch in the repository and indexes it
+    #
+    # @return [void]
+    #
+    # @api private
+    #
+    def load_branches
+      branch_repository.branch_list.each do |branch_info|
+        branch = Git::Branch.new(@base, branch_info)
+
+        @branches[branch_info.refname] = branch
+        index_branch_lookup(branch, refname: branch_info.refname)
+      end
+    end
 
     # @return [Git::Repository] the repository used to enumerate branches
     #

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -697,7 +697,31 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @deprecated Use `branch_list(name).first` and the name-based branch
+      #   operations instead
+      #
+      #   {#branch_list} returns immutable {Git::BranchInfo} value objects
+      #   rather than {Git::Branch}. It takes `git branch --list` patterns, so
+      #   pass the short name of a local branch or `"#{remote}/#{name}"` for a
+      #   remote-tracking branch; the `remotes/` and `refs/` prefixes this
+      #   method accepts match nothing. A `"#{remote}/#{name}"` pattern also
+      #   matches a local branch of that name, so take `find(&:remote?)` rather
+      #   than `first` for a remote-tracking branch. With no argument this
+      #   method wraps {#current_branch}, which is `'HEAD'` when HEAD is
+      #   detached; {#branch_list} has no entry for a detached or unborn HEAD,
+      #   so use {#current_branch_state} in those states. Call the
+      #   corresponding {Git::Repository} method (e.g. {#checkout},
+      #   {#branch_new}, {#branch_delete}) for operations on a branch.
+      #
+      # @see #branch_list
+      #
       def branch(branch_name = current_branch)
+        Git::Deprecation.warn(
+          'Git::Repository#branch is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#branch_list(name).first for a local branch, ' \
+          'Git::Repository#branch_list("remote/name").find(&:remote?) for a remote-tracking branch, ' \
+          'and the name-based branch operations instead.'
+        )
         Git::Branch.new(self, branch_name)
       end
 
@@ -724,7 +748,21 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @deprecated Use {#branch_list} instead
+      #
+      #   {#branch_list} returns `Array<Git::BranchInfo>` (immutable value
+      #   objects) rather than a {Git::Branches} collection. Filter it with
+      #   `select(&:remote?)` or `reject(&:remote?)` in place of
+      #   `branches.remote` and `branches.local`, and look a branch up by name
+      #   with `branch_list(name).first` in place of `branches[name]`.
+      #
+      # @see #branch_list
+      #
       def branches
+        Git::Deprecation.warn(
+          'Git::Repository#branches is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#branch_list instead.'
+        )
         Git::Branches.new(self)
       end
 

--- a/spec/integration/git/branch_spec.rb
+++ b/spec/integration/git/branch_spec.rb
@@ -13,13 +13,15 @@ RSpec.describe Git::Branch, :integration do
   end
 
   before do
+    allow(Git::Deprecation).to receive(:warn)
+
     write_file('README.md', "# Hello\n")
     repo.add('README.md')
     repo.commit('Initial commit')
 
     Git.init(bare_dir, bare: true)
     repo.remote_add('origin', bare_dir)
-    repo.branch('feature').create
+    repo.branch_new('feature')
     repo.push('origin', 'feature')
   end
 

--- a/spec/integration/git/branches_spec.rb
+++ b/spec/integration/git/branches_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Branches, :integration do
   context 'when initialized via Git::Repository (Git::Repository passed to constructor)' do
     let(:execution_context) { repo.execution_context }
     let(:repository) { Git::Repository.new(execution_context: execution_context) }
-    let(:branches) { repository.branches }
+    let(:branches) { Git::Deprecation.silence { repository.branches } }
 
     describe '#local' do
       it 'includes the current local branch' do

--- a/spec/integration/git/commands/branch/copy_spec.rb
+++ b/spec/integration/git/commands/branch/copy_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Git::Commands::Branch::Copy, :integration do
 
     describe 'when the command fails' do
       it 'raises FailedError when target exists without force' do
-        repo.branch('existing').create
+        repo.branch_new('existing')
 
         expect { command.call('existing') }.to raise_error(Git::FailedError)
       end

--- a/spec/integration/git/commands/branch/create_spec.rb
+++ b/spec/integration/git/commands/branch/create_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Git::Commands::Branch::Create, :integration do
 
     context 'when the command fails' do
       it 'raises FailedError when the branch already exists' do
-        repo.branch('existing-branch').create
+        repo.branch_new('existing-branch')
 
         expect { command.call('existing-branch') }.to raise_error(Git::FailedError, /existing-branch/)
       end

--- a/spec/integration/git/commands/branch/delete_spec.rb
+++ b/spec/integration/git/commands/branch/delete_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Git::Commands::Branch::Delete, :integration do
 
     describe 'when the command succeeds' do
       it 'returns exit code 0 when all branches deleted' do
-        repo.branch('feature').create
+        repo.branch_new('feature')
 
         result = command.call('feature')
 

--- a/spec/integration/git/commands/branch/move_spec.rb
+++ b/spec/integration/git/commands/branch/move_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Git::Commands::Branch::Move, :integration do
 
     describe 'when the command fails' do
       it 'raises FailedError when target exists without force' do
-        repo.branch('existing').create
+        repo.branch_new('existing')
 
         expect { command.call('existing') }.to raise_error(Git::FailedError)
       end

--- a/spec/integration/git/commands/checkout/branch_spec.rb
+++ b/spec/integration/git/commands/checkout/branch_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Git::Commands::Checkout::Branch, :integration do
   describe '#call' do
     describe 'when the command succeeds' do
       it 'returns a CommandLineResult when switching branches' do
-        repo.branch('feature').create
+        repo.branch_new('feature')
 
         result = command.call('feature')
 

--- a/spec/integration/git/commands/merge/abort_spec.rb
+++ b/spec/integration/git/commands/merge/abort_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Git::Commands::Merge::Abort, :integration do
   describe '#call' do
     describe 'when the command succeeds' do
       before do
-        repo.branch('feature').checkout
+        repo.checkout('feature', new_branch: true)
         write_file('file.txt', "feature change\n")
         repo.add('file.txt')
         repo.commit('Feature commit')

--- a/spec/integration/git/commands/merge/continue_spec.rb
+++ b/spec/integration/git/commands/merge/continue_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Git::Commands::Merge::Continue, :integration do
   describe '#call' do
     describe 'when the command succeeds' do
       before do
-        repo.branch('feature').checkout
+        repo.checkout('feature', new_branch: true)
         write_file('file.txt', "feature change\n")
         repo.add('file.txt')
         repo.commit('Feature commit')

--- a/spec/integration/git/commands/merge/quit_spec.rb
+++ b/spec/integration/git/commands/merge/quit_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Git::Commands::Merge::Quit, :integration do
     describe 'when the command succeeds' do
       context 'when a merge is in progress' do
         before do
-          repo.branch('feature').checkout
+          repo.checkout('feature', new_branch: true)
           write_file('file.txt', "feature change\n")
           repo.add('file.txt')
           repo.commit('Feature commit')

--- a/spec/integration/git/commands/merge/start_spec.rb
+++ b/spec/integration/git/commands/merge/start_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Git::Commands::Merge::Start, :integration do
   describe '#call' do
     describe 'when the command succeeds' do
       before do
-        repo.branch('feature').checkout
+        repo.checkout('feature', new_branch: true)
         write_file('feature.txt', "feature\n")
         repo.add('feature.txt')
         repo.commit('Feature commit')

--- a/spec/integration/git/commands/merge_base_spec.rb
+++ b/spec/integration/git/commands/merge_base_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Git::Commands::MergeBase, :integration do
   describe '#call' do
     describe 'when the command succeeds' do
       before do
-        repo.branch('feature').checkout
+        repo.checkout('feature', new_branch: true)
         write_file('feature.txt', "feature\n")
         repo.add('feature.txt')
         repo.commit('Feature commit')

--- a/spec/integration/git/commands/remote/update_spec.rb
+++ b/spec/integration/git/commands/remote/update_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe Git::Commands::Remote::Update, :integration do
         result = command.call('origin')
 
         expect(result).to be_a(Git::CommandLine::Result)
-        expect(repo.branches.remote.map(&:full)).to include("remotes/origin/#{initial_branch}")
+        expect(repo.branch_list.select(&:remote?).map(&:refname)).to include("refs/remotes/origin/#{initial_branch}")
       end
     end
 

--- a/spec/integration/git/commands/update_ref/batch_spec.rb
+++ b/spec/integration/git/commands/update_ref/batch_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Git::Commands::UpdateRef::Batch, :integration do
     context 'when the command fails' do
       it 'raises FailedError when any instruction is invalid' do
         head_sha = repo.rev_parse('HEAD')
-        repo.branch('survive').create
+        repo.branch_new('survive')
 
         expect do
           command.call(

--- a/spec/integration/git/commands/update_ref/delete_spec.rb
+++ b/spec/integration/git/commands/update_ref/delete_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::UpdateRef::Delete, :integration do
       write_file('file.txt', "content\n")
       repo.add('file.txt')
       repo.commit('Initial commit')
-      repo.branch('doomed').create
+      repo.branch_new('doomed')
     end
 
     context 'when the command succeeds' do

--- a/spec/integration/git/commands/update_ref/update_spec.rb
+++ b/spec/integration/git/commands/update_ref/update_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Git::Commands::UpdateRef::Update, :integration do
     context 'when the command succeeds' do
       it 'updates a ref to a new commit' do
         repo.rev_parse('HEAD')
-        repo.branch('test-branch').create
+        repo.branch_new('test-branch')
 
         write_file('file.txt', "updated\n")
         repo.add('file.txt')
@@ -34,7 +34,7 @@ RSpec.describe Git::Commands::UpdateRef::Update, :integration do
 
     context 'when the command fails' do
       it 'raises FailedError when oldvalue does not match' do
-        repo.branch('test-branch').create
+        repo.branch_new('test-branch')
         new_sha = repo.rev_parse('HEAD')
 
         expect { command.call('refs/heads/test-branch', new_sha, 'bad0' * 10) }

--- a/spec/integration/git/parsers/branch_spec.rb
+++ b/spec/integration/git/parsers/branch_spec.rb
@@ -26,7 +26,7 @@ RSpec.describe Git::Parsers::Branch, :integration do
         write_file('file.txt')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.branch('feature-branch').create
+        repo.branch_new('feature-branch')
       end
 
       it 'parses all branches' do
@@ -66,8 +66,8 @@ RSpec.describe Git::Parsers::Branch, :integration do
         write_file('file.txt')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.branch('feature/with-slash').create
-        repo.branch('feature/日本語').create
+        repo.branch_new('feature/with-slash')
+        repo.branch_new('feature/日本語')
       end
 
       it 'parses branch names with slashes' do

--- a/spec/integration/git/parsers/fsck_spec.rb
+++ b/spec/integration/git/parsers/fsck_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe Git::Parsers::Fsck, :integration do
         repo.add('file.txt')
         repo.commit('First root commit')
 
-        repo.branch('orphan-branch').checkout
+        repo.checkout('orphan-branch', new_branch: true)
         repo.checkout('another-root', orphan: true)
         repo.commit('Another root', allow_empty: true)
       end

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -120,9 +120,9 @@ RSpec.describe Git::Repository::Branching, :integration do
         repo.push('origin', 'main')
         # Push a second branch to the remote, then delete it locally so it only
         # exists as a remote-tracking branch
-        repo.branch('remote-only').create
+        repo.branch_new('remote-only')
         repo.push('origin', 'remote-only')
-        repo.branch('remote-only').delete
+        repo.branch_delete('remote-only')
       end
 
       it 'returns true' do
@@ -148,9 +148,9 @@ RSpec.describe Git::Repository::Branching, :integration do
 
     context '4.x backward-compatibility: local branch with slashes' do
       before do
-        repo.branch('topic/main').create
+        repo.branch_new('topic/main')
         repo.checkout('topic/main')
-        repo.branch('main').delete
+        repo.branch_delete('main')
       end
 
       it 'returns false for main when only topic/main exists (exact-name matching, no suffix matching)' do
@@ -175,9 +175,9 @@ RSpec.describe Git::Repository::Branching, :integration do
 
   describe '#branch_delete' do
     before do
-      repo.branch('to-delete').create
-      repo.branch('branch-1').create
-      repo.branch('branch-2').create
+      repo.branch_new('to-delete')
+      repo.branch_new('branch-1')
+      repo.branch_new('branch-2')
     end
 
     context 'when deleting a single merged branch' do
@@ -360,7 +360,7 @@ RSpec.describe Git::Repository::Branching, :integration do
       before do
         Git.init(bare_dir, bare: true)
         repo.remote_add('origin', bare_dir)
-        repo.branch('foo').create
+        repo.branch_new('foo')
         repo.checkout('foo')
         repo.push('origin', 'foo:bar')
         repo.config_set('branch.foo.remote', 'origin')

--- a/spec/support/contexts/diff_test_repository.rb
+++ b/spec/support/contexts/diff_test_repository.rb
@@ -155,7 +155,7 @@ module DiffTestRepositorySetup
   def setup_feature_branch
     # Create feature branch from after_add
     repo.checkout('after_add')
-    repo.branch('feature').checkout
+    repo.checkout('feature', new_branch: true)
 
     write_file('lib/feature.rb', "# frozen_string_literal: true\n\nmodule Feature\nend\n")
     repo.add('lib/feature.rb')

--- a/spec/unit/git/branch_spec.rb
+++ b/spec/unit/git/branch_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Git::Branch do
   let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
   let(:base) { Git::Repository.new(execution_context: execution_context) }
 
+  before { allow(Git::Deprecation).to receive(:warn) }
+
   describe '#initialize' do
     context 'with a BranchInfo object for a local branch' do
       subject(:branch) { described_class.new(base, branch_info) }
@@ -142,6 +144,16 @@ RSpec.describe Git::Branch do
         )
       end
 
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        allow(base).to receive(:branch_delete).with('feature').and_return('')
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Branch#delete is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#branch_delete(name) or, for a remote-tracking branch, ' \
+          'Git::Repository#branch_delete("remote/name", remotes: true) instead.'
+        )
+        delete_branch
+      end
+
       it 'deletes the local branch by short name' do
         expect(base).to receive(:branch_delete).with('feature').and_return('Deleted branch feature.')
 
@@ -200,6 +212,14 @@ RSpec.describe Git::Branch do
 
       before { allow(base).to receive(:current_branch).and_return('feature') }
 
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Branch#current is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#current_branch == name instead.'
+        )
+        branch.current
+      end
+
       it 'returns true' do
         expect(branch.current).to be true
       end
@@ -236,6 +256,14 @@ RSpec.describe Git::Branch do
 
     context 'when the branch contains the commit' do
       before { allow(base).to receive(:branch_contains).with('abc123', 'feature').and_return(['abc123']) }
+
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Branch#contains? is deprecated and will be removed in v6.0.0. ' \
+          'Use !Git::Repository#branch_contains(commit, name).empty? instead.'
+        )
+        branch.contains?('abc123')
+      end
 
       it 'returns true' do
         expect(branch.contains?('abc123')).to be true
@@ -277,14 +305,58 @@ RSpec.describe Git::Branch do
         allow(base).to receive(:reset).with(nil, hard: true).and_return(command_result(''))
       end
 
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        allow(base).to receive(:merge).with('other-branch', 'my message').and_return('merged')
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Branch#merge(branch) is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#merge_into(name, branch, message) instead. It takes an existing ' \
+          'local branch; for a remote-tracking branch, create a local branch from it first.'
+        )
+        branch.merge('other-branch', 'my message')
+      end
+
       it 'merges the given branch into this branch, then restores the original branch' do
         expect(base).to receive(:merge).with('other-branch', 'my message').and_return('merged')
         expect(base).to receive(:checkout).with('main').and_return('restored')
         expect(branch.merge('other-branch', 'my message')).to eq('restored')
       end
+
+      context 'when the nested in_branch and checkout warnings are not stubbed' do
+        let(:messages) { [] }
+
+        # Route real warnings to a collector so the silence around the nested
+        # deprecated call is exercised instead of bypassed by the stubbed
+        # Git::Deprecation.warn
+        around do |example|
+          original_behavior = Git::Deprecation.behavior
+          Git::Deprecation.behavior = ->(message, *) { messages << message }
+          example.run
+        ensure
+          Git::Deprecation.behavior = original_behavior
+        end
+
+        before do
+          allow(Git::Deprecation).to receive(:warn).and_call_original
+          allow(base).to receive(:merge).with('other-branch', nil).and_return('merged')
+        end
+
+        it 'lets only the Git::Branch#merge(branch) warning escape' do
+          branch.merge('other-branch')
+          expect(messages).to contain_exactly(a_string_including('Git::Branch#merge(branch) is deprecated'))
+        end
+      end
     end
 
     context 'when no branch is given' do
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        allow(base).to receive(:merge).with('feature').and_return('merged')
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Branch#merge with no arguments is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#merge(name) instead.'
+        )
+        branch.merge
+      end
+
       it 'merges this branch into the current branch' do
         expect(base).to receive(:merge).with('feature').and_return('merged')
         expect(branch.merge).to eq('merged')
@@ -309,6 +381,16 @@ RSpec.describe Git::Branch do
           symref: nil,
           upstream: nil
         )
+      end
+
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        allow(base).to receive(:update_ref).with('feature', 'newcommit').and_return(command_result(''))
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Branch#update_ref is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#update_ref(name, commit) or, for a remote-tracking branch, ' \
+          'Git::Repository#update_ref("remotes/remote/name", commit) instead.'
+        )
+        update
       end
 
       it 'calls update_ref with the short branch name and commit' do
@@ -362,6 +444,15 @@ RSpec.describe Git::Branch do
     end
 
     context 'when branch_new succeeds' do
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        allow(base).to receive(:branch_new).with('new-feature').and_return(command_result(''))
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Branch#create is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#branch_new instead.'
+        )
+        branch.create
+      end
+
       it 'calls branch_new on the repository' do
         expect(base).to receive(:branch_new).with('new-feature').and_return(command_result(''))
         branch.create
@@ -398,6 +489,16 @@ RSpec.describe Git::Branch do
     end
 
     let(:gcommit_obj) { instance_double(Git::Object::Commit) }
+
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      allow(base).to receive(:gcommit).with('feature').and_return(gcommit_obj)
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Branch#gcommit is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#gcommit(name) or, for a remote-tracking branch, ' \
+        'Git::Repository#gcommit("remotes/remote/name") instead.'
+      )
+      branch.gcommit
+    end
 
     it 'delegates to base.gcommit with the full refname' do
       allow(base).to receive(:gcommit).with('feature').and_return(gcommit_obj)
@@ -471,6 +572,16 @@ RSpec.describe Git::Branch do
       )
     end
 
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      allow(base).to receive(:archive).and_return('out.tar')
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Branch#archive is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#archive(name, file, opts) or, for a remote-tracking branch, ' \
+        'Git::Repository#archive("remotes/remote/name", file, opts) instead.'
+      )
+      branch.archive('out.tar', format: 'tar')
+    end
+
     it 'delegates to base.archive with full refname, file path, and options' do
       expect(base).to receive(:archive).with('feature', 'out.tar', { format: 'tar' }).and_return('out.tar')
       branch.archive('out.tar', format: 'tar')
@@ -493,6 +604,19 @@ RSpec.describe Git::Branch do
         symref: nil,
         upstream: nil
       )
+    end
+
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      allow(base).to receive(:branch_new).with('feature').and_return(command_result(''))
+      allow(base).to receive(:checkout).with('feature').and_return('')
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Branch#checkout is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#checkout(name) or, for a remote-tracking branch, ' \
+        'Git::Repository#checkout("remotes/remote/name") instead. Git::Repository#checkout does not ' \
+        'create a missing local branch (beyond the guess git makes from a unique remote-tracking ' \
+        'branch); call Git::Repository#branch_new first unless Git::Repository#local_branch? is true.'
+      )
+      branch.checkout
     end
 
     it 'calls check_if_create then checks out the full refname' do
@@ -527,6 +651,16 @@ RSpec.describe Git::Branch do
     end
 
     context 'when block returns truthy' do
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        allow(base).to receive(:commit_all).with('my message').and_return(command_result(''))
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Branch#in_branch is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#in_branch(name, message) instead. It takes an existing local ' \
+          'branch; for a remote-tracking branch, create a local branch from it first.'
+        )
+        branch.in_branch('my message') { true }
+      end
+
       it 'commits all changes and restores the original branch' do
         allow(base).to receive(:commit_all).with('my message').and_return(command_result(''))
         expect(base).to receive(:checkout).with('main').and_return('')
@@ -539,6 +673,31 @@ RSpec.describe Git::Branch do
         allow(base).to receive(:reset).with(nil, hard: true).and_return(command_result(''))
         expect(base).to receive(:checkout).with('main').and_return('')
         branch.in_branch { false }
+      end
+    end
+
+    context 'when the nested checkout warning is not stubbed' do
+      let(:messages) { [] }
+
+      # Route real warnings to a collector so the silence around the nested
+      # deprecated call is exercised instead of bypassed by the stubbed
+      # Git::Deprecation.warn
+      around do |example|
+        original_behavior = Git::Deprecation.behavior
+        Git::Deprecation.behavior = ->(message, *) { messages << message }
+        example.run
+      ensure
+        Git::Deprecation.behavior = original_behavior
+      end
+
+      before do
+        allow(Git::Deprecation).to receive(:warn).and_call_original
+        allow(base).to receive(:reset).with(nil, hard: true).and_return(command_result(''))
+      end
+
+      it 'lets only the Git::Branch#in_branch warning escape' do
+        branch.in_branch { false }
+        expect(messages).to contain_exactly(a_string_including('Git::Branch#in_branch is deprecated'))
       end
     end
   end

--- a/spec/unit/git/branches_spec.rb
+++ b/spec/unit/git/branches_spec.rb
@@ -43,9 +43,18 @@ RSpec.describe Git::Branches do
       let(:base) { instance_double(Git::Repository) }
 
       before do
+        allow(Git::Deprecation).to receive(:warn)
         allow(base).to receive(:branch_list).and_return([local_info, remote_info])
         allow(Git::Branch).to receive(:new).with(base, local_info).and_return(local_branch)
         allow(Git::Branch).to receive(:new).with(base, remote_info).and_return(remote_branch)
+      end
+
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Branches is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#branch_list instead.'
+        )
+        described_class.new(base)
       end
 
       it 'calls branch_list directly on the base' do
@@ -70,6 +79,7 @@ RSpec.describe Git::Branches do
   let(:described_instance) { described_class.new(repo_base) }
 
   before do
+    allow(Git::Deprecation).to receive(:warn)
     allow(repo_base).to receive(:branch_list).and_return(branch_infos)
     allow(Git::Branch).to receive(:new).with(repo_base, local_info).and_return(local_branch)
     allow(Git::Branch).to receive(:new).with(repo_base, remote_info).and_return(remote_branch)
@@ -228,6 +238,33 @@ RSpec.describe Git::Branches do
 
     it 'marks non-current branches with two spaces' do
       expect(result).to include('  remotes/origin/main')
+    end
+
+    context 'when the branches are real Git::Branch objects' do
+      let(:branch_infos) { [local_info] }
+      let(:messages) { [] }
+
+      # Route real warnings to a collector so the silence around the nested
+      # deprecated call is exercised instead of bypassed by the stubbed
+      # Git::Deprecation.warn
+      around do |example|
+        original_behavior = Git::Deprecation.behavior
+        Git::Deprecation.behavior = ->(message, *) { messages << message }
+        example.run
+      ensure
+        Git::Deprecation.behavior = original_behavior
+      end
+
+      before do
+        allow(Git::Deprecation).to receive(:warn).and_call_original
+        allow(Git::Branch).to receive(:new).with(repo_base, local_info).and_call_original
+        allow(repo_base).to receive(:current_branch).and_return('main')
+      end
+
+      it 'lets only the Git::Branches warning escape' do
+        expect(result).to eq("* main\n")
+        expect(messages).to contain_exactly(a_string_including('Git::Branches is deprecated'))
+      end
     end
   end
 end

--- a/spec/unit/git/repository/branching_spec.rb
+++ b/spec/unit/git/repository/branching_spec.rb
@@ -1180,10 +1180,21 @@ RSpec.describe Git::Repository::Branching do
     before do
       allow(Git::Commands::Branch::ShowCurrent)
         .to receive(:new).with(execution_context).and_return(show_current_command)
+      allow(Git::Deprecation).to receive(:warn)
     end
 
     context 'with an explicit branch name' do
       subject(:result) { described_instance.branch('feature') }
+
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Repository#branch is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#branch_list(name).first for a local branch, ' \
+          'Git::Repository#branch_list("remote/name").find(&:remote?) for a remote-tracking branch, ' \
+          'and the name-based branch operations instead.'
+        )
+        result
+      end
 
       it 'returns a Git::Branch for the given name' do
         expect(result).to be_a(Git::Branch)
@@ -1226,6 +1237,19 @@ RSpec.describe Git::Repository::Branching do
     subject(:result) { described_instance.branches }
 
     let(:branches_collection) { instance_double(Git::Branches) }
+
+    before do
+      allow(Git::Branches).to receive(:new).with(described_instance).and_return(branches_collection)
+      allow(Git::Deprecation).to receive(:warn)
+    end
+
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#branches is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#branch_list instead.'
+      )
+      result
+    end
 
     it 'constructs Git::Branches with self and returns the collection' do
       expect(Git::Branches).to receive(:new).with(described_instance).and_return(branches_collection)


### PR DESCRIPTION
## Summary

Deprecates `Git::Branch`, `Git::Branches`, `Git::Repository#branch`, and `Git::Repository#branches` in favor of `Git::Repository#branch_list` (which returns `Git::BranchInfo` value objects) and the name-based facade methods. This is a deprecation only: no removals, no signature changes, no behavior changes. Removal is gated by ADR 0006 for v6.0.0.

Two commits: the failing warning specs first, then the fix.

## Warning placement

- `Git::Repository#branch` and `Git::Repository#branches` warn at the facade entry point.
- `Git::Branches#initialize` warns because the class has no operations of its own, so `repo.branches` emits two warnings, the same way `repo.remote` does in #1751.
- Every `Git::Branch` operation (`checkout`, `create`, `delete`, `current`, `contains?`, both `merge` overloads, `update_ref`, `archive`, `gcommit`, `in_branch`) warns with a message naming its exact replacement. The `checkout` message says `Git::Repository#checkout` does not create the branch and points at `branch_new` followed by `checkout`. `merge(branch)` points at `merge_into`; `in_branch` points at `Git::Repository#in_branch`.
- `Git::Branch#initialize` does not warn. It is `@api private`, and every public route to it (`branch`, `branches`, `Git::Remote#branch`) already warns. The data readers `full`, `name`, `remote`, `to_s`, and `to_a` do not warn.
- Where one deprecated method calls another (`in_branch` calls `checkout`, `merge(branch)` calls `in_branch`, `Branches#to_s` calls `Branch#current`), the inner call is wrapped in `Git::Deprecation.silence` so each call emits one warning that names the right replacement.

## Spec callers

The suite raises on any deprecation warning. Spec setup that only needed a branch created, checked out, or deleted now uses `branch_new`, `checkout(name, new_branch: true)`, or `branch_delete`, and the one assertion over `branches.remote` reads `branch_list`. Specs whose subject is the deprecated API (`spec/unit/git/branch_spec.rb`, `spec/unit/git/branches_spec.rb`, the `#branch` and `#branches` examples in `spec/unit/git/repository/branching_spec.rb`, and the two integration specs) stub or silence the warning.

## UPGRADING.md

New `Git::Branch and Git::Branches deprecated` subsection under "Deprecated methods" with the return-shape note (`Git::Branch` accessors versus `Git::BranchInfo` members, and which `branch_list` patterns match), the `checkout` auto-create difference, the four `in_branch` and `merge_into` differences from the issue, and a per-call replacement table.

Closes #1639
