### PR TITLE
docs: name the 5.x maintenance branch and pin main to v6.0.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,5 +30,6 @@ fine to use `#` in footer values such as `Closes: #999` or `Refs: #999`.
 
 | Target | When |
 | --- | --- |
-| `main` | New features, breaking changes, all active development |
+| `main` | New features, breaking changes, all active development. Its next release is v6.0.0; every v5.x release is cut from `5.x` |
+| `5.x` | Security fixes, backward-compatible bug fixes, and backward-compatible features at the maintainers' discretion for the v5.x series |
 | `4.x` | Security fixes, backward-compatible bug fixes, and backward-compatible features at the maintainers' discretion for the v4.x series |

--- a/.github/skills/address-pr-feedback/SKILL.md
+++ b/.github/skills/address-pr-feedback/SKILL.md
@@ -37,9 +37,9 @@ plugin source to your context and proceed the same way.
 
 ## Changes and additions for ruby-git
 
-- **Protected branches** — never rewrite history on `main` or `4.x`. Wherever
-  the workflow says "the default branch or a release/maintenance branch", it
-  means exactly those two here.
+- **Protected branches** — never rewrite history on `main`, `5.x`, or `4.x`.
+  Wherever the workflow says "the default branch or a release/maintenance branch",
+  it means exactly those three here.
 - **Local CI** — before folding changes into commits, the project's local CI
   equivalent is:
 

--- a/.github/skills/development-workflow/SKILL.md
+++ b/.github/skills/development-workflow/SKILL.md
@@ -377,7 +377,7 @@ commit and complete the feature or bug fix.
      works on all platforms)
    - Then run in the terminal: `git push origin <branch>`
    - Then run in the terminal: `gh pr create --title "<title>" --base <target-branch> --body-file ./pr_body.md`
-     (choose `main` or `4.x` per the [branch strategy](../../../CONTRIBUTING.md))
+     (choose `main`, `5.x`, or `4.x` per the [branch strategy](../../../CONTRIBUTING.md))
 
    After creating the PR, verify the stored body with
    `gh pr view <number> --json body --jq '.body'`. If it is garbled, rewrite

--- a/.github/skills/pr-readiness-review/SKILL.md
+++ b/.github/skills/pr-readiness-review/SKILL.md
@@ -137,13 +137,14 @@ Execute and report results for:
 
 Before creating the PR, confirm the branch situation:
 
-- [ ] Changes are on a feature branch (not `main` or `4.x`), named
+- [ ] Changes are on a feature branch (not `main`, `5.x`, or `4.x`), named
   `<type>/<short-description>`
 - [ ] Branch targets the correct base: `main` for features/breaking changes;
-  `4.x` for security fixes and backward-compatible v4.x-only changes
+  `5.x` or `4.x` for security fixes and backward-compatible changes that apply only
+  to that series
 
 **If changes are on the wrong branch:** Create a new branch from the appropriate
-base (`origin/main` or `origin/4.x`) and relocate the existing work using the
+base (`origin/main`, `origin/5.x`, or `origin/4.x`) and relocate the existing work using the
 most appropriate Git approach — cherry-pick (specific commits), rebase (linear
 history), or recommit (uncommitted changes) — based on the situation.
 

--- a/.github/skills/rebase/SKILL.md
+++ b/.github/skills/rebase/SKILL.md
@@ -45,7 +45,7 @@ branch needs to be rebased onto `origin/main` and pushed.
 
 These rules are mandatory:
 
-- Never run this workflow on `main` or `4.x`.
+- Never run this workflow on `main`, `5.x`, or `4.x`.
 - Always fetch `origin` immediately before rebasing.
 - Always run rebase commands with `GIT_EDITOR=:` and `GIT_SEQUENCE_EDITOR=:` so
   no editor opens.
