### PR TITLE
feat!: remove Git::Repository#lib

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,14 +14,12 @@ Layout/LineLength:
   Exclude:
     - 'spec/unit/git/commands/tag/list_spec.rb'
 
-# Offense count: 4
+# Offense count: 2
 # Configuration parameters: CountComments, Max, CountAsOne.
 Metrics/ClassLength:
   Exclude:
-    - 'lib/git/base.rb'
     - 'lib/git/branch.rb'
     - 'lib/git/commands/arguments.rb'
-    - 'lib/git/lib.rb'
 
 # Offense count: 1
 # Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns.

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -11,6 +11,7 @@ to update your code when upgrading from the preceding major version.
   - [Renamed facade methods removed](#renamed-facade-methods-removed)
   - [`Git::Object::Tag` removed](#gitobjecttag-removed)
   - [`Git::CommandLineResult` removed](#gitcommandlineresult-removed)
+  - [`Git::Repository#lib` removed](#gitrepositorylib-removed)
 - [Upgrading to v5.x](#upgrading-to-v5x)
   - [Overview](#overview)
   - [Breaking changes](#breaking-changes)
@@ -141,6 +142,15 @@ warning. That hook is gone, so referencing `Git::CommandLineResult` raises
 `NameError`. `Git::CommandLine::Result` is the only name for the result object.
 The [`Git::CommandLineResult` deprecated](#gitcommandlineresult-deprecated) entry
 under "Upgrading to v5.x" is the migration reference.
+
+### `Git::Repository#lib` removed
+
+v6.0.0 removes `Git::Repository#lib`. In v5.x it emitted a deprecation warning and
+returned `self`, so a v4.x call like `g.lib.some_method(args)` was forwarded to
+`g.some_method(args)`. That shim is gone, so calling `g.lib` raises
+`NoMethodError`. Call the facade method directly on the repository object. The
+[`Git::Lib` removed](#gitlib-removed) entry under "Upgrading to v5.x" maps every
+v4.x `g.lib.*` call shape to its replacement.
 
 ---
 

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -149,24 +149,6 @@ module Git
       index_file && Pathname.new(index_file)
     end
 
-    # Returns `self` after emitting a deprecation warning.
-    #
-    # Legacy callers that used `git.lib.some_method` can migrate to calling the
-    # facade method directly on the repository object. This shim will be removed
-    # in v6.0.0.
-    #
-    # @return [self]
-    #
-    # @api private
-    #
-    def lib
-      Git::Deprecation.warn(
-        'Git::Repository#lib is deprecated and will be removed in v6.0.0. ' \
-        'Use the repository object directly.'
-      )
-      self
-    end
-
     # @return [String, nil] the git directory path
     #
     # @api private

--- a/spec/unit/git/repository_spec.rb
+++ b/spec/unit/git/repository_spec.rb
@@ -207,23 +207,6 @@ RSpec.describe Git::Repository do
     end
   end
 
-  describe '#lib' do
-    subject(:lib_result) { described_instance.lib }
-
-    it 'returns self' do
-      allow(Git::Deprecation).to receive(:warn)
-      expect(lib_result).to be(described_instance)
-    end
-
-    it 'emits a deprecation warning' do
-      allow(Git::Deprecation).to receive(:warn)
-      described_instance.lib
-      expect(Git::Deprecation).to have_received(:warn).with(
-        a_string_including('Git::Repository#lib', 'deprecated', 'v6.0.0')
-      )
-    end
-  end
-
   describe 'Git::Configuring mixin' do
     it 'is included in Git::Repository so that all config_* methods are available' do
       expect(described_class.ancestors).to include(Git::Configuring)


### PR DESCRIPTION
## Summary

v6.0.0 no longer ships `Git::Repository#lib`. In v5.x it warned and returned `self` so that v4.x `g.lib.some_method` calls forwarded to the facade. After this change `g.lib` raises `NoMethodError`.

- Remove `Git::Repository#lib` and its unit spec examples
- Add a "`Git::Repository#lib` removed" entry to the "Upgrading to v6.x" section of UPGRADING.md; the "`Git::Lib` removed" tables under "Upgrading to v5.x" stay as the migration reference
- Remove the stale `lib/git/lib.rb` and `lib/git/base.rb` entries under `Metrics/ClassLength` in `.rubocop_todo.yml` (neither file has existed since v5.0.0)

ADR-0007 gate check is recorded on the issue: the warning and the UPGRADING.md entry shipped in v5.0.0, and #1767 is closed.

Closes #1769