### PR TITLE
build!: raise the minimum supported Ruby version to 3.3

### DIFF
--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -334,7 +334,7 @@ Version constraints live in `git.gemspec`; do not restate them here.
 ## Compatibility
 
 - **Minimum Ruby (language level):** 3.3.0
-- **Supported Rubies:** MRI (macOS, Linux, Windows); latest JRuby and TruffleRuby on Linux
+- **Supported Rubies:** MRI (macOS, Linux, Windows); JRuby and TruffleRuby on Linux from the earliest release whose Ruby compatibility target is at or above the MRI floor (the CI matrix pins the exact versions tested)
 - **Minimum Git:** 2.28.0
 - **Platforms:** macOS, Linux, Windows (JRuby/TruffleRuby officially supported on Linux only)
 - Use `File.join` and forward slashes; avoid platform-specific paths in tests

--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -237,7 +237,7 @@ error classes.
 ### Ruby Style
 
 - `frozen_string_literal: true` at the top of every Ruby file
-- Ruby 3.2.0+ idioms; keyword arguments for multi-parameter methods
+- Ruby 3.3.0+ idioms; keyword arguments for multi-parameter methods
 - `private` keyword form (not `private :method_name`)
 - Pattern matching for complex conditionals where appropriate
 
@@ -333,7 +333,7 @@ Version constraints live in `git.gemspec`; do not restate them here.
 
 ## Compatibility
 
-- **Minimum Ruby (language level):** 3.2.0
+- **Minimum Ruby (language level):** 3.3.0
 - **Supported Rubies:** MRI (macOS, Linux, Windows); latest JRuby and TruffleRuby on Linux
 - **Minimum Git:** 2.28.0
 - **Platforms:** macOS, Linux, Windows (JRuby/TruffleRuby officially supported on Linux only)

--- a/.github/skills/pull-request-review/SKILL.md
+++ b/.github/skills/pull-request-review/SKILL.md
@@ -48,7 +48,7 @@ confirms.
 
 Evaluate the PR against these criteria:
 
-**Code Quality:** Ruby style (RuboCop-compliant), `frozen_string_literal: true`, proper naming (snake_case/PascalCase), single-responsibility, no duplication, Ruby 3.2+ idioms.
+**Code Quality:** Ruby style (RuboCop-compliant), `frozen_string_literal: true`, proper naming (snake_case/PascalCase), single-responsibility, no duplication, Ruby 3.3+ idioms.
 
 **Testing:** Changes are covered by atomic RSpec specs (`spec/`), well-named, and passing CI.
 
@@ -58,7 +58,7 @@ Evaluate the PR against these criteria:
 
 **Commits:** Conventional Commits format, lowercase subjects under 100 chars, no trailing period. Breaking changes use `!` and `BREAKING CHANGE:` footer.
 
-**Compatibility:** Backward compatible (or marked breaking), Ruby 3.2+, Git 2.28.0+, cross-platform (Windows/macOS/Linux).
+**Compatibility:** Backward compatible (or marked breaking), Ruby 3.3+, Git 2.28.0+, cross-platform (Windows/macOS/Linux).
 
 **Security:** No command injection, proper escaping via Git::CommandLine, input validation, resource cleanup.
 

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -24,8 +24,8 @@ jobs:
   # Ruby 3.4 hosts this job rather than the newest supported Ruby because it gates
   # merges: a lint gate should be insulated from churn in a brand-new major, and Ruby
   # 4.0 deprecations still surface through the matrix jobs below, which do run 4.0.
-  # 3.3+ is also a hard floor here, since yard-lint is only installed on 3.3 and later
-  # (see the gemspec) and YARD itself cannot build on JRuby or TruffleRuby.
+  # It also has to be MRI, since YARD and yard-lint cannot build on JRuby or
+  # TruffleRuby (see the gemspec).
   lint:
     name: Lint and Docs
 
@@ -109,10 +109,10 @@ jobs:
       matrix:
         # Only the minimum required versions of JRuby and TruffleRuby are tested.
         #
