### PR TITLE
feat(stash): add the StashInfo facade surface and deprecate the legacy stash API

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -20,6 +20,7 @@ to update your code when upgrading from the preceding major version.
     - [`Git` module mixin deprecations](#git-module-mixin-deprecations)
     - [`Git::Author` deprecated](#gitauthor-deprecated)
     - [`Git::Branch#stashes` deprecated](#gitbranchstashes-deprecated)
+    - [Legacy stash API deprecated](#legacy-stash-api-deprecated)
     - [`Git::Repository#remotes` deprecated](#gitrepositoryremotes-deprecated)
     - [`Git::Remote` deprecated](#gitremote-deprecated)
     - [`Git::Commands::CatFile::Raw` `allow_unknown_type` option deprecated](#gitcommandscatfileraw-allow_unknown_type-option-deprecated)
@@ -237,7 +238,7 @@ to the replacement shown to silence it.
 | `g.lib.config_list` | `g.config_list` — returns `Array<Git::ConfigEntryInfo>` |
 | `g.lib.config_set(name, value)` | `g.config_set(name, value)` |
 | `g.lib.git_version` | `g.git_version` |
-| `g.lib.stash_list` | `g.stashes_all` |
+| `g.lib.stash_list` | `g.stash_infos` — returns `Array<Git::StashInfo>`, newest first |
 | `g.lib.unmerged` | `g.unmerged` |
 | `g.lib.change_head_branch(name)` | `g.change_head_branch(name)` |
 | `g.lib.ls_remote(location, opts)` | `g.ls_remote(location, opts)` |
@@ -375,7 +376,7 @@ purpose-named methods.
 | `g.global_config` | `g.config_list(global: true)` |
 | `g.global_config(name, value)` | `g.config_set(name, value, global: true)` |
 | `g.parse_config(file)` | `g.config_list(file: file)` |
-| `g.stash_list` | `g.stashes_all` |
+| `g.stash_list` | `g.stash_infos` — returns `Array<Git::StashInfo>`; see [Legacy stash API deprecated](#legacy-stash-api-deprecated) |
 
 #### `Git` module mixin deprecations
 
@@ -416,34 +417,97 @@ Constructing `Git::Author` directly emits a deprecation warning naming
 
 `Git::Branch#stashes` ignores the branch it is called on and returns every stash
 in the repository, so `g.branch('feature').stashes` and `g.branch('main').stashes`
-return the same entries. Call `Git::Repository#stashes_all` instead; it is the
+return the same entries. Call `Git::Repository#stash_infos` instead; it is the
 query `Git::Branch#stashes` was already running.
 
 > **Return type change:** `Git::Branch#stashes` returns a `Git::Stashes`
-> collection of `Git::Stash` objects, newest first. `g.stashes_all` returns an
-> array of `[index, message]` pairs, oldest first. Code that read `stash.message`
-> from each entry should read the second element of each pair instead. Code that
-> iterated or indexed the collection must reverse the order first, because
-> `Git::Stashes` yields and indexes newest first while `g.stashes_all` is oldest
-> first.
+> collection of `Git::Stash` objects. `g.stash_infos` returns an array of
+> `Git::StashInfo` values. Both are newest first, so indexes carry over unchanged.
+> `Git::Stash#message` strips the `WIP on <branch>:` or `On <branch>:` prefix;
+> `Git::StashInfo#message` keeps the full message and exposes the branch name as
+> `Git::StashInfo#branch`.
 
 `Git::Stashes` also exposes `save`, `apply`, and `clear`. Those map to the
-repository's `stash_save`, `stash_apply`, and `stash_clear`, which are not
-deprecated. `Git::Stashes#apply(i)` already passed `i` to git as `stash@{i}`
-(`0` = newest), and `g.stash_apply(i)` does the same, so that index needs no
-conversion.
+repository's `stash_push`, `stash_apply`, and `stash_clear`. `Git::Stashes#apply(i)`
+already passed `i` to git as `stash@{i}` (`0` = newest), and `g.stash_apply(i)` does
+the same, so that index needs no conversion. The `Git::Stashes` class is deprecated
+as well; [Legacy stash API deprecated](#legacy-stash-api-deprecated) maps each of
+its methods.
 
 | Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
 |-----------------------------------------------------|-------------|
-| `g.branch(name).stashes` | `g.stashes_all` — returns `[[index, message], ...]` |
-| `g.branch(name).stashes.each { \|s\| puts s.message }` | `g.stashes_all.reverse_each { \|_index, message\| puts message }` |
-| `g.branch(name).stashes.all` | `g.stashes_all` |
-| `g.branch(name).stashes.size` | `g.stashes_all.size` |
-| `g.branch(name).stashes[i].message` (`0` = newest, `i` coerced with `to_i`) | `g.stashes_all.reverse[i.to_i][1]` |
-| `g.branch(name).stashes.save(message)` | `g.stash_save(message)` |
+| `g.branch(name).stashes` | `g.stash_infos` — returns `Array<Git::StashInfo>`, newest first |
+| `g.branch(name).stashes.each { \|s\| puts s.message }` | `g.stash_infos.each { \|info\| puts info.message }` |
+| `g.branch(name).stashes.all` (`[index, message]` pairs, oldest first) | `g.stash_infos.reverse` — see the ordering note in [Legacy stash API deprecated](#legacy-stash-api-deprecated) |
+| `g.branch(name).stashes.size` | `g.stash_infos.size` |
+| `g.branch(name).stashes[i].message` (`0` = newest, `i` coerced with `to_i`) | `g.stash_infos[i.to_i].message` |
+| `g.branch(name).stashes.save(message)` | `g.stash_push(message: message)` |
 | `g.branch(name).stashes.apply` | `g.stash_apply` |
 | `g.branch(name).stashes.apply(i)` (`0` = newest) | `g.stash_apply(i)` |
-| `g.branch(name).stashes.clear` | `g.stash_clear` |
+| `g.branch(name).stashes.clear` | `g.stash_clear` — returns git's stdout (normally `""`, which is truthy) where `Git::Stashes#clear` returned `nil` |
+
+#### Legacy stash API deprecated
+
+Starting in v5.4.0, the stash methods on `Git::Repository` are built around the
+immutable `Git::StashInfo` value object. `g.stash_infos` returns every entry as a
+`Git::StashInfo`, and `stash_push`, `stash_pop`, `stash_drop`, `stash_show`,
+`stash_branch`, `stash_create`, and `stash_store` each map onto the `git stash`
+subcommand of the same name. Every method that takes a stash (`stash_apply`,
+`stash_pop`, `stash_drop`, `stash_show`, `stash_branch`) accepts a `Git::StashInfo`,
+a `stash@{N}` name, an Integer index (`0` = newest), or `nil` for the newest entry.
+
+The legacy methods and classes are deprecated and removed in v6.0.0:
+`Git::Repository#stashes_all`, `Git::Repository#stash_save`,
+`Git::Repository#stash_list`, `Git::Stash`, and `Git::Stashes`. Constructing a
+`Git::Stash` or `Git::Stashes` emits one warning per object.
+
+> **Ordering flip:** `g.stashes_all` returns entries **oldest first** with a
+> sequential index of its own (`0` is the oldest). `g.stash_infos` returns entries
+> **newest first**, the order `git stash list` uses, and `Git::StashInfo#index` is
+> git's own `stash@{N}` number (`0` is the newest). `g.stashes_all.first` is
+> `g.stash_infos.last`. Code that reads an entry by position must reverse the
+> array or the index.
+
+> **Message difference:** `g.stashes_all` strips the `WIP on <branch>:` or
+> `On <branch>:` prefix from each message. `Git::StashInfo#message` keeps the full
+> message git stores, and `Git::StashInfo#branch` holds the branch name. A stash
+> created from a detached HEAD has the branch `"(no branch)"`, the label git writes
+> in its message. `branch` is `nil` only when the message has no branch prefix at
+> all, as for a `stash_store` entry with a custom message.
+
+`g.stash_save(message)` returned `true` when it created a stash and `false` when
+there were no local changes to save. `g.stash_push(message: message)` returns the
+new `Git::StashInfo`, or `nil` when there were no local changes, so a truthiness
+check such as `if g.stash_push(message: 'WIP')` still works.
+
+`g.stash_list` returned the `git stash list` text as a String. Build that text from
+`g.stash_infos` if you need it. In v6.0.0, `stash_list` returns
+`Array<Git::StashInfo>`, the same value as `stash_infos`, and `stash_infos` stays as
+a permanent alias. Move String callers of `stash_list` to `stash_infos` before
+upgrading so the return type change cannot go unnoticed.
+
+| Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
+|-----------------------------------------------------|-------------|
+| `g.stashes_all` | `g.stash_infos` — returns `Array<Git::StashInfo>`, newest first |
+| `g.stashes_all.each { \|index, message\| ... }` | `g.stash_infos.reverse_each.with_index { \|info, index\| ... info.message }` |
+| `g.stashes_all[i]` (`0` = oldest) | `g.stash_infos.reverse[i]` |
+| `g.stashes_all.last` | `g.stash_infos.first` |
+| `g.stash_save(message)` | `g.stash_push(message: message)` — returns `Git::StashInfo` or `nil` |
+| `g.stash_list` (String) | `g.stash_infos.map { \|s\| "#{s.name}: #{s.message}" }.join("\n")` |
+| `Git::Stash.new(g, message)` | `info = g.stash_push(message: message)` |
+| `Git::Stash.new(g, message, existing: true)` | `message` — `existing: true` only wrapped the String and never looked an entry up; code that needs a real entry picks one from `g.stash_infos` by index or name |
+| `stash.save` | `info = g.stash_push(message: message)` |
+| `stash.saved?` | `!info.nil?` — check the value `stash_push` returned rather than pushing again |
+| `stash.message` / `stash.to_s` | `info.message` — keeps the branch prefix; see the note above |
+| `Git::Stashes.new(g)` | `g.stash_infos` |
+| `stashes.all` (`[index, message]` pairs, oldest first) | `g.stash_infos.reverse` — see the ordering note above |
+| `stashes.each { \|s\| ... }` (newest first) | `g.stash_infos.each { \|info\| ... }` |
+| `stashes[i]` (`0` = newest, `i` coerced with `to_i`) | `g.stash_infos[i.to_i]` |
+| `stashes.size` | `g.stash_infos.size` |
+| `stashes.save(message)` | `g.stash_push(message: message)` |
+| `stashes.apply` / `stashes.apply(i)` | `g.stash_apply` / `g.stash_apply(i)` |
+| `stashes.clear` | `g.stash_clear` — returns git's stdout (normally `""`, which is truthy) where `Git::Stashes#clear` returned `nil` |
+
 #### `Git::Repository#remotes` deprecated
 
 `Git::Repository#remotes` is deprecated in favor of `Git::Repository#remote_list`
@@ -649,7 +713,7 @@ can resolve a local branch of that name and is only used where git expects it
 | `b.update_ref(commit)` (remote-tracking) | `g.update_ref("remotes/#{remote}/#{name}", commit)` |
 | `b.archive(file, opts)` | `g.archive(name, file, opts)` — pass `info.refname` for a remote-tracking branch |
 | `b.in_branch(message) { ... }` | `g.in_branch(name, message) { ... }` — local `b` only; see the differences above |
-| `b.stashes` | `g.stashes_all` — see [`Git::Branch#stashes` deprecated](#gitbranchstashes-deprecated) |
+| `b.stashes` | `g.stash_infos` — see [`Git::Branch#stashes` deprecated](#gitbranchstashes-deprecated) |
 
 #### `Git::Object::Tag` deprecated
 

--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -132,22 +132,26 @@ module Git
     #
     # The result is memoized after the first call.
     #
-    # @example Iterate over stash entries
+    # @example Iterate over stash entries (deprecated)
     #   git.branch('main').stashes.each { |s| puts s }
+    #
+    # @example The replacement
+    #   repo.stash_infos.each { |info| puts info.message }
     #
     # @return [Git::Stashes] the stash list
     #
-    # @deprecated Use {Git::Repository#stashes_all} instead
+    # @deprecated Use {Git::Repository#stash_infos} instead
     #
-    # @see Git::Repository#stashes_all
+    # @see Git::Repository#stash_infos
     #
     def stashes
       Git::Deprecation.warn(
         'Git::Branch#stashes is deprecated and will be removed in v6.0.0. ' \
         'It ignores the branch and returns all repository stashes. ' \
-        'Use Git::Repository#stashes_all instead.'
+        'Use Git::Repository#stash_infos instead.'
       )
-      @stashes ||= Git::Stashes.new(branch_repository)
+      # Git::Stashes is deprecated too; silence it so one stashes call emits one warning
+      @stashes ||= Git::Deprecation.silence { Git::Stashes.new(branch_repository) }
     end
 
     # Checks out this branch, attempting to create it first if it does not already exist

--- a/lib/git/repository/stashing.rb
+++ b/lib/git/repository/stashing.rb
@@ -2,16 +2,466 @@
 
 require 'git/commands/stash'
 require 'git/parsers/stash'
+require 'git/repository/shared_private'
 
 module Git
   class Repository
     # Facade methods for stash operations
+    #
+    # Each method maps onto a `git stash` subcommand. Methods that identify or
+    # create a stash entry ({#stash_infos}, {#stash_push}, {#stash_store}) return
+    # {Git::StashInfo} values; methods that only change or display the stash
+    # return git's stdout. Every method that takes a stash ({#stash_apply},
+    # {#stash_pop}, {#stash_drop}, {#stash_show}, {#stash_branch}) accepts a
+    # {Git::StashInfo}, a `stash@{N}` name, an Integer index (`0` is the most
+    # recent entry), or `nil` for the most recent entry. Methods that take
+    # options accept them as a trailing positional Hash, so
+    # `repo.stash_apply(index: true)` and `repo.stash_apply(nil, opts)` with a
+    # stored `opts` Hash both work.
+    #
+    # {#stashes_all}, {#stash_save}, and {#stash_list} are the legacy surface.
+    # They are deprecated and will be removed in v6.0.0.
     #
     # Included by {Git::Repository}.
     #
     # @api private
     #
     module Stashing
+      # Returns every stash entry as a {Git::StashInfo}, newest first
+      #
+      # The order and indices match `git stash list`: the first element is
+      # `stash@{0}`, the most recent entry.
+      #
+      # @example List stash entries (newest first)
+      #   repo.stash_infos.map(&:name) #=> ["stash@{0}", "stash@{1}"]
+      #
+      # @example Apply the oldest entry
+      #   repo.stash_apply(repo.stash_infos.last)
+      #
+      # @return [Array<Git::StashInfo>] the stash entries, newest first; empty
+      #   when there are none
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stash_infos
+        result = Git::Commands::Stash::List.new(@execution_context).call
+        Git::Parsers::Stash.parse_list(result.stdout)
+      end
+
+      # Option keys accepted by {#stash_push}
+      STASH_PUSH_ALLOWED_OPTS = %i[
+        patch p staged S keep_index k no_keep_index quiet q include_untracked u all a
+        message m pathspec_from_file pathspec_file_nul
+      ].freeze
+      private_constant :STASH_PUSH_ALLOWED_OPTS
+
+      # Save the working tree and index state to a new stash entry
+      #
+      # The stash list is read before and after the push and the entry counts are
+      # compared, so the return value is `nil` whenever git created no entry. This
+      # holds with `quiet: true`, which suppresses git's "No local changes to
+      # save" message.
+      #
+      # @overload stash_push(*pathspec, options = {})
+      #
+      #   @example Stash all changes with a message
+      #     info = repo.stash_push(message: 'WIP: feature work')
+      #     info.name    #=> "stash@{0}"
+      #     info.message #=> "On main: WIP: feature work"
+      #
+      #   @example Stash only specific paths
+      #     repo.stash_push('src/a.rb', 'src/b.rb', message: 'partial work')
+      #
+      #   @example Nothing to stash
+      #     repo.stash_push #=> nil
+      #
+      #   @param pathspec [Array<String>] paths that limit what gets stashed; when
+      #     empty, all changes are stashed
+      #
+      #   @param options [Hash] options for the push
+      #
+      #   @option options [Boolean, nil] :patch (nil) interactively select hunks to
+      #     stash (alias: `:p`)
+      #
+      #   @option options [Boolean, nil] :p (nil) alias for `:patch`
+      #
+      #   @option options [Boolean, nil] :staged (nil) stash only the staged changes
+      #     (alias: `:S`; requires git 2.35+)
+      #
+      #   @option options [Boolean, nil] :S (nil) alias for `:staged` (requires git
+      #     2.35+)
+      #
+      #   @option options [Boolean, nil] :keep_index (nil) keep the staged changes
+      #     in the index (alias: `:k`)
+      #
+      #   @option options [Boolean, nil] :k (nil) alias for `:keep_index`
+      #
+      #   @option options [Boolean, nil] :no_keep_index (nil) do not keep the staged
+      #     changes in the index
+      #
+      #   @option options [Boolean, nil] :quiet (nil) suppress informational
+      #     messages (alias: `:q`)
+      #
+      #   @option options [Boolean, nil] :q (nil) alias for `:quiet`
+      #
+      #   @option options [Boolean, nil] :include_untracked (nil) include untracked
+      #     files in the stash (alias: `:u`)
+      #
+      #   @option options [Boolean, nil] :u (nil) alias for `:include_untracked`
+      #
+      #   @option options [Boolean, nil] :all (nil) include untracked and ignored
+      #     files in the stash (alias: `:a`)
+      #
+      #   @option options [Boolean, nil] :a (nil) alias for `:all`
+      #
+      #   @option options [String] :message (nil) the stash message (alias: `:m`)
+      #
+      #   @option options [String] :m (nil) alias for `:message`
+      #
+      #   @option options [String] :pathspec_from_file (nil) read pathspecs from the
+      #     given file; pass `-` to read from standard input
+      #
+      #   @option options [Boolean, nil] :pathspec_file_nul (nil) when used with
+      #     `:pathspec_from_file`, pathspecs are NUL-separated
+      #
+      #   @return [Git::StashInfo, nil] the new entry, or `nil` when there were no
+      #     local changes to save
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stash_push(*pathspec)
+        pathspec, opts = Private.split_pathspec_and_opts(pathspec)
+        SharedPrivate.assert_valid_opts!(STASH_PUSH_ALLOWED_OPTS, **opts)
+        previous_count = stash_infos.size
+        Git::Commands::Stash::Push.new(@execution_context).call(*pathspec, **opts)
+        entries = stash_infos
+        entries.first if entries.size > previous_count
+      end
+
+      # Option keys accepted by {#stash_apply}
+      STASH_APPLY_ALLOWED_OPTS = %i[index quiet q].freeze
+      private_constant :STASH_APPLY_ALLOWED_OPTS
+
+      # Apply a stash entry to the working tree, keeping it in the stash list
+      #
+      # @example Apply the most recent entry
+      #   repo.stash_apply #=> "On branch main\nChanges not staged for commit:..."
+      #
+      # @example Apply an entry from {#stash_infos}
+      #   repo.stash_apply(repo.stash_infos.last)
+      #
+      # @example Apply an entry by name and restore the index too
+      #   repo.stash_apply('stash@{1}', index: true)
+      #
+      # @param stash [Git::StashInfo, String, Integer, nil] the entry to apply: a
+      #   {Git::StashInfo}, a `stash@{N}` name, an Integer `N` (`0` is the most
+      #   recent entry), or `nil` for the most recent entry
+      #
+      # @param opts [Hash] options for the apply
+      #
+      # @option opts [Boolean, nil] :index (nil) restore the index state as
+      #   well as the working tree
+      #
+      # @option opts [Boolean, nil] :quiet (nil) suppress informational
+      #   messages (alias: `:q`)
+      #
+      # @option opts [Boolean, nil] :q (nil) alias for `:quiet`
+      #
+      # @return [String] git's stdout from the apply
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stash_apply(stash = nil, opts = {})
+        stash, opts = Private.split_stash_and_opts(stash, opts)
+        SharedPrivate.assert_valid_opts!(STASH_APPLY_ALLOWED_OPTS, **opts)
+        Git::Commands::Stash::Apply.new(@execution_context).call(stash, **opts).stdout
+      end
+
+      # Option keys accepted by {#stash_pop}
+      STASH_POP_ALLOWED_OPTS = %i[index quiet q].freeze
+      private_constant :STASH_POP_ALLOWED_OPTS
+
+      # Apply a stash entry to the working tree and remove it from the stash list
+      #
+      # @example Pop the most recent entry
+      #   repo.stash_pop #=> "On branch main\n...Dropped refs/stash@{0} (abc1234...)"
+      #
+      # @example Pop an entry from {#stash_infos}
+      #   repo.stash_pop(repo.stash_infos.last)
+      #
+      # @param stash [Git::StashInfo, String, Integer, nil] the entry to pop: a
+      #   {Git::StashInfo}, a `stash@{N}` name, an Integer `N` (`0` is the most
+      #   recent entry), or `nil` for the most recent entry
+      #
+      # @param opts [Hash] options for the pop
+      #
+      # @option opts [Boolean, nil] :index (nil) restore the index state as
+      #   well as the working tree
+      #
+      # @option opts [Boolean, nil] :quiet (nil) suppress informational
+      #   messages (alias: `:q`)
+      #
+      # @option opts [Boolean, nil] :q (nil) alias for `:quiet`
+      #
+      # @return [String] git's stdout from the pop
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stash_pop(stash = nil, opts = {})
+        stash, opts = Private.split_stash_and_opts(stash, opts)
+        SharedPrivate.assert_valid_opts!(STASH_POP_ALLOWED_OPTS, **opts)
+        Git::Commands::Stash::Pop.new(@execution_context).call(stash, **opts).stdout
+      end
+
+      # Option keys accepted by {#stash_drop}
+      STASH_DROP_ALLOWED_OPTS = %i[quiet q].freeze
+      private_constant :STASH_DROP_ALLOWED_OPTS
+
+      # Remove a single stash entry from the stash list
+      #
+      # @example Drop the most recent entry
+      #   repo.stash_drop #=> "Dropped refs/stash@{0} (abc1234...)"
+      #
+      # @example Drop an entry from {#stash_infos}
+      #   repo.stash_drop(repo.stash_infos.last)
+      #
+      # @param stash [Git::StashInfo, String, Integer, nil] the entry to drop: a
+      #   {Git::StashInfo}, a `stash@{N}` name, an Integer `N` (`0` is the most
+      #   recent entry), or `nil` for the most recent entry
+      #
+      # @param opts [Hash] options for the drop
+      #
+      # @option opts [Boolean, nil] :quiet (nil) suppress informational
+      #   messages (alias: `:q`)
+      #
+      # @option opts [Boolean, nil] :q (nil) alias for `:quiet`
+      #
+      # @return [String] git's stdout from the drop
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stash_drop(stash = nil, opts = {})
+        stash, opts = Private.split_stash_and_opts(stash, opts)
+        SharedPrivate.assert_valid_opts!(STASH_DROP_ALLOWED_OPTS, **opts)
+        Git::Commands::Stash::Drop.new(@execution_context).call(stash, **opts).stdout
+      end
+
+      # Option keys accepted by {#stash_show}
+      STASH_SHOW_ALLOWED_OPTS = %i[
+        patch numstat raw shortstat unified U include_untracked u no_include_untracked
+        only_untracked find_renames M find_copies C find_copies_harder inter_hunk_context dirstat
+      ].freeze
+      private_constant :STASH_SHOW_ALLOWED_OPTS
+
+      # Show the changes recorded in a stash entry as a diff
+      #
+      # Without options, git prints a diffstat. The output is returned as git
+      # prints it.
+      #
+      # @example Show the diffstat of the most recent entry
+      #   repo.stash_show #=> " file.txt | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)"
+      #
+      # @example Show the full patch of an entry from {#stash_infos}
+      #   repo.stash_show(repo.stash_infos.last, patch: true)
+      #
+      # @param stash [Git::StashInfo, String, Integer, nil] the entry to show: a
+      #   {Git::StashInfo}, a `stash@{N}` name, an Integer `N` (`0` is the most
+      #   recent entry), or `nil` for the most recent entry
+      #
+      # @param opts [Hash] options for the show
+      #
+      # @option opts [Boolean, nil] :patch (nil) show the diff as a patch
+      #
+      # @option opts [Boolean, nil] :numstat (nil) show per-file insertion and
+      #   deletion counts
+      #
+      # @option opts [Boolean, nil] :raw (nil) show per-file mode, object id,
+      #   and status metadata
+      #
+      # @option opts [Boolean, nil] :shortstat (nil) show only the summary line
+      #
+      # @option opts [Integer, String] :unified (nil) number of context lines
+      #   in the patch (alias: `:U`)
+      #
+      # @option opts [Integer, String] :U (nil) alias for `:unified`
+      #
+      # @option opts [Boolean, nil] :include_untracked (nil) include the
+      #   untracked files recorded in the entry (alias: `:u`; requires git 2.30+)
+      #
+      # @option opts [Boolean, nil] :u (nil) alias for `:include_untracked`
+      #   (requires git 2.30+)
+      #
+      # @option opts [Boolean, nil] :no_include_untracked (nil) exclude the
+      #   untracked files recorded in the entry (requires git 2.30+)
+      #
+      # @option opts [Boolean, nil] :only_untracked (nil) show only the
+      #   untracked files recorded in the entry (requires git 2.30+)
+      #
+      # @option opts [Boolean, Integer, nil] :find_renames (nil) detect
+      #   renames, optionally with a similarity threshold (alias: `:M`)
+      #
+      # @option opts [Boolean, Integer, nil] :M (nil) alias for `:find_renames`
+      #
+      # @option opts [Boolean, Integer, nil] :find_copies (nil) detect copies
+      #   as well as renames, optionally with a similarity threshold (alias: `:C`)
+      #
+      # @option opts [Boolean, Integer, nil] :C (nil) alias for `:find_copies`
+      #
+      # @option opts [Boolean, nil] :find_copies_harder (nil) inspect unmodified
+      #   files as copy sources
+      #
+      # @option opts [Integer, String] :inter_hunk_context (nil) number of
+      #   context lines between hunks before they are merged
+      #
+      # @option opts [Boolean, String, nil] :dirstat (nil) include directory
+      #   statistics, optionally with parameters
+      #
+      # @return [String] git's stdout from the show
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stash_show(stash = nil, opts = {})
+        stash, opts = Private.split_stash_and_opts(stash, opts)
+        SharedPrivate.assert_valid_opts!(STASH_SHOW_ALLOWED_OPTS, **opts)
+        Git::Commands::Stash::Show.new(@execution_context).call(stash, **opts).stdout
+      end
+
+      # Create and check out a branch from the commit a stash entry was based on
+      #
+      # Applies the entry on the new branch and, when that succeeds, drops the
+      # entry from the stash list.
+      #
+      # @example Branch from the most recent entry
+      #   repo.stash_branch('feature') #=> "Switched to a new branch 'feature'\n..."
+      #
+      # @example Branch from an entry from {#stash_infos}
+      #   repo.stash_branch('feature', repo.stash_infos.last)
+      #
+      # @param branch_name [String] the name of the branch to create
+      #
+      # @param stash [Git::StashInfo, String, Integer, nil] the entry to branch
+      #   from: a {Git::StashInfo}, a `stash@{N}` name, an Integer `N` (`0` is the
+      #   most recent entry), or `nil` for the most recent entry
+      #
+      # @return [String] git's stdout from the branch command
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stash_branch(branch_name, stash = nil)
+        Git::Commands::Stash::Branch.new(@execution_context).call(branch_name, stash).stdout
+      end
+
+      # Create a stash commit without adding it to the stash list
+      #
+      # The working tree and index are left unchanged. Pass the returned object
+      # id to {#stash_store} to add it to the stash list later.
+      #
+      # @example Create a stash commit
+      #   repo.stash_create('WIP') #=> "3f8b2d9c..." (the full object id)
+      #
+      # @example Nothing to stash
+      #   repo.stash_create #=> nil
+      #
+      # @param message [String, nil] the message for the stash commit; `nil` for
+      #   git's default message
+      #
+      # @return [String, nil] the object id of the stash commit, or `nil` when
+      #   there were no local changes
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stash_create(message = nil)
+        oid = Git::Commands::Stash::Create.new(@execution_context).call(message).stdout.strip
+        oid.empty? ? nil : oid
+      end
+
+      # Option keys accepted by {#stash_store}
+      STASH_STORE_ALLOWED_OPTS = %i[message m quiet q].freeze
+      private_constant :STASH_STORE_ALLOWED_OPTS
+
+      # Add a stash commit created by {#stash_create} to the stash list
+      #
+      # The stash list is read after the store to return the new top entry.
+      #
+      # @example Store a stash commit
+      #   oid = repo.stash_create
+      #   info = repo.stash_store(oid, message: 'saved for later')
+      #   info.name    #=> "stash@{0}"
+      #   info.message #=> "saved for later"
+      #
+      # @param commit [String] the object id of the stash commit to store
+      #
+      # @param opts [Hash] options for the store
+      #
+      # @option opts [String] :message (nil) the message for the stash entry
+      #   (alias: `:m`)
+      #
+      # @option opts [String] :m (nil) alias for `:message`
+      #
+      # @option opts [Boolean, nil] :quiet (nil) suppress informational
+      #   messages (alias: `:q`)
+      #
+      # @option opts [Boolean, nil] :q (nil) alias for `:quiet`
+      #
+      # @return [Git::StashInfo] the stored entry, now at the top of the stash list
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stash_store(commit, opts = {})
+        SharedPrivate.assert_valid_opts!(STASH_STORE_ALLOWED_OPTS, **opts)
+        Git::Commands::Stash::Store.new(@execution_context).call(commit, **opts)
+        stash_infos.first
+      end
+
+      # Remove all stash entries
+      #
+      # Removes all entries from the stash list. Use with caution as this
+      # operation cannot be undone.
+      #
+      # @example Clear all stashes
+      #   repo.stash_clear #=> ""
+      #
+      # @return [String] the output from the git stash clear command
+      #   (typically empty)
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-stash git-stash documentation
+      #
+      def stash_clear
+        Git::Commands::Stash::Clear.new(@execution_context).call.stdout
+      end
+
       # Returns all stash entries as an array of index and message pairs
       #
       # Lists all stash entries in the repository ordered from oldest to newest.
@@ -35,12 +485,20 @@ module Git
       #   reference: `'stash@{%d}' % (total - 1 - index)`, or pass the string
       #   reference directly to {#stash_apply}.
       #
+      # @deprecated Use {#stash_infos} instead. It returns {Git::StashInfo} entries
+      #   newest first with git's own `stash@{N}` indices and the full message.
+      #   This method will be removed in v6.0.0.
+      #
+      # @see #stash_infos
+      #
       # @see https://git-scm.com/docs/git-stash git-stash documentation
       #
       def stashes_all
-        result = Git::Commands::Stash::List.new(@execution_context).call
-        stashes = Git::Parsers::Stash.parse_list(result.stdout)
-        stashes.reverse.each_with_index.map do |info, i|
+        Git::Deprecation.warn(
+          'Git::Repository#stashes_all is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#stash_infos instead.'
+        )
+        stash_infos.reverse.each_with_index.map do |info, i|
           message = info.message.sub(/^(?:WIP on|On)\s+[^:]+:\s*/, '')
           [i, message]
         end
@@ -57,26 +515,27 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
-      # @deprecated Use {#stashes_all} instead
+      # @deprecated Use {#stash_infos} instead and format the entries yourself:
+      #   `repo.stash_infos.map { |s| "#{s.name}: #{s.message}" }.join("\n")`.
+      #   This method will be removed in v6.0.0, and a later release will reuse
+      #   the name for a method returning `Array<Git::StashInfo>`.
       #
-      # @see #stashes_all
+      # @see #stash_infos
       #
       # @see https://git-scm.com/docs/git-stash git-stash documentation
       #
       def stash_list
         Git::Deprecation.warn(
           'Git::Repository#stash_list is deprecated and will be removed in v6.0.0. ' \
-          'Use Git::Repository#stashes_all instead.'
+          'Use Git::Repository#stash_infos instead.'
         )
-        result = Git::Commands::Stash::List.new(@execution_context).call
-        stashes = Git::Parsers::Stash.parse_list(result.stdout)
-        stashes.map { |info| "#{info.name}: #{info.message}" }.join("\n")
+        stash_infos.map { |info| "#{info.name}: #{info.message}" }.join("\n")
       end
 
       # Save the current working directory and index state to a new stash
       #
       # @example Save current changes
-      #   repo.stash_save('WIP: feature work')
+      #   repo.stash_save('WIP: feature work') #=> true
       #
       # @param message [String] the stash message
       #
@@ -85,59 +544,80 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @deprecated Use {#stash_push} with the `:message` option instead. It
+      #   returns the new {Git::StashInfo}, or `nil` when there were no local
+      #   changes to save. This method will be removed in v6.0.0.
+      #
+      # @see #stash_push
+      #
       # @see https://git-scm.com/docs/git-stash git-stash documentation
       #
       def stash_save(message) # rubocop:disable Naming/PredicateMethod
+        Git::Deprecation.warn(
+          'Git::Repository#stash_save is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#stash_push(message: ...) instead.'
+        )
         result = Git::Commands::Stash::Push.new(@execution_context).call(message: message)
         !result.stdout.include?('No local changes to save')
       end
 
-      # Apply a stash to the working directory
+      # Private helpers local to {Git::Repository::Stashing}
       #
-      # Applies the changes recorded in a stash entry to the working directory
-      # without removing the entry from the stash list. Unlike `git stash pop`,
-      # the stash entry is preserved after applying.
+      # @api private
       #
-      # @example Apply the most recent stash
-      #   repo.stash_apply #=> "HEAD is now at abc1234 Initial commit"
-      #
-      # @example Apply a specific stash entry by reference
-      #   repo.stash_apply('stash@{1}') #=> "HEAD is now at abc1234 Initial commit"
-      #
-      # @param id [String, Integer, nil] the stash identifier (e.g., `'stash@{0}'`,
-      #   `0`) or `nil` to apply the most recent stash entry. When an Integer is
-      #   given it is passed directly to git as `stash@{N}`, where `0` is the
-      #   **most recent** stash — the opposite order from {#stashes_all}'s
-      #   sequential indices, where `0` is the **oldest** stash.
-      #
-      # @return [String] the output from the git stash apply command
-      #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
-      #
-      # @see https://git-scm.com/docs/git-stash git-stash documentation
-      #
-      def stash_apply(id = nil)
-        Git::Commands::Stash::Apply.new(@execution_context).call(id).stdout
-      end
+      module Private
+        module_function
 
-      # Remove all stash entries
-      #
-      # Removes all entries from the stash list. Use with caution as this
-      # operation cannot be undone.
-      #
-      # @example Clear all stashes
-      #   repo.stash_clear #=> ""
-      #
-      # @return [String] the output from the git stash clear command
-      #   (typically empty)
-      #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
-      #
-      # @see https://git-scm.com/docs/git-stash git-stash documentation
-      #
-      def stash_clear
-        Git::Commands::Stash::Clear.new(@execution_context).call.stdout
+        # Separate the stash operand from a positional options Hash
+        #
+        # The stash-taking facade methods are declared `(stash = nil, opts = {})`.
+        # When the caller omits the stash and passes only options
+        # (`repo.stash_apply(index: true)`), Ruby binds the Hash to `stash`; this
+        # moves it to `opts` so both call shapes reach the command the same way.
+        #
+        # @example Options passed without a stash
+        #   Private.split_stash_and_opts({ index: true }, {}) #=> [nil, { index: true }]
+        #
+        # @example A stash and options
+        #   Private.split_stash_and_opts('stash@{1}', { index: true }) #=> ["stash@{1}", { index: true }]
+        #
+        # @param stash [Git::StashInfo, String, Integer, Hash, nil] the stash
+        #   operand, or the options Hash when the stash was omitted
+        #
+        # @param trailing [Hash] the second positional argument as bound by Ruby
+        #
+        # @return [Array(Object, Hash)] the stash operand and the options Hash
+        #
+        def split_stash_and_opts(stash, trailing)
+          return [nil, stash] if stash.is_a?(Hash) && trailing.empty?
+
+          [stash, trailing]
+        end
+
+        # Separate a trailing options Hash from a pathspec list
+        #
+        # {Git::Repository::Stashing#stash_push} takes a variadic pathspec, so
+        # its options arrive as the last positional argument when present.
+        #
+        # @example Pathspecs followed by options
+        #   Private.split_pathspec_and_opts(['a.rb', { message: 'WIP' }])
+        #   #=> [["a.rb"], { message: "WIP" }]
+        #
+        # @example Pathspecs only
+        #   Private.split_pathspec_and_opts(['a.rb']) #=> [["a.rb"], {}]
+        #
+        # @param pathspec [Array<String, Hash>] the positional arguments, possibly
+        #   ending in an options Hash
+        #
+        # @return [Array(Array<String>, Hash)] the pathspecs and the options Hash
+        #
+        def split_pathspec_and_opts(pathspec)
+          return [pathspec[0...-1], pathspec.last] if pathspec.last.is_a?(Hash)
+
+          [pathspec, {}]
+        end
       end
+      private_constant :Private
     end
   end
 end

--- a/lib/git/stash.rb
+++ b/lib/git/stash.rb
@@ -3,10 +3,24 @@
 module Git
   # Represents a single stash entry in a Git repository
   #
-  # @example Create a stash and inspect the result
+  # This class is deprecated and will be removed in v6.0.0. Use the
+  # {Git::Repository} stash methods and {Git::StashInfo} instead:
+  # {Git::Repository#stash_push} replaces `Git::Stash.new(repo, message)` and
+  # returns a {Git::StashInfo}, or `nil` when there was nothing to stash.
+  #
+  # @example Create a stash and inspect the result (deprecated)
   #   stash = Git::Stash.new(repo, 'WIP: feature work')
   #   stash.message  #=> "WIP: feature work"
   #   stash.saved?   #=> true
+  #
+  # @example The replacement
+  #   info = repo.stash_push(message: 'WIP: feature work')
+  #   info.message   #=> "On main: WIP: feature work"
+  #   info.nil?      #=> false
+  #
+  # @deprecated Use {Git::Repository#stash_push} and {Git::StashInfo} instead
+  #
+  # @see Git::Repository#stash_push
   #
   # @api public
   #
@@ -15,6 +29,8 @@ module Git
     #
     # When `existing` is `false` (the default), immediately calls {#save} to push
     # the current working-directory state onto the stash stack.
+    #
+    # Emits one deprecation warning per object.
     #
     # @example Create a new stash entry
     #   stash = Git::Stash.new(repo, 'WIP: feature work')
@@ -32,7 +48,15 @@ module Git
     #   without pushing any changes
     #
     # @return [void]
+    #
+    # @deprecated Use {Git::Repository#stash_push} and {Git::StashInfo} instead
+    #
     def initialize(base, message, existing: false)
+      Git::Deprecation.warn(
+        'Git::Stash is deprecated and will be removed in v6.0.0. ' \
+        'Use the Git::Repository stash methods (stash_push, stash_infos, stash_apply) ' \
+        'and Git::StashInfo instead.'
+      )
       @base = base
       @message = message
       save unless existing
@@ -48,8 +72,10 @@ module Git
     #   local changes to save
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
     def save
-      @saved = stash_repository.stash_save(@message)
+      # stash_save is deprecated too; silence it so one Git::Stash call emits one warning
+      @saved = Git::Deprecation.silence { stash_repository.stash_save(@message) }
     end
 
     # Returns whether the stash was saved successfully
@@ -60,6 +86,7 @@ module Git
     #
     # @return [Boolean, nil] `true` if changes were stashed, `false` if there were no
     #   local changes, `nil` if {#save} has not been called (e.g. `existing: true`)
+    #
     def saved?
       @saved
     end
@@ -71,6 +98,7 @@ module Git
     #   stash.message  #=> "WIP: feature work"
     #
     # @return [String] the stash message
+    #
     attr_reader :message
 
     # Returns the stash description as a string
@@ -80,6 +108,7 @@ module Git
     #   stash.to_s  #=> "WIP: feature work"
     #
     # @return [String] the stash message
+    #
     def to_s
       message
     end

--- a/lib/git/stashes.rb
+++ b/lib/git/stashes.rb
@@ -3,12 +3,23 @@
 module Git
   # Collection of stash entries for a Git repository
   #
-  # @example Iterate over stash entries
+  # This class is deprecated and will be removed in v6.0.0. Use the
+  # {Git::Repository} stash methods and {Git::StashInfo} instead:
+  # {Git::Repository#stash_infos} replaces the collection, and
+  # {Git::Repository#stash_push}, {Git::Repository#stash_apply}, and
+  # {Git::Repository#stash_clear} replace {#save}, {#apply}, and {#clear}.
+  #
+  # @example Iterate over stash entries (deprecated)
   #   git.stashes.each { |s| puts s.message }
   #
-  # @example Check and apply a stash
-  #   git.stashes.size   #=> 2
-  #   git.stashes.apply
+  # @example The replacement
+  #   repo.stash_infos.each { |info| puts info.message }
+  #   repo.stash_infos.size   #=> 2
+  #   repo.stash_apply
+  #
+  # @deprecated Use {Git::Repository#stash_infos} and {Git::StashInfo} instead
+  #
+  # @see Git::Repository#stash_infos
   #
   # @api public
   #
@@ -18,6 +29,7 @@ module Git
     # Initialize the stashes collection
     #
     # Loads all existing stash entries from the repository at construction time.
+    # Emits one deprecation warning per object.
     #
     # @example Load stashes for a repository
     #   stashes = Git::Stashes.new(repo)
@@ -28,14 +40,20 @@ module Git
     # @return [void]
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    # @deprecated Use {Git::Repository#stash_infos} and {Git::StashInfo} instead
+    #
     def initialize(base)
+      Git::Deprecation.warn(
+        'Git::Stashes is deprecated and will be removed in v6.0.0. ' \
+        'Use the Git::Repository stash methods (stash_infos, stash_push, stash_apply, stash_clear) ' \
+        'and Git::StashInfo instead.'
+      )
       @stashes = []
       @base = base
-
-      stash_repository.stashes_all.each do |stash|
-        message = stash[1]
-        @stashes.unshift(Git::Stash.new(@base, message, existing: true))
-      end
+      # stashes_all and Git::Stash are deprecated too; silence them so one
+      # Git::Stashes.new emits one warning
+      Git::Deprecation.silence { load_stashes }
     end
 
     # Returns all stash entries as an array of index and message pairs
@@ -51,7 +69,8 @@ module Git
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
     def all
-      stash_repository.stashes_all
+      # stashes_all is deprecated too; silence it so this call emits no second warning
+      Git::Deprecation.silence { stash_repository.stashes_all }
     end
 
     # Saves the current working-directory state to a new stash entry
@@ -65,8 +84,10 @@ module Git
     # @return [void]
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
     def save(message)
-      s = Git::Stash.new(@base, message)
+      # Git::Stash is deprecated too; silence it so this call emits no second warning
+      s = Git::Deprecation.silence { Git::Stash.new(@base, message) }
       @stashes.unshift(s) if s.saved?
     end
 
@@ -83,6 +104,7 @@ module Git
     # @return [String] the output from the git stash apply command
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
     def apply(index = nil)
       stash_repository.stash_apply(index)
     end
@@ -96,6 +118,7 @@ module Git
     # @return [void]
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
     def clear
       stash_repository.stash_clear
       @stashes = []
@@ -108,6 +131,7 @@ module Git
     #   git.stashes.size  #=> 2
     #
     # @return [Integer] the number of stashes
+    #
     def size
       @stashes.size
     end
@@ -145,11 +169,23 @@ module Git
     # @param index [Integer, #to_i] the stash index (0 = most recent)
     #
     # @return [Git::Stash, nil] the stash entry, or `nil` if the index is out of bounds
+    #
     def [](index)
       @stashes[index.to_i]
     end
 
     private
+
+    # Wraps every entry from the repository in a Git::Stash, newest first
+    #
+    # @return [void]
+    #
+    def load_stashes
+      stash_repository.stashes_all.each do |stash|
+        message = stash[1]
+        @stashes.unshift(Git::Stash.new(@base, message, existing: true))
+      end
+    end
 
     # Returns the facade interface for stash operations
     #

--- a/spec/integration/git/commands/stash/apply_spec.rb
+++ b/spec/integration/git/commands/stash/apply_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::Stash::Apply, :integration do
     describe 'when the command succeeds' do
       before do
         write_file('file.txt', "modified content\n")
-        repo.stash_save('WIP')
+        Git::Commands::Stash::Push.new(execution_context).call(message: 'WIP')
       end
 
       it 'returns a CommandLineResult with output' do

--- a/spec/integration/git/commands/stash/branch_spec.rb
+++ b/spec/integration/git/commands/stash/branch_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Git::Commands::Stash::Branch, :integration do
 
       # Create changes and stash them
       write_file('file.txt', 'modified content')
-      repo.stash_save('WIP changes')
+      Git::Commands::Stash::Push.new(execution_context).call(message: 'WIP changes')
     end
 
     describe 'when the command succeeds' do

--- a/spec/integration/git/commands/stash/drop_spec.rb
+++ b/spec/integration/git/commands/stash/drop_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Git::Commands::Stash::Drop, :integration do
     describe 'when the command succeeds' do
       before do
         write_file('file.txt', "modified\n")
-        repo.stash_save('WIP')
+        Git::Commands::Stash::Push.new(execution_context).call(message: 'WIP')
       end
 
       it 'returns a CommandLineResult' do

--- a/spec/integration/git/commands/stash/list_spec.rb
+++ b/spec/integration/git/commands/stash/list_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe Git::Commands::Stash::List, :integration do
       context 'with stashes' do
         before do
           write_file('file.txt', 'modified content')
-          repo.stash_save('WIP on feature')
+          Git::Commands::Stash::Push.new(execution_context).call(message: 'WIP on feature')
         end
 
         it 'returns CommandLineResult with output' do

--- a/spec/integration/git/commands/stash/pop_spec.rb
+++ b/spec/integration/git/commands/stash/pop_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Git::Commands::Stash::Pop, :integration do
     describe 'when the command succeeds' do
       before do
         write_file('file.txt', "modified content\n")
-        repo.stash_save('WIP')
+        Git::Commands::Stash::Push.new(execution_context).call(message: 'WIP')
       end
 
       it 'returns a CommandLineResult with output' do

--- a/spec/integration/git/commands/stash/show_spec.rb
+++ b/spec/integration/git/commands/stash/show_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe Git::Commands::Stash::Show, :integration do
     repo.commit('Initial commit')
 
     write_file('file.txt', "modified\n")
-    repo.stash_save('WIP')
+    Git::Commands::Stash::Push.new(execution_context).call(message: 'WIP')
   end
 
   describe '#call' do

--- a/spec/integration/git/parsers/stash_spec.rb
+++ b/spec/integration/git/parsers/stash_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Git::Parsers::Stash, :integration do
     context 'with a single stash' do
       before do
         write_file('file.txt', 'modified content')
-        repo.stash_save('WIP on feature')
+        Git::Commands::Stash::Push.new(execution_context).call(message: 'WIP on feature')
       end
 
       it 'parses the stash index correctly' do
@@ -85,13 +85,13 @@ RSpec.describe Git::Parsers::Stash, :integration do
     context 'with multiple stashes' do
       before do
         write_file('file.txt', 'first change')
-        repo.stash_save('First stash')
+        Git::Commands::Stash::Push.new(execution_context).call(message: 'First stash')
 
         write_file('file.txt', 'second change')
-        repo.stash_save('Second stash')
+        Git::Commands::Stash::Push.new(execution_context).call(message: 'Second stash')
 
         write_file('file.txt', 'third change')
-        repo.stash_save('Third stash')
+        Git::Commands::Stash::Push.new(execution_context).call(message: 'Third stash')
       end
 
       it 'returns stashes in order (newest first)' do

--- a/spec/integration/git/repository/stashing_spec.rb
+++ b/spec/integration/git/repository/stashing_spec.rb
@@ -3,6 +3,14 @@
 require 'spec_helper'
 require 'git/repository'
 require 'git/repository/stashing'
+
+# Single-command delegators (stash_apply, stash_pop, stash_drop, stash_show,
+# stash_branch, stash_clear) are covered end-to-end by the command integration
+# specs under spec/integration/git/commands/stash/. The examples here cover what
+# those specs do not: the multi-command orchestration in stash_push and
+# stash_store, the facade's own post-processing (stash_create, stashes_all), and a
+# Git::StashInfo argument reaching git as its stash@{N} name.
+
 RSpec.describe Git::Repository::Stashing, :integration do
   include_context 'in an empty repository'
 
@@ -14,7 +22,214 @@ RSpec.describe Git::Repository::Stashing, :integration do
     repo.commit('Initial commit')
   end
 
+  describe '#stash_infos' do
+    context 'when there are no stash entries' do
+      it 'returns an empty array' do
+        expect(described_instance.stash_infos).to eq([])
+      end
+    end
+
+    context 'when there are multiple stash entries' do
+      before do
+        write_file('file.txt', 'change for stash 1')
+        repo.stash_push(message: 'first change')
+
+        write_file('file.txt', 'change for stash 2')
+        repo.stash_push(message: 'second change')
+      end
+
+      it 'returns Git::StashInfo entries newest first with git indices and full messages' do
+        result = described_instance.stash_infos
+
+        expect(result).to all(be_a(Git::StashInfo))
+        expect(result.map(&:name)).to eq(['stash@{0}', 'stash@{1}'])
+        expect(result.map(&:index)).to eq([0, 1])
+        expect(result.map(&:message)).to eq(['On main: second change', 'On main: first change'])
+        expect(result.map(&:branch)).to eq(%w[main main])
+      end
+    end
+  end
+
+  describe '#stash_push' do
+    context 'when there are local changes to save' do
+      before { write_file('file.txt', 'modified content') }
+
+      it 'returns the new Git::StashInfo entry' do
+        result = described_instance.stash_push(message: 'my feature work')
+
+        expect(result).to be_a(Git::StashInfo)
+        expect(result).to have_attributes(name: 'stash@{0}', message: 'On main: my feature work', branch: 'main')
+      end
+
+      it 'returns the new entry rather than an older one when entries already exist' do
+        described_instance.stash_push(message: 'older work')
+        write_file('file.txt', 'newer content')
+
+        result = described_instance.stash_push(message: 'newer work')
+
+        expect(result).to have_attributes(name: 'stash@{0}', message: 'On main: newer work')
+        expect(described_instance.stash_infos.map(&:message)).to eq(['On main: newer work', 'On main: older work'])
+      end
+
+      it 'accepts the options as a positional Hash' do
+        opts = { message: 'my feature work' }
+
+        result = described_instance.stash_push(opts)
+
+        expect(result).to have_attributes(name: 'stash@{0}', message: 'On main: my feature work')
+      end
+    end
+
+    context 'when there are no local changes to save' do
+      it 'returns nil' do
+        expect(described_instance.stash_push(message: 'nothing to save')).to be_nil
+      end
+
+      it 'returns nil with quiet: true when an entry already exists' do
+        write_file('file.txt', 'modified content')
+        described_instance.stash_push(message: 'existing work')
+
+        expect(described_instance.stash_push(message: 'nothing to save', quiet: true)).to be_nil
+      end
+    end
+  end
+
+  describe '#stash_apply' do
+    context 'when given a Git::StashInfo' do
+      before do
+        write_file('file.txt', 'change for stash 1')
+        repo.stash_push(message: 'first change')
+        write_file('file.txt', 'change for stash 2')
+        repo.stash_push(message: 'second change')
+      end
+
+      it 'applies that entry and keeps it in the stash list' do
+        target = described_instance.stash_infos.last
+
+        described_instance.stash_apply(target)
+
+        expect(File.read(File.join(repo_dir, 'file.txt'))).to eq('change for stash 1')
+        expect(described_instance.stash_infos.size).to eq(2)
+      end
+    end
+  end
+
+  describe '#stash_pop' do
+    context 'when given a Git::StashInfo' do
+      before do
+        write_file('file.txt', 'change for stash 1')
+        repo.stash_push(message: 'first change')
+        write_file('file.txt', 'change for stash 2')
+        repo.stash_push(message: 'second change')
+      end
+
+      it 'applies that entry and removes it from the stash list' do
+        target = described_instance.stash_infos.last
+
+        described_instance.stash_pop(target)
+
+        expect(File.read(File.join(repo_dir, 'file.txt'))).to eq('change for stash 1')
+        expect(described_instance.stash_infos.map(&:message)).to eq(['On main: second change'])
+      end
+    end
+  end
+
+  describe '#stash_drop' do
+    context 'when given a Git::StashInfo' do
+      before do
+        write_file('file.txt', 'change for stash 1')
+        repo.stash_push(message: 'first change')
+        write_file('file.txt', 'change for stash 2')
+        repo.stash_push(message: 'second change')
+      end
+
+      it 'removes that entry from the stash list' do
+        target = described_instance.stash_infos.last
+
+        described_instance.stash_drop(target)
+
+        expect(described_instance.stash_infos.map(&:message)).to eq(['On main: second change'])
+      end
+    end
+  end
+
+  describe '#stash_show' do
+    context 'when given a Git::StashInfo' do
+      before do
+        write_file('file.txt', 'change for stash 1')
+        repo.stash_push(message: 'first change')
+        write_file('other.txt', 'unrelated')
+        repo.add('other.txt')
+        repo.stash_push(message: 'second change')
+      end
+
+      it 'shows the files changed by that entry' do
+        target = described_instance.stash_infos.last
+
+        result = described_instance.stash_show(target)
+
+        expect(result).to include('file.txt')
+        expect(result).not_to include('other.txt')
+      end
+    end
+  end
+
+  describe '#stash_branch' do
+    context 'when given a Git::StashInfo' do
+      before do
+        write_file('file.txt', 'change for stash 1')
+        repo.stash_push(message: 'first change')
+        write_file('file.txt', 'change for stash 2')
+        repo.stash_push(message: 'second change')
+      end
+
+      it 'creates the branch from that entry and drops it' do
+        target = described_instance.stash_infos.last
+
+        described_instance.stash_branch('from-stash', target)
+
+        expect(described_instance.current_branch).to eq('from-stash')
+        expect(File.read(File.join(repo_dir, 'file.txt'))).to eq('change for stash 1')
+        expect(described_instance.stash_infos.map(&:message)).to eq(['On main: second change'])
+      end
+    end
+  end
+
+  describe '#stash_create' do
+    context 'when there are local changes' do
+      before { write_file('file.txt', 'modified content') }
+
+      it 'returns the object id of a stash commit without adding a stash entry' do
+        result = described_instance.stash_create('created work')
+
+        expect(result).to match(/\A[0-9a-f]{40}\z/)
+        expect(described_instance.stash_infos).to eq([])
+      end
+    end
+
+    context 'when there are no local changes' do
+      it 'returns nil' do
+        expect(described_instance.stash_create).to be_nil
+      end
+    end
+  end
+
+  describe '#stash_store' do
+    before { write_file('file.txt', 'modified content') }
+
+    it 'returns the stored entry from the top of the stash list' do
+      oid = described_instance.stash_create('created work')
+
+      result = described_instance.stash_store(oid, message: 'stored work')
+
+      expect(result).to be_a(Git::StashInfo)
+      expect(result).to have_attributes(name: 'stash@{0}', oid: oid, message: 'stored work')
+    end
+  end
+
   describe '#stashes_all' do
+    before { allow(Git::Deprecation).to receive(:warn) }
+
     context 'when there are no stash entries' do
       it 'returns an empty array' do
         expect(described_instance.stashes_all).to eq([])
@@ -24,7 +239,7 @@ RSpec.describe Git::Repository::Stashing, :integration do
     context 'when there is one stash entry with a branch prefix' do
       before do
         write_file('file.txt', 'modified content')
-        repo.stash_save('my feature work')
+        repo.stash_push(message: 'my feature work')
       end
 
       it 'strips the branch prefix from the message' do
@@ -38,10 +253,10 @@ RSpec.describe Git::Repository::Stashing, :integration do
     context 'when there are multiple stash entries' do
       before do
         write_file('file.txt', 'change for stash 1')
-        repo.stash_save('first change')
+        repo.stash_push(message: 'first change')
 
         write_file('file.txt', 'change for stash 2')
-        repo.stash_save('second change')
+        repo.stash_push(message: 'second change')
       end
 
       it 'returns entries in oldest-first order' do
@@ -56,7 +271,7 @@ RSpec.describe Git::Repository::Stashing, :integration do
     context 'when a stash message contains a colon (e.g. "saving: work")' do
       before do
         write_file('file.txt', 'modified content')
-        repo.stash_save('saving: work')
+        repo.stash_push(message: 'saving: work')
       end
 
       it 'strips only the branch prefix and keeps the rest of the message' do
@@ -71,12 +286,12 @@ RSpec.describe Git::Repository::Stashing, :integration do
         sha = repo.log(1).execute.first.sha
         repo.checkout(sha)
         write_file('file.txt', 'detached change')
-        repo.stash_save('detached stash')
+        repo.stash_push(message: 'detached stash')
       end
 
       it 'returns the stash message without a branch prefix' do
         result = described_instance.stashes_all
-        # Git stores detached-HEAD stashes without an "On <branch>:" prefix
+        # Git stores detached-HEAD stashes as "On (no branch): <message>"; the facade strips that prefix too
         expect(result.first).to eq([0, 'detached stash'])
       end
     end
@@ -86,7 +301,7 @@ RSpec.describe Git::Repository::Stashing, :integration do
     before do
       write_file('file.txt', 'modified content')
       repo.add('file.txt')
-      described_instance.stash_save('WIP')
+      repo.stash_push(message: 'WIP')
     end
 
     it 'emits a deprecation warning' do

--- a/spec/unit/git/branch_spec.rb
+++ b/spec/unit/git/branch_spec.rb
@@ -532,9 +532,41 @@ RSpec.describe Git::Branch do
 
     before { allow(base).to receive(:stashes_all).and_return([]) }
 
-    it 'emits a deprecation warning via Git::Deprecation.warn' do
-      expect(Git::Deprecation).to receive(:warn).with(a_string_including('Git::Branch#stashes'))
+    it 'emits a deprecation warning pointing at Git::Repository#stash_infos' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Branch#stashes is deprecated and will be removed in v6.0.0. ' \
+        'It ignores the branch and returns all repository stashes. ' \
+        'Use Git::Repository#stash_infos instead.'
+      )
       branch.stashes
+    end
+
+    context 'when the Git::Stashes it builds emits deprecation warnings' do
+      let(:messages) { [] }
+
+      # Route real warnings to a collector so the silence around the nested
+      # deprecated call is exercised instead of bypassed by the stubbed
+      # Git::Deprecation.warn
+      around do |example|
+        original_behavior = Git::Deprecation.behavior
+        Git::Deprecation.behavior = ->(message, *) { messages << message }
+        example.run
+      ensure
+        Git::Deprecation.behavior = original_behavior
+      end
+
+      before do
+        allow(Git::Deprecation).to receive(:warn).and_call_original
+        allow(base).to receive(:stashes_all) do
+          Git::Deprecation.warn('Git::Repository#stashes_all is deprecated')
+          []
+        end
+      end
+
+      it 'lets only the Git::Branch#stashes warning escape' do
+        branch.stashes
+        expect(messages).to contain_exactly(a_string_including('Git::Branch#stashes is deprecated'))
+      end
     end
 
     it 'returns a Git::Stashes for the branch repository' do

--- a/spec/unit/git/repository/stashing_spec.rb
+++ b/spec/unit/git/repository/stashing_spec.rb
@@ -4,253 +4,882 @@ require 'spec_helper'
 require 'git/repository'
 require 'git/repository/stashing'
 
-# Integration-level coverage for Git::Repository::Stashing facade methods is
-# provided by the underlying command integration tests:
-#   spec/integration/git/commands/stash/push_spec.rb   (stash_save)
-#   spec/integration/git/commands/stash/apply_spec.rb  (stash_apply)
-# Each facade method delegates to a single Git::Commands::Stash::* class with no
-# multi-command orchestration. The unit specs below cover each facade method's own
-# behavior; the command integration specs cover end-to-end git execution.
+# Integration-level coverage for the Git::Repository::Stashing facade lives in
+# spec/integration/git/repository/stashing_spec.rb (the multi-command orchestration
+# in stash_push and stash_store, and Git::StashInfo arguments reaching git) and in
+# the command integration specs under spec/integration/git/commands/stash/.
 
 RSpec.describe Git::Repository::Stashing do
   let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
   let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
 
+  let(:list_command) { instance_double(Git::Commands::Stash::List) }
   let(:push_command) { instance_double(Git::Commands::Stash::Push) }
 
+  # Build a real Git::StashInfo (not an instance_double) so the facade forwards the
+  # value object the way callers pass it
+  def build_stash_info(index:, oid:, message: 'On main: WIP')
+    identity = Git::AuthorInfo.new(
+      name: 'Jane Doe', email: 'jane@example.com', date: Time.iso8601('2026-01-24T10:30:00-08:00')
+    )
+    Git::StashInfo.new(
+      index: index, name: "stash@{#{index}}", oid: oid, short_oid: oid[0, 7], branch: 'main',
+      message: message, author: identity, committer: identity
+    )
+  end
+
+  let(:stash_info) { build_stash_info(index: 2, oid: 'c' * 40) }
+
   before do
+    allow(Git::Commands::Stash::List).to receive(:new).with(execution_context).and_return(list_command)
     allow(Git::Commands::Stash::Push).to receive(:new).with(execution_context).and_return(push_command)
   end
 
-  describe '#stashes_all' do
-    let(:list_command) { instance_double(Git::Commands::Stash::List) }
+  describe '#stash_infos' do
+    subject(:result) { described_instance.stash_infos }
+
+    let(:list_result) { command_result('fixture') }
+    let(:parsed_stashes) { [build_stash_info(index: 0, oid: 'a' * 40), build_stash_info(index: 1, oid: 'b' * 40)] }
 
     before do
-      allow(Git::Commands::Stash::List).to receive(:new).with(execution_context).and_return(list_command)
+      allow(list_command).to receive(:call).with(no_args).and_return(list_result)
+      allow(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return(parsed_stashes)
+    end
+
+    it 'lists the stash entries then parses the output' do
+      expect(list_command).to receive(:call).with(no_args).and_return(list_result).ordered
+      expect(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return(parsed_stashes).ordered
+      expect(result).to eq(parsed_stashes)
     end
 
     context 'when there are no stash entries' do
       let(:list_result) { command_result('') }
-      let(:stash_infos) { [] }
+      let(:parsed_stashes) { [] }
 
-      before do
-        allow(list_command).to receive(:call).with(no_args).and_return(list_result)
-        allow(Git::Parsers::Stash).to receive(:parse_list).with('').and_return(stash_infos)
-      end
+      before { allow(Git::Parsers::Stash).to receive(:parse_list).with('').and_return(parsed_stashes) }
 
       it 'returns an empty array' do
-        expect(described_instance.stashes_all).to eq([])
+        expect(result).to eq([])
+      end
+    end
+  end
+
+  describe '#stash_push' do
+    subject(:result) { described_instance.stash_push(*pathspec, **options) }
+
+    let(:pathspec) { [] }
+    let(:options) { {} }
+    let(:existing_entry) { build_stash_info(index: 0, oid: 'a' * 40, message: 'On main: older work') }
+    let(:new_entry) { build_stash_info(index: 0, oid: 'b' * 40) }
+    let(:entries_before) { [] }
+    let(:entries_after) { [new_entry] }
+    let(:push_result) { command_result('Saved working directory and index state On main: WIP') }
+
+    before do
+      allow(list_command).to receive(:call).with(no_args).and_return(command_result('before'), command_result('after'))
+      allow(Git::Parsers::Stash).to receive(:parse_list).with('before').and_return(entries_before)
+      allow(Git::Parsers::Stash).to receive(:parse_list).with('after').and_return(entries_after)
+      allow(push_command).to receive(:call).and_return(push_result)
+    end
+
+    it 'lists the stash entries, pushes, then lists again to find the new entry' do
+      expect(list_command).to receive(:call).with(no_args).and_return(command_result('before')).ordered
+      expect(push_command).to receive(:call).with(no_args).and_return(push_result).ordered
+      expect(list_command).to receive(:call).with(no_args).and_return(command_result('after')).ordered
+      expect(result).to eq(new_entry)
+    end
+
+    context 'with a message' do
+      let(:options) { { message: 'WIP: feature work' } }
+
+      it 'passes the message to the push command' do
+        expect(push_command).to receive(:call).with(message: 'WIP: feature work').and_return(push_result)
+        result
+      end
+    end
+
+    context 'with pathspecs' do
+      let(:pathspec) { ['src/a.rb', 'src/b.rb'] }
+
+      it 'passes the pathspecs to the push command' do
+        expect(push_command).to receive(:call).with('src/a.rb', 'src/b.rb').and_return(push_result)
+        result
+      end
+    end
+
+    context 'with each whitelisted option' do
+      {
+        patch: true, p: true, staged: true, S: true, keep_index: true, k: true, no_keep_index: true,
+        quiet: true, q: true, include_untracked: true, u: true, all: true, a: true,
+        message: 'WIP: feature work', m: 'WIP: feature work', pathspec_from_file: 'paths.txt',
+        pathspec_file_nul: true
+      }.each do |key, value|
+        it "forwards #{key.inspect} to the push command" do
+          expect(push_command).to receive(:call).with(key => value).and_return(push_result)
+          described_instance.stash_push(key => value)
+        end
+      end
+    end
+
+    context 'with the options in a positional Hash (ADR-0005 call shape)' do
+      it 'splits the trailing Hash off the pathspecs and forwards it as options' do
+        opts = { message: 'WIP: feature work' }
+        expect(push_command).to receive(:call).with('src/a.rb', message: 'WIP: feature work').and_return(push_result)
+        described_instance.stash_push('src/a.rb', opts)
+      end
+    end
+
+    context 'with push options' do
+      let(:options) { { keep_index: true, include_untracked: true, quiet: true } }
+
+      it 'forwards the options to the push command' do
+        expect(push_command).to(
+          receive(:call).with(keep_index: true, include_untracked: true, quiet: true).and_return(push_result)
+        )
+        result
+      end
+    end
+
+    context 'when an entry already exists and there are local changes to save' do
+      let(:entries_before) { [existing_entry] }
+      let(:entries_after) { [new_entry, existing_entry.with(index: 1, name: 'stash@{1}')] }
+
+      it 'returns the new top-of-stack entry' do
+        expect(result).to eq(new_entry)
+      end
+    end
+
+    context 'when the new entry has the same object id as the previous top entry' do
+      # Re-stashing identical state within the same second produces an identical
+      # stash commit, so the entry count is what proves an entry was created
+      let(:entries_before) { [existing_entry] }
+      let(:entries_after) { [existing_entry, existing_entry.with(index: 1, name: 'stash@{1}')] }
+
+      it 'returns the new top-of-stack entry' do
+        expect(result).to eq(existing_entry)
+      end
+    end
+
+    context 'when there are no local changes to save and the stash list is empty' do
+      let(:entries_after) { [] }
+      let(:push_result) { command_result('No local changes to save') }
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+
+    context 'when there are no local changes to save, an entry already exists, and quiet: true hides the message' do
+      let(:options) { { quiet: true } }
+      let(:entries_before) { [existing_entry] }
+      let(:entries_after) { [existing_entry] }
+      let(:push_result) { command_result('') }
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+
+    context 'option whitelisting' do
+      let(:options) { { bogus: true } }
+
+      it 'raises ArgumentError for an unknown option' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+
+      it 'does not list or push' do
+        expect(list_command).not_to receive(:call)
+        expect(push_command).not_to receive(:call)
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+  end
+
+  describe '#stash_apply' do
+    subject(:result) { described_instance.stash_apply(*args, **options) }
+
+    let(:args) { [] }
+    let(:options) { {} }
+    let(:apply_command) { instance_double(Git::Commands::Stash::Apply) }
+    let(:apply_result) { command_result('HEAD is now at abc1234 Initial commit') }
+
+    before do
+      allow(Git::Commands::Stash::Apply).to receive(:new).with(execution_context).and_return(apply_command)
+      allow(apply_command).to receive(:call).and_return(apply_result)
+    end
+
+    context 'when no stash is given' do
+      it 'calls Git::Commands::Stash::Apply#call with nil' do
+        expect(apply_command).to receive(:call).with(nil).and_return(apply_result)
+        result
+      end
+
+      it 'returns the stdout string' do
+        expect(result).to eq('HEAD is now at abc1234 Initial commit')
+      end
+    end
+
+    context 'when a string stash reference is given' do
+      let(:args) { ['stash@{1}'] }
+
+      it 'calls Git::Commands::Stash::Apply#call with the reference' do
+        expect(apply_command).to receive(:call).with('stash@{1}').and_return(apply_result)
+        result
+      end
+    end
+
+    context 'when an integer index is given' do
+      let(:args) { [2] }
+
+      it 'calls Git::Commands::Stash::Apply#call with the integer' do
+        expect(apply_command).to receive(:call).with(2).and_return(apply_result)
+        result
+      end
+    end
+
+    context 'when a Git::StashInfo is given' do
+      let(:args) { [stash_info] }
+
+      # The facade forwards the value object itself; the arguments DSL calls #to_s
+      # on it, and the integration spec proves git receives the stash@{N} name
+      it 'forwards the Git::StashInfo to the apply command' do
+        expect(apply_command).to receive(:call).with(stash_info).and_return(apply_result)
+        result
+      end
+    end
+
+    context 'with the :index and :quiet options' do
+      let(:options) { { index: true, quiet: true } }
+
+      it 'forwards the options to the apply command' do
+        expect(apply_command).to receive(:call).with(nil, index: true, quiet: true).and_return(apply_result)
+        result
+      end
+    end
+
+    context 'with each whitelisted option' do
+      {
+        index: true, quiet: true, q: true
+      }.each do |key, value|
+        it "forwards #{key.inspect} to the apply command" do
+          expect(apply_command).to receive(:call).with(nil, key => value).and_return(apply_result)
+          described_instance.stash_apply(nil, key => value)
+        end
+      end
+    end
+
+    context 'with the options in a positional Hash (ADR-0005 call shape)' do
+      it 'forwards the Hash as options' do
+        opts = { index: true }
+        expect(apply_command).to receive(:call).with('stash@{1}', index: true).and_return(apply_result)
+        described_instance.stash_apply('stash@{1}', opts)
+      end
+    end
+
+    context 'option whitelisting' do
+      let(:options) { { bogus: true } }
+
+      it 'raises ArgumentError for an unknown option' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+  end
+
+  describe '#stash_pop' do
+    subject(:result) { described_instance.stash_pop(*args, **options) }
+
+    let(:args) { [] }
+    let(:options) { {} }
+    let(:pop_command) { instance_double(Git::Commands::Stash::Pop) }
+    let(:pop_result) { command_result('Dropped refs/stash@{0} (abc1234)') }
+
+    before do
+      allow(Git::Commands::Stash::Pop).to receive(:new).with(execution_context).and_return(pop_command)
+      allow(pop_command).to receive(:call).and_return(pop_result)
+    end
+
+    context 'when no stash is given' do
+      it 'calls Git::Commands::Stash::Pop#call with nil' do
+        expect(pop_command).to receive(:call).with(nil).and_return(pop_result)
+        result
+      end
+
+      it 'returns the stdout string' do
+        expect(result).to eq('Dropped refs/stash@{0} (abc1234)')
+      end
+    end
+
+    context 'when a string stash reference is given' do
+      let(:args) { ['stash@{1}'] }
+
+      it 'calls Git::Commands::Stash::Pop#call with the reference' do
+        expect(pop_command).to receive(:call).with('stash@{1}').and_return(pop_result)
+        result
+      end
+    end
+
+    context 'when an integer index is given' do
+      let(:args) { [1] }
+
+      it 'calls Git::Commands::Stash::Pop#call with the integer' do
+        expect(pop_command).to receive(:call).with(1).and_return(pop_result)
+        result
+      end
+    end
+
+    context 'when a Git::StashInfo is given' do
+      let(:args) { [stash_info] }
+
+      # The facade forwards the value object itself; the arguments DSL calls #to_s
+      # on it, and the integration spec proves git receives the stash@{N} name
+      it 'forwards the Git::StashInfo to the pop command' do
+        expect(pop_command).to receive(:call).with(stash_info).and_return(pop_result)
+        result
+      end
+    end
+
+    context 'with the :index and :quiet options' do
+      let(:options) { { index: true, quiet: true } }
+
+      it 'forwards the options to the pop command' do
+        expect(pop_command).to receive(:call).with(nil, index: true, quiet: true).and_return(pop_result)
+        result
+      end
+    end
+
+    context 'with each whitelisted option' do
+      {
+        index: true, quiet: true, q: true
+      }.each do |key, value|
+        it "forwards #{key.inspect} to the pop command" do
+          expect(pop_command).to receive(:call).with(nil, key => value).and_return(pop_result)
+          described_instance.stash_pop(nil, key => value)
+        end
+      end
+    end
+
+    context 'with the options in a positional Hash (ADR-0005 call shape)' do
+      it 'forwards the Hash as options' do
+        opts = { index: true }
+        expect(pop_command).to receive(:call).with('stash@{1}', index: true).and_return(pop_result)
+        described_instance.stash_pop('stash@{1}', opts)
+      end
+    end
+
+    context 'option whitelisting' do
+      let(:options) { { bogus: true } }
+
+      it 'raises ArgumentError for an unknown option' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+  end
+
+  describe '#stash_drop' do
+    subject(:result) { described_instance.stash_drop(*args, **options) }
+
+    let(:args) { [] }
+    let(:options) { {} }
+    let(:drop_command) { instance_double(Git::Commands::Stash::Drop) }
+    let(:drop_result) { command_result('Dropped refs/stash@{0} (abc1234)') }
+
+    before do
+      allow(Git::Commands::Stash::Drop).to receive(:new).with(execution_context).and_return(drop_command)
+      allow(drop_command).to receive(:call).and_return(drop_result)
+    end
+
+    context 'when no stash is given' do
+      it 'calls Git::Commands::Stash::Drop#call with nil' do
+        expect(drop_command).to receive(:call).with(nil).and_return(drop_result)
+        result
+      end
+
+      it 'returns the stdout string' do
+        expect(result).to eq('Dropped refs/stash@{0} (abc1234)')
+      end
+    end
+
+    context 'when a string stash reference is given' do
+      let(:args) { ['stash@{1}'] }
+
+      it 'calls Git::Commands::Stash::Drop#call with the reference' do
+        expect(drop_command).to receive(:call).with('stash@{1}').and_return(drop_result)
+        result
+      end
+    end
+
+    context 'when an integer index is given' do
+      let(:args) { [1] }
+
+      it 'calls Git::Commands::Stash::Drop#call with the integer' do
+        expect(drop_command).to receive(:call).with(1).and_return(drop_result)
+        result
+      end
+    end
+
+    context 'when a Git::StashInfo is given' do
+      let(:args) { [stash_info] }
+
+      # The facade forwards the value object itself; the arguments DSL calls #to_s
+      # on it, and the integration spec proves git receives the stash@{N} name
+      it 'forwards the Git::StashInfo to the drop command' do
+        expect(drop_command).to receive(:call).with(stash_info).and_return(drop_result)
+        result
+      end
+    end
+
+    context 'with the :quiet option' do
+      let(:options) { { quiet: true } }
+
+      it 'forwards the option to the drop command' do
+        expect(drop_command).to receive(:call).with(nil, quiet: true).and_return(drop_result)
+        result
+      end
+    end
+
+    context 'with each whitelisted option' do
+      {
+        quiet: true, q: true
+      }.each do |key, value|
+        it "forwards #{key.inspect} to the drop command" do
+          expect(drop_command).to receive(:call).with(nil, key => value).and_return(drop_result)
+          described_instance.stash_drop(nil, key => value)
+        end
+      end
+    end
+
+    context 'with the options in a positional Hash (ADR-0005 call shape)' do
+      it 'forwards the Hash as options' do
+        opts = { quiet: true }
+        expect(drop_command).to receive(:call).with('stash@{1}', quiet: true).and_return(drop_result)
+        described_instance.stash_drop('stash@{1}', opts)
+      end
+    end
+
+    context 'option whitelisting' do
+      let(:options) { { bogus: true } }
+
+      it 'raises ArgumentError for an unknown option' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+  end
+
+  describe '#stash_show' do
+    subject(:result) { described_instance.stash_show(*args, **options) }
+
+    let(:args) { [] }
+    let(:options) { {} }
+    let(:show_command) { instance_double(Git::Commands::Stash::Show) }
+    let(:show_result) { command_result(" file.txt | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)") }
+
+    before do
+      allow(Git::Commands::Stash::Show).to receive(:new).with(execution_context).and_return(show_command)
+      allow(show_command).to receive(:call).and_return(show_result)
+    end
+
+    context 'when no stash is given' do
+      it 'calls Git::Commands::Stash::Show#call with nil' do
+        expect(show_command).to receive(:call).with(nil).and_return(show_result)
+        result
+      end
+
+      it 'returns the stdout string' do
+        expect(result).to eq(" file.txt | 2 +-\n 1 file changed, 1 insertion(+), 1 deletion(-)")
+      end
+    end
+
+    context 'when a string stash reference is given' do
+      let(:args) { ['stash@{1}'] }
+
+      it 'calls Git::Commands::Stash::Show#call with the reference' do
+        expect(show_command).to receive(:call).with('stash@{1}').and_return(show_result)
+        result
+      end
+    end
+
+    context 'when an integer index is given' do
+      let(:args) { [1] }
+
+      it 'calls Git::Commands::Stash::Show#call with the integer' do
+        expect(show_command).to receive(:call).with(1).and_return(show_result)
+        result
+      end
+    end
+
+    context 'when a Git::StashInfo is given' do
+      let(:args) { [stash_info] }
+
+      # The facade forwards the value object itself; the arguments DSL calls #to_s
+      # on it, and the integration spec proves git receives the stash@{N} name
+      it 'forwards the Git::StashInfo to the show command' do
+        expect(show_command).to receive(:call).with(stash_info).and_return(show_result)
+        result
+      end
+    end
+
+    context 'with show options' do
+      let(:options) { { patch: true, include_untracked: true } }
+
+      it 'forwards the options to the show command' do
+        expect(show_command).to receive(:call).with(nil, patch: true, include_untracked: true).and_return(show_result)
+        result
+      end
+    end
+
+    context 'with each whitelisted option' do
+      {
+        patch: true, numstat: true, raw: true, shortstat: true, unified: 3, U: 3, include_untracked: true,
+        u: true, no_include_untracked: true, only_untracked: true, find_renames: 50, M: 50,
+        find_copies: 50, C: 50, find_copies_harder: true, inter_hunk_context: 2, dirstat: 'lines'
+      }.each do |key, value|
+        it "forwards #{key.inspect} to the show command" do
+          expect(show_command).to receive(:call).with(nil, key => value).and_return(show_result)
+          described_instance.stash_show(nil, key => value)
+        end
+      end
+    end
+
+    context 'with the options in a positional Hash (ADR-0005 call shape)' do
+      it 'forwards the Hash as options' do
+        opts = { patch: true }
+        expect(show_command).to receive(:call).with('stash@{1}', patch: true).and_return(show_result)
+        described_instance.stash_show('stash@{1}', opts)
+      end
+    end
+
+    context 'option whitelisting' do
+      let(:options) { { bogus: true } }
+
+      it 'raises ArgumentError for an unknown option' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+  end
+
+  describe '#stash_branch' do
+    subject(:result) { described_instance.stash_branch('feature', *args) }
+
+    let(:args) { [] }
+    let(:branch_command) { instance_double(Git::Commands::Stash::Branch) }
+    let(:branch_result) { command_result("Switched to a new branch 'feature'") }
+
+    before do
+      allow(Git::Commands::Stash::Branch).to receive(:new).with(execution_context).and_return(branch_command)
+      allow(branch_command).to receive(:call).and_return(branch_result)
+    end
+
+    context 'when no stash is given' do
+      it 'calls Git::Commands::Stash::Branch#call with the branch name and nil' do
+        expect(branch_command).to receive(:call).with('feature', nil).and_return(branch_result)
+        result
+      end
+
+      it 'returns the stdout string' do
+        expect(result).to eq("Switched to a new branch 'feature'")
+      end
+    end
+
+    context 'when a string stash reference is given' do
+      let(:args) { ['stash@{1}'] }
+
+      it 'calls Git::Commands::Stash::Branch#call with the branch name and the reference' do
+        expect(branch_command).to receive(:call).with('feature', 'stash@{1}').and_return(branch_result)
+        result
+      end
+    end
+
+    context 'when an integer index is given' do
+      let(:args) { [1] }
+
+      it 'calls Git::Commands::Stash::Branch#call with the branch name and the integer' do
+        expect(branch_command).to receive(:call).with('feature', 1).and_return(branch_result)
+        result
+      end
+    end
+
+    context 'when a Git::StashInfo is given' do
+      let(:args) { [stash_info] }
+
+      # The facade forwards the value object itself; the arguments DSL calls #to_s
+      # on it, and the integration spec proves git receives the stash@{N} name
+      it 'forwards the Git::StashInfo to the branch command' do
+        expect(branch_command).to receive(:call).with('feature', stash_info).and_return(branch_result)
+        result
+      end
+    end
+  end
+
+  describe '#stash_create' do
+    subject(:result) { described_instance.stash_create(*args) }
+
+    let(:args) { [] }
+    let(:create_command) { instance_double(Git::Commands::Stash::Create) }
+    let(:create_result) { command_result("#{'d' * 40}\n") }
+
+    before do
+      allow(Git::Commands::Stash::Create).to receive(:new).with(execution_context).and_return(create_command)
+      allow(create_command).to receive(:call).and_return(create_result)
+    end
+
+    context 'when no message is given' do
+      it 'calls Git::Commands::Stash::Create#call with nil' do
+        expect(create_command).to receive(:call).with(nil).and_return(create_result)
+        result
+      end
+
+      it 'returns the object id without surrounding whitespace' do
+        expect(result).to eq('d' * 40)
+      end
+    end
+
+    context 'when a message is given' do
+      let(:args) { ['WIP: feature work'] }
+
+      it 'calls Git::Commands::Stash::Create#call with the message' do
+        expect(create_command).to receive(:call).with('WIP: feature work').and_return(create_result)
+        result
+      end
+    end
+
+    context 'when there are no local changes' do
+      let(:create_result) { command_result('') }
+
+      it 'returns nil' do
+        expect(result).to be_nil
+      end
+    end
+  end
+
+  describe '#stash_store' do
+    subject(:result) { described_instance.stash_store(commit, **options) }
+
+    let(:commit) { 'd' * 40 }
+    let(:options) { {} }
+    let(:store_command) { instance_double(Git::Commands::Stash::Store) }
+    let(:store_result) { command_result('') }
+    let(:stored_entry) { build_stash_info(index: 0, oid: commit, message: 'Created via "git stash store".') }
+
+    before do
+      allow(Git::Commands::Stash::Store).to receive(:new).with(execution_context).and_return(store_command)
+      allow(store_command).to receive(:call).and_return(store_result)
+      allow(list_command).to receive(:call).with(no_args).and_return(command_result('fixture'))
+      allow(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return([stored_entry])
+    end
+
+    it 'stores the commit then lists the stash entries to return the new top entry' do
+      expect(store_command).to receive(:call).with(commit).and_return(store_result).ordered
+      expect(list_command).to receive(:call).with(no_args).and_return(command_result('fixture')).ordered
+      expect(result).to eq(stored_entry)
+    end
+
+    context 'with the :message and :quiet options' do
+      let(:options) { { message: 'restored work', quiet: true } }
+
+      it 'forwards the options to the store command' do
+        expect(store_command).to(
+          receive(:call).with(commit, message: 'restored work', quiet: true).and_return(store_result)
+        )
+        result
+      end
+    end
+
+    context 'with each whitelisted option' do
+      {
+        message: 'restored work', m: 'restored work', quiet: true, q: true
+      }.each do |key, value|
+        it "forwards #{key.inspect} to the store command" do
+          expect(store_command).to receive(:call).with(commit, key => value).and_return(store_result)
+          described_instance.stash_store(commit, key => value)
+        end
+      end
+    end
+
+    context 'with the options in a positional Hash (ADR-0005 call shape)' do
+      it 'forwards the Hash as options' do
+        opts = { message: 'restored work' }
+        expect(store_command).to receive(:call).with(commit, message: 'restored work').and_return(store_result)
+        described_instance.stash_store(commit, opts)
+      end
+    end
+
+    context 'option whitelisting' do
+      let(:options) { { bogus: true } }
+
+      it 'raises ArgumentError for an unknown option' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+
+      it 'does not store or list' do
+        expect(store_command).not_to receive(:call)
+        expect(list_command).not_to receive(:call)
+        expect { result }.to raise_error(ArgumentError, /Unknown options: bogus/)
+      end
+    end
+  end
+
+  describe '#stash_clear' do
+    subject(:result) { described_instance.stash_clear }
+
+    let(:clear_command) { instance_double(Git::Commands::Stash::Clear) }
+    let(:clear_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Stash::Clear).to receive(:new).with(execution_context).and_return(clear_command)
+      allow(clear_command).to receive(:call).and_return(clear_result)
+    end
+
+    it 'calls Git::Commands::Stash::Clear#call with no arguments' do
+      expect(clear_command).to receive(:call).with(no_args).and_return(clear_result)
+      result
+    end
+
+    it 'returns the stdout string' do
+      expect(result).to eq('')
+    end
+  end
+
+  describe '#stashes_all' do
+    subject(:result) { described_instance.stashes_all }
+
+    let(:list_result) { command_result('fixture') }
+    let(:parsed_stashes) { [] }
+
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+      allow(list_command).to receive(:call).with(no_args).and_return(list_result)
+      allow(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return(parsed_stashes)
+    end
+
+    it 'emits a deprecation warning pointing at stash_infos' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#stashes_all is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#stash_infos instead.'
+      )
+      result
+    end
+
+    context 'when there are no stash entries' do
+      it 'returns an empty array' do
+        expect(result).to eq([])
       end
     end
 
     context 'when there are stash entries with branch-prefixed messages' do
-      let(:list_result) { command_result('fixture') }
       let(:stash_info_older) { instance_double(Git::StashInfo, message: 'On main: Fix bug') }
       let(:stash_info_newer) { instance_double(Git::StashInfo, message: 'On main: Add feature') }
-      # parse_list returns newest-first; reversed to oldest-first
-      let(:stash_infos) { [stash_info_newer, stash_info_older] }
-
-      before do
-        allow(list_command).to receive(:call).with(no_args).and_return(list_result)
-        allow(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return(stash_infos)
-      end
-
-      it 'constructs Git::Commands::Stash::List with the execution context' do
-        expect(Git::Commands::Stash::List).to receive(:new).with(execution_context).and_return(list_command)
-        allow(list_command).to receive(:call).and_return(list_result)
-        described_instance.stashes_all
-      end
+      # parse_list returns newest-first; stashes_all reverses to oldest-first
+      let(:parsed_stashes) { [stash_info_newer, stash_info_older] }
 
       it 'calls Git::Commands::Stash::List#call with no arguments' do
         expect(list_command).to receive(:call).with(no_args).and_return(list_result)
-        described_instance.stashes_all
+        result
       end
 
       it 'passes the command stdout to Git::Parsers::Stash.parse_list' do
-        expect(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return(stash_infos)
-        described_instance.stashes_all
+        expect(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return(parsed_stashes)
+        result
       end
 
-      it 'returns stash entries in oldest-first order with sequential indices' do
-        expect(described_instance.stashes_all).to eq([[0, 'Fix bug'], [1, 'Add feature']])
-      end
-
-      it 'strips the branch prefix from the message' do
-        result = described_instance.stashes_all
-        expect(result.map(&:last)).to eq(['Fix bug', 'Add feature'])
+      it 'returns stash entries in oldest-first order with sequential indices and the branch prefix stripped' do
+        expect(result).to eq([[0, 'Fix bug'], [1, 'Add feature']])
       end
     end
 
     context 'when a stash entry has no branch prefix (custom message)' do
-      let(:list_result) { command_result('fixture') }
-      let(:stash_info) { instance_double(Git::StashInfo, message: 'custom message') }
-
-      before do
-        allow(list_command).to receive(:call).and_return(list_result)
-        allow(Git::Parsers::Stash).to receive(:parse_list).and_return([stash_info])
-      end
+      let(:parsed_stashes) { [instance_double(Git::StashInfo, message: 'custom message')] }
 
       it 'returns the message unchanged' do
-        expect(described_instance.stashes_all).to eq([[0, 'custom message']])
+        expect(result).to eq([[0, 'custom message']])
       end
     end
 
     context 'when a stash entry has a message with an internal colon (e.g. "saving: note")' do
-      let(:list_result) { command_result('fixture') }
-      let(:stash_info) { instance_double(Git::StashInfo, message: 'On main: saving: note') }
-
-      before do
-        allow(list_command).to receive(:call).and_return(list_result)
-        allow(Git::Parsers::Stash).to receive(:parse_list).and_return([stash_info])
-      end
+      let(:parsed_stashes) { [instance_double(Git::StashInfo, message: 'On main: saving: note')] }
 
       it 'strips only the first prefix, keeping subsequent colons in the message' do
-        expect(described_instance.stashes_all).to eq([[0, 'saving: note']])
+        expect(result).to eq([[0, 'saving: note']])
       end
     end
   end
 
   describe '#stash_save' do
-    context 'when there are local changes to save' do
-      let(:push_result) { command_result('Saved working directory and index state On main: WIP: feature work') }
+    subject(:result) { described_instance.stash_save('WIP: feature work') }
 
+    let(:push_result) { command_result('Saved working directory and index state On main: WIP: feature work') }
+
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+      allow(push_command).to receive(:call).with(message: 'WIP: feature work').and_return(push_result)
+    end
+
+    it 'emits a deprecation warning pointing at stash_push' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#stash_save is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#stash_push(message: ...) instead.'
+      )
+      result
+    end
+
+    context 'when there are local changes to save' do
       it 'calls Git::Commands::Stash::Push with the given message' do
         expect(push_command).to receive(:call).with(message: 'WIP: feature work').and_return(push_result)
-        described_instance.stash_save('WIP: feature work')
+        result
       end
 
       it 'returns true' do
-        allow(push_command).to receive(:call).with(message: 'WIP: feature work').and_return(push_result)
-        expect(described_instance.stash_save('WIP: feature work')).to be(true)
+        expect(result).to be(true)
       end
     end
 
     context 'when there are no local changes to save' do
       let(:push_result) { command_result('No local changes to save') }
 
-      it 'calls Git::Commands::Stash::Push with the given message' do
-        expect(push_command).to receive(:call).with(message: 'empty').and_return(push_result)
-        described_instance.stash_save('empty')
-      end
-
       it 'returns false' do
-        allow(push_command).to receive(:call).with(message: 'empty').and_return(push_result)
-        expect(described_instance.stash_save('empty')).to be(false)
-      end
-    end
-  end
-
-  describe '#stash_apply' do
-    let(:apply_command) { instance_double(Git::Commands::Stash::Apply) }
-    let(:apply_result) { command_result('HEAD is now at abc1234 Initial commit') }
-
-    before do
-      allow(Git::Commands::Stash::Apply).to receive(:new).with(execution_context).and_return(apply_command)
-    end
-
-    context 'when no id is given' do
-      it 'calls Git::Commands::Stash::Apply#call with nil' do
-        expect(apply_command).to receive(:call).with(nil).and_return(apply_result)
-        described_instance.stash_apply
-      end
-
-      it 'returns the stdout string' do
-        allow(apply_command).to receive(:call).with(nil).and_return(apply_result)
-        expect(described_instance.stash_apply).to eq('HEAD is now at abc1234 Initial commit')
-      end
-    end
-
-    context 'when a string stash reference is given' do
-      it 'calls Git::Commands::Stash::Apply#call with the reference' do
-        expect(apply_command).to receive(:call).with('stash@{1}').and_return(apply_result)
-        described_instance.stash_apply('stash@{1}')
-      end
-
-      it 'returns the stdout string' do
-        allow(apply_command).to receive(:call).with('stash@{1}').and_return(apply_result)
-        expect(described_instance.stash_apply('stash@{1}')).to eq('HEAD is now at abc1234 Initial commit')
-      end
-    end
-
-    context 'when an integer index is given' do
-      it 'calls Git::Commands::Stash::Apply#call with the integer' do
-        expect(apply_command).to receive(:call).with(2).and_return(apply_result)
-        described_instance.stash_apply(2)
+        expect(result).to be(false)
       end
     end
   end
 
   describe '#stash_list' do
-    let(:list_command) { instance_double(Git::Commands::Stash::List) }
+    subject(:result) { described_instance.stash_list }
+
+    let(:list_result) { command_result('fixture') }
+    let(:parsed_stashes) { [] }
 
     before do
-      allow(Git::Commands::Stash::List).to receive(:new).with(execution_context).and_return(list_command)
+      allow(Git::Deprecation).to receive(:warn)
+      allow(list_command).to receive(:call).with(no_args).and_return(list_result)
+      allow(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return(parsed_stashes)
     end
 
-    it 'emits a deprecation warning via Git::Deprecation.warn' do
-      allow(list_command).to receive(:call).with(no_args).and_return(command_result(''))
-      allow(Git::Parsers::Stash).to receive(:parse_list).with('').and_return([])
-      expect(Git::Deprecation).to receive(:warn).with(a_string_including('stash_list'))
-      described_instance.stash_list
+    it 'emits a deprecation warning pointing at stash_infos' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#stash_list is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#stash_infos instead.'
+      )
+      result
     end
 
     context 'when there are stash entries' do
-      let(:list_result) { command_result('fixture') }
       let(:stash_info_first) { instance_double(Git::StashInfo, name: 'stash@{0}', message: 'On main: WIP') }
       let(:stash_info_second) { instance_double(Git::StashInfo, name: 'stash@{1}', message: 'On main: Fix bug') }
-      let(:stash_infos) { [stash_info_first, stash_info_second] }
-
-      before do
-        allow(Git::Deprecation).to receive(:warn)
-        allow(list_command).to receive(:call).with(no_args).and_return(list_result)
-        allow(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return(stash_infos)
-      end
-
-      it 'calls Git::Commands::Stash::List with the execution context' do
-        expect(Git::Commands::Stash::List).to receive(:new).with(execution_context).and_return(list_command)
-        allow(list_command).to receive(:call).and_return(list_result)
-        described_instance.stash_list
-      end
+      let(:parsed_stashes) { [stash_info_first, stash_info_second] }
 
       it 'passes the command stdout to Git::Parsers::Stash.parse_list' do
-        expect(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return(stash_infos)
-        described_instance.stash_list
+        expect(Git::Parsers::Stash).to receive(:parse_list).with('fixture').and_return(parsed_stashes)
+        result
       end
 
       it 'returns a newline-joined "stash@{n}: <full message>" string' do
-        expect(described_instance.stash_list).to eq("stash@{0}: On main: WIP\nstash@{1}: On main: Fix bug")
+        expect(result).to eq("stash@{0}: On main: WIP\nstash@{1}: On main: Fix bug")
       end
     end
 
     context 'when there are no stash entries' do
-      before do
-        allow(Git::Deprecation).to receive(:warn)
-        allow(list_command).to receive(:call).with(no_args).and_return(command_result(''))
-        allow(Git::Parsers::Stash).to receive(:parse_list).with('').and_return([])
-      end
-
       it 'returns an empty string' do
-        expect(described_instance.stash_list).to eq('')
+        expect(result).to eq('')
       end
-    end
-  end
-
-  describe '#stash_clear' do
-    let(:clear_command) { instance_double(Git::Commands::Stash::Clear) }
-    let(:clear_result) { command_result('') }
-
-    before do
-      allow(Git::Commands::Stash::Clear).to receive(:new).with(execution_context).and_return(clear_command)
-    end
-
-    it 'calls Git::Commands::Stash::Clear with the execution context' do
-      expect(clear_command).to receive(:call).with(no_args).and_return(clear_result)
-      described_instance.stash_clear
-    end
-
-    it 'returns the stdout string' do
-      allow(clear_command).to receive(:call).and_return(clear_result)
-      expect(described_instance.stash_clear).to eq('')
     end
   end
 end

--- a/spec/unit/git/stash_spec.rb
+++ b/spec/unit/git/stash_spec.rb
@@ -3,27 +3,72 @@
 require 'spec_helper'
 
 RSpec.describe Git::Stash do
-  # Git::Stash accepts either Git::Repository (new form) or Git::Base (legacy) as base.
-  # These specs cover the Git::Repository path with stubbed collaborators; the
-  # Git::Base path is exercised end-to-end by
+  # These specs cover Git::Stash with stubbed Git::Repository collaborators. The
+  # real git path is exercised end-to-end by
   # spec/integration/git/repository/stashing_spec.rb.
 
   let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
   let(:repository) { Git::Repository.new(execution_context: execution_context) }
 
+  let(:deprecation_message) do
+    'Git::Stash is deprecated and will be removed in v6.0.0. ' \
+      'Use the Git::Repository stash methods (stash_push, stash_infos, stash_apply) ' \
+      'and Git::StashInfo instead.'
+  end
+
+  before { allow(Git::Deprecation).to receive(:warn) }
+
   describe '#initialize' do
-    context 'when base is Git::Repository and existing: false (default)' do
+    context 'when existing: false (default)' do
       before do
         allow(repository).to receive(:stash_save).with('test message').and_return(true)
+      end
+
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        expect(Git::Deprecation).to receive(:warn).with(deprecation_message)
+        described_class.new(repository, 'test message')
       end
 
       it 'calls stash_save on the repository with the message' do
         expect(repository).to receive(:stash_save).with('test message')
         described_class.new(repository, 'test message')
       end
+
+      context 'when stash_save itself emits a deprecation warning' do
+        let(:messages) { [] }
+
+        # Route real warnings to a collector so the silence around the nested
+        # deprecated call is exercised instead of bypassed by the stubbed
+        # Git::Deprecation.warn
+        around do |example|
+          original_behavior = Git::Deprecation.behavior
+          Git::Deprecation.behavior = ->(message, *) { messages << message }
+          example.run
+        ensure
+          Git::Deprecation.behavior = original_behavior
+        end
+
+        before do
+          allow(Git::Deprecation).to receive(:warn).and_call_original
+          allow(repository).to receive(:stash_save).with('test message') do
+            Git::Deprecation.warn('Git::Repository#stash_save is deprecated')
+            true
+          end
+        end
+
+        it 'lets only the Git::Stash warning escape' do
+          described_class.new(repository, 'test message')
+          expect(messages).to contain_exactly(a_string_including('Git::Stash is deprecated'))
+        end
+      end
     end
 
-    context 'when base is Git::Repository and existing: true' do
+    context 'when existing: true' do
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        expect(Git::Deprecation).to receive(:warn).with(deprecation_message)
+        described_class.new(repository, 'test message', existing: true)
+      end
+
       it 'does not call stash_save' do
         expect(repository).not_to receive(:stash_save)
         described_class.new(repository, 'test message', existing: true)
@@ -31,25 +76,62 @@ RSpec.describe Git::Stash do
     end
   end
 
+  describe '#save' do
+    subject(:stash) { described_class.new(repository, 'test message', existing: true) }
+
+    it 'calls stash_save on the repository and returns its result' do
+      expect(repository).to receive(:stash_save).with('test message').and_return(true)
+      expect(stash.save).to be(true)
+    end
+
+    context 'when stash_save itself emits a deprecation warning' do
+      let(:messages) { [] }
+
+      # Route real warnings to a collector so the silence around the nested
+      # deprecated call is exercised instead of bypassed by the stubbed
+      # Git::Deprecation.warn
+      around do |example|
+        original_behavior = Git::Deprecation.behavior
+        Git::Deprecation.behavior = ->(message, *) { messages << message }
+        example.run
+      ensure
+        Git::Deprecation.behavior = original_behavior
+      end
+
+      before do
+        allow(Git::Deprecation).to receive(:warn).and_call_original
+        allow(repository).to receive(:stash_save).with('test message') do
+          Git::Deprecation.warn('Git::Repository#stash_save is deprecated')
+          true
+        end
+        stash
+      end
+
+      it 'does not let the nested stash_save warning escape' do
+        expect { stash.save }.not_to(change { messages.size })
+      end
+    end
+  end
+
   describe '#saved?' do
-    context 'when base is Git::Repository and stash_save returns true (changes saved)' do
+    context 'when stash_save returns true (changes saved)' do
+      subject(:stash) { described_class.new(repository, 'test message') }
+
       before do
         allow(repository).to receive(:stash_save).with('test message').and_return(true)
       end
-
-      subject(:stash) { described_class.new(repository, 'test message') }
 
       it 'returns true' do
         expect(stash.saved?).to be(true)
       end
     end
 
-    context 'when base is Git::Repository and stash_save returns false (no changes to save)' do
+    context 'when stash_save returns false (no changes to save)' do
+      subject(:stash) { described_class.new(repository, 'test message') }
+
       before do
         allow(repository).to receive(:stash_save).with('test message').and_return(false)
       end
-
-      subject(:stash) { described_class.new(repository, 'test message') }
 
       it 'returns false' do
         expect(stash.saved?).to be(false)
@@ -66,11 +148,7 @@ RSpec.describe Git::Stash do
   end
 
   describe '#message' do
-    before do
-      allow(repository).to receive(:stash_save).with('my message').and_return(true)
-    end
-
-    subject(:stash) { described_class.new(repository, 'my message') }
+    subject(:stash) { described_class.new(repository, 'my message', existing: true) }
 
     it 'returns the stash message' do
       expect(stash.message).to eq('my message')
@@ -78,11 +156,7 @@ RSpec.describe Git::Stash do
   end
 
   describe '#to_s' do
-    before do
-      allow(repository).to receive(:stash_save).with('my message').and_return(true)
-    end
-
-    subject(:stash) { described_class.new(repository, 'my message') }
+    subject(:stash) { described_class.new(repository, 'my message', existing: true) }
 
     it 'returns the stash message' do
       expect(stash.to_s).to eq('my message')

--- a/spec/unit/git/stashes_spec.rb
+++ b/spec/unit/git/stashes_spec.rb
@@ -3,13 +3,18 @@
 require 'spec_helper'
 
 RSpec.describe Git::Stashes do
-  # Git::Stashes accepts either Git::Repository (new form) or Git::Base (legacy).
-  # These specs cover the Git::Repository path with stubbed collaborators; the
-  # Git::Base path is exercised end-to-end by
+  # These specs cover Git::Stashes with stubbed Git::Repository collaborators. The
+  # real git path is exercised end-to-end by
   # spec/integration/git/repository/stashing_spec.rb.
 
   let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
   let(:repository) { Git::Repository.new(execution_context: execution_context) }
+
+  let(:deprecation_message) do
+    'Git::Stashes is deprecated and will be removed in v6.0.0. ' \
+      'Use the Git::Repository stash methods (stash_infos, stash_push, stash_apply, stash_clear) ' \
+      'and Git::StashInfo instead.'
+  end
 
   # Git::Repository#stashes_all returns stashes in oldest-first order
   let(:mocked_stashes_all_result) do
@@ -20,23 +25,57 @@ RSpec.describe Git::Stashes do
   end
 
   before do
+    allow(Git::Deprecation).to receive(:warn)
     allow(repository).to receive(:stashes_all).and_return(mocked_stashes_all_result)
   end
 
   describe '#initialize' do
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      expect(Git::Deprecation).to receive(:warn).with(deprecation_message)
+      described_class.new(repository)
+    end
+
     it 'loads stashes from the repository' do
       stashes = described_class.new(repository)
       expect(stashes.size).to eq(2)
     end
 
     it 'creates Stash objects from stash data' do
-      stash_double = double('Stash', saved?: true)
+      stash_double = instance_double(Git::Stash, saved?: true)
       allow(Git::Stash).to receive(:new).and_return(stash_double)
 
       described_class.new(repository)
 
       expect(Git::Stash).to have_received(:new).with(repository, 'abc1234 Test', existing: true)
       expect(Git::Stash).to have_received(:new).with(repository, 'def5678 Work', existing: true)
+    end
+
+    context 'when stashes_all and Git::Stash.new themselves emit deprecation warnings' do
+      let(:messages) { [] }
+
+      # Route real warnings to a collector so the silence around the nested
+      # deprecated calls is exercised instead of bypassed by the stubbed
+      # Git::Deprecation.warn
+      around do |example|
+        original_behavior = Git::Deprecation.behavior
+        Git::Deprecation.behavior = ->(message, *) { messages << message }
+        example.run
+      ensure
+        Git::Deprecation.behavior = original_behavior
+      end
+
+      before do
+        allow(Git::Deprecation).to receive(:warn).and_call_original
+        allow(repository).to receive(:stashes_all) do
+          Git::Deprecation.warn('Git::Repository#stashes_all is deprecated')
+          mocked_stashes_all_result
+        end
+      end
+
+      it 'lets only the Git::Stashes warning escape' do
+        described_class.new(repository)
+        expect(messages).to contain_exactly(a_string_including('Git::Stashes is deprecated'))
+      end
     end
   end
 
@@ -66,17 +105,49 @@ RSpec.describe Git::Stashes do
       result = stashes.all
       expect(result).to eq(new_data)
     end
+
+    context 'when stashes_all itself emits a deprecation warning' do
+      let(:messages) { [] }
+
+      # Route real warnings to a collector so the silence around the nested
+      # deprecated call is exercised instead of bypassed by the stubbed
+      # Git::Deprecation.warn
+      around do |example|
+        original_behavior = Git::Deprecation.behavior
+        Git::Deprecation.behavior = ->(message, *) { messages << message }
+        example.run
+      ensure
+        Git::Deprecation.behavior = original_behavior
+      end
+
+      before do
+        allow(Git::Deprecation).to receive(:warn).and_call_original
+        allow(repository).to receive(:stashes_all) do
+          Git::Deprecation.warn('Git::Repository#stashes_all is deprecated')
+          mocked_stashes_all_result
+        end
+      end
+
+      it 'does not let the nested stashes_all warning escape' do
+        stashes
+        messages.clear
+
+        stashes.all
+
+        expect(messages).to be_empty
+      end
+    end
   end
 
   describe '#save' do
     subject(:stashes) { described_class.new(repository) }
 
     before do
-      allow(Git::Stash).to receive(:new).and_return(double('Stash', saved?: true))
+      allow(Git::Stash).to receive(:new).and_return(instance_double(Git::Stash, saved?: true))
     end
 
     context 'when there are changes to stash' do
-      let(:new_stash) { double('Stash', saved?: true) }
+      let(:new_stash) { instance_double(Git::Stash, saved?: true) }
 
       before do
         allow(Git::Stash).to receive(:new).with(repository, 'WIP').and_return(new_stash)
@@ -89,7 +160,7 @@ RSpec.describe Git::Stashes do
     end
 
     context 'when there are no changes to stash' do
-      let(:new_stash) { double('Stash', saved?: false) }
+      let(:new_stash) { instance_double(Git::Stash, saved?: false) }
 
       before do
         allow(Git::Stash).to receive(:new).with(repository, 'WIP').and_return(new_stash)
@@ -100,14 +171,42 @@ RSpec.describe Git::Stashes do
         expect(stashes.size).to eq(2)
       end
     end
+
+    context 'when the Git::Stash it builds emits a deprecation warning' do
+      let(:messages) { [] }
+
+      # Route real warnings to a collector so the silence around the nested
+      # deprecated call is exercised instead of bypassed by the stubbed
+      # Git::Deprecation.warn
+      around do |example|
+        original_behavior = Git::Deprecation.behavior
+        Git::Deprecation.behavior = ->(message, *) { messages << message }
+        example.run
+      ensure
+        Git::Deprecation.behavior = original_behavior
+      end
+
+      before do
+        allow(Git::Deprecation).to receive(:warn).and_call_original
+        allow(Git::Stash).to receive(:new).with(repository, 'WIP') do
+          Git::Deprecation.warn('Git::Stash is deprecated')
+          instance_double(Git::Stash, saved?: true)
+        end
+        stashes
+      end
+
+      it 'does not let the nested Git::Stash warning escape' do
+        expect { stashes.save('WIP') }.not_to(change { messages.size })
+      end
+    end
   end
 
   describe '#each' do
     subject(:stashes) { described_class.new(repository) }
 
     before do
-      allow(Git::Stash).to receive(:new).and_wrap_original do |_method, _base, message, **_kwargs|
-        instance_double('Git::Stash', saved?: true, message: message)
+      allow(Git::Stash).to receive(:new) do |_base, message, **_kwargs|
+        instance_double(Git::Stash, saved?: true, message: message)
       end
     end
 
@@ -135,8 +234,8 @@ RSpec.describe Git::Stashes do
     subject(:stashes) { described_class.new(repository) }
 
     before do
-      allow(Git::Stash).to receive(:new).and_wrap_original do |_method, _base, message, **_kwargs|
-        instance_double('Git::Stash', saved?: true, message: message)
+      allow(Git::Stash).to receive(:new) do |_base, message, **_kwargs|
+        instance_double(Git::Stash, saved?: true, message: message)
       end
     end
 
@@ -158,7 +257,7 @@ RSpec.describe Git::Stashes do
     subject(:stashes) { described_class.new(repository) }
 
     before do
-      allow(Git::Stash).to receive(:new).and_return(double('Stash', saved?: true))
+      allow(Git::Stash).to receive(:new).and_return(instance_double(Git::Stash, saved?: true))
     end
 
     it 'returns the number of stashes' do
@@ -170,7 +269,7 @@ RSpec.describe Git::Stashes do
     subject(:stashes) { described_class.new(repository) }
 
     before do
-      allow(Git::Stash).to receive(:new).and_return(double('Stash', saved?: true))
+      allow(Git::Stash).to receive(:new).and_return(instance_double(Git::Stash, saved?: true))
       allow(repository).to receive(:stash_clear)
     end
 
@@ -185,7 +284,7 @@ RSpec.describe Git::Stashes do
     subject(:stashes) { described_class.new(repository) }
 
     before do
-      allow(Git::Stash).to receive(:new).and_return(double('Stash', saved?: true))
+      allow(Git::Stash).to receive(:new).and_return(instance_double(Git::Stash, saved?: true))
       allow(repository).to receive(:stash_apply)
     end
 


### PR DESCRIPTION
Closes #1730. Part of the v6.0.0 roadmap (#1717); the breaking half stays in #1634.

## What this does

Adds the command-shaped stash methods to `Git::Repository` so all stash work can go through `Git::StashInfo`, and deprecates the legacy stash surface for removal in v6.0.0.

New facade methods in `lib/git/repository/stashing.rb`:

| Method | Returns |
| --- | --- |
| `stash_infos` | `Array<Git::StashInfo>`, newest first (`stash@{0}` first) |
| `stash_push(*pathspec, opts = {})` | the new `Git::StashInfo`, or `nil` when there were no local changes |
| `stash_pop`, `stash_drop`, `stash_show`, `stash_branch` | git's stdout |
| `stash_create(message = nil)` | the stash commit oid, or `nil` |
| `stash_store(commit, opts = {})` | the resulting `Git::StashInfo` |

`stash_apply` also takes `index:` and `quiet:` now. Every option-taking method accepts its options as a trailing positional Hash, as ADR-0005 requires for facade methods with no v4.x predecessor: `stash_push` splits the Hash off its pathspec list, and the stash-taking methods move a Hash bound to the stash parameter into `opts`, so `repo.stash_apply(index: true)` and `repo.stash_apply(nil, opts)` both work. Every stash-taking method accepts a `Git::StashInfo` alongside `String`, `Integer`, and `nil`; the arguments DSL stringifies it to its `stash@{N}` name, and the specs pass one through a real command class to prove that.

`stash_push` reads the stash list before and after the push and compares the entry counts, so `nil` detection works with `quiet: true` (which suppresses git's "No local changes to save" text) and when a re-stash produces an entry with the same oid as the previous top. That is two extra `git stash list` calls per push; `stash_store` makes one.

Deprecations, all naming v6.0.0 and their replacement:

- `Git::Repository#stashes_all` and `#stash_list` (already deprecated, message re-pointed) point at `stash_infos`
- `Git::Repository#stash_save` points at `stash_push(message: ...)`
- `Git::Stash.new` and `Git::Stashes.new` warn once per object
- `Git::Branch#stashes` (already deprecated, #1637) now points at `stash_infos`

Nested calls between deprecated APIs are wrapped in `Git::Deprecation.silence`, and each public entry point has a spec asserting it emits exactly one warning.

## Decisions recorded on #1634

The open questions from #1634 that affect this half are settled in a comment there: `stash_infos` is the 5.x name (v6.0.0 reuses `stash_list` for the array and keeps `stash_infos` as an alias), `stash_show` returns raw stdout for now, and `stash_push`/`stash_store` materialize a `Git::StashInfo` with an extra list call.

## Docs

`UPGRADING.md` gains a "Legacy stash API deprecated" section that maps every legacy idiom to its replacement and calls out the ordering flip (`stashes_all` is oldest first with its own indices; `stash_infos` is newest first with git's) and the message difference (`stashes_all` strips the branch prefix; `StashInfo#message` keeps it and `#branch` is separate). The `Git::Branch#stashes` section and the two rows that sent `stash_list` users to `stashes_all` now point at `stash_infos`.

## Commits

One `feat(stash)` commit with the implementation, docs, and specs. The command and parser integration specs build their fixture stash with `Git::Commands::Stash::Push` directly, since the test suite raises on deprecation warnings.

`bundle exec rake` passes with 100% line and branch coverage.


