### PR TITLE
fix(export): drop the redundant checkout that broke Git.export for tags (5.x)

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -338,14 +338,16 @@ module Git
   # @param options [Hash] options forwarded to {Git.clone} (`:remote` is ignored;
   #   `:depth` defaults to 1)
   #
-  # @option options [String] :branch the branch or tag to export instead of HEAD
+  # @option options [String] :branch the branch or tag to export instead of HEAD.
+  #   Give the short name (`main`, `v1.0.0`); a full ref path such as
+  #   `refs/tags/v1.0.0` or a commit SHA is not accepted. Use `:revision` to
+  #   export a SHA.
   #
   # @return [void]
   #
   def self.export(repository_url, directory = nil, options = {})
     options.delete(:remote)
     repo = clone(repository_url, directory, { depth: 1 }.merge(options))
-    repo.checkout("origin/#{options[:branch]}") if options[:branch]
     FileUtils.rm_r File.join(repo.dir.to_s, '.git')
   end
 

--- a/spec/integration/git/git_spec.rb
+++ b/spec/integration/git/git_spec.rb
@@ -2,11 +2,12 @@
 
 require 'spec_helper'
 
-# Integration tests for the Git module factory entry points: Git.open, Git.bare,
-# Git.init, and Git.clone.
+# Integration tests for the Git module entry points: Git.open, Git.bare, Git.init,
+# Git.clone, and Git.export.
 #
 # These exercise real path resolution against real repositories on disk and verify
-# that each entry point returns a properly configured Git::Repository.
+# that each factory entry point returns a properly configured Git::Repository, and
+# that Git.export writes the requested tree with no git metadata left behind.
 
 RSpec.describe Git, :integration do
   include Git::IntegrationTestHelpers
@@ -286,6 +287,113 @@ RSpec.describe Git, :integration do
       it 'initializes with the specified branch name' do
         head_content = File.read(File.join(repository.repo.to_s, 'HEAD'))
         expect(head_content).to include('trunk')
+      end
+    end
+  end
+
+  describe '.export' do
+    subject(:export) { Git.export(source_dir, export_dir, options) }
+
+    let(:source_dir) { Dir.mktmpdir }
+    let(:parent_dir) { Dir.mktmpdir }
+    let(:export_dir) { File.join(parent_dir, 'exported') }
+    let(:options) { {} }
+    let(:source) { init_test_repo(source_dir) }
+
+    # Dir.children lists dotfiles, so an expected list that omits '.git' also
+    # asserts that the .git directory was removed from the export.
+    let(:exported_entries) { Dir.children(export_dir).sort }
+
+    before do
+      commit_file(source, 'a.txt', 'Initial commit')
+      source.tag_create('v1.0.0')
+      source.tag_create('v2.0.0', annotate: true, message: 'Release 2.0.0')
+
+      source.branch_new('topic')
+      source.checkout('topic')
+      commit_file(source, 'topic.txt', 'Topic commit')
+
+      source.checkout('main')
+      commit_file(source, 'b.txt', 'Second commit')
+    end
+
+    after do
+      FileUtils.rm_rf(source_dir)
+      FileUtils.rm_rf(parent_dir)
+    end
+
+    def commit_file(repo, name, message)
+      File.write(File.join(source_dir, name), name, mode: 'wb')
+      repo.add(name)
+      repo.commit(message)
+    end
+
+    context 'without :branch' do
+      it 'exports the tree of the default branch' do
+        export
+        expect(exported_entries).to eq(['a.txt', 'b.txt'])
+      end
+    end
+
+    # :branch is forwarded to `git clone --branch`, which looks up a ref name the
+    # remote advertises. Branch short names and tag names resolve; full ref paths,
+    # SHAs, and revision expressions do not.
+    context 'with :branch set to a branch short name' do
+      let(:options) { { branch: 'topic' } }
+
+      it 'exports the tree of that branch' do
+        export
+        expect(exported_entries).to eq(['a.txt', 'topic.txt'])
+      end
+    end
+
+    context 'with :branch set to a lightweight tag' do
+      let(:options) { { branch: 'v1.0.0' } }
+
+      it 'exports the tree the tag points at' do
+        export
+        expect(exported_entries).to eq(['a.txt'])
+      end
+    end
+
+    context 'with :branch set to an annotated tag' do
+      let(:options) { { branch: 'v2.0.0' } }
+
+      it 'exports the tree the tag points at' do
+        export
+        expect(exported_entries).to eq(['a.txt'])
+      end
+    end
+
+    context 'with :branch set to a full ref path' do
+      let(:options) { { branch: 'refs/tags/v1.0.0' } }
+
+      it 'raises Git::FailedError' do
+        expect { export }.to raise_error(Git::FailedError, /not found in upstream origin/)
+      end
+
+      it 'leaves no export directory behind' do
+        expect { export }.to raise_error(Git::FailedError)
+        expect(File.exist?(export_dir)).to be(false)
+      end
+    end
+
+    context 'with :branch set to a commit SHA' do
+      let(:options) { { branch: source.rev_parse('HEAD') } }
+
+      it 'raises Git::FailedError' do
+        expect { export }.to raise_error(Git::FailedError, /not found in upstream origin/)
+      end
+    end
+
+    # A SHA is reachable through :revision (`git clone --revision`, git 2.49+),
+    # which export forwards to clone the same way it forwards :branch.
+    context 'with :revision set to a commit SHA' do
+      let(:options) { { revision: source.rev_parse('topic') } }
+
+      it 'exports the tree of that commit' do
+        export
+        expect(exported_entries).to eq(['a.txt', 'topic.txt'])
       end
     end
   end

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -82,19 +82,12 @@ RSpec.describe Git do
     end
 
     context 'when options include :branch' do