@@ -67,8 +67,8 @@ git status --short --branch
 git fetch --prune origin
 ```
 
-If the current branch is `main` or `4.x`, stop and ask the user to switch to a
-topic branch first.
+If the current branch is `main`, `5.x`, or `4.x`, stop and ask the user to switch to
+a topic branch first.
 
 If `git status --short --branch` shows uncommitted changes, stop and ask the
 user whether to commit or stash before continuing.

--- a/.github/skills/release-management/SKILL.md
+++ b/.github/skills/release-management/SKILL.md
@@ -131,9 +131,10 @@ and is checked when each removal PR merges, not here.
 - [ ] Replace the retired maintenance branch with the new one everywhere it is named:
       the push triggers in `release.yml`, `continuous_integration.yml`, and
       `enforce_conventional_commits.yml` under `.github/workflows/`, the branch tables
-      in `.github/copilot-instructions.md` and `CONTRIBUTING.md`, and the skills that
-      list the protected branches. `grep -rn '4\.x' .github CONTRIBUTING.md` finds
-      them all.
+      in `.github/copilot-instructions.md` and `CONTRIBUTING.md`, the release support
+      policy in `README.md`, the protected branch list in `.husky/pre-commit`, and the
+      skills that list the protected branches.
+      `grep -rn '4\.x' .github .husky CONTRIBUTING.md README.md` finds them all.
 - [ ] Close the milestone and update the roadmap issue.
 
 ## What NOT to Do

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main, 4.x]
+    branches: [main, 4.x, 5.x]
   workflow_dispatch:
 
 # Cancel an in-progress run when the same PR (or branch) gets a new push. For

--- a/.github/workflows/enforce_conventional_commits.yml
+++ b/.github/workflows/enforce_conventional_commits.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - main
       - 4.x
+      - 5.x
 
 # Cancel an in-progress run when the same PR gets a new push; only the commit messages
 # as they stand after the latest push are worth linting.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ name: Release Gem
 
 on:
   push:
-    branches: ["main", "4.x"]
+    branches: ["main", "4.x", "5.x"]
 
   workflow_dispatch:
 
@@ -38,6 +38,7 @@ jobs:
           token: ${{ secrets.AUTO_RELEASE_TOKEN }}
           config-file: .release-please-config.json
           manifest-file: .release-please-manifest.json
+          target-branch: ${{ github.ref_name }}
 
       - name: Setup ruby
         uses: ruby/setup-ruby@v1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,7 @@
 
 branch=$(git branch --show-current)
 
-protected_branches="main 4.x"
+protected_branches="main 5.x 4.x"
 
 for protected in $protected_branches; do
   if [ "$branch" = "$protected" ]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ bin/setup
 3. Run `npm install` (when npm is available) to install the Conventional Commit
    `commit-msg` hook used by this project (Husky + commitlint). A separate
    `pre-commit` hook is also installed that blocks direct commits to the
-   protected branches (`main`, `4.x`).
+   protected branches (`main`, `5.x`, `4.x`).
 4. Verify the toolchain by running `bundle exec rake --tasks`.
 
 `bin/setup` checks for [lychee](https://lychee.cli.rs) alongside Ruby, git, and
@@ -197,7 +197,7 @@ Once your pull request is ready for review, request a review from at least one
 
 During the review process, you may need to make additional commits; squash them.
 You will also need to rebase your branch onto the latest version of the target
-branch (e.g., `main` or `4.x`) before merging.
+branch (e.g., `main`, `5.x`, or `4.x`) before merging.
 
 At least one approval from a project maintainer is required before your pull request
 can be merged. The maintainer is responsible for ensuring that the pull request meets
@@ -219,11 +219,13 @@ first keeps the review cycle short.
 
 ## Branch strategy
 
-This project maintains two active branches:
+This project maintains `main` plus one maintenance branch for each supported previous
+major series:
 
 - **`main`**: All development. It releases the next version of the gem, including
-  the next major version.
-- **`4.x`**: The maintenance branch for the most recent previous major series. It
+  the next major version. Its next release is v6.0.0; every v5.x release is cut from
+  `5.x`.
+- **`5.x`** and **`4.x`**: The maintenance branches for the v5.x and v4.x series. Each
   receives bug fixes and security fixes, and backward-compatible features at the
   maintainers' discretion.
 
@@ -233,8 +235,10 @@ each major series is supported.
 When submitting a pull request:
 
 - **New features and breaking changes**: Target the `main` branch
-- **Bug fixes**: Target `main`, and maintainers will backport to `4.x` if applicable
-- **Security fixes**: Target both branches or `4.x` if the issue only affects v4.x
+- **Bug fixes**: Target `main`, and maintainers will backport to the maintenance
+  branches if applicable
+- **Security fixes**: Target `main` and every affected maintenance branch, or only a
+  maintenance branch if the issue affects that series alone
 
 Removing a deprecated API follows the
 [deprecation policy](.github/skills/breaking-change-analysis/SKILL.md#step-4-deprecation-policy):
@@ -1088,8 +1092,8 @@ $ LIST_UNCOVERED_DETAIL=true bundle exec rake spec:unit
 $ open coverage/index.html
 ```
 
-This policy applies to `main` only. The `4.x` maintenance branch predates it and is
-not held to these thresholds.
+This policy applies to `main` and `5.x`. The `4.x` maintenance branch predates it and
+is not held to these thresholds.
 
 #### Unit tests vs integration tests
 

--- a/README.md
+++ b/README.md
@@ -447,12 +447,13 @@ are in [UPGRADING.md](UPGRADING.md#upgrading-to-v600). See
 ### Release support policy
 
 All development happens on `main`, which releases the next version of the gem,
-including the next major version.
+including the next major version. The next release from `main` is v6.0.0. Every
+further v5.x release is cut from `5.x`.
 
-The most recent previous major series is maintained on a branch named for that
-series, currently `4.x`. It receives bug fixes and security fixes, and
-backward-compatible features at the maintainers' discretion. Fixes land on `main`
-first and are backported, except a fix for a problem that exists only in the
+Each supported previous major series is maintained on a branch named for that
+series, currently `5.x` and `4.x`. These branches receive bug fixes and security
+fixes, and backward-compatible features at the maintainers' discretion. Fixes land on
+`main` first and are backported, except a fix for a problem that exists only in a
 maintenance branch, which targets that branch directly.
 
 Support for a major series ends when the second major after it is released. v4.x is


### PR DESCRIPTION
## Summary

The `5.x` maintenance branch was cut from v5.4.1, and PR 1785 enables its workflows on that branch. This PR brings `main` in line with the branch cut.

- The docs commit is the same commit as on PR 1785, cherry-picked so both branches carry identical text. The branch strategy in `CONTRIBUTING.md`, the release support policy in `README.md`, the branch table in `.github/copilot-instructions.md`, the protected-branch list in `.husky/pre-commit`, and the skills that list protected branches now name `5.x` alongside `4.x`, and state that the next release from `main` is v6.0.0 with every v5.x release cut from `5.x`.
- `release-as: 6.0.0` in `.release-please-config.json` pins release-please on `main`, so a non-breaking commit merged before the first removal cannot open a v5.4.2 or v5.5.0 release PR from `main`. The key must be removed after v6.0.0 ships; the release-management checklist now records that step.

## Verification

`bundle exec rake markdown:links` passes locally. The `release-as` behavior is taken from the release-please manifest docs: it forces the next version and keeps applying until removed.
