### PR TITLE
feat!: raise the minimum supported git version to 2.43.0

### DIFF
--- a/.github/skills/command-implementation/REFERENCE.md
+++ b/.github/skills/command-implementation/REFERENCE.md
@@ -249,7 +249,7 @@ class SomeCommand < Git::Commands::Base
   end
 
   # optional — only when introduced after Git::MINIMUM_GIT_VERSION
-  requires_git_version '2.29.0'
+  requires_git_version '2.46.0'
 
   # optional for non-zero successful exits
   # reason comment
@@ -621,7 +621,7 @@ changes their meaning without touching their files — after edits, rerun
 
 `requires_git_version` is a **class-level** declaration only. Individual options do
 **not** carry version annotations. The declaration must use a `'major.minor.patch'`
-string (e.g., `'2.29.0'`), not a `Git::Version` or `Range` — pre-release versions
+string (e.g., `'2.46.0'`), not a `Git::Version` or `Range` — pre-release versions
 are not supported.
 
 | Scenario | Action |

--- a/.github/skills/command-test-conventions/SKILL.md
+++ b/.github/skills/command-test-conventions/SKILL.md
@@ -52,7 +52,7 @@ it, MUST-level structural, naming, stubbing, and coverage checks will not be app
 
 Before deciding that test coverage is missing for an option, alias, or flag
 form, determine the repository's minimum supported Git version from project
-metadata. In this repository, `git.gemspec` declares `git 2.28.0 or greater`.
+metadata. In this repository, `git.gemspec` declares `git 2.43.0 or greater`.
 
 Coverage expectations for CLI forms must be based on the minimum supported Git
 version, not only on the locally installed Git. Use version-matched upstream
@@ -530,7 +530,7 @@ end
 #### Guard tests for options introduced after the minimum supported Git version
 
 When an integration test exercises an option that was introduced after the minimum
-supported Git version (2.28.0), guard the example with
+supported Git version (2.43.0), guard the example with
 `skip: unless_git(minimum_version, feature_description)` to prevent failures on
 installations that do not yet have the required Git version. The `unless_git` helper
 is defined in `spec/spec_helper.rb`:
@@ -545,19 +545,19 @@ group require the same minimum version.
 
 ```ruby
 # ✅ Different options introduced in different git versions — guard each `it` individually
-it 'returns a CommandLineResult with the :verbose option',
-   skip: unless_git('2.33.0', 'git worktree list --verbose') do
+it 'returns a CommandLineResult with the :retry option',
+   skip: unless_git('2.46.0', 'git am --retry') do
   # ...
 end
 
-it 'returns a CommandLineResult with the :z option combined with :porcelain',
-   skip: unless_git('2.36.0', 'git worktree list --porcelain -z') do
+it 'returns a CommandLineResult with the :batch_updates option',
+   skip: unless_git('2.47.0', 'git update-ref --batch-updates') do
   # ...
 end
 
 # ✅ All tests in the group require the same version — guard the context/describe block
-RSpec.describe Git::Commands::ShowRef::Exists, :integration,
-               skip: unless_git('2.43.0', 'git show-ref --exists') do
+RSpec.describe Git::Commands::Am::Retry, :integration,
+               skip: unless_git('2.46.0', 'git am --retry') do
   # ...
 end
 ```
@@ -618,7 +618,7 @@ error. For example:
 
 ```ruby
 it 'succeeds when no merge is in progress' do
-  skip 'requires git 2.35.0 or later' unless Git.git_version >= Git::Version.new(2, 35, 0)
+  skip 'requires git 2.46.0 or later' unless Git.git_version >= Git::Version.new(2, 46, 0)
 
   expect { command.call }.not_to raise_error
 end

--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -335,7 +335,7 @@ Version constraints live in `git.gemspec`; do not restate them here.
 
 - **Minimum Ruby (language level):** 3.3.0
 - **Supported Rubies:** MRI (macOS, Linux, Windows); JRuby and TruffleRuby on Linux from the earliest release whose Ruby compatibility target is at or above the MRI floor (the CI matrix pins the exact versions tested)
-- **Minimum Git:** 2.28.0
+- **Minimum Git:** 2.43.0
 - **Platforms:** macOS, Linux, Windows (JRuby/TruffleRuby officially supported on Linux only)
 - Use `File.join` and forward slashes; avoid platform-specific paths in tests
 - Windows has different path handling, file-system behavior, and line endings; JRuby on Windows is not supported

--- a/.github/skills/pull-request-review/SKILL.md
+++ b/.github/skills/pull-request-review/SKILL.md
@@ -58,7 +58,7 @@ Evaluate the PR against these criteria:
 
 **Commits:** Conventional Commits format, lowercase subjects under 100 chars, no trailing period. Breaking changes use `!` and `BREAKING CHANGE:` footer.
 
-**Compatibility:** Backward compatible (or marked breaking), Ruby 3.3+, Git 2.28.0+, cross-platform (Windows/macOS/Linux).
+**Compatibility:** Backward compatible (or marked breaking), Ruby 3.3+, Git 2.43.0+, cross-platform (Windows/macOS/Linux).
 
 **Security:** No command injection, proper escaping via Git::CommandLine, input validation, resource cleanup.
 

--- a/.github/skills/review-cross-command-consistency/SKILL.md
+++ b/.github/skills/review-cross-command-consistency/SKILL.md
@@ -61,7 +61,7 @@ Before starting, you **MUST** load the following skill(s) in their entirety:
 Before flagging siblings as inconsistent for option names, aliases, negated
 forms, or documented values, determine the repository's minimum supported Git
 version from project metadata. In this repository, `git.gemspec` declares
-`git 2.28.0 or greater`.
+`git 2.43.0 or greater`.
 
 Consistency judgments for CLI surface area must be based on the minimum
 supported Git version, not only on the locally installed Git. Use

--- a/.github/skills/tdd-refactor-step/SKILL.md
+++ b/.github/skills/tdd-refactor-step/SKILL.md
@@ -146,10 +146,10 @@ When a magic value appears in logic:
 
 ```ruby
 # Before
