### PR TITLE
fix(errors): raise Git::Error instead of a bare SystemCallError from filesystem calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,8 +203,7 @@ the full API of its result.
 
 ## Errors raised by this gem
 
-The git gem raises only `ArgumentError` or errors that subclass `Git::Error`. It
-does not explicitly raise any other types of errors.
+The git gem raises only `ArgumentError` or errors that subclass `Git::Error`.
 
 Rescue `Git::Error` to catch any runtime error raised by this gem, unless you need
 more specific error handling.
@@ -214,6 +213,18 @@ begin
   # some git operation
 rescue Git::Error => e
   puts "An error occurred: #{e.message}"
+end
+```
+
+Operating system errors from the gem's own filesystem operations, such as reading
+a `.git` pointer file or creating a temporary file, are raised as `Git::Error`.
+The original `SystemCallError` is available through `cause`:
+
+```ruby
+begin
+  repo = Git.open('/path/to/repo')
+rescue Git::Error => e
+  puts e.cause.class if e.cause.is_a?(SystemCallError) #=> Errno::EACCES
 end
 ```
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -64,7 +64,9 @@ To prepare:
    your test suite and, if possible, staging.
 6. Fix each deprecation using the entries under
    [Deprecated methods](#deprecated-methods) until the suite is clean.
-7. Upgrade to v6.0.0.
+7. Replace any `rescue Errno::*` around gem calls with `rescue Git::Error` (see
+   [Filesystem errors raised as `Git::Error`](#filesystem-errors-raised-as-giterror)).
+8. Upgrade to v6.0.0.
 
 ### Minimum Ruby version
 
@@ -163,6 +165,40 @@ while still adding the method to `Git::Repository`. That module is gone, so refe
 monkeypatch to an application-owned module and include it into `Git::Repository`. The
 [`Git::Base` removed](#gitbase-removed) entry under "Upgrading to v5.x" shows the
 migration.
+
+### Filesystem errors raised as `Git::Error`
+
+The gem's own filesystem calls used to let a bare `SystemCallError` escape, which
+contradicted the documented contract that the gem raises only `ArgumentError` or a
+`Git::Error` subclass. Those calls now raise `Git::Error`, with the original error
+available through `cause`.
+
+The affected methods are `Git.open` (reading a gitdir pointer file), `Git.export`,
+`Git::Repository#chdir`, `#with_working`, `#with_temp_index`, `#with_temp_working`,
+`#cat_file_contents`, `#each_conflict`, `#conflicts`, `#archive`, and `#repo_size`.
+
+```ruby
+# v5.x
+begin
+  Git.open('/path/to/repo')
+rescue Errno::EACCES => e
+  handle_permission_problem(e)
+end
+
+# v6.x
+begin
+  Git.open('/path/to/repo')
+rescue Git::Error => e
+  raise unless e.cause.is_a?(Errno::EACCES)
+
+  handle_permission_problem(e.cause)
+end
+```
+
+Code that already rescues `Git::Error` needs no change. A `SystemCallError` raised by
+your own block inside `chdir`, `with_working`, `with_temp_index`, `with_temp_working`,
+or the block form of `cat_file_contents` still propagates unchanged, so the gem never
+relabels an error raised by your code.
 
 ---
 

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -89,6 +89,7 @@ require 'git/status_info'
 require 'git/stash'
 require 'git/stash_info'
 require 'git/stashes'
+require 'git/system_call_guard'
 require 'git/tag_delete_failure'
 require 'git/tag_delete_result'
 require 'git/tag_info'
@@ -280,11 +281,14 @@ module Git
   #
   # @return [void]
   #
+  # @raise [Git::Error] if the `.git` directory cannot be removed
+  #
   def self.export(repository_url, directory = nil, options = {})
     options.delete(:remote)
     repo = clone(repository_url, directory, { depth: 1 }.merge(options))
     repo.checkout("origin/#{options[:branch]}") if options[:branch]
-    FileUtils.rm_r File.join(repo.dir.to_s, '.git')
+    git_dir = File.join(repo.dir.to_s, '.git')
+    Git::SystemCallGuard.call('Failed to remove the .git directory') { FileUtils.rm_r(git_dir) }
   end
 
   # Get or set a git global configuration value

--- a/lib/git/errors.rb
+++ b/lib/git/errors.rb
@@ -6,10 +6,14 @@ module Git
   # Base class for all custom git module errors
   #
   # The git gem will only raise an `ArgumentError` or an error that is a subclass of
-  # `Git::Error`. It does not explicitly raise any other types of errors.
+  # `Git::Error`.
   #
   # It is recommended to rescue `Git::Error` to catch any runtime error raised by
   # this gem unless you need more specific error handling.
+  #
+  # Operating system errors from the gem's own filesystem operations, such as
+  # reading a `.git` pointer file or creating a temporary file, are raised as
+  # `Git::Error`. The original `SystemCallError` is available through `cause`.
   #
   # Git's custom errors are arranged in the following class heirarchy:
   #

--- a/lib/git/factories.rb
+++ b/lib/git/factories.rb
@@ -284,6 +284,9 @@ module Git
     # @raise [ArgumentError] if `working_dir` is not a directory or is not inside
     #   a git working tree
     #
+    # @raise [Git::Error] if the `.git` path is a gitdir pointer file that cannot
+    #   be read
+    #
     # @note This method opens working copies only. To open a bare repository, use
     #   `Git.bare`.
     #
@@ -327,6 +330,8 @@ module Git
     #   `Git.config.binary_path`.
     #
     # @return [Git::Repository] a repository bound to the bare repository directory
+    #
+    # @raise [Git::Error] if `git_dir` is a gitdir pointer file that cannot be read
     #
     # @api public
     #

--- a/lib/git/path_resolver.rb
+++ b/lib/git/path_resolver.rb
@@ -4,6 +4,7 @@ require 'git/commands/rev_parse'
 require 'git/errors'
 require 'git/execution_context'
 require 'git/execution_context/global'
+require 'git/system_call_guard'
 
 module Git
   # Resolves and normalizes the filesystem paths that locate a Git repository
@@ -43,6 +44,9 @@ module Git
     #
     # @return [Hash{Symbol => (String, nil)}] a hash with `:working_directory`,
     #   `:repository`, and `:index` keys
+    #
+    # @raise [Git::Error] if the repository path is a gitdir pointer file that
+    #   cannot be read
     #
     def resolve_paths(working_directory: nil, repository: nil, index: nil, bare: false)
       working_dir = resolve_working_directory(working_directory, bare: bare)
