### PR TITLE
docs: name the 5.x maintenance branch and pin main to v6.0.0

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,5 +30,6 @@ fine to use `#` in footer values such as `Closes: #999` or `Refs: #999`.
 
 | Target | When |
 | --- | --- |
-| `main` | New features, breaking changes, all active development |
+| `main` | New features, breaking changes, all active development. Its next release is v6.0.0; every further v5.x release is cut from `5.x` |
+| `5.x` | Security fixes, backward-compatible bug fixes, and backward-compatible features at the maintainers' discretion for the v5.x series |
 | `4.x` | Security fixes, backward-compatible bug fixes, and backward-compatible features at the maintainers' discretion for the v4.x series |

--- a/.github/skills/address-pr-feedback/SKILL.md
+++ b/.github/skills/address-pr-feedback/SKILL.md
@@ -37,9 +37,9 @@ plugin source to your context and proceed the same way.
 
 ## Changes and additions for ruby-git
 
-- **Protected branches** — never rewrite history on `main` or `4.x`. Wherever
-  the workflow says "the default branch or a release/maintenance branch", it
-  means exactly those two here.
+- **Protected branches** — never rewrite history on `main`, `5.x`, or `4.x`.
+  Wherever the workflow says "the default branch or a release/maintenance branch",
+  it means exactly those three here.
 - **Local CI** — before folding changes into commits, the project's local CI
   equivalent is:
 

--- a/.github/skills/development-workflow/SKILL.md
+++ b/.github/skills/development-workflow/SKILL.md
@@ -157,8 +157,10 @@ clean baseline, and create a clear implementation plan before writing any code.
 1. **Check Uncommitted Changes:** If there are any uncommitted changes in the
    project, ask the user what to do with them before continuing: include them in the
    current implementation plan, ignore them, or stash them before continuing.
-2. **Create Feature Branch:** Create a new branch from `origin/main` using the naming
-   convention `<type>/<short-description>` (e.g., `fix/issue-999`).
+2. **Create Feature Branch:** Decide the target branch first: `main`, `5.x`, or
+   `4.x` per the [branch strategy](../../../CONTRIBUTING.md#branch-strategy). Then
+   create a new branch from `origin/<target-branch>` using the naming convention
+   `<type>/<short-description>` (e.g., `fix/issue-999`).
 3. **Verify Project Setup:** Run `bin/setup` to ensure that the project is ready
    for development.
 4. **Verify Clean Baseline:** Ensure that all existing tests and linters pass by
@@ -377,7 +379,7 @@ commit and complete the feature or bug fix.
      works on all platforms)
    - Then run in the terminal: `git push origin <branch>`
    - Then run in the terminal: `gh pr create --title "<title>" --base <target-branch> --body-file ./pr_body.md`
-     (choose `main` or `4.x` per the [branch strategy](../../../CONTRIBUTING.md))
+     (the target branch chosen in Phase 1)
 
    After creating the PR, verify the stored body with
    `gh pr view <number> --json body --jq '.body'`. If it is garbled, rewrite

--- a/.github/skills/pr-readiness-review/SKILL.md
+++ b/.github/skills/pr-readiness-review/SKILL.md
@@ -137,13 +137,14 @@ Execute and report results for:
 
 Before creating the PR, confirm the branch situation:
 
-- [ ] Changes are on a feature branch (not `main` or `4.x`), named
+- [ ] Changes are on a feature branch (not `main`, `5.x`, or `4.x`), named
   `<type>/<short-description>`
 - [ ] Branch targets the correct base: `main` for features/breaking changes;
-  `4.x` for security fixes and backward-compatible v4.x-only changes
+  `5.x` or `4.x` for backports of fixes already on `main`, and for security fixes
+  and backward-compatible changes that apply only to that series
 
 **If changes are on the wrong branch:** Create a new branch from the appropriate
-base (`origin/main` or `origin/4.x`) and relocate the existing work using the
+base (`origin/main`, `origin/5.x`, or `origin/4.x`) and relocate the existing work using the
 most appropriate Git approach — cherry-pick (specific commits), rebase (linear
 history), or recommit (uncommitted changes) — based on the situation.
 

--- a/.github/skills/rebase/SKILL.md
+++ b/.github/skills/rebase/SKILL.md
@@ -45,7 +45,7 @@ branch needs to be rebased onto `origin/main` and pushed.
 
 These rules are mandatory:
 
-- Never run this workflow on `main` or `4.x`.
+- Never run this workflow on `main`, `5.x`, or `4.x`.
 - Always fetch `origin` immediately before rebasing.
 - Always run rebase commands with `GIT_EDITOR=:` and `GIT_SEQUENCE_EDITOR=:` so
   no editor opens.