-raise error if version < Git::Version.parse('2.28.0')
+raise error if version < Git::Version.parse('2.43.0')
 
 # After
-MINIMUM_GIT_VERSION = Git::Version.parse('2.28.0')
+MINIMUM_GIT_VERSION = Git::Version.parse('2.43.0')
 raise error if version < MINIMUM_GIT_VERSION
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -95,7 +95,7 @@ prerequisite is missing.
 | --- | --- | --- |
 | Ruby | `>= 3.3.0` (matches `required_ruby_version` in [`git.gemspec`](git.gemspec)) | A version manager such as [rbenv](https://github.com/rbenv/rbenv), [asdf](https://asdf-vm.com/), [chruby](https://github.com/postmodern/chruby), or [rvm](https://rvm.io/) is recommended so you can match the project's CI matrix. |
 | Bundler | Any 2.x or 4.x | Install with `gem install bundler`. |
-| git | `>= 2.28.0` (matches `git.gemspec` `requirements`) | Older git versions are not supported and the test suite will not pass against them. |
+| git | `>= 2.43.0` (matches `git.gemspec` `requirements`) | Older git versions are not supported and the test suite will not pass against them. |
 | Node.js / npm | Optional | Required only to install the local Conventional Commit `commit-msg` hook (Husky + commitlint). If npm is missing, `bin/setup` will warn and continue. CI will still validate commit messages. |
 | [lychee](https://lychee.cli.rs) | `>= 0.24.0` | Runs the markdown link check (`rake markdown:links`), which is part of the default task. The floor comes from [`.lychee.toml`](.lychee.toml): older releases cannot parse the enum form of `include_fragments`. Install with `brew install lychee` (macOS), `snap install lychee` (Ubuntu), `pacman -S lychee` (Arch), `winget install --id lycheeverse.lychee` (Windows), or see the [install docs](https://github.com/lycheeverse/lychee#installation). |
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ methods you can call on a repository object.
 ## Install
 
 This gem is a wrapper around the `git` command line, so a `git` executable (version
-2.28.0 or greater) must be installed and on your `PATH`. See the [Git version support
+2.43.0 or greater) must be installed and on your `PATH`. See the [Git version support
 policy](#git-version-support-policy) for details.
 
 Install the gem and add to the application's Gemfile by executing:
@@ -418,7 +418,7 @@ supports subprocess status reporting on JRuby for Windows (see
 
 ### Git version support policy
 
-This gem requires git version 2.28.0 or greater as specified in the gemspec. This
+This gem requires git version 2.43.0 or greater as specified in the gemspec. This
 requirement reflects:
 
 - The minimum git version necessary to support all features provided by this gem
@@ -426,9 +426,9 @@ requirement reflects:
   capabilities
 - The practical limitations of testing across multiple git versions in CI
 
-Git 2.28.0 was released on July 27, 2020. While this gem may work with earlier
-versions of git, compatibility with versions prior to 2.28.0 is not tested or
-guaranteed. Users on older git versions should upgrade to at least 2.28.0.
+Git 2.43.0 was released on November 20, 2023. While this gem may work with earlier
+versions of git, compatibility with versions prior to 2.43.0 is not tested or
+guaranteed. Users on older git versions should upgrade to at least 2.43.0.
 
 The supported git version may be increased in future major or minor releases of this
 gem as new git features are adopted or as maintaining backward compatibility becomes
@@ -508,8 +508,8 @@ deprecated during the v5.x series in favor of the immutable `*Info` value-object
 APIs. v6.0.0 will remove each deprecated class once a normal v5.x release has carried
 its deprecation warning and UPGRADING.md entry, per the
 [Deprecation policy](#deprecation-policy). v6.0.0 will not ship until every planned
-deprecation has shipped that way. v6.0.0 also raises the version floors: git ≥ 2.42.0,
-Ruby ≥ 3.4.
+deprecation has shipped that way. v6.0.0 also raises the version floors: git ≥ 2.43.0,
+Ruby ≥ 3.3.
 
 [Issue #1717](https://github.com/ruby-git/ruby-git/issues/1717) is the living
 roadmap, tracking scope, sequencing, and status. If your code uses the classes

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -6,6 +6,7 @@ to update your code when upgrading from the preceding major version.
 
 - [Upgrading to v6.0.0](#upgrading-to-v600)
   - [Minimum Ruby version](#minimum-ruby-version)
+  - [Minimum git version](#minimum-git-version)
 - [Upgrading to v5.x](#upgrading-to-v5x)
   - [Overview](#overview)
   - [Breaking changes](#breaking-changes)
@@ -48,12 +49,14 @@ To prepare:
 
 1. Upgrade to Ruby 3.3 or later if you are still on Ruby 3.2 (see
    [Minimum Ruby version](#minimum-ruby-version)).
-2. Upgrade to the latest v5.x release.
-3. Set `GIT_DEPRECATION_BEHAVIOR=raise` (or `Git::Deprecation.behavior = :raise`) in
+2. Check that `git --version` reports 2.43.0 or later everywhere the gem runs (see
+   [Minimum git version](#minimum-git-version)).
+3. Upgrade to the latest v5.x release.
+4. Set `GIT_DEPRECATION_BEHAVIOR=raise` (or `Git::Deprecation.behavior = :raise`) in
    your test suite and, if possible, staging.
-4. Fix each deprecation using the entries under
+5. Fix each deprecation using the entries under
    [Deprecated methods](#deprecated-methods) until the suite is clean.
-5. Upgrade to v6.0.0.
+6. Upgrade to v6.0.0.
 
 ### Minimum Ruby version
 
@@ -69,6 +72,21 @@ JRuby and TruffleRuby support is unchanged.
 
 If your application still runs on Ruby 3.2, upgrade Ruby before upgrading the gem,
 or stay on the latest v5.x release.
+
+### Minimum git version
+
+v6.0.0 requires git 2.43.0 or later. v5.x required 2.28.0.
+
+Git 2.43.0 was released on November 20, 2023, and is the version shipped by
+Ubuntu 24.04, RHEL 8.10 and 9.4, SLES 15 SP6, openSUSE Leap 15.6, and Alpine 3.19.
+Ubuntu 22.04 is the supported platform whose stock git (2.34) falls below the new
+floor. On Ubuntu 22.04, install a newer git (for example from the
+[git-core PPA](https://launchpad.net/~git-core/+archive/ubuntu/ppa)) or stay on
+v5.x. Apple's git 2.39 from Xcode 16 also falls below the floor; Xcode 26 ships
+git 2.50.
+
+Features that need a git newer than 2.43.0 stay gated per command and raise
+`Git::VersionError` on older installations, as `git am --retry` (2.46.0) does today.
 
 ---
 

--- a/bin/build-git-versions
+++ b/bin/build-git-versions
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 # frozen_string_literal: true
 
-# Download and build every Git release (>= 2.28.0, the minimum version
+# Download and build every Git release (>= 2.43.0, the minimum version
 # supported by this gem) from the kernel.org mirror.
 #
 # For each release, this script:
@@ -49,7 +49,7 @@ require 'securerandom'
 require 'fileutils'
 
 MIRROR_URL = 'https://mirrors.edge.kernel.org/pub/software/scm/git/'
-MIN_VERSION = '2.28.0'
+MIN_VERSION = '2.43.0'
 HTTP_OPEN_TIMEOUT = 10
 HTTP_READ_TIMEOUT = 30
 HTTP_RETRIES = 3

--- a/bin/docker-git
+++ b/bin/docker-git
@@ -7,7 +7,7 @@ usage() {
   echo ""
   echo "Usage: $(basename "$0") <version>"
   echo ""
-  echo "Example: $(basename "$0") 2.28.0"
+  echo "Example: $(basename "$0") 2.43.0"
   exit 1
 }
 

--- a/bin/setup
+++ b/bin/setup
@@ -43,7 +43,7 @@ required_ruby_version() {
 }
 
 # Extract the minimum git version from the gemspec requirements line
-# (e.g., `spec.requirements = ['git 2.28.0 or greater']`). The gemspec is the
+# (e.g., `spec.requirements = ['git 2.43.0 or greater']`). The gemspec is the
 # authoritative source; bin/setup must not duplicate it.
 required_git_version() {
   local v

--- a/git.gemspec
+++ b/git.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
 
   spec.require_paths = ['lib']
   spec.required_ruby_version = '>= 3.3.0'
-  spec.requirements = ['git 2.28.0 or greater']
+  spec.requirements = ['git 2.43.0 or greater']
 
   spec.add_dependency 'activesupport', '>= 5.0'
   spec.add_dependency 'addressable', '~> 2.8'

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -116,7 +116,7 @@ module Git
   #
   # @api public
   #
-  MINIMUM_GIT_VERSION = Version.parse('2.28.0')
+  MINIMUM_GIT_VERSION = Version.parse('2.43.0')
 
   # Compatibility shim for code that monkeypatches the `Git::Base` class from
   # versions prior to 5.0.0.

--- a/lib/git/commands/maintenance.rb
+++ b/lib/git/commands/maintenance.rb
@@ -19,8 +19,6 @@ module Git
     # - {Maintenance::Register} — add repository to maintenance config
     # - {Maintenance::Unregister} — remove repository from maintenance config
     #
-    # All subcommands require Git 2.30.0 or later.
-    #
     # @see https://git-scm.com/docs/git-maintenance git-maintenance documentation
     #
     # @api private

--- a/lib/git/commands/maintenance/register.rb
+++ b/lib/git/commands/maintenance/register.rb
@@ -22,8 +22,6 @@ module Git
       # @api private
       #
       class Register < Git::Commands::Base
-        requires_git_version '2.30.0'
-
         arguments do
           literal 'maintenance'
           literal 'register'
@@ -64,8 +62,6 @@ module Git
         #   @raise [ArgumentError] if unsupported options are provided
         #
         #   @raise [Git::FailedError] if git exits with a non-zero exit status
-        #
-        #   @raise [Git::VersionError] if git version is below 2.30.0
         #
         #   @api public
         def call(*, **)

--- a/lib/git/commands/maintenance/run.rb
+++ b/lib/git/commands/maintenance/run.rb
@@ -28,8 +28,6 @@ module Git
       # @api private
       #
       class Run < Git::Commands::Base
-        requires_git_version '2.30.0'
-
         arguments do
           literal 'maintenance'
           literal 'run'
@@ -99,8 +97,6 @@ module Git
         #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
-        #
-        #     @raise [Git::VersionError] if git version is below 2.30.0
         #
         #     @api public
       end

--- a/lib/git/commands/maintenance/start.rb
+++ b/lib/git/commands/maintenance/start.rb
@@ -22,8 +22,6 @@ module Git
       # @api private
       #
       class Start < Git::Commands::Base
-        requires_git_version '2.30.0'
-
         arguments do
           literal 'maintenance'
           literal 'start'
@@ -63,8 +61,6 @@ module Git
         #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
-        #
-        #     @raise [Git::VersionError] if git version is below 2.30.0
       end
     end
   end

--- a/lib/git/commands/maintenance/stop.rb
+++ b/lib/git/commands/maintenance/stop.rb
@@ -19,8 +19,6 @@ module Git
       # @api private
       #
       class Stop < Git::Commands::Base
-        requires_git_version '2.30.0'
-
         arguments do
           literal 'maintenance'
           literal 'stop'
@@ -52,8 +50,6 @@ module Git
         #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
-        #
-        #     @raise [Git::VersionError] if git version is below 2.30.0
       end
     end
   end

--- a/lib/git/commands/maintenance/unregister.rb
+++ b/lib/git/commands/maintenance/unregister.rb
@@ -22,8 +22,6 @@ module Git
       # @api private
       #
       class Unregister < Git::Commands::Base
-        requires_git_version '2.30.0'
-
         arguments do
           literal 'maintenance'
           literal 'unregister'
@@ -74,8 +72,6 @@ module Git
         #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
-        #
-        #     @raise [Git::VersionError] if git version is below 2.30.0
         #
         #     @api public
       end

--- a/lib/git/commands/show_ref.rb
+++ b/lib/git/commands/show_ref.rb
@@ -18,7 +18,7 @@ module Git
     # - {ShowRef::ExcludeExisting} — stdin-based filter for ref names, excluding
     #   refs that already exist in the repository
     #   (`git show-ref --exclude-existing[=<pattern>]`)
-    # - {ShowRef::Exists} — boolean existence check without output (git >= 2.43)
+    # - {ShowRef::Exists} — boolean existence check without output
     #   (`git show-ref --exists <ref>`)
     #
     # @example List all refs matching a pattern

--- a/lib/git/commands/show_ref/exclude_existing.rb
+++ b/lib/git/commands/show_ref/exclude_existing.rb
@@ -16,7 +16,7 @@ module Git
       #
       # For standard ref listing, use {Git::Commands::ShowRef::List}.
       # For strict per-ref verification, use {Git::Commands::ShowRef::Verify}.
-      # For a boolean existence check (git >= 2.43), use {Git::Commands::ShowRef::Exists}.
+      # For a boolean existence check, use {Git::Commands::ShowRef::Exists}.
       #
       # @example Filter refs that do not exist locally
       #   cmd = Git::Commands::ShowRef::ExcludeExisting.new(execution_context)

--- a/lib/git/commands/show_ref/exists.rb
+++ b/lib/git/commands/show_ref/exists.rb
@@ -25,11 +25,6 @@ module Git
       #   result = cmd.call('refs/heads/main')
       #   result.status.exitstatus  # => 0 (exists) or 2 (not found)
       #
-      # @note Requires git 2.43 or later
-      #
-      #   Earlier versions do not recognise the `--exists` flag and will exit
-      #   non-zero with an "unknown option" error.
-      #
       # @note `arguments` block audited against https://git-scm.com/docs/git-show-ref/2.53.0
       #
       # @see Git::Commands::ShowRef

--- a/lib/git/commands/show_ref/list.rb
+++ b/lib/git/commands/show_ref/list.rb
@@ -16,7 +16,7 @@ module Git
       #
       # For strict per-ref verification, use {Git::Commands::ShowRef::Verify}.
       # For stdin-based filtering, use {Git::Commands::ShowRef::ExcludeExisting}.
-      # For a simple boolean existence check (git >= 2.43), use {Git::Commands::ShowRef::Exists}.
+      # For a simple boolean existence check, use {Git::Commands::ShowRef::Exists}.
       #
       # @example List all refs
       #   cmd = Git::Commands::ShowRef::List.new(execution_context)

--- a/lib/git/commands/show_ref/verify.rb
+++ b/lib/git/commands/show_ref/verify.rb
@@ -18,7 +18,7 @@ module Git
       #
       # For pattern-based listing, use {ShowRef::List}.
       # For stdin-based filtering, use {ShowRef::ExcludeExisting}.
-      # For a silent boolean check (git >= 2.43), use {ShowRef::Exists}.
+      # For a silent boolean check, use {ShowRef::Exists}.
       #
       # @example Verify a single ref
       #   cmd = Git::Commands::ShowRef::Verify.new(execution_context)

--- a/lib/git/commands/worktree/repair.rb
+++ b/lib/git/commands/worktree/repair.rb
@@ -34,9 +34,6 @@ module Git
           operand :path, repeatable: true
         end
 
-        # git worktree repair was introduced in git 2.29.0
-        requires_git_version '2.29.0'
-
         # @!method call(*)
         #
         #   @overload call(*path, **options)
@@ -66,8 +63,6 @@ module Git
         #     @raise [ArgumentError] if unsupported options are provided
         #
         #     @raise [Git::FailedError] if git exits with a non-zero exit status
-        #
-        #     @raise [Git::VersionError] if git version is below 2.29.0
         #
         #     @api public
       end

--- a/lib/git/repository/stashing.rb
+++ b/lib/git/repository/stashing.rb
@@ -88,10 +88,9 @@ module Git
       #   @option options [Boolean, nil] :p (nil) alias for `:patch`
       #
       #   @option options [Boolean, nil] :staged (nil) stash only the staged changes
-      #     (alias: `:S`; requires git 2.35+)
+      #     (alias: `:S`)
       #
-      #   @option options [Boolean, nil] :S (nil) alias for `:staged` (requires git
-      #     2.35+)
+      #   @option options [Boolean, nil] :S (nil) alias for `:staged`
       #
       #   @option options [Boolean, nil] :keep_index (nil) keep the staged changes
       #     in the index (alias: `:k`)
@@ -304,16 +303,15 @@ module Git
       # @option opts [Integer, String] :U (nil) alias for `:unified`
       #
       # @option opts [Boolean, nil] :include_untracked (nil) include the
-      #   untracked files recorded in the entry (alias: `:u`; requires git 2.30+)
+      #   untracked files recorded in the entry (alias: `:u`)
       #
       # @option opts [Boolean, nil] :u (nil) alias for `:include_untracked`
-      #   (requires git 2.30+)
       #
       # @option opts [Boolean, nil] :no_include_untracked (nil) exclude the
-      #   untracked files recorded in the entry (requires git 2.30+)
+      #   untracked files recorded in the entry
       #
       # @option opts [Boolean, nil] :only_untracked (nil) show only the
-      #   untracked files recorded in the entry (requires git 2.30+)
+      #   untracked files recorded in the entry
       #
       # @option opts [Boolean, Integer, nil] :find_renames (nil) detect
       #   renames, optionally with a similarity threshold (alias: `:M`)

--- a/lib/git/repository/worktree_operations.rb
+++ b/lib/git/repository/worktree_operations.rb
@@ -235,8 +235,6 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
-      # @raise [Git::VersionError] if the installed git is older than 2.29.0
-      #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
       #
       def worktree_repair(*paths)

--- a/spec/integration/git/commands/checkout_index_spec.rb
+++ b/spec/integration/git/commands/checkout_index_spec.rb
@@ -24,10 +24,7 @@ RSpec.describe Git::Commands::CheckoutIndex, :integration do
     end
 
     describe 'when the command fails' do
-      # git checkout-index only exits non-zero for a missing path starting in 2.30.0; on
-      # 2.28.0-2.29.x it warns on stderr but exits 0.
-      it 'raises FailedError for a nonexistent file path',
-         skip: unless_git('2.30.0', 'git checkout-index exit status for a nonexistent path') do
+      it 'raises FailedError for a nonexistent file path' do
         expect { command.call('nonexistent.txt') }.to raise_error(Git::FailedError)
       end
     end

--- a/spec/integration/git/commands/maintenance/register_spec.rb
+++ b/spec/integration/git/commands/maintenance/register_spec.rb
@@ -3,10 +3,7 @@
 require 'spec_helper'
 require 'git/commands/maintenance/register'
 
-# --config-file requires git 2.39.0, so these integration tests require 2.39.0
-# even though the command itself supports 2.30.0.
-RSpec.describe Git::Commands::Maintenance::Register, :integration,
-               skip: unless_git('2.39.0', 'git maintenance register --config-file') do
+RSpec.describe Git::Commands::Maintenance::Register, :integration do
   include_context 'in an empty repository'
 
   subject(:command) { described_class.new(execution_context) }

--- a/spec/integration/git/commands/maintenance/run_spec.rb
+++ b/spec/integration/git/commands/maintenance/run_spec.rb
@@ -3,10 +3,7 @@
 require 'spec_helper'
 require 'git/commands/maintenance/run'
 
-# GIT_CONFIG_GLOBAL (used for global config isolation) requires git 2.32.0,
-# so these integration tests require 2.32.0 even though the command itself supports 2.30.0.
-RSpec.describe Git::Commands::Maintenance::Run, :integration,
-               skip: unless_git('2.32.0', 'git maintenance run') do
+RSpec.describe Git::Commands::Maintenance::Run, :integration do
   include_context 'in an empty repository'
 
   subject(:command) { described_class.new(execution_context) }

--- a/spec/integration/git/commands/maintenance/start_spec.rb
+++ b/spec/integration/git/commands/maintenance/start_spec.rb
@@ -4,15 +4,11 @@ require 'spec_helper'
 require 'git/commands/maintenance/start'
 require 'git/commands/maintenance/stop'
 
-# GIT_CONFIG_GLOBAL (used for global config isolation) requires git 2.32.0,
-# so these integration tests require 2.32.0 even though the command itself supports 2.30.0.
-#
 # `git maintenance start` installs OS-level scheduler entries (launchctl on macOS,
 # systemd-timer on Linux) that cannot be safely redirected. These tests are therefore
 # restricted to CI where the environment is guaranteed clean.
 RSpec.describe Git::Commands::Maintenance::Start, :integration,
-               skip: unless_git('2.32.0', 'git maintenance start') ||
-                     unless_ci_build('git maintenance start') do
+               skip: unless_ci_build('git maintenance start') do
   include_context 'in an empty repository'
 
   subject(:command) { described_class.new(execution_context) }

--- a/spec/integration/git/commands/maintenance/stop_spec.rb
+++ b/spec/integration/git/commands/maintenance/stop_spec.rb
@@ -3,15 +3,11 @@
 require 'spec_helper'
 require 'git/commands/maintenance/stop'
 
-# GIT_CONFIG_GLOBAL (used for global config isolation) requires git 2.32.0,
-# so these integration tests require 2.32.0 even though the command itself supports 2.30.0.
-#
 # `git maintenance stop` removes OS-level scheduler entries (launchctl on macOS,
 # systemd-timer on Linux). Running it on a developer machine that has existing
 # maintenance configured would silently disable their setup. Restricted to CI.
 RSpec.describe Git::Commands::Maintenance::Stop, :integration,
-               skip: unless_git('2.32.0', 'git maintenance stop') ||
-                     unless_ci_build('git maintenance stop') do
+               skip: unless_ci_build('git maintenance stop') do
   include_context 'in an empty repository'
 
   subject(:command) { described_class.new(execution_context) }

--- a/spec/integration/git/commands/maintenance/unregister_spec.rb
+++ b/spec/integration/git/commands/maintenance/unregister_spec.rb
@@ -3,10 +3,7 @@
 require 'spec_helper'
 require 'git/commands/maintenance/unregister'
 
-# --config-file requires git 2.39.0, so these integration tests require 2.39.0
-# even though the command itself supports 2.30.0.
-RSpec.describe Git::Commands::Maintenance::Unregister, :integration,
-               skip: unless_git('2.39.0', 'git maintenance unregister --config-file') do
+RSpec.describe Git::Commands::Maintenance::Unregister, :integration do
   include_context 'in an empty repository'
 
   subject(:command) { described_class.new(execution_context) }

--- a/spec/integration/git/commands/show_ref/exists_spec.rb
+++ b/spec/integration/git/commands/show_ref/exists_spec.rb
@@ -3,7 +3,7 @@
 require 'spec_helper'
 require 'git/commands/show_ref/exists'
 
-RSpec.describe Git::Commands::ShowRef::Exists, :integration, skip: unless_git('2.43.0', 'git show-ref --exists') do
+RSpec.describe Git::Commands::ShowRef::Exists, :integration do
   include_context 'in an empty repository'
 
   subject(:command) { described_class.new(execution_context) }

--- a/spec/integration/git/commands/worktree/repair_spec.rb
+++ b/spec/integration/git/commands/worktree/repair_spec.rb
@@ -3,8 +3,7 @@
 require 'spec_helper'
 require 'git/commands/worktree/repair'
 
-RSpec.describe Git::Commands::Worktree::Repair, :integration,
-               skip: unless_git('2.29.0', 'git worktree repair') do
+RSpec.describe Git::Commands::Worktree::Repair, :integration do
   include_context 'in an empty repository'
 
   subject(:command) { described_class.new(execution_context) }

--- a/spec/integration/git/parsers/config_entry_spec.rb
+++ b/spec/integration/git/parsers/config_entry_spec.rb
@@ -142,8 +142,7 @@ RSpec.describe Git::Parsers::ConfigEntry, :integration do
         set_cmd.call('http.https://example.com.proxy', 'http://proxy.example.com', local: true)
       end
 
-      it 'returns a ConfigEntryInfo with scope, key, and value populated',
-         skip: unless_git('2.42.0', 'git config --get-urlmatch --show-scope reporting the correct scope') do
+      it 'returns a ConfigEntryInfo with scope, key, and value populated' do
         raw = urlmatch_cmd.call('http.proxy', 'https://example.com', local: true, show_scope: true, null: true).stdout
 
         result = described_class.parse_urlmatch(raw)

--- a/spec/integration/git/repository/configuring_spec.rb
+++ b/spec/integration/git/repository/configuring_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Git::Repository, :integration do
     end
   end
 
-  describe '#global_config', skip: unless_git('2.32.0', 'GIT_CONFIG_GLOBAL isolation') do
+  describe '#global_config' do
     before { allow(Git::Deprecation).to receive(:warn).with(a_string_including('Git::Repository#global_config is deprecated')) }
 
     around do |example|

--- a/spec/integration/git/repository/object_operations_spec.rb
+++ b/spec/integration/git/repository/object_operations_spec.rb
@@ -76,7 +76,7 @@ RSpec.describe Git::Repository::ObjectOperations, :integration do
 
     context 'with a real SSH-signed commit',
             if: !Gem.win_platform?,
-            skip: unless_git('2.34', 'SSH commit signing') || unless_command('ssh-keygen', 'SSH commit signing') do
+            skip: unless_command('ssh-keygen', 'SSH commit signing') do
       let(:ssh_key_file) { File.join(repo_dir, '.git', 'test-key') }
 
       before do

--- a/spec/integration/git/repository/worktree_operations_spec.rb
+++ b/spec/integration/git/repository/worktree_operations_spec.rb
@@ -136,18 +136,10 @@ RSpec.describe Git::Repository::WorktreeOperations, :integration do
         FileUtils.rm_rf(worktree_path)
       end
 
-      context 'on git versions before 2.42.0', if: Git.git_version < Git::Version.new(2, 42, 0) do
-        it 'raises Git::FailedError' do
-          expect { unborn_instance.worktree_add(worktree_path) }.to raise_error(Git::FailedError, /worktree/)
-        end
-      end
+      it 'succeeds and creates a second worktree entry' do
+        unborn_instance.worktree_add(worktree_path)
 
-      context 'on git versions 2.42.0 and later', if: Git.git_version >= Git::Version.new(2, 42, 0) do
-        it 'succeeds and creates a second worktree entry' do
-          unborn_instance.worktree_add(worktree_path)
-
-          expect(unborn_instance.worktree_list.size).to eq(2)
-        end
+        expect(unborn_instance.worktree_list.size).to eq(2)
       end
     end
   end

--- a/spec/integration/git/repository/worktree_operations_spec.rb
+++ b/spec/integration/git/repository/worktree_operations_spec.rb
@@ -282,38 +282,30 @@ RSpec.describe Git::Repository::WorktreeOperations, :integration do
   end
 
   describe '#worktree_repair' do
-    context 'on git versions 2.29.0 and later', if: Git.git_version >= Git::Version.new(2, 29, 0) do
-      let(:worktree_path) { new_worktree_path }
-      let(:moved_path) { new_worktree_path }
+    let(:worktree_path) { new_worktree_path }
+    let(:moved_path) { new_worktree_path }
 
-      before do
-        described_instance.worktree_add(worktree_path)
-        FileUtils.mv(worktree_path, moved_path)
-      end
-
-      after do
-        FileUtils.rm_rf(worktree_path)
-        FileUtils.rm_rf(moved_path)
-      end
-
-      it 'reconnects a linked worktree that was moved without git' do
-        described_instance.worktree_repair(moved_path)
-
-        expect(described_instance.worktree_list.map(&:path)).to include(File.realpath(moved_path))
-      end
-
-      # With no paths, git repairs the link of the worktree at the current
-      # directory rather than the one named by --git-dir, so the example passes
-      # the moved path to keep the outcome independent of the test's cwd.
-      it 'returns the output from git as a String' do
-        expect(described_instance.worktree_repair(moved_path)).to be_a(String)
-      end
+    before do
+      described_instance.worktree_add(worktree_path)
+      FileUtils.mv(worktree_path, moved_path)
     end
 
-    context 'on git versions before 2.29.0', if: Git.git_version < Git::Version.new(2, 29, 0) do
-      it 'raises Git::VersionError' do
-        expect { described_instance.worktree_repair }.to raise_error(Git::VersionError, /2\.29\.0/)
-      end
+    after do
+      FileUtils.rm_rf(worktree_path)
+      FileUtils.rm_rf(moved_path)
+    end
+
+    it 'reconnects a linked worktree that was moved without git' do
+      described_instance.worktree_repair(moved_path)
+
+      expect(described_instance.worktree_list.map(&:path)).to include(File.realpath(moved_path))
+    end
+
+    # With no paths, git repairs the link of the worktree at the current
+    # directory rather than the one named by --git-dir, so the example passes
+    # the moved path to keep the outcome independent of the test's cwd.
+    it 'returns the output from git as a String' do
+      expect(described_instance.worktree_repair(moved_path)).to be_a(String)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,10 +89,10 @@ end
 # an example group when the installed git is too old to support the feature
 # under test.
 #
-# @param minimum_version [String] the minimum git version required (e.g., `'2.43.0'`)
+# @param minimum_version [String] the minimum git version required (e.g., `'2.46.0'`)
 #
 #   Shorter strings are treated as if trailing `.0` components were appended, so
-#   `'2.43'` is equivalent to `'2.43.0'`.
+#   `'2.46'` is equivalent to `'2.46.0'`.
 #
 # @param feature [String] the feature name to include in the skip reason
 #
@@ -100,7 +100,7 @@ end
 #   otherwise a human-readable skip reason string
 #
 # @example
-#   RSpec.describe MyFeature, skip: unless_git('2.43', 'git show-ref --exists') do
+#   RSpec.describe MyFeature, skip: unless_git('2.46', 'git am --retry') do
 #     it 'works' do
 #       # ...
 #     end
@@ -445,7 +445,7 @@ end
 #
 # @example
 #   let(:execution_context) { execution_context_double }
-#   let(:execution_context) { execution_context_double('2.30.0') }
+#   let(:execution_context) { execution_context_double('2.46.0') }
 #
 def execution_context_double(version = '99.99.99')
   double('ExecutionContext', git_version: Git::Version.parse(version))
@@ -459,7 +459,7 @@ end
 # @return [Git::Version] the version that git_version will return when called
 #
 # @example
-#   stub_git_version(execution_context, '2.28.0')
+#   stub_git_version(execution_context, '2.43.0')
 #
 def stub_git_version(context, version)
   git_version = Git::Version.parse(version)

--- a/spec/unit/git/commands/base_spec.rb
+++ b/spec/unit/git/commands/base_spec.rb
@@ -347,7 +347,7 @@ RSpec.describe Git::Commands::Base do
 
       it 'raises VersionError when git version is below MINIMUM_GIT_VERSION' do
         expect { command.call }
-          .to raise_error(Git::VersionError, /The git gem requires git >= 2.28.0/)
+          .to raise_error(Git::VersionError, /The git gem requires git >= 2.43.0/)
       end
     end
 
@@ -355,17 +355,17 @@ RSpec.describe Git::Commands::Base do
       let(:command_class) do
         Class.new(described_class) do
           arguments { literal 'status' }
-          requires_git_version '2.30.0'
+          requires_git_version '2.46.0'
         end
       end
-      let(:execution_context) { execution_context_double('2.29.0') }
+      let(:execution_context) { execution_context_double('2.45.0') }
       let(:command) { command_class.new(execution_context) }
 
       it 'raises VersionError when git version is below class minimum' do
         expect { command.call }
           .to raise_error(Git::VersionError) do |error|
-            expect(error.message).to match(/requires git >= 2.30.0/)
-            expect(error.actual_version).to eq(Git::Version.parse('2.29.0'))
+            expect(error.message).to match(/requires git >= 2.46.0/)
+            expect(error.actual_version).to eq(Git::Version.parse('2.45.0'))
           end
       end
     end
@@ -393,7 +393,7 @@ RSpec.describe Git::Commands::Base do
       let(:command_class) do
         Class.new(described_class) do
           arguments { literal 'status' }
-          requires_git_version '2.35.0'
+          requires_git_version '2.46.0'
         end
       end
       let(:execution_context) { execution_context_double('2.27.0') }
@@ -402,7 +402,7 @@ RSpec.describe Git::Commands::Base do
       it 'fails with floor message when both floor and class constraint would fail' do
         # Should fail with floor message, not class-level message
         expect { command.call }
-          .to raise_error(Git::VersionError, /The git gem requires git >= 2.28.0/)
+          .to raise_error(Git::VersionError, /The git gem requires git >= 2.43.0/)
       end
     end
 
@@ -410,10 +410,10 @@ RSpec.describe Git::Commands::Base do
       let(:command_class) do
         Class.new(described_class) do
           arguments { literal 'status' }
-          requires_git_version '2.30.0'
+          requires_git_version '2.46.0'
         end
       end
-      let(:execution_context) { execution_context_double('2.35.0') }
+      let(:execution_context) { execution_context_double('2.50.0') }
       let(:command) { command_class.new(execution_context) }
 
       it 'executes normally when version requirements are met' do
@@ -432,7 +432,7 @@ RSpec.describe Git::Commands::Base do
           arguments { literal 'status' }
         end
       end
-      let(:execution_context) { execution_context_double('2.35.0') }
+      let(:execution_context) { execution_context_double('2.43.0') }
       let(:command) { command_class.new(execution_context) }
 
       it 'executes normally when no version constraint is declared' do

--- a/spec/unit/git/minimum_git_version_spec.rb
+++ b/spec/unit/git/minimum_git_version_spec.rb
@@ -5,8 +5,8 @@ require 'spec_helper'
 RSpec.describe 'Git module' do
   describe 'MINIMUM_GIT_VERSION' do
     # Change detector: ensures intentional updates when bumping minimum version
-    it 'is defined as Git::Version 2.28.0' do
-      expect(Git::MINIMUM_GIT_VERSION).to eq(Git::Version.new(2, 28, 0))
+    it 'is defined as Git::Version 2.43.0' do
+      expect(Git::MINIMUM_GIT_VERSION).to eq(Git::Version.new(2, 43, 0))
     end
   end
 end


### PR DESCRIPTION
v6.0.0 requires git 2.43.0 or later; v5.x required 2.28.0. Git 2.43.0 is the version shipped by the supported LTS distributions (Ubuntu 24.04, RHEL 8.10 and 9.4, SLES 15 SP6, openSUSE Leap 15.6, and Alpine 3.19). Ubuntu 22.04 (git 2.34) is the supported platform whose stock git falls below the floor; its users install a newer git or stay on v5.x.

The change lands as three commits, in an order where each is green on its own:

1. `feat!: raise the minimum supported git version to 2.43.0` sets `Git::MINIMUM_GIT_VERSION` and the gemspec requirement to 2.43.0, and updates README, CONTRIBUTING, UPGRADING, the bin scripts, the agent skills, and the spec helper and base spec examples to state the new floor. This commit carries the `BREAKING CHANGE:` footer, so release-please lists the floor change in the v6.0.0 release notes as the README policy requires.
2. `refactor(commands): drop version gates below the 2.43.0 floor` removes the `requires_git_version` declarations from `Worktree::Repair` (2.29.0) and the five `Maintenance` commands (2.30.0) with their `VersionError` docs, and drops the stash option notes that named git 2.30+ and 2.35+ and the show-ref notes that named git 2.43. `Base` checks the gem-wide floor before any per-command constraint, so these gates were dead once the floor moved.
3. `test: remove git version skips at or below 2.43.0` removes the `unless_git` skips at or below 2.43 and the version-gated contexts in the worktree operations integration spec. The 2.46 skip for `git am --retry` stays.

Closes #1140

