### PR TITLE
docs(upgrading): remove two misplaced rows from the configuration methods table

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -375,8 +375,6 @@ purpose-named methods.
 | `g.global_config(name)` | `g.config_get(name, global: true)` |
 | `g.global_config` | `g.config_list(global: true)` |
 | `g.global_config(name, value)` | `g.config_set(name, value, global: true)` |
-| `g.parse_config(file)` | `g.config_list(file: file)` |
-| `g.stash_list` | `g.stash_infos` — returns `Array<Git::StashInfo>`; see [Legacy stash API deprecated](#legacy-stash-api-deprecated) |
 
 #### `Git` module mixin deprecations
 


### PR DESCRIPTION
Closes #1761

## What changed

Removes two rows from the "v4.x-style configuration methods" table in `UPGRADING.md`:

- `g.parse_config(file)` → `g.config_list(file: file)`. There is no `Git::Repository#parse_config` in v5.x; the call raises `NoMethodError`. The `#lib` shim section already lists `g.lib.parse_config(file)` under "Methods that raise `NoMethodError` in v5.x" with the same replacement, and that row is now the only mention.
- `g.stash_list` → `g.stash_infos`. This is a stash method, not a configuration method. The "Legacy stash API deprecated" section still documents it in full, including the v6.0.0 return-type change.

After this change the configuration table lists only configuration methods that work in v5.x with a deprecation warning. Nothing in `lib/` changes.

## Verification

`bundle exec rake` passes, including the markdown lint.
