### PR TITLE
docs: state what a failure leaves behind for the operations ADR-0009 covers

### DIFF
--- a/docs/adr/0009-a-failed-operation-leaves-behind-whatever-the-caller-can-use.md
+++ b/docs/adr/0009-a-failed-operation-leaves-behind-whatever-the-caller-can-use.md
@@ -59,8 +59,8 @@ they touch no repository state.
 The guarantee is per operation and stated in each operation's own documentation. A
 reader cannot infer it from the operation's shape. An operation that switches HEAD,
 leaves git mid operation, or writes to a caller-named path says in its YARD docs what
-a failure leaves behind. Issue 1831 tracks the operations whose docs do not say so
-yet.
+a failure leaves behind. Issue 1831 audited the operations whose docs did not say
+so when this record was written.
 
 An operation may still discard state on a path that has not failed. `#in_branch`
 hard-resets the working tree when its block returns a falsy value. That is the

--- a/lib/git/branch.rb
+++ b/lib/git/branch.rb
@@ -173,6 +173,9 @@ module Git
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
     #
+    # @note If the checkout fails, a local branch that this method created
+    #   beforehand is left in place.
+    #
     # @deprecated Use {Git::Repository::Branching#checkout} with the branch name instead
     #
     #   {Git::Repository::Branching#checkout} does not create a missing local

--- a/lib/git/factories.rb
+++ b/lib/git/factories.rb
@@ -166,6 +166,14 @@ module Git
     # @raise [Git::UnexpectedResultError] if the cloned directory cannot be
     #   determined from git's output
     #
+    # @note If git fails before the transfer completes, git removes `directory`
+    #   and the separate git directory it created, or empties `directory` when
+    #   it existed before the call. A `:repository` path that already exists is
+    #   refused before the transfer starts. If the transfer completes but the
+    #   checkout fails, or the `:timeout` or the global timeout kills git, what
+    #   git wrote is left in place. If {Git::UnexpectedResultError} is raised,
+    #   the completed clone is left in place.
+    #
     # @api public
     #
     def clone(repository_url, directory = nil, options = {})
@@ -226,6 +234,12 @@ module Git
     # @return [Git::Repository] a repository bound to the newly initialized repository
     #
     # @raise [Git::FailedError] if git exits with a non-zero exit status
+    #
+    # @note If git exits non-zero after it starts writing, whatever it wrote is
+    #   left in place: `directory` when git created it, and a git directory
+    #   (`.git`, or the `:repository` path and the gitfile pointing at it) that
+    #   git may not recognize as a repository. If git succeeds but the
+    #   repository cannot be opened, the initialized repository is left in place.
     #
     # @api public
     #

--- a/lib/git/object.rb
+++ b/lib/git/object.rb
@@ -223,6 +223,9 @@ module Git
       #
       # @raise [Git::FailedError] if `git archive` fails
       #
+      # @note A failure leaves nothing behind and does not replace an existing
+      #   `file`; see {Git::Repository::ObjectOperations#archive}.
+      #
       # @api public
       #
       def archive(file = nil, opts = {})

--- a/lib/git/repository/branching.rb
+++ b/lib/git/repository/branching.rb
@@ -175,6 +175,10 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @note A refused checkout leaves HEAD, the index, and the working tree as
+      #   they were, and the branch `:new_branch` or `:orphan` names is not
+      #   created.
+      #
       def checkout(branch = nil, opts = {})
         if branch.is_a?(Hash) && opts.empty?
           opts = branch
@@ -284,6 +288,10 @@ module Git
       # @raise [ArgumentError] if unsupported options are provided
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @note git does not stop at the first path it cannot write, so a failure
+      #   leaves the files it did write in place, under `:prefix` when one is
+      #   given.
       #
       def checkout_index(options = {})
         SharedPrivate.assert_valid_opts!(CHECKOUT_INDEX_ALLOWED_OPTS, **options)

--- a/lib/git/repository/merging.rb
+++ b/lib/git/repository/merging.rb
@@ -82,6 +82,10 @@ module Git
       #
       # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
+      # @note On a conflict, the merge is left in progress: the conflicted paths
+      #   are in the index and working tree, and `MERGE_HEAD` is set until the
+      #   caller commits the resolution or aborts the merge.
+      #
       def merge(branch, message = nil, opts = {})
         SharedPrivate.assert_valid_opts!(MERGE_ALLOWED_OPTS, **opts)
 
