### PR TITLE
feat(export): deprecate the :remote option to Git.export

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -34,6 +34,7 @@ to update your code when upgrading from the preceding major version.
     - [`Git.clone` option renames](#gitclone-option-renames)
     - [`Git::Log` Enumerable interface deprecated](#gitlog-enumerable-interface-deprecated)
     - [`Git::Object::Commit#set_commit` deprecated](#gitobjectcommitset_commit-deprecated)
+    - [`Git.export` `:remote` option deprecated](#gitexport-remote-option-deprecated)
 
 ## Upgrading to v6.0.0
 
@@ -1116,5 +1117,22 @@ effect.
 | Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
 |-----------------------------------------------------|-------------|
 | `commit.set_commit(data)` | `commit.from_data(data)` |
+
+#### `Git.export` `:remote` option deprecated
+
+`Git.export` has always dropped a `:remote` option before calling `Git.clone`
+without telling the caller. Passing it now emits a deprecation warning. The option
+is still dropped, so the export itself is unchanged, and it will be removed in a
+future major release. Once it is removed, passing `:remote` raises `ArgumentError`
+like any other unsupported option (see [Unsupported options raise
+`ArgumentError`](#unsupported-options-raise-argumenterror)).
+
+There is no replacement option. `:remote` renamed the clone's remote, and
+`Git.export` deletes the `.git` directory before returning, so the name was never
+observable in the result. Delete the option from the call.
+
+| Deprecated call (works in v5.x, removed in a future major release) | Replacement |
+|--------------------------------------------------------------------|-------------|
+| `Git.export(url, dir, remote: name)` | `Git.export(url, dir)` |
 
 ---

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -346,7 +346,13 @@ module Git
   # @return [void]
   #
   def self.export(repository_url, directory = nil, options = {})
-    options.delete(:remote)
+    if options.key?(:remote)
+      Git::Deprecation.warn(
+        'The :remote option to Git.export is ignored, is deprecated, and will be removed in a future ' \
+        'major release. Delete it from the call.'
+      )
+      options.delete(:remote)
+    end
     repo = clone(repository_url, directory, { depth: 1 }.merge(options))
     FileUtils.rm_r File.join(repo.dir.to_s, '.git')
   end

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -327,16 +327,19 @@ module Git
   # Exports the current HEAD (or the specific branch given in <tt>options[:branch]</tt>)
   # into the given `directory`. It then removes all traces of git from the directory.
   #
-  # Takes the same options as {Git.clone} except that `:remote` is silently ignored
-  # and `:depth` defaults to 1.
+  # Takes the same options as {Git.clone} except that `:depth` defaults to 1 and
+  # `:remote` is ignored with a deprecation warning.
   #
   # @param repository_url [String, URI, Pathname] the repository to export from
   #
   # @param directory [String, Pathname, nil] the directory to export into; defaults to the
   #   repository basename
   #
-  # @param options [Hash] options forwarded to {Git.clone} (`:remote` is ignored;
-  #   `:depth` defaults to 1)
+  # @param options [Hash] options forwarded to {Git.clone} (`:depth` defaults to 1)
+  #
+  # @option options [String] :remote deprecated and ignored; delete it from the call.
+  #   Passing it emits a deprecation warning and it will be removed in a future
+  #   major release.
   #
   # @option options [String] :branch the branch or tag to export instead of HEAD.
   #   Give the short name (`main`, `v1.0.0`); a full ref path such as

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -67,6 +67,11 @@ RSpec.describe Git do
       result
     end
 
+    it 'does not emit a deprecation warning' do
+      expect(Git::Deprecation).not_to receive(:warn)
+      result
+    end
+
     it 'removes the .git directory from the cloned repository' do
       expect(FileUtils).to receive(:rm_r).with(File.join(directory, '.git'))
       result
@@ -74,6 +79,16 @@ RSpec.describe Git do
 
     context 'when options include :remote' do
       let(:options) { { remote: 'upstream' } }
+
+      before { allow(Git::Deprecation).to receive(:warn) }
+
+      it 'emits a deprecation warning saying the option is ignored and should be deleted' do
+        expect(Git::Deprecation).to receive(:warn).with(
+          'The :remote option to Git.export is ignored, is deprecated, and will be removed in a future ' \
+          'major release. Delete it from the call.'
+        )
+        result
+      end
 
       it 'removes :remote before passing options to clone' do
         expect(described_class).to receive(:clone).with(repository_url, directory, { depth: 1 }).and_return(repo)


### PR DESCRIPTION
## Summary

`Git.export` has always dropped a `:remote` option before calling `Git.clone` without telling the caller. This PR deprecates the option in v5.x, the first half of issue 1820:

- `Git.export` emits a `Git::Deprecation` warning when `options` contains `:remote`, saying the option is ignored, will be removed in a future major release, and should be deleted from the call. The option is still dropped, so the export itself is unchanged.
- The YARD doc for `Git.export` replaces the "silently ignored" claim with an `@option` entry for the deprecated key.
- `UPGRADING.md` gets a matching entry under "Deprecated methods".

The warning says "a future major release" rather than naming one, per ADR-0007, because the issue's release window leaves open whether the removal lands in v6.0.0 or v7.0.0.

The second half, removing the drop on `main` so `:remote` raises `ArgumentError` through `Git.clone`'s existing validation, is a separate PR that stays in draft until this warning is in a released v5.x.

## Testing

Unit tests in `spec/unit/git_spec.rb` cover the warning text when `:remote` is given, the absence of a warning otherwise, and that `:remote` is still removed before the options reach `Git.clone`. `bundle exec rake default` passes.

Refs #1820