@@ -106,9 +110,11 @@ module Git
     #
     def execute_rev_parse_toplevel(working_dir, binary_path: :use_global_config, git_ssh: :use_global_config)
       execution_context = Git::ExecutionContext::Global.new(binary_path: binary_path, git_ssh: git_ssh)
-      Git::Commands::RevParse.new(execution_context).call(
-        show_toplevel: true, chdir: File.expand_path(working_dir)
-      ).stdout
+      expanded_dir = Git::SystemCallGuard.call('Failed to expand the working directory path') do
+        File.expand_path(working_dir)
+      end
+
+      Git::Commands::RevParse.new(execution_context).call(show_toplevel: true, chdir: expanded_dir).stdout
     rescue Errno::ENOENT
       raise ArgumentError, 'Failed to find the root of the worktree: git binary not found'
     rescue Git::FailedError
@@ -124,12 +130,15 @@ module Git
     #
     # @return [String, nil] the absolute path, or `nil` for bare repos
     #
+    # @raise [Git::Error] if the path cannot be expanded, which happens when the
+    #   process working directory has been removed
+    #
     # @api private
     #
     def resolve_working_directory(path, bare:)
       return nil if bare
 
-      File.expand_path(path || Dir.pwd)
+      Git::SystemCallGuard.call('Failed to resolve the working directory') { File.expand_path(path || Dir.pwd) }
     end
     private_class_method :resolve_working_directory
 
@@ -149,14 +158,19 @@ module Git
     #
     # @return [String] the absolute path to the repository
     #
+    # @raise [Git::Error] if the path cannot be expanded, which happens when the
+    #   process working directory has been removed
+    #
     # @api private
     #
     def resolve_repository(path, working_dir, bare:, bare_default: nil)
-      initial_path = if bare
-                       File.expand_path(path || bare_default || Dir.pwd)
-                     else
-                       File.expand_path(path || '.git', working_dir)
-                     end
+      initial_path = Git::SystemCallGuard.call('Failed to resolve the repository directory') do
+        if bare
+          File.expand_path(path || bare_default || Dir.pwd)
+        else
+          File.expand_path(path || '.git', working_dir)
+        end
+      end
 
       resolve_gitdir_pointer(initial_path)
     end
@@ -171,6 +185,8 @@ module Git
     #
     # @return [String] the resolved absolute path
     #
+    # @raise [Git::Error] if `path` is a file that cannot be read
+    #
     # Relative pointer targets are resolved from the directory containing the
     # pointer file itself, matching git's pointer-file semantics.
     #
@@ -179,7 +195,7 @@ module Git
     def resolve_gitdir_pointer(path)
       return path unless File.file?(path)
 
-      gitdir_content = File.read(path).strip
+      gitdir_content = Git::SystemCallGuard.call('Failed to read the gitdir pointer file') { File.read(path) }.strip
       return path unless gitdir_content.start_with?('gitdir: ')
 
       gitdir_path = gitdir_content.sub(/\Agitdir: /, '')

--- a/lib/git/repository.rb
+++ b/lib/git/repository.rb
@@ -20,6 +20,7 @@ require 'git/repository/staging'
 require 'git/repository/stashing'
 require 'git/repository/status_operations'
 require 'git/repository/worktree_operations'
+require 'git/system_call_guard'
 
 module Git
   # The main public interface for interacting with a Git repository
@@ -302,12 +303,32 @@ module Git
     #
     # @return [Integer] the total size in bytes of the repository directory
     #
+    # @raise [Git::Error] if the repository directory cannot be traversed, for
+    #   example when a subdirectory cannot be searched
+    #
     def repo_size
       repository = repo
       return 0 unless repository&.directory?
 
+      Git::SystemCallGuard.call('Failed to compute the repository size') do
+        repo_size_of_directory(repository.to_s)
+      end
+    end
+
+    private
+
+    # Sums the size of every regular file under `dir`
+    #
+    # Symbolic links are not followed. Entries that disappear between the
+    # traversal and the `lstat` call are skipped.
+    #
+    # @param dir [String] the directory to traverse
+    #
+    # @return [Integer] the total size in bytes of the files under `dir`
+    #
+    def repo_size_of_directory(dir)
       total = 0
-      Find.find(repository.to_s) do |path|
+      Find.find(dir) do |path|
         stat = File.lstat(path)
         total += stat.size if stat.file?
       rescue Errno::ENOENT
@@ -315,8 +336,6 @@ module Git
       end
       total
     end
-
-    private
 
     # Normalizes deprecated `config` call shapes into positional arguments
     #

--- a/lib/git/repository/context_helpers.rb
+++ b/lib/git/repository/context_helpers.rb
@@ -4,6 +4,7 @@ require 'fileutils'
 require 'pathname'
 require 'tmpdir'
 require 'git/execution_context/repository'
+require 'git/system_call_guard'
 
 module Git
   class Repository
@@ -32,6 +33,8 @@ module Git
       # @raise [ArgumentError] if the repository has no working directory (bare
       #   repository)
       #
+      # @raise [Git::Error] if the working directory cannot be entered
+      #
       # @yield [dir] the repository working directory
       #
       # @yieldparam dir [Pathname] the working directory path
@@ -41,7 +44,7 @@ module Git
       def chdir
         raise ArgumentError, 'cannot chdir: repository has no working directory (bare repository)' if dir.nil?
 
-        Dir.chdir(dir.to_s) { yield dir }
+        context_helpers_chdir(dir.to_s) { yield dir }
       end
 
       # Temporarily switches the git index to `new_index` for the duration of
@@ -92,6 +95,8 @@ module Git
       #
       # @return [Object] the value returned by the block
       #
+      # @raise [Git::Error] if the temporary directory cannot be created
+      #
       # @yield [repo] the repository instance with the temporary index active
       #
       # @yieldparam repo [Git::Repository] `self`
@@ -102,7 +107,7 @@ module Git
         # Use a unique temp directory so the index file path is collision-free
         # and does not exist until git writes it. An existing empty file would
         # be treated as a corrupt index by git.
-        temp_dir = Dir.mktmpdir('git-temp-index-')
+        temp_dir = context_helpers_mktmpdir('git-temp-index-')
         begin
           with_index(File.join(temp_dir, 'index'), &)
         ensure
@@ -131,6 +136,8 @@ module Git
       #
       # @raise [ArgumentError] if `work_dir` does not exist on disk
       #
+      # @raise [Git::Error] if `work_dir` cannot be entered
+      #
       # @yield [repo] the repository instance with the new working directory
       #   active
       #
@@ -141,7 +148,7 @@ module Git
       def with_working(work_dir) # :yields: self
         old_context = @execution_context
         set_working(work_dir)