@@ -67,8 +67,8 @@ git status --short --branch
 git fetch --prune origin
 ```
 
-If the current branch is `main` or `4.x`, stop and ask the user to switch to a
-topic branch first.
+If the current branch is `main`, `5.x`, or `4.x`, stop and ask the user to switch to
+a topic branch first.
 
 If `git status --short --branch` shows uncommitted changes, stop and ask the
 user whether to commit or stash before continuing.

--- a/.github/skills/release-management/SKILL.md
+++ b/.github/skills/release-management/SKILL.md
@@ -14,6 +14,7 @@ This workflow describes how releases are managed for the ruby-git gem.
 - [How Releases Work](#how-releases-work)
 - [Developer Responsibilities](#developer-responsibilities)
 - [Checking Release Readiness](#checking-release-readiness)
+- [Cutting a maintenance branch](#cutting-a-maintenance-branch)
 - [Major release readiness](#major-release-readiness)
 - [After a major release](#after-a-major-release)
 - [What NOT to Do](#what-not-to-do)
@@ -39,7 +40,9 @@ Releases are **fully automated** via
 [release-please](https://github.com/googleapis/release-please) and the
 `.github/workflows/release.yml` workflow:
 
-1. Developers merge PRs with **conventional commit** messages into `main`
+1. Developers merge PRs with **conventional commit** messages into a release
+   branch: `main` for the next major, or a maintenance branch such as `5.x` or
+   `4.x` for a patch or minor release of an earlier series
 2. release-please automatically opens (and keeps updated) a **release PR** that
    bumps `lib/git/version.rb` and regenerates `CHANGELOG.md`
 3. When a maintainer merges the release PR, release-please creates a **GitHub
@@ -76,7 +79,7 @@ manually edit `lib/git/version.rb` or `CHANGELOG.md`.
 
 Before a maintainer merges a release PR:
 
-1. **Ensure CI passes on `main`:**
+1. **Ensure CI passes on the release branch** (`main`, `5.x`, or `4.x`):
 
    ```bash
    bundle exec rake default
@@ -96,6 +99,30 @@ Before a maintainer merges a release PR:
 
 4. **Review the release PR** — verify the auto-generated changelog and version
    bump look correct.
+
+## Cutting a maintenance branch
+
+`main` becomes the release line for the next major as soon as the first removal merges
+([ADR-0007](../../../docs/adr/0007-removals-require-one-normal-release-of-deprecation-not-calendar-soak.md)),
+which can be long before that major ships. Cut the maintenance branch for the current
+major at that point, not after the major release, so the series can keep releasing
+while `main` is pinned to the next major:
+
+- [ ] Create the branch (e.g. `5.x`) from the latest tag of that major and apply the
+      release branch ruleset.
+- [ ] On the new branch, add it to the `push` trigger and the release job guard in
+      `release.yml`, to the `pull_request` triggers in `continuous_integration.yml`
+      and `enforce_conventional_commits.yml`, and to the `push` trigger in
+      `warm_bundler_caches.yml`, all under `.github/workflows/`. The workflow that
+      runs is the one on the branch pushed to or targeted, and a Bundler cache is
+      readable only from the ref that wrote it, its base ref, and the default branch,
+      so the copies on `main` need no change.
+- [ ] Name the new branch beside the existing maintenance branch everywhere that one is
+      listed: the branch tables in `.github/copilot-instructions.md` and
+      `CONTRIBUTING.md`, the release support policy in `README.md`, the protected
+      branch list in `.husky/pre-commit`, and the skills that list the protected
+      branches. `grep -rn '<N>\.x' .github .husky CONTRIBUTING.md README.md`, with the
+      existing maintenance branch's major in place of `<N>`, finds them all.
 
 ## Major release readiness
 
@@ -126,14 +153,16 @@ and is checked when each removal PR merges, not here.
 ## After a major release
 
 - [ ] Add a README announcement entry dated the release day.
