### PR TITLE
refactor(path_resolver): remove the unreachable git-binary-not-found rescue

### DIFF
--- a/lib/git/factories.rb
+++ b/lib/git/factories.rb
@@ -285,7 +285,8 @@ module Git
     #   a git working tree
     #
     # @raise [Git::Error] if the `.git` path is a gitdir pointer file that cannot
-    #   be read
+    #   be read, if the git binary cannot be found or fails to launch, or if a
+    #   filesystem call made while resolving the paths fails
     #
     # @note This method opens working copies only. To open a bare repository, use
     #   `Git.bare`.
@@ -477,6 +478,9 @@ module Git
     # @return [String] the absolute path to the root of the working tree
     #
     # @raise [ArgumentError] if `working_dir` is not inside a git working tree
+    #
+    # @raise [Git::Error] if the git binary cannot be found or fails to launch, or
+    #   if `working_dir` cannot be expanded to an absolute path
     #
     # @api private
     #

--- a/lib/git/path_resolver.rb
+++ b/lib/git/path_resolver.rb
@@ -85,7 +85,8 @@ module Git
     # @raise [ArgumentError] if `working_dir` does not exist, is not a
     #   directory, or is not inside a git working tree
     #
-    #   Also raised if the git binary cannot be found.
+    # @raise [Git::Error] if the git binary cannot be found or fails to launch, or
+    #   if `working_dir` cannot be expanded to an absolute path
     #
     def root_of_worktree(working_dir, binary_path: :use_global_config, git_ssh: :use_global_config)
       raise ArgumentError, "'#{working_dir}' does not exist or is not a directory" unless Dir.exist?(working_dir)
@@ -103,8 +104,10 @@ module Git
     #
     # @return [String] the top-level directory reported by git
     #
-    # @raise [ArgumentError] if the git binary is not found or `working_dir` is
-    #   not inside a git working tree
+    # @raise [ArgumentError] if `working_dir` is not inside a git working tree
+    #
+    # @raise [Git::Error] if the git binary cannot be found or fails to launch, or
+    #   if `working_dir` cannot be expanded to an absolute path
     #
     # @api private
     #
@@ -115,8 +118,6 @@ module Git
       end
 
       Git::Commands::RevParse.new(execution_context).call(show_toplevel: true, chdir: expanded_dir).stdout
-    rescue Errno::ENOENT
-      raise ArgumentError, 'Failed to find the root of the worktree: git binary not found'
     rescue Git::FailedError
       raise ArgumentError, "'#{working_dir}' is not in a git working tree"
     end

--- a/spec/unit/git/path_resolver_spec.rb
+++ b/spec/unit/git/path_resolver_spec.rb
@@ -284,21 +284,10 @@ RSpec.describe Git::PathResolver do
       end
     end
 
-    context 'when the git binary cannot be found' do
-      before do
-        allow(rev_parse_command).to receive(:call).and_raise(Errno::ENOENT)
-      end
-
-      it 'raises ArgumentError indicating the git binary was not found' do
-        expect { root }.to raise_error(ArgumentError, /git binary not found/)
-      end
-    end
-
     context 'when the working directory path cannot be expanded' do
       before do
         # A relative path is expanded against Dir.pwd, which fails when the
-        # process working directory has been removed. Without the guard this
-        # ENOENT is misreported as a missing git binary.
+        # process working directory has been removed.
         allow(File).to receive(:expand_path).with(working_dir).and_raise(Errno::ENOENT, 'getcwd')
       end
 


### PR DESCRIPTION
Follow-up to #1805, which surfaced this while reviewing the merged commit.

## Problem

`Git::PathResolver.execute_rev_parse_toplevel` rescued `Errno::ENOENT` and re-raised
`ArgumentError, 'Failed to find the root of the worktree: git binary not found'`. Nothing
reaches that branch.

`Git::CommandLine::Base#run_process_executer` converts `ProcessExecuter::SpawnError` into
`Git::Error` before it leaves the command layer, so a missing or unlaunchable binary arrives
as `Git::Error` with the `Errno` as `cause`. process_executer wraps the spawn in
`rescue StandardError`, so every spawn-time `Errno` takes that path, including a `chdir:` to a
directory removed after the caller's existence check. Verified against a nonexistent binary
path:

```ruby
Git::PathResolver.root_of_worktree(dir, binary_path: '/nonexistent/git')
# Git::Error: Failed to spawn process: No such file or directory - /nonexistent/git
# cause: Errno::ENOENT
```

The method's only other `Errno::ENOENT` source was `File.expand_path`, and #1805 moved it
behind `Git::SystemCallGuard`, so it now raises `Git::Error` too.

## Change

- Remove the unreachable `rescue Errno::ENOENT` from `execute_rev_parse_toplevel`.
- Widen the `@raise` tags on `root_of_worktree`, `execute_rev_parse_toplevel`, `Git.open`, and
  `resolve_open_working_dir` to the errors callers actually see. They documented `ArgumentError`
  for a missing binary, which was never what callers got, and none of them mentioned the
  `Git::Error` a failed path expansion raises since #1805.

## Tests

The spec covering the removed branch stubbed the `RevParse` double to raise `Errno::ENOENT`
directly, so it asserted its own stub rather than any reachable behavior. It is deleted rather
than rewritten: with the rescue gone, `PathResolver` has no branch there, and a spec driving the
real command objects would be asserting `Git::CommandLine::Base`'s `SpawnError` conversion,
which belongs to that class's spec.

`path_resolver.rb` keeps 100% line and branch coverage.

## Risk

None at runtime. The removed branch was unreachable, so no caller-visible behavior changes. The
`@raise` corrections describe what the code already did.

Unit 6175 examples, integration 661 examples (4 pending), 0 failures. RuboCop and
`rake yard:lint` clean.
