### PR TITLE
docs: document the Git.clone option renames in UPGRADING.md

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -30,6 +30,7 @@ to update your code when upgrading from the preceding major version.
     - [`Git::Object::Tag` deprecated](#gitobjecttag-deprecated)
     - [`Git::Status` deprecated](#gitstatus-deprecated)
     - [`Git::Worktree` and `Git::Worktrees` deprecated](#gitworktree-and-gitworktrees-deprecated)
+    - [`Git.clone` option renames](#gitclone-option-renames)
 
 ## Upgrading to v6.0.0
 
@@ -1017,5 +1018,26 @@ is the `Git::WorktreeInfo` that replaces it.
 | `wt.dir` | `info.path` |
 | `wt.full`, `wt.to_s` | `info.path` — or `"#{info.path} #{info.head}"` for the descriptor that entries from `g.worktrees` produced |
 | `wt.to_a` | `[info.path]` |
+
+#### `Git.clone` option renames
+
+Three `Git.clone` options were renamed in v5.x. The v4.x names still work. Each
+deprecated option present on a call emits its own deprecation warning, so a call
+that uses two of them warns twice. Each value is passed through to the
+replacement option, except that `:path` is dropped when `:chdir` is also given.
+
+> **Precedence and value notes:**
+> - `:path` and `:chdir` both run `git clone` from inside the given directory.
+>   When both are given, `:chdir` wins and `:path` is dropped.
+> - `:recursive` carries its value over to `:recurse_submodules` unchanged.
+>   `:recurse_submodules` also accepts a pathspec `String` or `Array<String>`
+>   to initialize only a subset of submodules, which `:recursive` never did.
+> - `:remote` and `:origin` have the same effect (`git clone --origin name`).
+
+| Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
+|-----------------------------------------------------|-------------|
+| `Git.clone(url, dir, path: p)` | `Git.clone(url, dir, chdir: p)` |
+| `Git.clone(url, dir, recursive: true)` | `Git.clone(url, dir, recurse_submodules: true)` — or a pathspec `String` or `Array<String>` for a subset of submodules |
+| `Git.clone(url, dir, remote: name)` | `Git.clone(url, dir, origin: name)` |
 
 ---


### PR DESCRIPTION
## Summary

`Git.clone` still accepts the v4.x `:path`, `:recursive`, and `:remote` options, warning once per call and translating each to its v5.x name. None of them had an `UPGRADING.md` entry, so a user clearing warnings had nothing to follow, and under ADR-0007 their v6.0.0 removal cannot merge until the entry has shipped in a normal release.

This PR adds a "`Git.clone` option renames" section under "Deprecated methods" and lists it in the table of contents. Nothing under `lib/` changes.

| Deprecated option | Replacement | Note |
|---|---|---|
| `path: p` | `chdir: p` | When both are given, `:chdir` wins and `:path` is dropped |
| `recursive: true` | `recurse_submodules: true` | Value carries over unchanged; `:recurse_submodules` also accepts a pathspec `String` or `Array<String>` |
| `remote: name` | `origin: name` | Same effect (`git clone --origin name`) |

## Verification

- Each mapping was checked against the translation helpers in `lib/git/factories.rb` and the option docs in `lib/git/commands/clone.rb`.
- `bundle exec rake` passes (unit and integration specs, RuboCop, markdown link check, YARD build/lint/example tests, gem build).

Closes #1763
