### PR TITLE
feat(export)!: reject the :remote option to Git.export

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -44,6 +44,7 @@ to update your code when upgrading from the preceding major version.
     - [`Git.clone` option renames](#gitclone-option-renames)
     - [`Git::Log` Enumerable interface deprecated](#gitlog-enumerable-interface-deprecated)
     - [`Git::Object::Commit#set_commit` deprecated](#gitobjectcommitset_commit-deprecated)
+    - [`Git.export` `:remote` option deprecated](#gitexport-remote-option-deprecated)
 
 ## Upgrading to v6.x
 
@@ -196,9 +197,13 @@ now falls through to the normal option validation, so passing one raises
 [`Git.clone` option renames](#gitclone-option-renames) entry under "Upgrading to
 v5.x" maps each removed option to its replacement.
 
-`Git.export` still drops a `:remote` option before calling `Git.clone`, as its
-documentation states, so `Git.export(url, dir, remote: name)` does not raise. That
-behavior was never a deprecation and is unchanged.
+`Git.export` no longer drops a `:remote` option before calling `Git.clone`, so
+`Git.export(url, dir, remote: name)` also raises `ArgumentError`. The option was
+deprecated in v5.x (see [`Git.export` `:remote` option
+deprecated](#gitexport-remote-option-deprecated) under "Upgrading to v5.x"). There
+is no replacement: `:remote` renamed the clone's remote, and `Git.export` deletes
+the `.git` directory before returning, so the name was never observable. Delete the
+option from the call.
 
 ### Filesystem errors raised as `Git::Error`
 
@@ -1297,5 +1302,22 @@ effect.
 | Deprecated call (works in v5.x, removed in v6.0.0) | Replacement |
 |-----------------------------------------------------|-------------|
 | `commit.set_commit(data)` | `commit.from_data(data)` |
+
+#### `Git.export` `:remote` option deprecated
+
+`Git.export` has always dropped a `:remote` option before calling `Git.clone`
+without telling the caller. Passing it now emits a deprecation warning. The option
+is still dropped, so the export itself is unchanged, and it will be removed in a
+future major release. Once it is removed, passing `:remote` raises `ArgumentError`
+like any other unsupported option (see [Unsupported options raise
+`ArgumentError`](#unsupported-options-raise-argumenterror)).
+
+There is no replacement option. `:remote` renamed the clone's remote, and
+`Git.export` deletes the `.git` directory before returning, so the name was never
+observable in the result. Delete the option from the call.
+
+| Deprecated call (works in v5.x, removed in a future major release) | Replacement |
+|--------------------------------------------------------------------|-------------|
+| `Git.export(url, dir, remote: name)` | `Git.export(url, dir)` |
 
 ---

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -266,16 +266,14 @@ module Git
   # Exports the current HEAD (or the specific branch given in <tt>options[:branch]</tt>)
   # into the given `directory`. It then removes all traces of git from the directory.
   #
-  # Takes the same options as {Git.clone} except that `:remote` is silently ignored
-  # and `:depth` defaults to 1.
+  # Takes the same options as {Git.clone} except that `:depth` defaults to 1.
   #
   # @param repository_url [String, URI, Pathname] the repository to export from
   #
   # @param directory [String, Pathname, nil] the directory to export into; defaults to the
   #   repository basename
   #
-  # @param options [Hash] options forwarded to {Git.clone} (`:remote` is ignored;
-  #   `:depth` defaults to 1)
+  # @param options [Hash] options forwarded to {Git.clone} (`:depth` defaults to 1)
   #
   # @option options [String] :branch the branch or tag to export instead of HEAD.
   #   Give the short name (`main`, `v1.0.0`); a full ref path such as
@@ -287,7 +285,6 @@ module Git
   # @raise [Git::Error] if the `.git` directory cannot be removed
   #
   def self.export(repository_url, directory = nil, options = {})
-    options.delete(:remote)
     repo = clone(repository_url, directory, { depth: 1 }.merge(options))
     git_dir = File.join(repo.dir.to_s, '.git')
     Git::SystemCallGuard.call('Failed to remove the .git directory') { FileUtils.rm_r(git_dir) }

--- a/spec/integration/git/git_spec.rb
+++ b/spec/integration/git/git_spec.rb
@@ -387,6 +387,17 @@ RSpec.describe Git, :integration do
       end
     end
 
+    # :remote was Git.clone's v4.x name for :origin. Git.export used to drop it
+    # silently; it now reaches Git.clone's option validation like any other
+    # unsupported option.
+    context 'with :remote' do
+      let(:options) { { remote: 'upstream' } }
+
+      it 'raises ArgumentError naming the unsupported option' do
+        expect { export }.to raise_error(ArgumentError, /Unsupported options: :remote/)
+      end
+    end
+
     # :branch is forwarded to `git clone --branch`, which looks up a ref name the
     # remote advertises. Branch short names and tag names resolve; full ref paths,
     # SHAs, and revision expressions do not.

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -75,8 +75,10 @@ RSpec.describe Git do
     context 'when options include :remote' do
       let(:options) { { remote: 'upstream' } }
 
-      it 'removes :remote before passing options to clone' do
-        expect(described_class).to receive(:clone).with(repository_url, directory, { depth: 1 }).and_return(repo)
+      it 'forwards :remote to clone so its option validation rejects it' do
+        expect(described_class).to receive(:clone)
+          .with(repository_url, directory, { depth: 1, remote: 'upstream' })
+          .and_return(repo)
         result
       end
     end


### PR DESCRIPTION
## Summary

Second half of issue 1820. `Git.export` no longer drops a `:remote` option before calling `Git.clone`, so the option falls through to `Git.clone`'s existing option validation and raises `ArgumentError: Unsupported options: :remote`. No new validation code is added.

- `lib/git.rb`: delete `options.delete(:remote)` and the two doc claims that `:remote` is ignored.
- `UPGRADING.md`: rewrite the `Git.export` paragraph under "`Git.clone` legacy options removed", which said the behavior was unchanged, and add the v5.x deprecation entry from #1821 to the copy of the v5.x section here so the paragraph can link to it.
- Tests: the unit test that asserted `:remote` was removed now asserts it is forwarded to `Git.clone`, and an integration test covers the `ArgumentError`.

## Release gate

**Draft until #1821 is in a released v5.x.** Under ADR-0007 a removal merges to main only once its deprecation warning and `UPGRADING.md` entry are in a previous normal release. The v6.0.0 release PR (#1788) may ship first. If it does, this PR needs its `UPGRADING.md` text moved from the v6.x section to a new v7.x section before merging, per the release window note on the issue.

## Testing

`bundle exec rake default` passes.

Closes #1820