@@ -393,6 +397,12 @@ module Git
       # @raise [ArgumentError] when unsupported options are provided
       #
       # @raise [Git::FailedError] when git exits with a non-zero exit status
+      #
+      # @note On a conflict, the revert is left in progress with the conflicted
+      #   paths in the index and working tree until the caller continues, skips,
+      #   or aborts it. When more than one commit is reverted, the revert commits
+      #   made before the conflict are on the branch; aborting the revert removes
+      #   them again.
       #
       def revert(commitish = nil, opts = {})
         commitish = 'HEAD' if commitish.nil?

--- a/lib/git/repository/object_operations.rb
+++ b/lib/git/repository/object_operations.rb
@@ -631,6 +631,9 @@ module Git
       #
       # @raise [Git::Error] if the archive file cannot be written
       #
+      # @note A failure leaves nothing behind: the staging and temporary files
+      #   are removed and an existing `file` is not replaced.
+      #
       # @see https://git-scm.com/docs/git-archive git-archive documentation
       #
       def archive(treeish, file = nil, opts = {})

--- a/lib/git/repository/remote_operations.rb
+++ b/lib/git/repository/remote_operations.rb
@@ -192,6 +192,12 @@ module Git
       #
       # @raise [Git::FailedError] when git exits with a non-zero status
       #
+      # @note The fetch completes before the merge starts, so a failure after the
+      #   fetch leaves `FETCH_HEAD` and any updated remote-tracking branches in
+      #   place. On a conflict, the merge is left in progress as described at
+      #   {#merge}, or the rebase when the repository is configured to pull with
+      #   rebase.
+      #
       def pull(remote = nil, branch = nil, opts = {})
         raise ArgumentError, 'You must specify a remote if a branch is specified' if remote.nil? && !branch.nil?
 

--- a/lib/git/repository/staging.rb
+++ b/lib/git/repository/staging.rb
@@ -164,6 +164,11 @@ module Git
       #
       # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
+      # @note If a patch fails to apply, the `git am` session is left in progress
+      #   until the caller continues, skips, or aborts it. The patches applied
+      #   before it are already committed on the current branch; aborting the
+      #   session removes them again.
+      #
       def apply_mail(file)
         return unless File.exist?(file)
 

--- a/lib/git/repository/stashing.rb
+++ b/lib/git/repository/stashing.rb
@@ -178,6 +178,11 @@ module Git
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
       #
+      # @note If git exits non-zero, nothing is unwound: whatever git applied stays
+      #   in the working tree and index, including untracked files restored from
+      #   the entry even when git refused to touch the tracked files, and on a
+      #   conflict the conflicted paths are left for the caller to resolve.
+      #
       # @see https://git-scm.com/docs/git-stash git-stash documentation
       #
       def stash_apply(stash = nil, opts = {})
@@ -217,6 +222,10 @@ module Git
       # @raise [ArgumentError] if unsupported options are provided
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @note If git exits non-zero, nothing is unwound, as described at
+      #   {#stash_apply}, and the entry is kept in the stash list rather than
+      #   dropped.
       #
       # @see https://git-scm.com/docs/git-stash git-stash documentation
       #
@@ -366,6 +375,10 @@ module Git
       # @return [String] git's stdout from the branch command
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @note If applying the entry fails, `branch_name` has already been created
+      #   and checked out, so the repository is left on it with whatever git could
+      #   apply in the working tree, and the entry stays in the stash list.
       #
       # @see https://git-scm.com/docs/git-stash git-stash documentation
       #

--- a/lib/git/repository/worktree_operations.rb
+++ b/lib/git/repository/worktree_operations.rb
@@ -93,11 +93,17 @@ module Git
       #
       # @param commitish [String, nil] branch, tag, or commit to check out
       #
-      #   When `nil`, git creates a new branch named after the final path component
+      #   When `nil`, git checks out the branch named after the final path
+      #   component, creating it when no such branch exists
       #
       # @return [String] the output from the git worktree add command
       #
       # @raise [Git::FailedError] if git exits with a non-zero exit status
+      #
+      # @note When `commitish` is `nil` and git creates the branch, it does so
+      #   before it creates the worktree, so a failure after that point leaves
+      #   the new branch in place without a worktree. A branch that already
+      #   existed is left as it was.
       #
       # @see https://git-scm.com/docs/git-worktree git-worktree documentation
       #

