### PR TITLE
feat(tag): add tag_list and tag_create and deprecate the Git::Object::Tag returns

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,6 +24,7 @@ to update your code when upgrading from the preceding major version.
     - [`Git::Remote` deprecated](#gitremote-deprecated)
     - [`Git::Commands::CatFile::Raw` `allow_unknown_type` option deprecated](#gitcommandscatfileraw-allow_unknown_type-option-deprecated)
     - [`Git::Branch` and `Git::Branches` deprecated](#gitbranch-and-gitbranches-deprecated)
+    - [`Git::Object::Tag` deprecated](#gitobjecttag-deprecated)
 
 ## Upgrading to v6.0.0
 
@@ -266,7 +267,7 @@ shim cannot forward them). Update call sites directly:
 
 | v4.x call | Notes |
 |-----------|-------|
-| `g.lib.list_files(ref_dir)` | Walked `.git/refs/` directly. Use `g.branch_list`, `g.tags`, or `g.remote_list` instead. |
+| `g.lib.list_files(ref_dir)` | Walked `.git/refs/` directly. Use `g.branch_list`, `g.tag_list`, or `g.remote_list` instead. |
 
 ##### Internal plumbing methods (no replacement)
 
@@ -647,5 +648,96 @@ can resolve a local branch of that name and is only used where git expects it
 | `b.archive(file, opts)` | `g.archive(name, file, opts)` — pass `info.refname` for a remote-tracking branch |
 | `b.in_branch(message) { ... }` | `g.in_branch(name, message) { ... }` — local `b` only; see the differences above |
 | `b.stashes` | `g.stashes_all` — see [`Git::Branch#stashes` deprecated](#gitbranchstashes-deprecated) |
+
+#### `Git::Object::Tag` deprecated
+
+`Git::Object::Tag`, `Git::Repository#tag`, `Git::Repository#tags`, and
+`Git::Repository#tag_add` are deprecated and are removed in v6.0.0. Read tag data
+through `Git::Repository#tag_list`, which returns one `Git::TagInfo` value object per
+tag, create tags with `Git::Repository#tag_create`, which returns the new tag's
+`Git::TagInfo`, and call the repository-level operations (`archive`, `log`, `diff`,
+`cat_file_contents`, and so on) with the tag's object ID,
+`info.oid || info.target_oid`, which is the object a `Git::Object::Tag` pinned when
+it was constructed. Calling `g.tag`, `g.tags`, or
+`g.tag_add`, and constructing a `Git::Object::Tag`, each emit one deprecation
+warning; their return values are unchanged. `g.add_tag` already warned, pointing at
+`g.tag_add`, and now emits two warnings for a creation call, one for itself and one
+for the `g.tag_add` it calls; `g.add_tag(name, d: true)` emits three, adding the
+`:d`/`:delete` warning described below. The readers on a `Git::Object::Tag` do not
+warn.
+
+> **Return shape change:** `Git::Object::Tag` exposes `name`, `sha`, `objectish`,
+> `annotated?`, `message`, and `tagger`. `Git::TagInfo` exposes `name`, `oid`,
+> `target_oid`, `objecttype`, `annotated?`, `lightweight?`, `message`, and
+> `tagger`. `name` and `annotated?` are unchanged. `tagger` keeps the same `name`
+> and `email`, but `tagger.date` differs: `t.tagger.date` is a `Time` in the
+> process's local zone, while `info.tagger.date` keeps the UTC offset recorded in
+> the tag object. Both name the same instant. `message` differs for an annotated
+> tag created with an empty message (`message: ''`): `t.message` returns `""` and
+> `info.message` returns `nil`, the same value a lightweight tag has. `t.sha` and
+> `t.objectish` are the tag object's ID for an annotated tag and
+> the tagged object's ID for a lightweight tag. `Git::TagInfo` separates the two:
+> `oid` is the tag object's ID (`nil` for a lightweight tag) and `target_oid` is
+> the ID of the object the tag points to (set for both kinds), so
+> `info.oid || info.target_oid` reproduces `t.sha`. The target is usually a
+> commit, but a tag can point at any git object, and `info.objecttype` reports
+> which kind (`tag` for an annotated tag, or the target's own type such as
+> `commit` or `blob` for a lightweight one).
+>
+> **Missing tags:** `g.tag(name)` raises `Git::UnexpectedResultError` when no tag
+> has that name. `g.tag_list(name).first` returns `nil`.
+>
+> **Deleting through `tag_add`:** `g.tag_add(name, d: true)`, which was already
+> deprecated, deletes the tag and emits a second warning pointing at
+> `g.tag_delete`. `g.tag_create` rejects `:d` and `:delete` with `ArgumentError`.
+>
+> **Extra positional arguments:** `g.tag_add(name, target, extra)` ignores
+> `extra` and tags `target`. `g.tag_create` raises `ArgumentError` when more than
+> one positional argument follows the name.
+>
+> **Object identity:** every `Git::Object::Tag` resolves its tag to an object ID
+> when it is constructed and runs `size`, `contents`, `grep`, `diff`, `log`, and
+> `archive` against that ID, so moving or deleting the tag afterwards does not
+> redirect an existing object. `Git::Object::Tag.new(g, sha, name)` uses the
+> supplied `sha` as that ID; the other forms look it up from the ref. `annotated?`,
+> `message`, and `tagger` always read the ref `name`. `Git::TagInfo` describes the
+> ref only: `g.tag_list(name).first` returns whatever `name` points at now, or
+> `nil` once the tag is deleted. Keep the same identity by passing `id` (see the
+> table) rather than `name` to the operation replacements; they accept any object.
+> To read an annotated tag object by ID without going through its ref, use
+> `g.cat_file_tag(id)`, which returns the tag object's `object`, `type`, `tag`,
+> `tagger`, and `message`.
+
+In the table, `name` is the tag name, `t` is a `Git::Object::Tag`, `info` is the
+`Git::TagInfo` that replaces it, and `id` is `info.oid || info.target_oid` (or the
+`sha` given to the three-argument constructor), the object `t` pinned.
+
+| Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
+|-----------------------------------------------------|-------------|
+| `g.tag(name)` | `g.tag_list(name).first` — a `Git::TagInfo`, or `nil` when the tag does not exist |
+| `g.tags` | `g.tag_list` — returns `Array<Git::TagInfo>` |
+| `g.tags.map(&:name)` | `g.tag_list.map(&:name)` |
+| `g.tag_add(name, opts)` | `g.tag_create(name, opts)` — returns a `Git::TagInfo` |
+| `g.tag_add(name, target, opts)` | `g.tag_create(name, target, opts)` |
+| `g.tag_add(name, d: true)` | `g.tag_delete(name)` |
+| `g.add_tag(name, opts)`, `g.add_tag(name, target, opts)` | `g.tag_create(name, ...)` — its warning names `g.tag_add`, which is deprecated too; go straight to `g.tag_create` |
+| `g.add_tag(name, d: true)` | `g.tag_delete(name)` — `g.tag_create` rejects `:d`; see the deletion note above |
+| `Git::Object::Tag.new(g, name)` | `g.tag_list(name).first` |
+| `Git::Object::Tag.new(g, sha, name)` | `g.tag_list(name).first` — reads the ref rather than `sha`; use `sha` as `id` for the operations below, or read the object with `g.cat_file_tag(sha)`; see the object identity note above |
+| `Git::Object.new(g, name, nil, true)` | `g.tag_list(name).first` — its warning names `Git::Object::Tag.new`, which is deprecated too |
+| `t.name` | `info.name` |
+| `t.sha`, `t.objectish`, `t.to_s` | `info.oid \|\| info.target_oid` — see the return shape change above |
+| `t.annotated?` | `info.annotated?` |
+| `t.message` | `info.message` — `nil` rather than `""` for an annotated tag with an empty message |
+| `t.tagger` | `info.tagger` — `date` keeps the recorded UTC offset; see the return shape change above |
+| `t.tag?` | not needed; every `Git::TagInfo` is a tag |
+| `t.size` | `g.cat_file_size(id)` — `id` rather than `name` keeps this and the operations below on the object `t` pinned; see the object identity note above |
+| `t.contents` | `g.cat_file_contents(id)` |
+| `t.contents { \|file\| ... }` | `g.cat_file_contents(id) { \|file\| ... }` — streams to a temporary file instead of buffering the object |
+| `t.contents_array` | `g.cat_file_contents(id).split("\n")` |
+| `t.grep(string, path, opts)` | `g.grep(string, path, opts.merge(object: id))` |
+| `t.diff(other)` | `g.diff(id, other)` |
+| `t.log(count)` | `g.log(count).object(id)` |
+| `t.archive(file, opts)` | `g.archive(id, file, opts)` |
 
 ---

--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -538,6 +538,18 @@ module Git
     # Annotated tags contain additional metadata such as the tagger's name, email, and
     # the date when the tag was created, along with a message.
     #
+    # @deprecated Use {Git::Repository::ObjectOperations#tag_list} and
+    #   {Git::TagInfo} instead
+    #
+    #   {Git::TagInfo} is an immutable value object carrying the tag's `name`,
+    #   `oid`, `target_oid`, `annotated?`, `message`, and `tagger`. Call the
+    #   corresponding {Git::Repository} method (e.g. `archive`, `log`, `diff`,
+    #   `cat_file_contents`) with `info.oid || info.target_oid` for operations
+    #   on a tag; that is the object this class resolves and pins at
+    #   construction, so a later move of the tag does not redirect an existing
+    #   object, whereas the tag name would. Constructing a `Git::Object::Tag`
+    #   emits a deprecation warning.
+    #
     class Tag < AbstractObject
       # @return [String] the tag name
       #
@@ -551,6 +563,13 @@ module Git
       #
       # @overload initialize(base, sha, name)
       #
+      #   `sha` is kept as the object that the inherited operations (`size`,
+      #   `contents`, `grep`, `diff`, `log`, `archive`) run against; `annotated?`,
+      #   `message`, and `tagger` read the ref `name`. {Git::TagInfo} describes a
+      #   ref, so there is no OID-based replacement for this form: pass `sha` to
+      #   the {Git::Repository} operation directly, or read the tag object with
+      #   {Git::Repository::ObjectOperations#cat_file_tag}.
+      #
       #   @param base [Git::Repository] the git repository
       #
       #   @param sha [String] the SHA of the tag object
@@ -558,12 +577,11 @@ module Git
       #   @param name [String] the name of the tag
       #
       def initialize(base, sha, name = nil)
-        if name.nil?
-          name = sha
-          sha = base.tag_sha(name)
-          raise Git::UnexpectedResultError, "Tag '#{name}' does not exist." if sha == ''
-        end
-
+        Git::Deprecation.warn(
+          'Git::Object::Tag is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#tag_list and Git::TagInfo instead.'
+        )
+        sha, name = resolve_sha_and_name(base, sha, name)
         super(base, sha)
 
         @name = name
@@ -608,6 +626,31 @@ module Git
       end
 
       private
+
+      # Resolves the two-argument constructor form to a SHA and a tag name
+      #
+      # In the two-argument form `sha` carries the tag name and the SHA is
+      # looked up from the repository.
+      #
+      # @param base [Git::Repository] the git repository
+      #
+      # @param sha [String] the SHA of the tag object, or the tag name in the
+      #   two-argument form
+      #
+      # @param name [String, nil] the tag name, or `nil` in the two-argument form
+      #
+      # @return [Array(String, String)] the resolved `[sha, name]` pair
+      #
+      # @raise [Git::UnexpectedResultError] if the tag does not exist
+      #
+      def resolve_sha_and_name(base, sha, name)
+        return [sha, name] unless name.nil?
+
+        resolved = base.tag_sha(sha)
+        raise Git::UnexpectedResultError, "Tag '#{sha}' does not exist." if resolved == ''
+
+        [resolved, sha]
+      end
 
       # Loads annotated tag data when available
       #
@@ -663,14 +706,19 @@ module Git
     #
     # @return [Git::Object::Tag] the tag object wrapper
     #
-    # @deprecated use `Git::Object::Tag.new` instead
+    # @deprecated Use {Git::Repository::ObjectOperations#tag_list} instead
+    #
+    #   The warning names `Git::Object::Tag.new`, the replacement this path
+    #   shipped with, and the {Git::Object::Tag} constructor is deprecated as
+    #   well; this method silences it so one call emits one warning. Go
+    #   straight to `Git::Repository#tag_list(name).first`.
     #
     private_class_method def self.new_tag(base, objectish)
       Git::Deprecation.warn(
         'Git::Object.new with is_tag argument is deprecated and will be removed in v6.0.0. ' \
         'Use Git::Object::Tag.new instead.'
       )
-      Git::Object::Tag.new(base, objectish)
+      Git::Deprecation.silence { Git::Object::Tag.new(base, objectish) }
     end
 
     # Returns the repository used for object lookup

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -721,8 +721,28 @@ module Git
       # @raise [Git::FailedError] if the underlying `git show-ref` invocation
       #   exits with an unexpected status (i.e., outside the allowed 0..1 range)
       #
+      # @deprecated Use `tag_list(name).first` instead
+      #
+      #   {#tag_list} returns immutable {Git::TagInfo} value objects rather
+      #   than {Git::Object::Tag}. `tag_list(name).first` is `nil` when the tag
+      #   does not exist, where this method raises
+      #   {Git::UnexpectedResultError}. Call the corresponding
+      #   {Git::Repository} method (e.g. {#archive}, {#log}, {#diff},
+      #   {#cat_file_contents}) with `info.oid || info.target_oid` for
+      #   operations on a tag; that is the object this method's return value
+      #   pins at construction, so a later move of the tag does not redirect
+      #   it, whereas the tag name would. The
+      #   {Git::Object::Tag} constructor is deprecated too; this method
+      #   silences it so one call emits one warning.
+      #
+      # @see #tag_list
+      #
       def tag(tag_name)
-        Git::Object::Tag.new(self, tag_name)
+        Git::Deprecation.warn(
+          'Git::Repository#tag is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#tag_list(name).first instead.'
+        )
+        Git::Deprecation.silence { Git::Object::Tag.new(self, tag_name) }
       end
 
       # Returns the appropriate git object for the given object reference
@@ -753,6 +773,47 @@ module Git
         Git::Object.new(self, objectish)
       end
 
+      # Returns the tags in the repository as structured objects
+      #
+      # @example List all tags
+      #   repo.tag_list
+      #   # => [#<data Git::TagInfo name="v1.0.0", oid=nil, target_oid="abc123...", ...>,
+      #   #     #<data Git::TagInfo name="v2.0.0", oid="def456...", target_oid="789abc...", ...>]
+      #
+      # @example Look up a single tag by name
+      #   repo.tag_list('v1.0.0').first
+      #   # => #<data Git::TagInfo name="v1.0.0", ...>
+      #
+      # @example Look up a tag that does not exist
+      #   repo.tag_list('nonexistent').first #=> nil
+      #
+      # @example Filter using glob patterns
+      #   repo.tag_list('v1.*', 'v2.*')
+      #
+      # @example List only annotated tags
+      #   repo.tag_list.select(&:annotated?)
+      #
+      # @param patterns [Array<String>] optional shell wildcard patterns passed
+      #   directly to `git tag --list`; when empty (the default) all tags are
+      #   returned
+      #
+      # @return [Array<Git::TagInfo>] parsed tag information for every tag
+      #   matching the patterns, in the order `git tag --list` reports them
+      #
+      #   Returns an empty array when the repository has no tags or no tag
+      #   matches the given patterns.
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-tag git-tag
+      #
+      def tag_list(*patterns)
+        result = Git::Commands::Tag::List.new(@execution_context).call(
+          *patterns, format: Git::Parsers::Tag::FORMAT_STRING
+        )
+        Git::Parsers::Tag.parse_list(result.stdout)
+      end
+
       # Returns all tags in the repository as tag objects
       #
       # Runs `git tag --list` with a machine-readable format, parses the output,
@@ -769,30 +830,50 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @deprecated Use {#tag_list} instead
+      #
+      #   {#tag_list} returns `Array<Git::TagInfo>` (immutable value objects)
+      #   rather than `Array<Git::Object::Tag>`. Look a tag up by name with
+      #   `tag_list(name).first`, and call the corresponding {Git::Repository}
+      #   method (e.g. {#archive}, {#log}, {#diff}, {#cat_file_contents}) with
+      #   `info.oid || info.target_oid` for operations on a tag; that is the
+      #   object each returned {Git::Object::Tag} pins at construction, so a
+      #   later move of the tag does not redirect it, whereas the tag name
+      #   would. The {Git::Object::Tag}
+      #   constructor is deprecated too; this method silences it so one call
+      #   emits one warning.
+      #
+      # @see #tag_list
+      #
       def tags
-        result = Git::Commands::Tag::List.new(@execution_context).call(format: Git::Parsers::Tag::FORMAT_STRING)
-        Git::Parsers::Tag.parse_list(result.stdout).map { |info| tag(info.name) }
+        Git::Deprecation.warn(
+          'Git::Repository#tags is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#tag_list instead.'
+        )
+        Git::Deprecation.silence { tag_list.map { |info| Git::Object::Tag.new(self, info.name) } }
       end
 
-      # Option keys accepted by {#tag_add}
-      TAG_ADD_ALLOWED_OPTS = %i[
+      # Option keys accepted by {#tag_create} and {#tag_add}
+      TAG_CREATE_ALLOWED_OPTS = %i[
         annotate a sign s no_sign local_user u force f message m file F
         edit e no_edit trailer cleanup create_reflog
       ].freeze
-      private_constant :TAG_ADD_ALLOWED_OPTS
+      private_constant :TAG_CREATE_ALLOWED_OPTS
 
-      # Create a new tag
+      # Create a new tag and return its metadata
       #
-      # @overload tag_add(name, options = {})
+      # @overload tag_create(name, options = {})
       #
       #   @example Create a lightweight tag on HEAD
-      #     repo.tag_add('v1.0.0')
+      #     repo.tag_create('v1.0.0')
+      #     # => #<data Git::TagInfo name="v1.0.0", oid=nil, target_oid="abc123...", ...>
       #
       #   @example Create an annotated tag on HEAD
-      #     repo.tag_add('v1.0.0', annotate: true, message: 'Release 1.0.0')
+      #     repo.tag_create('v1.0.0', annotate: true, message: 'Release 1.0.0')
+      #     # => #<data Git::TagInfo name="v1.0.0", oid="def456...", message="Release 1.0.0", ...>
       #
       #   @example Replace an existing tag on HEAD
-      #     repo.tag_add('v1.0.0', force: true)
+      #     repo.tag_create('v1.0.0', force: true)
       #
       #   @param name [String] the name of the tag to create
       #
@@ -847,6 +928,65 @@ module Git
       #   @option options [Boolean, nil] :create_reflog (nil) create a reflog for
       #     the tag
       #
+      #   @return [Git::TagInfo] the newly created tag
+      #
+      # @overload tag_create(name, target, options = {})
+      #
+      #   @example Create a lightweight tag on a specific commit
+      #     repo.tag_create('v1.0.0', 'abc123')
+      #
+      #   @example Create an annotated tag on a specific commit
+      #     repo.tag_create('v1.0.0', 'abc123', annotate: true, message: 'Release 1.0.0')
+      #
+      #   @param name [String] the name of the tag to create
+      #
+      #   @param target [String] the object to tag (commit SHA, branch name, etc.)
+      #
+      #   @param options [Hash] options for creating the tag (same keys as the
+      #     first overload)
+      #
+      #   @return [Git::TagInfo] the newly created tag
+      #
+      # @raise [ArgumentError] if unsupported options are provided, including the
+      #   `:d` and `:delete` keys that {#tag_add} accepts; use {#tag_delete} to
+      #   delete a tag
+      #
+      # @raise [ArgumentError] if an annotated or signed tag is requested without
+      #   a message
+      #
+      # @raise [ArgumentError] if more than one positional argument follows the
+      #   name (before any options hash); {#tag_add} silently ignored the extra
+      #   arguments and tagged the first
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-tag git-tag
+      #
+      def tag_create(name, *args)
+        target, options = Private.tag_target_and_options(args, strict: true)
+        SharedPrivate.assert_valid_opts!(TAG_CREATE_ALLOWED_OPTS, **options)
+        Private.create_tag(@execution_context, name, target, options)
+        tag_list(name).first
+      end
+
+      # Create a new tag
+      #
+      # @overload tag_add(name, options = {})
+      #
+      #   @example Create a lightweight tag on HEAD
+      #     repo.tag_add('v1.0.0')
+      #
+      #   @example Create an annotated tag on HEAD
+      #     repo.tag_add('v1.0.0', annotate: true, message: 'Release 1.0.0')
+      #
+      #   @example Replace an existing tag on HEAD
+      #     repo.tag_add('v1.0.0', force: true)
+      #
+      #   @param name [String] the name of the tag to create
+      #
+      #   @param options [Hash] options for creating the tag (same keys as
+      #     {#tag_create})
+      #
       #   @return [Git::Object::Tag] the newly created tag
       #
       # @overload tag_add(name, target, options = {})
@@ -861,8 +1001,8 @@ module Git
       #
       #   @param target [String] the object to tag (commit SHA, branch name, etc.)
       #
-      #   @param options [Hash] options for creating the tag (same keys as the
-      #     first overload)
+      #   @param options [Hash] options for creating the tag (same keys as
+      #     {#tag_create})
       #
       #   @return [Git::Object::Tag] the newly created tag
       #
@@ -893,17 +1033,31 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @deprecated Use {#tag_create} instead
+      #
+      #   {#tag_create} accepts the same `name`, `target`, and options and
+      #   returns a {Git::TagInfo} (an immutable value object) rather than a
+      #   {Git::Object::Tag}. It does not accept the `:d`/`:delete` form; use
+      #   {#tag_delete} for that. The {Git::Object::Tag} constructor is
+      #   deprecated too; this method silences it so one call emits one
+      #   warning, except that the `:d`/`:delete` form emits a second warning
+      #   of its own.
+      #
+      # @see #tag_create
+      #
       def tag_add(name, *args)
-        options = args.last.is_a?(Hash) ? args.pop : {}
-        target = args.first
+        Git::Deprecation.warn(
+          'Git::Repository#tag_add is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#tag_create instead.'
+        )
+        target, options = Private.tag_target_and_options(args)
 
         return Private.tag_add_delete_deprecated(self, name, target, options) if options[:d] || options[:delete]
 
         options = options.except(:d, :delete)
-        SharedPrivate.assert_valid_opts!(TAG_ADD_ALLOWED_OPTS, **options)
-        Private.validate_tag_options!(options)
-        Git::Commands::Tag::Create.new(@execution_context).call(name, target, **options)
-        tag(name)
+        SharedPrivate.assert_valid_opts!(TAG_CREATE_ALLOWED_OPTS, **options)
+        Private.create_tag(@execution_context, name, target, options)
+        Git::Deprecation.silence { Git::Object::Tag.new(self, name) }
       end
 
       # @overload add_tag(name, options = {})
@@ -931,7 +1085,14 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
-      # @deprecated Use {#tag_add} instead
+      # @deprecated Use {#tag_create} instead
+      #
+      #   The warning names {#tag_add}, the replacement this method shipped
+      #   with, and {#tag_add} is deprecated as well, so a creation call emits
+      #   two warnings: one for this method and one for {#tag_add}. The delete
+      #   form `add_tag(name, d: true)` emits a third, for the deprecated `:d`
+      #   and `:delete` options on {#tag_add}; use {#tag_delete} for that. Go
+      #   straight to {#tag_create} for creation.
       #
       def add_tag(name, *)
         Git::Deprecation.warn(
@@ -981,6 +1142,82 @@ module Git
       #
       module Private
         module_function
+
+        # Splits the variadic `*args` of {ObjectOperations#tag_create} and
+        # {ObjectOperations#tag_add} into the target and the options hash
+        #
+        # Both methods accept `(name, opts = {})` and `(name, target, opts = {})`,
+        # so a trailing `Hash` is the options and anything before it is the
+        # target.
+        #
+        # @param args [Array] the arguments after the tag name
+        #
+        # @param strict [Boolean] when `true`, raise instead of silently ignoring
+        #   a second positional argument before the options; `tag_create` is
+        #   strict, while the deprecated `tag_add` keeps its lenient behavior
+        #
+        # @return [Array((String, nil), Hash)] the two-element tuple
+        #   `[target, options]`; `target` is `nil` when only options were given
+        #
+        # @raise [ArgumentError] if `strict` is `true` and more than one
+        #   positional argument precedes the options hash
+        #
+        # @api private
+        #
+        def tag_target_and_options(args, strict: false)
+          args = args.dup
+          options = args.last.is_a?(Hash) ? args.pop : {}
+          if strict && args.size > 1
+            raise ArgumentError,
+                  "Expected at most one target before the options, got #{args.size}: #{args.inspect}"
+          end
+
+          [args.first, options]
+        end
+
+        # Validates the tag-creation options and runs `git tag`
+        #
+        # @param execution_context [Git::ExecutionContext::Repository] the
+        #   execution context for git commands
+        #
+        # @param name [String] the name of the tag to create
+        #
+        # @param target [String, nil] the object to tag, or `nil` for HEAD
+        #
+        # @param options [Hash] the tag-creation options, already checked
+        #   against the allowed keys (see {ObjectOperations#tag_create} for the
+        #   full list)
+        #
+        # @option options [Boolean, nil] :annotate (nil) make an annotated tag;
+        #   requires a message (alias: `:a`)
+        #
+        # @option options [Boolean, nil] :sign (nil) make a signed tag; requires
+        #   a message (alias: `:s`)
+        #
+        # @option options [String] :local_user (nil) sign with the given key;
+        #   requires a message (alias: `:u`)
+        #
+        # @option options [String] :message (nil) the tag message (alias: `:m`)
+        #
+        # @option options [String] :file (nil) a file to read the tag message
+        #   from (alias: `:F`)
+        #
+        # @option options [Boolean, nil] :force (nil) replace an existing tag
+        #   (alias: `:f`)
+        #
+        # @return [void]
+        #
+        # @raise [ArgumentError] when an annotated or signed tag is requested
+        #   without a message
+        #
+        # @raise [Git::FailedError] if git exits with a non-zero exit status
+        #
+        # @api private
+        #
+        def create_tag(execution_context, name, target, options)
+          validate_tag_options!(options)
+          Git::Commands::Tag::Create.new(execution_context).call(name, target, **options)
+        end
 
         # Validate that a message is present when an annotated or signed tag is
         # requested

--- a/lib/git/tag_info.rb
+++ b/lib/git/tag_info.rb
@@ -43,7 +43,8 @@ module Git
   #   info.lightweight?  #=> true
   #   info.tagger        #=> nil
   #
-  # @see Git::Tag for the full-featured tag object with operations
+  # @see Git::Repository::ObjectOperations#tag_list for the repository method
+  #   that returns these
   #
   # @see Git::Commands::Tag::List for the command that produces these
   #

--- a/spec/integration/git/commands/describe_spec.rb
+++ b/spec/integration/git/commands/describe_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Git::Commands::Describe, :integration do
     write_file('file.txt', 'content')
     repo.add('file.txt')
     repo.commit('Initial commit')
-    repo.tag_add('v1.0.0')
+    repo.tag_create('v1.0.0')
   end
 
   describe '#call' do

--- a/spec/integration/git/commands/diff_spec.rb
+++ b/spec/integration/git/commands/diff_spec.rb
@@ -50,13 +50,13 @@ RSpec.describe Git::Commands::Diff, :integration do
         File.write(File.join(@check_repo_dir, 'file.txt'), "clean content\n", mode: 'wb')
         check_repo.add('file.txt')
         check_repo.commit('Initial commit')
-        check_repo.tag_add('check_clean')
+        check_repo.tag_create('check_clean')
 
         # Commit that introduces trailing whitespace
         File.write(File.join(@check_repo_dir, 'file.txt'), "trailing whitespace   \n", mode: 'wb')
         check_repo.add('file.txt')
         check_repo.commit('Add trailing whitespace')
-        check_repo.tag_add('check_dirty')
+        check_repo.tag_create('check_dirty')
 
         @check_command = described_class.new(check_repo.execution_context)
       end

--- a/spec/integration/git/commands/show_ref/list_spec.rb
+++ b/spec/integration/git/commands/show_ref/list_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Git::Commands::ShowRef::List, :integration do
     write_file('file.txt', "content\n")
     repo.add('.')
     repo.commit('Initial commit')
-    repo.tag_add('v1.0')
+    repo.tag_create('v1.0')
   end
 
   describe '#call' do

--- a/spec/integration/git/commands/tag/delete_spec.rb
+++ b/spec/integration/git/commands/tag/delete_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Git::Commands::Tag::Delete, :integration do
       write_file('file.txt', 'content')
       repo.add('file.txt')
       repo.commit('Initial commit')
-      repo.tag_add('v1.0.0')
+      repo.tag_create('v1.0.0')
     end
 
     context 'when the command succeeds' do
@@ -25,7 +25,7 @@ RSpec.describe Git::Commands::Tag::Delete, :integration do
       end
 
       it 'returns exit code 1 for partial failure' do
-        repo.tag_add('v2.0.0')
+        repo.tag_create('v2.0.0')
 
         result = command.call('v1.0.0', 'nonexistent', 'v2.0.0')
 

--- a/spec/integration/git/commands/tag/list_spec.rb
+++ b/spec/integration/git/commands/tag/list_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Commands::Tag::List, :integration do
         write_file('file.txt', 'content')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.tag_add('v1.0.0')
+        repo.tag_create('v1.0.0')
 
         result = command.call
 

--- a/spec/integration/git/parsers/branch_spec.rb
+++ b/spec/integration/git/parsers/branch_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Git::Parsers::Branch, :integration do
         write_file('file.txt')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.tag_add('v1.0.0')
+        repo.tag_create('v1.0.0')
         write_file('file2.txt')
         repo.add('file2.txt')
         repo.commit('Second commit')

--- a/spec/integration/git/parsers/fsck_spec.rb
+++ b/spec/integration/git/parsers/fsck_spec.rb
@@ -84,7 +84,7 @@ RSpec.describe Git::Parsers::Fsck, :integration do
         write_file('file.txt', 'content')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.tag_add('v1.0.0', annotate: true, message: 'Version 1.0.0')
+        repo.tag_create('v1.0.0', annotate: true, message: 'Version 1.0.0')
       end
 
       it 'returns tagged objects with tag name' do

--- a/spec/integration/git/parsers/tag_spec.rb
+++ b/spec/integration/git/parsers/tag_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Git::Parsers::Tag, :integration do
         write_file('file.txt', 'content')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.tag_add('v1.0.0')
+        repo.tag_create('v1.0.0')
       end
 
       it 'returns tag with populated metadata' do
@@ -58,7 +58,7 @@ RSpec.describe Git::Parsers::Tag, :integration do
         write_file('file.txt', 'content')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.tag_add('v2.0.0', annotate: true, message: 'Release version 2.0.0')
+        repo.tag_create('v2.0.0', annotate: true, message: 'Release version 2.0.0')
       end
 
       it 'returns tag with populated metadata' do
@@ -104,8 +104,8 @@ RSpec.describe Git::Parsers::Tag, :integration do
         write_file('file.txt', 'content')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.tag_add('v1.0.0', annotate: true, message: multiline_message)
-        repo.tag_add('v1.1.0', annotate: true, message: 'Simple message')
+        repo.tag_create('v1.0.0', annotate: true, message: multiline_message)
+        repo.tag_create('v1.1.0', annotate: true, message: 'Simple message')
       end
 
       it 'captures full multi-line message' do
@@ -129,17 +129,17 @@ RSpec.describe Git::Parsers::Tag, :integration do
         write_file('file1.txt', 'content1')
         repo.add('file1.txt')
         repo.commit('First commit')
-        repo.tag_add('v1.0.0')
+        repo.tag_create('v1.0.0')
 
         write_file('file2.txt', 'content2')
         repo.add('file2.txt')
         repo.commit('Second commit')
-        repo.tag_add('v1.1.0', annotate: true, message: 'Version 1.1.0')
+        repo.tag_create('v1.1.0', annotate: true, message: 'Version 1.1.0')
 
         write_file('file3.txt', 'content3')
         repo.add('file3.txt')
         repo.commit('Third commit')
-        repo.tag_add('v2.0.0')
+        repo.tag_create('v2.0.0')
       end
 
       it 'returns all tags' do
@@ -167,8 +167,8 @@ RSpec.describe Git::Parsers::Tag, :integration do
         write_file('file.txt', 'content')
         repo.add('file.txt')
         repo.commit('Initial commit')
-        repo.tag_add('release/v1.0')
-        repo.tag_add('feature-branch-tag')
+        repo.tag_create('release/v1.0')
+        repo.tag_create('feature-branch-tag')
       end
 
       it 'handles tags with slashes' do

--- a/spec/integration/git/repository/branching_spec.rb
+++ b/spec/integration/git/repository/branching_spec.rb
@@ -417,7 +417,7 @@ RSpec.describe Git::Repository::Branching, :integration do
 
     context 'on an unborn branch that shares its name with a tag' do
       before do
-        repo.tag_add('scratch')
+        repo.tag_create('scratch')
         repo.checkout('scratch', orphan: true)
       end
 
@@ -555,7 +555,7 @@ RSpec.describe Git::Repository::Branching, :integration do
 
     context 'when HEAD is on an unborn branch that shares its name with a tag' do
       before do
-        repo.tag_add('scratch')
+        repo.tag_create('scratch')
         repo.checkout('scratch', orphan: true)
       end
 

--- a/spec/integration/git/repository/merging_spec.rb
+++ b/spec/integration/git/repository/merging_spec.rb
@@ -146,7 +146,7 @@ RSpec.describe Git::Repository::Merging, :integration do
 
     context 'when HEAD is on an unborn branch that shares its name with a tag' do
       before do
-        repo.tag_add('scratch')
+        repo.tag_create('scratch')
         repo.checkout('scratch', orphan: true)
       end
 

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -464,6 +464,115 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
   # spec/unit/git/repository/object_operations_spec.rb verify the delegation
   # contract and argument forwarding.
 
+  describe '#tag_list' do
+    let(:head_sha) { described_instance.rev_parse('HEAD') }
+
+    context 'when the repository has no tags' do
+      it 'returns an empty array' do
+        expect(described_instance.tag_list).to eq([])
+      end
+    end
+
+    context 'with a lightweight tag' do
+      before { repo.tag_add('v1.0.0') }
+
+      it 'returns a Git::TagInfo whose oid is nil and whose target_oid is the tagged commit' do
+        result = described_instance.tag_list
+        expect(result.size).to eq(1)
+        expect(result.first).to be_a(Git::TagInfo)
+        expect(result.first).to have_attributes(
+          name: 'v1.0.0', oid: nil, target_oid: head_sha, annotated?: false, message: nil
+        )
+      end
+    end
+
+    context 'with an annotated tag' do
+      before { repo.tag_add('v1.0.0', annotate: true, message: 'Release 1.0.0') }
+
+      it 'returns a Git::TagInfo carrying the tag object oid, the target commit, and the message' do
+        info = described_instance.tag_list.first
+        expect(info).to have_attributes(
+          name: 'v1.0.0', target_oid: head_sha, annotated?: true, message: 'Release 1.0.0'
+        )
+        expect(info.oid).to match(/\A[0-9a-f]{40}\z/)
+        expect(info.oid).not_to eq(head_sha)
+      end
+    end
+
+    context 'with patterns' do
+      before do
+        repo.tag_add('v1.0.0')
+        repo.tag_add('v1.1.0')
+        repo.tag_add('v2.0.0')
+      end
+
+      it 'returns only the tags matching a single pattern' do
+        expect(described_instance.tag_list('v1.*').map(&:name)).to eq(%w[v1.0.0 v1.1.0])
+      end
+
+      it 'returns the tags matching any of several patterns' do
+        expect(described_instance.tag_list('v1.0.*', 'v2.*').map(&:name)).to eq(%w[v1.0.0 v2.0.0])
+      end
+
+      it 'returns nil from .first when no tag has the given name' do
+        expect(described_instance.tag_list('nonexistent').first).to be_nil
+      end
+    end
+  end
+
+  describe '#tag_create' do
+    let(:head_sha) { described_instance.rev_parse('HEAD') }
+
+    context 'with no target and no options' do
+      it 'creates a lightweight tag on HEAD and returns its Git::TagInfo' do
+        info = described_instance.tag_create('v1.0.0')
+        expect(info).to be_a(Git::TagInfo)
+        expect(info).to have_attributes(
+          name: 'v1.0.0', oid: nil, target_oid: head_sha, annotated?: false, message: nil
+        )
+      end
+    end
+
+    context 'with a target commit' do
+      let!(:first_sha) { head_sha }
+
+      before do
+        write_file('README.md', "# Hello World\n\nSecond commit\n")
+        repo.add('README.md')
+        repo.commit('Second commit')
+      end
+
+      it 'creates the tag pointing at the given commit' do
+        info = described_instance.tag_create('v1.0.0', first_sha)
+        expect(info).to have_attributes(name: 'v1.0.0', target_oid: first_sha)
+        expect(info.target_oid).not_to eq(described_instance.rev_parse('HEAD'))
+      end
+    end
+
+    context 'with annotate and a message' do
+      it 'creates an annotated tag carrying the message' do
+        info = described_instance.tag_create('v1.0.0', annotate: true, message: 'Release 1.0.0')
+        expect(info).to have_attributes(
+          name: 'v1.0.0', target_oid: head_sha, annotated?: true, message: 'Release 1.0.0'
+        )
+        expect(info.oid).to match(/\A[0-9a-f]{40}\z/)
+      end
+    end
+
+    # Facade-owned validation (annotated/signed without a message, unsupported
+    # options) and command error wrapping (tagging an existing name without
+    # :force) are pure-Ruby or command concerns with no added end-to-end signal;
+    # they are covered by the unit spec and command integration specs.
+    context 'when the tag already exists' do
+      before { described_instance.tag_create('v1.0.0') }
+
+      it 'replaces the existing tag when force is given' do
+        replaced = described_instance.tag_create('v1.0.0', force: true, annotate: true, message: 'replaced')
+        expect(replaced).to have_attributes(name: 'v1.0.0', annotated?: true, message: 'replaced')
+      end
+    end
+  end
+
   describe '#tag_add' do
     context 'with no target and no options' do
       it 'creates a lightweight tag on HEAD' do

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -101,7 +101,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
   describe '#cat_file_tag' do
     before do
-      repo.tag_add('v1.0', annotate: true, message: 'Release v1.0')
+      repo.tag_create('v1.0', annotate: true, message: 'Release v1.0')
     end
 
     context 'with a valid annotated tag' do
@@ -126,7 +126,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
     context 'with an annotated tag whose message is empty' do
       before do
-        repo.tag_add('v2.0', annotate: true, message: '')
+        repo.tag_create('v2.0', annotate: true, message: '')
       end
 
       it 'returns a Hash without raising NoMethodError' do
@@ -143,7 +143,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
   describe '#tag_sha' do
     context 'when the tag exists' do
       before do
-        repo.tag_add('v1.0')
+        repo.tag_create('v1.0')
       end
 
       it 'returns the SHA of the tagged commit as a String' do
@@ -462,7 +462,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
   # already exercised by the #cat_file_type, #cat_file_contents, and #tag_sha
   # integration tests above. Unit tests in
   # spec/unit/git/repository/object_operations_spec.rb verify the delegation
-  # contract and argument forwarding.
+  # contract, argument forwarding, and the #tag deprecation warning.
 
   describe '#tag_list' do
     let(:head_sha) { described_instance.rev_parse('HEAD') }
@@ -474,7 +474,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     end
 
     context 'with a lightweight tag' do
-      before { repo.tag_add('v1.0.0') }
+      before { repo.tag_create('v1.0.0') }
 
       it 'returns a Git::TagInfo whose oid is nil and whose target_oid is the tagged commit' do
         result = described_instance.tag_list
@@ -487,7 +487,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     end
 
     context 'with an annotated tag' do
-      before { repo.tag_add('v1.0.0', annotate: true, message: 'Release 1.0.0') }
+      before { repo.tag_create('v1.0.0', annotate: true, message: 'Release 1.0.0') }
 
       it 'returns a Git::TagInfo carrying the tag object oid, the target commit, and the message' do
         info = described_instance.tag_list.first
@@ -501,9 +501,9 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
     context 'with patterns' do
       before do
-        repo.tag_add('v1.0.0')
-        repo.tag_add('v1.1.0')
-        repo.tag_add('v2.0.0')
+        repo.tag_create('v1.0.0')
+        repo.tag_create('v1.1.0')
+        repo.tag_create('v2.0.0')
       end
 
       it 'returns only the tags matching a single pattern' do
@@ -573,10 +573,13 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     end
   end
 
+  # #tag_add is deprecated; each call is silenced so the :raise deprecation
+  # behavior configured in spec_helper does not abort the example. The
+  # deprecation warning itself is asserted in the unit spec.
   describe '#tag_add' do
     context 'with no target and no options' do
       it 'creates a lightweight tag on HEAD' do
-        tag = described_instance.tag_add('v1.0.0')
+        tag = Git::Deprecation.silence { described_instance.tag_add('v1.0.0') }
         expect(tag).to be_a(Git::Object::Tag)
         expect(tag.name).to eq('v1.0.0')
         expect(tag.annotated?).to be(false)
@@ -586,14 +589,16 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     context 'with a target commit' do
       it 'creates the tag pointing at the given commit' do
         head_sha = described_instance.rev_parse('HEAD')
-        tag = described_instance.tag_add('v1.0.0', head_sha)
+        tag = Git::Deprecation.silence { described_instance.tag_add('v1.0.0', head_sha) }
         expect(tag.objectish).to eq(head_sha)
       end
     end
 
     context 'with annotate and a message' do
       it 'creates an annotated tag carrying the message' do
-        tag = described_instance.tag_add('v1.0.0', annotate: true, message: 'Release 1.0.0')
+        tag = Git::Deprecation.silence do
+          described_instance.tag_add('v1.0.0', annotate: true, message: 'Release 1.0.0')
+        end
         expect(tag.annotated?).to be(true)
         expect(tag.message).to eq('Release 1.0.0')
       end
@@ -604,10 +609,12 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
     # :force) are pure-Ruby or command concerns with no added end-to-end signal;
     # they are covered by the unit spec and command integration specs.
     context 'when the tag already exists' do
-      before { described_instance.tag_add('v1.0.0') }
+      before { described_instance.tag_create('v1.0.0') }
 
       it 'replaces the existing tag when force is given' do
-        replaced = described_instance.tag_add('v1.0.0', force: true, annotate: true, message: 'replaced')
+        replaced = Git::Deprecation.silence do
+          described_instance.tag_add('v1.0.0', force: true, annotate: true, message: 'replaced')
+        end
         expect(replaced.annotated?).to be(true)
         expect(replaced.message).to eq('replaced')
       end

--- a/spec/support/contexts/diff_test_repository.rb
+++ b/spec/support/contexts/diff_test_repository.rb
@@ -22,13 +22,13 @@ module DiffTestRepositorySetup
     write_file('README.md', "# Project\n\nThis is a test project.\n")
     repo.add('README.md')
     repo.commit('Initial commit')
-    repo.tag_add('initial')
+    repo.tag_create('initial')
 
     # Modify file
     write_file('README.md', "# Project\n\nThis is a test project.\n\n## Installation\n\nRun `bundle install`.\n")
     repo.add('README.md')
     repo.commit('Add installation section')
-    repo.tag_add('after_modify')
+    repo.tag_create('after_modify')
   end
 
   def setup_file_operations
@@ -37,19 +37,19 @@ module DiffTestRepositorySetup
     write_file('docs.md', "# Documentation\n\nThis is a test project.\n\n## Installation\n\nRun `bundle install`.\n")
     repo.add(all: true)
     repo.commit('Rename README to docs')
-    repo.tag_add('after_rename')
+    repo.tag_create('after_rename')
 
     # Delete file
     FileUtils.rm(File.join(repo_dir, 'docs.md'))
     repo.add(all: true)
     repo.commit('Remove docs file')
-    repo.tag_add('after_delete')
+    repo.tag_create('after_delete')
 
     # Add new file
     write_file('lib/main.rb', "# frozen_string_literal: true\n\nmodule Main\n  VERSION = '1.0.0'\nend\n")
     repo.add('lib/main.rb')
     repo.commit('Add main library')
-    repo.tag_add('after_add')
+    repo.tag_create('after_add')
   end
 
   def setup_special_cases
@@ -57,7 +57,7 @@ module DiffTestRepositorySetup
     write_file('image.png', "\x89PNG\r\n\x1a\n\x00\x00\x00\rIHDR\x00\x00\x00\x01")
     repo.add('image.png')
     repo.commit('Add binary image')
-    repo.tag_add('after_binary')
+    repo.tag_create('after_binary')
 
     # Change file mode (make executable) - skip on Windows where chmod isn't supported
     write_file('bin/run', "#!/usr/bin/env ruby\nputs 'Hello'\n")
@@ -68,26 +68,26 @@ module DiffTestRepositorySetup
       repo.add('bin/run')
       repo.commit('Make run script executable')
     end
-    repo.tag_add('after_mode_change')
+    repo.tag_create('after_mode_change')
 
     # Add file with spaces in path
     write_file('path with spaces/file name.txt', "Content in spaced path\n")
     repo.add(all: true)
     repo.commit('Add file with spaces')
-    repo.tag_add('after_spaces')
+    repo.tag_create('after_spaces')
 
     # Add file with UTF-8 characters (skull ☠ = U+2620)
     write_file('file☠skull.rb', "# frozen_string_literal: true\n\nmodule Skull\nend\n")
     repo.add(all: true)
     repo.commit('Add file with UTF-8 name')
-    repo.tag_add('after_utf8')
+    repo.tag_create('after_utf8')
 
     # Rename UTF-8 file
     FileUtils.mv(File.join(repo_dir, 'file☠skull.rb'), File.join(repo_dir, 'renamed☠skull.rb'))
     write_file('renamed☠skull.rb', "# frozen_string_literal: true\n\nmodule RenamedSkull\nend\n")
     repo.add(all: true)
     repo.commit('Rename UTF-8 file')
-    repo.tag_add('after_utf8_rename')
+    repo.tag_create('after_utf8_rename')
 
     # Add file with tab in name (git escapes as \t)
     setup_tab_filename
@@ -98,8 +98,8 @@ module DiffTestRepositorySetup
     write_file('CHANGELOG.md', "# Changelog\n\n## 1.1.0\n\n- Added helper\n")
     repo.add(all: true)
     repo.commit('Bump version and add helper')
-    repo.tag_add('after_multi')
-    repo.tag_add('main_tip')
+    repo.tag_create('after_multi')
+    repo.tag_create('main_tip')
   end
 
   def setup_tab_filename
@@ -111,7 +111,7 @@ module DiffTestRepositorySetup
       repo.add(all: true)
       repo.commit('Add file with tab in name')
     end
-    repo.tag_add('after_tab_filename')
+    repo.tag_create('after_tab_filename')
   end
 
   def setup_submodule
@@ -125,7 +125,7 @@ module DiffTestRepositorySetup
     sub_repo.commit('Initial submodule commit')
 
     # Add submodule to main repo
-    repo.tag_add('before_submodule')
+    repo.tag_create('before_submodule')
     submodule_path = File.join(repo_dir, 'vendor/submodule')
     Dir.chdir(repo_dir) do
       # Allow file:// protocol for local submodule (needed for newer git versions)
@@ -134,7 +134,7 @@ module DiffTestRepositorySetup
       system('git', 'submodule', 'add', submodule_source, 'vendor/submodule', out: File::NULL, err: File::NULL)
       system('git', 'commit', '-m', 'Add submodule', out: File::NULL, err: File::NULL)
     end
-    repo.tag_add('after_submodule')
+    repo.tag_create('after_submodule')
 
     # Update submodule to new commit (only if submodule was successfully added)
     if Dir.exist?(submodule_path)
@@ -149,7 +149,7 @@ module DiffTestRepositorySetup
         system('git', 'commit', '-m', 'Update submodule pointer', out: File::NULL, err: File::NULL)
       end
     end
-    repo.tag_add('after_submodule_update')
+    repo.tag_create('after_submodule_update')
   end
 
   def setup_feature_branch
@@ -160,7 +160,7 @@ module DiffTestRepositorySetup
     write_file('lib/feature.rb', "# frozen_string_literal: true\n\nmodule Feature\nend\n")
     repo.add('lib/feature.rb')
     repo.commit('Add feature module')
-    repo.tag_add('feature_tip')
+    repo.tag_create('feature_tip')
 
     # Return to main
     repo.checkout('main')

--- a/spec/unit/git/object_spec.rb
+++ b/spec/unit/git/object_spec.rb
@@ -614,6 +614,14 @@ RSpec.describe Git::Object::Tag do
     let(:sha) { 'tagsha123abc' }
     let(:name) { 'v1.0' }
 
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Object::Tag is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#tag_list and Git::TagInfo instead.'
+      )
+      tag
+    end
+
     context 'with name only (two-argument form)' do
       let(:sha) { 'v1.0' }
       let(:name) { nil }

--- a/spec/unit/git/object_spec.rb
+++ b/spec/unit/git/object_spec.rb
@@ -607,6 +607,8 @@ RSpec.describe Git::Object::Tag do
   let(:repository) { Git::Repository.new(execution_context: execution_context) }
   let(:described_instance) { described_class.new(repository, 'tagsha123abc', 'v1.0') }
 
+  before { allow(Git::Deprecation).to receive(:warn) }
+
   describe '#initialize' do
     subject(:tag) { described_class.new(base, sha, name) }
 
@@ -875,7 +877,33 @@ RSpec.describe Git::Object do
       it 'creates a Tag via the deprecated new_tag path and emits a deprecation warning' do
         result = described_class.new(repository, 'v1.0', nil, true)
         expect(result).to be_a(Git::Object::Tag)
-        expect(Git::Deprecation).to have_received(:warn).with(a_string_including('deprecated'))
+        expect(Git::Deprecation).to have_received(:warn).with(
+          a_string_including('Git::Object.new with is_tag argument is deprecated')
+        )
+      end
+
+      context 'when the nested Git::Object::Tag warning is not stubbed' do
+        let(:messages) { [] }
+
+        # Route real warnings to a collector so the silence around the nested
+        # deprecated constructor is exercised instead of bypassed by the stubbed
+        # Git::Deprecation.warn
+        around do |example|
+          original_behavior = Git::Deprecation.behavior
+          Git::Deprecation.behavior = ->(message, *) { messages << message }
+          example.run
+        ensure
+          Git::Deprecation.behavior = original_behavior
+        end
+
+        before { allow(Git::Deprecation).to receive(:warn).and_call_original }
+
+        it 'lets only the Git::Object.new warning escape' do
+          described_class.new(repository, 'v1.0', nil, true)
+          expect(messages).to contain_exactly(
+            a_string_including('Git::Object.new with is_tag argument is deprecated')
+          )
+        end
       end
     end
 

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -1255,6 +1255,15 @@ RSpec.describe Git::Repository::ObjectOperations do
 
     let(:tag_object) { instance_double(Git::Object::Tag) }
 
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      allow(Git::Object::Tag).to receive(:new).and_return(tag_object)
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#tag is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#tag_list(name).first instead.'
+      )
+      result
+    end
+
     it 'delegates to Git::Object::Tag.new with the repository as base' do
       expect(Git::Object::Tag).to receive(:new)
         .with(described_instance, 'v1.0')
@@ -1294,6 +1303,14 @@ RSpec.describe Git::Repository::ObjectOperations do
       allow(described_instance).to receive(:tag).with('v2.0.0').and_return(tag_second)
     end
 
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#tags is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#tag_list instead.'
+      )
+      result
+    end
+
     it 'constructs Git::Commands::Tag::List with the execution context' do
       expect(Git::Commands::Tag::List).to receive(:new).with(execution_context).and_return(list_command)
       result
@@ -1324,6 +1341,177 @@ RSpec.describe Git::Repository::ObjectOperations do
     end
   end
 
+  describe '#tag_list' do
+    subject(:result) { described_instance.tag_list(*patterns) }
+
+    let(:patterns) { [] }
+    let(:list_command) { instance_double(Git::Commands::Tag::List) }
+    let(:list_result) { instance_double(Git::CommandLine::Result, stdout: 'raw-stdout') }
+    let(:parsed_tags) { [instance_double(Git::TagInfo), instance_double(Git::TagInfo)] }
+
+    before do
+      allow(Git::Commands::Tag::List).to receive(:new).with(execution_context).and_return(list_command)
+      allow(list_command).to receive(:call).and_return(list_result)
+      allow(Git::Parsers::Tag).to receive(:parse_list).with('raw-stdout').and_return(parsed_tags)
+    end
+
+    it 'constructs Git::Commands::Tag::List with the execution context' do
+      expect(Git::Commands::Tag::List).to receive(:new).with(execution_context).and_return(list_command)
+      result
+    end
+
+    it 'lists tags with the parser format string then parses the output' do
+      expect(list_command).to(
+        receive(:call).with(format: Git::Parsers::Tag::FORMAT_STRING).and_return(list_result).ordered
+      )
+      expect(Git::Parsers::Tag).to receive(:parse_list).with('raw-stdout').and_return(parsed_tags).ordered
+      expect(result).to eq(parsed_tags)
+    end
+
+    context 'with patterns' do
+      let(:patterns) { ['v1.*', 'v2.*'] }
+
+      it 'forwards the patterns to the list command' do
+        expect(list_command).to(
+          receive(:call).with('v1.*', 'v2.*', format: Git::Parsers::Tag::FORMAT_STRING).and_return(list_result)
+        )
+        result
+      end
+    end
+
+    context 'when there are no tags' do
+      let(:parsed_tags) { [] }
+
+      it 'returns an empty array' do
+        expect(result).to eq([])
+      end
+    end
+  end
+
+  describe '#tag_create' do
+    let(:create_command) { instance_double(Git::Commands::Tag::Create) }
+    let(:create_result) { instance_double(Git::CommandLine::Result) }
+    let(:list_command) { instance_double(Git::Commands::Tag::List) }
+    let(:list_result) { instance_double(Git::CommandLine::Result, stdout: 'raw-stdout') }
+    let(:tag_info) { instance_double(Git::TagInfo, name: 'v1.0.0') }
+
+    before do
+      allow(Git::Commands::Tag::Create).to receive(:new).with(execution_context).and_return(create_command)
+      allow(create_command).to receive(:call).and_return(create_result)
+      allow(Git::Commands::Tag::List).to receive(:new).with(execution_context).and_return(list_command)
+      allow(list_command).to receive(:call).and_return(list_result)
+      allow(Git::Parsers::Tag).to receive(:parse_list).with('raw-stdout').and_return([tag_info])
+    end
+
+    it 'constructs Git::Commands::Tag::Create with the execution context' do
+      expect(Git::Commands::Tag::Create).to receive(:new).with(execution_context).and_return(create_command)
+      described_instance.tag_create('v1.0.0')
+    end
+
+    it 'creates the tag, lists it by name, then parses the output' do
+      expect(create_command).to receive(:call).with('v1.0.0', nil).and_return(create_result).ordered
+      expect(list_command).to(
+        receive(:call).with('v1.0.0', format: Git::Parsers::Tag::FORMAT_STRING).and_return(list_result).ordered
+      )
+      expect(Git::Parsers::Tag).to receive(:parse_list).with('raw-stdout').and_return([tag_info]).ordered
+      described_instance.tag_create('v1.0.0')
+    end
+
+    it 'returns the Git::TagInfo for the created tag' do
+      expect(described_instance.tag_create('v1.0.0')).to be(tag_info)
+    end
+
+    context 'with no target and no options' do
+      it 'calls the create command with a nil commit and no options' do
+        expect(create_command).to receive(:call).with('v1.0.0', nil).and_return(create_result)
+        described_instance.tag_create('v1.0.0')
+      end
+    end
+
+    context 'with a target commit' do
+      it 'forwards the target as the commit operand' do
+        expect(create_command).to receive(:call).with('v1.0.0', 'abc123').and_return(create_result)
+        described_instance.tag_create('v1.0.0', 'abc123')
+      end
+    end
+
+    context 'with an options hash only' do
+      it 'forwards the options and a nil commit' do
+        expect(create_command).to receive(:call)
+          .with('v1.0.0', nil, annotate: true, message: 'hi').and_return(create_result)
+        described_instance.tag_create('v1.0.0', annotate: true, message: 'hi')
+      end
+    end
+
+    context 'with both a target and an options hash' do
+      it 'forwards the target and options' do
+        expect(create_command).to receive(:call)
+          .with('v1.0.0', 'abc123', force: true).and_return(create_result)
+        described_instance.tag_create('v1.0.0', 'abc123', force: true)
+      end
+    end
+
+    context 'with a positional options hash (legacy call shape)' do
+      it 'accepts the trailing hash as options' do
+        expect(create_command).to receive(:call)
+          .with('v1.0.0', nil, force: true).and_return(create_result)
+        described_instance.tag_create('v1.0.0', { force: true })
+      end
+    end
+
+    context 'when an unknown option is provided' do
+      it 'raises ArgumentError without calling git' do
+        expect(Git::Commands::Tag::Create).not_to receive(:new)
+        expect { described_instance.tag_create('v1.0.0', bogus: true) }
+          .to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+
+    context 'when the :d option is provided' do
+      it 'rejects it as an unknown option without calling git' do
+        expect(Git::Commands::Tag::Create).not_to receive(:new)
+        expect { described_instance.tag_create('v1.0.0', d: true) }
+          .to raise_error(ArgumentError, /Unknown options: d/)
+      end
+    end
+
+    context 'when the :delete option is provided' do
+      it 'rejects it as an unknown option without calling git' do
+        expect(Git::Commands::Tag::Create).not_to receive(:new)
+        expect { described_instance.tag_create('v1.0.0', delete: true) }
+          .to raise_error(ArgumentError, /Unknown options: delete/)
+      end
+    end
+
+    context 'when an annotated tag is requested without a message' do
+      it 'raises ArgumentError without calling git' do
+        expect(Git::Commands::Tag::Create).not_to receive(:new)
+        expect { described_instance.tag_create('v1.0.0', annotate: true) }
+          .to raise_error(ArgumentError, 'Cannot create an annotated or signed tag without a message.')
+      end
+    end
+
+    context 'when a signed tag is requested without a message' do
+      it 'raises ArgumentError without calling git' do
+        expect(Git::Commands::Tag::Create).not_to receive(:new)
+        expect { described_instance.tag_create('v1.0.0', s: true) }
+          .to raise_error(ArgumentError, 'Cannot create an annotated or signed tag without a message.')
+      end
+    end
+
+    context 'when an annotated tag is requested with a message' do
+      it 'creates the tag and returns it' do
+        expect(described_instance.tag_create('v1.0.0', annotate: true, message: 'release')).to be(tag_info)
+      end
+    end
+
+    context 'when an annotated tag is requested with a :file option' do
+      it 'creates the tag and returns it' do
+        expect(described_instance.tag_create('v1.0.0', annotate: true, file: 'msg.txt')).to be(tag_info)
+      end
+    end
+  end
+
   describe '#tag_add' do
     let(:create_command) { instance_double(Git::Commands::Tag::Create) }
     let(:command_result) { instance_double(Git::CommandLine::Result) }
@@ -1333,6 +1521,14 @@ RSpec.describe Git::Repository::ObjectOperations do
       allow(Git::Commands::Tag::Create).to receive(:new).with(execution_context).and_return(create_command)
       allow(create_command).to receive(:call).and_return(command_result)
       allow(described_instance).to receive(:tag).with('v1.0.0').and_return(tag_object)
+    end
+
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#tag_add is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#tag_create instead.'
+      )
+      described_instance.tag_add('v1.0.0')
     end
 
     it 'constructs Git::Commands::Tag::Create with the execution context' do

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -1255,6 +1255,8 @@ RSpec.describe Git::Repository::ObjectOperations do
 
     let(:tag_object) { instance_double(Git::Object::Tag) }
 
+    before { allow(Git::Deprecation).to receive(:warn) }
+
     it 'emits a deprecation warning via Git::Deprecation.warn' do
       allow(Git::Object::Tag).to receive(:new).and_return(tag_object)
       expect(Git::Deprecation).to receive(:warn).with(
@@ -1269,6 +1271,31 @@ RSpec.describe Git::Repository::ObjectOperations do
         .with(described_instance, 'v1.0')
         .and_return(tag_object)
       expect(result).to be(tag_object)
+    end
+
+    context 'when the nested Git::Object::Tag warning is not stubbed' do
+      let(:messages) { [] }
+
+      # Route real warnings to a collector so the silence around the nested
+      # deprecated constructor is exercised instead of bypassed by the stubbed
+      # Git::Deprecation.warn
+      around do |example|
+        original_behavior = Git::Deprecation.behavior
+        Git::Deprecation.behavior = ->(message, *) { messages << message }
+        example.run
+      ensure
+        Git::Deprecation.behavior = original_behavior
+      end
+
+      before do
+        allow(Git::Deprecation).to receive(:warn).and_call_original
+        allow(described_instance).to receive(:tag_sha).with('v1.0').and_return('tagsha123abc')
+      end
+
+      it 'lets only the Git::Repository#tag warning escape' do
+        result
+        expect(messages).to contain_exactly(a_string_including('Git::Repository#tag is deprecated'))
+      end
     end
   end
 
@@ -1299,8 +1326,9 @@ RSpec.describe Git::Repository::ObjectOperations do
       allow(Git::Parsers::Tag).to receive(:parse_list).with('raw-stdout').and_return(
         [instance_double(Git::TagInfo, name: 'v1.0.0'), instance_double(Git::TagInfo, name: 'v2.0.0')]
       )
-      allow(described_instance).to receive(:tag).with('v1.0.0').and_return(tag_first)
-      allow(described_instance).to receive(:tag).with('v2.0.0').and_return(tag_second)
+      allow(Git::Object::Tag).to receive(:new).with(described_instance, 'v1.0.0').and_return(tag_first)
+      allow(Git::Object::Tag).to receive(:new).with(described_instance, 'v2.0.0').and_return(tag_second)
+      allow(Git::Deprecation).to receive(:warn)
     end
 
     it 'emits a deprecation warning via Git::Deprecation.warn' do
@@ -1337,6 +1365,32 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       it 'returns an empty array' do
         expect(result).to eq([])
+      end
+    end
+
+    context 'when the nested Git::Object::Tag warnings are not stubbed' do
+      let(:messages) { [] }
+
+      # Route real warnings to a collector so the silence around the nested
+      # deprecated constructors is exercised instead of bypassed by the stubbed
+      # Git::Deprecation.warn
+      around do |example|
+        original_behavior = Git::Deprecation.behavior
+        Git::Deprecation.behavior = ->(message, *) { messages << message }
+        example.run
+      ensure
+        Git::Deprecation.behavior = original_behavior
+      end
+
+      before do
+        allow(Git::Deprecation).to receive(:warn).and_call_original
+        allow(Git::Object::Tag).to receive(:new).and_call_original
+        allow(described_instance).to receive(:tag_sha).and_return('tagsha123abc')
+      end
+
+      it 'lets only the Git::Repository#tags warning escape' do
+        result
+        expect(messages).to contain_exactly(a_string_including('Git::Repository#tags is deprecated'))
       end
     end
   end
@@ -1457,6 +1511,26 @@ RSpec.describe Git::Repository::ObjectOperations do
           .with('v1.0.0', nil, force: true).and_return(create_result)
         described_instance.tag_create('v1.0.0', { force: true })
       end
+
+      it 'accepts a target followed by the trailing hash' do
+        expect(create_command).to receive(:call)
+          .with('v1.0.0', 'abc123', force: true).and_return(create_result)
+        described_instance.tag_create('v1.0.0', 'abc123', { force: true })
+      end
+    end
+
+    context 'with more than one positional argument after the name' do
+      it 'raises ArgumentError without calling git' do
+        expect(Git::Commands::Tag::Create).not_to receive(:new)
+        expect { described_instance.tag_create('v1.0.0', 'HEAD', 'main') }
+          .to raise_error(ArgumentError, 'Expected at most one target before the options, got 2: ["HEAD", "main"]')
+      end
+
+      it 'raises ArgumentError when the extra arguments precede an options hash' do
+        expect(Git::Commands::Tag::Create).not_to receive(:new)
+        expect { described_instance.tag_create('v1.0.0', 'HEAD', 'main', force: true) }
+          .to raise_error(ArgumentError, /Expected at most one target/)
+      end
     end
 
     context 'when an unknown option is provided' do
@@ -1520,7 +1594,8 @@ RSpec.describe Git::Repository::ObjectOperations do
     before do
       allow(Git::Commands::Tag::Create).to receive(:new).with(execution_context).and_return(create_command)
       allow(create_command).to receive(:call).and_return(command_result)
-      allow(described_instance).to receive(:tag).with('v1.0.0').and_return(tag_object)
+      allow(Git::Object::Tag).to receive(:new).with(described_instance, 'v1.0.0').and_return(tag_object)
+      allow(Git::Deprecation).to receive(:warn)
     end
 
     it 'emits a deprecation warning via Git::Deprecation.warn' do
@@ -1540,6 +1615,32 @@ RSpec.describe Git::Repository::ObjectOperations do
       expect(described_instance.tag_add('v1.0.0')).to be(tag_object)
     end
 
+    context 'when the nested Git::Object::Tag warning is not stubbed' do
+      let(:messages) { [] }
+
+      # Route real warnings to a collector so the silence around the nested
+      # deprecated constructor is exercised instead of bypassed by the stubbed
+      # Git::Deprecation.warn
+      around do |example|
+        original_behavior = Git::Deprecation.behavior
+        Git::Deprecation.behavior = ->(message, *) { messages << message }
+        example.run
+      ensure
+        Git::Deprecation.behavior = original_behavior
+      end
+
+      before do
+        allow(Git::Deprecation).to receive(:warn).and_call_original
+        allow(Git::Object::Tag).to receive(:new).and_call_original
+        allow(described_instance).to receive(:tag_sha).with('v1.0.0').and_return('tagsha123abc')
+      end
+
+      it 'lets only the Git::Repository#tag_add warning escape' do
+        described_instance.tag_add('v1.0.0')
+        expect(messages).to contain_exactly(a_string_including('Git::Repository#tag_add is deprecated'))
+      end
+    end
+
     context 'with no target and no options' do
       it 'calls the create command with a nil commit and no options' do
         expect(create_command).to receive(:call).with('v1.0.0', nil).and_return(command_result)
@@ -1551,6 +1652,13 @@ RSpec.describe Git::Repository::ObjectOperations do
       it 'forwards the target as the commit operand' do
         expect(create_command).to receive(:call).with('v1.0.0', 'abc123').and_return(command_result)
         described_instance.tag_add('v1.0.0', 'abc123')
+      end
+    end
+
+    context 'with more than one positional argument after the name' do
+      it 'keeps the legacy behavior of tagging the first and ignoring the rest' do
+        expect(create_command).to receive(:call).with('v1.0.0', 'abc123').and_return(command_result)
+        described_instance.tag_add('v1.0.0', 'abc123', 'ignored')
       end
     end
 
@@ -1637,11 +1745,11 @@ RSpec.describe Git::Repository::ObjectOperations do
 
       before do
         allow(described_instance).to receive(:tag_delete).with('v1.0.0').and_return(delete_stdout)
-        allow(Git::Deprecation).to receive(:warn)
       end
 
-      it 'issues a deprecation warning' do
-        expect(Git::Deprecation).to receive(:warn).with(/deprecated/)
+      it 'issues the :d/:delete deprecation warning after the tag_add warning' do
+        expect(Git::Deprecation).to receive(:warn).with(/tag_add is deprecated/).ordered
+        expect(Git::Deprecation).to receive(:warn).with(/Passing :d or :delete to tag_add is deprecated/).ordered
         described_instance.tag_add('v1.0.0', d: true)
       end
 


### PR DESCRIPTION
# Description

Adds `Git::TagInfo`-returning facade methods and deprecates every facade path that returns the AR-style `Git::Object::Tag`. This is steps 3 and 4 of the facade migration pattern for tags: additive plus deprecation only, non-breaking, for a 5.x minor. The warnings name v6.0.0 as the removal release, which satisfies the ADR-0007 gate for the removal in #1726.

## New methods

- `Git::Repository#tag_list(*patterns)` runs `git tag --list` with the `Git::Parsers::Tag` format string and the given patterns and returns `Array<Git::TagInfo>`. It mirrors `branch_list`.
- `Git::Repository#tag_create(name, *args)` accepts the same call shapes as `tag_add` (`tag_create(name, opts = {})` and `tag_create(name, target, opts = {})`), reuses the same option whitelist and message validation, runs `git tag`, and returns the new tag's `Git::TagInfo`.

## Deprecations

Each of these keeps its behavior and return value and now calls `Git::Deprecation.warn`:

| Deprecated | Warning points at |
|---|---|
| `Git::Repository#tag` | `Git::Repository#tag_list(name).first` |
| `Git::Repository#tags` | `Git::Repository#tag_list` |
| `Git::Repository#tag_add` | `Git::Repository#tag_create` |
| `Git::Object::Tag.new` | `Git::Repository#tag_list` and `Git::TagInfo` |

The three facade methods and `Git::Object.new_tag` wrap their `Git::Object::Tag.new` calls in `Git::Deprecation.silence` so one call emits one warning. `add_tag` already warned and keeps its existing warning (which names `tag_add`), so one `add_tag` call now emits two warnings; its YARD doc and the UPGRADING entry say so. The `tag_add(name, d: true)` form keeps its own second warning as well.

`UPGRADING.md` gains a "`Git::Object::Tag` deprecated" section mapping each old call shape to its replacement, plus a return-shape note mapping `Git::Object::Tag` readers to `Git::TagInfo` fields. The stale `@see Git::Tag` reference on `Git::TagInfo` now points at `tag_list`.

## Design decisions

1. **No separate single-tag lookup.** A single tag is `tag_list(name).first`, which is `nil` when the tag does not exist. The deprecated `tag(name)` raises `Git::UnexpectedResultError` in that case; the docs and UPGRADING call out the difference.
2. **`tag_create` keeps the `tag_add` call shapes with positional options**, per ADR-0005. It does not accept the deprecated `:d`/`:delete` delete form; those keys are rejected as unsupported options, and `tag_delete` is the way to delete a tag.
3. **Existing warning strings are left as they are.** `add_tag` still points at `tag_add` and `Git::Object.new(..., true)` still points at `Git::Object::Tag.new`; both callees now warn in turn, and the YARD docs and UPGRADING rows tell callers to go straight to `tag_create` and `tag_list`.

## Tests

- Commit 1 adds the specs first and records in its body that all 33 new examples fail for the expected reasons (`NoMethodError` for `tag_list`/`tag_create`, and `Git::Deprecation.warn` not received for the deprecation specs) while the existing examples still pass.
- Commit 2 adds the implementation and the spec changes needed to keep the suite green under `Git::Deprecation.behavior = :raise`: spec setup that only needed a tag to exist now calls `tag_create`, specs whose subject is a deprecated path stub or silence the warning, and new examples route real warnings to a collector to prove only the outer warning escapes.
- `bundle exec rake` passes: rubocop, markdown links, yard (build, lint, example tests), unit specs at 100% line and branch coverage, and integration specs.

Closes #1719

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).