-        Dir.chdir(dir.to_s) { yield self }
+        context_helpers_chdir(dir.to_s) { yield self }
       ensure
         @execution_context = old_context
       end
@@ -160,6 +167,9 @@ module Git
       #
       # @return [Object] the value returned by the block
       #
+      # @raise [Git::Error] if the temporary directory cannot be created or
+      #   removed
+      #
       # @yield [repo] the repository instance with the temporary working
       #   directory active
       #
@@ -167,8 +177,10 @@ module Git
       #
       # @yieldreturn [Object] returned as the method's return value
       #
-      def with_temp_working(&block) # :yields: self
-        Dir.mktmpdir('temp-workdir') { |temp_dir| with_working(temp_dir, &block) }
+      def with_temp_working(&) # :yields: self
+        Git::SystemCallGuard.call('Failed to create or remove a temporary directory') do |guard|
+          Dir.mktmpdir('temp-workdir') { |temp_dir| guard.unguarded { with_working(temp_dir, &) } }
+        end
       end
 
       # Sets the git index to `index_file` and rebuilds the execution context
@@ -231,6 +243,49 @@ module Git
 
       private
 
+      # Runs the block with the process working directory set to `path`
+      #
+      # A `SystemCallError` from entering or leaving `path` is raised as
+      # {Git::Error}. A `SystemCallError` raised by the block propagates
+      # unchanged.
+      #
+      # The message does not name a directory because `Dir.chdir` fails on
+      # either leg: entering `path`, or restoring the previous directory
+      # afterward. The underlying `SystemCallError` names the directory that
+      # actually failed.
+      #
+      # @param path [String] the directory to enter
+      #
+      # @return [Object] the value returned by the block
+      #
+      # @raise [Git::Error] if `path` cannot be entered
+      #
+      # @yield the code to run inside `path`
+      #
+      # @yieldreturn [Object] returned as the method's return value
+      #
+      # @api private
+      #
+      def context_helpers_chdir(path, &block)
+        Git::SystemCallGuard.call('Failed to change directory') do |guard|
+          Dir.chdir(path) { guard.unguarded(&block) }
+        end
+      end
+
+      # Creates a temporary directory, raising {Git::Error} on failure
+      #
+      # @param prefix [String] the directory name prefix
+      #
+      # @return [String] the path of the new directory
+      #
+      # @raise [Git::Error] if the directory cannot be created
+      #
+      # @api private
+      #
+      def context_helpers_mktmpdir(prefix)
+        Git::SystemCallGuard.call('Failed to create a temporary directory') { Dir.mktmpdir(prefix) }
+      end
+
       # Resolves deprecated `check` argument semantics with `must_exist:`
       #
       # @param check [Boolean, nil] deprecated positional existence-check value
@@ -268,8 +323,13 @@ module Git
       #
       # @raise [ArgumentError] if `must_exist` is `true` and the path does not exist
       #
+      # @raise [Git::Error] if the path cannot be expanded, which happens when
+      #   `path` is relative and the process working directory has been removed
+      #
       def context_helpers_validate_path(path, must_exist)
-        Pathname.new(File.expand_path(path.to_s)).tap do |expanded_path|
+        expanded = Git::SystemCallGuard.call('Failed to expand the path') { File.expand_path(path.to_s) }
+
+        Pathname.new(expanded).tap do |expanded_path|
           raise ArgumentError, "path does not exist: #{expanded_path}" if must_exist && !expanded_path.exist?
         end
       end

--- a/lib/git/repository/merging.rb
+++ b/lib/git/repository/merging.rb
@@ -7,6 +7,7 @@ require 'git/commands/merge_base'
 require 'git/commands/revert/start'
 require 'git/commands/show'
 require 'git/repository/shared_private'
+require 'git/system_call_guard'
 
 module Git
   class Repository
@@ -278,6 +279,9 @@ module Git
       # @raise [Git::FailedError] when `git diff --cached` exits outside the
       #   allowed range (exit code > 2)
       #
+      # @raise [Git::Error] when the staged content cannot be written to a
+      #   temporary file
+      #
       # @yield [file, your_version, their_version] passes conflict details for
       #   each unmerged file
       #
@@ -320,6 +324,9 @@ module Git
       #
       # @raise [Git::FailedError] when `git diff --cached` exits outside the
       #   allowed range (exit code > 2)
+      #
+      # @raise [Git::Error] when the staged content cannot be written to a
+      #   temporary file
       #
       # @yield [file, your_version, their_version] passes conflict details for
       #   each unmerged file
@@ -429,6 +436,9 @@ module Git
         #
         # @return [void]
         #
+        # @raise [Git::Error] if the staged content cannot be written to a
+        #   temporary file
+        #
         # @yield [f] yields the open Tempfile containing the staged content
         #
         # @yieldparam f [Tempfile] open IO object for the staged content
@@ -437,11 +447,13 @@ module Git
         #
         # @api private
         #
-        def write_staged_file(execution_context, file_path, stage)
-          Tempfile.create([STAGE_PREFIXES[stage], File.basename(file_path)]) do |f|
-            Git::Commands::Show.new(execution_context).call(":#{stage}:#{file_path}", out: f)
-            f.flush
-            yield f
+        def write_staged_file(execution_context, file_path, stage, &block)
+          Git::SystemCallGuard.call('Failed to write the staged content to a temporary file') do |guard|
+            Tempfile.create([STAGE_PREFIXES[stage], File.basename(file_path)]) do |f|
+              Git::Commands::Show.new(execution_context).call(":#{stage}:#{file_path}", out: f)
+              f.flush
+              guard.unguarded { block.call(f) }
+            end
           end
         end
       end

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -17,6 +17,7 @@ require 'git/parsers/grep'
 require 'git/parsers/ls_tree'
 require 'git/parsers/tag'
 require 'git/repository/shared_private'
+require 'git/system_call_guard'
 require 'git/escaped_path'
 require 'tempfile'
 require 'zlib'
@@ -72,20 +73,25 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @raise [Git::Error] if a block is given and the object content cannot be
+      #   written to a temporary file
+      #
       # @see https://git-scm.com/docs/git-cat-file git-cat-file documentation
       #
-      def cat_file_contents(object)
+      def cat_file_contents(object, &block)
         raise ArgumentError, "Invalid object: '#{object}'" if object&.start_with?('-')
 
         return Git::Commands::CatFile::Raw.new(@execution_context).call(object, p: true).stdout unless block_given?
 
         # Stream git output directly to a tempfile to avoid buffering large
         # object content in memory when a block is given.