-        ruby: ["3.2", "4.0", "truffleruby-24.2.1", "jruby-10.0.0.1"]
+        ruby: ["3.3", "4.0", "truffleruby-24.2.1", "jruby-10.0.0.1"]
         operating-system: [ubuntu-latest]
         include:
-          - ruby: "3.2"
+          - ruby: "3.3"
             operating-system: windows-latest
 
     steps:
@@ -149,7 +149,7 @@ jobs:
 
   # The branch ruleset cannot require the matrix jobs above directly. A required status
   # check is matched by name, and `build`'s name is a template -- GitHub only expands it
-  # into "Ruby 3.2 on ubuntu-latest" and friends when it evaluates the matrix. The
+  # into "Ruby 3.3 on ubuntu-latest" and friends when it evaluates the matrix. The
   # job-level `if:` short-circuits before that happens, so a release PR reports one check
   # named literally "Ruby ${{ matrix.ruby }} on ${{ matrix.operating-system }}" and the
   # five expanded names never report at all. Required checks that never report block a PR

--- a/.github/workflows/warm_bundler_caches.yml
+++ b/.github/workflows/warm_bundler_caches.yml
@@ -13,7 +13,7 @@ name: Warm Bundler Caches
 # The matrix below must stay in sync with continuous_integration.yml: setup-ruby's
 # cache key embeds the runner OS, the resolved Ruby version, and the Gemfile.lock hash,
 # so a pair that is not warmed here still starts cold in CI. That includes the lint
-# job's Ruby 3.4 and the Windows 3.2 job, neither of which appears in CI's main matrix
+# job's Ruby 3.4 and the Windows 3.3 job, neither of which appears in CI's main matrix
 # list. The head rubies from experimental_continuous_integration.yml are deliberately
 # absent: that workflow already runs on `push: [main]` and warms its own caches.
 #
@@ -49,7 +49,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - ruby: "3.2"
+          - ruby: "3.3"
             operating-system: ubuntu-latest
 
           - # Hosts the lint and locale jobs in continuous_integration.yml
@@ -65,7 +65,7 @@ jobs:
           - ruby: "jruby-10.0.0.1"
             operating-system: ubuntu-latest
 
-          - ruby: "3.2"
+          - ruby: "3.3"
             operating-system: windows-latest
 
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -41,7 +41,7 @@ AllCops:
   # Pinned explicitly rather than inferred because main_branch_shared_rubocop_config
   # sets 3.1, which is older than this gem supports, and a value inherited through
   # inherit_gem takes precedence over inference from the gemspec.
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
 
   Exclude:
     # archive/ holds frozen records of completed projects. The Ruby in there is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -93,7 +93,7 @@ prerequisite is missing.
 
 | Tool | Required version | Notes |
 | --- | --- | --- |
