### PR TITLE
docs(export): describe what a failed .git removal leaves behind

### DIFF
--- a/lib/git.rb
+++ b/lib/git.rb
@@ -327,6 +327,11 @@ module Git
   # Exports the current HEAD (or the specific branch given in <tt>options[:branch]</tt>)
   # into the given `directory`. It then removes all traces of git from the directory.
   #
+  # Removing `.git` is not atomic. If it fails, the exported files are complete and
+  # usable, but the directory keeps whatever part of `.git` could not be deleted.
+  # Nothing is cleaned up, because the exported files are the deliverable and the
+  # leftover has to be removed by hand once the cause of the failure is fixed.
+  #
   # Takes the same options as {Git.clone} except that `:depth` defaults to 1 and
   # `:remote` is ignored with a deprecation warning.
   #
@@ -347,6 +352,10 @@ module Git
   #   export a SHA.
   #
   # @return [void]
+  #
+  # @raise [SystemCallError] if the `.git` directory cannot be removed. The exported
+  #   files are left in place, and the directory keeps whatever part of `.git` could
+  #   not be deleted.
   #
   def self.export(repository_url, directory = nil, options = {})
     if options.key?(:remote)


### PR DESCRIPTION
# Description

Documentation-only fix for issue #1823 on the `5.x` branch.

`FileUtils.rm_r` is not atomic, so when `Git.export` cannot remove `.git` it raises
partway through: the exported files are complete and usable, but the directory keeps
whatever part of `.git` could not be deleted. Nothing documented that, so a caller
could not tell whether they had a usable export, a partial one, or nothing.

This adds a paragraph to the method summary and a `@raise` tag describing what a
failure leaves behind. No behavior changes: `5.x` lets the `SystemCallError` escape,
and adding context would mean rescuing and re-raising, which risks the exception
class or message text on a maintenance branch. The message change ships on `main`
in #1824.

Refs #1823

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed.
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).
