### PR TITLE
docs(readme): replace the v5.0.0 release banner with a v6.0.0 development note

### DIFF
--- a/.github/skills/release-management/SKILL.md
+++ b/.github/skills/release-management/SKILL.md
@@ -100,6 +100,12 @@ Before a maintainer merges a release PR:
 4. **Review the release PR** — verify the auto-generated changelog and version
    bump look correct.
 
+5. **Retire the release banner** — if `README.md` opens with a banner announcing
+   this major's `.0.0` release and the release PR is the major's first minor, merge
+   a docs PR that removes the banner before merging the release PR. The banner
+   announces the major; once the series has a minor, the dated announcement entry
+   carries the history.
+
 ## Cutting a maintenance branch
 
 `main` becomes the release line for the next major as soon as the first removal merges
@@ -120,6 +126,14 @@ On `main`:
 
 - [ ] Add a README announcement entry dated the cut day: every further v<N>.x release
       comes from the new branch, and the next release from `main` is v<N+1>.0.0.
+- [ ] Put a development note at the top of `README.md`, replacing the release banner
+      if one is still there: `main` is unreleased v<N+1>.0.0 development, the current
+      release series is v<N>.x, released from the new branch, and the
+      "Upgrading to v<N+1>.x" section of `UPGRADING.md` says what changes. Name the
+      series, not a tag: later v<N>.x releases do not touch `main`, so a tag in the
+      note would go stale. This goes on a `main`-only commit, never on the shared docs
+      commit: the new branch keeps whatever `README.md` opened with at the branch
+      point.
 - [ ] Pin the next release from `main` to the next major with a `Release-As: <N+1>.0.0`
       footer on the announcement commit. Without the pin, the first commit merged to
       `main` after the cut has release-please open a release PR for the next v<N> patch
@@ -184,6 +198,12 @@ and is checked when each removal PR merges, not here.
 - [ ] README examples use no removed APIs.
 - [ ] The changelog preview in the release PR reads correctly and every removal commit
       carries a `BREAKING CHANGE` footer.
+- [ ] The development note at the top of `README.md` is replaced with a release banner
+      naming the new major and linking to `UPGRADING.md` and `CHANGELOG.md`, in a docs
+      PR merged before the release PR. `README.md` ships in the gem and on RubyDoc, so
+      a banner added after the release never reaches the major's own artifact. The
+      major's first minor release removes the banner; see
+      [Checking Release Readiness](#checking-release-readiness).
 
 ## After a major release
 

--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?log
 [![AI Policy](https://img.shields.io/badge/AI%20Policy-Doc-blue)](AI_POLICY.md)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-> **v5.0.0 is released.** It is a major release with a redesigned internal
-> architecture, but compatibility shims keep most v4.x code running unchanged.
-> See [UPGRADING.md](UPGRADING.md) for the migration guide and
-> [CHANGELOG.md](CHANGELOG.md) for full release notes.
+> **This branch is unreleased v6.0.0 development.** The current release series
+> is v5.x, released from the `5.x` branch. v6.0.0 removes the APIs deprecated
+> during v5.x. See [Upgrading to v6.x](UPGRADING.md#upgrading-to-v6x) for what
+> changes.
 
 - [Summary](#summary)
 - [Install](#install)


### PR DESCRIPTION
## Summary

Replaces the README banner that announced v5.0.0 with a note that `main` is unreleased v6.0.0 development, and records the banner swaps in the release checklists so they happen at the right time in future majors.

The banner is stale on `main` for two reasons:

- The current release series is v5.x, released from the `5.x` branch, and v5.0.0 is no longer the version anyone installs.
- `main` is pinned to v6.0.0 and the `Git::Base` shim and the other v5.x compatibility shims are already removed, so the banner's claim that "compatibility shims keep most v4.x code running unchanged" no longer describes what this README documents.

The new banner says what `main` is, names the current release series and the branch it is released from, and links to the "Upgrading to v6.x" section of UPGRADING.md. It names the series rather than a tag because later v5.x releases do not touch `main`, so a tag would go stale.

The dated 2026-07-28 announcement further down still mentions the shims. It is a historical entry that was accurate on that date, so it is left unchanged.

The `5.x` branch carries its own copy of the v5.0.0 banner, so released v5.x gems and their rubygems.org pages are unaffected.

## Release checklist

Nothing in the release process recorded either banner swap, which is how the v5.0.0 banner outlived the shims it described. The second commit adds three items to the release-management skill:

- When cutting a maintenance branch, put the development note at the top of README.md, replacing the release banner if one is still there, on a `main`-only commit.
- Before the major's release PR merges, replace the development note with a release banner. README.md ships in the gem, so a banner added after the release never reaches the major's own artifact.
- In the release readiness checklist, remove that banner when the release PR is the major's first minor, so the removal has a trigger that is checkable when it runs.
