### PR TITLE
docs(upgrading): document the Git::Log Enumerable and Commit#set_commit deprecations

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -32,6 +32,8 @@ to update your code when upgrading from the preceding major version.
     - [`Git::Status` deprecated](#gitstatus-deprecated)
     - [`Git::Worktree` and `Git::Worktrees` deprecated](#gitworktree-and-gitworktrees-deprecated)
     - [`Git.clone` option renames](#gitclone-option-renames)
+    - [`Git::Log` Enumerable interface deprecated](#gitlog-enumerable-interface-deprecated)
+    - [`Git::Object::Commit#set_commit` deprecated](#gitobjectcommitset_commit-deprecated)
 
 ## Upgrading to v6.0.0
 
@@ -1072,5 +1074,47 @@ replacement option, except that `:path` is dropped when `:chdir` is also given.
 | `Git.clone(url, dir, path: p)` | `Git.clone(url, dir, chdir: p)` |
 | `Git.clone(url, dir, recursive: true)` | `Git.clone(url, dir, recurse_submodules: true)` — or a pathspec `String` or `Array<String>` for a subset of submodules |
 | `Git.clone(url, dir, remote: name)` | `Git.clone(url, dir, origin: name)` |
+
+#### `Git::Log` Enumerable interface deprecated
+
+`Git::Log` is a query builder. Calling `each`, `size`, `to_s`, `first`, `last`, or
+`[]` directly on it runs the query and emits a deprecation warning; those methods
+are removed in v6.0.0. Call `Git::Log#execute` instead. It runs the query and
+returns a `Git::Log::Result`, which includes `Enumerable` and provides the same
+six methods. The chainable query methods on `Git::Log` (`since`, `author`,
+`between`, `path`, `max_count`, and so on) are unchanged.
+
+`Git::Log` includes `Enumerable`, so every `Enumerable` method called on the
+builder (`map`, `select`, `count`, `to_a`, `include?`, and so on) goes through the
+deprecated `each` and emits its warning. Move those calls to the result as well,
+not only the six named methods.
+
+> **Snapshot results:** `execute` returns a snapshot. The builder re-runs
+> `git log` only when a query method (`since`, `max_count`, and so on) has been
+> called since the last run, even with the same value as before, so calling
+> `execute` twice on an untouched builder returns equal results without a second
+> `git log`. Keep the result object when a chain of operations needs the same
+> commits rather than calling `g.log` again, which builds a new query.
+
+In the table, `g` is a `Git::Repository`.
+
+| Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
+|-----------------------------------------------------|-------------|
+| `g.log.each { \|c\| ... }` | `g.log.execute.each { \|c\| ... }` |
+| `g.log.size` | `g.log.execute.size` |
+| `g.log.to_s` | `g.log.execute.to_s` — commits joined with newlines, as before |
+| `g.log.first`, `g.log.last` | `g.log.execute.first`, `g.log.execute.last` |
+| `g.log[i]`, `g.log[range]` | `g.log.execute[i]`, `g.log.execute[range]` |
+| any other `Enumerable` method on the log (`map`, `select`, `count`, `to_a`, `include?`, ...) | the same method on `g.log.execute` |
+
+#### `Git::Object::Commit#set_commit` deprecated
+
+`Git::Object::Commit#set_commit` is deprecated and is removed in v6.0.0. Call
+`from_data` instead; it takes the same parsed commit data hash and has the same
+effect.
+
+| Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
+|-----------------------------------------------------|-------------|
+| `commit.set_commit(data)` | `commit.from_data(data)` |
 
 ---

--- a/spec/unit/git/log_spec.rb
+++ b/spec/unit/git/log_spec.rb
@@ -367,9 +367,59 @@ RSpec.describe Git::Log::Result do
     end
   end
 
+  it 'responds to every method the deprecated Git::Log Enumerable interface provides' do
+    expect(result).to respond_to(:each, :size, :to_s, :first, :last, :[])
+  end
+
+  it 'is Enumerable' do
+    expect(result).to be_a(Enumerable)
+  end
+
+  describe '#each' do
+    it 'yields each commit in query order' do
+      expect { |block| result.each(&block) }.to yield_successive_args(*commits)
+    end
+
+    it 'returns an enumerator over the commits when no block is given' do
+      expect(result.each.to_a).to eq(commits)
+    end
+  end
+
+  describe '#size' do
+    it 'returns the number of commits' do
+      expect(result.size).to eq(3)
+    end
+  end
+
   describe '#to_s' do
     it 'joins the commit string representations with newlines, leading with the first commit sha' do
       expect(result.to_s).to eq("aaa111\nbbb222\nccc333")
+    end
+  end
+
+  describe '#first' do
+    it 'returns the first commit' do
+      expect(result.first).to be(commits.first)
+    end
+  end
+
+  describe '#last' do
+    it 'returns the last commit' do
+      expect(result.last).to be(commits.last)
+    end
+  end
+
+  describe '#[]' do
+    it 'returns the commit at an integer index' do
+      expect(result[1]).to be(commits[1])
+    end
+
+    it 'returns the commits in a range' do
+      expect(result[0..1]).to eq(commits[0..1])
+    end
+
+    it 'returns nil for an index past the end' do
+      expect(result[3]).to be_nil
     end
   end
 end


### PR DESCRIPTION
## Summary

Closes #1764.

Two object-layer deprecations already emit a v6.0.0 warning but had no entry in `UPGRADING.md`. Under ADR-0007 their removal cannot merge until the entry has shipped in a normal release. This PR adds the entries and changes nothing under `lib/`.

- **`Git::Log` Enumerable interface deprecated**: maps `each`, `size`, `to_s`, `first`, `last`, `[]`, and the general `Enumerable` case to their `Git::Log#execute` forms, and states the snapshot behavior of `execute`.
- **`Git::Object::Commit#set_commit` deprecated**: maps `set_commit(data)` to `from_data(data)`.
- Adds table of contents entries for both sections.
- Adds unit specs verifying that `Git::Log::Result` responds to `each`, `size`, `to_s`, `first`, `last`, and `[]` as the entry claims.

## Acceptance criteria

- [x] `UPGRADING.md` maps each deprecated `Git::Log` call, including the general `Enumerable` case, to its `execute` form and states the snapshot behavior
- [x] `UPGRADING.md` maps `set_commit` to `from_data`
- [x] The table of contents lists the new sections
- [x] `Git::Log::Result` is verified to respond to `each`, `size`, `to_s`, `first`, `last`, and `[]` as the entry claims
- [x] `bundle exec rake` passes (unit and integration specs, RuboCop, lychee link and anchor check, YARD)