--- a/spec/unit/git/repository/object_operations_spec.rb
+++ b/spec/unit/git/repository/object_operations_spec.rb
@@ -989,41 +989,81 @@ RSpec.describe Git::Repository::ObjectOperations do
       end
     end
 
-    context 'when the archive command raises during staging' do
-      before do
-        allow(archive_command).to receive(:call).and_raise(RuntimeError, 'archive failed')
-      end
-
-      it 'cleans up the staging temp file and re-raises' do
-        expect { described_instance.archive('HEAD') }.to raise_error(RuntimeError, /archive failed/)
-      end
-    end
-
-    context 'when gzip post-processing raises an error' do
-      before do
-        allow(Zlib::GzipWriter).to receive(:open).and_raise(RuntimeError, 'gzip failed')
-      end
-
-      it 'cleans up temp files and re-raises' do
-        expect { described_instance.archive('HEAD', nil, add_gzip: true) }.to raise_error(RuntimeError, /gzip failed/)
-      end
-    end
-
-    context 'when atomically renaming the staging file to the destination fails' do
-      let(:tmpfile) do
-        t = Tempfile.new(['archive_unit', '.zip'])
-        t.close
-        t
-      end
-
-      after { tmpfile.close! }
+    context 'when a step fails after a staging file is created' do
+      let(:staging_paths) { [] }
 
       before do
-        allow(File).to receive(:rename).and_raise(RuntimeError, 'rename failed')
+        allow(Tempfile).to receive(:create).and_wrap_original do |original, *args, **kwargs|
+          original.call(*args, **kwargs).tap { |file| staging_paths << file.path }
+        end
       end
 
-      it 'cleans up the staging file and re-raises' do
-        expect { described_instance.archive('HEAD', tmpfile.path) }.to raise_error(RuntimeError, /rename failed/)
+      # The first expectation guards against a vacuous pass: the cleanup check
+      # means nothing unless a staging file was created. It couples these
+      # examples to Tempfile.create, but watching Dir.tmpdir instead would be
+      # flaky when other examples or processes write there.
+      def expect_staging_files_removed
+        expect(staging_paths).not_to be_empty
+        expect(staging_paths.select { |path| File.exist?(path) }).to be_empty
+      end
+
+      context 'when the archive command raises during staging' do
+        before do
+          allow(archive_command).to receive(:call).and_raise(RuntimeError, 'archive failed')
+        end
+
+        it 're-raises the error' do
+          expect { described_instance.archive('HEAD') }.to raise_error(RuntimeError, /archive failed/)
+        end
+
+        it 'removes the staging file' do
+          expect { described_instance.archive('HEAD') }.to raise_error(RuntimeError, /archive failed/)
+          expect_staging_files_removed
+        end
+      end
+
+      context 'when gzip post-processing raises an error' do
+        before do
+          allow(Zlib::GzipWriter).to receive(:open).and_raise(RuntimeError, 'gzip failed')
+        end
+
+        it 're-raises the error' do
+          expect { described_instance.archive('HEAD', nil, add_gzip: true) }.to raise_error(RuntimeError, /gzip failed/)
+        end
+
+        it 'removes the staging file' do
+          expect { described_instance.archive('HEAD', nil, add_gzip: true) }.to raise_error(RuntimeError, /gzip failed/)
+          expect_staging_files_removed
+        end
+      end
+
+      context 'when atomically renaming the staging file to the destination fails' do
+        let(:tmpfile) do
+          t = Tempfile.new(['archive_unit', '.zip'])
+          t.close
+          t
+        end
+
+        after { tmpfile.close! }
+
+        before do
+          File.write(tmpfile.path, 'original content', mode: 'wb')
+          allow(File).to receive(:rename).and_raise(RuntimeError, 'rename failed')
+        end
+
+        it 're-raises the error' do
+          expect { described_instance.archive('HEAD', tmpfile.path) }.to raise_error(RuntimeError, /rename failed/)
+        end
+
+        it 'removes the staging file' do
+          expect { described_instance.archive('HEAD', tmpfile.path) }.to raise_error(RuntimeError, /rename failed/)
+          expect_staging_files_removed
+        end
+
+        it 'leaves the destination as it was' do
+          expect { described_instance.archive('HEAD', tmpfile.path) }.to raise_error(RuntimeError, /rename failed/)
+          expect(File.read(tmpfile.path)).to eq('original content')
+        end
       end
     end
 