-        Tempfile.create do |file|
-          file.binmode
-          Git::Commands::CatFile::Raw.new(@execution_context).call(object, p: true, out: file)
-          file.rewind
-          yield file
+        Git::SystemCallGuard.call('Failed to write the object content to a temporary file') do |guard|
+          Tempfile.create do |file|
+            file.binmode
+            Git::Commands::CatFile::Raw.new(@execution_context).call(object, p: true, out: file)
+            file.rewind
+            guard.unguarded { block.call(file) }
+          end
         end
       end
 
@@ -298,6 +304,10 @@ module Git
       #
       # Returns an empty string when the tag does not exist.
       #
+      # Reads the loose ref file under `refs/tags` directly when it exists and
+      # falls back to `git show-ref` otherwise, including when the file cannot
+      # be read.
+      #
       # @example Get the SHA of an existing tag
       #   repo.tag_sha('v1.0')
       #   #=> "abc1234567890abcdef1234567890abcdef123456"
@@ -315,9 +325,7 @@ module Git
       def tag_sha(tag_name)
         tags_dir = File.expand_path(File.join(@execution_context.git_dir, 'refs', 'tags'))
         head = File.expand_path(File.join(tags_dir, tag_name))
-        return File.read(head).chomp if head.start_with?("#{tags_dir}#{File::SEPARATOR}") && File.file?(head)
-
-        Private.show_ref_tag_sha(@execution_context, tag_name)
+        Private.loose_tag_sha(tags_dir, head) || Private.show_ref_tag_sha(@execution_context, tag_name)
       end
 
       # Returns all recursive entries for a given tree object
@@ -621,20 +629,17 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @raise [Git::Error] if the archive file cannot be written
+      #
       # @see https://git-scm.com/docs/git-archive git-archive documentation
       #
       def archive(treeish, file = nil, opts = {})
         SharedPrivate.assert_valid_opts!(ARCHIVE_ALLOWED_OPTS, **opts)
         raise ArgumentError, "#{file.inspect} is a directory" if file && File.directory?(file)
 
-        tmp = Private.write_archive_tmp(@execution_context, treeish, opts, dest_dir: Private.staging_dir_for(file))
-        return tmp unless file
-
-        Private.atomic_replace(tmp, file)
-        file
-      rescue StandardError
-        FileUtils.rm_f(tmp) if tmp
-        raise
+        Git::SystemCallGuard.call('Failed to write the archive') do
+          Private.write_archive(@execution_context, treeish, file, opts)
+        end
       end
 
       # Returns a blob object for the given object reference
@@ -1020,6 +1025,27 @@ module Git
           raise ArgumentError, 'Cannot create an annotated or signed tag without a message.'
         end
 
+        # Read the SHA from a loose tag ref file without forking git
+        #
+        # Returns `nil` when the ref is not a loose file under `tags_dir` or when
+        # the file cannot be read, so the caller falls back to `git show-ref`.
+        #
+        # @param tags_dir [String] absolute path of the `refs/tags` directory
+        #
+        # @param head [String] absolute path of the candidate loose ref file
+        #
+        # @return [String, nil] the SHA in the file, or `nil` to fall back to git
+        #
+        # @api private
+        #
+        def loose_tag_sha(tags_dir, head)
+          return nil unless head.start_with?("#{tags_dir}#{File::SEPARATOR}") && File.file?(head)
+
+          File.read(head).chomp
+        rescue SystemCallError
+          nil
+        end
+
         # Returns the direct SHA for a tag reference
         #
         # Returns the hash from `refs/tags/<name>` only. Returns an empty string
@@ -1076,6 +1102,45 @@ module Git
           return Dir.tmpdir unless file
 
           File.dirname(File.expand_path(file))
+        end
+
+        # Write a git archive, staging it in a temporary file first
+        #
+        # @param execution_context [Git::ExecutionContext] the execution context
+        #
+        # @param treeish [String] tree-ish to archive
+        #
+        # @param file [String, nil] destination path, or `nil` to keep the
+        #   temporary file
+        #
+        # @param opts [Hash] caller-supplied options (read-only)
+        #
+        # @option opts [String] :format ('zip') archive format (`'tar'`, `'zip'`,
+        #   or `'tgz'`)
+        #
+        # @option opts [Boolean, nil] :add_gzip (nil) apply gzip post-processing
+        #   to the generated archive
+        #
+        # @option opts [String] :prefix (nil) prefix for entries in the archive
+        #
+        # @option opts [String] :path (nil) path within `treeish` to archive
+        #
+        # @option opts [String] :remote (nil) remote repository from which to
+        #   retrieve the archive
+        #
+        # @return [String] path to the written archive file
+        #
+        # @api private
+        #
+        def write_archive(execution_context, treeish, file, opts)
+          tmp = write_archive_tmp(execution_context, treeish, opts, dest_dir: staging_dir_for(file))
+          return tmp unless file
+
+          atomic_replace(tmp, file)
+          file
+        rescue StandardError
+          FileUtils.rm_f(tmp) if tmp
+          raise
         end
 
         # Write a git archive to a fresh temporary file and return its path

