### PR TITLE
feat(worktree): add WorktreeInfo, cover every subcommand, and deprecate the legacy API

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -26,6 +26,7 @@ to update your code when upgrading from the preceding major version.
     - [`Git::Branch` and `Git::Branches` deprecated](#gitbranch-and-gitbranches-deprecated)
     - [`Git::Object::Tag` deprecated](#gitobjecttag-deprecated)
     - [`Git::Status` deprecated](#gitstatus-deprecated)
+    - [`Git::Worktree` and `Git::Worktrees` deprecated](#gitworktree-and-gitworktrees-deprecated)
 
 ## Upgrading to v6.0.0
 
@@ -824,5 +825,61 @@ In the table, `g` is a `Git::Repository`, `status` is the `Git::Status` from
 | `file.mode_index` | `info.mode_worktree` |
 | `file.blob` | `g.object(info.sha_index)` when `info.sha_index` is set and not all zeros — it is `nil` for untracked, ignored, and unmerged entries and all zeros when the path is not in the index; legacy `blob` returned `nil` without a lookup when no SHA was available and fell back to `sha_repo` when `sha_index` was `nil`. For an unmerged entry read a stage instead: `g.object(info.unmerged_stages[2][:sha])` |
 | `file.blob(:repo)` | `g.object(info.sha_head)` when `info.sha_head` is set and not all zeros — it is `nil` for untracked, ignored, and unmerged entries and all zeros when the path is not in HEAD |
+
+#### `Git::Worktree` and `Git::Worktrees` deprecated
+
+`Git::Worktree`, `Git::Worktrees`, `Git::Repository#worktree`,
+`Git::Repository#worktrees`, and `Git::Repository#worktrees_all` are deprecated
+and are removed in v6.0.0. Read worktree data through
+`Git::Repository#worktree_list`, which returns one `Git::WorktreeInfo` value
+object per worktree, and call the repository-level operations (`worktree_add`,
+`worktree_remove`, `worktree_move`, `worktree_lock`, `worktree_unlock`,
+`worktree_repair`, and `worktree_prune`) with the worktree path or its
+`Git::WorktreeInfo`. Return values are unchanged. Calling `g.worktree`,
+`g.worktrees`, or `g.worktrees_all`, constructing a `Git::Worktrees`, and calling
+`gcommit`, `add`, or `remove` on a `Git::Worktree` each emit a deprecation
+warning; the `dir`, `full`, `to_s`, and `to_a` readers on `Git::Worktree` do not.
+`g.worktrees` emits two warnings, one for itself and one for the `Git::Worktrees`
+it constructs, and `g.worktree(dir).add` emits one for `g.worktree` and one for
+`add`.
+
+> **Return shape change:** `worktrees_all` returns `[directory, sha]` pairs and
+> omits the main worktree of a bare repository, which has no checked-out commit.
+> `worktree_list` returns `Git::WorktreeInfo` objects with `path`, `head`,
+> `branch` (the full refname, such as `refs/heads/main`, or `nil` when detached
+> or bare), `bare?`, `detached?`, `locked?` with `lock_reason`, and `prunable?`
+> with `prune_reason`. It includes the bare main worktree, with `head` and
+> `branch` set to `nil`. `Git::WorktreeInfo#to_s` is the path, so an entry can be
+> passed to any method that takes a worktree path.
+>
+> **`gcommit` return type:** `Git::Worktree#gcommit` returned a
+> `Git::Object::Commit` for a worktree obtained from `g.worktree(dir)` and a raw
+> SHA `String` for one obtained from `g.worktrees`. `info.head` is always a
+> `String` (or `nil` for a bare main worktree); call `g.gcommit(info.head)` for
+> the commit object.
+>
+> **`full` and `to_s`:** `Git::Worktree#full` and `#to_s` append the commitish
+> given at construction to the path, so entries from `g.worktrees` read
+> `"/path/to/wt <sha>"`. `Git::WorktreeInfo#to_s` is the path alone.
+
+In the table, `dir` is the worktree path, `wt` is a `Git::Worktree`, and `info`
+is the `Git::WorktreeInfo` that replaces it.
+
+| Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
+|-----------------------------------------------------|-------------|
+| `g.worktrees_all` | `g.worktree_list.map { \|w\| [w.path, w.head] }` — includes a bare main worktree as `[path, nil]`; add `.reject(&:bare?)` before `map` to omit it as `worktrees_all` did |
+| `g.worktrees` | `g.worktree_list` — returns `Array<Git::WorktreeInfo>`; the deprecated call emits two warnings |
+| `g.worktrees[dir]` | `g.worktree_list.find { \|w\| w.path == dir }` — `nil` when not found; `dir` is the path as git reports it (absolute, with symlinks resolved), as before |
+| `g.worktrees.size` | `g.worktree_list.size` |
+| `g.worktrees.each { \|wt\| ... }` | `g.worktree_list.each { \|info\| ... }` |
+| `g.worktrees.to_s` | `g.worktree_list.map { \|w\| "#{w.path} #{w.head}\n" }.join` |
+| `g.worktrees.prune` | `g.worktree_prune` |
+| `g.worktree(dir).add` | `g.worktree_add(dir)` |
+| `g.worktree(dir, commitish).add` | `g.worktree_add(dir, commitish)` |
+| `g.worktree(dir).remove` | `g.worktree_remove(dir)` — or `g.worktree_remove(info)` |
+| `wt.gcommit` | `info.head` — always a `String`, or `nil` for a bare main worktree; `g.gcommit(info.head)` for the commit object |
+| `wt.dir` | `info.path` |
+| `wt.full`, `wt.to_s` | `info.path` — or `"#{info.path} #{info.head}"` for the descriptor that entries from `g.worktrees` produced |
+| `wt.to_a` | `[info.path]` |
 
 ---

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -95,6 +95,7 @@ require 'git/tag_info'
 require 'git/url'
 require 'git/version'
 require 'git/worktree'
+require 'git/worktree_info'
 require 'git/worktrees'
 
 # The Git module provides the basic functions to open a git

--- a/lib/git/parsers/worktree.rb
+++ b/lib/git/parsers/worktree.rb
@@ -1,0 +1,185 @@
+# frozen_string_literal: true
+
+require 'git/worktree_info'
+
+module Git
+  module Parsers
+    # Parser for git worktree command output
+    #
+    # Handles parsing of `git worktree list --porcelain` output into structured
+    # data objects.
+    #
+    # @note Known limitation: git C-quotes a lock or prune reason that contains
+    #   unusual characters such as a newline or a non-ASCII byte (see the
+    #   `--porcelain` description in the git-worktree documentation). The reason
+    #   is returned as git prints it, quotes and escapes included; it is not
+    #   unquoted.
+    #
+    # ## Design Note: Namespace Organization
+    #
+    # This parser creates and returns {Git::WorktreeInfo} objects, which live at
+    # the top-level `Git::` namespace rather than within `Git::Parsers::`. This
+    # is intentional:
+    #
+    # - **Parsers are infrastructure** - marked `@api private`, users shouldn't
+    #   interact with them directly
+    # - **Info classes are public API** - returned by commands and used throughout
+    #   the codebase
+    # - **Info classes are domain entities** - represent core git concepts
+    #   (worktrees as data)
+    #
+    # Keeping Info classes at `Git::` improves discoverability and correctly
+    # reflects their role as public types rather than parser internals.
+    #
+    # @api private
+    #
+    module Worktree
+      # Pattern splitting a porcelain line into its key and optional value
+      #
+      # The key is everything before the first space and the value is everything
+      # after it, so a path or reason that contains spaces is kept intact. The
+      # pattern matches every line; a line with no space has a nil value.
+      LINE_PATTERN = /\A(?<key>[^ ]*)(?: (?<value>.*))?\z/
+
+      # Attribute values for a worktree with no flags set
+      #
+      # @return [Hash{Symbol => Object}]
+      DEFAULT_ATTRS = {
+        head: nil, branch: nil, bare: false, detached: false,
+        locked: false, lock_reason: nil, prunable: false, prune_reason: nil
+      }.freeze
+
+      module_function
+
+      # Parse git worktree list --porcelain output into WorktreeInfo objects
+      #
+      # Records are separated by a blank line. Each record starts with a
+      # `worktree <path>` line followed by any of `HEAD <sha>`, `branch <ref>`,
+      # `bare`, `detached`, `locked [<reason>]`, and `prunable <reason>`.
+      #
+      # @example
+      #   Git::Parsers::Worktree.parse_list(
+      #     "worktree /tmp/wt/main\nHEAD f3e2c1f...\nbranch refs/heads/main\n"
+      #   )
+      #   # => [#<data Git::WorktreeInfo path="/tmp/wt/main", ...>]
+      #
+      # @param stdout [String] output from `git worktree list --porcelain`
+      #
+      # @return [Array<Git::WorktreeInfo>] one entry per worktree, in the order
+      #   git listed them (the main worktree first)
+      #
+      # @raise [Git::UnexpectedResultError] if a record does not start with a
+      #   `worktree` line or contains an unrecognized key
+      #
+      def parse_list(stdout)
+        records(stdout).map { |lines| parse_record(lines, stdout) }
+      end
+
+      # Split the output into records, each an array of chomped non-blank lines
+      #
+      # Blank lines separate records. `chunk` drops every run of lines whose
+      # block value is `:_separator`, so only the non-blank runs are returned.
+      #
+      # @param stdout [String] output from `git worktree list --porcelain`
+      #
+      # @return [Array<Array<String>>] the lines of each record
+      #
+      def records(stdout)
+        stdout.each_line(chomp: true).chunk { |line| line.empty? ? :_separator : true }.map { |_, lines| lines }
+      end
+
+      # Parse one record into a WorktreeInfo
+      #
+      # @param lines [Array<String>] the lines of the record
+      #
+      # @param stdout [String] the full output (for error messages)
+      #
+      # @return [Git::WorktreeInfo] the parsed entry
+      #
+      # @raise [Git::UnexpectedResultError] if the record does not start with a
+      #   `worktree` line or contains an unrecognized key
+      #
+      def parse_record(lines, stdout)
+        key, path = split_line(lines.first)
+        unless key == 'worktree' && path
+          raise Git::UnexpectedResultError,
+                unexpected_line_error(stdout, lines.first, 'expected a record to start with "worktree <path>"')
+        end
+
+        Git::WorktreeInfo.new(path: path, **DEFAULT_ATTRS, **record_attrs(lines.drop(1), stdout))
+      end
+
+      # Collect the attributes set by the lines that follow the `worktree` line
+      #
+      # @param lines [Array<String>] the record's lines after the first
+      #
+      # @param stdout [String] the full output (for error messages)
+      #
+      # @return [Hash{Symbol => Object}] the attributes to override in DEFAULT_ATTRS
+      #
+      # @raise [Git::UnexpectedResultError] if a line has an unrecognized key
+      #
+      def record_attrs(lines, stdout)
+        lines.each_with_object({}) { |line, attrs| attrs.merge!(line_attrs(line, stdout)) }
+      end
+
+      # Map one porcelain line to the WorktreeInfo attributes it sets
+      #
+      # @param line [String] a chomped line of porcelain output
+      #
+      # @param stdout [String] the full output (for error messages)
+      #
+      # @return [Hash{Symbol => Object}] the attributes set by the line
+      #
+      # @raise [Git::UnexpectedResultError] if the line has an unrecognized key
+      #
+      def line_attrs(line, stdout)
+        key, value = split_line(line)
+
+        case key
+        when 'HEAD' then { head: value }
+        when 'branch' then { branch: value }
+        when 'bare' then { bare: true }
+        when 'detached' then { detached: true }
+        when 'locked' then { locked: true, lock_reason: value }
+        when 'prunable' then { prunable: true, prune_reason: value }
+        else raise Git::UnexpectedResultError, unexpected_line_error(stdout, line, 'unrecognized key')
+        end
+      end
+
+      # Split a porcelain line into its key and optional value
+      #
+      # @param line [String] a chomped line of porcelain output
+      #
+      # @return [Array(String, String), Array(String, nil)] the key and the
+      #   value, or nil when the line has no value
+      #
+      def split_line(line)
+        match = LINE_PATTERN.match(line)
+        [match[:key], match[:value]]
+      end
+
+      # Generate the error message for a line the parser cannot handle
+      #
+      # @param stdout [String] the full output
+      #
+      # @param line [String] the problematic line
+      #
+      # @param reason [String] why the line is unexpected
+      #
+      # @return [String] the formatted error message
+      #
+      def unexpected_line_error(stdout, line, reason)
+        <<~ERROR
+          Unexpected line in output from `git worktree list --porcelain`: #{reason}
+
+          Line:
+            "#{line}"
+
+          Full output:
+            #{stdout.gsub("\n", "\n  ")}
+        ERROR
+      end
+    end
+  end
+end

--- a/lib/git/repository/worktree_operations.rb
+++ b/lib/git/repository/worktree_operations.rb
@@ -1,22 +1,55 @@
 # frozen_string_literal: true
 
 require 'git/commands/worktree'
+require 'git/parsers/worktree'
 require 'git/worktree'
+require 'git/worktree_info'
 require 'git/worktrees'
 
 module Git
   class Repository
-    # Facade methods for worktree operations
+    # Facade methods for worktree operations: listing, adding, removing, moving,
+    # locking, repairing, and pruning worktrees
     #
     # Included by {Git::Repository}.
     #
     # @api private
     #
     module WorktreeOperations
+      # Returns every worktree attached to the repository
+      #
+      # Lists the main worktree first, then each linked worktree, in the order
+      # git reports them. The main worktree of a bare repository is included
+      # with {Git::WorktreeInfo#bare?} true and no head or branch.
+      #
+      # @example List all worktrees
+      #   repo.worktree_list.map(&:path)
+      #   #=> ["/path/to/main", "/tmp/feature"]
+      #
+      # @example Find the worktree that has a branch checked out
+      #   info = repo.worktree_list.find { |w| w.branch == 'refs/heads/feature' }
+      #   info.path     #=> "/tmp/feature"
+      #   info.head     #=> "b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1"
+      #   info.locked?  #=> false
+      #
+      # @return [Array<Git::WorktreeInfo>] one entry per worktree
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @raise [Git::UnexpectedResultError] if the worktree listing cannot be
+      #   parsed
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      def worktree_list
+        result = Git::Commands::Worktree::List.new(@execution_context).call(porcelain: true)
+        Git::Parsers::Worktree.parse_list(result.stdout)
+      end
+
       # Returns all worktrees as an array of directory and SHA pairs
       #
-      # Lists all worktrees attached to the repository, including the main
-      # worktree and all linked worktrees.
+      # Lists the main worktree and all linked worktrees. The main worktree of
+      # a bare repository has no checked-out commit and is omitted.
       #
       # @example List all worktrees
       #   repo.worktrees_all
@@ -30,20 +63,22 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @deprecated Use {#worktree_list} instead
+      #
+      #   {#worktree_list} returns one {Git::WorktreeInfo} per worktree, with
+      #   `path` and `head` in place of the pair, and includes the main worktree
+      #   of a bare repository.
+      #
+      # @see #worktree_list
+      #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
       #
       def worktrees_all
-        worktree_entries = []
-        current_directory = ''
-        command_output = Git::Commands::Worktree::List.new(@execution_context).call(porcelain: true).stdout
-
-        command_output.each_line(chomp: true) do |line|
-          key, value = line.split(' ', 2)
-          current_directory = value if key == 'worktree'
-          worktree_entries << [current_directory, value] if key == 'HEAD'
-        end
-
-        worktree_entries
+        Git::Deprecation.warn(
+          'Git::Repository#worktrees_all is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#worktree_list instead.'
+        )
+        worktree_list.reject { |worktree| worktree.head.nil? }.map { |worktree| [worktree.path, worktree.head] }
       end
 
       # Create a new linked worktree at the given directory
@@ -75,10 +110,15 @@ module Git
 
       # Remove a linked worktree
       #
-      # @example Remove a worktree
+      # @example Remove a worktree by path
       #   repo.worktree_remove('/tmp/feature')
       #
-      # @param dir [String] filesystem path of the worktree to remove
+      # @example Remove a worktree from the list
+      #   info = repo.worktree_list.find { |w| w.branch == 'refs/heads/feature' }
+      #   repo.worktree_remove(info)
+      #
+      # @param worktree [String, Git::WorktreeInfo] the path of the worktree to
+      #   remove, or its entry from {#worktree_list}
       #
       # @return [String] the output from the git worktree remove command
       #   (typically empty)
@@ -87,8 +127,120 @@ module Git
       #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
       #
-      def worktree_remove(dir)
-        Git::Commands::Worktree::Remove.new(@execution_context).call(dir).stdout
+      def worktree_remove(worktree)
+        Git::Commands::Worktree::Remove.new(@execution_context).call(worktree.to_s).stdout
+      end
+
+      # Move a linked worktree to a new location
+      #
+      # @example Move a worktree
+      #   repo.worktree_move('/tmp/feature', '/tmp/feature-moved')
+      #
+      # @example Move a locked worktree
+      #   repo.worktree_move('/tmp/feature', '/tmp/feature-moved', force: 2)
+      #
+      # @param worktree [String, Git::WorktreeInfo] the path of the worktree to
+      #   move, or its entry from {#worktree_list}
+      #
+      # @param new_path [String] the destination path
+      #
+      # @param opts [Hash] options for the move
+      #
+      # @option opts [Boolean, Integer, nil] :force (nil) override git's
+      #   safeguards; git refuses to move a locked worktree unless the flag is
+      #   given twice, so pass `2` for that
+      #
+      # @return [String] the output from the git worktree move command
+      #   (typically empty)
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      def worktree_move(worktree, new_path, opts = {})
+        Git::Commands::Worktree::Move.new(@execution_context).call(worktree.to_s, new_path, **opts).stdout
+      end
+
+      # Lock a linked worktree so that `git worktree prune` leaves it alone
+      #
+      # Lock a worktree whose directory is on removable media or a network
+      # share that is not always mounted.
+      #
+      # @example Lock a worktree
+      #   repo.worktree_lock('/tmp/feature')
+      #
+      # @example Lock a worktree with a reason
+      #   repo.worktree_lock('/tmp/feature', reason: 'on an external drive')
+      #
+      # @param worktree [String, Git::WorktreeInfo] the path of the worktree to
+      #   lock, or its entry from {#worktree_list}
+      #
+      # @param opts [Hash] options for the lock
+      #
+      # @option opts [String, nil] :reason (nil) an explanation stored with the
+      #   lock and reported as {Git::WorktreeInfo#lock_reason}
+      #
+      # @return [String] the output from the git worktree lock command
+      #   (typically empty)
+      #
+      # @raise [ArgumentError] if unsupported options are provided
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      def worktree_lock(worktree, opts = {})
+        Git::Commands::Worktree::Lock.new(@execution_context).call(worktree.to_s, **opts).stdout
+      end
+
+      # Unlock a linked worktree
+      #
+      # @example Unlock a worktree
+      #   repo.worktree_unlock('/tmp/feature')
+      #
+      # @param worktree [String, Git::WorktreeInfo] the path of the worktree to
+      #   unlock, or its entry from {#worktree_list}
+      #
+      # @return [String] the output from the git worktree unlock command
+      #   (typically empty)
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      def worktree_unlock(worktree)
+        Git::Commands::Worktree::Unlock.new(@execution_context).call(worktree.to_s).stdout
+      end
+
+      # Repair the links between the repository and its linked worktrees
+      #
+      # With no paths, repairs the link from each linked worktree back to the
+      # repository, which is needed after the repository directory was moved.
+      # Given the current paths of linked worktrees that were moved without
+      # {#worktree_move}, also repairs the repository's links to them.
+      #
+      # @example Repair after the repository directory was moved
+      #   repo.worktree_repair
+      #
+      # @example Repair after a linked worktree was moved by hand
+      #   repo.worktree_repair('/new/path/to/feature')
+      #
+      # @param paths [Array<String, Git::WorktreeInfo>] the current paths of the
+      #   worktrees to repair, or their entries from {#worktree_list}
+      #
+      # @return [String] the output from the git worktree repair command, which
+      #   reports each repair made
+      #
+      # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @raise [Git::VersionError] if the installed git is older than 2.29.0
+      #
+      # @see https://git-scm.com/docs/git-worktree git-worktree documentation
+      #
+      def worktree_repair(*paths)
+        Git::Commands::Worktree::Repair.new(@execution_context).call(*paths.map(&:to_s)).stdout
       end
 
       # Prune stale worktree administrative files
@@ -128,7 +280,22 @@ module Git
       #
       # @return [Git::Worktree] a worktree domain object for the given path
       #
+      # @deprecated Use {#worktree_add} and {#worktree_remove} instead
+      #
+      #   `repo.worktree(dir, commitish).add` becomes
+      #   `repo.worktree_add(dir, commitish)` and `repo.worktree(dir).remove`
+      #   becomes `repo.worktree_remove(dir)`. Read a worktree's checked-out
+      #   commit from {Git::WorktreeInfo#head} via {#worktree_list}.
+      #
+      # @see #worktree_add
+      #
+      # @see #worktree_remove
+      #
       def worktree(dir, commitish = nil)
+        Git::Deprecation.warn(
+          'Git::Repository#worktree is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#worktree_add and Git::Repository#worktree_remove instead.'
+        )
         Git::Worktree.new(self, dir, commitish)
       end
 
@@ -151,7 +318,20 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @deprecated Use {#worktree_list} instead
+      #
+      #   {#worktree_list} returns `Array<Git::WorktreeInfo>`. Look a worktree up
+      #   by path with `worktree_list.find { |w| w.path == path }` in place of
+      #   `worktrees[path]`, and call {#worktree_prune} in place of
+      #   `worktrees.prune`. Calling this method emits one deprecation warning.
+      #
+      # @see #worktree_list
+      #
       def worktrees
+        Git::Deprecation.warn(
+          'Git::Repository#worktrees is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#worktree_list instead.'
+        )
         Git::Worktrees.new(self)
       end
     end

--- a/lib/git/worktree.rb
+++ b/lib/git/worktree.rb
@@ -12,6 +12,17 @@ module Git
   #   worktree.add
   #   worktree.remove
   #
+  # @deprecated Use {Git::Repository::WorktreeOperations#worktree_list} and the
+  #   path-based worktree operations on {Git::Repository} instead
+  #
+  #   {Git::Repository::WorktreeOperations#worktree_list} returns immutable
+  #   {Git::WorktreeInfo} value objects. Operations that lived on this class are
+  #   called on the repository with the worktree path instead (for example
+  #   {Git::Repository::WorktreeOperations#worktree_add} and
+  #   {Git::Repository::WorktreeOperations#worktree_remove}). {#gcommit},
+  #   {#add}, and {#remove} each emit a deprecation warning; the `dir`, `full`,
+  #   `to_s`, and `to_a` readers do not.
+  #
   # @api public
   #
   class Worktree
@@ -69,7 +80,19 @@ module Git
     # @raise [Git::FailedError] if git must resolve the commit and exits with a
     #   non-zero exit status
     #
+    # @deprecated Use {Git::WorktreeInfo#head} from
+    #   {Git::Repository::WorktreeOperations#worktree_list} instead
+    #
+    #   `head` is always the commit SHA as a `String` (or `nil` for a bare main
+    #   worktree). Call `repo.gcommit(info.head)` for the commit object.
+    #
+    # @see Git::WorktreeInfo#head
+    #
     def gcommit
+      Git::Deprecation.warn(
+        'Git::Worktree#gcommit is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::WorktreeInfo#head from Git::Repository#worktree_list instead.'
+      )
       @gcommit ||= worktree_repository.gcommit(@full)
       @gcommit
     end
@@ -87,7 +110,15 @@ module Git
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
+    # @deprecated Use {Git::Repository::WorktreeOperations#worktree_add} instead
+    #
+    # @see Git::Repository::WorktreeOperations#worktree_add
+    #
     def add
+      Git::Deprecation.warn(
+        'Git::Worktree#add is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#worktree_add instead.'
+      )
       worktree_repository.worktree_add(@dir, @gcommit)
     end
 
@@ -102,7 +133,15 @@ module Git
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
+    # @deprecated Use {Git::Repository::WorktreeOperations#worktree_remove} instead
+    #
+    # @see Git::Repository::WorktreeOperations#worktree_remove
+    #
     def remove
+      Git::Deprecation.warn(
+        'Git::Worktree#remove is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#worktree_remove instead.'
+      )
       worktree_repository.worktree_remove(@dir)
     end
 

--- a/lib/git/worktree_info.rb
+++ b/lib/git/worktree_info.rb
@@ -1,0 +1,128 @@
+# frozen_string_literal: true
+
+module Git
+  # Immutable value object for one entry of `git worktree list`
+  #
+  # Each entry carries what `git worktree list --porcelain` reports for a
+  # worktree: its path, the checked-out HEAD and branch, and whether it is bare,
+  # detached, locked, or prunable, with the reason git gives for the last two.
+  #
+  # @example A locked linked worktree with a branch checked out
+  #   info = Git::WorktreeInfo.new(
+  #     path: '/tmp/wt/linked',
+  #     head: 'f3e2c1ffb860086504eeb27b77a1d0028b68fd8f',
+  #     branch: 'refs/heads/linked',
+  #     bare: false,
+  #     detached: false,
+  #     locked: true,
+  #     lock_reason: 'on purpose',
+  #     prunable: false,
+  #     prune_reason: nil
+  #   )
+  #
+  #   info.path         # => '/tmp/wt/linked'
+  #   info.head         # => 'f3e2c1ffb860086504eeb27b77a1d0028b68fd8f'
+  #   info.branch       # => 'refs/heads/linked'
+  #   info.locked?      # => true
+  #   info.lock_reason  # => 'on purpose'
+  #   info.detached?    # => false
+  #   info.to_s         # => '/tmp/wt/linked'
+  #
+  # @example Pass an entry back to a worktree operation
+  #   info = repo.worktree_list.find { |w| w.branch == 'refs/heads/linked' }
+  #   repo.worktree_remove(info)
+  #
+  # @see Git::Repository::WorktreeOperations#worktree_list for the repository
+  #   method that returns these
+  #
+  # @api public
+  #
+  # @!attribute [r] path
+  #   @return [String] the worktree directory as git reports it
+  #
+  # @!attribute [r] head
+  #   @return [String, nil] the full object ID of the checked-out HEAD commit
+  #     (the all-zero object ID when the branch has no commits yet), or nil for a
+  #     bare main worktree
+  #
+  # @!attribute [r] branch
+  #   @return [String, nil] the full refname of the checked-out branch (e.g.,
+  #     'refs/heads/main'), or nil when the worktree is bare or detached
+  #
+  # @!attribute [r] bare
+  #   @return [Boolean] true if this is the main worktree of a bare repository
+  #
+  # @!attribute [r] detached
+  #   @return [Boolean] true if HEAD is detached in this worktree
+  #
+  # @!attribute [r] locked
+  #   @return [Boolean] true if the worktree is locked
+  #
+  # @!attribute [r] lock_reason
+  #   @return [String, nil] the reason given when the worktree was locked, or nil
+  #     when it is not locked or was locked without a reason
+  #
+  # @!attribute [r] prunable
+  #   @return [Boolean] true if `git worktree prune` would remove this entry
+  #
+  # @!attribute [r] prune_reason
+  #   @return [String, nil] git's explanation of why the entry is prunable, or
+  #     nil when it is not prunable
+  #
+  WorktreeInfo = Data.define(
+    :path,
+    :head,
+    :branch,
+    :bare,
+    :detached,
+    :locked,
+    :lock_reason,
+    :prunable,
+    :prune_reason
+  ) do
+    # Whether this is the main worktree of a bare repository
+    #
+    # @example
+    #   info.bare? # => false
+    #
+    # @return [Boolean] true if the worktree is bare
+    def bare? = bare
+
+    # Whether HEAD is detached in this worktree
+    #
+    # @example
+    #   info.detached? # => false
+    #
+    # @return [Boolean] true if HEAD is detached
+    def detached? = detached
+
+    # Whether the worktree is locked
+    #
+    # @example
+    #   info.locked? # => true
+    #
+    # @return [Boolean] true if the worktree is locked
+    def locked? = locked
+
+    # Whether `git worktree prune` would remove this entry
+    #
+    # @example
+    #   info.prunable? # => false
+    #
+    # @return [Boolean] true if the entry is prunable
+    def prunable? = prunable
+
+    # Returns the worktree path
+    #
+    # Lets an entry be passed directly to the worktree operations that take a
+    # path, such as {Git::Repository::WorktreeOperations#worktree_remove}.
+    #
+    # @example Convert to string
+    #   info.to_s # => '/tmp/wt/linked'
+    #
+    # @return [String] the worktree path
+    def to_s
+      path
+    end
+  end
+end

--- a/lib/git/worktrees.rb
+++ b/lib/git/worktrees.rb
@@ -10,6 +10,15 @@ module Git
   #   worktrees = repo.worktrees
   #   worktrees.each { |wt| puts wt.dir }
   #
+  # @deprecated Use {Git::Repository::WorktreeOperations#worktree_list} instead
+  #
+  #   {Git::Repository::WorktreeOperations#worktree_list} returns
+  #   `Array<Git::WorktreeInfo>` (immutable value objects). Look a worktree up
+  #   by path with `worktree_list.find { |w| w.path == path }` in place of
+  #   {#[]}, and call {Git::Repository::WorktreeOperations#worktree_prune} in
+  #   place of {#prune}. Constructing a `Git::Worktrees` emits a deprecation
+  #   warning.
+  #
   # @api public
   #
   class Worktrees
@@ -24,12 +33,21 @@ module Git
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
+    # @deprecated Use {Git::Repository::WorktreeOperations#worktree_list} instead
+    #
+    # @see Git::Repository::WorktreeOperations#worktree_list
+    #
     def initialize(base)
+      Git::Deprecation.warn(
+        'Git::Worktrees is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#worktree_list instead.'
+      )
       @worktrees = {}
 
       @base = base
 
-      worktree_repository.worktrees_all.each do |w|
+      # worktrees_all is deprecated too; silence it so one Git::Worktrees.new emits one warning
+      Git::Deprecation.silence { worktree_repository.worktrees_all }.each do |w|
         @worktrees[w[0]] = Git::Worktree.new(@base, w[0], w[1])
       end
     end

--- a/spec/integration/git/parsers/worktree_spec.rb
+++ b/spec/integration/git/parsers/worktree_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Integration tests for Git::Parsers::Worktree
+#
+# These tests verify that the parser correctly handles real
+# `git worktree list --porcelain` output.
+#
+RSpec.describe Git::Parsers::Worktree, :integration do
+  include_context 'in an empty repository'
+
+  # Run `git worktree list --porcelain` in the given repository and return raw output
+  def git_worktree_output(repository = repo)
+    repository.execution_context.command_capturing('worktree', 'list', '--porcelain').stdout
+  end
+
+  before do
+    write_file('README.md', "# Hello\n")
+    repo.add('README.md')
+    repo.commit('Initial commit')
+  end
+
+  describe '.parse_list' do
+    context 'with only the main worktree' do
+      it 'returns one Git::WorktreeInfo for the main worktree on its branch' do
+        result = described_class.parse_list(git_worktree_output)
+
+        expect(result.size).to eq(1)
+        expect(result.first).to have_attributes(
+          path: File.realpath(repo_dir), branch: 'refs/heads/main', bare: false, detached: false,
+          locked: false, lock_reason: nil, prunable: false, prune_reason: nil
+        )
+        expect(result.first.head).to match(/\A[0-9a-f]{40}\z/)
+      end
+    end
+
+    context 'with linked worktrees in every reported state' do
+      let(:worktrees_dir) { Dir.mktmpdir('worktrees') }
+      let(:locked_path) { File.join(worktrees_dir, 'locked') }
+      let(:locked_with_reason_path) { File.join(worktrees_dir, 'locked-with-reason') }
+      let(:detached_path) { File.join(worktrees_dir, 'detached') }
+      let(:prunable_path) { File.join(worktrees_dir, 'prunable') }
+
+      before do
+        add = Git::Commands::Worktree::Add.new(execution_context)
+        lock = Git::Commands::Worktree::Lock.new(execution_context)
+
+        add.call(locked_path)
+        lock.call(locked_path)
+
+        add.call(locked_with_reason_path)
+        lock.call(locked_with_reason_path, reason: 'on purpose')
+
+        add.call(detached_path, detach: true)
+
+        add.call(prunable_path)
+        FileUtils.rm_rf(prunable_path)
+      end
+
+      after { FileUtils.rm_rf(worktrees_dir) }
+
+      # Find the parsed entry for a worktree path (git reports resolved absolute paths)
+      def entry_for(result, path)
+        result.find { |info| info.path == File.join(File.realpath(worktrees_dir), File.basename(path)) }
+      end
+
+      it 'lists the main worktree first' do
+        result = described_class.parse_list(git_worktree_output)
+
+        expect(result.first.path).to eq(File.realpath(repo_dir))
+      end
+
+      it 'returns one entry per worktree' do
+        result = described_class.parse_list(git_worktree_output)
+
+        expect(result.size).to eq(5)
+      end
+
+      it 'parses a worktree locked without a reason' do
+        result = described_class.parse_list(git_worktree_output)
+
+        expect(entry_for(result, locked_path)).to have_attributes(
+          branch: 'refs/heads/locked', locked: true, lock_reason: nil, detached: false, prunable: false
+        )
+      end
+
+      it 'parses a worktree locked with a reason' do
+        result = described_class.parse_list(git_worktree_output)
+
+        expect(entry_for(result, locked_with_reason_path)).to have_attributes(
+          branch: 'refs/heads/locked-with-reason', locked: true, lock_reason: 'on purpose'
+        )
+      end
+
+      it 'parses a detached worktree with a nil branch' do
+        result = described_class.parse_list(git_worktree_output)
+
+        entry = entry_for(result, detached_path)
+        expect(entry).to have_attributes(branch: nil, detached: true, locked: false)
+        expect(entry.head).to match(/\A[0-9a-f]{40}\z/)
+      end
+
+      it 'parses a prunable worktree with its prune reason' do
+        result = described_class.parse_list(git_worktree_output)
+
+        entry = entry_for(result, prunable_path)
+        expect(entry).to have_attributes(prunable: true, locked: false)
+        expect(entry.prune_reason).to be_a(String)
+        expect(entry.prune_reason).not_to be_empty
+      end
+    end
+
+    context 'with a bare repository' do
+      let(:bare_dir) { Dir.mktmpdir('bare_repo') }
+      let(:bare_repo) { Git.init(bare_dir, bare: true) }
+
+      after { FileUtils.rm_rf(bare_dir) }
+
+      it 'returns a bare entry with no head or branch' do
+        result = described_class.parse_list(git_worktree_output(bare_repo))
+
+        expect(result).to eq(
+          [
+            Git::WorktreeInfo.new(
+              path: File.realpath(bare_dir), head: nil, branch: nil, bare: true, detached: false,
+              locked: false, lock_reason: nil, prunable: false, prune_reason: nil
+            )
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/integration/git/repository/worktree_operations_spec.rb
+++ b/spec/integration/git/repository/worktree_operations_spec.rb
@@ -5,25 +5,38 @@ require 'securerandom'
 require 'git/repository'
 require 'git/repository/worktree_operations'
 
-# worktree_add, worktree_remove, and worktree_prune are one-line delegators with no
-# facade-owned post-processing. Baseline coverage for their happy paths comes from
-# the command integration tests (spec/integration/git/commands/worktree/). The
-# integration tests below are added only for real-git behaviors that need an
-# unborn (no-commit) repository or multi-worktree state to reproduce: version-
-# dependent unborn-repo behavior, the main-worktree removal failure mode, and
-# prune's effect on a manually deleted linked worktree.
+# worktree_add and worktree_prune are one-line delegators with no facade-owned
+# post-processing. Baseline coverage for their happy paths comes from the command
+# integration tests (spec/integration/git/commands/worktree/). Their integration
+# tests below cover only real-git behaviors that need an unborn (no-commit)
+# repository or multi-worktree state to reproduce.
 #
-# worktree and worktrees are factory methods that construct domain objects
-# (Git::Worktree and Git::Worktrees) without running git commands directly; they
-# have no integration tests and are fully covered by the unit tests.
+# worktree_list and worktrees_all turn porcelain output into Ruby values; their
+# integration tests verify that post-processing against actual git output,
+# including a bare repository, which worktree_list reports and worktrees_all omits.
 #
-# worktrees_all parses porcelain output inline inside the facade. This integration
-# test verifies that the parsing logic works correctly against actual git output.
+# worktree_remove, worktree_move, worktree_lock, worktree_unlock, and
+# worktree_repair accept a Git::WorktreeInfo in place of a path; their integration
+# tests verify that a Git::WorktreeInfo argument reaches git as the worktree path.
+#
+# worktree and worktrees are deprecated factory methods that construct domain
+# objects (Git::Worktree and Git::Worktrees) without running git commands directly;
+# they have no integration tests and are fully covered by the unit tests.
 
 RSpec.describe Git::Repository::WorktreeOperations, :integration do
   include_context 'in an empty repository'
 
   let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  # A unique path for a linked worktree beside the test repository
+  def new_worktree_path
+    File.join(repo_dir, '..', "worktree-#{SecureRandom.hex(4)}")
+  end
+
+  # The Git::WorktreeInfo that worktree_list reports for the given path
+  def info_for(path)
+    described_instance.worktree_list.find { |info| info.path == File.realpath(path) }
+  end
 
   before do
     write_file('README.md', "# Hello\n")
@@ -31,56 +44,32 @@ RSpec.describe Git::Repository::WorktreeOperations, :integration do
     repo.commit('Initial commit')
   end
 
-  describe '#worktrees_all' do
+  describe '#worktree_list' do
     context 'when only the main worktree exists' do
-      it 'returns one entry for the main worktree' do
-        result = described_instance.worktrees_all
-        expect(result.length).to eq(1)
-      end
+      it 'returns one Git::WorktreeInfo for the main worktree on its branch' do
+        result = described_instance.worktree_list
 
-      it 'returns the main worktree directory as the first element' do
-        result = described_instance.worktrees_all
-        expect(result.first.first).to eq(File.realpath(repo_dir))
-      end
-
-      it 'returns a full 40-character SHA as the second element' do
-        result = described_instance.worktrees_all
-        expect(result.first.last).to match(/\A[0-9a-f]{40}\z/)
+        expect(result.size).to eq(1)
+        expect(result.first).to be_a(Git::WorktreeInfo)
+        expect(result.first).to have_attributes(
+          path: File.realpath(repo_dir), branch: 'refs/heads/main', bare: false, detached: false,
+          locked: false, prunable: false
+        )
+        expect(result.first.head).to match(/\A[0-9a-f]{40}\z/)
       end
     end
 
     context 'when a linked worktree has been added' do
-      let(:worktree_path) { File.join(repo_dir, '..', "worktree-#{SecureRandom.hex(4)}") }
+      let(:worktree_path) { new_worktree_path }
 
-      before do
-        Git::Commands::Worktree::Add.new(execution_context).call(worktree_path)
-      end
+      before { described_instance.worktree_add(worktree_path) }
 
-      after do
-        Git::Commands::Worktree::Remove.new(execution_context).call(worktree_path, force: true)
-        Git::Commands::Worktree::Prune.new(execution_context).call
-      end
+      after { FileUtils.rm_rf(worktree_path) }
 
-      it 'returns two entries' do
-        result = described_instance.worktrees_all
-        expect(result.length).to eq(2)
-      end
+      it 'lists the main worktree first, followed by the linked worktree' do
+        paths = described_instance.worktree_list.map(&:path)
 
-      it 'includes the main worktree directory' do
-        result = described_instance.worktrees_all
-        directories = result.map(&:first)
-        expect(directories).to include(File.realpath(repo_dir))
-      end
-
-      it 'includes the linked worktree directory' do
-        result = described_instance.worktrees_all
-        directories = result.map(&:first)
-        expect(directories).to include(File.realpath(worktree_path))
-      end
-
-      it 'returns a valid 40-character SHA for each entry' do
-        shas = described_instance.worktrees_all.map(&:last)
-        expect(shas).to all(match(/\A[0-9a-f]{40}\z/))
+        expect(paths).to eq([File.realpath(repo_dir), File.realpath(worktree_path)])
       end
     end
 
@@ -92,9 +81,45 @@ RSpec.describe Git::Repository::WorktreeOperations, :integration do
       after { FileUtils.rm_rf(unborn_repo_dir) }
 
       it 'lists only the main worktree' do
-        result = unborn_instance.worktrees_all
-        expect(result.length).to eq(1)
-        expect(result.first.first).to eq(File.realpath(unborn_repo_dir))
+        result = unborn_instance.worktree_list
+
+        expect(result.size).to eq(1)
+        expect(result.first.path).to eq(File.realpath(unborn_repo_dir))
+      end
+    end
+
+    context 'when the repository is bare' do
+      let(:bare_dir) { Dir.mktmpdir('bare_repo') }
+      let(:bare_instance) { Git::Repository.new(execution_context: Git.init(bare_dir, bare: true).execution_context) }
+
+      after { FileUtils.rm_rf(bare_dir) }
+
+      it 'includes the bare main worktree with a nil head and branch' do
+        result = bare_instance.worktree_list
+
+        expect(result.size).to eq(1)
+        expect(result.first).to have_attributes(path: File.realpath(bare_dir), head: nil, branch: nil, bare: true)
+      end
+    end
+  end
+
+  describe '#worktrees_all' do
+    it 'returns a [directory, sha] pair for each worktree reported by worktree_list' do
+      infos = described_instance.worktree_list
+      result = Git::Deprecation.silence { described_instance.worktrees_all }
+
+      expect(result).to eq(infos.map { |info| [info.path, info.head] })
+    end
+
+    context 'when the repository is bare' do
+      let(:bare_dir) { Dir.mktmpdir('bare_repo') }
+      let(:bare_instance) { Git::Repository.new(execution_context: Git.init(bare_dir, bare: true).execution_context) }
+
+      after { FileUtils.rm_rf(bare_dir) }
+
+      it 'omits the bare main worktree that worktree_list includes' do
+        expect(bare_instance.worktree_list.size).to eq(1)
+        expect(Git::Deprecation.silence { bare_instance.worktrees_all }).to eq([])
       end
     end
   end
@@ -121,37 +146,180 @@ RSpec.describe Git::Repository::WorktreeOperations, :integration do
         it 'succeeds and creates a second worktree entry' do
           unborn_instance.worktree_add(worktree_path)
 
-          expect(unborn_instance.worktrees_all.length).to eq(2)
+          expect(unborn_instance.worktree_list.size).to eq(2)
         end
       end
     end
   end
 
   describe '#worktree_remove' do
+    let(:worktree_path) { new_worktree_path }
+
+    before { described_instance.worktree_add(worktree_path) }
+
+    after { FileUtils.rm_rf(worktree_path) }
+
+    context 'when given a Git::WorktreeInfo' do
+      it 'removes that worktree' do
+        removed_path = File.realpath(worktree_path)
+
+        described_instance.worktree_remove(info_for(worktree_path))
+
+        expect(described_instance.worktree_list.map(&:path)).not_to include(removed_path)
+      end
+    end
+
     context 'when removing the main worktree' do
-      let(:linked_worktree_path) { File.join(repo_dir, '..', "worktree-#{SecureRandom.hex(4)}") }
-
-      before do
-        described_instance.worktree_add(linked_worktree_path)
-      end
-
-      after do
-        Git::Commands::Worktree::Remove.new(execution_context).call(linked_worktree_path, force: true)
-        Git::Commands::Worktree::Prune.new(execution_context).call
-      end
-
       it 'raises Git::FailedError and leaves all worktrees intact' do
         expect { described_instance.worktree_remove(File.realpath(repo_dir)) }
           .to raise_error(Git::FailedError, /main working tree/)
 
-        expect(described_instance.worktrees_all.length).to eq(2)
+        expect(described_instance.worktree_list.size).to eq(2)
+      end
+    end
+  end
+
+  describe '#worktree_move' do
+    let(:worktree_path) { new_worktree_path }
+    let(:new_path) { new_worktree_path }
+
+    before { described_instance.worktree_add(worktree_path) }
+
+    after do
+      FileUtils.rm_rf(worktree_path)
+      FileUtils.rm_rf(new_path)
+    end
+
+    it 'moves the worktree to the new path' do
+      old_path = File.realpath(worktree_path)
+
+      described_instance.worktree_move(worktree_path, new_path)
+
+      paths = described_instance.worktree_list.map(&:path)
+      expect(paths).to include(File.realpath(new_path))
+      expect(paths).not_to include(old_path)
+    end
+
+    context 'when given a Git::WorktreeInfo' do
+      it 'moves that worktree to the new path' do
+        described_instance.worktree_move(info_for(worktree_path), new_path)
+
+        expect(described_instance.worktree_list.map(&:path)).to include(File.realpath(new_path))
+      end
+    end
+
+    context 'when the worktree is locked' do
+      before { described_instance.worktree_lock(worktree_path) }
+
+      it 'moves the worktree when force is given twice' do
+        described_instance.worktree_move(worktree_path, new_path, force: 2)
+
+        expect(described_instance.worktree_list.map(&:path)).to include(File.realpath(new_path))
+      end
+    end
+
+    context 'with an unsupported option' do
+      it 'raises ArgumentError' do
+        expect { described_instance.worktree_move(worktree_path, new_path, bogus: true) }
+          .to raise_error(ArgumentError, /Unsupported options: :bogus/)
+      end
+    end
+  end
+
+  describe '#worktree_lock' do
+    let(:worktree_path) { new_worktree_path }
+
+    before { described_instance.worktree_add(worktree_path) }
+
+    after { FileUtils.rm_rf(worktree_path) }
+
+    it 'locks the worktree with no reason' do
+      described_instance.worktree_lock(worktree_path)
+
+      expect(info_for(worktree_path)).to have_attributes(locked: true, lock_reason: nil)
+    end
+
+    context 'with a reason' do
+      it 'locks the worktree and records the reason' do
+        described_instance.worktree_lock(worktree_path, reason: 'on purpose')
+
+        expect(info_for(worktree_path)).to have_attributes(locked: true, lock_reason: 'on purpose')
+      end
+    end
+
+    context 'when given a Git::WorktreeInfo' do
+      it 'locks that worktree' do
+        described_instance.worktree_lock(info_for(worktree_path))
+
+        expect(info_for(worktree_path).locked?).to be true
+      end
+    end
+  end
+
+  describe '#worktree_unlock' do
+    let(:worktree_path) { new_worktree_path }
+
+    before do
+      described_instance.worktree_add(worktree_path)
+      described_instance.worktree_lock(worktree_path, reason: 'on purpose')
+    end
+
+    after { FileUtils.rm_rf(worktree_path) }
+
+    it 'unlocks the worktree' do
+      described_instance.worktree_unlock(worktree_path)
+
+      expect(info_for(worktree_path)).to have_attributes(locked: false, lock_reason: nil)
+    end
+
+    context 'when given a Git::WorktreeInfo' do
+      it 'unlocks that worktree' do
+        described_instance.worktree_unlock(info_for(worktree_path))
+
+        expect(info_for(worktree_path).locked?).to be false
+      end
+    end
+  end
+
+  describe '#worktree_repair' do
+    context 'on git versions 2.29.0 and later', if: Git.git_version >= Git::Version.new(2, 29, 0) do
+      let(:worktree_path) { new_worktree_path }
+      let(:moved_path) { new_worktree_path }
+
+      before do
+        described_instance.worktree_add(worktree_path)
+        FileUtils.mv(worktree_path, moved_path)
+      end
+
+      after do
+        FileUtils.rm_rf(worktree_path)
+        FileUtils.rm_rf(moved_path)
+      end
+
+      it 'reconnects a linked worktree that was moved without git' do
+        described_instance.worktree_repair(moved_path)
+
+        expect(described_instance.worktree_list.map(&:path)).to include(File.realpath(moved_path))
+      end
+
+      # With no paths, git repairs the link of the worktree at the current
+      # directory rather than the one named by --git-dir, so the example passes
+      # the moved path to keep the outcome independent of the test's cwd.
+      it 'returns the output from git as a String' do
+        expect(described_instance.worktree_repair(moved_path)).to be_a(String)
+      end
+    end
+
+    context 'on git versions before 2.29.0', if: Git.git_version < Git::Version.new(2, 29, 0) do
+      it 'raises Git::VersionError' do
+        expect { described_instance.worktree_repair }.to raise_error(Git::VersionError, /2\.29\.0/)
       end
     end
   end
 
   describe '#worktree_prune' do
     context 'when a linked worktree has been manually deleted' do
-      let(:worktree_path) { File.join(repo_dir, '..', "worktree-#{SecureRandom.hex(4)}") }
+      let(:worktree_path) { new_worktree_path }
 
       before do
         described_instance.worktree_add(worktree_path)
@@ -161,7 +329,7 @@ RSpec.describe Git::Repository::WorktreeOperations, :integration do
       it 'removes the deleted worktree from the worktree list' do
         described_instance.worktree_prune
 
-        expect(described_instance.worktrees_all.length).to eq(1)
+        expect(described_instance.worktree_list.size).to eq(1)
       end
     end
   end

--- a/spec/integration/git/worktrees_spec.rb
+++ b/spec/integration/git/worktrees_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Git::Worktrees, :integration do
   context 'when initialized via Git::Repository (Git::Repository passed to constructor)' do
     let(:execution_context) { repo.execution_context }
     let(:repository) { Git::Repository.new(execution_context: execution_context) }
-    let(:worktrees) { repository.worktrees }
+    let(:worktrees) { Git::Deprecation.silence { repository.worktrees } }
 
     describe '#size' do
       it 'returns 1 for a repository with only the main worktree' do

--- a/spec/unit/git/parsers/worktree_spec.rb
+++ b/spec/unit/git/parsers/worktree_spec.rb
@@ -1,0 +1,234 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::Parsers::Worktree do
+  # Build a Git::WorktreeInfo with every flag off unless overridden
+  def worktree_info(path:, **overrides)
+    Git::WorktreeInfo.new(
+      path: path, head: nil, branch: nil, bare: false, detached: false,
+      locked: false, lock_reason: nil, prunable: false, prune_reason: nil, **overrides
+    )
+  end
+
+  let(:sha) { 'f3e2c1ffb860086504eeb27b77a1d0028b68fd8f' }
+
+  describe '.parse_list' do
+    subject(:result) { described_class.parse_list(stdout) }
+
+    context 'when the output is empty' do
+      let(:stdout) { '' }
+
+      it 'returns an empty array' do
+        expect(result).to eq([])
+      end
+    end
+
+    context 'with a main worktree on a branch' do
+      let(:stdout) do
+        "worktree /tmp/wt/main\n" \
+          "HEAD #{sha}\n" \
+          "branch refs/heads/main\n"
+      end
+
+      it 'returns one Git::WorktreeInfo with the path, head, and branch' do
+        expect(result).to eq(
+          [worktree_info(path: '/tmp/wt/main', head: sha, branch: 'refs/heads/main')]
+        )
+      end
+    end
+
+    context 'with a bare main worktree' do
+      let(:stdout) do
+        "worktree /tmp/wt/repo.git\n" \
+          "bare\n"
+      end
+
+      it 'returns a bare Git::WorktreeInfo with a nil head and branch' do
+        expect(result).to eq([worktree_info(path: '/tmp/wt/repo.git', bare: true)])
+      end
+    end
+
+    context 'with a detached worktree' do
+      let(:stdout) do
+        "worktree /tmp/wt/det\n" \
+          "HEAD #{sha}\n" \
+          "detached\n"
+      end
+
+      it 'returns a detached Git::WorktreeInfo with a nil branch' do
+        expect(result).to eq([worktree_info(path: '/tmp/wt/det', head: sha, detached: true)])
+      end
+    end
+
+    context 'with a locked worktree without a reason' do
+      let(:stdout) do
+        "worktree /tmp/wt/det\n" \
+          "HEAD #{sha}\n" \
+          "detached\n" \
+          "locked\n"
+      end
+
+      it 'returns a locked Git::WorktreeInfo with a nil lock_reason' do
+        expect(result).to eq(
+          [worktree_info(path: '/tmp/wt/det', head: sha, detached: true, locked: true)]
+        )
+      end
+    end
+
+    context 'with a locked worktree with a reason' do
+      let(:stdout) do
+        "worktree /tmp/wt/linked\n" \
+          "HEAD #{sha}\n" \
+          "branch refs/heads/linked\n" \
+          "locked on purpose\n"
+      end
+
+      it 'returns a locked Git::WorktreeInfo with the lock_reason' do
+        expect(result).to eq(
+          [
+            worktree_info(
+              path: '/tmp/wt/linked', head: sha, branch: 'refs/heads/linked',
+              locked: true, lock_reason: 'on purpose'
+            )
+          ]
+        )
+      end
+    end
+
+    context 'with a C-quoted lock reason' do
+      let(:stdout) do
+        "worktree /tmp/wt/linked\n" \
+          "HEAD #{sha}\n" \
+          "branch refs/heads/linked\n" \
+          "locked \"line1\\nline2 \\303\\251\"\n"
+      end
+
+      it 'returns the lock_reason as git prints it, without unquoting' do
+        expect(result.first.lock_reason).to eq('"line1\\nline2 \\303\\251"')
+      end
+    end
+
+    context 'with a prunable worktree' do
+      let(:stdout) do
+        "worktree /tmp/wt/gone\n" \
+          "HEAD #{sha}\n" \
+          "branch refs/heads/gone\n" \
+          "prunable gitdir file points to non-existent location\n"
+      end
+
+      it 'returns a prunable Git::WorktreeInfo with the prune_reason' do
+        expect(result).to eq(
+          [
+            worktree_info(
+              path: '/tmp/wt/gone', head: sha, branch: 'refs/heads/gone',
+              prunable: true, prune_reason: 'gitdir file points to non-existent location'
+            )
+          ]
+        )
+      end
+    end
+
+    context 'with multiple worktrees' do
+      let(:stdout) do
+        "worktree /tmp/wt/main\n" \
+          "HEAD #{sha}\n" \
+          "branch refs/heads/main\n" \
+          "\n" \
+          "worktree /tmp/wt/det\n" \
+          "HEAD #{sha}\n" \
+          "detached\n" \
+          "locked\n" \
+          "\n" \
+          "worktree /tmp/wt/gone\n" \
+          "HEAD #{sha}\n" \
+          "branch refs/heads/gone\n" \
+          "prunable gitdir file points to non-existent location\n" \
+          "\n" \
+          "worktree /tmp/wt/linked\n" \
+          "HEAD #{sha}\n" \
+          "branch refs/heads/linked\n" \
+          "locked on purpose\n" \
+          "\n"
+      end
+
+      it 'returns one Git::WorktreeInfo per record in the order git printed them' do
+        expect(result).to eq(
+          [
+            worktree_info(path: '/tmp/wt/main', head: sha, branch: 'refs/heads/main'),
+            worktree_info(path: '/tmp/wt/det', head: sha, detached: true, locked: true),
+            worktree_info(
+              path: '/tmp/wt/gone', head: sha, branch: 'refs/heads/gone',
+              prunable: true, prune_reason: 'gitdir file points to non-existent location'
+            ),
+            worktree_info(
+              path: '/tmp/wt/linked', head: sha, branch: 'refs/heads/linked',
+              locked: true, lock_reason: 'on purpose'
+            )
+          ]
+        )
+      end
+    end
+
+    context 'when a worktree path contains spaces' do
+      let(:stdout) do
+        "worktree /tmp/worktree with spaces\n" \
+          "HEAD #{sha}\n" \
+          "detached\n"
+      end
+
+      it 'preserves the full path' do
+        expect(result.first.path).to eq('/tmp/worktree with spaces')
+      end
+    end
+
+    context 'when the output uses CRLF line endings' do
+      let(:stdout) do
+        "worktree /tmp/wt/main\r\n" \
+          "HEAD #{sha}\r\n" \
+          "branch refs/heads/main\r\n" \
+          "\r\n" \
+          "worktree /tmp/wt/det\r\n" \
+          "HEAD #{sha}\r\n" \
+          "detached\r\n"
+      end
+
+      it 'parses records without carriage returns in the values' do
+        expect(result).to eq(
+          [
+            worktree_info(path: '/tmp/wt/main', head: sha, branch: 'refs/heads/main'),
+            worktree_info(path: '/tmp/wt/det', head: sha, detached: true)
+          ]
+        )
+      end
+    end
+
+    context 'when a record does not start with a worktree line' do
+      let(:stdout) do
+        "HEAD #{sha}\n" \
+          "branch refs/heads/main\n"
+      end
+
+      it 'raises Git::UnexpectedResultError with the full output in the message' do
+        expect { result }.to raise_error(Git::UnexpectedResultError, /git worktree list --porcelain/) do |error|
+          expect(error.message).to include("HEAD #{sha}")
+          expect(error.message).to include('branch refs/heads/main')
+        end
+      end
+    end
+
+    context 'when a record contains an unrecognized key' do
+      let(:stdout) do
+        "worktree /tmp/wt/main\n" \
+          "HEAD #{sha}\n" \
+          "unexpected value\n"
+      end
+
+      it 'raises Git::UnexpectedResultError naming the line and including the full output' do
+        expect { result }.to raise_error(Git::UnexpectedResultError, /unexpected value/) do |error|
+          expect(error.message).to include('worktree /tmp/wt/main')
+        end
+      end
+    end
+  end
+end

--- a/spec/unit/git/repository/worktree_operations_spec.rb
+++ b/spec/unit/git/repository/worktree_operations_spec.rb
@@ -5,131 +5,135 @@ require 'git/repository'
 require 'git/repository/worktree_operations'
 
 # Integration-level coverage for facade methods in Git::Repository::WorktreeOperations:
-#   worktree_add, worktree_remove, and worktree_prune are one-line delegators to
-#   single Git::Commands::Worktree::* classes with no post-processing. Their
-#   end-to-end coverage comes from the command integration tests:
-#     spec/integration/git/commands/worktree/add_spec.rb    (worktree_add)
-#     spec/integration/git/commands/worktree/remove_spec.rb (worktree_remove)
-#     spec/integration/git/commands/worktree/prune_spec.rb  (worktree_prune)
-#   worktree and worktrees are factory methods that construct domain objects
-#   (Git::Worktree and Git::Worktrees) without running git commands directly;
-#   their behavior is fully covered by the unit tests below.
-#   worktrees_all does facade-owned inline parsing of porcelain output; its
-#   integration test is in spec/integration/git/repository/worktree_operations_spec.rb.
+#   worktree_add and worktree_prune are one-line delegators to single
+#   Git::Commands::Worktree::* classes with no post-processing. Their end-to-end
+#   coverage comes from the command integration tests:
+#     spec/integration/git/commands/worktree/add_spec.rb   (worktree_add)
+#     spec/integration/git/commands/worktree/prune_spec.rb (worktree_prune)
+#   worktree_list and worktrees_all (parser post-processing) and worktree_remove,
+#   worktree_move, worktree_lock, worktree_unlock, and worktree_repair (a
+#   Git::WorktreeInfo argument reaching git) are covered in
+#   spec/integration/git/repository/worktree_operations_spec.rb.
+#   worktree and worktrees are deprecated factory methods that construct domain
+#   objects (Git::Worktree and Git::Worktrees) without running git commands
+#   directly; their behavior is fully covered by the unit tests below.
 
 RSpec.describe Git::Repository::WorktreeOperations do
   let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
   let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
 
-  describe '#worktrees_all' do
-    subject(:result) { described_instance.worktrees_all }
+  # Build a real Git::WorktreeInfo (not an instance_double) so the examples that
+  # pass one to a facade method exercise Git::WorktreeInfo#to_s
+  def worktree_info(path:, head:, **overrides)
+    Git::WorktreeInfo.new(
+      path: path, head: head, branch: nil, bare: false, detached: false,
+      locked: false, lock_reason: nil, prunable: false, prune_reason: nil, **overrides
+    )
+  end
+
+  let(:main_info) do
+    worktree_info(
+      path: '/path/to/main', head: '4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a', branch: 'refs/heads/main'
+    )
+  end
+
+  let(:linked_info) do
+    worktree_info(
+      path: '/tmp/feature', head: 'b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1', branch: 'refs/heads/feature'
+    )
+  end
+
+  let(:bare_info) { worktree_info(path: '/path/to/repo.git', head: nil, bare: true) }
+
+  describe '#worktree_list' do
+    subject(:result) { described_instance.worktree_list }
 
     let(:list_command) { instance_double(Git::Commands::Worktree::List) }
-    let(:list_result) { command_result('') }
+    let(:list_result) { command_result('porcelain output') }
+    let(:parsed_worktrees) { [main_info, linked_info] }
 
     before do
       allow(Git::Commands::Worktree::List).to receive(:new).with(execution_context).and_return(list_command)
       allow(list_command).to receive(:call).with(porcelain: true).and_return(list_result)
+      allow(Git::Parsers::Worktree).to receive(:parse_list).with('porcelain output').and_return(parsed_worktrees)
     end
 
     it 'constructs Git::Commands::Worktree::List with the execution context' do
       expect(Git::Commands::Worktree::List).to receive(:new).with(execution_context).and_return(list_command)
-      described_instance.worktrees_all
+      result
     end
 
-    it 'calls #call with porcelain: true' do
-      expect(list_command).to receive(:call).with(porcelain: true).and_return(list_result)
-      described_instance.worktrees_all
+    it 'lists worktrees in porcelain format then parses the output' do
+      expect(list_command).to receive(:call).with(porcelain: true).and_return(list_result).ordered
+      expect(Git::Parsers::Worktree).to(
+        receive(:parse_list).with('porcelain output').and_return(parsed_worktrees).ordered
+      )
+
+      expect(result).to eq(parsed_worktrees)
     end
 
-    context 'when the output is empty (no worktrees reported)' do
+    context 'when no worktrees are reported' do
+      let(:parsed_worktrees) { [] }
+
+      it 'returns an empty array' do
+        expect(result).to eq([])
+      end
+    end
+  end
+
+  describe '#worktrees_all' do
+    subject(:result) { described_instance.worktrees_all }
+
+    let(:list_command) { instance_double(Git::Commands::Worktree::List) }
+    let(:list_result) { command_result('porcelain output') }
+    let(:parsed_worktrees) { [main_info, linked_info] }
+
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+      allow(Git::Commands::Worktree::List).to receive(:new).with(execution_context).and_return(list_command)
+      allow(list_command).to receive(:call).with(porcelain: true).and_return(list_result)
+      allow(Git::Parsers::Worktree).to receive(:parse_list).with('porcelain output').and_return(parsed_worktrees)
+    end
+
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#worktrees_all is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#worktree_list instead.'
+      )
+      result
+    end
+
+    it 'lists worktrees in porcelain format then parses the output' do
+      expect(list_command).to receive(:call).with(porcelain: true).and_return(list_result).ordered
+      expect(Git::Parsers::Worktree).to(
+        receive(:parse_list).with('porcelain output').and_return(parsed_worktrees).ordered
+      )
+
+      result
+    end
+
+    it 'returns a [directory, sha] pair for each worktree' do
+      expect(result).to eq(
+        [
+          ['/path/to/main', '4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a'],
+          ['/tmp/feature', 'b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1']
+        ]
+      )
+    end
+
+    context 'when no worktrees are reported' do
+      let(:parsed_worktrees) { [] }
+
       it 'returns an empty array' do
         expect(result).to eq([])
       end
     end
 
-    context 'when there is one worktree' do
-      let(:list_result) do
-        command_result(
-          "worktree /path/to/main\n" \
-          "HEAD 4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a\n" \
-          "branch refs/heads/main\n"
-        )
-      end
+    context 'when the listing includes a bare main worktree' do
+      let(:parsed_worktrees) { [bare_info, linked_info] }
 
-      it 'returns a single [directory, sha] pair' do
-        expect(result).to eq(
-          [['/path/to/main', '4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a']]
-        )
-      end
-    end
-
-    context 'when there are multiple worktrees' do
-      let(:list_result) do
-        command_result(
-          "worktree /path/to/main\n" \
-          "HEAD 4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a\n" \
-          "branch refs/heads/main\n" \
-          "\n" \
-          "worktree /tmp/worktree-1\n" \
-          "HEAD b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1\n" \
-          "detached\n"
-        )
-      end
-
-      it 'returns a [directory, sha] pair for each worktree' do
-        expect(result).to eq(
-          [
-            ['/path/to/main', '4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a'],
-            ['/tmp/worktree-1', 'b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1']
-          ]
-        )
-      end
-    end
-
-    context 'when a worktree path contains spaces' do
-      let(:list_result) do
-        command_result(
-          "worktree /path/to/main\n" \
-          "HEAD 4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a\n" \
-          "branch refs/heads/main\n" \
-          "\n" \
-          "worktree /tmp/worktree with spaces\n" \
-          "HEAD b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1\n" \
-          "detached\n"
-        )
-      end
-
-      it 'preserves the full directory path when parsing worktree entries' do
-        expect(result).to eq(
-          [
-            ['/path/to/main', '4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a'],
-            ['/tmp/worktree with spaces', 'b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1']
-          ]
-        )
-      end
-    end
-
-    context 'when git output uses CRLF line endings' do
-      let(:list_result) do
-        command_result(
-          "worktree /path/to/main\r\n" \
-          "HEAD 4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a\r\n" \
-          "branch refs/heads/main\r\n" \
-          "\r\n" \
-          "worktree /tmp/worktree with spaces\r\n" \
-          "HEAD b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1\r\n" \
-          "detached\r\n"
-        )
-      end
-
-      it 'parses entries without carriage returns in directory or sha values' do
-        expect(result).to eq(
-          [
-            ['/path/to/main', '4bef5ab0c8e7c19c6be2c0f55ccd45eec1f3d32a'],
-            ['/tmp/worktree with spaces', 'b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1']
-          ]
-        )
+      it 'omits the bare worktree, which has no HEAD' do
+        expect(result).to eq([['/tmp/feature', 'b8c63202c3c0ebd37b7e45fd0c22e6c20d5bead1']])
       end
     end
   end
@@ -178,29 +182,227 @@ RSpec.describe Git::Repository::WorktreeOperations do
   end
 
   describe '#worktree_remove' do
-    subject(:result) { described_instance.worktree_remove(dir) }
+    subject(:result) { described_instance.worktree_remove(worktree) }
 
-    let(:dir) { '/tmp/feature' }
+    let(:worktree) { '/tmp/feature' }
     let(:remove_command) { instance_double(Git::Commands::Worktree::Remove) }
     let(:remove_result) { command_result('') }
 
     before do
       allow(Git::Commands::Worktree::Remove).to receive(:new).with(execution_context).and_return(remove_command)
-      allow(remove_command).to receive(:call).with(dir).and_return(remove_result)
+      allow(remove_command).to receive(:call).with('/tmp/feature').and_return(remove_result)
     end
 
     it 'constructs Git::Commands::Worktree::Remove with the execution context' do
       expect(Git::Commands::Worktree::Remove).to receive(:new).with(execution_context).and_return(remove_command)
-      described_instance.worktree_remove(dir)
+      result
     end
 
-    it 'calls #call with the directory' do
-      expect(remove_command).to receive(:call).with(dir).and_return(remove_result)
-      described_instance.worktree_remove(dir)
+    context 'when given a String path' do
+      it 'calls #call with the path' do
+        expect(remove_command).to receive(:call).with('/tmp/feature').and_return(remove_result)
+        result
+      end
+
+      it 'returns the stdout string' do
+        expect(result).to eq('')
+      end
     end
 
-    it 'returns the stdout string' do
-      expect(result).to eq('')
+    context 'when given a Git::WorktreeInfo' do
+      let(:worktree) { linked_info }
+
+      it 'calls #call with the path of the worktree' do
+        expect(remove_command).to receive(:call).with('/tmp/feature').and_return(remove_result)
+        result
+      end
+    end
+  end
+
+  describe '#worktree_move' do
+    subject(:result) { described_instance.worktree_move(worktree, new_path) }
+
+    let(:worktree) { '/tmp/feature' }
+    let(:new_path) { '/tmp/feature-moved' }
+    let(:move_command) { instance_double(Git::Commands::Worktree::Move) }
+    let(:move_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Worktree::Move).to receive(:new).with(execution_context).and_return(move_command)
+      allow(move_command).to receive(:call).and_return(move_result)
+    end
+
+    it 'constructs Git::Commands::Worktree::Move with the execution context' do
+      expect(Git::Commands::Worktree::Move).to receive(:new).with(execution_context).and_return(move_command)
+      result
+    end
+
+    context 'when given a String path' do
+      it 'calls #call with the path and the new path' do
+        expect(move_command).to receive(:call).with('/tmp/feature', '/tmp/feature-moved').and_return(move_result)
+        result
+      end
+
+      it 'returns the stdout string' do
+        expect(result).to eq('')
+      end
+    end
+
+    context 'when given a Git::WorktreeInfo' do
+      let(:worktree) { linked_info }
+
+      it 'calls #call with the path of the worktree and the new path' do
+        expect(move_command).to receive(:call).with('/tmp/feature', '/tmp/feature-moved').and_return(move_result)
+        result
+      end
+    end
+
+    context 'with the force option' do
+      it 'forwards force: to #call' do
+        expect(move_command).to(
+          receive(:call).with('/tmp/feature', '/tmp/feature-moved', force: true).and_return(move_result)
+        )
+        described_instance.worktree_move(worktree, new_path, force: true)
+      end
+    end
+
+    context 'signature compatibility' do
+      it 'accepts the options as a positional Hash' do
+        expect(move_command).to(
+          receive(:call).with('/tmp/feature', '/tmp/feature-moved', force: true).and_return(move_result)
+        )
+        described_instance.worktree_move(worktree, new_path, { force: true })
+      end
+    end
+  end
+
+  describe '#worktree_lock' do
+    subject(:result) { described_instance.worktree_lock(worktree) }
+
+    let(:worktree) { '/tmp/feature' }
+    let(:lock_command) { instance_double(Git::Commands::Worktree::Lock) }
+    let(:lock_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Worktree::Lock).to receive(:new).with(execution_context).and_return(lock_command)
+      allow(lock_command).to receive(:call).and_return(lock_result)
+    end
+
+    it 'constructs Git::Commands::Worktree::Lock with the execution context' do
+      expect(Git::Commands::Worktree::Lock).to receive(:new).with(execution_context).and_return(lock_command)
+      result
+    end
+
+    context 'when given a String path' do
+      it 'calls #call with the path' do
+        expect(lock_command).to receive(:call).with('/tmp/feature').and_return(lock_result)
+        result
+      end
+
+      it 'returns the stdout string' do
+        expect(result).to eq('')
+      end
+    end
+
+    context 'when given a Git::WorktreeInfo' do
+      let(:worktree) { linked_info }
+
+      it 'calls #call with the path of the worktree' do
+        expect(lock_command).to receive(:call).with('/tmp/feature').and_return(lock_result)
+        result
+      end
+    end
+
+    context 'with the reason option' do
+      it 'forwards reason: to #call' do
+        expect(lock_command).to receive(:call).with('/tmp/feature', reason: 'on NFS share').and_return(lock_result)
+        described_instance.worktree_lock(worktree, reason: 'on NFS share')
+      end
+    end
+
+    context 'signature compatibility' do
+      it 'accepts the options as a positional Hash' do
+        expect(lock_command).to receive(:call).with('/tmp/feature', reason: 'on NFS share').and_return(lock_result)
+        described_instance.worktree_lock(worktree, { reason: 'on NFS share' })
+      end
+    end
+  end
+
+  describe '#worktree_unlock' do
+    subject(:result) { described_instance.worktree_unlock(worktree) }
+
+    let(:worktree) { '/tmp/feature' }
+    let(:unlock_command) { instance_double(Git::Commands::Worktree::Unlock) }
+    let(:unlock_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Worktree::Unlock).to receive(:new).with(execution_context).and_return(unlock_command)
+      allow(unlock_command).to receive(:call).with('/tmp/feature').and_return(unlock_result)
+    end
+
+    it 'constructs Git::Commands::Worktree::Unlock with the execution context' do
+      expect(Git::Commands::Worktree::Unlock).to receive(:new).with(execution_context).and_return(unlock_command)
+      result
+    end
+
+    context 'when given a String path' do
+      it 'calls #call with the path' do
+        expect(unlock_command).to receive(:call).with('/tmp/feature').and_return(unlock_result)
+        result
+      end
+
+      it 'returns the stdout string' do
+        expect(result).to eq('')
+      end
+    end
+
+    context 'when given a Git::WorktreeInfo' do
+      let(:worktree) { linked_info }
+
+      it 'calls #call with the path of the worktree' do
+        expect(unlock_command).to receive(:call).with('/tmp/feature').and_return(unlock_result)
+        result
+      end
+    end
+  end
+
+  describe '#worktree_repair' do
+    let(:repair_command) { instance_double(Git::Commands::Worktree::Repair) }
+    let(:repair_result) { command_result('') }
+
+    before do
+      allow(Git::Commands::Worktree::Repair).to receive(:new).with(execution_context).and_return(repair_command)
+      allow(repair_command).to receive(:call).and_return(repair_result)
+    end
+
+    it 'constructs Git::Commands::Worktree::Repair with the execution context' do
+      expect(Git::Commands::Worktree::Repair).to receive(:new).with(execution_context).and_return(repair_command)
+      described_instance.worktree_repair
+    end
+
+    context 'when no paths are given' do
+      it 'calls #call with no arguments' do
+        expect(repair_command).to receive(:call).with(no_args).and_return(repair_result)
+        described_instance.worktree_repair
+      end
+
+      it 'returns the stdout string' do
+        expect(described_instance.worktree_repair).to eq('')
+      end
+    end
+
+    context 'when given a String path' do
+      it 'calls #call with the path' do
+        expect(repair_command).to receive(:call).with('/tmp/feature').and_return(repair_result)
+        described_instance.worktree_repair('/tmp/feature')
+      end
+    end
+
+    context 'when given several paths including a Git::WorktreeInfo' do
+      it 'calls #call with the path of each worktree' do
+        expect(repair_command).to receive(:call).with('/tmp/other', '/tmp/feature').and_return(repair_result)
+        described_instance.worktree_repair('/tmp/other', linked_info)
+      end
     end
   end
 
@@ -237,6 +439,19 @@ RSpec.describe Git::Repository::WorktreeOperations do
     let(:commitish) { nil }
     let(:worktree_double) { instance_double(Git::Worktree) }
 
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+      allow(Git::Worktree).to receive(:new).and_return(worktree_double)
+    end
+
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#worktree is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#worktree_add and Git::Repository#worktree_remove instead.'
+      )
+      result
+    end
+
     context 'when called without a commitish' do
       it 'returns a Git::Worktree for the directory with no commitish' do
         expect(Git::Worktree).to receive(:new).with(described_instance, dir, nil).and_return(worktree_double)
@@ -258,6 +473,19 @@ RSpec.describe Git::Repository::WorktreeOperations do
     subject(:result) { described_instance.worktrees }
 
     let(:worktrees_collection) { instance_double(Git::Worktrees) }
+
+    before do
+      allow(Git::Deprecation).to receive(:warn)
+      allow(Git::Worktrees).to receive(:new).with(described_instance).and_return(worktrees_collection)
+    end
+
+    it 'emits a deprecation warning via Git::Deprecation.warn' do
+      expect(Git::Deprecation).to receive(:warn).with(
+        'Git::Repository#worktrees is deprecated and will be removed in v6.0.0. ' \
+        'Use Git::Repository#worktree_list instead.'
+      )
+      result
+    end
 
     it 'returns a Git::Worktrees collection for all worktrees' do
       expect(Git::Worktrees).to receive(:new).with(described_instance).and_return(worktrees_collection)

--- a/spec/unit/git/worktree_info_spec.rb
+++ b/spec/unit/git/worktree_info_spec.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Git::WorktreeInfo do
+  # Default attributes describing a linked worktree with a branch checked out
+  let(:default_attrs) do
+    {
+      path: '/tmp/wt/linked',
+      head: 'f3e2c1ffb860086504eeb27b77a1d0028b68fd8f',
+      branch: 'refs/heads/linked',
+      bare: false,
+      detached: false,
+      locked: false,
+      lock_reason: nil,
+      prunable: false,
+      prune_reason: nil
+    }
+  end
+
+  describe '#initialize' do
+    subject(:info) { described_class.new(**default_attrs) }
+
+    it 'stores all members' do
+      expect(info).to have_attributes(**default_attrs)
+    end
+
+    context 'with a bare main worktree' do
+      subject(:info) do
+        described_class.new(**default_attrs, path: '/tmp/repo.git', head: nil, branch: nil, bare: true)
+      end
+
+      it 'has a nil head and branch' do
+        expect(info).to have_attributes(path: '/tmp/repo.git', head: nil, branch: nil, bare: true)
+      end
+    end
+
+    context 'with a detached worktree' do
+      subject(:info) { described_class.new(**default_attrs, branch: nil, detached: true) }
+
+      it 'has a nil branch' do
+        expect(info).to have_attributes(branch: nil, detached: true)
+      end
+    end
+  end
+
+  describe '#bare?' do
+    it 'returns true when bare is true' do
+      info = described_class.new(**default_attrs, head: nil, branch: nil, bare: true)
+      expect(info.bare?).to be true
+    end
+
+    it 'returns false when bare is false' do
+      info = described_class.new(**default_attrs)
+      expect(info.bare?).to be false
+    end
+  end
+
+  describe '#detached?' do
+    it 'returns true when detached is true' do
+      info = described_class.new(**default_attrs, branch: nil, detached: true)
+      expect(info.detached?).to be true
+    end
+
+    it 'returns false when detached is false' do
+      info = described_class.new(**default_attrs)
+      expect(info.detached?).to be false
+    end
+  end
+
+  describe '#locked?' do
+    it 'returns true when locked is true' do
+      info = described_class.new(**default_attrs, locked: true, lock_reason: 'on purpose')
+      expect(info.locked?).to be true
+    end
+
+    it 'returns true when locked without a reason' do
+      info = described_class.new(**default_attrs, locked: true, lock_reason: nil)
+      expect(info.locked?).to be true
+    end
+
+    it 'returns false when locked is false' do
+      info = described_class.new(**default_attrs)
+      expect(info.locked?).to be false
+    end
+  end
+
+  describe '#prunable?' do
+    it 'returns true when prunable is true' do
+      info = described_class.new(
+        **default_attrs, prunable: true, prune_reason: 'gitdir file points to non-existent location'
+      )
+      expect(info.prunable?).to be true
+    end
+
+    it 'returns false when prunable is false' do
+      info = described_class.new(**default_attrs)
+      expect(info.prunable?).to be false
+    end
+  end
+
+  describe '#to_s' do
+    it 'returns the worktree path' do
+      info = described_class.new(**default_attrs)
+      expect(info.to_s).to eq('/tmp/wt/linked')
+    end
+  end
+
+  describe 'immutability' do
+    it 'is frozen' do
+      info = described_class.new(**default_attrs)
+      expect(info).to be_frozen
+    end
+  end
+
+  describe 'equality' do
+    it 'considers two infos with the same attributes equal' do
+      expect(described_class.new(**default_attrs)).to eq(described_class.new(**default_attrs))
+    end
+
+    it 'considers two infos with different attributes not equal' do
+      info1 = described_class.new(**default_attrs)
+      info2 = described_class.new(**default_attrs, path: '/tmp/wt/other')
+      expect(info1).not_to eq(info2)
+    end
+  end
+end

--- a/spec/unit/git/worktree_spec.rb
+++ b/spec/unit/git/worktree_spec.rb
@@ -11,6 +11,8 @@ RSpec.describe Git::Worktree do
   let(:base) { instance_double(Git::Repository) }
   let(:dir)  { '/path/to/wt' }
 
+  before { allow(Git::Deprecation).to receive(:warn) }
+
   # ---------------------------------------------------------------------------
   # #initialize
   # ---------------------------------------------------------------------------
@@ -23,6 +25,11 @@ RSpec.describe Git::Worktree do
     context 'when gcommit is nil' do
       it 'sets both full and dir to the path' do
         expect(instance).to have_attributes(full: dir, dir: dir)
+      end
+
+      it 'does not emit a deprecation warning' do
+        expect(Git::Deprecation).not_to receive(:warn)
+        instance
       end
     end
 
@@ -52,6 +59,14 @@ RSpec.describe Git::Worktree do
         allow(base).to receive(:gcommit).with(dir).and_return(commit_object)
       end
 
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Worktree#gcommit is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::WorktreeInfo#head from Git::Repository#worktree_list instead.'
+        )
+        wt.gcommit
+      end
+
       it 'calls base.gcommit with the full descriptor' do
         expect(base).to receive(:gcommit).with(dir)
         wt.gcommit
@@ -70,6 +85,14 @@ RSpec.describe Git::Worktree do
 
     context 'when a gcommit was given at construction' do
       let(:gcommit) { 'abc123' }
+
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Worktree#gcommit is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::WorktreeInfo#head from Git::Repository#worktree_list instead.'
+        )
+        wt.gcommit
+      end
 
       it 'returns the pre-set gcommit' do
         expect(result).to eq(gcommit)
@@ -92,6 +115,15 @@ RSpec.describe Git::Worktree do
 
     context 'when base is a Git::Repository (new form)' do
       context 'when gcommit is nil' do
+        it 'emits a deprecation warning via Git::Deprecation.warn' do
+          allow(base).to receive(:worktree_add).with(dir, nil).and_return('output')
+          expect(Git::Deprecation).to receive(:warn).with(
+            'Git::Worktree#add is deprecated and will be removed in v6.0.0. ' \
+            'Use Git::Repository#worktree_add instead.'
+          )
+          wt.add
+        end
+
         it 'calls worktree_add on base directly with dir and nil' do
           expect(base).to receive(:worktree_add).with(dir, nil).and_return('output')
           wt.add
@@ -117,6 +149,15 @@ RSpec.describe Git::Worktree do
     let(:wt) { described_class.new(base, dir) }
 
     context 'when base is a Git::Repository (new form)' do
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        allow(base).to receive(:worktree_remove).with(dir).and_return('')
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Worktree#remove is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#worktree_remove instead.'
+        )
+        wt.remove
+      end
+
       it 'calls worktree_remove on base directly with dir' do
         expect(base).to receive(:worktree_remove).with(dir).and_return('')
         wt.remove
@@ -136,6 +177,11 @@ RSpec.describe Git::Worktree do
 
     it 'returns an array containing just the dir' do
       expect(result).to eq([dir])
+    end
+
+    it 'does not emit a deprecation warning' do
+      expect(Git::Deprecation).not_to receive(:warn)
+      result
     end
 
     context 'when gcommit is set' do
@@ -159,6 +205,11 @@ RSpec.describe Git::Worktree do
 
     it 'returns the dir as the full descriptor' do
       expect(result).to eq(dir)
+    end
+
+    it 'does not emit a deprecation warning' do
+      expect(Git::Deprecation).not_to receive(:warn)
+      result
     end
 
     context 'when gcommit is set' do

--- a/spec/unit/git/worktrees_spec.rb
+++ b/spec/unit/git/worktrees_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe Git::Worktrees do
   let(:described_instance) { described_class.new(repo_base) }
 
   before do
+    allow(Git::Deprecation).to receive(:warn)
     allow(repo_base).to receive(:worktrees_all).and_return([
                                                              ['/repo',        'abc123'],
                                                              ['/repo/linked', 'def456']
@@ -42,6 +43,14 @@ RSpec.describe Git::Worktrees do
         allow(Git::Worktree).to receive(:new).with(base, '/repo/linked', 'def456').and_return(wt_linked)
       end
 
+      it 'emits a deprecation warning via Git::Deprecation.warn' do
+        expect(Git::Deprecation).to receive(:warn).with(
+          'Git::Worktrees is deprecated and will be removed in v6.0.0. ' \
+          'Use Git::Repository#worktree_list instead.'
+        )
+        described_class.new(base)
+      end
+
       it 'calls worktrees_all on base directly' do
         expect(base).to receive(:worktrees_all).and_return([])
         described_class.new(base)
@@ -55,6 +64,35 @@ RSpec.describe Git::Worktrees do
 
       it 'populates the collection with both worktrees' do
         expect(described_class.new(base).size).to eq(2)
+      end
+    end
+
+    context 'when worktrees_all itself emits a deprecation warning' do
+      let(:base) { instance_double(Git::Repository) }
+      let(:messages) { [] }
+
+      # Route real warnings to a collector so the silence in #initialize is
+      # exercised instead of bypassed by the stubbed Git::Deprecation.warn
+      around do |example|
+        original_behavior = Git::Deprecation.behavior
+        Git::Deprecation.behavior = ->(message, *) { messages << message }
+        example.run
+      ensure
+        Git::Deprecation.behavior = original_behavior
+      end
+
+      before do
+        allow(Git::Deprecation).to receive(:warn).and_call_original
+        allow(base).to receive(:worktrees_all) do
+          Git::Deprecation.warn('Git::Repository#worktrees_all is deprecated')
+          [['/repo', 'abc123']]
+        end
+        allow(Git::Worktree).to receive(:new).with(base, '/repo', 'abc123').and_return(wt_main)
+      end
+
+      it 'lets only the Git::Worktrees warning escape' do
+        described_class.new(base)
+        expect(messages).to contain_exactly(a_string_including('Git::Worktrees is deprecated'))
       end
     end
   end


### PR DESCRIPTION
## Summary

Implements the 5.x additive and deprecation half of the worktree redesign (#1731). Nothing here is a breaking change; the v6.0.0 removals stay on #1635.

- **`Git::WorktreeInfo`**: immutable `Data.define` carrying everything `git worktree list --porcelain` reports (`path`, `head`, `branch`, `bare`, `detached`, `locked` + `lock_reason`, `prunable` + `prune_reason`), with predicate readers and `to_s` returning the path.
- **`Git::Parsers::Worktree`**: parses the line-oriented porcelain output (the `-z` form needs git 2.36, above the 2.28.0 floor). Raises `Git::UnexpectedResultError` with the full output for a record without a `worktree` line or an unrecognized key. A C-quoted lock or prune reason is returned as git prints it, documented as a known limitation.
- **Facade**: `worktree_list` returns `Array<Git::WorktreeInfo>` in git's order. `worktrees_all` is reimplemented on the parser and keeps its `[path, head]` return, still omitting a bare main worktree. `worktree_remove` accepts a `WorktreeInfo` or a path. New `worktree_move`, `worktree_lock`, `worktree_unlock`, and `worktree_repair` take a positional `opts = {}` per ADR-0005 and pass options through to the command class. `worktree_add` and `worktree_prune` are unchanged.
- **Deprecations**: `Git::Worktrees#initialize`, `Git::Worktree#add`/`#remove`/`#gcommit`, and `Git::Repository#worktree`/`#worktrees`/`#worktrees_all` emit `Git::Deprecation.warn` naming their replacements and v6.0.0. `Git::Worktrees` silences the nested `worktrees_all` warning so one construction emits one warning. The `Git::Worktree` readers do not warn.
- **UPGRADING.md**: a `Git::Worktree and Git::Worktrees deprecated` section mapping every legacy idiom to its replacement, including the `gcommit` dual-return quirk and the bare-worktree omission in `worktrees_all`.

## Commits

A single `feat(worktree)` commit carrying the implementation, the `lib/git.rb` require, `UPGRADING.md`, and the unit and integration specs for the value object, the parser, the facade methods, and every deprecation warning.

## Review notes

Two rounds of Copilot review raised findings that were answered on their threads rather than changed:

- `Git::Parsers::Worktree.records` does not pass blank-line separator groups to the record parser. `Enumerable#chunk` drops every run whose block value is `:_separator`; a comment on the method now says so.
- The keyword-style calls in the specs and YARD examples (`worktree_move(a, b, force: 2)`) do not raise against the positional `opts = {}` signature. Ruby 3 removed only the hash-to-keywords conversion; keywords passed to a method with no keyword parameters still collect into the positional hash. ADR-0005 requires that signature so both call shapes work.

## Verification

`bundle exec rake default` (unit and integration specs, rubocop, markdown links, yard, build) passes with no new YARD warnings. The `worktree_repair` integration tests are guarded on git 2.29.0.

Closes #1731