-- [ ] Create the maintenance branch for the previous major (e.g. `5.x`) from its last
-      tag and apply branch protection.
-- [ ] Replace the retired maintenance branch with the new one everywhere it is named:
-      the push triggers in `release.yml`, `continuous_integration.yml`, and
-      `enforce_conventional_commits.yml` under `.github/workflows/`, the branch tables
-      in `.github/copilot-instructions.md` and `CONTRIBUTING.md`, and the skills that
-      list the protected branches. `grep -rn '4\.x' .github CONTRIBUTING.md` finds
-      them all.
+- [ ] Support for the oldest maintenance branch ends with this release (see the release
+      support policy in `README.md`). Retire it everywhere it is named. In the workflow
+      triggers and release job guard under `.github/workflows/`, replace it with the
+      newer maintenance branch, which the cutting step left out of the copies on
+      `main`. Everywhere else the newer branch is already listed, so remove the retired
+      one: the branch tables in `.github/copilot-instructions.md` and
+      `CONTRIBUTING.md`, the release support policy in `README.md`, the protected
+      branch list in `.husky/pre-commit`, and the skills that list the protected
+      branches. `grep -rn '<N>\.x' .github .husky CONTRIBUTING.md README.md`, with the
+      retired branch's major in place of `<N>`, finds them all.
 - [ ] Close the milestone and update the roadmap issue.
 
 ## What NOT to Do

--- a/.github/skills/release-management/SKILL.md
+++ b/.github/skills/release-management/SKILL.md
@@ -153,6 +153,8 @@ and is checked when each removal PR merges, not here.
 ## After a major release
 
 - [ ] Add a README announcement entry dated the release day.
+- [ ] Remove `release-as` from `.release-please-config.json` if it was set to pin the
+      major. release-please keeps applying it to every later release until it is removed.
 - [ ] Support for the oldest maintenance branch ends with this release (see the release
       support policy in `README.md`). Retire it everywhere it is named. In the workflow
       triggers and release job guard under `.github/workflows/`, replace it with the

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -2,7 +2,7 @@
 
 branch=$(git branch --show-current)
 
-protected_branches="main 4.x"
+protected_branches="main 5.x 4.x"
 
 for protected in $protected_branches; do
   if [ "$branch" = "$protected" ]; then

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -6,6 +6,7 @@
       "package-name": "git",
       "changelog-path": "CHANGELOG.md",
       "version-file": "lib/git/version.rb",
+      "release-as": "6.0.0",
       "bump-minor-pre-major": true,
       "bump-patch-for-minor-pre-major": true,
       "draft": false,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ bin/setup
 3. Run `npm install` (when npm is available) to install the Conventional Commit
    `commit-msg` hook used by this project (Husky + commitlint). A separate
    `pre-commit` hook is also installed that blocks direct commits to the
