### PR TITLE
docs: adopt a release-based deprecation policy and supersede ADR-0006

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -31,4 +31,4 @@ fine to use `#` in footer values such as `Closes: #999` or `Refs: #999`.
 | Target | When |
 | --- | --- |
 | `main` | New features, breaking changes, all active development |
-| `4.x` | Security fixes and backward-compatible bug fixes for the v4.x series |
+| `4.x` | Security fixes, backward-compatible bug fixes, and backward-compatible features at the maintainers' discretion for the v4.x series |

--- a/.github/skills/breaking-change-analysis/SKILL.md
+++ b/.github/skills/breaking-change-analysis/SKILL.md
@@ -17,7 +17,7 @@ or modifying default behavior.
 - [Step 2: Find All Usages](#step-2-find-all-usages)
 - [Step 3: Assess and Document Impact](#step-3-assess-and-document-impact)
   - [Prove the safety claim](#prove-the-safety-claim)
-- [Step 4: Plan Migration Path](#step-4-plan-migration-path)
+- [Step 4: Deprecation policy](#step-4-deprecation-policy)
 
 ## How to use this skill
 
@@ -109,28 +109,61 @@ fixture repository, or a query against the RubyGems dump showing no dependent ge
 affected. Record the fact and its proof in the **Safety Proof** section of the
 assessment. A safety claim backed only by reasoning is an open question, not a
 finding — the step is complete when every such claim names its fact and the code that
-proved it.
+proved it. This proof applies to hard breaks and behavior changes that have no
+deprecation path. The deprecation policy in [Step 4](#step-4-deprecation-policy)
+governs removal of a deprecated API.
 
-## Step 4: Plan Migration Path
+## Step 4: Deprecation policy
 
-**Project versioning policy:**
-- Breaking changes are batched for major releases
-- Use deprecation warnings in the current major series before removal in the next major release
-- Whether a specific removal may land in the next major is governed by the removal
-  gate in
-  [ADR-0006](../../../docs/adr/0006-removals-require-proven-safety-and-calendar-soak.md)
+**Removal gate.** A removal PR merges to main only when its deprecation warning and
+`UPGRADING.md` entry are contained in a previous normal release. Once any removal has
+merged to main, main becomes the release line for the next major version. If another
+release of the previous major is needed, it is cut from a branch created for that major
+(e.g. `4.x` or `5.x`). "Normal release" is semver's term for a non-pre-release version.
 
-**Deprecation approach:**
+The gate sets the earliest major a removal may land in, not the one it must land in. A
+removal may land in any major after the gate is met; which one is a roadmap decision
+recorded on the API's issue.
+
+**What a deprecation ships.** All of the following land in the same minor release:
+
+- A runtime warning via `Git::Deprecation.warn` that names the replacement. A YARD tag
+  alone does not count. Do not use ActiveSupport's `deprecate_methods`; it bakes the
+  horizon into the message.
+- The replacement API.
+- An `UPGRADING.md` entry that agrees with the warning.
+- A `@deprecated` YARD tag with migration guidance.
+
+**Warning wording.** When the removing major is decided:
 
 ```ruby
-# @deprecated Use {#new_method} instead. Will be removed in the next major release.
-def old_method(*args)
-  warn "[DEPRECATION] `old_method` is deprecated. Use `new_method` instead."
-  new_method(*args)
-end
+Git::Deprecation.warn(
+  'Git::Author is deprecated and will be removed in v6.0.0. Use Git::AuthorInfo instead.'
+)
 ```
 
-**Documentation requirements:**
-- Add `@deprecated` YARD tag with migration guidance
-- Mark commits with `!` for breaking changes and include `BREAKING CHANGE:` footer
+When it is not yet decided:
+
+```ruby
+Git::Deprecation.warn(
+  'Git::Author is deprecated and will be removed in a future major release. ' \
+  'Use Git::AuthorInfo instead.'
+)
+```
+
+Deciding or changing the named major later is a documentation change that ships in a
+minor. Update the warning, the YARD tag, and the `UPGRADING.md` entry together.
+
+**When to deprecate.** Add a warning only when removal in a future major is intended.
+An API that will be kept but discouraged is documented as legacy with no warning; the
+hollow shells in
+[ADR-0002](../../../docs/adr/0002-commit-tree-and-blob-become-hollow-shells.md) are
+the precedent. Removing a warning (un-deprecating) is a non-breaking change.
+
+[ADR-0007](../../../docs/adr/0007-removals-require-one-normal-release-of-deprecation-not-calendar-soak.md)
+records the decision and its rationale.
+
+**Commit requirements:**
+
+- Mark removal commits with `!` and include a `BREAKING CHANGE:` footer
 - DO NOT update CHANGELOG.md — it is auto-generated from commit messages

--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -340,6 +340,11 @@ Version constraints live in `git.gemspec`; do not restate them here.
 - Use `File.join` and forward slashes; avoid platform-specific paths in tests
 - Windows has different path handling, file-system behavior, and line endings; JRuby on Windows is not supported
 - Document git version requirements for features that need newer git
+- Deprecating or removing public API follows the deprecation policy in
+  [Breaking Change Analysis, Step 4](../breaking-change-analysis/SKILL.md#step-4-deprecation-policy);
+  the user-facing statements are the README's
+  [Deprecation policy](../../../README.md#deprecation-policy) and
+  [Release support policy](../../../README.md#release-support-policy) subsections
 
 ## Performance
 

--- a/.github/skills/release-management/SKILL.md
+++ b/.github/skills/release-management/SKILL.md
@@ -14,6 +14,8 @@ This workflow describes how releases are managed for the ruby-git gem.
 - [How Releases Work](#how-releases-work)
 - [Developer Responsibilities](#developer-responsibilities)
 - [Checking Release Readiness](#checking-release-readiness)
+- [Major release readiness](#major-release-readiness)
+- [After a major release](#after-a-major-release)
 - [What NOT to Do](#what-not-to-do)
 - [Useful Commands](#useful-commands)
 
@@ -53,8 +55,10 @@ Key config files:
 | `lib/git/version.rb` | Version constant (updated automatically by release-please) |
 | `CHANGELOG.md` | Release history (updated automatically by release-please) |
 
-The versioning strategy is `prerelease` with `beta` as the prerelease type. The
-config also sets `bump-minor-pre-major: true` and `bump-patch-for-minor-pre-major: true`.
+`prerelease` is `false`, so release-please never proposes a beta and every release is
+a normal release. The config also sets `bump-minor-pre-major: true` and
+`bump-patch-for-minor-pre-major: true`, which affect version bumps only while the major
+version is 0.
 
 ## Developer Responsibilities
 
@@ -92,6 +96,45 @@ Before a maintainer merges a release PR:
 
 4. **Review the release PR** — verify the auto-generated changelog and version
    bump look correct.
+
+## Major release readiness
+
+Before merging the release PR for a major version, run
+[Checking Release Readiness](#checking-release-readiness), then confirm each item
+below. The per-PR removal gate lives in
+[Breaking Change Analysis, Step 4](../breaking-change-analysis/SKILL.md#step-4-deprecation-policy)
+and is checked when each removal PR merges, not here.
+
+- [ ] Version floors are updated everywhere they are set: `required_ruby_version` in
+      `git.gemspec`, `TargetRubyVersion` in `.rubocop.yml`, the CI workflow matrices
+      under `.github/workflows/`, `Git::MINIMUM_GIT_VERSION` in `lib/git.rb`, the
+      README "Ruby version support policy" and "Git version support policy"
+      subsections, and the Compatibility list in
+      [Project Context](../project-context/SKILL.md#compatibility). Include any RuboCop
+      cleanup a `TargetRubyVersion` bump triggers.
+- [ ] ADR-0004 audit: the options the new git floor kills are deprecated in this major
+      ([ADR-0004](../../../docs/adr/0004-the-option-surface-is-the-union-of-the-supported-git-range.md)).
+- [ ] Carried deprecations, if any, have their warning text, `@deprecated` YARD tag,
+      and `UPGRADING.md` entry updated to name the major the roadmap decided for them,
+      or "a future major release" while that is undecided, and the horizon passed to
+      `ActiveSupport::Deprecation.new` in `lib/git.rb` is bumped to the next major.
+- [ ] The "Upgrading to vN.0.0" section of `UPGRADING.md` is complete.
+- [ ] README examples use no removed APIs.
+- [ ] The changelog preview in the release PR reads correctly and every removal commit
+      carries a `BREAKING CHANGE` footer.
+
+## After a major release
+
+- [ ] Add a README announcement entry dated the release day.
+- [ ] Create the maintenance branch for the previous major (e.g. `5.x`) from its last
+      tag and apply branch protection.
+- [ ] Replace the retired maintenance branch with the new one everywhere it is named:
+      the push triggers in `release.yml`, `continuous_integration.yml`, and
+      `enforce_conventional_commits.yml` under `.github/workflows/`, the branch tables
+      in `.github/copilot-instructions.md` and `CONTRIBUTING.md`, and the skills that
+      list the protected branches. `grep -rn '4\.x' .github CONTRIBUTING.md` finds
+      them all.
+- [ ] Close the milestone and update the roadmap issue.
 
 ## What NOT to Do
 

--- a/.github/skills/roadmap-tickets/SKILL.md
+++ b/.github/skills/roadmap-tickets/SKILL.md
@@ -34,9 +34,10 @@ maintainer approves the breakdown before anything is published.
 
 - [Development Workflow](../development-workflow/SKILL.md) — implements a
   published ticket (triage through PR)
-- [Breaking Change Analysis](../breaking-change-analysis/SKILL.md) — the Safety
-  Proof step that removal tickets gate on, per
-  [ADR-0006](../../../docs/adr/0006-removals-require-proven-safety-and-calendar-soak.md)
+- [Breaking Change Analysis](../breaking-change-analysis/SKILL.md) — the
+  [deprecation policy](../breaking-change-analysis/SKILL.md#step-4-deprecation-policy)
+  that removal tickets follow, recorded in
+  [ADR-0007](../../../docs/adr/0007-removals-require-one-normal-release-of-deprecation-not-calendar-soak.md)
 - [Project Context](../project-context/SKILL.md) — domain vocabulary for ticket
   titles and bodies
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -221,16 +221,29 @@ first keeps the review cycle short.
 
 This project maintains two active branches:
 
-- **`main`**: Active development for the next major version (v5.0.0+). This branch
-  may contain breaking changes.
-- **`4.x`**: Maintenance branch for the v4.x release series. This branch receives bug
-  fixes and backward-compatible improvements only.
+- **`main`**: All development. It releases the next version of the gem, including
+  the next major version.
+- **`4.x`**: The maintenance branch for the most recent previous major series. It
+  receives bug fixes and security fixes, and backward-compatible features at the
+  maintainers' discretion.
+
+The README's [Release support policy](README.md#release-support-policy) says how long
+each major series is supported.
 
 When submitting a pull request:
 
 - **New features and breaking changes**: Target the `main` branch
 - **Bug fixes**: Target `main`, and maintainers will backport to `4.x` if applicable
 - **Security fixes**: Target both branches or `4.x` if the issue only affects v4.x
+
+Removing a deprecated API follows the
+[deprecation policy](.github/skills/breaking-change-analysis/SKILL.md#step-4-deprecation-policy):
+
+A removal PR merges to main only when its deprecation warning and `UPGRADING.md` entry
+are contained in a previous normal release. Once any removal has merged to main, main
+becomes the release line for the next major version. If another release of the
+previous major is needed, it is cut from a branch created for that major (e.g. `4.x`
+or `5.x`).
 
 ## AI-assisted contributions
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?log
 - [Project policies](#project-policies)
   - [Ruby version support policy](#ruby-version-support-policy)
   - [Git version support policy](#git-version-support-policy)
+  - [Deprecation policy](#deprecation-policy)
+  - [Release support policy](#release-support-policy)
 - [Project announcements](#project-announcements)
   - [2026-08-23: v5.x deprecations and the v6.0.0 roadmap](#2026-08-23-v5x-deprecations-and-the-v600-roadmap)
   - [2026-07-28: v5.0.0 released](#2026-07-28-v500-released)
@@ -296,9 +298,9 @@ See [the Active Support Deprecation
 documentation](https://api.rubyonrails.org/classes/ActiveSupport/Deprecation.html)
 for more details.
 
-If you silence deprecation warnings, reenable them before upgrading the git gem to
-the next major version. This makes it easier to identify changes needed for the
-upgrade.
+Before upgrading the git gem to the next major version, follow the upgrade procedure
+in [UPGRADING.md](UPGRADING.md#upgrading-to-v600). It turns the warnings into errors so
+that you cannot miss one.
 
 For the full list of deprecated methods and their replacements, see
 [UPGRADING.md](UPGRADING.md).
@@ -382,6 +384,8 @@ opening issues or pull requests.
 | [AI_POLICY](AI_POLICY.md) | AI-assisted contributions are welcome. Contributors are expected to read and apply the AI Policy, and ensure any AI-assisted work meets our quality, security, and licensing standards. |
 | [Ruby version support policy](#ruby-version-support-policy) | Supported Ruby runtimes and platforms; bump decisions and CI coverage expectations. |
 | [Git version support policy](#git-version-support-policy) | Minimum supported git version and how version bumps are communicated and enforced. |
+| [Deprecation policy](#deprecation-policy) | When an API may be removed, what a deprecation warning says, and how to upgrade across a major version. |
+| [Release support policy](#release-support-policy) | Which branch releases what, and how long each major series is supported. |
 | [GOVERNANCE](GOVERNANCE.md) | Principles-first governance defining maintainer/project lead roles, least-privilege access, consensus/majority decisions, and nomination/emeritus steps. |
 | [MAINTAINERS](MAINTAINERS.md) | Lists active maintainers (Project Lead noted) and emeritus alumni with links; see governance for role scope. |
 | [LICENSE](LICENSE) | MIT License terms for using, modifying, and redistributing this project. |
@@ -418,6 +422,42 @@ The supported git version may be increased in future major or minor releases of 
 gem as new git features are adopted or as maintaining backward compatibility becomes
 impractical. Such changes will be documented in the CHANGELOG and release notes.
 
+### Deprecation policy
+
+This gem removes an API only in a major release, and only after a normal release
+deprecated it with a runtime warning and documented its replacement in
+[UPGRADING.md](UPGRADING.md). A normal release is one that is not a pre-release. The
+warning names the major release that removes the API once that is decided. Until then
+it says the API will be removed in a future major release.
+
+The recommended way to upgrade across a major version:
+
+1. Upgrade to the latest release of the major series you are on.
+2. Set `GIT_DEPRECATION_BEHAVIOR=raise` (or `Git::Deprecation.behavior = :raise`) in
+   your test suite and, if possible, staging.
+3. Fix each deprecation using the entries in [UPGRADING.md](UPGRADING.md) until the
+   suite is clean.
+4. Upgrade to the next major release.
+
+Because every deprecation warning is present in the last release of a major series,
+this procedure finds every change the next major requires. The version-specific steps
+are in [UPGRADING.md](UPGRADING.md#upgrading-to-v600). See
+[Deprecations](#deprecations) for how to configure the warnings.
+
+### Release support policy
+
+All development happens on `main`, which releases the next version of the gem,
+including the next major version.
+
+The most recent previous major series is maintained on a branch named for that
+series, currently `4.x`. It receives bug fixes and security fixes, and
+backward-compatible features at the maintainers' discretion. Fixes land on `main`
+first and are backported, except a fix for a problem that exists only in the
+maintenance branch, which targets that branch directly.
+
+Support for a major series ends when the second major after it is released. v4.x is
+supported until v6.0.0 ships, and v5.x until v7.0.0.
+
 ## Project announcements
 
 ### 2026-08-23: v5.x deprecations and the v6.0.0 roadmap
@@ -426,10 +466,11 @@ The road to v6.0.0 is now planned and public. The remaining ActiveRecord-style
 classes (`Git::Branch`, `Git::Remote`, `Git::Stash`, `Git::Worktree`,
 `Git::Object::Tag`, `Git::Status`, `Git::Author`, and their collections) will be
 deprecated during the v5.x series in favor of the immutable `*Info` value-object
-APIs. v6.0.0 will remove each deprecated class that passes the project's removal
-gate: a mandated deprecation soak period plus a proven-safe check. Any class that
-does not pass carries forward, still deprecated. v6.0.0 also raises the version
-floors: git ≥ 2.42.0, Ruby ≥ 3.4.
+APIs. v6.0.0 will remove each deprecated class once a normal v5.x release has carried
+its deprecation warning and UPGRADING.md entry, per the
+[Deprecation policy](#deprecation-policy). v6.0.0 will not ship until every planned
+deprecation has shipped that way. v6.0.0 also raises the version floors: git ≥ 2.42.0,
+Ruby ≥ 3.4.
 
 [Issue #1717](https://github.com/ruby-git/ruby-git/issues/1717) is the living
 roadmap, tracking scope, sequencing, and status. If your code uses the classes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -4,6 +4,7 @@ This document covers breaking changes and migration steps when upgrading the
 `git` gem to a new major version. Each section describes what changed and how
 to update your code when upgrading from the preceding major version.
 
+- [Upgrading to v6.0.0](#upgrading-to-v600)
 - [Upgrading to v5.x](#upgrading-to-v5x)
   - [Overview](#overview)
   - [Breaking changes](#breaking-changes)
@@ -23,6 +24,25 @@ to update your code when upgrading from the preceding major version.
     - [`Git::Remote` deprecated](#gitremote-deprecated)
     - [`Git::Commands::CatFile::Raw` `allow_unknown_type` option deprecated](#gitcommandscatfileraw-allow_unknown_type-option-deprecated)
     - [`Git::Branch` and `Git::Branches` deprecated](#gitbranch-and-gitbranches-deprecated)
+
+## Upgrading to v6.0.0
+
+v6.0.0 is not yet released. This section will be completed when it ships.
+
+v6.0.0 removes the APIs deprecated during v5.x under the project's
+[deprecation policy](README.md#deprecation-policy).
+[Issue 1717](https://github.com/ruby-git/ruby-git/issues/1717) tracks its scope.
+
+To prepare:
+
+1. Upgrade to the latest v5.x release.
+2. Set `GIT_DEPRECATION_BEHAVIOR=raise` (or `Git::Deprecation.behavior = :raise`) in
+   your test suite and, if possible, staging.
+3. Fix each deprecation using the entries under
+   [Deprecated methods](#deprecated-methods) until the suite is clean.
+4. Upgrade to v6.0.0.
+
+---
 
 ## Upgrading to v5.x
 

--- a/docs/adr/0006-removals-require-proven-safety-and-calendar-soak.md
+++ b/docs/adr/0006-removals-require-proven-safety-and-calendar-soak.md
@@ -1,5 +1,7 @@
 # Removals require proven safety and calendar soak
 
+Superseded by [ADR-0007](0007-removals-require-one-normal-release-of-deprecation-not-calendar-soak.md)
+
 A major release deletes a deprecated API only when two conditions both hold. First, a
 Safety Proof per the breaking-change-analysis skill: the single fact the removal is
 safe because of, proven by running real code — reverse-dependency evidence, not

--- a/docs/adr/0007-removals-require-one-normal-release-of-deprecation-not-calendar-soak.md
+++ b/docs/adr/0007-removals-require-one-normal-release-of-deprecation-not-calendar-soak.md
@@ -1,0 +1,45 @@
+# Removals require one normal release of deprecation, not calendar soak
+
+This record supersedes
+[ADR-0006](0006-removals-require-proven-safety-and-calendar-soak.md) and first applies
+to v6.0.0.
+
+A removal PR merges to main only when its deprecation warning and `UPGRADING.md` entry
+are contained in a previous normal release. Once any removal has merged to main, main
+becomes the release line for the next major version. If another release of the previous
+major is needed, it is cut from a branch created for that major (e.g. `4.x` or `5.x`).
+"Normal release" is semver's term for a non-pre-release version.
+
+The gate sets the earliest major a removal may land in, not the one it must land in. A
+removal may land in any major after the gate is met, and which one is a roadmap decision
+recorded on the API's issue. The warning names that major once it is decided, for
+example "will be removed in v6.0.0", and otherwise says "will be removed in a future
+major release". The `UPGRADING.md` entry agrees with the warning. Deciding or changing
+the named major later is a documentation change that ships in a minor.
+
+A warning is added only when removal in a future major is intended. An API that will be
+kept but discouraged is documented as legacy with no warning, as ADR-0002 did for the
+hollow shells. Removing a warning, which un-deprecates the API, is a non-breaking change.
+
+This record rejects ADR-0006's six-month calendar soak because the supported upgrade
+procedure is deliberate rather than incidental. A user upgrades to the latest minor of
+the current major, sets `GIT_DEPRECATION_BEHAVIOR=raise`, clears every warning, then
+upgrades to the next major. The latest minor carries every warning, so the time between
+a deprecating minor and the major does not matter. ADR-0006 assumed users discover
+warnings by chance during routine minor bumps. Its "before the final minor of the
+series" condition is also only knowable in retrospect and could force an empty release.
+
+The Safety Proof is no longer a removal condition. The deprecation period is the safety
+mechanism. The "prove it by running real code" discipline in the breaking-change-analysis
+skill stays for hard breaks and behavior changes that have no deprecation path.
+Reverse-dependency evidence is still useful, for example for outreach to dependents, but
+is not part of the gate. The evidence recorded on issue 1718 stands. The accepted risk is
+that a capability gap in a replacement API, found after the major ships, has no fallback
+and becomes a feature request.
+
+One consequence carries over from ADR-0006. Warnings only reach adopters of the
+deprecating series. Users who jump from an older major straight to the new one never see
+them, and `UPGRADING.md` is the instrument for them.
+
+ADR-0004 is unchanged. The options its floor-raise audit finds are deprecated under this
+policy, and the issue 1718 evidence it cites stands.


### PR DESCRIPTION
## Summary

Adopts a release-based deprecation policy and supersedes ADR-0006. A deprecated API may be removed once a normal release has carried its warning and `UPGRADING.md` entry; the Safety Proof and the six-month calendar soak are no longer removal conditions. The supported upgrade procedure (upgrade to the latest minor, set `GIT_DEPRECATION_BEHAVIOR=raise`, clear every warning, upgrade to the major) is what makes the period safe.

Documentation only. No changes under `lib/` or `spec/`.

What changed:

- `docs/adr/0007-removals-require-one-normal-release-of-deprecation-not-calendar-soak.md` records the decision; ADR-0006 gets a `Superseded by` line.
- `breaking-change-analysis` Step 4 is now the policy's normative home (gate, deprecation contents, warning wording, when to deprecate). Step 3 scopes the Safety Proof to hard breaks and behavior changes without a deprecation path.
- `release-management` gains "Major release readiness" and "After a major release" checklists and no longer claims a prerelease/beta strategy (`.release-please-config.json` has `prerelease: false`).
- `roadmap-tickets` and `project-context` point at the new policy.
- README gains "Deprecation policy" and "Release support policy" subsections, the Deprecations section points at the upgrade procedure, and the 2026-08-23 announcement describes the new gate.
- CONTRIBUTING's branch strategy and the copilot-instructions branch table match the release support policy.
- UPGRADING.md gains an "Upgrading to v6.0.0" section with the upgrade procedure.

## Decisions

- **P1. Removal gate.** A removal PR merges to main only when its deprecation warning and `UPGRADING.md` entry are contained in a previous normal release. Once any removal has merged, main is the release line for the next major, and further releases of the previous major come from a branch named for it.
- **P2.** The gate sets the earliest major a removal may land in, not the one it must land in. Which major is a roadmap decision recorded on the API's issue.
- **P3.** A deprecation ships, in one minor: a `Git::Deprecation.warn` warning naming the replacement, the replacement API, an `UPGRADING.md` entry, and a `@deprecated` YARD tag.
- **P4.** The warning names the removing major when decided ("will be removed in v6.0.0") and otherwise says "a future major release". Changing the named major later is a documentation change that ships in a minor.
- **P5.** A warning is added only when removal is intended. Kept-but-discouraged APIs are documented as legacy with no warning (ADR-0002's hollow shells). Un-deprecating is non-breaking.
- **P6.** The Safety Proof is no longer a removal condition. It stays for hard breaks and behavior changes with no deprecation path. The issue 1718 evidence stands as recorded. Accepted risk: a replacement capability gap found after the major ships becomes a feature request.
- **P7.** Rejected: calendar soak. The upgrade procedure is deliberate, so the latest minor carries every warning and elapsed time is irrelevant. ADR-0006's "before the final minor" was only knowable in retrospect.
- **P8.** Kept from ADR-0006: warnings only reach adopters of the deprecating series; `UPGRADING.md` is the instrument for users who jump majors.
- **P9.** ADR-0004 is unchanged; its floor-raise audit feeds the deprecation step.
- **P10. Release support.** All development on `main`; the previous major is maintained on a branch named for it (currently `4.x`). A major series is supported until the second major after it ships.

## Verification

- `lychee --config .lychee.toml` on every changed file: 315 links, 0 errors.
- `commitlint --from main`: 0 problems on all five commits.
- `markdownlint` on the changed files: no link-fragment or structural errors in changed lines (the repo has no markdownlint config; the remaining output is the default 80-column rule and pre-existing table-style notes).
- `git diff --stat main..HEAD` touches only markdown under `docs/`, `.github/`, and the repo root.

## Follow-up

Tracker edits to make on the day this merges, so the roadmap does not describe a policy that is not yet in force:

- Issue 1717: rewrite decisions 1, 2, and 7 and the sequencing paragraph to cite ADR-0007. Decision 2 becomes "v6.0.0 ships after the last planned deprecation is in a normal release".
- Issue 1718: add a comment that the tier column no longer applies and the evidence stands.
- v6.0.0 milestone: the due date follows the Author, Tag, and Status deprecations rather than a six-month clock.

Refs: #1717
