### PR TITLE
refactor(repository)!: yield a derived repository from the with_* context helpers

### DIFF
--- a/.github/skills/facade-test-conventions/SKILL.md
+++ b/.github/skills/facade-test-conventions/SKILL.md
@@ -117,7 +117,11 @@ Setup invariants:
   Modules are mixed into the class; tests must exercise the class to reflect
   real call sites.
 - `execution_context` is an `instance_double(Git::ExecutionContext::Repository)`
-  — never a `double('ExecutionContext')` and never a real context.
+  — never a `double('ExecutionContext')`. The one exception is a facade whose
+  behavior under test is deriving a new context (`dup_with`): there a real
+  `Git::ExecutionContext::Repository` is allowed because it is a value object
+  with no disk access, and a stub of `dup_with` would re-implement it. Say so
+  in a comment on the `let`.
 - Each command class is stubbed with `allow(Klass).to receive(:new).with(execution_context).and_return(...)`
   so the facade's command construction (with the right execution context) is
   verified by the stub.
@@ -211,8 +215,9 @@ end
   on the CLI tokens that reach git.
 - **Parser internals.** Stub the parser class method and assert the facade calls
   it with the right input. Parser parsing is covered by `spec/unit/git/parsers/`.
-- **Real command execution.** Facade unit tests must not exercise
-  `Git::ExecutionContext::Repository` for real. Use `instance_double`.
+- **Real command execution.** Facade unit tests must not run commands through
+  `Git::ExecutionContext::Repository`. Use `instance_double`, except for the
+  derived-context case named under "Setup invariants".
 - **Multiple input strings exercising the same code path** — one test per
   argument type is sufficient (string vs. array vs. nil), not one per value.
 - **`#initialize` of the facade module.** The module is mixed into

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -71,8 +71,9 @@ To prepare:
    [Deprecated methods](#deprecated-methods) until the suite is clean.
 7. Replace any `rescue Errno::*` around gem calls with `rescue Git::Error` (see
    [Filesystem errors raised as `Git::Error`](#filesystem-errors-raised-as-giterror)).
-8. Inside a `with_index`, `with_temp_index`, `with_working`, or `with_temp_working`
-   block, call methods on the block parameter rather than on the outer repository
+8. Give every `with_index`, `with_temp_index`, `with_working`, and
+   `with_temp_working` block a parameter and call methods on it rather than on the
+   outer repository; v5.6.0 and later warn for a block with no positional parameter
    (see [Context helpers yield a separate
    repository](#context-helpers-yield-a-separate-repository)).
 9. Upgrade to v6.0.0.
@@ -255,9 +256,13 @@ repository of the receiver's class bound to that index or working tree, yield it
 and leave the receiver bound to its original index and working tree.
 
 Code that uses the block parameter and finishes with it before the block ends needs
-no change. Code that ignores the parameter and calls methods on the outer repository
-inside the block now runs those calls against the original index or working tree.
-Use the block parameter instead:
+no change. A block that declares no positional parameter, the v5.x form, now raises
+`ArgumentError` before the block runs. Starting in v5.6.0 that form warns through
+`Git::Deprecation`, so clear the warning on the latest v5.x release before upgrading.
+A call with no block raises `ArgumentError` instead of `LocalJumpError`. Code that
+declares the parameter but ignores it and calls methods on the outer repository
+inside the block runs those calls against the original index or working tree. Use the
+block parameter instead:
 
 ```ruby
 # v5.x
@@ -274,7 +279,9 @@ end
 ```
 
 The same applies to reading `index` or `dir` inside the block to find the temporary
-path: read them on the block parameter.
+path: read them on the block parameter. A block that needs only the changed process
+directory, such as one that writes files inside `with_temp_working`, still declares
+the parameter (`do |_scratch|`).
 
 A helper nested inside another must also be called on the block parameter. A nested
 call on the outer repository derives from the outer repository's original index and

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -15,6 +15,8 @@ to update your code when upgrading from the preceding major version.
   - [`Git::Base` compatibility shim removed](#gitbase-compatibility-shim-removed)
   - [`Git.binary_version` and `Git.ls_remote(nil)` removed](#gitbinary_version-and-gitls_remotenil-removed)
   - [`Git.clone` legacy options removed](#gitclone-legacy-options-removed)
+  - [Filesystem errors raised as `Git::Error`](#filesystem-errors-raised-as-giterror)
+  - [Context helpers yield a separate repository](#context-helpers-yield-a-separate-repository)
 - [Upgrading to v5.x](#upgrading-to-v5x)
   - [Overview](#overview)
   - [Breaking changes](#breaking-changes)
@@ -69,7 +71,11 @@ To prepare:
    [Deprecated methods](#deprecated-methods) until the suite is clean.
 7. Replace any `rescue Errno::*` around gem calls with `rescue Git::Error` (see
    [Filesystem errors raised as `Git::Error`](#filesystem-errors-raised-as-giterror)).
-8. Upgrade to v6.0.0.
+8. Inside a `with_index`, `with_temp_index`, `with_working`, or `with_temp_working`
+   block, call methods on the block parameter rather than on the outer repository
+   (see [Context helpers yield a separate
+   repository](#context-helpers-yield-a-separate-repository)).
+9. Upgrade to v6.0.0.
 
 ### Minimum Ruby version
 
@@ -213,8 +219,9 @@ contradicted the documented contract that the gem raises only `ArgumentError` or
 available through `cause`.
 
 The affected methods are `Git.open` (reading a gitdir pointer file), `Git.export`,
-`Git::Repository#chdir`, `#with_working`, `#with_temp_index`, `#with_temp_working`,
-`#cat_file_contents`, `#each_conflict`, `#conflicts`, `#archive`, and `#repo_size`.
+`Git::Repository#chdir`, `#with_index`, `#with_working`, `#with_temp_index`,
+`#with_temp_working`, `#set_index`, `#set_working`, `#cat_file_contents`,
+`#each_conflict`, `#conflicts`, `#archive`, and `#repo_size`.
 
 ```ruby
 # v5.x
@@ -238,6 +245,86 @@ Code that already rescues `Git::Error` needs no change. A `SystemCallError` rais
 your own block inside `chdir`, `with_working`, `with_temp_index`, `with_temp_working`,
 or the block form of `cat_file_contents` still propagates unchanged, so the gem never
 relabels an error raised by your code.
+
+### Context helpers yield a separate repository
+
+`Git::Repository#with_index`, `#with_temp_index`, `#with_working`, and
+`#with_temp_working` used to rebind the receiver to the other index or working tree
+for the duration of the block and yield the receiver itself. They now build a second
+repository of the receiver's class bound to that index or working tree, yield it,
+and leave the receiver bound to its original index and working tree.
+
+Code that uses the block parameter and finishes with it before the block ends needs
+no change. Code that ignores the parameter and calls methods on the outer repository
+inside the block now runs those calls against the original index or working tree.
+Use the block parameter instead:
+
+```ruby
+# v5.x
+repo.with_temp_index do
+  repo.read_tree('HEAD')
+  repo.write_tree
+end
+
+# v6.x
+repo.with_temp_index do |indexed|
+  indexed.read_tree('HEAD')
+  indexed.write_tree
+end
+```
+
+The same applies to reading `index` or `dir` inside the block to find the temporary
+path: read them on the block parameter.
+
+A helper nested inside another must also be called on the block parameter. A nested
+call on the outer repository derives from the outer repository's original index and
+working tree, so it does not see the outer block's temporary location:
+
+```ruby
+# v5.x
+repo.with_temp_working do
+  repo.with_temp_index do
+    repo.add('.')
+    repo.write_tree
+  end
+end
+
+# v6.x
+repo.with_temp_working do |scratch|
+  scratch.with_temp_index do |indexed|
+    indexed.add('.')
+    indexed.write_tree
+  end
+end
+```
+
+Calling `set_index` or `set_working` on the outer repository inside the block is no
+longer undone when the block ends. In v5.x the block restored the receiver's
+original index and working tree on exit; in v6.x the receiver stays bound to
+whatever `set_index` or `set_working` gave it.
+
+The repository yielded by `with_temp_index` or `with_temp_working` stays bound to
+the temporary path after the block removes it. This is the one case where code that
+already used the block parameter has to change. If the yielded repository escapes
+the block, directly or inside an object that holds it and later runs commands, calls
+against the removed working tree raise `Git::Error`. Against the removed index,
+reads do not raise: git treats the missing index file as an empty index, so
+`ls_files` returns nothing and `status_info` reports every tracked file both as
+deleted and as untracked. Writes such as `add` do raise `Git::Error`. Reads from
+the object database, such as `Git::Object::AbstractObject#contents`, still work. In
+v5.x an escaped object held the outer repository, which had been rebound to the
+original path by then.
+
+The yielded repository is built with `self.class.new(execution_context:)`, so a
+subclass of `Git::Repository` has to accept that call. A subclass whose `initialize`
+takes different keywords raises `ArgumentError` from these helpers. One that takes a
+positional argument instead receives the keywords as a Hash and yields a
+misconfigured repository, so check the constructor rather than waiting for an
+exception.
+
+`with_working` and `with_temp_working` still change the process working directory
+with `Dir.chdir` for the duration of the block, so they remain unsafe to call from
+more than one thread at a time.
 
 ---
 

--- a/docs/adr/0009-a-failed-operation-leaves-behind-whatever-the-caller-can-use.md
+++ b/docs/adr/0009-a-failed-operation-leaves-behind-whatever-the-caller-can-use.md
@@ -42,19 +42,21 @@ have to work out which one happened.
 
 ## Consequences
 
-Block-taking methods like `File.open`, `Dir.chdir`, and the gem's own `with_*`
-methods all restore on the way out, so a reader assumes any block-taking method puts
-things back when the block ends.
+Block-taking methods like `File.open` and `Dir.chdir` restore on the way out, so a
+reader assumes any block-taking method puts things back when the block ends.
 
-`Git::Repository#in_branch` takes a block, as `with_index` does, but does not put
+`Git::Repository#in_branch` takes a block, as `File.open` does, but does not put
 things back when the block ends. Reviewers who report its missing `ensure` are right
 about the usual convention and wrong about the code. `#in_branch` breaks the
 convention on purpose, and the reply to the report is this record and the method's
 `@note`, not a change to the code.
 
-The `with_*` methods are consistent with the record. They restore only the gem's own
-execution context and remove a scratch directory, which is the third case above, and
-they touch no repository state.
+The `with_*` methods are consistent with this ADR. Each yields a second repository
+of the receiver's class bound to the other index or working tree and leaves the
+receiver bound to its original index and working tree, so there is nothing on the
+receiver to restore when the block ends. The working directory variants change the
+process working directory back afterward, as `Dir.chdir` does. The temporary
+variants remove the scratch directory they created, which is the third case above.
 
 The guarantee is per operation and stated in each operation's own documentation. A
 reader cannot infer it from the operation's shape. An operation that switches HEAD,

--- a/lib/git/repository/context_helpers.rb
+++ b/lib/git/repository/context_helpers.rb
@@ -10,9 +10,17 @@ module Git
   class Repository
     # Facade methods for block-based directory and index context helpers
     #
-    # These helpers allow callers to temporarily change the working directory,
-    # the git index, or both, restoring the original state unconditionally when
-    # the block exits — even if the block raises an exception.
+    # The `with_*` helpers build a second {Git::Repository} bound to a different
+    # index file or working directory, yield it, and leave the receiver bound to
+    # its original index and working directory. Nothing on the receiver changes,
+    # so nothing on it is restored when the block exits. The working directory
+    # variants change the process working directory for the duration of the
+    # block and change it back afterward. The temporary variants remove the
+    # scratch directory they created, even if the block raises an exception.
+    #
+    # The second repository is built with `self.class.new(execution_context:)`,
+    # so a subclass of {Git::Repository} must accept that constructor call for
+    # the helpers to yield an instance of the subclass.
     #
     # Included by {Git::Repository}.
     #
@@ -47,63 +55,75 @@ module Git
         context_helpers_chdir(dir.to_s) { yield dir }
       end
 
-      # Temporarily switches the git index to `new_index` for the duration of
-      # the block
+      # Yields a repository bound to `new_index` in place of the receiver's index
       #
-      # Rebuilds the repository execution context to point to the new index file,
-      # yields `self`, then unconditionally restores the original execution
-      # context — even if the block raises an exception.
+      # Yields a second repository bound to `new_index`; its working directory
+      # and git directory are the receiver's. The receiver is not changed, so
+      # calls on it inside the block still use the original index.
       #
       # @example Read a tree into a custom index
-      #   repo.with_index('/tmp/custom.index') do
-      #     repo.read_tree('HEAD')
+      #   repo.with_index('/tmp/custom.index') do |indexed|
+      #     indexed.read_tree('HEAD')
       #   end
       #
       # @param new_index [String, Pathname] path to the replacement index file
       #
       # @return [Object] the value returned by the block
       #
-      # @yield [repo] the repository instance with the new index active
+      # @raise [Git::Error] if `new_index` cannot be expanded to an absolute path
       #
-      # @yieldparam repo [Git::Repository] `self`
+      # @yield [repo] the repository bound to `new_index`
+      #
+      # @yieldparam repo [Git::Repository] a new repository of the receiver's
+      #   class bound to `new_index`
       #
       # @yieldreturn [Object] returned as the method's return value
       #
-      def with_index(new_index) # :yields: self
-        old_context = @execution_context
-        set_index(new_index, must_exist: false)
-        yield self
-      ensure
-        @execution_context = old_context
+      def with_index(new_index)
+        new_path = context_helpers_validate_path(new_index, false)
+        yield context_helpers_derived_repository(git_index_file: new_path.to_s)
       end
 
-      # Temporarily switches the git index to a new temporary file for the
-      # duration of the block, then removes the file
+      # Yields a repository bound to a new temporary index file, then removes
+      # the file
       #
       # The temporary index file does not exist until git creates it on first
       # write. A unique temporary directory is created to hold the index path,
       # avoiding the risk of presenting an empty file to git (which git would
-      # reject as a corrupt index). The directory — and any files inside it —
-      # are removed unconditionally after the block exits, even if the block
-      # raises an exception.
+      # reject as a corrupt index). The directory, and any files inside it, are
+      # removed unconditionally after the block exits, even if the block raises
+      # an exception. The yielded repository is bound as {#with_index} binds it.
       #
-      # @example Stage changes using a temporary index
-      #   repo.with_temp_index do
-      #     repo.read_tree('HEAD')
-      #     repo.write_tree
+      # @example Write a tree from a temporary index
+      #   tree_sha = repo.with_temp_index do |indexed|
+      #     indexed.read_tree('HEAD')
+      #     indexed.add('generated.txt')
+      #     indexed.write_tree
       #   end
       #
       # @return [Object] the value returned by the block
       #
       # @raise [Git::Error] if the temporary directory cannot be created
       #
-      # @yield [repo] the repository instance with the temporary index active
+      # @yield [repo] the repository bound to the temporary index
       #
-      # @yieldparam repo [Git::Repository] `self`
+      # @yieldparam repo [Git::Repository] a new repository of the receiver's
+      #   class bound to an index file inside the temporary directory
       #
       # @yieldreturn [Object] returned as the method's return value
       #
-      def with_temp_index(&) # :yields: self
+      # @note The yielded repository stays bound to the temporary index path
+      #   after the directory that held it is removed. Do not let it, or an
+      #   object that holds it and later runs commands against the index,
+      #   escape the block. Git treats the missing index file as an empty
+      #   index, so reads such as {Git::Repository::StatusOperations#ls_files}
+      #   return nothing and {Git::Repository::StatusOperations#status_info}
+      #   reports every tracked file both as deleted and as untracked; writes
+      #   such as {Git::Repository::Staging#add} raise {Git::Error}. Reads from
+      #   the object database, such as {Git::Object::AbstractObject#contents},
+      #   still work.
+      #
+      def with_temp_index(&)
         # Use a unique temp directory so the index file path is collision-free
         # and does not exist until git writes it. An existing empty file would
         # be treated as a corrupt index by git.
@@ -115,18 +135,23 @@ module Git
         end
       end
 
-      # Temporarily switches the git working directory to `work_dir` for the
-      # duration of the block
+      # Yields a repository bound to `work_dir` in place of the receiver's
+      # working directory
       #
-      # Rebuilds the repository execution context to point to the new working
-      # directory, changes the process working directory via `Dir.chdir`, yields
-      # `self`, then unconditionally restores the original execution context —
-      # even if the block raises an exception.
+      # Yields a second repository bound to `work_dir`. It shares the
+      # receiver's index and git directory, so staging through it changes what
+      # the receiver sees as staged. The process working directory is changed
+      # to `work_dir` via `Dir.chdir` for the duration of the block and changed
+      # back afterward. The receiver is not changed, so calls on it inside the
+      # block still use the original working directory.
+      #
+      # `Dir.chdir` is process-global, so this method is not safe to call from
+      # more than one thread at a time.
       #
       # @example Commit changes from a different worktree path
-      #   repo.with_working('/path/to/worktree') do
-      #     repo.add('.')
-      #     repo.commit('chore: automated update')
+      #   repo.with_working('/path/to/worktree') do |worktree|
+      #     worktree.add('.')
+      #     worktree.commit('chore: automated update')
       #   end
       #
       # @param work_dir [String, Pathname] path to the replacement working
@@ -136,33 +161,36 @@ module Git
       #
       # @raise [ArgumentError] if `work_dir` does not exist on disk
       #
-      # @raise [Git::Error] if `work_dir` cannot be entered
+      # @raise [Git::Error] if `work_dir` cannot be expanded to an absolute path
+      #   or cannot be entered
       #
-      # @yield [repo] the repository instance with the new working directory
-      #   active
+      # @yield [repo] the repository bound to `work_dir`
       #
-      # @yieldparam repo [Git::Repository] `self`
+      # @yieldparam repo [Git::Repository] a new repository of the receiver's
+      #   class bound to `work_dir`
       #
       # @yieldreturn [Object] returned as the method's return value
       #
-      def with_working(work_dir) # :yields: self
-        old_context = @execution_context
-        set_working(work_dir)
-        context_helpers_chdir(dir.to_s) { yield self }
-      ensure
-        @execution_context = old_context
+      def with_working(work_dir)
+        new_path = context_helpers_validate_path(work_dir, true)
+        repo = context_helpers_derived_repository(git_work_dir: new_path.to_s)
+        context_helpers_chdir(new_path.to_s) { yield repo }
       end
 
-      # Temporarily switches the git working directory to a new temporary
-      # directory for the duration of the block, then removes the directory and
-      # its contents
+      # Yields a repository bound to a new temporary working directory, then
+      # removes the directory and its contents
       #
-      # The temporary directory is removed unconditionally after the block
-      # exits, even if the block raises an exception.
+      # The process working directory is changed to the temporary directory for
+      # the duration of the block, as {#with_working} does, so this method is
+      # not safe to call from more than one thread at a time. The directory is
+      # removed unconditionally after the block exits, even if the block raises
+      # an exception. The yielded repository is bound as {#with_working} binds
+      # it.
       #
       # @example Write files in an isolated temporary working directory
-      #   repo.with_temp_working do
+      #   repo.with_temp_working do |scratch|
       #     File.write('scratch.txt', 'temporary content')
+      #     scratch.untracked_files #=> ["scratch.txt"]
       #   end
       #
       # @return [Object] the value returned by the block
@@ -170,14 +198,21 @@ module Git
       # @raise [Git::Error] if the temporary directory cannot be created or
       #   removed
       #
-      # @yield [repo] the repository instance with the temporary working
-      #   directory active
+      # @yield [repo] the repository bound to the temporary working directory
       #
-      # @yieldparam repo [Git::Repository] `self`
+      # @yieldparam repo [Git::Repository] a new repository of the receiver's
+      #   class bound to the temporary directory
       #
       # @yieldreturn [Object] returned as the method's return value
       #
-      def with_temp_working(&) # :yields: self
+      # @note The yielded repository stays bound to the temporary working
+      #   directory after it is removed. Do not let it, or an object that holds
+      #   it and later runs commands against the working tree, escape the
+      #   block: calls that read or write the working tree then raise
+      #   {Git::Error}. Reads from the object database, such as
+      #   {Git::Object::AbstractObject#contents}, still work.
+      #
+      def with_temp_working(&)
         Git::SystemCallGuard.call('Failed to create or remove a temporary directory') do |guard|
           Dir.mktmpdir('temp-workdir') { |temp_dir| guard.unguarded { with_working(temp_dir, &) } }
         end
@@ -208,7 +243,7 @@ module Git
       def set_index(index_file, check = nil, must_exist: nil)
         must_exist = context_helpers_deprecate_check_argument(check, must_exist)
         new_path = context_helpers_validate_path(index_file, must_exist)
-        context_helpers_rebuild_context(git_index_file: new_path.to_s)
+        @execution_context = context_helpers_derived_context(git_index_file: new_path.to_s)
         nil
       end
 
@@ -237,7 +272,7 @@ module Git
       def set_working(work_dir, check = nil, must_exist: nil)
         must_exist = context_helpers_deprecate_check_argument(check, must_exist)
         new_path = context_helpers_validate_path(work_dir, must_exist)
-        context_helpers_rebuild_context(git_work_dir: new_path.to_s)
+        @execution_context = context_helpers_derived_context(git_work_dir: new_path.to_s)
         nil
       end
 
@@ -334,7 +369,11 @@ module Git
         end
       end
 
-      # Rebuilds the repository execution context with selected overrides
+      # Copies this execution context with selected overrides applied
+      #
+      # The single place the gem derives one repository context from another.
+      # {#set_index} and {#set_working} assign the result to the receiver; the
+      # `with_*` helpers wrap it in a second repository instead.
       #
       # @param overrides [Hash] execution-context attributes to override
       #
@@ -343,10 +382,30 @@ module Git
       # @option overrides [String, nil] :git_work_dir replacement working directory
       #   path
       #
-      # @return [void]
+      # @return [Git::ExecutionContext::Repository] the derived execution context
       #
-      def context_helpers_rebuild_context(**overrides)
-        @execution_context = @execution_context.dup_with(**overrides)
+      # @api private
+      #
+      def context_helpers_derived_context(**overrides)
+        @execution_context.dup_with(**overrides)
+      end
+
+      # Builds a repository of the receiver's class bound to a copy of this
+      # execution context with selected overrides, leaving the receiver untouched
+      #
+      # @param overrides [Hash] execution-context attributes to override
+      #
+      # @option overrides [String, nil] :git_index_file replacement index file path
+      #
+      # @option overrides [String, nil] :git_work_dir replacement working directory
+      #   path
+      #
+      # @return [Git::Repository] a new repository built from the derived context
+      #
+      # @api private
+      #
+      def context_helpers_derived_repository(**overrides)
+        self.class.new(execution_context: context_helpers_derived_context(**overrides))
       end
     end
   end

--- a/lib/git/repository/context_helpers.rb
+++ b/lib/git/repository/context_helpers.rb
@@ -22,11 +22,21 @@ module Git
     # so a subclass of {Git::Repository} must accept that constructor call for
     # the helpers to yield an instance of the subclass.
     #
+    # Each `with_*` helper requires a block that declares a positional parameter
+    # for the yielded repository and raises `ArgumentError` otherwise. A block with no
+    # positional parameter is the v5.x form, which relied on the receiver being
+    # rebound; failing fast keeps that form from running against the original
+    # index or working directory.
+    #
     # Included by {Git::Repository}.
     #
     # @api private
     #
     module ContextHelpers
+      # Parameter types from `Proc#parameters` that receive a positional argument
+      CONTEXT_HELPERS_POSITIONAL_PARAMETERS = %i[req opt rest].freeze
+      private_constant :CONTEXT_HELPERS_POSITIONAL_PARAMETERS
+
       # Changes the current working directory to the repository working directory
       # for the duration of the block
       #
@@ -70,6 +80,9 @@ module Git
       #
       # @return [Object] the value returned by the block
       #
+      # @raise [ArgumentError] if no block is given or the block declares no
+      #   positional parameter
+      #
       # @raise [Git::Error] if `new_index` cannot be expanded to an absolute path
       #
       # @yield [repo] the repository bound to `new_index`
@@ -79,7 +92,8 @@ module Git
       #
       # @yieldreturn [Object] returned as the method's return value
       #
-      def with_index(new_index)
+      def with_index(new_index, &block)
+        context_helpers_require_repository_block(block)
         new_path = context_helpers_validate_path(new_index, false)
         yield context_helpers_derived_repository(git_index_file: new_path.to_s)
       end
@@ -103,6 +117,9 @@ module Git
       #
       # @return [Object] the value returned by the block
       #
+      # @raise [ArgumentError] if no block is given or the block declares no
+      #   positional parameter
+      #
       # @raise [Git::Error] if the temporary directory cannot be created
       #
       # @yield [repo] the repository bound to the temporary index
@@ -115,21 +132,22 @@ module Git
       # @note The yielded repository stays bound to the temporary index path
       #   after the directory that held it is removed. Do not let it, or an
       #   object that holds it and later runs commands against the index,
-      #   escape the block. Git treats the missing index file as an empty
-      #   index, so reads such as {Git::Repository::StatusOperations#ls_files}
+      #   escape the block. Git treats the missing index file, even with its
+      #   directory gone, as an empty index, so reads such as {Git::Repository::StatusOperations#ls_files}
       #   return nothing and {Git::Repository::StatusOperations#status_info}
       #   reports every tracked file both as deleted and as untracked; writes
       #   such as {Git::Repository::Staging#add} raise {Git::Error}. Reads from
       #   the object database, such as {Git::Object::AbstractObject#contents},
       #   still work.
       #
-      def with_temp_index(&)
+      def with_temp_index(&block)
+        context_helpers_require_repository_block(block)
         # Use a unique temp directory so the index file path is collision-free
         # and does not exist until git writes it. An existing empty file would
         # be treated as a corrupt index by git.
         temp_dir = context_helpers_mktmpdir('git-temp-index-')
         begin
-          with_index(File.join(temp_dir, 'index'), &)
+          with_index(File.join(temp_dir, 'index'), &block)
         ensure
           FileUtils.remove_entry(temp_dir, true)
         end
@@ -159,7 +177,8 @@ module Git
       #
       # @return [Object] the value returned by the block
       #
-      # @raise [ArgumentError] if `work_dir` does not exist on disk
+      # @raise [ArgumentError] if `work_dir` does not exist on disk, if no block
+      #   is given, or if the block declares no positional parameter
       #
       # @raise [Git::Error] if `work_dir` cannot be expanded to an absolute path
       #   or cannot be entered
@@ -171,7 +190,8 @@ module Git
       #
       # @yieldreturn [Object] returned as the method's return value
       #
-      def with_working(work_dir)
+      def with_working(work_dir, &block)
+        context_helpers_require_repository_block(block)
         new_path = context_helpers_validate_path(work_dir, true)
         repo = context_helpers_derived_repository(git_work_dir: new_path.to_s)
         context_helpers_chdir(new_path.to_s) { yield repo }
@@ -195,6 +215,9 @@ module Git
       #
       # @return [Object] the value returned by the block
       #
+      # @raise [ArgumentError] if no block is given or the block declares no
+      #   positional parameter
+      #
       # @raise [Git::Error] if the temporary directory cannot be created or
       #   removed
       #
@@ -212,9 +235,10 @@ module Git
       #   {Git::Error}. Reads from the object database, such as
       #   {Git::Object::AbstractObject#contents}, still work.
       #
-      def with_temp_working(&)
+      def with_temp_working(&block)
+        context_helpers_require_repository_block(block)
         Git::SystemCallGuard.call('Failed to create or remove a temporary directory') do |guard|
-          Dir.mktmpdir('temp-workdir') { |temp_dir| guard.unguarded { with_working(temp_dir, &) } }
+          Dir.mktmpdir('temp-workdir') { |temp_dir| guard.unguarded { with_working(temp_dir, &block) } }
         end
       end
 
@@ -243,7 +267,7 @@ module Git
       def set_index(index_file, check = nil, must_exist: nil)
         must_exist = context_helpers_deprecate_check_argument(check, must_exist)
         new_path = context_helpers_validate_path(index_file, must_exist)
-        @execution_context = context_helpers_derived_context(git_index_file: new_path.to_s)
+        @execution_context = @execution_context.dup_with(git_index_file: new_path.to_s)
         nil
       end
 
@@ -272,7 +296,7 @@ module Git
       def set_working(work_dir, check = nil, must_exist: nil)
         must_exist = context_helpers_deprecate_check_argument(check, must_exist)
         new_path = context_helpers_validate_path(work_dir, must_exist)
-        @execution_context = context_helpers_derived_context(git_work_dir: new_path.to_s)
+        @execution_context = @execution_context.dup_with(git_work_dir: new_path.to_s)
         nil
       end
 
@@ -305,6 +329,31 @@ module Git
         Git::SystemCallGuard.call('Failed to change directory') do |guard|
           Dir.chdir(path) { guard.unguarded(&block) }
         end
+      end
+
+      # Raises unless `block` declares a positional parameter for the yielded
+      # repository
+      #
+      # A block with no positional parameter is the v5.x form that relied on
+      # the receiver being rebound; it fails fast rather than running against
+      # the original index or working directory. The check reads the block's
+      # parameter list rather than its arity because an optional parameter
+      # (`|repo = nil|`) gives a proc an arity of zero although it receives the
+      # repository, while keyword and block parameters cannot receive it.
+      #
+      # @param block [Proc, nil] the block passed to a `with_*` helper
+      #
+      # @return [void]
+      #
+      # @raise [ArgumentError] if `block` is nil or declares no positional
+      #   parameter
+      #
+      # @api private
+      #
+      def context_helpers_require_repository_block(block)
+        return if block&.parameters&.any? { |type, _name| CONTEXT_HELPERS_POSITIONAL_PARAMETERS.include?(type) }
+
+        raise ArgumentError, 'a block that accepts the yielded repository is required'
       end
 
       # Creates a temporary directory, raising {Git::Error} on failure
@@ -369,27 +418,6 @@ module Git
         end
       end
 
-      # Copies this execution context with selected overrides applied
-      #
-      # The single place the gem derives one repository context from another.
-      # {#set_index} and {#set_working} assign the result to the receiver; the
-      # `with_*` helpers wrap it in a second repository instead.
-      #
-      # @param overrides [Hash] execution-context attributes to override
-      #
-      # @option overrides [String, nil] :git_index_file replacement index file path
-      #
-      # @option overrides [String, nil] :git_work_dir replacement working directory
-      #   path
-      #
-      # @return [Git::ExecutionContext::Repository] the derived execution context
-      #
-      # @api private
-      #
-      def context_helpers_derived_context(**overrides)
-        @execution_context.dup_with(**overrides)
-      end
-
       # Builds a repository of the receiver's class bound to a copy of this
       # execution context with selected overrides, leaving the receiver untouched
       #
@@ -405,7 +433,7 @@ module Git
       # @api private
       #
       def context_helpers_derived_repository(**overrides)
-        self.class.new(execution_context: context_helpers_derived_context(**overrides))
+        self.class.new(execution_context: @execution_context.dup_with(**overrides))
       end
     end
   end

--- a/spec/integration/git/repository/context_helpers_spec.rb
+++ b/spec/integration/git/repository/context_helpers_spec.rb
@@ -56,6 +56,16 @@ RSpec.describe Git::Repository::ContextHelpers, :integration do
       expect(described_instance.index).to eq(original_index)
       expect(described_instance.ls_files.keys).to contain_exactly('tracked.txt')
     end
+
+    it 'leaves an escaped repository bound to the removed index' do
+      escaped = described_instance.with_temp_index do |temp_repo|
+        temp_repo.read_tree('HEAD')
+        temp_repo
+      end
+      expect(escaped.ls_files).to be_empty
+      expect { escaped.add('extra.txt') }.to raise_error(Git::Error)
+      expect(escaped.object('HEAD:tracked.txt').contents).to eq('tracked')
+    end
   end
 
   describe '#with_temp_working' do
@@ -71,13 +81,13 @@ RSpec.describe Git::Repository::ContextHelpers, :integration do
 
     it 'changes the process directory back after the block returns' do
       original_pwd = File.realpath(Dir.pwd)
-      described_instance.with_temp_working { nil }
+      described_instance.with_temp_working { |_repo| nil }
       expect(File.realpath(Dir.pwd)).to eq(original_pwd)
     end
 
     it 'changes the process directory back even when the block raises' do
       original_pwd = File.realpath(Dir.pwd)
-      expect { described_instance.with_temp_working { raise 'block error' } }.to raise_error('block error')
+      expect { described_instance.with_temp_working { |_repo| raise 'block error' } }.to raise_error('block error')
       expect(File.realpath(Dir.pwd)).to eq(original_pwd)
     end
 
@@ -98,7 +108,7 @@ RSpec.describe Git::Repository::ContextHelpers, :integration do
       original_dir = described_instance.dir
       receiver_dir = nil
       receiver_untracked = nil
-      described_instance.with_temp_working do
+      described_instance.with_temp_working do |_repo|
         File.write('scratch.txt', "scratch\n")
         receiver_dir = described_instance.dir
         receiver_untracked = described_instance.untracked_files
@@ -115,6 +125,12 @@ RSpec.describe Git::Repository::ContextHelpers, :integration do
         temp_repo.add('scratch.txt')
       end
       expect(described_instance.ls_files.keys).to contain_exactly('tracked.txt', 'scratch.txt')
+    end
+
+    it 'leaves an escaped repository bound to the removed working directory' do
+      escaped = described_instance.with_temp_working { |temp_repo| temp_repo }
+      expect { escaped.untracked_files }.to raise_error(Git::Error)
+      expect(escaped.object('HEAD:tracked.txt').contents).to eq('tracked')
     end
   end
 end

--- a/spec/integration/git/repository/context_helpers_spec.rb
+++ b/spec/integration/git/repository/context_helpers_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'git/repository'
+require 'git/repository/context_helpers'
+
+# Integration tests for Git::Repository::ContextHelpers.
+#
+# #with_temp_index and #with_temp_working are exercised end-to-end because the
+# facade owns the behavior under test: it builds a second repository bound to a
+# temporary index or working tree, yields it, and leaves the receiver bound to
+# the original. Only real git can show that the yielded repository reads and
+# writes the temporary location while the receiver does not.
+#
+# The temporary path shape and the removal of the temporary directory need no
+# git and are covered by the unit specs. #chdir, #with_index, #with_working,
+# #set_index, and #set_working are pure path/context manipulations with no
+# git-command delegation of their own; the unit specs cover them, and the temp
+# variants above cover the derived repository they share.
+
+RSpec.describe Git::Repository::ContextHelpers, :integration do
+  include_context 'in an empty repository'
+
+  let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
+
+  before do
+    write_file('tracked.txt', "tracked\n")
+    repo.add('tracked.txt')
+    repo.commit('Initial commit')
+  end
+
+  describe '#with_temp_index' do
+    before { write_file('extra.txt', "extra\n") }
+
+    it 'reads and writes the temporary index through the yielded repository' do
+      staged = nil
+      described_instance.with_temp_index do |temp_repo|
+        temp_repo.read_tree('HEAD')
+        temp_repo.add('extra.txt')
+        staged = temp_repo.ls_files.keys
+      end
+      expect(staged).to contain_exactly('tracked.txt', 'extra.txt')
+    end
+
+    it 'leaves the receiver index untouched inside and after the block' do
+      original_index = described_instance.index
+      receiver_index = nil
+      receiver_staged = nil
+      described_instance.with_temp_index do |temp_repo|
+        temp_repo.add('extra.txt')
+        receiver_index = described_instance.index
+        receiver_staged = described_instance.ls_files.keys
+      end
+      expect(receiver_index).to eq(original_index)
+      expect(receiver_staged).to contain_exactly('tracked.txt')
+      expect(described_instance.index).to eq(original_index)
+      expect(described_instance.ls_files.keys).to contain_exactly('tracked.txt')
+    end
+  end
+
+  describe '#with_temp_working' do
+    it 'changes the process directory to the temporary working directory during the block' do
+      pwd_in_block = nil
+      yielded_dir = nil
+      described_instance.with_temp_working do |temp_repo|
+        pwd_in_block = File.realpath(Dir.pwd)
+        yielded_dir = File.realpath(temp_repo.dir.to_s)
+      end
+      expect(pwd_in_block).to eq(yielded_dir)
+    end
+
+    it 'changes the process directory back after the block returns' do
+      original_pwd = File.realpath(Dir.pwd)
+      described_instance.with_temp_working { nil }
+      expect(File.realpath(Dir.pwd)).to eq(original_pwd)
+    end
+
+    it 'changes the process directory back even when the block raises' do
+      original_pwd = File.realpath(Dir.pwd)
+      expect { described_instance.with_temp_working { raise 'block error' } }.to raise_error('block error')
+      expect(File.realpath(Dir.pwd)).to eq(original_pwd)
+    end
+
+    it 'reads and writes the temporary working tree through the yielded repository' do
+      checked_out = nil
+      untracked = nil
+      described_instance.with_temp_working do |temp_repo|
+        temp_repo.checkout_index(all: true)
+        checked_out = File.read(File.join(temp_repo.dir, 'tracked.txt'))
+        File.write('scratch.txt', "scratch\n")
+        untracked = temp_repo.untracked_files
+      end
+      expect(checked_out).to eq("tracked\n")
+      expect(untracked).to contain_exactly('scratch.txt')
+    end
+
+    it 'keeps files written in the temporary directory out of the receiver working tree' do
+      original_dir = described_instance.dir
+      receiver_dir = nil
+      receiver_untracked = nil
+      described_instance.with_temp_working do
+        File.write('scratch.txt', "scratch\n")
+        receiver_dir = described_instance.dir
+        receiver_untracked = described_instance.untracked_files
+      end
+      expect(receiver_dir).to eq(original_dir)
+      expect(receiver_untracked).to be_empty
+      expect(described_instance.dir).to eq(original_dir)
+      expect(file_exist?('scratch.txt')).to be(false)
+    end
+
+    it 'shares the receiver index with the yielded repository' do
+      described_instance.with_temp_working do |temp_repo|
+        File.write('scratch.txt', "scratch\n")
+        temp_repo.add('scratch.txt')
+      end
+      expect(described_instance.ls_files.keys).to contain_exactly('tracked.txt', 'scratch.txt')
+    end
+  end
+end

--- a/spec/unit/git/repository/context_helpers_spec.rb
+++ b/spec/unit/git/repository/context_helpers_spec.rb
@@ -4,18 +4,22 @@ require 'spec_helper'
 require 'git/repository'
 require 'git/repository/context_helpers'
 
-# Integration-level coverage is provided by the underlying command integration
-# tests. No facade integration spec is needed for this module: the helpers are
-# pure path/context manipulations with no git-command delegation.
+# The with_temp_index and with_temp_working integration specs in
+# spec/integration/git/repository/context_helpers_spec.rb show the yielded
+# repository reading and writing the temporary location against real git. The
+# remaining helpers are pure path/context manipulations with no git-command
+# delegation and are covered here only.
 
 RSpec.describe Git::Repository::ContextHelpers do
   let(:git_dir) { '/repo/.git' }
   let(:work_dir) { '/repo' }
   let(:index_file) { '/repo/.git/index' }
 
+  # A real context rather than a double: it is a value object with no disk
+  # access, and its dup_with is what carries the outer override into a helper
+  # nested inside another.
   let(:execution_context) do
-    instance_double(
-      Git::ExecutionContext::Repository,
+    Git::ExecutionContext::Repository.new(
       git_dir: git_dir,
       git_work_dir: work_dir,
       git_index_file: index_file,
@@ -25,29 +29,6 @@ RSpec.describe Git::Repository::ContextHelpers do
   end
 
   let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
-
-  # Shared stub: any `dup_with` call on the execution_context double returns a
-  # new double reflecting the requested overrides. Individual describe blocks
-  # override this for tests that require specific assertions on the rebuilt context.
-  before do
-    allow(execution_context).to receive(:dup_with) do |**kwargs|
-      rebuilt = instance_double(
-        Git::ExecutionContext::Repository,
-        git_dir: kwargs.fetch(:git_dir, git_dir),
-        git_work_dir: kwargs.fetch(:git_work_dir, work_dir),
-        git_index_file: kwargs.fetch(:git_index_file, index_file)
-      )
-      allow(rebuilt).to receive(:dup_with) do |**inner|
-        instance_double(
-          Git::ExecutionContext::Repository,
-          git_dir: inner.fetch(:git_dir, git_dir),
-          git_work_dir: inner.fetch(:git_work_dir, work_dir),
-          git_index_file: inner.fetch(:git_index_file, index_file)
-        )
-      end
-      rebuilt
-    end
-  end
 
   # ---------------------------------------------------------------------------
   # #chdir
@@ -119,8 +100,7 @@ RSpec.describe Git::Repository::ContextHelpers do
 
     context 'when the repository is bare (no working directory)' do
       let(:execution_context) do
-        instance_double(
-          Git::ExecutionContext::Repository,
+        Git::ExecutionContext::Repository.new(
           git_dir: git_dir,
           git_work_dir: nil,
           git_index_file: index_file,
@@ -229,41 +209,69 @@ RSpec.describe Git::Repository::ContextHelpers do
   # ---------------------------------------------------------------------------
 
   describe '#with_index' do
-    let(:temp_context) { instance_double(Git::ExecutionContext::Repository) }
+    # A directory the spec owns, so the index file inside it is known not to
+    # exist rather than assumed absent from a shared location such as /tmp.
+    let(:temp_dir) { Dir.mktmpdir('context-helpers-') }
+    let(:new_index) { File.join(temp_dir, 'idx') }
+    let(:expanded_index) { File.expand_path(new_index) }
 
-    before do
-      allow(execution_context).to receive(:dup_with).and_return(temp_context)
-      allow(temp_context).to receive(:git_index_file).and_return('/tmp/idx')
+    after { FileUtils.remove_entry(temp_dir, true) }
+
+    it 'yields a repository other than the receiver bound to the new index' do
+      yielded = nil
+      described_instance.with_index(new_index) { |repo| yielded = repo }
+      expect(yielded).to be_a(Git::Repository)
+      expect(yielded).not_to be(described_instance)
+      expect(yielded.index).to eq(Pathname.new(expanded_index))
     end
 
-    it 'yields self' do
-      expect { |b| described_instance.with_index('/tmp/idx', &b) }
-        .to yield_with_args(described_instance)
+    it 'yields an instance of the receiver class' do
+      subclass_instance = Class.new(Git::Repository).new(execution_context: execution_context)
+      yielded = nil
+      subclass_instance.with_index(new_index) { |repo| yielded = repo }
+      expect(yielded).to be_an_instance_of(subclass_instance.class)
     end
 
     it 'returns the value returned by the block' do
-      result = described_instance.with_index('/tmp/idx') { 'hello' }
+      result = described_instance.with_index(new_index) { 'hello' }
       expect(result).to eq('hello')
     end
 
-    it 'sets the index to the new value during the block' do
-      entered_index = nil
-      described_instance.with_index('/tmp/idx') { entered_index = described_instance.index }
-      expect(entered_index).to eq(Pathname.new('/tmp/idx'))
+    it 'leaves the receiver execution context unchanged inside and after the block' do
+      original_context = described_instance.execution_context
+      context_in_block = nil
+      described_instance.with_index(new_index) { context_in_block = described_instance.execution_context }
+      expect(context_in_block).to be(original_context)
+      expect(described_instance.execution_context).to be(original_context)
     end
 
-    it 'restores the original execution context after the block' do
-      original_ctx = described_instance.execution_context
-      described_instance.with_index('/tmp/idx') { nil }
-      expect(described_instance.execution_context).to be(original_ctx)
+    it 'leaves the receiver execution context unchanged when the block raises' do
+      original_context = described_instance.execution_context
+      expect { described_instance.with_index(new_index) { raise 'block error' } }
+        .to raise_error('block error')
+      expect(described_instance.execution_context).to be(original_context)
     end
 
-    it 'restores the original execution context even when the block raises' do
-      original_ctx = described_instance.execution_context
-      expect do
-        described_instance.with_index('/tmp/idx') { raise 'boom' }
-      end.to raise_error('boom')
-      expect(described_instance.execution_context).to be(original_ctx)
+    it 'does not require the index file to exist' do
+      expect(File.exist?(expanded_index)).to be(false)
+      expect { described_instance.with_index(new_index) { nil } }.not_to raise_error
+    end
+
+    context 'when the path cannot be expanded' do
+      before do
+        # File.expand_path consults Dir.pwd for a relative path, so it fails
+        # when the process working directory has been removed. Other callers
+        # (Dir.mktmpdir, the temp-dir cleanup) must still expand normally.
+        allow(File).to receive(:expand_path).and_call_original
+        allow(File).to receive(:expand_path).with('relative/index').and_raise(Errno::ENOENT, 'getcwd')
+      end
+
+      it 'raises Git::Error with the system error as cause' do
+        expect { described_instance.with_index('relative/index') { nil } }
+          .to raise_error(Git::Error, /Failed to expand the path/) do |error|
+            expect(error.cause).to be_a(Errno::ENOENT)
+          end
+      end
     end
   end
 
@@ -292,27 +300,33 @@ RSpec.describe Git::Repository::ContextHelpers do
       end
     end
 
-    it 'yields self' do
-      expect { |b| described_instance.with_temp_index(&b) }.to yield_with_args(described_instance)
+    it 'yields a repository other than the receiver' do
+      yielded = nil
+      described_instance.with_temp_index { |repo| yielded = repo }
+      expect(yielded).to be_a(Git::Repository)
+      expect(yielded).not_to be(described_instance)
     end
 
-    it 'sets the index to a different temporary path during the block' do
-      index_during_block = nil
-      described_instance.with_temp_index { index_during_block = described_instance.index }
-      expect(index_during_block).not_to eq(Pathname.new(index_file))
+    it 'yields a repository bound to an index inside a new temporary directory' do
+      yielded_index = nil
+      described_instance.with_temp_index { |repo| yielded_index = repo.index }
+      expect(yielded_index).not_to eq(Pathname.new(index_file))
+      expect(yielded_index.basename.to_s).to eq('index')
     end
 
-    it 'restores the original execution context after the block' do
-      original_ctx = described_instance.execution_context
-      described_instance.with_temp_index { nil }
-      expect(described_instance.execution_context).to be(original_ctx)
+    it 'leaves the receiver execution context unchanged inside and after the block' do
+      original_context = described_instance.execution_context
+      context_in_block = nil
+      described_instance.with_temp_index { context_in_block = described_instance.execution_context }
+      expect(context_in_block).to be(original_context)
+      expect(described_instance.execution_context).to be(original_context)
     end
 
     it 'cleans up the temporary directory after the block succeeds' do
       temp_dir = nil
-      described_instance.with_temp_index do
-        temp_dir = File.dirname(described_instance.index.to_s)
-        FileUtils.touch(described_instance.index.to_s)
+      described_instance.with_temp_index do |repo|
+        temp_dir = File.dirname(repo.index.to_s)
+        FileUtils.touch(repo.index.to_s)
       end
       expect(temp_dir).not_to be_nil
       expect(Dir.exist?(temp_dir)).to be(false)
@@ -321,9 +335,9 @@ RSpec.describe Git::Repository::ContextHelpers do
     it 'cleans up the temporary directory even when the block raises' do
       temp_dir = nil
       expect do
-        described_instance.with_temp_index do
-          temp_dir = File.dirname(described_instance.index.to_s)
-          FileUtils.touch(described_instance.index.to_s)
+        described_instance.with_temp_index do |repo|
+          temp_dir = File.dirname(repo.index.to_s)
+          FileUtils.touch(repo.index.to_s)
           raise 'block error'
         end
       end.to raise_error('block error')
@@ -443,18 +457,24 @@ RSpec.describe Git::Repository::ContextHelpers do
     let(:expanded_work_dir) { File.expand_path(real_work_dir) }
 
     after { FileUtils.remove_entry(real_work_dir, true) }
-    let(:temp_context) do
-      instance_double(Git::ExecutionContext::Repository, git_work_dir: expanded_work_dir)
-    end
 
     before do
-      allow(execution_context).to receive(:dup_with).and_return(temp_context)
       allow(Dir).to receive(:chdir).with(expanded_work_dir).and_yield
     end
 
-    it 'yields self' do
-      expect { |b| described_instance.with_working(real_work_dir, &b) }
-        .to yield_with_args(described_instance)
+    it 'yields a repository other than the receiver bound to the new working directory' do
+      yielded = nil
+      described_instance.with_working(real_work_dir) { |repo| yielded = repo }
+      expect(yielded).to be_a(Git::Repository)
+      expect(yielded).not_to be(described_instance)
+      expect(yielded.dir).to eq(Pathname.new(expanded_work_dir))
+    end
+
+    it 'yields an instance of the receiver class' do
+      subclass_instance = Class.new(Git::Repository).new(execution_context: execution_context)
+      yielded = nil
+      subclass_instance.with_working(real_work_dir) { |repo| yielded = repo }
+      expect(yielded).to be_an_instance_of(subclass_instance.class)
     end
 
     it 'returns the value returned by the block' do
@@ -467,18 +487,19 @@ RSpec.describe Git::Repository::ContextHelpers do
       described_instance.with_working(real_work_dir) { nil }
     end
 
-    it 'restores the original execution context after the block' do
-      original_ctx = described_instance.execution_context
-      described_instance.with_working(real_work_dir) { nil }
-      expect(described_instance.execution_context).to be(original_ctx)
+    it 'leaves the receiver execution context unchanged inside and after the block' do
+      original_context = described_instance.execution_context
+      context_in_block = nil
+      described_instance.with_working(real_work_dir) { context_in_block = described_instance.execution_context }
+      expect(context_in_block).to be(original_context)
+      expect(described_instance.execution_context).to be(original_context)
     end
 
-    it 'restores the original execution context even when the block raises' do
-      original_ctx = described_instance.execution_context
-      expect do
-        described_instance.with_working(real_work_dir) { raise 'boom' }
-      end.to raise_error('boom')
-      expect(described_instance.execution_context).to be(original_ctx)
+    it 'leaves the receiver execution context unchanged when the block raises' do
+      original_context = described_instance.execution_context
+      expect { described_instance.with_working(real_work_dir) { raise 'block error' } }
+        .to raise_error('block error')
+      expect(described_instance.execution_context).to be(original_context)
     end
 
     context 'when the working directory cannot be entered' do
@@ -493,10 +514,11 @@ RSpec.describe Git::Repository::ContextHelpers do
           end
       end
 
-      it 'restores the original execution context' do
-        original_ctx = described_instance.execution_context
-        expect { described_instance.with_working(real_work_dir) { nil } }.to raise_error(Git::Error)
-        expect(described_instance.execution_context).to be(original_ctx)
+      it 'leaves the receiver execution context unchanged' do
+        original_context = described_instance.execution_context
+        expect { described_instance.with_working(real_work_dir) { nil } }
+          .to raise_error(Git::Error, /Failed to change directory/)
+        expect(described_instance.execution_context).to be(original_context)
       end
     end
 
@@ -556,19 +578,31 @@ RSpec.describe Git::Repository::ContextHelpers do
       end
     end
 
-    it 'yields self' do
-      expect { |b| described_instance.with_temp_working(&b) }.to yield_with_args(described_instance)
+    it 'yields a repository other than the receiver' do
+      yielded = nil
+      described_instance.with_temp_working { |repo| yielded = repo }
+      expect(yielded).to be_a(Git::Repository)
+      expect(yielded).not_to be(described_instance)
     end
 
-    it 'restores the original execution context after the block' do
-      original_ctx = described_instance.execution_context
-      described_instance.with_temp_working { nil }
-      expect(described_instance.execution_context).to be(original_ctx)
+    it 'yields a repository bound to a new temporary working directory' do
+      yielded_dir = nil
+      described_instance.with_temp_working { |repo| yielded_dir = repo.dir }
+      expect(yielded_dir).not_to eq(Pathname.new(work_dir))
+      expect(yielded_dir.basename.to_s).to start_with('temp-workdir')
+    end
+
+    it 'leaves the receiver execution context unchanged inside and after the block' do
+      original_context = described_instance.execution_context
+      context_in_block = nil
+      described_instance.with_temp_working { context_in_block = described_instance.execution_context }
+      expect(context_in_block).to be(original_context)
+      expect(described_instance.execution_context).to be(original_context)
     end
 
     it 'cleans up the temporary directory after the block succeeds' do
       temp_dir = nil
-      described_instance.with_temp_working { temp_dir = described_instance.dir.to_s }
+      described_instance.with_temp_working { |repo| temp_dir = repo.dir.to_s }
       expect(temp_dir).not_to be_nil
       expect(Dir.exist?(temp_dir)).to be(false)
     end
@@ -576,8 +610,8 @@ RSpec.describe Git::Repository::ContextHelpers do
     it 'cleans up the temporary directory even when the block raises' do
       temp_dir = nil
       expect do
-        described_instance.with_temp_working do
-          temp_dir = described_instance.dir.to_s
+        described_instance.with_temp_working do |repo|
+          temp_dir = repo.dir.to_s
           raise 'block error'
         end
       end.to raise_error('block error')
@@ -591,17 +625,29 @@ RSpec.describe Git::Repository::ContextHelpers do
   # ---------------------------------------------------------------------------
 
   describe 'nested context helpers' do
-    it 'restores the original execution context after nested with_index inside with_working' do
-      original_ctx = described_instance.execution_context
-      allow(Dir).to receive(:chdir).and_yield
+    before { allow(Dir).to receive(:chdir).and_yield }
+
+    it 'yields a repository carrying both the working directory and index overrides' do
+      inner = nil
+      Dir.mktmpdir do |outer_work|
+        described_instance.with_working(outer_work) do |working_repo|
+          working_repo.with_index('/tmp/inner_idx') { |repo| inner = repo }
+        end
+        expect(inner.dir).to eq(Pathname.new(File.expand_path(outer_work)))
+      end
+      expect(inner.index).to eq(Pathname.new(File.expand_path('/tmp/inner_idx')))
+    end
+
+    it 'leaves the receiver execution context unchanged after nested with_index inside with_working' do
+      original_context = described_instance.execution_context
 
       Dir.mktmpdir do |outer_work|
-        described_instance.with_working(outer_work) do
-          described_instance.with_index('/tmp/inner_idx') { nil }
+        described_instance.with_working(outer_work) do |working_repo|
+          working_repo.with_index('/tmp/inner_idx') { nil }
         end
       end
 
-      expect(described_instance.execution_context).to be(original_ctx)
+      expect(described_instance.execution_context).to be(original_context)
     end
   end
 end

--- a/spec/unit/git/repository/context_helpers_spec.rb
+++ b/spec/unit/git/repository/context_helpers_spec.rb
@@ -30,6 +30,38 @@ RSpec.describe Git::Repository::ContextHelpers do
 
   let(:described_instance) { Git::Repository.new(execution_context: execution_context) }
 
+  # All four with_* helpers route through one private block guard. This group
+  # pins its contract once; each helper runs it through `call_helper`, a lambda
+  # that forwards the given block to the helper under test.
+  shared_examples 'a helper that requires a repository block' do
+    it 'raises ArgumentError when no block is given' do
+      expect { call_helper.call }
+        .to raise_error(ArgumentError, /block that accepts the yielded repository/)
+    end
+
+    it 'raises ArgumentError when the block declares no parameter' do
+      expect { call_helper.call { nil } }
+        .to raise_error(ArgumentError, /block that accepts the yielded repository/)
+    end
+
+    it 'raises ArgumentError when the block declares only a keyword parameter' do
+      expect { call_helper.call { |**_opts| nil } }
+        .to raise_error(ArgumentError, /block that accepts the yielded repository/)
+    end
+
+    it 'accepts a block that declares an unused parameter' do
+      expect { call_helper.call { |_| nil } }.not_to raise_error
+    end
+
+    it 'accepts a block that declares an optional parameter' do
+      expect { call_helper.call { |_repo = nil| nil } }.not_to raise_error
+    end
+
+    it 'accepts a block that takes a splat' do
+      expect { call_helper.call { |*| nil } }.not_to raise_error
+    end
+  end
+
   # ---------------------------------------------------------------------------
   # #chdir
   # ---------------------------------------------------------------------------
@@ -100,12 +132,11 @@ RSpec.describe Git::Repository::ContextHelpers do
 
     context 'when the repository is bare (no working directory)' do
       let(:execution_context) do
-        Git::ExecutionContext::Repository.new(
+        instance_double(
+          Git::ExecutionContext::Repository,
           git_dir: git_dir,
           git_work_dir: nil,
-          git_index_file: index_file,
-          binary_path: '/usr/bin/git',
-          git_ssh: nil
+          git_index_file: index_file
         )
       end
 
@@ -217,6 +248,10 @@ RSpec.describe Git::Repository::ContextHelpers do
 
     after { FileUtils.remove_entry(temp_dir, true) }
 
+    it_behaves_like 'a helper that requires a repository block' do
+      let(:call_helper) { ->(&block) { described_instance.with_index(new_index, &block) } }
+    end
+
     it 'yields a repository other than the receiver bound to the new index' do
       yielded = nil
       described_instance.with_index(new_index) { |repo| yielded = repo }
@@ -232,29 +267,37 @@ RSpec.describe Git::Repository::ContextHelpers do
       expect(yielded).to be_an_instance_of(subclass_instance.class)
     end
 
+    it 'leaves a set_index made on the receiver inside the block in place after the block' do
+      other_index = '/repo/.git/other.index'
+      described_instance.with_index(new_index) do |_repo|
+        described_instance.set_index(other_index, must_exist: false)
+      end
+      expect(described_instance.index).to eq(Pathname.new(File.expand_path(other_index)))
+    end
+
     it 'returns the value returned by the block' do
-      result = described_instance.with_index(new_index) { 'hello' }
+      result = described_instance.with_index(new_index) { |_repo| 'hello' }
       expect(result).to eq('hello')
     end
 
     it 'leaves the receiver execution context unchanged inside and after the block' do
       original_context = described_instance.execution_context
       context_in_block = nil
-      described_instance.with_index(new_index) { context_in_block = described_instance.execution_context }
+      described_instance.with_index(new_index) { |_repo| context_in_block = described_instance.execution_context }
       expect(context_in_block).to be(original_context)
       expect(described_instance.execution_context).to be(original_context)
     end
 
     it 'leaves the receiver execution context unchanged when the block raises' do
       original_context = described_instance.execution_context
-      expect { described_instance.with_index(new_index) { raise 'block error' } }
+      expect { described_instance.with_index(new_index) { |_repo| raise 'block error' } }
         .to raise_error('block error')
       expect(described_instance.execution_context).to be(original_context)
     end
 
     it 'does not require the index file to exist' do
       expect(File.exist?(expanded_index)).to be(false)
-      expect { described_instance.with_index(new_index) { nil } }.not_to raise_error
+      expect { described_instance.with_index(new_index) { |_repo| nil } }.not_to raise_error
     end
 
     context 'when the path cannot be expanded' do
@@ -267,7 +310,7 @@ RSpec.describe Git::Repository::ContextHelpers do
       end
 
       it 'raises Git::Error with the system error as cause' do
-        expect { described_instance.with_index('relative/index') { nil } }
+        expect { described_instance.with_index('relative/index') { |_repo| nil } }
           .to raise_error(Git::Error, /Failed to expand the path/) do |error|
             expect(error.cause).to be_a(Errno::ENOENT)
           end
@@ -280,13 +323,26 @@ RSpec.describe Git::Repository::ContextHelpers do
   # ---------------------------------------------------------------------------
 
   describe '#with_temp_index' do
+    it_behaves_like 'a helper that requires a repository block' do
+      let(:call_helper) { ->(&block) { described_instance.with_temp_index(&block) } }
+    end
+
+    context 'when the block cannot receive the repository' do
+      it 'does not create a temporary directory before rejecting the block' do
+        allow(Dir).to receive(:mktmpdir).and_call_original
+        expect { described_instance.with_temp_index { nil } }
+          .to raise_error(ArgumentError, /block that accepts the yielded repository/)
+        expect(Dir).not_to have_received(:mktmpdir)
+      end
+    end
+
     context 'when the temporary directory cannot be created' do
       before do
         allow(Dir).to receive(:mktmpdir).and_raise(Errno::EACCES, '/tmp')
       end
 
       it 'raises Git::Error with the system error as cause' do
-        expect { described_instance.with_temp_index { nil } }
+        expect { described_instance.with_temp_index { |_repo| nil } }
           .to raise_error(Git::Error, /Failed to create a temporary directory.*Permission denied/) do |error|
             expect(error.cause).to be_a(Errno::EACCES)
           end
@@ -295,7 +351,7 @@ RSpec.describe Git::Repository::ContextHelpers do
 
     context 'when the block raises a SystemCallError' do
       it 'lets the SystemCallError propagate unchanged' do
-        expect { described_instance.with_temp_index { raise Errno::ENOENT, 'caller.txt' } }
+        expect { described_instance.with_temp_index { |_repo| raise Errno::ENOENT, 'caller.txt' } }
           .to raise_error(Errno::ENOENT, /caller\.txt/)
       end
     end
@@ -317,7 +373,7 @@ RSpec.describe Git::Repository::ContextHelpers do
     it 'leaves the receiver execution context unchanged inside and after the block' do
       original_context = described_instance.execution_context
       context_in_block = nil
-      described_instance.with_temp_index { context_in_block = described_instance.execution_context }
+      described_instance.with_temp_index { |_repo| context_in_block = described_instance.execution_context }
       expect(context_in_block).to be(original_context)
       expect(described_instance.execution_context).to be(original_context)
     end
@@ -462,6 +518,10 @@ RSpec.describe Git::Repository::ContextHelpers do
       allow(Dir).to receive(:chdir).with(expanded_work_dir).and_yield
     end
 
+    it_behaves_like 'a helper that requires a repository block' do
+      let(:call_helper) { ->(&block) { described_instance.with_working(real_work_dir, &block) } }
+    end
+
     it 'yields a repository other than the receiver bound to the new working directory' do
       yielded = nil
       described_instance.with_working(real_work_dir) { |repo| yielded = repo }
@@ -478,26 +538,26 @@ RSpec.describe Git::Repository::ContextHelpers do
     end
 
     it 'returns the value returned by the block' do
-      result = described_instance.with_working(real_work_dir) { 'result' }
+      result = described_instance.with_working(real_work_dir) { |_repo| 'result' }
       expect(result).to eq('result')
     end
 
     it 'changes the process directory to the expanded working directory during the block' do
       expect(Dir).to receive(:chdir).with(expanded_work_dir).and_yield
-      described_instance.with_working(real_work_dir) { nil }
+      described_instance.with_working(real_work_dir) { |_repo| nil }
     end
 
     it 'leaves the receiver execution context unchanged inside and after the block' do
       original_context = described_instance.execution_context
       context_in_block = nil
-      described_instance.with_working(real_work_dir) { context_in_block = described_instance.execution_context }
+      described_instance.with_working(real_work_dir) { |_repo| context_in_block = described_instance.execution_context }
       expect(context_in_block).to be(original_context)
       expect(described_instance.execution_context).to be(original_context)
     end
 
     it 'leaves the receiver execution context unchanged when the block raises' do
       original_context = described_instance.execution_context
-      expect { described_instance.with_working(real_work_dir) { raise 'block error' } }
+      expect { described_instance.with_working(real_work_dir) { |_repo| raise 'block error' } }
         .to raise_error('block error')
       expect(described_instance.execution_context).to be(original_context)
     end
@@ -508,7 +568,7 @@ RSpec.describe Git::Repository::ContextHelpers do
       end
 
       it 'raises Git::Error with the system error as cause' do
-        expect { described_instance.with_working(real_work_dir) { nil } }
+        expect { described_instance.with_working(real_work_dir) { |_repo| nil } }
           .to raise_error(Git::Error, /Failed to change directory.*No such file or directory/) do |error|
             expect(error.cause).to be_a(Errno::ENOENT)
           end
@@ -516,7 +576,7 @@ RSpec.describe Git::Repository::ContextHelpers do
 
       it 'leaves the receiver execution context unchanged' do
         original_context = described_instance.execution_context
-        expect { described_instance.with_working(real_work_dir) { nil } }
+        expect { described_instance.with_working(real_work_dir) { |_repo| nil } }
           .to raise_error(Git::Error, /Failed to change directory/)
         expect(described_instance.execution_context).to be(original_context)
       end
@@ -524,14 +584,14 @@ RSpec.describe Git::Repository::ContextHelpers do
 
     context 'when the block raises a SystemCallError' do
       it 'lets the SystemCallError propagate unchanged' do
-        expect { described_instance.with_working(real_work_dir) { raise Errno::ENOENT, 'caller.txt' } }
+        expect { described_instance.with_working(real_work_dir) { |_repo| raise Errno::ENOENT, 'caller.txt' } }
           .to raise_error(Errno::ENOENT, /caller\.txt/)
       end
     end
 
     it 'raises ArgumentError when work_dir does not exist' do
       expect do
-        described_instance.with_working('/nonexistent/path/for/test')
+        described_instance.with_working('/nonexistent/path/for/test') { |_| nil }
       end.to raise_error(ArgumentError, /path does not exist/)
     end
   end
@@ -545,13 +605,26 @@ RSpec.describe Git::Repository::ContextHelpers do
       allow(Dir).to receive(:chdir).and_yield
     end
 
+    it_behaves_like 'a helper that requires a repository block' do
+      let(:call_helper) { ->(&block) { described_instance.with_temp_working(&block) } }
+    end
+
+    context 'when the block cannot receive the repository' do
+      it 'does not create a temporary directory before rejecting the block' do
+        allow(Dir).to receive(:mktmpdir).and_call_original
+        expect { described_instance.with_temp_working { nil } }
+          .to raise_error(ArgumentError, /block that accepts the yielded repository/)
+        expect(Dir).not_to have_received(:mktmpdir)
+      end
+    end
+
     context 'when the temporary directory cannot be created' do
       before do
         allow(Dir).to receive(:mktmpdir).and_raise(Errno::EACCES, '/tmp')
       end
 
       it 'raises Git::Error with the system error as cause' do
-        expect { described_instance.with_temp_working { nil } }
+        expect { described_instance.with_temp_working { |_repo| nil } }
           .to raise_error(Git::Error, /Failed to create or remove a temporary directory.*Permission denied/) do |error|
             expect(error.cause).to be_a(Errno::EACCES)
           end
@@ -564,7 +637,7 @@ RSpec.describe Git::Repository::ContextHelpers do
       end
 
       it 'raises Git::Error with the system error as cause' do
-        expect { described_instance.with_temp_working { nil } }
+        expect { described_instance.with_temp_working { |_repo| nil } }
           .to raise_error(Git::Error, /Failed to create or remove a temporary directory.*Permission denied/) do |error|
             expect(error.cause).to be_a(Errno::EACCES)
           end
@@ -573,7 +646,7 @@ RSpec.describe Git::Repository::ContextHelpers do
 
     context 'when the block raises a SystemCallError' do
       it 'lets the SystemCallError propagate unchanged' do
-        expect { described_instance.with_temp_working { raise Errno::ENOENT, 'caller.txt' } }
+        expect { described_instance.with_temp_working { |_repo| raise Errno::ENOENT, 'caller.txt' } }
           .to raise_error(Errno::ENOENT, /caller\.txt/)
       end
     end
@@ -595,7 +668,7 @@ RSpec.describe Git::Repository::ContextHelpers do
     it 'leaves the receiver execution context unchanged inside and after the block' do
       original_context = described_instance.execution_context
       context_in_block = nil
-      described_instance.with_temp_working { context_in_block = described_instance.execution_context }
+      described_instance.with_temp_working { |_repo| context_in_block = described_instance.execution_context }
       expect(context_in_block).to be(original_context)
       expect(described_instance.execution_context).to be(original_context)
     end
@@ -638,12 +711,22 @@ RSpec.describe Git::Repository::ContextHelpers do
       expect(inner.index).to eq(Pathname.new(File.expand_path('/tmp/inner_idx')))
     end
 
+    it 'derives a nested call on the outer repository from the outer repository, not the outer block' do
+      inner = nil
+      Dir.mktmpdir do |outer_work|
+        described_instance.with_working(outer_work) do |_working_repo|
+          described_instance.with_index('/tmp/inner_idx') { |repo| inner = repo }
+        end
+      end
+      expect(inner.dir).to eq(Pathname.new(work_dir))
+    end
+
     it 'leaves the receiver execution context unchanged after nested with_index inside with_working' do
       original_context = described_instance.execution_context
 
       Dir.mktmpdir do |outer_work|
         described_instance.with_working(outer_work) do |working_repo|
-          working_repo.with_index('/tmp/inner_idx') { nil }
+          working_repo.with_index('/tmp/inner_idx') { |_repo| nil }
         end
       end
 


### PR DESCRIPTION
## Summary

`Git::Repository#with_index`, `#with_temp_index`, `#with_working`, and `#with_temp_working` used to swap the receiver's `@execution_context` for the duration of the block, yield `self`, and restore the context in `ensure`. They now build a copy of the execution context with the override, wrap it in a new `Git::Repository`, and yield that. The receiver is never touched, so there is nothing to restore. The temporary variants still remove the scratch directory they created.

This is a behavior change for callers that ignore the block parameter and call the outer repository inside the block. To keep the v5.x form from running silently against the wrong index or working tree, the helpers now raise `ArgumentError` when no block is given or the block declares no positional parameter. Issue #1835 adds a `Git::Deprecation` warning for the zero-arity block on the `5.x` branch, shipping in v5.6.0, so that form has a deprecation path. A call with no block already raised `LocalJumpError` in v5.x and is not deprecated there. The change ships in v6.0.0 with an UPGRADING.md entry, and under ADR-0007 this PR merges only after v5.6.0 is released.

The PR is three commits: the derived-repository refactor, the ADR-0009 Consequences edit, and the block-parameter check.

## Changes

- `with_index` and `with_working` derive a new repository of the receiver's class (`self.class.new`, as issue 1830 specifies) through a private `context_helpers_derived_repository` helper that calls `dup_with` on the execution context. The module docstring and UPGRADING.md state that a subclass must accept `initialize(execution_context:)`. `with_working` keeps `must_exist: true`, so a missing directory still raises `ArgumentError`, and keeps the process-global `Dir.chdir`.
- `set_index` and `set_working` keep their behavior; the block forms no longer call them. Issue 1833 deprecates them separately.
- All four helpers raise `ArgumentError` before doing any filesystem work when the block is missing or declares no positional parameter. The check reads `Proc#parameters` rather than arity, so `|repo = nil|` is accepted (its arity is zero) while keyword-only and block-only parameters are rejected. Blocks that declare a parameter, including `|_|`, a splat, or `&:read_tree`, are unaffected. `chdir` is unchanged.
- Unit specs assert the receiver's execution context is unchanged inside and after the block, that the yielded context carries the override, that a subclass receiver yields a subclass instance, that a missing, parameterless, or keyword-only block raises `ArgumentError` while an unused, optional, or splat parameter does not (a shared example group each helper runs, the first in the suite), that the temp variants reject the block before creating a directory, that a `set_index` on the receiver inside the block stays in place, and that a nested call on the outer repository derives from the outer repository. The spec builds a real `Git::ExecutionContext::Repository` because `dup_with` is the behavior under test; the facade-test-conventions skill now records that exception.
- New integration specs run `with_temp_index` and `with_temp_working` against a real repository: the yielded repository reads and writes the temporary index or working tree, the receiver is untouched inside and after the block, the temporary directory is gone afterward, and a repository that escapes the block behaves as the `@note` describes (empty index reads, `Git::Error` on writes and working-tree calls, object reads still work).
- YARD: the module docstring, `@yield` and `@yieldparam` tags, and `@example` blocks describe the yielded repository, the `:yields: self` comments are gone, and the temp variants carry a `@note` saying the yielded repository must not escape the block: once the temporary path is removed, working-tree calls raise `Git::Error`, index reads see an empty index (git treats a missing index file as empty) and index writes raise `Git::Error`, while object-database reads still work.
- ADR-0009 Consequences no longer says the `with_*` methods restore on the way out (separate commit).
- UPGRADING.md gains a "Context helpers yield a separate repository" entry and a preparation step. The entry also notes that `set_index` and `set_working` called on the outer repository inside a block are no longer undone on exit, that a block without a parameter raises `ArgumentError` and v5.6.0 warns for it, and that a call with no block raises `ArgumentError` instead of `LocalJumpError`.

## Out of scope

The `Dir.chdir` in `with_working` stays, so `with_working` and `with_temp_working` remain unsafe to call from more than one thread at a time. The docs say so.

Closes #1830
Refs #1835


