### PR TITLE
docs(upgrading): document the Git::Repository option renames

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,6 +17,7 @@ to update your code when upgrading from the preceding major version.
   - [Deprecated methods](#deprecated-methods)
     - [Facade method renames](#facade-method-renames)
     - [`Git::Repository` method renames](#gitrepository-method-renames)
+    - [`Git::Repository` option renames](#gitrepository-option-renames)
     - [v4.x-style configuration methods](#v4x-style-configuration-methods)
     - [`Git` module mixin deprecations](#git-module-mixin-deprecations)
     - [Module-level `Git` function deprecations](#module-level-git-function-deprecations)
@@ -389,6 +390,38 @@ replacement returns, except `branches_all`.
 | `g.is_remote_branch?(name)` | `g.remote_branch?(name)` |
 | `g.is_branch?(name)` | `g.branch?(name)` |
 | `g.branches_all` | `g.branch_list` — returns `Array<Git::BranchInfo>`; see the return shape change above |
+
+#### `Git::Repository` option renames
+
+Five methods accept a v4.x option or positional argument under its old name.
+The old form still works in v5.x but emits a deprecation warning and is
+translated to the v5.x form shown below.
+
+> **`clean`:** `force: 2` runs `git clean -ff`, which also removes untracked
+> nested git repositories. A `false` or `nil` value for `:ff` or `:force_force`
+> still warns and has no effect; a value other than `true`, `false`, or `nil`
+> raises `ArgumentError`. When the deprecated key is `true` and a valid
+> `:force` is also given, `:force` is raised to `2` (a `:force` already at `2`
+> is unchanged). An invalid `:force` value such as `0` is passed through
+> unchanged and still raises `ArgumentError`; the deprecated key does not mask
+> it.
+
+> **`diff_path_status`:** `:path_limiter` accepts the same values as `:path`
+> (a `String`, a `Pathname`, or an `Array` of them). When both keys are given,
+> `:path_limiter` wins and no warning is emitted.
+
+> **`set_working` and `set_index`:** `must_exist:` defaults to `true`. When
+> both the positional argument and `must_exist:` are given, they are OR'ed so
+> the more restrictive value wins.
+
+| Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
+|-----------------------------------------------------|-------------|
+| `g.clean(ff: true)` | `g.clean(force: 2)` |
+| `g.clean(force_force: true)` | `g.clean(force: 2)` |
+| `g.diff_path_status(ref1, ref2, path: p)` | `g.diff_path_status(ref1, ref2, path_limiter: p)` |
+| `g.commit(message, add_all: true)` | `g.commit(message, all: true)` — runs `git commit -a` |
+| `g.set_working(dir, check)` | `g.set_working(dir, must_exist: check)` |
+| `g.set_index(file, check)` | `g.set_index(file, must_exist: check)` |
 
 #### v4.x-style configuration methods
 


### PR DESCRIPTION
# Description

Adds an `UPGRADING.md` entry for the five `Git::Repository` methods that still accept a
v4.x option or positional argument under its old name: `clean` (`:ff`, `:force_force`),
`diff_path_status` (`:path`), `commit` (`:add_all`), and `set_working` / `set_index`
(positional `check`). Each emits a v6.0.0 deprecation warning, but none was listed in
`UPGRADING.md`, so under ADR-0007 their removal could not merge.

The new section sits under "Deprecated methods" next to "Facade method renames" and is
linked from the table of contents. Each replacement and precedence note was checked
against the facade code:

- `clean`: `:ff` / `:force_force` translate to `force: 2`. `false` and `nil` still warn
  with no effect; values other than `true`, `false`, or `nil` raise `ArgumentError`.
  Combined with an explicit `:force`, a valid value is raised to `2` rather than
  replaced, which is why the note says "raised to `2`" instead of "the result is
  `force: 2`". An invalid `:force` such as `0` passes through and still raises
  `ArgumentError`.
- `diff_path_status`: `:path_limiter` wins when both keys are given, and no warning fires.
- `commit`: `:add_all` maps to `:all` (`git commit -a`).
- `set_working` / `set_index`: `must_exist:` defaults to `true`; the positional argument and
  `must_exist:` are OR'ed when both are given.

No changes under `lib/`.

Closes #1766

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed (documentation-only change; no tests affected).
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).