-      let(:options) { { branch: 'develop' } }
+      let(:options) { { branch: 'v1.0.0' } }
 
-      before { allow(repo).to receive(:checkout) }
-
-      it 'checks out the origin branch on the cloned repository' do
-        expect(repo).to receive(:checkout).with('origin/develop')
-        result
-      end
-    end
-
-    context 'when options do not include :branch' do
-      it 'does not check out a branch' do
-        expect(repo).not_to receive(:checkout)
+      it 'forwards :branch to clone so git resolves the branch or tag' do
+        expect(described_class).to receive(:clone)
+          .with(repository_url, directory, { depth: 1, branch: 'v1.0.0' })
+          .and_return(repo)
         result
       end
     end


### PR DESCRIPTION
Backport of #1816 to the `5.x` series.

## What this changes

`Git.export(url, dir, branch: <tag>)` raised `Git::FailedError` and left a full clone —
`.git` and all — at the path the caller asked to export into. This removes the line that
caused it:

```ruby
repo.checkout("origin/#{options[:branch]}") if options[:branch]
```

`export` forwards its options to `Git.clone`, which already passes `:branch` to
`git clone --branch` and checks the branch or tag out during the clone. The extra
checkout re-checked-out the same commit for a branch (detaching HEAD, invisible once
`.git` is gone) and failed for a tag, because tags live in `refs/tags/`, not
`refs/remotes/origin/`.

Removing it also makes the clone the only fallible step before `.git` is removed, so a
failed export leaves nothing behind instead of a directory holding a clone.

## Backward compatibility

A failure becomes a success, and the intermediate checkout it removes was unobservable —
`.git` is deleted before `export` returns. No rescue clause changes class, so this
qualifies for the maintenance branches under Branch & PR Strategy.

## Tests

The unit spec could not have caught this: it stubs both `Git.clone` and `FileUtils.rm_r`,
so no git ever runs, and it pinned `checkout('origin/develop')` as expected behavior
without proving that call works. It now asserts that `:branch` reaches `clone`.

A new integration spec in `spec/integration/git/git_spec.rb` runs against a real
repository and pins the accepted set of ref kinds:

| `:branch` value | Result |
| --- | --- |
| branch short name | exports that branch's tree |
| lightweight tag | exports the tagged tree |
| annotated tag | exports the tagged tree |
| full ref path (`refs/tags/v1.0.0`) | `Git::FailedError`, nothing left on disk |
| commit SHA | `Git::FailedError` |

A SHA is reachable through `:revision` (`git clone --revision`, git 2.49+), which `export`
forwards the same way; that path is covered too.

Refs #1815
