### PR TITLE
fix(export): drop the redundant checkout that broke Git.export for tags (4.x)

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -308,10 +308,13 @@ module Git # rubocop:disable Style/OneClassPerFile
   # See +clone+ for options.  Does not obey the <tt>:remote</tt> option,
   # since the .git info will be deleted anyway; always uses the default
   # remote, 'origin.'
+  #
+  # <tt>options[:branch]</tt> is the short name of the ref: a branch name such as
+  # 'main' or a tag name such as 'v1.0.0'. A full ref path such as
+  # 'refs/tags/v1.0.0' or a commit SHA is not accepted.
   def self.export(repository, name, options = {})
     options.delete(:remote)
     repo = clone(repository, name, { depth: 1 }.merge(options))
-    repo.checkout("origin/#{options[:branch]}") if options[:branch]
     FileUtils.rm_r File.join(repo.dir.to_s, '.git')
   end
 

--- a/tests/units/test_export.rb
+++ b/tests/units/test_export.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+# Tests for Git.export
+#
+# Git.export forwards its options to Git.clone, so :branch accepts what
+# `git clone --branch` accepts: a branch short name or a tag name, resolved against
+# the refs the remote advertises. Full ref paths and SHAs are not accepted.
+#
+class TestExport < Test::Unit::TestCase
+  def test_export_without_branch_exports_the_default_branch
+    in_temp_dir do |path|
+      source = create_source_repo
+      export_dir = File.join(path, 'exported')
+
+      Git.export(source.dir.to_s, export_dir)
+
+      assert_equal(['a.txt', 'b.txt'], exported_entries(export_dir))
+    end
+  end
+
+  def test_export_with_a_branch_short_name
+    in_temp_dir do |path|
+      source = create_source_repo
+      export_dir = File.join(path, 'exported')
+
+      Git.export(source.dir.to_s, export_dir, branch: 'topic')
+
+      assert_equal(['a.txt', 'topic.txt'], exported_entries(export_dir))
+    end
+  end
+
+  def test_export_with_a_lightweight_tag
+    in_temp_dir do |path|
+      source = create_source_repo
+      export_dir = File.join(path, 'exported')
+
+      Git.export(source.dir.to_s, export_dir, branch: 'v1.0.0')
+
+      assert_equal(['a.txt'], exported_entries(export_dir))
+    end
+  end
+
+  def test_export_with_an_annotated_tag
+    in_temp_dir do |path|
+      source = create_source_repo
+      export_dir = File.join(path, 'exported')
+
+      Git.export(source.dir.to_s, export_dir, branch: 'v2.0.0')
+
+      assert_equal(['a.txt'], exported_entries(export_dir))
+    end
+  end
+
+  def test_export_with_a_full_ref_path_fails_and_leaves_nothing_behind
+    in_temp_dir do |path|
+      source = create_source_repo
+      export_dir = File.join(path, 'exported')
+
+      assert_raise(Git::FailedError) do
+        Git.export(source.dir.to_s, export_dir, branch: 'refs/tags/v1.0.0')
+      end
+
+      assert(!File.exist?(export_dir))
+    end
+  end
+
+  def test_export_with_a_commit_sha_fails
+    in_temp_dir do |path|
+      source = create_source_repo
+      export_dir = File.join(path, 'exported')
+
+      assert_raise(Git::FailedError) do
+        Git.export(source.dir.to_s, export_dir, branch: source.rev_parse('HEAD'))
+      end
+    end
+  end
+
+  private
+
+  # Build a repository whose default branch, topic branch, and tags each hold a
+  # different set of files, so an export can be told apart by what it contains
+  #
+  def create_source_repo
+    Dir.mkdir('source')
+    repo = Git.init('source', initial_branch: 'main')
+    repo.config('user.name', 'Test User')
+    repo.config('user.email', 'test@example.com')
+
+    repo.chdir { commit_source_history(repo) }
+
+    repo
+  end
+
+  def commit_source_history(repo)
+    commit_file(repo, 'a.txt', 'Initial commit')
+    repo.add_tag('v1.0.0')
+    repo.add_tag('v2.0.0', annotate: true, message: 'Release 2.0.0')
+
+    repo.branch('topic').checkout
+    commit_file(repo, 'topic.txt', 'Topic commit')
+
+    repo.checkout('main')
+    commit_file(repo, 'b.txt', 'Second commit')
+  end
+
+  def commit_file(repo, name, message)
+    new_file(name, name)
+    repo.add(name)
+    repo.commit(message)
+  end
+
+  # Dir.children lists dotfiles, so an expected list that omits '.git' also asserts
+  # that the .git directory was removed from the export
+  #
+  def exported_entries(dir)
+    Dir.children(dir).sort
+  end
+end


### PR DESCRIPTION
Backport of #1816 to the `4.x` series.

## What this changes

`Git.export(url, dir, branch: <tag>)` raised `Git::FailedError` and left a full clone —
`.git` and all — at the path the caller asked to export into. This removes the line that
caused it:

```ruby
repo.checkout("origin/#{options[:branch]}") if options[:branch]
```

`export` forwards its options to `Git.clone`, which maps `:branch` to `git clone --branch`
through `CLONE_OPTION_MAP` and checks the branch or tag out during the clone. The extra
checkout re-checked-out the same commit for a branch (detaching HEAD, invisible once
`.git` is gone) and failed for a tag, because tags live in `refs/tags/`, not
`refs/remotes/origin/`.

Removing it also makes the clone the only fallible step before `.git` is removed, so a
failed export leaves nothing behind instead of a directory holding a clone.

## Backward compatibility

A failure becomes a success, and the intermediate checkout it removes was unobservable —
`.git` is deleted before `export` returns. No rescue clause changes class, so this
qualifies for the maintenance branches under Branch & PR Strategy.

## Tests

`Git.export` had no test coverage on this branch. The new `tests/units/test_export.rb`
runs against a real repository and pins the accepted set of ref kinds:

| `:branch` value | Result |
| --- | --- |
| branch short name | exports that branch's tree |
| lightweight tag | exports the tagged tree |
| annotated tag | exports the tagged tree |
| full ref path (`refs/tags/v1.0.0`) | `Git::FailedError`, nothing left on disk |
| commit SHA | `Git::FailedError` |

There is no `:revision` option on `4.x` — its `CLONE_OPTION_MAP` predates it — so branches
and tags are the whole accepted set here. The `Git.export` doc comment now says so.

Refs #1815
