### PR TITLE
feat!: remove the Git.clone legacy options (:path, :recursive, :remote)

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -14,6 +14,7 @@ to update your code when upgrading from the preceding major version.
   - [`Git::Repository#lib` removed](#gitrepositorylib-removed)
   - [`Git::Base` compatibility shim removed](#gitbase-compatibility-shim-removed)
   - [`Git.binary_version` and `Git.ls_remote(nil)` removed](#gitbinary_version-and-gitls_remotenil-removed)
+  - [`Git.clone` legacy options removed](#gitclone-legacy-options-removed)
 - [Upgrading to v5.x](#upgrading-to-v5x)
   - [Overview](#overview)
   - [Breaking changes](#breaking-changes)
@@ -183,6 +184,21 @@ v6.0.0 removes two module-level shims on `Git`:
 The [Module-level `Git` function
 deprecations](#module-level-git-function-deprecations) entry under "Upgrading to
 v5.x" maps each call shape to its replacement.
+
+### `Git.clone` legacy options removed
+
+v6.0.0 removes the three v4.x option names that `Git.clone` accepted with a
+deprecation warning throughout v5.x: `:path`, `:recursive`, and `:remote`. Each
+now falls through to the normal option validation, so passing one raises
+`ArgumentError` (see [Unsupported options raise
+`ArgumentError`](#unsupported-options-raise-argumenterror)). Use `:chdir`,
+`:recurse_submodules`, and `:origin` instead; those options are unchanged. The
+[`Git.clone` option renames](#gitclone-option-renames) entry under "Upgrading to
+v5.x" maps each removed option to its replacement.
+
+`Git.export` still drops a `:remote` option before calling `Git.clone`, as its
+documentation states, so `Git.export(url, dir, remote: name)` does not raise. That
+behavior was never a deprecation and is unchanged.
 
 ### Filesystem errors raised as `Git::Error`
 
@@ -1220,10 +1236,11 @@ is the `Git::WorktreeInfo` that replaces it.
 
 #### `Git.clone` option renames
 
-Three `Git.clone` options were renamed in v5.x. The v4.x names still work. Each
-deprecated option present on a call emits its own deprecation warning, so a call
-that uses two of them warns twice. Each value is passed through to the
-replacement option, except that `:path` is dropped when `:chdir` is also given.
+Three `Git.clone` options were renamed in v5.x. The v4.x names still work in
+v5.x. Each deprecated option present on a call emits its own deprecation
+warning, so a call that uses two of them warns twice. Each value is passed
+through to the replacement option, except that `:path` is dropped when `:chdir`
+is also given.
 
 > **Precedence and value notes:**
 > - `:path` and `:chdir` both run `git clone` from inside the given directory.

--- a/lib/git/factories.rb
+++ b/lib/git/factories.rb
@@ -17,7 +17,7 @@ module Git
   #
   # @api private
   #
-  module Factories # rubocop:disable Metrics/ModuleLength
+  module Factories
     # Clone a repository into a new directory
     #
     # @example Clone into the default directory
@@ -155,13 +155,6 @@ module Git
     #
     # @option options [String, Pathname, nil] :chdir run `git clone` from within
     #   this directory
-    #
-    # @option options [String, Pathname, nil] :path deprecated; use `:chdir` instead
-    #
-    # @option options [Boolean, nil] :recursive deprecated; use
-    #   `:recurse_submodules` instead
-    #
-    # @option options [String, nil] :remote deprecated; use `:origin` instead
     #
     # @return [Git::Repository] a repository bound to the cloned working copy or
     #   bare repository
@@ -532,9 +525,6 @@ module Git
     #
     def prepare_clone_options(options)
       opts = options.dup
-      deprecate_clone_path_option!(opts)
-      deprecate_clone_recursive_option!(opts)
-      deprecate_clone_remote_option!(opts)
       context_opts = extract_clone_context_options!(opts)
       normalize_clone_repository_option!(opts)
 
@@ -739,84 +729,6 @@ module Git
       raise Git::UnexpectedResultError, "Unable to determine clone directory from: #{stderr}" unless match
 
       [match[2], !match[1].nil?]
-    end
-
-    # Handle the deprecated `:path` option for {clone}
-    #
-    # @param opts [Hash] clone options (mutated in place)
-    #
-    # @option opts [String, Pathname, nil] :path deprecated; use `:chdir`
-    #   instead
-    #
-    # @option opts [String, Pathname, nil] :chdir run `git clone` from within
-    #   this directory
-    #
-    # @return [void] mutates `opts` in place
-    #
-    # @api private
-    #
-    def deprecate_clone_path_option!(opts)
-      return unless opts.key?(:path)
-
-      if defined?(Git::Deprecation)
-        Git::Deprecation.warn(
-          'The :path option for Git.clone is deprecated and will be removed in v6.0.0. ' \
-          'Use :chdir instead.'
-        )
-      end
-      path = opts.delete(:path)
-      opts[:chdir] ||= path
-    end
-
-    # Handle the deprecated `:recursive` option for {clone}
-    #
-    # @param opts [Hash] clone options (mutated in place)
-    #
-    # @option opts [Boolean, nil] :recursive deprecated; use
-    #   `:recurse_submodules` instead
-    #
-    # @option opts [Boolean, String, Array<String>, nil] :recurse_submodules
-    #   initialize submodules after cloning
-    #
-    # @return [void] mutates `opts` in place
-    #
-    # @api private
-    #
-    def deprecate_clone_recursive_option!(opts)
-      return unless opts.key?(:recursive)
-
-      if defined?(Git::Deprecation)
-        Git::Deprecation.warn(
-          'The :recursive option for Git.clone is deprecated and will be removed in v6.0.0. ' \
-          'Use :recurse_submodules instead.'
-        )
-      end
-      opts[:recurse_submodules] = opts.delete(:recursive)
-    end
-
-    # Handle the deprecated `:remote` option for {clone}
-    #
-    # @param opts [Hash] clone options (mutated in place)
-    #
-    # @option opts [String, nil] :remote deprecated; use `:origin` instead
-    #
-    # @option opts [String, nil] :origin remote name to use instead of
-    #   `origin`
-    #
-    # @return [void] mutates `opts` in place
-    #
-    # @api private
-    #
-    def deprecate_clone_remote_option!(opts)
-      return unless opts.key?(:remote)
-
-      if defined?(Git::Deprecation)
-        Git::Deprecation.warn(
-          'The :remote option for Git.clone is deprecated and will be removed in v6.0.0. ' \
-          'Use :origin instead.'
-        )
-      end
-      opts[:origin] = opts.delete(:remote)
     end
   end
 end

--- a/spec/unit/git/factories_spec.rb
+++ b/spec/unit/git/factories_spec.rb
@@ -345,74 +345,31 @@ RSpec.describe Git::Factories do
       end
     end
 
-    context 'with deprecated :path option' do
-      let(:options) { { path: '/output' } }
+    context 'with a v4.x option removed in v6.0.0' do
+      # Let the real Commands::Clone bind the options so its validation runs
+      before { allow(Git::Commands::Clone).to receive(:new).with(global_context).and_call_original }
 
-      it 'emits a deprecation warning' do
-        expect(Git::Deprecation).to receive(:warn).with(/path.*deprecated/i)
-        repository
-      end
+      context 'with :path' do
+        let(:options) { { path: '/output' } }
 
-      it 'uses :path value as :chdir' do
-        allow(Git::Deprecation).to receive(:warn)
-        repository
-        expect(clone_command).to have_received(:call).with(repository_url, nil, chdir: '/output')
-      end
-
-      context 'when Git::Deprecation is unavailable' do
-        before { hide_const('Git::Deprecation') }
-
-        it 'still uses :path value as :chdir' do
-          repository
-          expect(clone_command).to have_received(:call).with(repository_url, nil, chdir: '/output')
+        it 'raises ArgumentError' do
+          expect { repository }.to raise_error(ArgumentError, /Unsupported options: :path/)
         end
       end
-    end
 
-    context 'with deprecated :recursive option' do
-      let(:options) { { recursive: true } }
+      context 'with :recursive' do
+        let(:options) { { recursive: true } }
 
-      it 'emits a deprecation warning' do
-        expect(Git::Deprecation).to receive(:warn).with(/recursive.*deprecated/i)
-        repository
-      end
-
-      it 'maps :recursive to :recurse_submodules' do
-        allow(Git::Deprecation).to receive(:warn)
-        repository
-        expect(clone_command).to have_received(:call).with(repository_url, nil, recurse_submodules: true)
-      end
-
-      context 'when Git::Deprecation is unavailable' do
-        before { hide_const('Git::Deprecation') }
-
-        it 'still maps :recursive to :recurse_submodules' do
-          repository
-          expect(clone_command).to have_received(:call).with(repository_url, nil, recurse_submodules: true)
+        it 'raises ArgumentError' do
+          expect { repository }.to raise_error(ArgumentError, /Unsupported options: :recursive/)
         end
       end
-    end
 
-    context 'with deprecated :remote option' do
-      let(:options) { { remote: 'upstream' } }
+      context 'with :remote' do
+        let(:options) { { remote: 'upstream' } }
 
-      it 'emits a deprecation warning' do
-        expect(Git::Deprecation).to receive(:warn).with(/remote.*deprecated/i)
-        repository
-      end
-
-      it 'maps :remote to :origin' do
-        allow(Git::Deprecation).to receive(:warn)
-        repository
-        expect(clone_command).to have_received(:call).with(repository_url, nil, origin: 'upstream')
-      end
-
-      context 'when Git::Deprecation is unavailable' do
-        before { hide_const('Git::Deprecation') }
-
-        it 'still maps :remote to :origin' do
-          repository
-          expect(clone_command).to have_received(:call).with(repository_url, nil, origin: 'upstream')
+        it 'raises ArgumentError' do
+          expect { repository }.to raise_error(ArgumentError, /Unsupported options: :remote/)
         end
       end
     end


### PR DESCRIPTION
Closes #1774. Part of the v6.0.0 roadmap, #1717.

## Summary

Removes the three v4.x option names that `Git.clone` accepted with a deprecation warning throughout v5.x:

| Removed | Use instead |
|---------|-------------|
| `:path` | `:chdir` |
| `:recursive` | `:recurse_submodules` |
| `:remote` | `:origin` |

The private `deprecate_clone_*_option!` translators are gone, so the old keys fall through to the `Git::Commands::Clone` option validation and raise `ArgumentError` (`Unsupported options: :path`) as any unknown option does. `:chdir`, `:recurse_submodules`, and `:origin` are unchanged.

`Git.export` still drops `:remote` before calling `Git.clone`. That behavior is documented on `Git.export` and is not a deprecation, so it is left as is.

## ADR-0007 gate

- All three warnings are present in the `v5.0.0` tag.
- The UPGRADING.md entry (#1763) shipped in v5.4.1 (#1767). Both issues are closed and `v5.4.1` is on RubyGems.
- The gate check is recorded on #1774.

## Changes

- `lib/git/factories.rb`: remove the three translators, their calls in `prepare_clone_options`, and the three "deprecated; use ... instead" `@option` tags on `Git.clone`. No `Git::Deprecation.warn` call remains in `Git::Factories`. The `Metrics/ModuleLength` disable on the module is dropped because the module no longer exceeds the limit.
- `spec/unit/git/factories_spec.rb`: the deprecated-option examples are replaced by a context that lets the real `Git::Commands::Clone` bind the options and asserts `ArgumentError` for each of the three keys.
- `UPGRADING.md`: new "`Git.clone` legacy options removed" entry under "Upgrading to v6.x". The v5.x "`Git.clone` option renames" entry stays as the migration reference.

## Verification

`bundle exec rake default` passes (unit, integration, RuboCop, YARD, markdown links).
