### PR TITLE
docs: record ADR-0008 on converting errors from outside the gem at the boundary

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -33,3 +33,11 @@ fine to use `#` in footer values such as `Closes: #999` or `Refs: #999`.
 | `main` | New features, breaking changes, all active development. Its next release is v6.0.0; every further v5.x release is cut from `5.x` |
 | `5.x` | Security fixes, backward-compatible bug fixes, and backward-compatible features at the maintainers' discretion for the v5.x series |
 | `4.x` | Security fixes, backward-compatible bug fixes, and backward-compatible features at the maintainers' discretion for the v4.x series |
+
+A fix that changes the class of a raised exception is a backward-compatible bug fix
+only when every `rescue` clause that caught the old class still catches the new one:
+the new class subclasses the old, or the old is kept as a catchable alias. Otherwise it
+is a behavior change with no deprecation path and ships in the next major with an
+`UPGRADING.md` entry. When a maintenance branch documents a contract that the old
+behavior breaks, that branch gets a documentation fix instead. The reason is recorded
+in [ADR-0008](../docs/adr/0008-errors-from-outside-the-gem-are-converted-at-the-boundary-that-admits-them.md).

--- a/.github/skills/breaking-change-analysis/SKILL.md
+++ b/.github/skills/breaking-change-analysis/SKILL.md
@@ -110,8 +110,11 @@ affected. Record the fact and its proof in the **Safety Proof** section of the
 assessment. A safety claim backed only by reasoning is an open question, not a
 finding — the step is complete when every such claim names its fact and the code that
 proved it. This proof applies to hard breaks and behavior changes that have no
