### PR TITLE
docs: record ADR-0009 on what a failed operation leaves behind

### DIFF
--- a/.github/skills/facade-implementation/REFERENCE.md
+++ b/.github/skills/facade-implementation/REFERENCE.md
@@ -315,8 +315,11 @@ Rules for a method that checks out a branch, does work there, and switches back,
 4. Run the restore checkout only on the success path. A restore that ran on some
    failures and not others would make HEAD's location depend on which failure
    occurred, and a restore that always ran would carry unfinished work onto the
-   original branch. `ensure` is still right for scratch files and temporary
-   directories, which the table above covers.
+   original branch. A scratch file is removed on the failure path, with `rescue`
+   and re-raise, not in `ensure`: `#archive` returns its temporary file as the
+   deliverable when the caller names no destination, and an `ensure` would delete
+   the return value. `ensure` fits only a scratch path that is never returned,
+   such as the temporary directory `with_temp_working` creates.
 
 Rule 5 applies more widely, to any method that switches HEAD, leaves git mid
 operation, or writes to a caller-named path, whether or not it switches back:

--- a/.github/skills/facade-implementation/REFERENCE.md
+++ b/.github/skills/facade-implementation/REFERENCE.md
@@ -46,6 +46,7 @@ is loaded by subagents during the [Facade Implementation](SKILL.md) workflow.
   - [Changing the legacy return type or signature on extraction](#changing-the-legacy-return-type-or-signature-on-extraction)
   - [Bypassing `@execution_context`](#bypassing-execution_context)
   - [Placing an overridable policy default after caller options](#placing-an-overridable-policy-default-after-caller-options)
+  - [Restoring HEAD on failure](#restoring-head-on-failure)
   - [Skipping option whitelisting on opaque opts hashes](#skipping-option-whitelisting-on-opaque-opts-hashes)
   - [Mixing facade and command responsibilities](#mixing-facade-and-command-responsibilities)
   - [Adding a topic module whose methods fit an existing one](#adding-a-topic-module-whose-methods-fit-an-existing-one)
@@ -292,26 +293,39 @@ It does not depend on how many commands the method runs.
 
 | What the failure leaves | Do | Example |
 | --- | --- | --- |
-| A repository stopped mid operation | Leave it | `#merge_into` leaves a conflicted merge on the target branch |
+| A repository left mid operation | Leave it | `#merge_into` leaves a conflicted merge on the target branch |
 | The output the caller asked for | Leave it | `Git.export` leaves the exported files when `.git` cannot be removed |
 | A private scratch file the caller never named | Remove it and re-raise | `#archive` deletes its temporary file |
-| Gem-internal state (`@execution_context`) | Restore it in `ensure` | `#with_working`, `#with_index`, `#with_temp_index` |
 
-Rules for a method that switches HEAD:
+Rules for a method that checks out a branch, does work there, and switches back, as
+`#in_branch` and `#merge_into` do:
 
 1. Validate and whitelist **before the first mutating call**, so a rejected argument
    cannot leave the repository on another branch. `#merge_into` rejects `:no_commit` and
    an empty source list up front for this reason.
 2. Guard the target with `SharedPrivate.assert_local_branch!`. A commit SHA, tag, or
-   remote-tracking branch detaches HEAD, and work committed there would be stranded at a
-   commit nothing references.
-3. Capture the return point with `SharedPrivate.head_restore_point`, never with
+   remote-tracking branch detaches HEAD. The checkout, the merge, and the restore
+   checkout each exit 0, and the restore leaves the commit made there with nothing
+   referencing it. Git has no command for the composite, so it cannot report the loss.
+   This is the
+   [silent-wrong-result exception](../project-context/SKILL.md#the-silent-wrong-result-exception).
+3. Capture the restore point with `SharedPrivate.head_restore_point`, never with
    `current_branch`, which reports `'HEAD'` when detached. The helper also rejects an
    unborn HEAD, which cannot be checked out again by name.
-4. Do **not** wrap the restore checkout in `ensure`. With a conflicted merge in the
-   worktree that checkout fails on its own and the `ensure` masks the original error.
-5. Document the failure state in the method's YARD docs as a bold `**Note:**`, because
-   Ruby convention says a block-taking method restores and this one does not.
+4. Run the restore checkout only on the success path. A restore that ran on some
+   failures and not others would make HEAD's location depend on which failure
+   occurred, and a restore that always ran would carry unfinished work onto the
+   original branch. `ensure` is still right for scratch files and temporary
+   directories, which the table above covers.
+
+Rule 5 applies more widely, to any method that switches HEAD, leaves git mid
+operation, or writes to a caller-named path, whether or not it switches back:
+
+5. Say what a failure leaves behind. ADR-0009 requires every such operation to state
+   it in its YARD docs; a facade method states it in a `@note` tag, in the form
+   [`@note` for the failure state](../facade-yard-documentation/SKILL.md#note-for-the-failure-state)
+   gives. It matters most for a block-taking method, because Ruby convention says
+   one restores and this one does not.
 
 ```ruby
 def merge_into(target_branch, branch, message = nil, opts = {})
@@ -322,7 +336,8 @@ def merge_into(target_branch, branch, message = nil, opts = {})
   restore_point = SharedPrivate.head_restore_point(self)
   checkout(target_branch)
   output = merge(branch, message, opts)
-  checkout(restore_point)   # not in an ensure — see rule 4
+  # Runs only on success. See ADR-0009.
+  checkout(restore_point)
   output
 end
 ```
@@ -950,6 +965,12 @@ Place overridable policy defaults before the caller's `**opts` so the caller's
 value wins on key collision. This does not apply to fixed policy options (not in
 `ALLOWED_OPTS`): `assert_valid_opts!` prevents those keys from reaching the
 command call at all.
+
+### Restoring HEAD on failure
+
+A restore checkout wrapped in `ensure`, or one that runs on some failures and not
+others, breaks ADR-0009. Run it on the success path only. See
+[Failure state](#failure-state) rule 4.
 
 ### Skipping option whitelisting on opaque opts hashes
 

--- a/.github/skills/facade-implementation/REFERENCE.md
+++ b/.github/skills/facade-implementation/REFERENCE.md
@@ -18,6 +18,7 @@ is loaded by subagents during the [Facade Implementation](SKILL.md) workflow.
   - [One-line delegator](#one-line-delegator)
   - [Orchestration sequence](#orchestration-sequence)
   - [Sequencing multiple commands](#sequencing-multiple-commands)
+  - [Failure state](#failure-state)
 - [Topic module skeleton](#topic-module-skeleton)
 - [The five facade responsibilities checklist](#the-five-facade-responsibilities-checklist)
   - [Filesystem calls in facade methods](#filesystem-calls-in-facade-methods)
@@ -280,6 +281,55 @@ end
 
 Do not build a generic dispatcher or a "run everything in parallel" abstraction.
 Explicit sequential calls are the documented pattern.
+
+### Failure state
+
+When a facade method can fail after it has already changed something, decide what a
+failure leaves behind before writing the body. The rule is
+[ADR-0009](../../../docs/adr/0009-a-failed-operation-leaves-behind-whatever-the-caller-can-use.md):
+leave behind whatever the caller can use, and remove only what is of no use to anyone.
+It does not depend on how many commands the method runs.
+
+| What the failure leaves | Do | Example |
+| --- | --- | --- |
+| A repository stopped mid operation | Leave it | `#merge_into` leaves a conflicted merge on the target branch |
+| The output the caller asked for | Leave it | `Git.export` leaves the exported files when `.git` cannot be removed |
+| A private scratch file the caller never named | Remove it and re-raise | `#archive` deletes its temporary file |
+| Gem-internal state (`@execution_context`) | Restore it in `ensure` | `#with_working`, `#with_index`, `#with_temp_index` |
+
+Rules for a method that switches HEAD:
+
+1. Validate and whitelist **before the first mutating call**, so a rejected argument
+   cannot leave the repository on another branch. `#merge_into` rejects `:no_commit` and
+   an empty source list up front for this reason.
+2. Guard the target with `SharedPrivate.assert_local_branch!`. A commit SHA, tag, or
+   remote-tracking branch detaches HEAD, and work committed there would be stranded at a
+   commit nothing references.
+3. Capture the return point with `SharedPrivate.head_restore_point`, never with
+   `current_branch`, which reports `'HEAD'` when detached. The helper also rejects an
+   unborn HEAD, which cannot be checked out again by name.
+4. Do **not** wrap the restore checkout in `ensure`. With a conflicted merge in the
+   worktree that checkout fails on its own and the `ensure` masks the original error.
+5. Document the failure state in the method's YARD docs as a bold `**Note:**`, because
+   Ruby convention says a block-taking method restores and this one does not.
+
+```ruby
+def merge_into(target_branch, branch, message = nil, opts = {})
+  SharedPrivate.assert_valid_opts!(MERGE_INTO_ALLOWED_OPTS, **opts)
+  raise ArgumentError, 'at least one branch to merge is required' if Array(branch).empty?
+
+  SharedPrivate.assert_local_branch!(self, target_branch)
+  restore_point = SharedPrivate.head_restore_point(self)
+  checkout(target_branch)
+  output = merge(branch, message, opts)
+  checkout(restore_point)   # not in an ensure — see rule 4
+  output
+end
+```
+
+Before adding a cleanup on a failure path, check that it can actually run. A cleanup
+that fails for the same reason as the operation it is cleaning up after buys nothing,
+and one that deletes the caller's deliverable is worse than doing nothing.
 
 ## Topic module skeleton
 

--- a/.github/skills/facade-implementation/SKILL.md
+++ b/.github/skills/facade-implementation/SKILL.md
@@ -106,7 +106,7 @@ See [REFERENCE.md](REFERENCE.md) for the full reference covering:
 
 - Files to generate
 - Topic module selection (existing modules + decision rules for creating a new module)
-- Designing a facade method (return type, signature, body shape)
+- Designing a facade method (return type, signature, body shape, failure state)
 - Topic module skeleton (file layout)
 - The five facade responsibilities as a checklist, plus the `Git::SystemCallGuard`
   rule for filesystem calls a facade method makes itself
@@ -227,6 +227,10 @@ This skill supports three modes. Determine which mode applies before starting:
      [ADR-0005](../../../docs/adr/0005-the-facade-keeps-the-v4x-call-shape.md))
    - has tests that verify call-shape compatibility when classification is
      `legacy-contract` (positional hash and/or keyword-arg / `**opts` forms where required)
+   - follows the [Failure state](REFERENCE.md#failure-state) rules where they
+     apply: a method that checks out a branch and switches back runs the restore
+     checkout only on success and has both `SharedPrivate` guards, and any method
+     the rules cover has a `@note` that says what a failure leaves behind
 
 5. **Run quality gates** — discover the prerequisite tasks for `default`
    and run them sequentially, fixing failures before advancing:
@@ -264,6 +268,7 @@ For **review** mode, produce:
 | Signature shape matches classification | Pass/Fail | ... |
 | Return value matches documented contract | Pass/Fail | ... |
 | Parser/result-class wiring correct | Pass/Fail | ... |
+| Failure state (HEAD restore, guards, `@note`) | Pass/Fail | ... |
 | YARD docs complete | Pass/Fail | ... |
 | Unit + integration coverage | Pass/Fail | ... |
 

--- a/.github/skills/facade-yard-documentation/SKILL.md
+++ b/.github/skills/facade-yard-documentation/SKILL.md
@@ -25,6 +25,7 @@ parser, or execution context that implements the behavior.
   - [Documenting forwarded options with `@overload`](#documenting-forwarded-options-with-overload)
   - [Return type rules](#return-type-rules)
   - [`@raise` rules](#raise-rules)
+  - [`@note` for the failure state](#note-for-the-failure-state)
   - [Cross-referencing the implementation](#cross-referencing-the-implementation)
   - [Common issues](#common-issues)
 - [Workflow](#workflow)
@@ -316,6 +317,25 @@ Scope `@raise` tags by call-shape:
 - Specific to one or more overloads: keep only in those overload blocks
 - Never duplicate identical `@raise` tags at both top level and overload level
 
+### `@note` for the failure state
+
+A facade method that the facade-implementation
+[Failure state](../facade-implementation/REFERENCE.md#failure-state) rules cover (rule
+5 says which) carries a `@note` tag that says what a failure leaves behind. The gem
+does not restore repository state on failure, and a reader cannot infer that from the
+method's shape, so the note is the only place the guarantee is stated. Keep it at top
+level after `@raise` and any `@yield` tags and before `@deprecated` and `@see`, the
+order `.yard-lint.yml` enforces.
+
+```ruby
+# @note If the merge fails, the repository is left checked out on
+#   `target_branch` rather than restored to the original branch. On a
+#   conflict, the merge is also left in progress.
+```
+
+The rule and its reason are in
+[ADR-0009](../../../docs/adr/0009-a-failed-operation-leaves-behind-whatever-the-caller-can-use.md).
+
 ### Cross-referencing the implementation
 
 When useful, cross-link to the underlying components with `@see` tags **at the
@@ -399,6 +419,9 @@ For each facade module file, run through these checks in order:
   the relevant overload only
 - [ ] no duplicate identical `@raise` appears at both top level and overload level
 - [ ] `@see` tags appear at the end and are limited to non-obvious cross-links
+- [ ] `@note` states the failure state on every method the facade-implementation
+  Failure state rules cover (see [`@note` for the
+  failure state](#note-for-the-failure-state))
 
 ### 3. Formatting consistency
 

--- a/.github/skills/facade-yard-documentation/SKILL.md
+++ b/.github/skills/facade-yard-documentation/SKILL.md
@@ -328,9 +328,11 @@ level after `@raise` and any `@yield` tags and before `@deprecated` and `@see`, 
 order `.yard-lint.yml` enforces.
 
 ```ruby
-# @note If the merge fails, the repository is left checked out on
-#   `target_branch` rather than restored to the original branch. On a
-#   conflict, the merge is also left in progress.
+# @note If the merge or the restore checkout fails, the repository is left
+#   checked out on `target_branch` rather than restored to the original
+#   branch. On a conflict, the merge is also left in progress. When the
+#   restore checkout is the step that fails, the merge has already been
+#   committed on `target_branch`.
 ```
 
 The rule and its reason are in

--- a/.github/skills/project-context/SKILL.md
+++ b/.github/skills/project-context/SKILL.md
@@ -98,7 +98,9 @@ Git::Repository (facade — topic modules under lib/git/repository/)
   the right command class, calls parsers, constructs rich response objects.
   **Parser-contract options** (e.g. `no_color: true`, `pretty: 'raw'`,
   `format: FORMAT_STRING`) are passed explicitly at the facade call site — this makes
-  the parser contract auditable by reading the topic module method.
+  the parser contract auditable by reading the topic module method. What a facade
+  method leaves behind when it fails partway through is decided in
+  [ADR-0009](../../../docs/adr/0009-a-failed-operation-leaves-behind-whatever-the-caller-can-use.md): it leaves whatever the caller can use.
 
 `Git::Commands::Base` provides default `#initialize(execution_context)` and `#call`.
 Command classes that need non-zero successful exits declare

--- a/.github/skills/pull-request-review/SKILL.md
+++ b/.github/skills/pull-request-review/SKILL.md
@@ -60,7 +60,7 @@ Evaluate the PR against these criteria:
 
 **Compatibility:** Backward compatible (or marked breaking), Ruby 3.3+, Git 2.43.0+, cross-platform (Windows/macOS/Linux).
 
-**Security:** No command injection, proper escaping via Git::CommandLine, input validation, resource cleanup.
+**Security:** No command injection, proper escaping via Git::CommandLine, input validation, resource cleanup. Before flagging a missing cleanup or restore on a failure path, check the method's `@note` and `docs/adr/`: ADR-0009 decides what a failed operation leaves behind, and some methods leave state behind on purpose.
 
 ## Step 3: Present Review Findings
 

--- a/docs/adr/0009-a-failed-operation-leaves-behind-whatever-the-caller-can-use.md
+++ b/docs/adr/0009-a-failed-operation-leaves-behind-whatever-the-caller-can-use.md
@@ -1,60 +1,70 @@
 # A failed operation leaves behind whatever the caller can use
 
-A facade method that fails partway through does not undo its earlier steps. It removes
-only what would be of no use to anyone, and leaves everything else exactly where the
-failure left it. The test is whether the caller can do something with what remains, not
-which layer created it.
+*An operation* is any method a caller invokes that runs one or more git commands: a
+`Git::Repository` facade method, a `Git` module function such as `Git.export`, or a
+method on an object the gem returns, such as `Git::Object::Commit#archive`.
 
-Three kinds of leftover, decided the same way each time. A repository stopped mid
-operation stays: `Git::Repository#merge_into` leaves a conflicted merge checked out on
-the target branch, because `git status` names that state and resolving it is ordinary
-git work. A finished deliverable stays: `Git.export` leaves the exported files in place
-when it cannot remove `.git`, because the files are what the caller asked for and only
-the vestigial `.git` is unwanted. A private scratch file goes: `Git::Repository#archive`
-and its `atomic_replace` helper delete the temporary file they wrote and re-raise, so a
-failure never leaves a partial archive at the caller's destination.
+*A failure* is the operation letting an exception escape.
 
-The rejected alternative in every case is unwinding to the pre-call state. It is the
-obvious-looking option, and it fails for a different reason each time it is tried. In
-`merge_into` and `#in_branch` the restore checkout is deliberately not wrapped in
-`ensure`: with a conflicted merge in the worktree that checkout fails on its own, and
-the `ensure` would raise a second error that masks the real one. In `Git.export` a
-cleanup cannot outrun the failure that triggered it, because the permission wall that
-stopped `.git` from being removed stops the cleanup too, and a cleanup that did succeed
-would delete the exported files, turning a partial success into a total loss. Only the
-scratch-file case has an unwind that is both possible and harmless, which is why it is
-the only one that unwinds.
+A step that fails and is handled within the operation is part of the operation's
+normal flow and is not a failure. An example is when `Git::Repository#no_commits?`
+rescues the `Git::FailedError` raised when `git rev-parse` exits non-zero on an
+unborn HEAD and returns `true`.
 
-Gem-internal state is not covered by any of this and always unwinds.
-`Git::Repository#with_index`, `#with_working`, and `#with_temp_index` restore the
-execution context in `ensure`, because a context left pointing at a removed temporary
-directory breaks every later call on that object and no caller can repair it from a
-shell.
+An operation that fails partway through leaves everything where the failure left it,
+except what would be of no use to the caller. The test is whether the caller can do
+something with what remains. Which layer created it does not matter.
 
-Leaving repository state in place is safe only when git reports it, so the two guards
-that establish that condition run before anything is mutated. `SharedPrivate.assert_local_branch!`
-rejects a commit SHA, tag, or remote-tracking branch, each of which detaches HEAD, so
-that work committed there cannot be stranded at a commit nothing references.
-`SharedPrivate.head_restore_point` rejects an unborn HEAD, which has no ref to return
-to. These are preconditions of the rule rather than incidental validation: without them
-a failure would leave a state git cannot describe and the caller cannot name.
+A failure can leave three kinds of state behind. The test decides each one:
+
+1. **A repository left mid operation.** Leave the repository as the failure left it
+   when the caller can use it. When `Git::Repository#merge_into` fails on a merge
+   conflict, the repository stays checked out on the target branch with the merge in
+   progress. That state can stay because `git status` names it and resolving the
+   conflict is ordinary git work.
+2. **A finished deliverable.** Leave the deliverable in place when the caller can use
+   it. When `Git.export` cannot remove `.git`, the exported files stay where they
+   are. They are what the caller asked for, and only `.git` is unwanted.
+3. **A private scratch file.** Clean up the scratch file because the caller cannot use
+   it. When `Git::Repository#archive` fails, its private helpers delete the
+   temporary file they wrote and re-raise, so no partial archive is left at the
+   caller's destination.
+
+Restoring the pre-call state, a rollback or unwind, is rejected, whether on every
+failure or conditionally when the restore can succeed.
+
+For `#merge_into` and `Git::Repository#in_branch`, a restore that ran on every
+failure would carry unfinished work in the working tree onto the original branch. For
+`#merge_into` a conflicted merge would also make the restore fail on its own and hide
+the error that stopped the merge. A restore that ran conditionally would leave a
+different state after different failure modes of the same step, and the caller would
+have to work out which one happened.
 
 ## Consequences
 
-Ruby convention runs the other way. `File.open`, `Dir.chdir`, and the gem's own
-`with_*` methods all restore on the way out, so a block-taking method reads as a context
-manager. `Git::Repository#in_branch` takes a block, is named like one of them, and does
-not behave like one. Reviewers have raised its missing `ensure` repeatedly, which is the
-convention working as expected rather than a defect in the review.
+Block-taking methods like `File.open`, `Dir.chdir`, and the gem's own `with_*`
+methods all restore on the way out, so a reader assumes any block-taking method puts
+things back when the block ends.
 
-So the guarantee is per-method and stated in the method's own documentation, never
-inferred from its shape. Every facade method that switches HEAD, leaves git mid
-operation, or writes to a caller-named path says in its YARD docs what a failure leaves
-behind. `#in_branch`, `#merge_into`, and `Git.export` each document that today.
+`Git::Repository#in_branch` takes a block, as `with_index` does, but does not put
+things back when the block ends. Reviewers who report its missing `ensure` are right
+about the usual convention and wrong about the code. `#in_branch` breaks the
+convention on purpose, and the reply to the report is this record and the method's
+`@note`, not a change to the code.
 
-A method may still discard state on a path that has not failed. `#in_branch` hard-resets
-the working tree when its block returns a falsy value. That is the documented contract,
-not a failure path, and this record does not speak to it.
+The `with_*` methods are consistent with the record. They restore only the gem's own
+execution context and remove a scratch directory, which is the third case above, and
+they touch no repository state.
 
-The operational rules are normative policy in
-[Facade Implementation - Failure state](../../.github/skills/facade-implementation/REFERENCE.md#failure-state).
+The guarantee is per operation and stated in each operation's own documentation. A
+reader cannot infer it from the operation's shape. An operation that switches HEAD,
+leaves git mid operation, or writes to a caller-named path says in its YARD docs what
+a failure leaves behind. Issue 1831 tracks the operations whose docs do not say so
+yet.
+
+An operation may still discard state on a path that has not failed. `#in_branch`
+hard-resets the working tree when its block returns a falsy value. That is the
+documented contract, not a failure, so this record does not cover it.
+
+The operational rules are normative policy in [Facade Implementation - Failure
+state](../../.github/skills/facade-implementation/REFERENCE.md#failure-state).

--- a/docs/adr/0009-a-failed-operation-leaves-behind-whatever-the-caller-can-use.md
+++ b/docs/adr/0009-a-failed-operation-leaves-behind-whatever-the-caller-can-use.md
@@ -1,0 +1,60 @@
+# A failed operation leaves behind whatever the caller can use
+
+A facade method that fails partway through does not undo its earlier steps. It removes
+only what would be of no use to anyone, and leaves everything else exactly where the
+failure left it. The test is whether the caller can do something with what remains, not
+which layer created it.
+
+Three kinds of leftover, decided the same way each time. A repository stopped mid
+operation stays: `Git::Repository#merge_into` leaves a conflicted merge checked out on
+the target branch, because `git status` names that state and resolving it is ordinary
+git work. A finished deliverable stays: `Git.export` leaves the exported files in place
+when it cannot remove `.git`, because the files are what the caller asked for and only
+the vestigial `.git` is unwanted. A private scratch file goes: `Git::Repository#archive`
+and its `atomic_replace` helper delete the temporary file they wrote and re-raise, so a
+failure never leaves a partial archive at the caller's destination.
+
+The rejected alternative in every case is unwinding to the pre-call state. It is the
+obvious-looking option, and it fails for a different reason each time it is tried. In
+`merge_into` and `#in_branch` the restore checkout is deliberately not wrapped in
+`ensure`: with a conflicted merge in the worktree that checkout fails on its own, and
+the `ensure` would raise a second error that masks the real one. In `Git.export` a
+cleanup cannot outrun the failure that triggered it, because the permission wall that
+stopped `.git` from being removed stops the cleanup too, and a cleanup that did succeed
+would delete the exported files, turning a partial success into a total loss. Only the
+scratch-file case has an unwind that is both possible and harmless, which is why it is
+the only one that unwinds.
+
+Gem-internal state is not covered by any of this and always unwinds.
+`Git::Repository#with_index`, `#with_working`, and `#with_temp_index` restore the
+execution context in `ensure`, because a context left pointing at a removed temporary
+directory breaks every later call on that object and no caller can repair it from a
+shell.
+
+Leaving repository state in place is safe only when git reports it, so the two guards
+that establish that condition run before anything is mutated. `SharedPrivate.assert_local_branch!`
+rejects a commit SHA, tag, or remote-tracking branch, each of which detaches HEAD, so
+that work committed there cannot be stranded at a commit nothing references.
+`SharedPrivate.head_restore_point` rejects an unborn HEAD, which has no ref to return
+to. These are preconditions of the rule rather than incidental validation: without them
+a failure would leave a state git cannot describe and the caller cannot name.
+
+## Consequences
+
+Ruby convention runs the other way. `File.open`, `Dir.chdir`, and the gem's own
+`with_*` methods all restore on the way out, so a block-taking method reads as a context
+manager. `Git::Repository#in_branch` takes a block, is named like one of them, and does
+not behave like one. Reviewers have raised its missing `ensure` repeatedly, which is the
+convention working as expected rather than a defect in the review.
+
+So the guarantee is per-method and stated in the method's own documentation, never
+inferred from its shape. Every facade method that switches HEAD, leaves git mid
+operation, or writes to a caller-named path says in its YARD docs what a failure leaves
+behind. `#in_branch`, `#merge_into`, and `Git.export` each document that today.
+
+A method may still discard state on a path that has not failed. `#in_branch` hard-resets
+the working tree when its block returns a falsy value. That is the documented contract,
+not a failure path, and this record does not speak to it.
+
+The operational rules are normative policy in
+[Facade Implementation - Failure state](../../.github/skills/facade-implementation/REFERENCE.md#failure-state).

--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -260,10 +260,6 @@ module Git
     # given message before switching back to the original branch. If the block returns
     # a falsy value, a hard reset is performed before switching back.
     #
-    # **Note:** the restore checkout is not wrapped in `ensure`. If the block,
-    # the commit, or the reset raises an exception, the repository will be left
-    # checked out on this branch rather than restored to the original.
-    #
     # @example Commit a new file on a feature branch
     #   git.branch('feature').in_branch('Add README') do
     #     File.write('README.md', '# Hello')
@@ -280,6 +276,10 @@ module Git
     # @yield Executes the block with this branch checked out
     #
     # @yieldreturn [Object] return a truthy value to commit all changes, a falsy value to hard-reset
+    #
+    # @note If the block, the commit, or the reset raises an exception, the
+    #   repository will be left checked out on this branch rather than restored to
+    #   the original.
     #
     # @deprecated Use {Git::Repository::Branching#in_branch} with the branch name instead
     #
@@ -302,6 +302,7 @@ module Git
       # checkout is deprecated too; silence it so one in_branch call emits one warning
       Git::Deprecation.silence { checkout }
       yield ? branch_repository.commit_all(message) : branch_repository.reset(nil, hard: true)
+      # Runs only on success. See ADR-0009.
       branch_repository.checkout(old_current)
     end
 

--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -277,9 +277,12 @@ module Git
     #
     # @yieldreturn [Object] return a truthy value to commit all changes, a falsy value to hard-reset
     #
-    # @note If the block, the commit, or the reset raises an exception, the
-    #   repository will be left checked out on this branch rather than restored to
-    #   the original.
+    # @note If the block, the commit, the reset, or the restore checkout raises
+    #   an exception, the repository will be left checked out on this branch
+    #   rather than restored to the original. When the restore checkout is the
+    #   step that fails, the commit or reset has already run. When HEAD was
+    #   detached before the call, the restore checkout is a no-op and the
+    #   repository stays on this branch even on success.
     #
     # @deprecated Use {Git::Repository::Branching#in_branch} with the branch name instead
     #
@@ -302,7 +305,9 @@ module Git
       # checkout is deprecated too; silence it so one in_branch call emits one warning
       Git::Deprecation.silence { checkout }
       yield ? branch_repository.commit_all(message) : branch_repository.reset(nil, hard: true)
-      # Runs only on success. See ADR-0009.
+      # Runs only on success. See ADR-0009. This deprecated method keeps its v4.x
+      # restore point: `current_branch` reports 'HEAD' when detached, so a detached
+      # HEAD is not restored. The replacement uses SharedPrivate.head_restore_point.
       branch_repository.checkout(old_current)
     end
 

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -238,9 +238,10 @@ module Git
       # @yieldreturn [Object] a truthy value to commit all changes, a falsy value to
       #   hard-reset
       #
-      # @note If the block, the commit, or the reset raises an exception, the
-      #   repository is left checked out on `branch` rather than restored to the
-      #   original branch.
+      # @note If the block, the commit, the reset, or the restore checkout raises
+      #   an exception, the repository is left checked out on `branch` rather than
+      #   restored to the original branch. When the restore checkout is the step
+      #   that fails, the commit or reset has already run.
       #
       def in_branch(branch, message = 'in branch work')
         SharedPrivate.assert_local_branch!(self, branch)

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -206,10 +206,6 @@ module Git
       # commits yet) cannot be checked out again by name, so it is rejected before
       # any checkout happens.
       #
-      # **Note:** the restore checkout is not wrapped in `ensure`. If the block,
-      # the commit, or the reset raises an exception, the repository is left
-      # checked out on `branch` rather than restored to the original branch.
-      #
       # @example Commit a new file on a feature branch
       #   repo.in_branch('feature', 'Add README') do
       #     File.write('README.md', '# Hello')
@@ -242,6 +238,10 @@ module Git
       # @yieldreturn [Object] a truthy value to commit all changes, a falsy value to
       #   hard-reset
       #
+      # @note If the block, the commit, or the reset raises an exception, the
+      #   repository is left checked out on `branch` rather than restored to the
+      #   original branch.
+      #
       def in_branch(branch, message = 'in branch work')
         SharedPrivate.assert_local_branch!(self, branch)
         restore_point = SharedPrivate.head_restore_point(self)
@@ -251,6 +251,7 @@ module Git
         else
           reset(nil, hard: true)
         end
+        # Runs only on success. See ADR-0009.
         checkout(restore_point)
       end
 

--- a/lib/git/repository/merging.rb
+++ b/lib/git/repository/merging.rb
@@ -175,9 +175,11 @@ module Git
       #
       # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
-      # @note If the merge fails, the repository is left checked out on
-      #   `target_branch` rather than restored to the original branch. On a
-      #   conflict, the merge is also left in progress.
+      # @note If the merge or the restore checkout fails, the repository is left
+      #   checked out on `target_branch` rather than restored to the original
+      #   branch. On a conflict, the merge is also left in progress. When the
+      #   restore checkout is the step that fails, the merge has already been
+      #   committed on `target_branch`.
       #
       def merge_into(target_branch, branch, message = nil, opts = {})
         SharedPrivate.assert_valid_opts!(MERGE_INTO_ALLOWED_OPTS, **opts)

--- a/lib/git/repository/merging.rb
+++ b/lib/git/repository/merging.rb
@@ -127,17 +127,12 @@ module Git
       # branch is checked out, so those failures never leave the repository on
       # `target_branch`. Anything rejected later, such as an option value that is
       # not accepted or a source ref that does not exist, surfaces inside {#merge}
-      # after the checkout and follows the Note below.
+      # after the checkout and leaves the repository checked out on `target_branch`.
       #
       # The `:no_commit` option is not accepted: a merge stopped before its commit
       # would leave `target_branch` unchanged and the restore checkout would carry
       # the staged result onto the original branch. To merge without committing,
       # call {#checkout} and {#merge} directly.
-      #
-      # **Note:** the restore checkout is not wrapped in `ensure`. If the merge
-      # fails (for example, on a conflict), the repository is left checked out on
-      # `target_branch` with the merge in progress rather than restored to the
-      # original branch.
       #
       # @example Merge a feature branch into main while staying on the current branch
       #   repo.merge_into('main', 'feature')
@@ -180,6 +175,10 @@ module Git
       #
       # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
+      # @note If the merge fails, the repository is left checked out on
+      #   `target_branch` rather than restored to the original branch. On a
+      #   conflict, the merge is also left in progress.
+      #
       def merge_into(target_branch, branch, message = nil, opts = {})
         SharedPrivate.assert_valid_opts!(MERGE_INTO_ALLOWED_OPTS, **opts)
         raise ArgumentError, 'at least one branch to merge is required' if Array(branch).empty?
@@ -188,6 +187,7 @@ module Git
         restore_point = SharedPrivate.head_restore_point(self)
         checkout(target_branch)
         output = merge(branch, message, opts)
+        # Runs only on success. See ADR-0009.
         checkout(restore_point)
         output
       end


### PR DESCRIPTION
# Description

Records ADR-0009, and adds the operational rules it points at to the
facade-implementation skill. Documentation only; no code changes.

The rule is already written into three method docs and explained in none of them: a
facade method that fails partway through leaves behind whatever the caller can use, and
removes only what is of no use to anyone. `#merge_into` leaves a conflicted merge on the
target branch, `Git.export` leaves the exported files when `.git` cannot be removed, and
`#archive` deletes the temporary file it wrote. One test decides all three.

What earns the record is the rejected alternative. Unwinding to the pre-call state is the
obvious-looking option and it fails for a different reason each time it comes up:

- In `#merge_into` and `#in_branch` the restore checkout is deliberately not wrapped in
  `ensure`. With a conflicted merge in the worktree that checkout fails on its own, so
  the `ensure` would raise a second error masking the real one.
- In `Git.export` a cleanup cannot outrun the failure that triggered it, because the
  permission wall that stopped `.git` from being removed stops the cleanup too. A
  cleanup that did succeed would delete the exported files, turning a partial success
  into a total loss. Issue 1823 has the measurements.
- `#archive`'s scratch file is the only unwind that is both possible and harmless, which
  is why it is the only one that unwinds.

The skill's Failure state rules state the two guards as preconditions rather than
incidental validation. `assert_local_branch!` and `head_restore_point` run before anything is
mutated, so a failure cannot leave a state git has no way to report: a commit stranded
at an unreferenced SHA, or an unborn HEAD with no ref to return to.

The consequences section says plainly that Ruby convention runs the other way. `File.open`,
`Dir.chdir`, and the gem's own `with_*` methods all restore on the way out, so
`#in_branch` reads like a context manager and is not one. Reviewers have flagged its
missing `ensure` repeatedly, which is the convention working rather than a defect in the
review, and it is why the guarantee is stated per method instead of inferred from the
method's shape.

The skill gains a **Failure state** section keyed on the same test rather than on how many
commands a method runs, since `Git.export` sequences none and still falls under the rule.

## Checklist

- [x] I reviewed and applied the project's [AI Policy](../AI_POLICY.md). I understand
  and verify any AI-assisted changes included in this PR and ensured they meet
  quality, security, and licensing standards.
- [x] I ran `bundle exec rake` locally on this branch and it passed (see
  [Local development setup](../CONTRIBUTING.md#local-development-setup)).
- [x] Tests added/updated as needed. None needed; documentation only.
- [x] `bundle exec rake spec:unit` reports 100% line and branch coverage (see
  [Test coverage policy](../CONTRIBUTING.md#test-coverage-policy)).
- [x] Documentation updated where applicable (README and/or YARD).