-| Ruby | `>= 3.2.0` (matches `required_ruby_version` in [`git.gemspec`](git.gemspec)) | A version manager such as [rbenv](https://github.com/rbenv/rbenv), [asdf](https://asdf-vm.com/), [chruby](https://github.com/postmodern/chruby), or [rvm](https://rvm.io/) is recommended so you can match the project's CI matrix. |
+| Ruby | `>= 3.3.0` (matches `required_ruby_version` in [`git.gemspec`](git.gemspec)) | A version manager such as [rbenv](https://github.com/rbenv/rbenv), [asdf](https://asdf-vm.com/), [chruby](https://github.com/postmodern/chruby), or [rvm](https://rvm.io/) is recommended so you can match the project's CI matrix. |
 | Bundler | Any 2.x or 4.x | Install with `gem install bundler`. |
 | git | `>= 2.28.0` (matches `git.gemspec` `requirements`) | Older git versions are not supported and the test suite will not pass against them. |
 | Node.js / npm | Optional | Required only to install the local Conventional Commit `commit-msg` hook (Husky + commitlint). If npm is missing, `bin/setup` will warn and continue. CI will still validate commit messages. |

--- a/Gemfile
+++ b/Gemfile
@@ -14,9 +14,7 @@ gemspec name: 'git'
 # intentionally: https://github.com/jcouball/yard-lint/tree/feature/tag-separator
 #
 # Scope this to the same runtimes as the gemspec's yard-lint dependency: it is
-# excluded on JRuby (RUBY_PLATFORM == 'java') and TruffleRuby, and requires
-# Ruby >= 3.3.
-if !(RUBY_PLATFORM == 'java' || RUBY_ENGINE == 'truffleruby') &&
-   Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.3.0')
+# excluded on JRuby (RUBY_PLATFORM == 'java') and TruffleRuby.
+unless RUBY_PLATFORM == 'java' || RUBY_ENGINE == 'truffleruby'
   gem 'yard-lint', git: 'https://github.com/jcouball/yard-lint', ref: 'ef71742f2c88e2c296a20ab25fb4f25a4a384374'
 end

--- a/README.md
+++ b/README.md
@@ -398,8 +398,18 @@ This gem is expected to function correctly on:
 
 - All [non-EOL versions](https://www.ruby-lang.org/en/downloads/branches/) of the MRI
   Ruby on Mac, Linux, and Windows
-- The latest version of JRuby 9.4+ on Linux
-- The latest version of TruffleRuby 24+ on Linux
+- JRuby and TruffleRuby on Linux, starting from the earliest release whose Ruby
+  compatibility target is at or above the oldest supported MRI version, unless a
+  newer release is otherwise needed (for example, when a release does not
+  implement a feature the gem depends on)
+
+Consult the CI build matrix in
+[`.github/workflows/continuous_integration.yml`](.github/workflows/continuous_integration.yml)
+for the exact JRuby and TruffleRuby versions tested. Newer releases of each engine
+are expected to work but are not tested.
+
+Because the JRuby and TruffleRuby floors derive from the MRI floor, they move
+whenever the oldest supported MRI version changes.
 
 This project intends to support the latest version of JRuby on Windows once
 the [process_executer](https://github.com/main-branch/process_executer) gem properly

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -5,6 +5,7 @@ This document covers breaking changes and migration steps when upgrading the
 to update your code when upgrading from the preceding major version.
 
 - [Upgrading to v6.0.0](#upgrading-to-v600)
+  - [Minimum Ruby version](#minimum-ruby-version)
 - [Upgrading to v5.x](#upgrading-to-v5x)
   - [Overview](#overview)
   - [Breaking changes](#breaking-changes)
@@ -45,12 +46,29 @@ v6.0.0 removes the APIs deprecated during v5.x under the project's
 
 To prepare:
 
-1. Upgrade to the latest v5.x release.
-2. Set `GIT_DEPRECATION_BEHAVIOR=raise` (or `Git::Deprecation.behavior = :raise`) in
+1. Upgrade to Ruby 3.3 or later if you are still on Ruby 3.2 (see
+   [Minimum Ruby version](#minimum-ruby-version)).
+2. Upgrade to the latest v5.x release.
+3. Set `GIT_DEPRECATION_BEHAVIOR=raise` (or `Git::Deprecation.behavior = :raise`) in
    your test suite and, if possible, staging.
-3. Fix each deprecation using the entries under
+4. Fix each deprecation using the entries under
    [Deprecated methods](#deprecated-methods) until the suite is clean.
-4. Upgrade to v6.0.0.
+5. Upgrade to v6.0.0.
+
+### Minimum Ruby version
+
+v6.0.0 requires Ruby 3.3.0 or later. v5.x supports Ruby 3.2, which reached end of
+life on 2026-04-01. The
+[Ruby version support policy](README.md#ruby-version-support-policy) commits the
+gem to the MRI versions that are still maintained, so the floor moves when a Ruby
+version leaves maintenance rather than with the gem's major version. Ruby 3.3 is
+in security maintenance until about 2027-03-31, so it stays supported in v6.0.0.
+A 3.4 floor can land in a later v6.x release once 3.3 reaches end of life.
+
+JRuby and TruffleRuby support is unchanged.
+
+If your application still runs on Ruby 3.2, upgrade Ruby before upgrading the gem,
+or stay on the latest v5.x release.
 
 ---
 

--- a/bin/setup
+++ b/bin/setup
@@ -29,7 +29,7 @@ version_ge() {
 }
 
 # Extract the minimum Ruby version from required_ruby_version in the gemspec
-# (e.g., `spec.required_ruby_version = '>= 3.2.0'`). The gemspec is the
+# (e.g., `spec.required_ruby_version = '>= 3.3.0'`). The gemspec is the
 # authoritative source; bin/setup must not duplicate it.
 required_ruby_version() {
   local v

--- a/git.gemspec
+++ b/git.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.metadata['rubygems_mfa_required'] = 'true'
 
   spec.require_paths = ['lib']
-  spec.required_ruby_version = '>= 3.2.0'
+  spec.required_ruby_version = '>= 3.3.0'
   spec.requirements = ['git 2.28.0 or greater']
 
   spec.add_dependency 'activesupport', '>= 5.0'
@@ -74,9 +74,6 @@ Gem::Specification.new do |spec|
   # is also a C extension and so could not install on JRuby regardless.
   install_docs = mri
 
-  # yard-lint requires Ruby >= 3.3.
-  install_yard_lint = install_docs && Gem.ruby_version >= Gem::Version.new('3.3.0')
-
   # i18n 1.15+ uses Fiber.[] (Ruby 3.2 Fiber storage), which TruffleRuby < 34.0.0 does
   # not implement, so those runtimes hold at the last release that works there.
   pin_old_i18n = RUBY_ENGINE == 'truffleruby' &&
@@ -98,7 +95,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov-rspec', '~> 1.1'
   spec.add_development_dependency 'yard', '~> 0.9', '>= 0.9.28' if install_docs
   spec.add_development_dependency 'yard_example_test', '~> 0.2', '>= 0.2.1' if install_docs
-  spec.add_development_dependency 'yard-lint', '~> 1.8' if install_yard_lint
+  spec.add_development_dependency 'yard-lint', '~> 1.8' if install_docs
 
   # Specify which files should be added to the gem when it is released.
   #


### PR DESCRIPTION
v6.0.0 requires Ruby 3.3 or later. The gemspec floor was 3.2, which reached end of life on 2026-04-01. The README's Ruby version support policy commits the gem to every maintained MRI version, so dropping 3.2 is within policy. Ruby 3.3 is in security maintenance until about 2027-03-31 and stays supported; a 3.4 floor can land in a later v6.x release.

Changes:

- `required_ruby_version` is `>= 3.3.0` in the gemspec, and the `Gem.ruby_version` gates that kept yard-lint off Ruby 3.2 are gone from the gemspec, Gemfile, and `.rubocop.yml`.
- The CI and cache-warming matrices replace Ruby 3.2 with 3.3. JRuby 10 stays the JRuby floor.
- UPGRADING.md gains a "Minimum Ruby version" section under "Upgrading to v6.0.0" and adds the Ruby upgrade as the first preparation step. CONTRIBUTING.md, `bin/setup`, and the project-context and pull-request-review skills state the new floor.
- The README support policy no longer names fixed JRuby and TruffleRuby series (which had drifted from CI). It now states the rule the CI matrix already follows: each engine is supported from the earliest release whose Ruby compatibility target is at or above the oldest supported MRI version, unless a newer release is otherwise needed, and points to the CI matrix for the exact versions tested. The project-context skill says the same.

The build commit is marked breaking with `!` and a `BREAKING CHANGE:` footer, so release-please lists the floor change under breaking changes in the v6.0.0 release notes.

This PR and #1794 both edit the "To prepare" list in UPGRADING.md. Whichever merges second needs a rebase.

Closes #1722