-deprecation path. The deprecation policy in [Step 4](#step-4-deprecation-policy)
-governs removal of a deprecated API.
+deprecation path. A change to the class of a raised exception is such a behavior change
+unless it passes the rescue-compatibility test in
+[Branch & PR Strategy](../../copilot-instructions.md#branch--pr-strategy). The
+deprecation policy in [Step 4](#step-4-deprecation-policy) governs removal of a
+deprecated API.
 
 ## Step 4: Deprecation policy
 

--- a/.github/skills/facade-implementation/REFERENCE.md
+++ b/.github/skills/facade-implementation/REFERENCE.md
@@ -20,6 +20,7 @@ is loaded by subagents during the [Facade Implementation](SKILL.md) workflow.
   - [Sequencing multiple commands](#sequencing-multiple-commands)
 - [Topic module skeleton](#topic-module-skeleton)
 - [The five facade responsibilities checklist](#the-five-facade-responsibilities-checklist)
+  - [Filesystem calls in facade methods](#filesystem-calls-in-facade-methods)
 - [Argument pre-processing patterns](#argument-pre-processing-patterns)
   - [Path normalization](#path-normalization)
   - [Option whitelisting (preventing API expansion)](#option-whitelisting-preventing-api-expansion)
@@ -344,6 +345,16 @@ facade method, confirm whether each responsibility applies and is handled:
   class or a result-class factory method to produce the documented return type.
   Returning the raw `Git::CommandLine::Result` is acceptable only when that is the
   documented public contract for the topic module.
+
+### Filesystem calls in facade methods
+
+A call the facade method makes itself that can raise `SystemCallError` (reading a ref
+file, creating a temporary file, changing directory) runs inside
+`Git::SystemCallGuard.call`, and a caller's block is yielded inside `guard.unguarded`.
+Predicates such as `File.file?` do not raise and stay unwrapped. A site with a fallback
+may rescue `SystemCallError` locally and recover instead, as `tag_sha` does. The rule
+and its reason are in
+[Project Context - Error Hierarchy](../project-context/SKILL.md#error-hierarchy).
 
 ## Argument pre-processing patterns
 

--- a/.github/skills/facade-implementation/SKILL.md
+++ b/.github/skills/facade-implementation/SKILL.md
@@ -108,7 +108,8 @@ See [REFERENCE.md](REFERENCE.md) for the full reference covering:
 - Topic module selection (existing modules + decision rules for creating a new module)
 - Designing a facade method (return type, signature, body shape)
 - Topic module skeleton (file layout)
-- The five facade responsibilities as a checklist
+- The five facade responsibilities as a checklist, plus the `Git::SystemCallGuard`
+  rule for filesystem calls a facade method makes itself
 - Argument pre-processing patterns (path normalization, option whitelisting via
   `SharedPrivate.assert_valid_opts!` + `private_constant`,
   deprecation handling, defaults)

--- a/.github/skills/pr-readiness-review/SKILL.md
+++ b/.github/skills/pr-readiness-review/SKILL.md
@@ -140,8 +140,10 @@ Before creating the PR, confirm the branch situation:
 - [ ] Changes are on a feature branch (not `main`, `5.x`, or `4.x`), named
   `<type>/<short-description>`
 - [ ] Branch targets the correct base: `main` for features/breaking changes;
-  `5.x` or `4.x` for backports of fixes already on `main`, and for security fixes
-  and backward-compatible changes that apply only to that series
+  `5.x` or `4.x` for backports of fixes already on `main` that pass the
+  rescue-compatibility test in
+  [Branch & PR Strategy](../../copilot-instructions.md#branch--pr-strategy), and for
+  security fixes and backward-compatible changes that apply only to that series
 
 **If changes are on the wrong branch:** Create a new branch from the appropriate
 base (`origin/main`, `origin/5.x`, or `origin/4.x`) and relocate the existing work using the

--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -293,15 +293,52 @@ See [CONTRIBUTING.md](../../../CONTRIBUTING.md) for authoritative, complete guid
 
 ### Error Hierarchy
 
-All gem errors inherit from `Git::Error`:
+This section is the authority on which errors the gem raises and how errors from
+outside the gem are converted. The reason is recorded in
+[ADR-0008](../../../docs/adr/0008-errors-from-outside-the-gem-are-converted-at-the-boundary-that-admits-them.md).
 
-- `Git::FailedError` — non-zero exit status
-- `Git::SignaledError` — killed by signal
-- `Git::TimeoutError` — exceeded timeout (subclass of `SignaledError`)
-- `ArgumentError` — invalid arguments
+The gem raises only `ArgumentError` or errors that subclass `Git::Error`:
 
-All errors include structured data (command, output, status) for debugging. Never
-swallow exceptions silently.
+- `Git::Error` — base class for every runtime failure. `Git::GitExecuteError` is a
+  deprecated alias of it, not a separate class
+- `Git::CommandLineError` — git ran and did not succeed; carries the command, output,
+  and status. Subclasses: `Git::FailedError` (non-zero exit), `Git::SignaledError`
+  (killed by signal), `Git::TimeoutError` (exceeded timeout, subclass of
+  `SignaledError`)
+- `Git::ProcessIOError` — I/O with the git process failed
+- `Git::UnexpectedResultError` — git output did not parse
+- `Git::VersionError` — the installed git does not meet a version requirement
+- `ArgumentError` — a caller mistake. Deliberately not a `Git::Error`, so a broad
+  `rescue Git::Error` cannot hide a programming error. A deprecated call under the
+  `raise` deprecation behavior raises `ActiveSupport::DeprecationException` for the
+  same reason.
+
+Converting errors from outside the gem:
+
+- Any error a standard library or gem call can raise is converted at that call, to
+  `ArgumentError` for a caller mistake or to `Git::Error` (or a subclass) otherwise,
+  with the underlying error as `cause`. The class the library chose does not decide
+  which one: a foreign `ArgumentError` is converted like any other class when the
+  failure is not a caller mistake. No site is exempt because its failure is unlikely
+  or because the caller chose the path.
+- Wrap every call the gem initiates that can raise `SystemCallError` in
+  `Git::SystemCallGuard.call`. The guard converts only that family; a call that can
+  raise another class, such as `Zlib::Error`, needs its own rescue. Predicates such as
+  `File.file?` do not raise and stay unwrapped. When the method yields to a caller's
+  block, yield inside `guard.unguarded` so an error raised by the caller's code passes
+  through unchanged.
+- Parsers convert the `ArgumentError` from `Time.iso8601` to
+  `Git::UnexpectedResultError`, because a malformed date in git's output is not a
+  caller mistake. Subprocess errors are converted in `Git::CommandLine`; command
+  classes do not convert them again.
+- `Git::Deprecation.warn` is not a conversion site. Under the `raise` deprecation
+  behavior it raises `ActiveSupport::DeprecationException`, which passes through
+  unchanged because the caller configured that behavior.
+- A site may recover instead of raise when it has a fallback. `tag_sha` reads the
+  loose ref with a local `rescue SystemCallError` and falls through to
+  `git show-ref`. Never swallow an exception silently. The deprecated `Git::Branch`
+  paths slated for removal, which swallow errors in `check_if_create`, predate the
+  rule and are not held to it.
 
 ### Path Handling
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,7 +227,9 @@ major series:
   cut from `5.x`.
 - **`5.x`** and **`4.x`**: The maintenance branches for the v5.x and v4.x series. Each
   receives bug fixes and security fixes, and backward-compatible features at the
-  maintainers' discretion.
+  maintainers' discretion. A fix that changes the class of a raised exception is
+  backported only when it passes the rescue-compatibility test in
+  [Branch & PR Strategy](.github/copilot-instructions.md#branch--pr-strategy).
 
 The README's [Release support policy](README.md#release-support-policy) says how long
 each major series is supported.
@@ -236,7 +238,7 @@ When submitting a pull request:
 
 - **New features and breaking changes**: Target the `main` branch
 - **Bug fixes**: Target `main`, and maintainers will backport to the maintenance
-  branches if applicable
+  branches if applicable and the change passes the rescue-compatibility test above
 - **Security fixes**: Target `main` and every affected maintenance branch, or only a
   maintenance branch if the issue affects that series alone
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,14 @@ rescue Git::Error => e
 end
 ```
 
+The promise covers errors the gem raises from its own operations. Two things pass
+through unchanged. An error raised by a block your code passes to a method such as
+`chdir` or `with_temp_working` is your error, and the gem does not relabel it. And
+with the `raise` behavior described under [Deprecation policy](#deprecation-policy), a
+deprecated call raises `ActiveSupport::DeprecationException`, which is intentionally
+not a `Git::Error` so a broad rescue cannot hide a deprecation your code opted to
+treat as fatal.
+
 See [`Git::Error`](https://rubydoc.info/gems/git/Git/Error) for more information.
 
 ## Specifying and handling timeouts

--- a/docs/adr/0008-errors-from-outside-the-gem-are-converted-at-the-boundary-that-admits-them.md
+++ b/docs/adr/0008-errors-from-outside-the-gem-are-converted-at-the-boundary-that-admits-them.md
@@ -1,0 +1,63 @@
+# Errors from outside the gem are converted at the boundary that admits them
+
+The README promises that the gem raises only `ArgumentError` or errors that subclass
+`Git::Error`. The rule that keeps the promise: any error a standard library or gem call
+can raise is converted at the boundary where it enters, to whichever of the two
+contract classes fits. A caller mistake becomes `ArgumentError`. A failure at run time
+becomes `Git::Error` or a subclass, with the underlying error as `cause`. The class the
+library chose does not decide which one: `Time.iso8601` reports a malformed date as an
+`ArgumentError`, but a malformed date in git's output is not a caller mistake, so the
+parsers convert it to `Git::UnexpectedResultError`. The subprocess layer converts
+process_executer's errors the same way, and `Git::SystemCallGuard` converts
+`SystemCallError` from the gem's own filesystem calls (issues 1804 and 1806, PR 1805).
+The guard covers only that family. A call that can raise something else, such as a
+`Zlib::Error`, needs its own conversion. The guard is the case that forced the rule to
+be written down.
+
+The rule covers errors from operations the gem chose to perform. It does not cover a
+defect in the gem, which raises whatever Ruby raises because wrapping a `NoMethodError`
+would hide the defect. It does not cover an error raised inside a caller's block, which
+the gem relays rather than raises, so `Git::SystemCallGuard#unguarded` marks the region
+where a facade method such as `chdir` yields to the caller. And it does not cover
+`Git::Deprecation.warn`, which raises `ActiveSupport::DeprecationException` under the
+`raise` deprecation behavior: the caller asked for that, so the gem relays it too.
+
+Within that scope there are no carve-outs. A site is not exempt because its failure is
+unlikely, and a path is not exempt because the caller chose it. Issue 1804 reported two
+`File.read` sites that let a bare `Errno` escape, and three cheaper fixes were rejected.
+Wrapping only the two reported reads leaves every other filesystem call the gem makes
+leaking the same way. Wrapping only the paths the gem chooses itself, such as temporary
+files, draws a line the README sentence does not draw. Documenting the leak keeps the
+code and changes the sentence. Each option turns "raises only" into "raises only,
+except", and a caller who has to enumerate the exceptions gains nothing from rescuing
+`Git::Error`.
+
+Two classes are kept out of the `Git::Error` hierarchy on purpose, so that a broad
+`rescue Git::Error` around a git operation cannot hide a programming error. That is
+why `ArgumentError` is the contract's second class rather than a `Git::Error` subclass,
+and why a deprecated call under the `raise` deprecation behavior raises
+`ActiveSupport::DeprecationException` rather than a gem error.
+
+## Consequences
+
+The exception class follows the kind of failure, not the path and not the class the
+library raised. Validating an argument raises `ArgumentError`, and a filesystem
+operation that fails raises `Git::Error`, even when both stem from the same missing
+directory. `with_working` does both in turn.
+
+A site may recover instead of raise when it has a fallback. `tag_sha` reads the loose
+ref file only to avoid forking git, and falls through to `git show-ref` when the read
+fails.
+
+A change of exception class has no deprecation path, because a `rescue` clause cannot
+see a warning. It is backward compatible only when every rescue clause that caught the
+old class still catches the new one. This change fails that test. A caller who rescued
+`Errno::EACCES` around the affected methods, which `UPGRADING.md` lists, loses the
+catch, and the new error cannot also be a `SystemCallError`. So the fix ships in
+v6.0.0 only. Issue 1804 records the withdrawn backport, and issue 1809 the
+documentation fix for the v4.x and v5.x series, whose README makes a promise the code
+there does not keep. The test is policy in
+[Branch & PR Strategy](../../.github/copilot-instructions.md#branch--pr-strategy).
+
+The operational rules are normative policy in
+[Project Context - Error Hierarchy](../../.github/skills/project-context/SKILL.md#error-hierarchy).

--- a/lib/git/errors.rb
+++ b/lib/git/errors.rb
@@ -15,6 +15,12 @@ module Git
   # reading a `.git` pointer file or creating a temporary file, are raised as
   # `Git::Error`. The original `SystemCallError` is available through `cause`.
   #
+  # The promise covers errors the gem raises from its own operations. An error
+  # raised by a block your code passes to a method such as `chdir` propagates
+  # unchanged, and when `Git::Deprecation.behavior` is `:raise` a deprecated call
+  # raises `ActiveSupport::DeprecationException`, which is intentionally not a
+  # `Git::Error`.
+  #
   # Git's custom errors are arranged in the following class heirarchy:
   #
   # ```text


### PR DESCRIPTION
## Summary

Records ADR-0008, the decision behind `Git::SystemCallGuard` and the rule that errors from outside the gem are converted at the boundary that admits them, and puts the operational policy in the places the ADR README assigns to it.

Issue #1804 led to the guard and to PR #1805. The reason for the whole-surface fix, the three cheaper fixes that were rejected, and the consequences were not recorded anywhere in the repository.

## What the ADR records

- The general rule: any error a library call can raise is converted where it enters, to `ArgumentError` for a caller mistake or `Git::Error` otherwise, with the underlying error as `cause`. The class the library chose does not decide which one — `Time.iso8601` reports a malformed date as an `ArgumentError`, but a malformed date in git's output is not a caller mistake, so the parsers convert it. The guard covers only the `SystemCallError` family.
- The scope: errors from operations the gem chose to perform. 

  Defects in the gem, errors from a caller's own block, and the `ActiveSupport::DeprecationException` a caller asked for by setting the `raise` deprecation behavior are relayed unchanged.
- The three rejected options from issue #1804 and the reason they lost: each turns "raises only" into "raises only, except".
- `ArgumentError` and `ActiveSupport::DeprecationException` under the `raise` deprecation behavior are kept out of the `Git::Error` hierarchy on purpose, so a broad rescue cannot hide a programming error.
- Consequences: the exception class follows the kind of failure, a site with a fallback may recover instead of raise, and the fix ships in v6.0.0 only because a change of exception class has no deprecation path.

## Policy changes

- **Project Context, Error Hierarchy** is now the authority on the error classes and the conversion rules, with the guard and `unguarded` usage. The stale list that placed `ArgumentError` under `Git::Error` is corrected.
- **facade-implementation REFERENCE** gets a "Filesystem calls in facade methods" section.
- **Branch & PR Strategy** in copilot-instructions gets the rescue-compatibility test: an exception-class change is backward compatible only when every rescue clause that caught the old class still catches the new one. CONTRIBUTING, the pr-readiness-review checklist, and the breaking-change-analysis skill link to it.
- **README** and the `Git::Error` class comment state the scope of the contract: errors from a caller's own block and deprecations under the `raise` behavior pass through unchanged.

## Related issues

- #1809 tracks the documentation fix for the v4.x and v5.x series, which keep the old behavior.
- #1810, #1811, and #1812 track sites found during review that still let a foreign error escape (encoding conversion, `IO.pipe`, and Zlib in `archive`).

Refs: #1804
