### PR TITLE
feat!: remove Git.binary_version and the Git.ls_remote(nil) shim

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -13,6 +13,7 @@ to update your code when upgrading from the preceding major version.
   - [`Git::CommandLineResult` removed](#gitcommandlineresult-removed)
   - [`Git::Repository#lib` removed](#gitrepositorylib-removed)
   - [`Git::Base` compatibility shim removed](#gitbase-compatibility-shim-removed)
+  - [`Git.binary_version` and `Git.ls_remote(nil)` removed](#gitbinary_version-and-gitls_remotenil-removed)
 - [Upgrading to v5.x](#upgrading-to-v5x)
   - [Overview](#overview)
   - [Breaking changes](#breaking-changes)
@@ -165,6 +166,23 @@ while still adding the method to `Git::Repository`. That module is gone, so refe
 monkeypatch to an application-owned module and include it into `Git::Repository`. The
 [`Git::Base` removed](#gitbase-removed) entry under "Upgrading to v5.x" shows the
 migration.
+
+### `Git.binary_version` and `Git.ls_remote(nil)` removed
+
+v6.0.0 removes two module-level shims on `Git`:
+
+- `Git.binary_version` is gone, so calling it raises `NoMethodError`. `Git.git_version`
+  is the only way to read the git version. It returns a `Git::Version`;
+  `Git.git_version.to_a` reproduces the `[major, minor, patch]` Array, and the
+  optional binary path argument is preserved as `Git.git_version(binary_path)`.
+- `Git.ls_remote` no longer accepts `nil` as the repository argument. In v5.x `nil`
+  was normalized to `'.'` with a deprecation warning. Passing `nil` now raises
+  `ArgumentError`. Omitting the argument still defaults to `'.'`, so `Git.ls_remote`
+  and `Git.ls_remote('.', opts)` are unchanged.
+
+The [Module-level `Git` function
+deprecations](#module-level-git-function-deprecations) entry under "Upgrading to
+v5.x" maps each call shape to its replacement.
 
 ### Filesystem errors raised as `Git::Error`
 

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -350,10 +350,10 @@ module Git
   # @example From a specific remote of the current repository
   #   references = Git.ls_remote('origin')
   #
-  # @param repository [String, nil] the target repository location or the name of a remote
+  # @param repository [String] the target repository location or the name of a remote
   #
-  #   Defaults to `'.'` (the current directory). Passing `nil` explicitly is
-  #   deprecated and will be removed in v6.0.0; pass `'.'` or omit the argument.
+  #   Defaults to `'.'` (the current directory). Passing `nil` raises
+  #   `ArgumentError`; pass `'.'` or omit the argument.
   #
   # @param options [Hash] the options to pass to the git command
   #
@@ -411,8 +411,11 @@ module Git
   #
   # @return [Hash{String => Hash}] the available references of the target repo
   #
+  # @raise [ArgumentError] if `repository` is `nil` or `options` contains an unknown key
+  #
   def self.ls_remote(repository = '.', options = {})
-    repository = normalize_ls_remote_repository(repository)
+    raise ArgumentError, 'repository must not be nil' if repository.nil?
+
     options = options.dup
     log = options.delete(:log)
     unknown = options.keys - LS_REMOTE_ALLOWED_OPTS
@@ -422,29 +425,6 @@ module Git
     output_lines = Git::Commands::LsRemote.new(context).call(repository, **options).stdout.split("\n")
     Git::Parsers::LsRemote.parse_output(output_lines)
   end
-
-  # Normalize the repository argument for {.ls_remote}
-  #
-  # Returns the repository unchanged unless it is nil, in which case a
-  # deprecation warning is emitted and `'.'` is returned.
-  #
-  # @param repository [String, nil] the repository argument passed by the caller
-  #
-  # @return [String] the normalized repository value (`'.'` when nil was given)
-  #
-  # @api private
-  #
-  def self.normalize_ls_remote_repository(repository)
-    return repository unless repository.nil?
-
-    Git::Deprecation.warn(
-      'Passing nil as the repository to Git.ls_remote is deprecated and will ' \
-      "be removed in v6.0.0. Pass '.' explicitly or omit the argument instead."
-    )
-
-    '.'
-  end
-  private_class_method :normalize_ls_remote_repository
 
   # Thread-safe cache for git versions, keyed by binary path.
   @git_version_cache_mutex = Mutex.new
@@ -681,32 +661,4 @@ module Git
     raise ArgumentError, "#{invalid.join(', ')} scope requires a repository"
   end
   private_class_method :assert_valid_scope!
-
-  # Return the version of the git binary
-  #
-  # @example Basic usage
-  #   Git.binary_version  # => [2, 46, 0]
-  #
-  # @param binary_path [String, nil] path to the git binary; defaults to
-  #   `Git::Config.instance.binary_path`
-  #
-  # @return [Array<Integer>] the version of the git binary
-  #
-  # @deprecated Use {Git.git_version} instead, which returns a
-  #   {Git::Version} (not an Array)
-  #
-  #   For the legacy array shape, call: `Git.git_version.to_a`.
-  #   The optional binary_path argument is preserved:
-  #   `Git.git_version(binary_path)`.
-  #
-  def self.binary_version(binary_path = nil)
-    binary_path ||= Git::Config.instance.binary_path
-    Git::Deprecation.warn(
-      'Git.binary_version is deprecated and will be removed in v6.0.0. ' \
-      'Use Git.git_version instead, which returns a Git::Version ' \
-      '(not an Array). For the legacy array shape, call: Git.git_version.to_a. ' \
-      'The optional binary_path argument is preserved: Git.git_version(binary_path).'
-    )
-    git_version(binary_path).to_a
-  end
 end

--- a/spec/unit/git/git_configure_spec.rb
+++ b/spec/unit/git/git_configure_spec.rb
@@ -2,8 +2,8 @@
 
 require 'spec_helper'
 
-# These specs verify that Git.configure, Git.config, Git.git_version, and
-# Git.binary_version resolve global config through Git::Config.instance.
+# These specs verify that Git.configure, Git.config, and Git.git_version
+# resolve global config through Git::Config.instance.
 # They also verify that Git extends Git::Configuring for structured config access.
 #
 RSpec.describe Git do
@@ -76,19 +76,6 @@ RSpec.describe Git do
       allow(Git).to receive(:cached_git_version).and_return(Git::Version.new(2, 42, 0))
       described_class.git_version
       expect(Git).to have_received(:cached_git_version).with(expected_path)
-    end
-  end
-
-  describe '.binary_version' do
-    before do
-      allow(Git::Deprecation).to receive(:warn)
-      allow(Git).to receive(:git_version).and_return(Git::Version.new(2, 42, 0))
-    end
-
-    it 'delegates to Git.git_version for the default binary path' do
-      result = described_class.binary_version
-      expect(Git).to have_received(:git_version)
-      expect(result).to eq([2, 42, 0])
     end
   end
 end

--- a/spec/unit/git/git_remote_utilities_spec.rb
+++ b/spec/unit/git/git_remote_utilities_spec.rb
@@ -38,10 +38,12 @@ RSpec.describe Git do
     end
 
     context 'when repository is nil' do
-      it "emits a deprecation warning and defaults to '.'" do
-        expect(ls_remote_command).to receive(:call).with('.').and_return(command_result(''))
-        expect(Git::Deprecation).to receive(:warn).with(a_string_including('nil'))
-        described_class.ls_remote(nil)
+      it 'raises ArgumentError without running the command' do
+        allow(ls_remote_command).to receive(:call)
+
+        expect { described_class.ls_remote(nil) }.to raise_error(ArgumentError, /repository must not be nil/)
+
+        expect(ls_remote_command).not_to have_received(:call)
       end
     end
 

--- a/spec/unit/git/git_version_spec.rb
+++ b/spec/unit/git/git_version_spec.rb
@@ -123,44 +123,4 @@ RSpec.describe Git do
       end
     end
   end
-
-  describe '.binary_version' do
-    before do
-      allow(Git::Deprecation).to receive(:warn)
-      allow(Git).to receive(:git_version).and_return(Git::Version.new(2, 42, 0))
-    end
-
-    it 'emits a deprecation warning' do
-      described_class.binary_version
-
-      expect(Git::Deprecation).to have_received(:warn).with(
-        'Git.binary_version is deprecated and will be removed in v6.0.0. ' \
-        'Use Git.git_version instead, which returns a Git::Version ' \
-        '(not an Array). For the legacy array shape, call: Git.git_version.to_a. ' \
-        'The optional binary_path argument is preserved: Git.git_version(binary_path).'
-      ).once
-    end
-
-    it 'emits exactly one deprecation warning per call' do
-      described_class.binary_version
-
-      expect(Git::Deprecation).to have_received(:warn).exactly(1).time
-    end
-
-    it 'still returns an Array of integers' do
-      expect(described_class.binary_version).to eq([2, 42, 0])
-    end
-
-    context 'when called with an explicit binary_path' do
-      it 'passes the explicit binary_path to git_version' do
-        described_class.binary_version('/explicit/git')
-
-        expect(Git).to have_received(:git_version).with('/explicit/git')
-      end
-
-      it 'still returns an Array of integers' do
-        expect(described_class.binary_version('/explicit/git')).to eq([2, 42, 0])
-      end
-    end
-  end
 end


### PR DESCRIPTION
Closes #1773. Part of the v6.0.0 roadmap, #1717.

## Summary

Removes two module-level shims on `Git` that v5.0.0 deprecated:

- `Git.binary_version` is removed. `Git.git_version` (returning `Git::Version`) is the only way to read the git version; `Git.git_version.to_a` gives the legacy Array.
- The private normalizer that turned a `nil` repository in `Git.ls_remote` into `'.'` with a warning is removed. `Git.ls_remote(nil)` now raises `ArgumentError`. Omitting the argument still defaults to `'.'`.

The `ls_remote(nil)` decision (raise rather than pass `nil` through to git) is recorded on the issue. Passing `nil` through would make git fall back to the current branch's remote, a different result from `'.'`.

## ADR-0007 gate

- Both warnings are present in the `v5.0.0` tag.
- The UPGRADING.md entry (#1762) shipped in v5.4.1 (#1767). Both issues are closed and `v5.4.1` is on RubyGems.

## Changes

- `lib/git.rb`: remove `Git.binary_version` and `normalize_ls_remote_repository`; `ls_remote` raises `ArgumentError` on `nil`; YARD `@param` and `@raise` updated. No `Git::Deprecation.warn` call remains in the version or ls-remote code (the remaining calls belong to the config API, #1771).
- Specs: the `.binary_version` examples are removed from `git_version_spec.rb` and `git_configure_spec.rb`; the `ls_remote(nil)` example now asserts `ArgumentError` and that the command is not run.
- `UPGRADING.md`: new "Upgrading to v6.x" entry stating both removals and the `ls_remote(nil)` behavior. The v5.x "Module-level `Git` function deprecations" entry stays as the migration reference.

## Verification

`bundle exec rake default` passes (unit, integration, RuboCop, YARD, markdown links).
