### PR TITLE
fix(export): say what the destination holds when removing .git fails

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -266,6 +266,11 @@ module Git
   # Exports the current HEAD (or the specific branch given in <tt>options[:branch]</tt>)
   # into the given `directory`. It then removes all traces of git from the directory.
   #
+  # Removing `.git` is not atomic. If it fails, the exported files are complete and
+  # usable, but the directory keeps whatever part of `.git` could not be deleted.
+  # Nothing is cleaned up, because the exported files are the deliverable and the
+  # leftover has to be removed by hand once the cause of the failure is fixed.
+  #
   # Takes the same options as {Git.clone} except that `:depth` defaults to 1.
   #
   # @param repository_url [String, URI, Pathname] the repository to export from
@@ -282,7 +287,9 @@ module Git
   #
   # @return [void]
   #
-  # @raise [Git::Error] if the `.git` directory cannot be removed
+  # @raise [Git::Error] if the `.git` directory cannot be removed. The exported
+  #   files are left in place, and the directory keeps whatever part of `.git`
+  #   could not be deleted.
   #
   def self.export(repository_url, directory = nil, options = {})
     repo = clone(repository_url, directory, { depth: 1 }.merge(options))

--- a/lib/git.rb
+++ b/lib/git.rb
@@ -287,7 +287,10 @@ module Git
   def self.export(repository_url, directory = nil, options = {})
     repo = clone(repository_url, directory, { depth: 1 }.merge(options))
     git_dir = File.join(repo.dir.to_s, '.git')
-    Git::SystemCallGuard.call('Failed to remove the .git directory') { FileUtils.rm_r(git_dir) }
+    Git::SystemCallGuard.call(
+      "Failed to remove '#{git_dir}'; the exported files are in place, but part of the " \
+      'repository remains and has to be removed by hand'
+    ) { FileUtils.rm_r(git_dir) }
   end
 
   # Get or set a git global configuration value

--- a/spec/integration/git/git_spec.rb
+++ b/spec/integration/git/git_spec.rb
@@ -459,5 +459,27 @@ RSpec.describe Git, :integration do
         expect(exported_entries).to eq(['a.txt', 'topic.txt'])
       end
     end
+
+    # The removal is stubbed rather than blocked with chmod: a permission-based
+    # setup behaves differently on Windows and silently no-ops when the suite
+    # runs as root. Only the export's own call is stubbed; the cleanup in the
+    # `after` hook goes through FileUtils.rm_rf, which calls rm_r with keywords.
+    context 'when the .git directory cannot be removed' do
+      before do
+        allow(FileUtils).to receive(:rm_r).and_call_original
+        allow(FileUtils).to receive(:rm_r).with(end_with('.git')).and_raise(Errno::EACCES, 'objects/pack')
+      end
+
+      it 'raises Git::Error saying the exported files are in place' do
+        expect { export }.to raise_error(
+          Git::Error, /the exported files are in place, but part of the repository remains/
+        )
+      end
+
+      it 'leaves the exported files in place next to the .git remnant' do
+        expect { export }.to raise_error(Git::Error)
+        expect(exported_entries).to eq(['.git', 'a.txt', 'b.txt'])
+      end
+    end
   end
 end

--- a/spec/unit/git_spec.rb
+++ b/spec/unit/git_spec.rb
@@ -100,10 +100,20 @@ RSpec.describe Git do
       end
 
       it 'raises Git::Error with the system error as cause' do
-        expect { result }
-          .to raise_error(Git::Error, /Failed to remove the \.git directory.*Permission denied/) do |error|
-            expect(error.cause).to be_a(Errno::EACCES)
-          end
+        expect { result }.to raise_error(Git::Error, /Permission denied/) do |error|
+          expect(error.cause).to be_a(Errno::EACCES)
+        end
+      end
+
+      # FileUtils.rm_r is not atomic, so a failure leaves the exported files in
+      # place next to whatever part of .git it could not delete. The message has
+      # to say so because nothing else tells the caller what the directory holds.
+      it 'names the directory and says the exported files are in place' do
+        expect { result }.to raise_error(
+          Git::Error,
+          "Failed to remove '/tmp/example/.git'; the exported files are in place, but part of the " \
+          'repository remains and has to be removed by hand: Permission denied - /tmp/example/.git'
+        )
       end
     end
   end


### PR DESCRIPTION
# Description

When `Git.export` cannot remove the `.git` directory, the error now says what the
destination holds. `FileUtils.rm_r` is not atomic, so a failure leaves the exported
files complete and usable next to whatever part of `.git` could not be deleted. The
old message only named the file that could not be removed, so a caller could not tell
whether they had a usable export, a partial one, or nothing.

Changes:

- The `Git::SystemCallGuard` message names the directory and says the exported files
  are in place and the remnant has to be removed by hand. The underlying
  `Permission denied` detail is still appended.
- The method summary and `@raise` tag describe what a failure leaves behind.
- Unit tests cover the new message. Integration tests cover that the exported files
  are still present after the failure. The removal is stubbed rather than blocked with
  `chmod`, which behaves differently on Windows and no-ops as root.

Nothing is cleaned up on failure, on purpose: the exported files are the deliverable,
and a cleanup would hit the same permission wall that caused the failure (see the
issue for the verification).

The existing unit test that matched the old message text was updated to the new text.

Closes #1823

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).
