### PR TITLE
feat!: remove the five renamed facade methods

### DIFF
--- a/.github/skills/facade-implementation/REFERENCE.md
+++ b/.github/skills/facade-implementation/REFERENCE.md
@@ -821,10 +821,10 @@ the replacement, and their operation methods stay.
 already destined for deprecation. When you touch one of these areas, add the
 value-object-returning method instead.
 
-Tags are where this bites. `Git::TagInfo` and its parser exist, but no facade method
-returns one yet: `tag`, `add_tag`, and the rest all hand back `Git::Object::Tag`. So
-following the guardrail for a tag means writing the missing facade method first, not
-reaching for one that is already there.
+Tags are the worked example. `tag`, `tags`, and `tag_add` return `Git::Object::Tag`
+and are deprecated. `tag_list` and `tag_create` return `Git::TagInfo` and are the
+pattern for any new tag facade method. Build on that pair rather than on the
+deprecated three.
 
 `Git::Object::Commit`, `Tree`, and `Blob` are a deliberate exception to step 4. See
 [ADR-0002](../../../docs/adr/0002-commit-tree-and-blob-become-hollow-shells.md).

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -8,6 +8,7 @@ to update your code when upgrading from the preceding major version.
   - [Minimum Ruby version](#minimum-ruby-version)
   - [Minimum git version](#minimum-git-version)
   - [Minimum addressable version](#minimum-addressable-version)
+  - [Renamed facade methods removed](#renamed-facade-methods-removed)
 - [Upgrading to v5.x](#upgrading-to-v5x)
   - [Overview](#overview)
   - [Breaking changes](#breaking-changes)
@@ -107,6 +108,16 @@ The `~> 2.8` constraint already permits 2.9.0, so most applications resolve it a
 `bundle update addressable`. The upgrade fails only when another gem in the bundle
 caps addressable below 2.9.0. In that case, update or replace that gem, or stay on
 the latest v5.x release.
+
+### Renamed facade methods removed
+
+v6.0.0 removes the five `Git::Repository` methods that v5.0.0 renamed to the
+`noun_verb` convention: `add_remote`, `remove_remote`, `set_remote_url`, `add_tag`,
+and `delete_tag`. Each one warned throughout v5.x and named its replacement. The
+[Facade method renames](#facade-method-renames) table under "Upgrading to v5.x" is
+the migration reference. For `add_tag`, go straight to `tag_create`: the `tag_add`
+that the v5.x warning names is deprecated too (see
+[`Git::Object::Tag` deprecated](#gitobjecttag-deprecated)).
 
 ---
 

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -1060,48 +1060,6 @@ module Git
         Git::Deprecation.silence { Git::Object::Tag.new(self, name) }
       end
 
-      # @overload add_tag(name, options = {})
-      #
-      #   @param name [String] the name of the tag to create
-      #
-      #   @param options [Hash] options for creating the tag
-      #
-      #   @return [Git::Object::Tag] the newly created tag
-      #
-      # @overload add_tag(name, target, options = {})
-      #
-      #   @param name [String] the name of the tag to create
-      #
-      #   @param target [String] the object to tag (commit SHA, branch name, etc.)
-      #
-      #   @param options [Hash] options for creating the tag
-      #
-      #   @return [Git::Object::Tag] the newly created tag
-      #
-      # @raise [ArgumentError] if unsupported options are provided
-      #
-      # @raise [ArgumentError] if an annotated or signed tag is requested without
-      #   a message
-      #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
-      #
-      # @deprecated Use {#tag_create} instead
-      #
-      #   The warning names {#tag_add}, the replacement this method shipped
-      #   with, and {#tag_add} is deprecated as well, so a creation call emits
-      #   two warnings: one for this method and one for {#tag_add}. The delete
-      #   form `add_tag(name, d: true)` emits a third, for the deprecated `:d`
-      #   and `:delete` options on {#tag_add}; use {#tag_delete} for that. Go
-      #   straight to {#tag_create} for creation.
-      #
-      def add_tag(name, *)
-        Git::Deprecation.warn(
-          'Git::Repository#add_tag is deprecated and will be removed in v6.0.0. ' \
-          'Use Git::Repository#tag_add instead.'
-        )
-        tag_add(name, *)
-      end
-
       # Delete a tag
       #
       # @example Delete a tag
@@ -1118,22 +1076,6 @@ module Git
         raise Git::FailedError, result if result.status.exitstatus.positive?
 
         result.stdout
-      end
-
-      # @param name [String] the name of the tag to delete
-      #
-      # @return [String] git's stdout from the delete
-      #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
-      #
-      # @deprecated Use {#tag_delete} instead
-      #
-      def delete_tag(name)
-        Git::Deprecation.warn(
-          'Git::Repository#delete_tag is deprecated and will be removed in v6.0.0. ' \
-          'Use Git::Repository#tag_delete instead.'
-        )
-        tag_delete(name)
       end
 
       # Private helpers

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -346,41 +346,6 @@ module Git
         nil
       end
 
-      # @param name [String] the name for the new remote
-      #
-      # @param url [String, Git::Repository] the URL of the remote repository
-      #
-      #   A {Git::Repository} instance is accepted for local references and converted
-      #   to `url.repo.to_s`.
-      #
-      # @param opts [Hash] options for adding the remote
-      #
-      # @option opts [Boolean, nil] :fetch (nil) fetch from the remote immediately
-      #   after adding it (`-f`)
-      #
-      #   The deprecated alias `:with_fetch` is accepted and normalized
-      #   automatically.
-      #
-      # @option opts [String, nil] :track (nil) track only the given branch during
-      #   fetch (`-t`)
-      #
-      # @return [Git::Remote] the newly added remote
-      #
-      # @raise [ArgumentError] when unsupported option keys are provided
-      #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
-      #
-      # @deprecated Use {#remote_add} instead
-      #
-      def add_remote(name, url, opts = {})
-        Git::Deprecation.warn(
-          'Git::Repository#add_remote is deprecated and will be removed in v6.0.0. ' \
-          'Use Git::Repository#remote_add instead.'
-        )
-        remote_add(name, url, opts)
-        Git::Remote.new(self, name)
-      end
-
       # Removes a remote from this repository
       #
       # Deletes the remote named `name` along with its associated configuration,
@@ -397,22 +362,6 @@ module Git
       #
       def remote_remove(name)
         Git::Commands::Remote::Remove.new(@execution_context).call(name)
-      end
-
-      # @param name [String] the name of the remote to remove
-      #
-      # @return [Git::CommandLine::Result] the result of calling `git remote remove`
-      #
-      # @raise [Git::FailedError] when git exits with a non-zero status
-      #
-      # @deprecated Use {#remote_remove} instead
-      #
-      def remove_remote(name)
-        Git::Deprecation.warn(
-          'Git::Repository#remove_remote is deprecated and will be removed in v6.0.0. ' \
-          'Use Git::Repository#remote_remove instead.'
-        )
-        remote_remove(name)
       end
 
       # Sets the URL for an existing remote
@@ -442,28 +391,6 @@ module Git
         Git::Commands::Remote::SetUrl.new(@execution_context).call(name, url)
 
         nil
-      end
-
-      # @param name [String] the name of the remote to update
-      #
-      # @param url [String, Git::Repository] the new URL for the remote
-      #
-      #   A {Git::Repository} instance is accepted for local references and converted
-      #   to `url.repo.to_s`.
-      #
-      # @return [Git::Remote] the updated remote
-      #
-      # @raise [Git::FailedError] if git exits with a non-zero exit status
-      #
-      # @deprecated Use {#remote_set_url} instead
-      #
-      def set_remote_url(name, url)
-        Git::Deprecation.warn(
-          'Git::Repository#set_remote_url is deprecated and will be removed in v6.0.0. ' \
-          'Use Git::Repository#remote_set_url instead.'
-        )
-        remote_set_url(name, url)
-        Git::Remote.new(self, name)
       end
 
       # Configures which branches are fetched for a remote

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -1798,32 +1798,6 @@ RSpec.describe Git::Repository::ObjectOperations do
     end
   end
 
-  # ---------------------------------------------------------------------------
-  # #add_tag (deprecated alias for #tag_add)
-  # ---------------------------------------------------------------------------
-
-  describe '#add_tag' do
-    let(:tag_object) { instance_double(Git::Object::Tag) }
-
-    before do
-      allow(described_instance).to receive(:tag_add).and_return(tag_object)
-      allow(Git::Deprecation).to receive(:warn)
-    end
-
-    it 'emits a deprecation warning matching /add_tag is deprecated/' do
-      expect(Git::Deprecation).to receive(:warn).with(/add_tag is deprecated/)
-      described_instance.add_tag('v1.0.0')
-    end
-
-    it 'calls tag_add with all arguments forwarded and returns its return value' do
-      expect(described_instance)
-        .to receive(:tag_add).with('v1.0.0', 'abc123', { force: true })
-        .and_return(tag_object)
-      result = described_instance.add_tag('v1.0.0', 'abc123', force: true)
-      expect(result).to be(tag_object)
-    end
-  end
-
   describe '#tag_delete' do
     subject(:result) { described_instance.tag_delete('v1.0.0') }
 
@@ -1864,32 +1838,6 @@ RSpec.describe Git::Repository::ObjectOperations do
           expect(error.result).to be(command_result)
         end
       end
-    end
-  end
-
-  # ---------------------------------------------------------------------------
-  # #delete_tag (deprecated alias for #tag_delete)
-  # ---------------------------------------------------------------------------
-
-  describe '#delete_tag' do
-    let(:delete_stdout) { "Deleted tag 'v1.0.0' (was abc123)\n" }
-
-    before do
-      allow(described_instance).to receive(:tag_delete).and_return(delete_stdout)
-      allow(Git::Deprecation).to receive(:warn)
-    end
-
-    it 'emits a deprecation warning matching /delete_tag is deprecated/' do
-      expect(Git::Deprecation).to receive(:warn).with(/delete_tag is deprecated/)
-      described_instance.delete_tag('v1.0.0')
-    end
-
-    it 'calls tag_delete with all arguments forwarded and returns its return value' do
-      expect(described_instance)
-        .to receive(:tag_delete).with('v1.0.0')
-        .and_return(delete_stdout)
-      result = described_instance.delete_tag('v1.0.0')
-      expect(result).to be(delete_stdout)
     end
   end
 end

--- a/spec/unit/git/repository/remote_operations_spec.rb
+++ b/spec/unit/git/repository/remote_operations_spec.rb
@@ -706,37 +706,6 @@ RSpec.describe Git::Repository::RemoteOperations do
   end
 
   # ---------------------------------------------------------------------------
-  # #add_remote (deprecated alias for #remote_add)
-  # ---------------------------------------------------------------------------
-
-  describe '#add_remote' do
-    let(:remote_object) { instance_double(Git::Remote) }
-
-    before do
-      allow(described_instance).to receive(:remote_add).and_return(nil)
-      allow(Git::Deprecation).to receive(:warn)
-      allow(Git::Remote).to receive(:new).with(described_instance, 'upstream').and_return(remote_object)
-    end
-
-    it 'emits a deprecation warning matching /add_remote is deprecated/' do
-      expect(Git::Deprecation).to receive(:warn).with(/add_remote is deprecated/)
-      described_instance.add_remote('upstream', 'https://example.com/repo.git')
-    end
-
-    it 'calls remote_add with all arguments forwarded' do
-      expect(described_instance)
-        .to receive(:remote_add).with('upstream', 'https://example.com/repo.git', { fetch: true })
-      described_instance.add_remote('upstream', 'https://example.com/repo.git', fetch: true)
-    end
-
-    it 'returns a Git::Remote for the named remote' do
-      expect(Git::Remote).to receive(:new).with(described_instance, 'upstream').and_return(remote_object)
-      result = described_instance.add_remote('upstream', 'https://example.com/repo.git')
-      expect(result).to be(remote_object)
-    end
-  end
-
-  # ---------------------------------------------------------------------------
   # #remote_remove
   # ---------------------------------------------------------------------------
 
@@ -764,32 +733,6 @@ RSpec.describe Git::Repository::RemoteOperations do
     end
 
     it 'returns the Git::CommandLine::Result' do
-      expect(result).to be(remove_result)
-    end
-  end
-
-  # ---------------------------------------------------------------------------
-  # #remove_remote (deprecated alias for #remote_remove)
-  # ---------------------------------------------------------------------------
-
-  describe '#remove_remote' do
-    let(:remove_result) { command_result('') }
-
-    before do
-      allow(described_instance).to receive(:remote_remove).and_return(remove_result)
-      allow(Git::Deprecation).to receive(:warn)
-    end
-
-    it 'emits a deprecation warning matching /remove_remote is deprecated/' do
-      expect(Git::Deprecation).to receive(:warn).with(/remove_remote is deprecated/)
-      described_instance.remove_remote('upstream')
-    end
-
-    it 'calls remote_remove with all arguments forwarded and returns its return value' do
-      expect(described_instance)
-        .to receive(:remote_remove).with('upstream')
-        .and_return(remove_result)
-      result = described_instance.remove_remote('upstream')
       expect(result).to be(remove_result)
     end
   end
@@ -963,37 +906,6 @@ RSpec.describe Git::Repository::RemoteOperations do
           .and_return(set_url_result)
         result
       end
-    end
-  end
-
-  # ---------------------------------------------------------------------------
-  # #set_remote_url (deprecated alias for #remote_set_url)
-  # ---------------------------------------------------------------------------
-
-  describe '#set_remote_url' do
-    let(:remote_object) { instance_double(Git::Remote) }
-
-    before do
-      allow(described_instance).to receive(:remote_set_url).and_return(nil)
-      allow(Git::Deprecation).to receive(:warn)
-      allow(Git::Remote).to receive(:new).with(described_instance, 'origin').and_return(remote_object)
-    end
-
-    it 'emits a deprecation warning matching /set_remote_url is deprecated/' do
-      expect(Git::Deprecation).to receive(:warn).with(/set_remote_url is deprecated/)
-      described_instance.set_remote_url('origin', 'https://example.com/repo.git')
-    end
-
-    it 'calls remote_set_url with all arguments forwarded' do
-      expect(described_instance)
-        .to receive(:remote_set_url).with('origin', 'https://example.com/repo.git')
-      described_instance.set_remote_url('origin', 'https://example.com/repo.git')
-    end
-
-    it 'returns a Git::Remote for the named remote' do
-      expect(Git::Remote).to receive(:new).with(described_instance, 'origin').and_return(remote_object)
-      result = described_instance.set_remote_url('origin', 'https://example.com/repo.git')
-      expect(result).to be(remote_object)
     end
   end
 


### PR DESCRIPTION
## Summary

Removes the five `Git::Repository` methods that v5.0.0 renamed to the `noun_verb` convention and kept as deprecated wrappers: `add_remote`, `remove_remote`, `set_remote_url`, `add_tag`, and `delete_tag`. Their unit spec examples go with them. The "Upgrading to v6.x" section of UPGRADING.md now states that the names are gone, and the v5.x "Facade method renames" table stays as the migration reference.

Under ADR-0007 the removal may land because v5.0.0 shipped the warnings and the UPGRADING.md entry, and #1767 (v5.4.1) is closed. The gate check is recorded on #1772.

`add_tag` was a forwarding wrapper around `tag_add`, so removing it first lets #1726 delete `tag_add` without touching a caller.

A second commit updates the tag example in the facade-implementation skill's guardrail, which still said no facade method returned `Git::TagInfo` and named `add_tag`.

## Commits

- `feat!: remove the five renamed facade methods` (breaking; `BREAKING CHANGE:` footer)
- `docs(skills): update the tag example in the facade-implementation guardrail`

## Verification

`bundle exec rake` passes: unit and integration specs, RuboCop, markdown links, YARD, and build.

Closes #1772