### PR TITLE
ci(release): move the workflow description into comments

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,13 +1,12 @@
 ---
 name: Release Gem
 
-description: |
-  This workflow creates a new release on GitHub and publishes the gem to
-  RubyGems.org.
-
-  The workflow uses the `googleapis/release-please-action` to handle the
-  release creation process and the `rubygems/release-gem` action to publish
-  the gem to rubygems.org
+# This workflow creates a new release on GitHub and publishes the gem to
+# RubyGems.org.
+#
+# The workflow uses the `googleapis/release-please-action` to handle the
+# release creation process and the `rubygems/release-gem` action to publish
+# the gem to rubygems.org
 
 on:
   push:

--- a/spec/unit/github_workflows_spec.rb
+++ b/spec/unit/github_workflows_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'yaml'
+
+# Guards the workflow files under .github/workflows.
+#
+# GitHub Actions ignores top-level keys it does not recognize, so a typo or a stray
+# key never breaks a workflow run. actionlint rejects them, and these files are copied
+# into other repositories that run actionlint, so this catches them in the existing
+# suite instead of in someone else's CI.
+RSpec.describe '.github/workflows' do
+  # The top-level keys actionlint accepts for a workflow, as listed in its
+  # "unexpected key ... for \"workflow\" section" error message.
+  supported_keys = %w[concurrency defaults env jobs name on permissions run-name].freeze
+
+  workflow_files = Dir.glob(File.join(File.expand_path('../..', __dir__), '.github', 'workflows', '*.yml'))
+
+  it 'has at least one workflow file to check' do
+    expect(workflow_files).not_to be_empty
+  end
+
+  workflow_files.each do |workflow_file|
+    it "uses only supported top-level keys in #{File.basename(workflow_file)}" do
+      # YAML 1.1 treats bare `on`, `yes`, and `true` (in any case) as the same boolean,
+      # so loading the file would collapse all of them into a single `true` key and
+      # hide an unsupported spelling. Read the keys from the syntax tree, which keeps
+      # each scalar as written.
+      mapping = YAML.parse_file(workflow_file).root
+      keys = mapping.children.each_slice(2).map { |key, _value| key.value }
+
+      expect(keys - supported_keys).to be_empty
+    end
+  end
+end


### PR DESCRIPTION
Implements the actionable half of issue 1734.

## Part 1: not applicable to this repository

Part 1 concerns a `resolve-feedback` skill that no longer exists here. The local `address-pr-feedback` skill is a thin override with no GraphQL query. The plugin it defers to (`jcouball-github`, installed at 3.1.0 and upstream `main`) already has the pagination fix. Nothing to change in this repository.

## Part 2: fixed

`.github/workflows/release.yml` had a top-level `description:` key. GitHub Actions ignores unknown top-level keys, so the workflow ran fine, but actionlint rejects it:

```
.github/workflows/release.yml:4:1: unexpected key "description" for "workflow" section. expected one of "concurrency", "defaults", "env", "jobs", "name", "on", "permissions", "run-name" [syntax-check]
```

One commit with two changes:

- `.github/workflows/release.yml`: converts the `description:` block to `#` comments directly below `name:`, keeping every word. Nothing else in the file changes.
- `spec/unit/github_workflows_spec.rb`: new spec that checks every `.github/workflows/*.yml` and asserts its top-level keys are among the ones actionlint accepts. It reads the keys from the Psych syntax tree rather than loading the document, because YAML 1.1 treats bare `on`, `yes`, and `true` as the same boolean and loading would collapse them into a single `true` key. It also asserts the file list is not empty so a wrong glob cannot pass vacuously. It does not shell out to actionlint, which is not installed in CI.

No other workflow in `.github/workflows` has an unsupported top-level key. `actionlint` run locally reports nothing after the change, and `bundle exec rake default` passes.

Closes #1734