### PR DESCRIPTION
Closes #1831

ADR-0009 says an operation that switches HEAD, leaves git mid operation, or writes to a caller-named path states in its YARD docs what a failure leaves behind. This PR audits the candidates the issue lists, adds a `@note` tag where neither the method's own docs nor git's documentation already say, and covers four operations the issue's list missed. Every state below was reproduced with git 2.55.0 in a scratch repository before the note was written.

## Notes added

| Method | What a failure leaves behind |
| --- | --- |
| `Git::Repository#merge` | the merge in progress: conflicted paths in the index and working tree, `MERGE_HEAD` set until the caller commits or aborts |
| `Git::Repository#checkout` | nothing: a refused checkout leaves HEAD, the index, and the working tree as they were, and the branch `:new_branch` or `:orphan` names is not created |
| `Git::Repository#revert` | the revert in progress; in a multi-commit revert the earlier revert commits are on the branch, and aborting removes them again |
| `Git::Repository#pull` | the fetch has completed (`FETCH_HEAD`, remote-tracking branches); on a conflict the merge is in progress, or the rebase when the repository pulls with rebase |
| `Git::Repository#stash_apply`, `#stash_pop` | nothing is unwound: what git applied stays, including untracked files restored even when git refused to touch tracked files; conflicted paths are left to resolve; the entry stays in the list, and `stash_pop` does not drop it |
| `Git::Repository#stash_branch` | the new branch is created and checked out before the apply, so a failed apply leaves the repository on it with the entry still in the list |
| `Git::Repository#archive` | nothing: the staging or temporary file is removed and an existing `file` is not replaced |
| `Git::Object::AbstractObject#archive` | same, in one sentence pointing at the facade method |
| `Git::Repository#apply_mail` | the `git am` session in progress; patches applied before the failing one are committed, and aborting removes them again |
| `Git::Repository#checkout_index` | git does not stop at the first path it cannot write, so the files it did write stay, under `:prefix` when given |
| `Git::Repository#worktree_add` | with no `commitish`, git creates the branch before the worktree, so a later failure leaves the branch without a worktree |
| `Git.clone` | before the transfer completes, git removes `directory` and the separate git directory it created, or empties a pre-existing `directory`; an existing `:repository` path is refused up front; after the transfer, a failed checkout or a timeout kill leaves what git wrote; a clone the gem cannot open stays in place complete |
| `Git.init` | whatever git wrote before failing: `directory` when git created it, and a git directory or gitfile git may not recognize; a repository the gem cannot open stays in place |
| `Git::Branch#checkout` | a local branch this method created before the checkout failed |

`stash_branch`, `apply_mail`, `checkout_index`, and `Git.init` are not on the issue's list. They match the ADR's triggers and leave state behind, so they get the same treatment. `worktree_add` is on the list; the branch-first order is why it keeps a note.

## Dropped from the list

`Git::Repository#checkout` was on the list and keeps a short note anyway, because git makes it atomic and saying so is cheaper than leaving a reader to wonder.

- `Git::Repository#apply`: `git apply` checks every hunk before writing and touches nothing when a hunk does not apply (git-apply, under `--reject`).
- `Git::Repository#read_tree`: git writes the index only on success, and the facade does not expose `-m`, so there is no conflict state to leave.

The deprecated wrappers `Git::Branch#archive`, `Git::Branch#merge`, `Git::Remote#merge`, and `Git::Stashes#apply` also delegate to methods above, but #1723, #1724, and #1725 remove them in v6.0.0, so they get no note. `Git::Branch#checkout` keeps one because the issue names it.

## ADR

The ADR sentence that said issue 1831 tracks the undocumented operations now says the issue audited them, so it stays true after this merges.

## Tests

The archive unit specs for the three failure paths now assert that the staging file is gone and, for the rename failure, that the destination still holds its original content. The note promises both and nothing checked them before.

## Checks

- `bundle exec rspec spec/unit/git/repository/object_operations_spec.rb`: all examples pass
- `bundle exec rubocop` on the changed files: no offenses
- `bundle exec rake yard:lint`: no offenses
- `bundle exec rake yard:build`: no warnings