--- a/lib/git/system_call_guard.rb
+++ b/lib/git/system_call_guard.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+require 'git/errors'
+
+module Git
+  # Convert `SystemCallError` raised by the gem's own filesystem calls to {Git::Error}
+  #
+  # The gem promises to raise only `ArgumentError` or a subclass of {Git::Error}.
+  # Filesystem calls such as `File.read`, `Dir.chdir`, or `Tempfile.create` can
+  # raise a bare `SystemCallError` (`Errno::ENOENT`, `Errno::EACCES`, and so on).
+  # Wrapping those calls in {.call} keeps the promise: the `SystemCallError` is
+  # re-raised as a {Git::Error} with the original error available as `cause`.
+  #
+  # Helpers that yield to caller-supplied blocks must not relabel errors raised
+  # by the caller's own code. {#unguarded} marks that region so a
+  # `SystemCallError` raised inside it propagates unchanged.
+  #
+  # @example Guard a single filesystem call
+  #   content = Git::SystemCallGuard.call('Failed to read the gitdir pointer file') do
+  #     File.read(path)
+  #   end
+  #
+  # @example Guard setup and cleanup but not the caller's block
+  #   def with_tempfile(&block)
+  #     Git::SystemCallGuard.call('Failed to create a temporary file') do |guard|
+  #       Tempfile.create do |file|
+  #         guard.unguarded { block.call(file) }
+  #       end
+  #     end
+  #   end
+  #
+  # @api private
+  #
+  class SystemCallGuard
+    # Run the block, converting any `SystemCallError` it raises to {Git::Error}
+    #
+    # @param message [String] prefix for the {Git::Error} message
+    #
+    # @return [Object] the value returned by the block
+    #
+    # @raise [Git::Error] if the block raises a `SystemCallError` outside an
+    #   unguarded region
+    #
+    # @yield [guard] the guarded region
+    #
+    # @yieldparam guard [Git::SystemCallGuard] use {#unguarded} to exempt a region
+    #
+    # @yieldreturn [Object] returned as the method's return value
+    #
+    def self.call(message, &)
+      new.call(message, &)
+    end
+
+    # Run the block, converting any `SystemCallError` it raises to {Git::Error}
+    #
+    # @param (see .call)
+    #
+    # @return (see .call)
+    #
+    # @raise (see .call)
+    #
+    # @yield (see .call)
+    #
+    # @yieldparam (see .call)
+    #
+    # @yieldreturn (see .call)
+    #
+    def call(message)
+      yield self
+    rescue SystemCallError => e
+      raise if e.equal?(@unguarded_error)
+
+      raise Git::Error, "#{message}: #{e.message}"
+    end
+
+    # Run the block with `SystemCallError` conversion suspended
+    #
+    # If the block raises a `SystemCallError`, the enclosing {#call} re-raises
+    # that same error unchanged. Any other `SystemCallError` reaching {#call},
+    # including one raised while unwinding from the block's error, is converted.
+    #
+    # @return [Object] the value returned by the block
+    #
+    # @yield the region exempt from conversion
+    #
+    # @yieldreturn [Object] returned as the method's return value
+    #
+    def unguarded
+      yield
+    rescue SystemCallError => e
+      @unguarded_error = e
+      raise
+    end
+  end
+end

--- a/spec/integration/git/git_spec.rb
+++ b/spec/integration/git/git_spec.rb
@@ -34,6 +34,58 @@ RSpec.describe Git, :integration do
       expect(repository.repo_size).to be > 0
     end
 
+    context 'when a repository subdirectory is readable but not searchable' do
+      let(:unsearchable_dir) { File.join(repo_dir, '.git', 'objects') }
+
+      before do
+        skip 'POSIX file modes are not supported on Windows' if Gem.win_platform?
+        skip 'root bypasses POSIX file modes' if Process.euid.zero?
+
+        # Mode 0444 lets Find.find list the directory but makes File.lstat fail
+        # on each entry inside it. Mode 0 would instead fail the listing itself,
+        # which Find.find swallows under its default ignore_error: true.
+        # Open the repository before restricting the mode: Git.open shells out
+        # to git, which needs to read the object store.
+        repository
+
+        File.write(File.join(unsearchable_dir, 'probe.txt'), 'x' * 10)
+        File.chmod(0o444, unsearchable_dir)
+      end
+
+      after { File.chmod(0o755, unsearchable_dir) if File.exist?(unsearchable_dir) }
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { repository.repo_size }
+          .to raise_error(Git::Error, /Failed to compute the repository size/) do |error|
+            expect(error.cause).to be_a(Errno::EACCES)
+          end
+      end
+    end
+
+    context 'when a repository subdirectory cannot be listed at all' do
+      let(:unlistable_dir) { File.join(repo_dir, '.git', 'objects') }
+      let!(:size_before) do
+        skip 'POSIX file modes are not supported on Windows' if Gem.win_platform?
+        skip 'root bypasses POSIX file modes' if Process.euid.zero?
+
+        repository
+
+        File.write(File.join(unlistable_dir, 'probe.txt'), 'x' * 10)
+        repository.repo_size
+      end
+
+      before { File.chmod(0, unlistable_dir) }
+
+      after { File.chmod(0o755, unlistable_dir) if File.exist?(unlistable_dir) }
+
+      it 'silently skips the subtree rather than raising' do
+        # Find.find swallows the Dir.children failure under its default
+        # ignore_error: true, so the total is quietly low rather than an error.
+        # This pins that behavior so a change to Find's default is noticed.
+        expect(repository.repo_size).to be < size_before
+      end
+    end
+
     context 'when given an explicit repository path' do
       let(:options) { { repository: File.join(repo_dir, '.git') } }
 

--- a/spec/unit/git/path_resolver_spec.rb
+++ b/spec/unit/git/path_resolver_spec.rb
@@ -119,6 +119,46 @@ RSpec.describe Git::PathResolver do
       end
     end
 
+    context 'when the gitdir pointer file cannot be read' do
+      let(:pointer_file) { File.expand_path('/repo/.git') }
+      let(:args) { { working_directory: '/repo', repository: pointer_file } }
+
+      before do
+        allow(File).to receive(:file?).with(pointer_file).and_return(true)
+        allow(File).to receive(:read).with(pointer_file).and_raise(Errno::EACCES, pointer_file)
+      end
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { paths }.to raise_error(Git::Error, /gitdir pointer file.*Permission denied/) do |error|
+          expect(error.cause).to be_a(Errno::EACCES)
+        end
+      end
+    end
+
+    context 'when the working directory has been removed' do
+      let(:args) { {} }
+
+      before { allow(Dir).to receive(:pwd).and_raise(Errno::ENOENT, 'getcwd') }
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { paths }.to raise_error(Git::Error, /Failed to resolve the working directory/) do |error|
+          expect(error.cause).to be_a(Errno::ENOENT)
+        end
+      end
+    end
+
+    context 'when the bare repository path cannot be expanded' do
+      let(:args) { { bare: true } }
+
+      before { allow(Dir).to receive(:pwd).and_raise(Errno::ENOENT, 'getcwd') }
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { paths }.to raise_error(Git::Error, /Failed to resolve the repository directory/) do |error|
+          expect(error.cause).to be_a(Errno::ENOENT)
+        end
+      end
+    end
+
     context 'when the repository path is a file without a gitdir pointer' do
       let(:tmp_dir) { Dir.mktmpdir }
       let(:plain_file) { File.join(tmp_dir, '.git') }
@@ -251,6 +291,21 @@ RSpec.describe Git::PathResolver do
 
       it 'raises ArgumentError indicating the git binary was not found' do
         expect { root }.to raise_error(ArgumentError, /git binary not found/)
+      end
+    end
+
+    context 'when the working directory path cannot be expanded' do
+      before do
+        # A relative path is expanded against Dir.pwd, which fails when the
+        # process working directory has been removed. Without the guard this
+        # ENOENT is misreported as a missing git binary.
+        allow(File).to receive(:expand_path).with(working_dir).and_raise(Errno::ENOENT, 'getcwd')
+      end
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { root }.to raise_error(Git::Error, /Failed to expand the working directory path/) do |error|
+          expect(error.cause).to be_a(Errno::ENOENT)
+        end
       end
     end
 