-   protected branches (`main`, `4.x`).
+   protected branches (`main`, `5.x`, `4.x`).
 4. Verify the toolchain by running `bundle exec rake --tasks`.
 
 `bin/setup` checks for [lychee](https://lychee.cli.rs) alongside Ruby, git, and
@@ -197,7 +197,7 @@ Once your pull request is ready for review, request a review from at least one
 
 During the review process, you may need to make additional commits; squash them.
 You will also need to rebase your branch onto the latest version of the target
-branch (e.g., `main` or `4.x`) before merging.
+branch (e.g., `main`, `5.x`, or `4.x`) before merging.
 
 At least one approval from a project maintainer is required before your pull request
 can be merged. The maintainer is responsible for ensuring that the pull request meets
@@ -219,11 +219,13 @@ first keeps the review cycle short.
 
 ## Branch strategy
 
-This project maintains two active branches:
+This project maintains `main` plus one maintenance branch for each supported previous
+major series:
 
 - **`main`**: All development. It releases the next version of the gem, including
-  the next major version.
-- **`4.x`**: The maintenance branch for the most recent previous major series. It
+  the next major version. Its next release is v6.0.0; every further v5.x release is
+  cut from `5.x`.
+- **`5.x`** and **`4.x`**: The maintenance branches for the v5.x and v4.x series. Each
   receives bug fixes and security fixes, and backward-compatible features at the
   maintainers' discretion.
 
@@ -233,8 +235,10 @@ each major series is supported.
 When submitting a pull request:
 
 - **New features and breaking changes**: Target the `main` branch
-- **Bug fixes**: Target `main`, and maintainers will backport to `4.x` if applicable
-- **Security fixes**: Target both branches or `4.x` if the issue only affects v4.x
+- **Bug fixes**: Target `main`, and maintainers will backport to the maintenance
+  branches if applicable
+- **Security fixes**: Target `main` and every affected maintenance branch, or only a
+  maintenance branch if the issue affects that series alone
 
 Removing a deprecated API follows the
 [deprecation policy](.github/skills/breaking-change-analysis/SKILL.md#step-4-deprecation-policy):
@@ -981,9 +985,9 @@ skill. Follow it when writing or reviewing specs under `spec/unit/`.
 
 #### Test coverage policy
 
-**Every pull request to `main` must keep `bundle exec rake spec:unit` at 100% line
-coverage and 100% branch coverage of `lib/`.** CI fails the build when it drops
-below either threshold.
+**Every pull request to `main` or `5.x` must keep `bundle exec rake spec:unit` at
+100% line coverage and 100% branch coverage of `lib/`.** CI fails the build when it
+drops below either threshold.
 
 This is enforceable without being onerous because unit coverage in this project is
 deterministic: `lib/` has no Ruby-version, Ruby-engine, or platform conditionals, and
@@ -1088,8 +1092,8 @@ $ LIST_UNCOVERED_DETAIL=true bundle exec rake spec:unit
 $ open coverage/index.html
 ```
 
-This policy applies to `main` only. The `4.x` maintenance branch predates it and is
-not held to these thresholds.
+This policy applies to `main` and `5.x`. The `4.x` maintenance branch predates it and
+is not held to these thresholds.
 
 #### Unit tests vs integration tests
 

--- a/README.md
+++ b/README.md
@@ -448,12 +448,13 @@ are in [UPGRADING.md](UPGRADING.md#upgrading-to-v600). See
 ### Release support policy
 
 All development happens on `main`, which releases the next version of the gem,
-including the next major version.
+including the next major version. The next release from `main` is v6.0.0. Every
+further v5.x release is cut from `5.x`.
 
-The most recent previous major series is maintained on a branch named for that
-series, currently `4.x`. It receives bug fixes and security fixes, and
-backward-compatible features at the maintainers' discretion. Fixes land on `main`
-first and are backported, except a fix for a problem that exists only in the
+Each supported previous major series is maintained on a branch named for that
+series, currently `5.x` and `4.x`. These branches receive bug fixes and security
+fixes, and backward-compatible features at the maintainers' discretion. Fixes land on
+`main` first and are backported, except a fix for a problem that exists only in a
 maintenance branch, which targets that branch directly.
 
 Support for a major series ends when the second major after it is released. v4.x is

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?log
   - [Deprecation policy](#deprecation-policy)
   - [Release support policy](#release-support-policy)
 - [Project announcements](#project-announcements)
+  - [2026-09-04: v5.x releases move to the 5.x branch](#2026-09-04-v5x-releases-move-to-the-5x-branch)
   - [2026-09-04: Retired branches deleted](#2026-09-04-retired-branches-deleted)
   - [2026-08-23: v5.x deprecations and the v6.0.0 roadmap](#2026-08-23-v5x-deprecations-and-the-v600-roadmap)
   - [2026-07-28: v5.0.0 released](#2026-07-28-v500-released)
@@ -461,6 +462,19 @@ Support for a major series ends when the second major after it is released. v4.x
 supported until v6.0.0 ships, and v5.x until v7.0.0.
 
 ## Project announcements
+
+### 2026-09-04: v5.x releases move to the `5.x` branch
+
+On September 4, 2026, we created the `5.x` branch from v5.4.1. Every further v5.x
+release is cut from that branch, and the next release from `main` is v6.0.0. Nothing
+changes for users of the gem: v5.x continues to receive bug fixes and security fixes
+per the [Release support policy](#release-support-policy), and v4.x is supported
+until v6.0.0 ships.
+
+For contributors, fixes still land on `main` first and are backported to `5.x`. A fix
+for a problem that exists only in v5.x targets `5.x` directly. See the
+[branch strategy](CONTRIBUTING.md#branch-strategy) and
+[issue #1717](https://github.com/ruby-git/ruby-git/issues/1717), the v6.0.0 roadmap.
 
 ### 2026-09-04: Retired branches deleted
 


### PR DESCRIPTION
## Summary

The `5.x` maintenance branch was cut from v5.4.1, and PR 1785 enables its workflows on that branch. This PR brings `main` in line with the branch cut in three commits.

- **Docs.** The same commit as on PR 1785, cherry-picked so both branches carry identical text. The branch strategy in `CONTRIBUTING.md`, the release support policy in `README.md`, the branch table in `.github/copilot-instructions.md`, the protected-branch list in `.husky/pre-commit`, and the skills that list protected branches now name `5.x` alongside `4.x`, and state that the next release from `main` is v6.0.0 with every v5.x release cut from `5.x`.
- **Release pin.** `release-as: 6.0.0` in `.release-please-config.json` pins release-please on `main`, so a non-breaking commit merged before the first removal cannot open a v5.4.2 or v5.5.0 release PR from `main`. The key must be removed after v6.0.0 ships; the release-management checklist now records that step.
- **Announcement.** A README project announcement dated today says v5.x releases now come from `5.x` and `main` releases v6.0.0 next.

## Verification

`bundle exec rake markdown:links` passes locally. The `release-as` behavior is taken from the release-please manifest docs: it forces the next version and keeps applying until removed.