--- a/spec/unit/git/repository/context_helpers_spec.rb
+++ b/spec/unit/git/repository/context_helpers_spec.rb
@@ -72,6 +72,51 @@ RSpec.describe Git::Repository::ContextHelpers do
       expect(result).to eq(42)
     end
 
+    context 'when the working directory cannot be entered' do
+      before do
+        allow(Dir).to receive(:chdir).with(work_dir).and_raise(Errno::ENOENT, work_dir)
+      end
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { described_instance.chdir { nil } }
+          .to raise_error(Git::Error, /Failed to change directory.*No such file or directory/) do |error|
+            expect(error.cause).to be_a(Errno::ENOENT)
+          end
+      end
+    end
+
+    context 'when the block raises a SystemCallError' do
+      it 'lets the SystemCallError propagate unchanged' do
+        expect { described_instance.chdir { raise Errno::ENOENT, 'caller.txt' } }
+          .to raise_error(Errno::ENOENT, /caller\.txt/)
+      end
+    end
+
+    context 'when the previous directory cannot be restored' do
+      before do
+        # Dir.chdir's block form also fails on the way out, after the block has
+        # run. The reported directory must be the one that failed, not the one
+        # that was entered successfully.
+        allow(Dir).to receive(:chdir).with(work_dir) do |_path, &block|
+          block.call
+          raise Errno::ENOENT, '/deleted/previous/dir'
+        end
+      end
+
+      it 'raises Git::Error naming the directory that could not be restored' do
+        expect { described_instance.chdir { nil } }
+          .to raise_error(Git::Error, %r{Failed to change directory.*/deleted/previous/dir}) do |error|
+            expect(error.cause).to be_a(Errno::ENOENT)
+          end
+      end
+
+      it 'does not name the successfully entered directory' do
+        expect { described_instance.chdir { nil } }.to raise_error(Git::Error) do |error|
+          expect(error.message).not_to include(work_dir)
+        end
+      end
+    end
+
     context 'when the repository is bare (no working directory)' do
       let(:execution_context) do
         instance_double(
@@ -227,6 +272,26 @@ RSpec.describe Git::Repository::ContextHelpers do
   # ---------------------------------------------------------------------------
 
   describe '#with_temp_index' do
+    context 'when the temporary directory cannot be created' do
+      before do
+        allow(Dir).to receive(:mktmpdir).and_raise(Errno::EACCES, '/tmp')
+      end
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { described_instance.with_temp_index { nil } }
+          .to raise_error(Git::Error, /Failed to create a temporary directory.*Permission denied/) do |error|
+            expect(error.cause).to be_a(Errno::EACCES)
+          end
+      end
+    end
+
+    context 'when the block raises a SystemCallError' do
+      it 'lets the SystemCallError propagate unchanged' do
+        expect { described_instance.with_temp_index { raise Errno::ENOENT, 'caller.txt' } }
+          .to raise_error(Errno::ENOENT, /caller\.txt/)
+      end
+    end
+
     it 'yields self' do
       expect { |b| described_instance.with_temp_index(&b) }.to yield_with_args(described_instance)
     end
@@ -305,6 +370,21 @@ RSpec.describe Git::Repository::ContextHelpers do
 
     it 'returns nil (void)' do
       expect(described_instance.set_working('/other/dir', must_exist: false)).to be_nil
+    end
+
+    context 'when the path cannot be expanded' do
+      before do
+        # File.expand_path consults Dir.pwd for a relative path, so it fails
+        # when the process working directory has been removed.
+        allow(File).to receive(:expand_path).with('relative/dir').and_raise(Errno::ENOENT, 'getcwd')
+      end
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { described_instance.set_working('relative/dir', must_exist: false) }
+          .to raise_error(Git::Error, /Failed to expand the path/) do |error|
+            expect(error.cause).to be_a(Errno::ENOENT)
+          end
+      end
     end
 
     context 'when must_exist: true and the directory exists' do
@@ -401,6 +481,32 @@ RSpec.describe Git::Repository::ContextHelpers do
       expect(described_instance.execution_context).to be(original_ctx)
     end
 
+    context 'when the working directory cannot be entered' do
+      before do
+        allow(Dir).to receive(:chdir).with(expanded_work_dir).and_raise(Errno::ENOENT, expanded_work_dir)
+      end
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { described_instance.with_working(real_work_dir) { nil } }
+          .to raise_error(Git::Error, /Failed to change directory.*No such file or directory/) do |error|
+            expect(error.cause).to be_a(Errno::ENOENT)
+          end
+      end
+
+      it 'restores the original execution context' do
+        original_ctx = described_instance.execution_context
+        expect { described_instance.with_working(real_work_dir) { nil } }.to raise_error(Git::Error)
+        expect(described_instance.execution_context).to be(original_ctx)
+      end
+    end
+
+    context 'when the block raises a SystemCallError' do
+      it 'lets the SystemCallError propagate unchanged' do
+        expect { described_instance.with_working(real_work_dir) { raise Errno::ENOENT, 'caller.txt' } }
+          .to raise_error(Errno::ENOENT, /caller\.txt/)
+      end
+    end
+
     it 'raises ArgumentError when work_dir does not exist' do
       expect do
         described_instance.with_working('/nonexistent/path/for/test')
@@ -415,6 +521,39 @@ RSpec.describe Git::Repository::ContextHelpers do
   describe '#with_temp_working' do
     before do
       allow(Dir).to receive(:chdir).and_yield
+    end
+
+    context 'when the temporary directory cannot be created' do
+      before do
+        allow(Dir).to receive(:mktmpdir).and_raise(Errno::EACCES, '/tmp')
+      end
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { described_instance.with_temp_working { nil } }
+          .to raise_error(Git::Error, /Failed to create or remove a temporary directory.*Permission denied/) do |error|
+            expect(error.cause).to be_a(Errno::EACCES)
+          end
+      end
+    end
+
+    context 'when the temporary directory cannot be removed' do
+      before do
+        allow(FileUtils).to receive(:remove_entry).and_raise(Errno::EACCES, '/tmp/temp-workdir')
+      end
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { described_instance.with_temp_working { nil } }
+          .to raise_error(Git::Error, /Failed to create or remove a temporary directory.*Permission denied/) do |error|
+            expect(error.cause).to be_a(Errno::EACCES)
+          end
+      end
+    end
+
+    context 'when the block raises a SystemCallError' do
+      it 'lets the SystemCallError propagate unchanged' do
+        expect { described_instance.with_temp_working { raise Errno::ENOENT, 'caller.txt' } }
+          .to raise_error(Errno::ENOENT, /caller\.txt/)
+      end
     end
 
     it 'yields self' do

--- a/spec/unit/git/repository/merging_spec.rb
+++ b/spec/unit/git/repository/merging_spec.rb
@@ -626,6 +626,28 @@ RSpec.describe Git::Repository::Merging do
         expect { |b| described_instance.each_conflict(&b) }.to yield_control.once
       end
 
+      context 'when the temporary file cannot be created' do
+        before do
+          allow(Tempfile).to receive(:create).and_raise(Errno::EACCES, '/tmp')
+        end
+
+        it 'raises Git::Error with the system error as cause' do
+          expect { described_instance.each_conflict { nil } }
+            .to raise_error(Git::Error,
+                            /Failed to write the staged content to a temporary file.*Permission denied/) do |error|
+              expect(error.cause).to be_a(Errno::EACCES)
+            end
+        end
+      end
+
+      context 'when the block raises a SystemCallError' do
+        it 'lets the SystemCallError propagate unchanged' do
+          failing_block = proc { raise Errno::ENOENT, 'caller.txt' }
+          expect { described_instance.each_conflict(&failing_block) }
+            .to raise_error(Errno::ENOENT, /caller\.txt/)
+        end
+      end
+
       it 'yields the file path as the first argument' do
         described_instance.each_conflict do |file, _your, _their|
           expect(file).to eq('example.txt')

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -89,6 +89,34 @@ RSpec.describe Git::Repository::ObjectOperations do
       end
     end
 
+    context 'with a block when the temporary file cannot be created' do
+      before do
+        allow(Tempfile).to receive(:create).and_raise(Errno::EACCES, '/tmp')
+      end
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { described_instance.cat_file_contents('HEAD') { |_f| nil } }
+          .to raise_error(Git::Error,
+                          /Failed to write the object content to a temporary file.*Permission denied/) do |error|
+            expect(error.cause).to be_a(Errno::EACCES)
+          end
+      end
+    end
+
+    context 'with a block that raises a SystemCallError' do
+      before do
+        allow(raw_command).to receive(:call) do |_object, **kwargs|
+          kwargs[:out].write('content')
+          command_result('')
+        end
+      end
+
+      it 'lets the SystemCallError propagate unchanged' do
+        expect { described_instance.cat_file_contents('HEAD') { |_f| raise Errno::ENOENT, 'caller.txt' } }
+          .to raise_error(Errno::ENOENT, /caller\.txt/)
+      end
+    end
+
     context 'when object starts with a hyphen' do
       subject(:result) { described_instance.cat_file_contents('--batch') }
 
@@ -454,6 +482,23 @@ RSpec.describe Git::Repository::ObjectOperations do
       it 'reads the SHA directly from the file without forking a git process' do
         expect(described_instance.tag_sha('v1.0')).to eq('abc1234')
         expect(Git::Commands::ShowRef::List).not_to have_received(:new)
+      end
+    end
+
+    context 'when the loose ref file exists but cannot be read' do
+      before do
+        allow(File).to receive(:file?).with(tag_ref_path).and_return(true)
+        allow(File).to receive(:read).with(tag_ref_path).and_raise(Errno::EACCES, tag_ref_path)
+        allow(show_ref_list_command).to receive(:call)
+          .and_return(command_result("abc1234 refs/tags/v1.0\n"))
+      end
+
+      it 'falls through to git show-ref and returns the SHA' do
+        expect(described_instance.tag_sha('v1.0')).to eq('abc1234')
+      end
+
+      it 'does not raise the SystemCallError' do
+        expect { described_instance.tag_sha('v1.0') }.not_to raise_error
       end
     end
 
@@ -982,6 +1027,27 @@ RSpec.describe Git::Repository::ObjectOperations do
       end
     end
 
+    context 'when the destination cannot be written' do
+      let(:tmpfile) do
+        t = Tempfile.new(['archive_unit', '.zip'])
+        t.close
+        t
+      end
+
+      after { tmpfile.close! }
+
+      before do
+        allow(File).to receive(:rename).and_raise(Errno::EACCES, tmpfile.path)
+      end
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { described_instance.archive('HEAD', tmpfile.path) }
+          .to raise_error(Git::Error, /Failed to write the archive.*Permission denied/) do |error|
+            expect(error.cause).to be_a(Errno::EACCES)
+          end
+      end
+    end
+
     context 'with an output path that does not yet exist' do
       let(:new_dest) { File.join(Dir.tmpdir, "archive_unit_new_#{Process.pid}.zip") }
 
@@ -999,8 +1065,11 @@ RSpec.describe Git::Repository::ObjectOperations do
                                            .and_raise(Errno::ENOSPC, 'No space left on device')
       end
 
-      it 'propagates the error' do
-        expect { described_instance.archive('HEAD') }.to raise_error(Errno::ENOSPC)
+      it 'raises Git::Error with the system error as cause' do
+        expect { described_instance.archive('HEAD') }
+          .to raise_error(Git::Error, /Failed to write the archive.*No space left on device/) do |error|
+            expect(error.cause).to be_a(Errno::ENOSPC)
+          end
       end
     end
 
@@ -1011,8 +1080,11 @@ RSpec.describe Git::Repository::ObjectOperations do
                                            .and_raise(Errno::ENOSPC, 'No space left on device')
       end
 
-      it 'propagates the error' do
-        expect { described_instance.archive('HEAD', nil, add_gzip: true) }.to raise_error(Errno::ENOSPC)
+      it 'raises Git::Error with the system error as cause' do
+        expect { described_instance.archive('HEAD', nil, add_gzip: true) }
+          .to raise_error(Git::Error, /Failed to write the archive.*No space left on device/) do |error|
+            expect(error.cause).to be_a(Errno::ENOSPC)
+          end
       end
     end
 

--- a/spec/unit/git/repository_spec.rb
+++ b/spec/unit/git/repository_spec.rb
@@ -205,6 +205,18 @@ RSpec.describe Git::Repository do
         expect(repo_size).to eq(150)
       end
     end
+
+    context 'when a directory cannot be searched' do
+      before do
+        allow(File).to receive(:lstat).and_raise(Errno::EACCES, repo_dir)
+      end
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { repo_size }.to raise_error(Git::Error, /Failed to compute the repository size/) do |error|
+          expect(error.cause).to be_a(Errno::EACCES)
+        end
+      end
+    end
   end
 
   describe 'Git::Configuring mixin' do

--- a/spec/unit/git/system_call_guard_spec.rb
+++ b/spec/unit/git/system_call_guard_spec.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/system_call_guard'
+
+RSpec.describe Git::SystemCallGuard do
+  describe '.call' do
+    context 'when the block completes without error' do
+      it 'returns the value returned by the block' do
+        expect(described_class.call('Failed to read') { 42 }).to eq(42)
+      end
+    end
+
+    context 'when the block raises a SystemCallError' do
+      subject(:call) do
+        described_class.call('Failed to read pointer') { raise Errno::EACCES, '/repo/.git' }
+      end
+
+      it 'raises Git::Error with the message prefix and the system error message' do
+        expect { call }.to raise_error(Git::Error, 'Failed to read pointer: Permission denied - /repo/.git')
+      end
+
+      it 'sets the SystemCallError as the cause of the Git::Error' do
+        expect { call }.to raise_error(Git::Error) do |error|
+          expect(error.cause).to be_a(Errno::EACCES)
+        end
+      end
+    end
+
+    context 'when the block raises an error that is not a SystemCallError' do
+      it 'lets the error propagate unchanged' do
+        expect { described_class.call('Failed') { raise ArgumentError, 'bad' } }
+          .to raise_error(ArgumentError, 'bad')
+      end
+    end
+
+    context 'when a SystemCallError is raised inside an unguarded region' do
+      it 'lets the SystemCallError propagate unchanged' do
+        expect do
+          described_class.call('Failed') { |guard| guard.unguarded { raise Errno::ENOENT, 'caller.txt' } }
+        end.to raise_error(Errno::ENOENT, 'No such file or directory - caller.txt')
+      end
+    end
+
+    context 'when a SystemCallError is raised after an unguarded region completes' do
+      it 'raises Git::Error' do
+        expect do
+          described_class.call('Failed to clean up') do |guard|
+            guard.unguarded { :ok }
+            raise Errno::ENOENT, 'tmpdir'
+          end
+        end.to raise_error(Git::Error, 'Failed to clean up: No such file or directory - tmpdir')
+      end
+    end
+
+    context 'when a SystemCallError is raised while unwinding from an unguarded region that raised' do
+      it 'raises Git::Error for the second error' do
+        expect do
+          described_class.call('Failed to restore directory') do |guard|
+            guard.unguarded { raise Errno::ENOENT, 'caller.txt' }
+          ensure
+            raise Errno::ENOENT, 'original-dir'
+          end
+        end.to raise_error(Git::Error, 'Failed to restore directory: No such file or directory - original-dir')
+      end
+    end
+
+    context 'when an unguarded SystemCallError passes through a nested guard' do
+      it 'lets the SystemCallError propagate unchanged through both guards' do
+        expect do
+          described_class.call('Outer') do |outer|
+            outer.unguarded do
+              described_class.call('Inner') { |inner| inner.unguarded { raise Errno::ENOENT, 'caller.txt' } }
+            end
+          end
+        end.to raise_error(Errno::ENOENT, 'No such file or directory - caller.txt')
+      end
+    end
+
+    context 'when the unguarded region completes without error' do
+      it 'returns the value returned by the unguarded block' do
+        result = described_class.call('Failed') { |guard| guard.unguarded { :inner } }
+        expect(result).to eq(:inner)
+      end
+    end
+  end
+end

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -98,5 +98,18 @@ RSpec.describe Git do
         result
       end
     end
+
+    context 'when the .git directory cannot be removed' do
+      before do
+        allow(FileUtils).to receive(:rm_r).and_raise(Errno::EACCES, File.join(directory, '.git'))
+      end
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { result }
+          .to raise_error(Git::Error, /Failed to remove the \.git directory.*Permission denied/) do |error|
+            expect(error.cause).to be_a(Errno::EACCES)
+          end
+      end
+    end
   end
 end


### PR DESCRIPTION
Closes #1804
Closes #1806

## Problem

The README promises that the gem raises only `ArgumentError` or a `Git::Error` subclass. Several filesystem calls let a bare `SystemCallError` escape. The two `File.read` sites in the report fail on a permission problem alone, no race needed: `File.file?` returns true for a file the process cannot read.

The gap was wider than the two reported sites. `Dir.chdir`, `Dir.mktmpdir`, `Tempfile.create`, the archive staging and rename steps, `FileUtils.rm_r` in `Git.export`, the `File.lstat` traversal in `repo_size` (issue 1806), and the `Dir.pwd`/`File.expand_path` path resolution all had the same problem.

## Change

- Add `Git::SystemCallGuard`, a private helper that rescues `SystemCallError` and re-raises `Git::Error` with the original as `cause`. Helpers that yield to a caller's block use `guard.unguarded` so a `SystemCallError` raised by the caller's own code propagates unchanged.
- Guard every site: the gitdir pointer read in `Git.open`, `chdir`, `with_working`, `with_temp_index`, `with_temp_working`, block-form `cat_file_contents`, `each_conflict` and `conflicts`, `archive`, `Git.export`, `repo_size`, and the path expansion in `Git::PathResolver` and `set_index`/`set_working`.
- `File.expand_path` consults `Dir.pwd` for a relative path, so it fails when the process working directory has been removed. In `root_of_worktree` that `Errno::ENOENT` was previously reported as "git binary not found".
- The `chdir` guard message no longer names the target directory. `Dir.chdir`'s block form fails on either leg, and naming the target was wrong when restoring the previous directory is what failed. The underlying `SystemCallError` names the directory that actually failed.
- `tag_sha` is the one site that does not raise. The loose ref read is a fast path, so on a system error it falls through to `git show-ref`.
- README and the `Git::Error` doc drop the "does not explicitly raise" hedge and say the original `SystemCallError` is available through `cause`. `@raise [Git::Error]` added to each affected public method.

## Behavior change

Code that rescued `Errno::*` directly around the methods above now sees `Git::Error`. This is a bug fix, not a breaking change: the documented contract has always been `Git::Error`, and the bare `Errno` was never part of the public API. Ships in v6.0.0 only; `5.x` is unchanged.

## Tests

Unit specs for each site stub the filesystem call to raise `Errno::EACCES`, `Errno::ENOSPC`, or `Errno::ENOENT` and assert `Git::Error` with the `Errno` as `cause`. Pass-through specs assert a `SystemCallError` raised inside a caller's block is unchanged, and a `chdir` spec asserts the restore-leg failure names the directory that failed rather than the one entered. Two existing archive specs that expected a bare `Errno::ENOSPC` now expect `Git::Error`.
