### PR TITLE
feat(repository): deprecate with_* context helper blocks that declare no parameter

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -35,6 +35,7 @@ to update your code when upgrading from the preceding major version.
     - [`Git::Log` Enumerable interface deprecated](#gitlog-enumerable-interface-deprecated)
     - [`Git::Object::Commit#set_commit` deprecated](#gitobjectcommitset_commit-deprecated)
     - [`Git.export` `:remote` option deprecated](#gitexport-remote-option-deprecated)
+    - [Context helper blocks that declare no parameter deprecated](#context-helper-blocks-that-declare-no-parameter-deprecated)
 
 ## Upgrading to v6.0.0
 
@@ -1134,5 +1135,41 @@ observable in the result. Delete the option from the call.
 | Deprecated call (works in v5.x, removed in a future major release) | Replacement |
 |--------------------------------------------------------------------|-------------|
 | `Git.export(url, dir, remote: name)` | `Git.export(url, dir)` |
+
+#### Context helper blocks that declare no parameter deprecated
+
+`Git::Repository#with_index`, `#with_temp_index`, `#with_working`, and
+`#with_temp_working` yield `self` in v5.x, so a block could ignore the yielded
+value and call methods on the receiver. Calling one of these helpers with a block
+that declares no positional parameter (`do ... end`, `{ }`, `{ || }`, or a block
+with only keyword or block parameters) now emits a deprecation warning. The
+behavior is otherwise unchanged: the helpers still yield `self`, and a call with
+no block still raises `LocalJumpError`.
+
+In v6.0.0 these helpers yield a separate repository bound to the other index or
+working tree instead of rebinding the receiver, and they raise `ArgumentError` for
+a block that declares no positional parameter. A call with no block also raises
+`ArgumentError` in v6.0.0 instead of `LocalJumpError`. Declare a block parameter
+and call methods on it. The parameter is required even when the block never uses
+the repository, for example a `with_temp_working` block that only writes files
+(`do |_scratch|`). Blocks that already declare a positional parameter (`|repo|`,
+`|_|`, `|repo = nil|`, `|*args|`, or a symbol-to-proc such as `&:write_tree`) do
+not warn. Both versions read the block's parameter list rather than its arity, so
+the v5.x warning and the v6.0.0 error agree on every block form.
+
+The warning detects only the block's parameter list. Adding an unused parameter
+(`|_|`) silences it but does not fix a block that still calls methods on the outer
+repository; that block does not warn and acts on the wrong repository in v6.0.0,
+so review those blocks by hand.
+
+| Deprecated call (works in v5.x, raises in v6.0.0) | Replacement |
+|---------------------------------------------------|-------------|
+| `g.with_index(path) { g.read_tree('HEAD') }` | `g.with_index(path) { \|r\| r.read_tree('HEAD') }` |
+| `g.with_temp_index { g.read_tree('HEAD') }` | `g.with_temp_index { \|r\| r.read_tree('HEAD') }` |
+| `g.with_working(dir) { g.add('.') }` | `g.with_working(dir) { \|r\| r.add('.') }` |
+| `g.with_temp_working { g.add('.') }` | `g.with_temp_working { \|r\| r.add('.') }` |
+
+`chdir` is not part of this deprecation. It yields the directory path in both
+versions.
 
 ---

--- a/lib/git/repository/context_helpers.rb
+++ b/lib/git/repository/context_helpers.rb
@@ -18,6 +18,10 @@ module Git
     # @api private
     #
     module ContextHelpers
+      # Parameter types from `Proc#parameters` that receive a positional argument
+      CONTEXT_HELPERS_POSITIONAL_PARAMETERS = %i[req opt rest].freeze
+      private_constant :CONTEXT_HELPERS_POSITIONAL_PARAMETERS
+
       # Changes the current working directory to the repository working directory
       # for the duration of the block
       #
@@ -51,9 +55,13 @@ module Git
       # yields `self`, then unconditionally restores the original execution
       # context — even if the block raises an exception.
       #
+      # Deprecated form: a block that declares no positional parameter emits a
+      # deprecation warning, because v6.0.0 yields a separate repository
+      # instead of `self`.
+      #
       # @example Read a tree into a custom index
-      #   repo.with_index('/tmp/custom.index') do
-      #     repo.read_tree('HEAD')
+      #   repo.with_index('/tmp/custom.index') do |r|
+      #     r.read_tree('HEAD')
       #   end
       #
       # @param new_index [String, Pathname] path to the replacement index file
@@ -66,7 +74,8 @@ module Git
       #
       # @yieldreturn [Object] returned as the method's return value
       #
-      def with_index(new_index) # :yields: self
+      def with_index(new_index, &block) # :yields: self
+        context_helpers_warn_if_block_declares_no_parameter(:with_index, block)
         old_context = @execution_context
         set_index(new_index, must_exist: false)
         yield self
@@ -84,10 +93,14 @@ module Git
       # are removed unconditionally after the block exits, even if the block
       # raises an exception.
       #
+      # Deprecated form: a block that declares no positional parameter emits a
+      # deprecation warning, because v6.0.0 yields a separate repository
+      # instead of `self`.
+      #
       # @example Stage changes using a temporary index
-      #   repo.with_temp_index do
-      #     repo.read_tree('HEAD')
-      #     repo.write_tree
+      #   repo.with_temp_index do |r|
+      #     r.read_tree('HEAD')
+      #     r.write_tree
       #   end
       #
       # @return [Object] the value returned by the block
@@ -98,13 +111,17 @@ module Git
       #
       # @yieldreturn [Object] returned as the method's return value
       #
-      def with_temp_index(&) # :yields: self
+      def with_temp_index(&block) # :yields: self
+        context_helpers_warn_if_block_declares_no_parameter(:with_temp_index, block)
         # Use a unique temp directory so the index file path is collision-free
         # and does not exist until git writes it. An existing empty file would
         # be treated as a corrupt index by git.
         temp_dir = Dir.mktmpdir('git-temp-index-')
         begin
-          with_index(File.join(temp_dir, 'index'), &)
+          # The inner block declares a parameter so with_index does not warn a
+          # second time under its own name; forwarding &block would.
+          # rubocop:disable-next Style/ExplicitBlockArgument
+          with_index(File.join(temp_dir, 'index')) { |repo| yield repo }
         ensure
           FileUtils.remove_entry(temp_dir, true)
         end
@@ -118,10 +135,14 @@ module Git
       # `self`, then unconditionally restores the original execution context —
       # even if the block raises an exception.
       #
+      # Deprecated form: a block that declares no positional parameter emits a
+      # deprecation warning, because v6.0.0 yields a separate repository
+      # instead of `self`.
+      #
       # @example Commit changes from a different worktree path
-      #   repo.with_working('/path/to/worktree') do
-      #     repo.add('.')
-      #     repo.commit('chore: automated update')
+      #   repo.with_working('/path/to/worktree') do |r|
+      #     r.add('.')
+      #     r.commit('chore: automated update')
       #   end
       #
       # @param work_dir [String, Pathname] path to the replacement working
@@ -138,7 +159,8 @@ module Git
       #
       # @yieldreturn [Object] returned as the method's return value
       #
-      def with_working(work_dir) # :yields: self
+      def with_working(work_dir, &block) # :yields: self
+        context_helpers_warn_if_block_declares_no_parameter(:with_working, block)
         old_context = @execution_context
         set_working(work_dir)
         Dir.chdir(dir.to_s) { yield self }
@@ -153,9 +175,14 @@ module Git
       # The temporary directory is removed unconditionally after the block
       # exits, even if the block raises an exception.
       #
+      # Deprecated form: a block that declares no positional parameter emits a
+      # deprecation warning, because v6.0.0 yields a separate repository
+      # instead of `self`.
+      #
       # @example Write files in an isolated temporary working directory
-      #   repo.with_temp_working do
+      #   repo.with_temp_working do |r|
       #     File.write('scratch.txt', 'temporary content')
+      #     r.add('scratch.txt')
       #   end
       #
       # @return [Object] the value returned by the block
@@ -168,7 +195,11 @@ module Git
       # @yieldreturn [Object] returned as the method's return value
       #
       def with_temp_working(&block) # :yields: self
-        Dir.mktmpdir('temp-workdir') { |temp_dir| with_working(temp_dir, &block) }
+        context_helpers_warn_if_block_declares_no_parameter(:with_temp_working, block)
+        # The inner block declares a parameter so with_working does not warn a
+        # second time under its own name; forwarding &block would.
+        # rubocop:disable-next Style/ExplicitBlockArgument
+        Dir.mktmpdir('temp-workdir') { |temp_dir| with_working(temp_dir) { |repo| yield repo } }
       end
 
       # Sets the git index to `index_file` and rebuilds the execution context
@@ -230,6 +261,42 @@ module Git
       end
 
       private
+
+      # Emits a deprecation warning when `block` declares no positional parameter
+      #
+      # In v6.0.0 the `with_*` helpers yield a separate repository instead of
+      # rebinding the receiver, so a block that calls methods on the receiver
+      # (the v5.x form) acts on the wrong repository there. v6.0.0 raises
+      # `ArgumentError` for that form using this same rule: the block must
+      # declare a required, optional, or splat positional parameter. The rule
+      # reads `Proc#parameters` rather than arity because an optional parameter
+      # gives a proc an arity of zero although it receives the repository,
+      # while keyword and block parameters cannot receive it.
+      #
+      # A missing block is not checked here; the helper's `yield` raises
+      # `LocalJumpError` as before.
+      #
+      # The warning reports the helper's caller, not this helper's caller, so
+      # the location points at the block that needs changing.
+      #
+      # @param helper [Symbol] the public helper name used in the warning
+      #
+      # @param block [Proc, nil] the block passed to the helper
+      #
+      # @return [void]
+      #
+      def context_helpers_warn_if_block_declares_no_parameter(helper, block)
+        return if block.nil?
+        return if block.parameters.any? { |type, _name| CONTEXT_HELPERS_POSITIONAL_PARAMETERS.include?(type) }
+
+        Git::Deprecation.warn(
+          "Calling Git::Repository##{helper} with a block that declares no positional " \
+          'parameter is deprecated and will be removed in v6.0.0, where the helper ' \
+          'yields a separate repository instead of self. Declare a block parameter and ' \
+          "call methods on it instead: #{helper} { |repo| repo.some_method }",
+          caller_locations(2)
+        )
+      end
 
       # Resolves deprecated `check` argument semantics with `must_exist:`
       #

--- a/spec/unit/git/repository/context_helpers_spec.rb
+++ b/spec/unit/git/repository/context_helpers_spec.rb
@@ -8,6 +8,72 @@ require 'git/repository/context_helpers'
 # tests. No facade integration spec is needed for this module: the helpers are
 # pure path/context manipulations with no git-command delegation.
 
+# Shared coverage for the deprecation of blocks that declare no positional
+# parameter. Each including describe defines `call_helper` as a lambda that
+# forwards its block to the helper under test. The block forms mirror the
+# ArgumentError cases in the v6.0.0 spec so the two branches pin the same rule.
+RSpec.shared_examples 'a context helper that deprecates blocks with no parameter' do |helper|
+  context 'deprecation handling' do
+    let(:expected_warning) do
+      a_string_including("Git::Repository##{helper} ", 'v6.0.0', '|repo|')
+    end
+
+    context 'when the block declares no parameter' do
+      it 'emits a deprecation warning naming the helper, v6.0.0, and the block-parameter form' do
+        expect(Git::Deprecation).to receive(:warn).with(expected_warning, anything)
+        call_helper.call { nil }
+      end
+
+      it 'still returns the value returned by the block' do
+        allow(Git::Deprecation).to receive(:warn)
+        expect(call_helper.call { 'value' }).to eq('value')
+      end
+    end
+
+    context 'when the block declares only a keyword parameter' do
+      it 'emits a deprecation warning' do
+        expect(Git::Deprecation).to receive(:warn).with(expected_warning, anything)
+        call_helper.call { |key: nil| key }
+      end
+    end
+
+    context 'when the block declares a parameter' do
+      it 'does not emit a deprecation warning' do
+        expect(Git::Deprecation).not_to receive(:warn)
+        call_helper.call { |_repo| nil }
+      end
+    end
+
+    context 'when the block declares an optional parameter' do
+      it 'does not emit a deprecation warning' do
+        expect(Git::Deprecation).not_to receive(:warn)
+        call_helper.call { |_repo = nil| nil }
+      end
+    end
+
+    context 'when the block declares a splat parameter' do
+      it 'does not emit a deprecation warning' do
+        expect(Git::Deprecation).not_to receive(:warn)
+        call_helper.call { |*_args| nil }
+      end
+    end
+
+    context 'when the block is a symbol-to-proc' do
+      it 'does not emit a deprecation warning' do
+        expect(Git::Deprecation).not_to receive(:warn)
+        call_helper.call(&:itself)
+      end
+    end
+
+    context 'when no block is given' do
+      it 'raises LocalJumpError without emitting a deprecation warning' do
+        expect(Git::Deprecation).not_to receive(:warn)
+        expect { call_helper.call }.to raise_error(LocalJumpError, /no block given/)
+      end
+    end
+  end
+end
+
 RSpec.describe Git::Repository::ContextHelpers do
   let(:git_dir) { '/repo/.git' }
   let(:work_dir) { '/repo' }
@@ -184,6 +250,8 @@ RSpec.describe Git::Repository::ContextHelpers do
   # ---------------------------------------------------------------------------
 
   describe '#with_index' do
+    let(:call_helper) { ->(&block) { described_instance.with_index('/tmp/idx', &block) } }
+
     let(:temp_context) { instance_double(Git::ExecutionContext::Repository) }
 
     before do
@@ -197,29 +265,31 @@ RSpec.describe Git::Repository::ContextHelpers do
     end
 
     it 'returns the value returned by the block' do
-      result = described_instance.with_index('/tmp/idx') { 'hello' }
+      result = described_instance.with_index('/tmp/idx') { |_repo| 'hello' }
       expect(result).to eq('hello')
     end
 
     it 'sets the index to the new value during the block' do
       entered_index = nil
-      described_instance.with_index('/tmp/idx') { entered_index = described_instance.index }
+      described_instance.with_index('/tmp/idx') { |_repo| entered_index = described_instance.index }
       expect(entered_index).to eq(Pathname.new('/tmp/idx'))
     end
 
     it 'restores the original execution context after the block' do
       original_ctx = described_instance.execution_context
-      described_instance.with_index('/tmp/idx') { nil }
+      described_instance.with_index('/tmp/idx') { |_repo| nil }
       expect(described_instance.execution_context).to be(original_ctx)
     end
 
     it 'restores the original execution context even when the block raises' do
       original_ctx = described_instance.execution_context
       expect do
-        described_instance.with_index('/tmp/idx') { raise 'boom' }
+        described_instance.with_index('/tmp/idx') { |_repo| raise 'boom' }
       end.to raise_error('boom')
       expect(described_instance.execution_context).to be(original_ctx)
     end
+
+    it_behaves_like 'a context helper that deprecates blocks with no parameter', :with_index
   end
 
   # ---------------------------------------------------------------------------
@@ -227,25 +297,27 @@ RSpec.describe Git::Repository::ContextHelpers do
   # ---------------------------------------------------------------------------
 
   describe '#with_temp_index' do
+    let(:call_helper) { ->(&block) { described_instance.with_temp_index(&block) } }
+
     it 'yields self' do
       expect { |b| described_instance.with_temp_index(&b) }.to yield_with_args(described_instance)
     end
 
     it 'sets the index to a different temporary path during the block' do
       index_during_block = nil
-      described_instance.with_temp_index { index_during_block = described_instance.index }
+      described_instance.with_temp_index { |_repo| index_during_block = described_instance.index }
       expect(index_during_block).not_to eq(Pathname.new(index_file))
     end
 
     it 'restores the original execution context after the block' do
       original_ctx = described_instance.execution_context
-      described_instance.with_temp_index { nil }
+      described_instance.with_temp_index { |_repo| nil }
       expect(described_instance.execution_context).to be(original_ctx)
     end
 
     it 'cleans up the temporary directory after the block succeeds' do
       temp_dir = nil
-      described_instance.with_temp_index do
+      described_instance.with_temp_index do |_repo|
         temp_dir = File.dirname(described_instance.index.to_s)
         FileUtils.touch(described_instance.index.to_s)
       end
@@ -256,7 +328,7 @@ RSpec.describe Git::Repository::ContextHelpers do
     it 'cleans up the temporary directory even when the block raises' do
       temp_dir = nil
       expect do
-        described_instance.with_temp_index do
+        described_instance.with_temp_index do |_repo|
           temp_dir = File.dirname(described_instance.index.to_s)
           FileUtils.touch(described_instance.index.to_s)
           raise 'block error'
@@ -265,6 +337,8 @@ RSpec.describe Git::Repository::ContextHelpers do
       expect(temp_dir).not_to be_nil
       expect(Dir.exist?(temp_dir)).to be(false)
     end
+
+    it_behaves_like 'a context helper that deprecates blocks with no parameter', :with_temp_index
   end
 
   # ---------------------------------------------------------------------------
@@ -359,6 +433,8 @@ RSpec.describe Git::Repository::ContextHelpers do
   # ---------------------------------------------------------------------------
 
   describe '#with_working' do
+    let(:call_helper) { ->(&block) { described_instance.with_working(real_work_dir, &block) } }
+
     let(:real_work_dir) { Dir.mktmpdir('context-helpers-') }
     let(:expanded_work_dir) { File.expand_path(real_work_dir) }
 
@@ -378,25 +454,25 @@ RSpec.describe Git::Repository::ContextHelpers do
     end
 
     it 'returns the value returned by the block' do
-      result = described_instance.with_working(real_work_dir) { 'result' }
+      result = described_instance.with_working(real_work_dir) { |_repo| 'result' }
       expect(result).to eq('result')
     end
 
     it 'changes the process directory to the expanded working directory during the block' do
       expect(Dir).to receive(:chdir).with(expanded_work_dir).and_yield
-      described_instance.with_working(real_work_dir) { nil }
+      described_instance.with_working(real_work_dir) { |_repo| nil }
     end
 
     it 'restores the original execution context after the block' do
       original_ctx = described_instance.execution_context
-      described_instance.with_working(real_work_dir) { nil }
+      described_instance.with_working(real_work_dir) { |_repo| nil }
       expect(described_instance.execution_context).to be(original_ctx)
     end
 
     it 'restores the original execution context even when the block raises' do
       original_ctx = described_instance.execution_context
       expect do
-        described_instance.with_working(real_work_dir) { raise 'boom' }
+        described_instance.with_working(real_work_dir) { |_repo| raise 'boom' }
       end.to raise_error('boom')
       expect(described_instance.execution_context).to be(original_ctx)
     end
@@ -406,6 +482,8 @@ RSpec.describe Git::Repository::ContextHelpers do
         described_instance.with_working('/nonexistent/path/for/test')
       end.to raise_error(ArgumentError, /path does not exist/)
     end
+
+    it_behaves_like 'a context helper that deprecates blocks with no parameter', :with_working
   end
 
   # ---------------------------------------------------------------------------
@@ -413,6 +491,8 @@ RSpec.describe Git::Repository::ContextHelpers do
   # ---------------------------------------------------------------------------
 
   describe '#with_temp_working' do
+    let(:call_helper) { ->(&block) { described_instance.with_temp_working(&block) } }
+
     before do
       allow(Dir).to receive(:chdir).and_yield
     end
@@ -423,13 +503,13 @@ RSpec.describe Git::Repository::ContextHelpers do
 
     it 'restores the original execution context after the block' do
       original_ctx = described_instance.execution_context
-      described_instance.with_temp_working { nil }
+      described_instance.with_temp_working { |_repo| nil }
       expect(described_instance.execution_context).to be(original_ctx)
     end
 
     it 'cleans up the temporary directory after the block succeeds' do
       temp_dir = nil
-      described_instance.with_temp_working { temp_dir = described_instance.dir.to_s }
+      described_instance.with_temp_working { |_repo| temp_dir = described_instance.dir.to_s }
       expect(temp_dir).not_to be_nil
       expect(Dir.exist?(temp_dir)).to be(false)
     end
@@ -437,7 +517,7 @@ RSpec.describe Git::Repository::ContextHelpers do
     it 'cleans up the temporary directory even when the block raises' do
       temp_dir = nil
       expect do
-        described_instance.with_temp_working do
+        described_instance.with_temp_working do |_repo|
           temp_dir = described_instance.dir.to_s
           raise 'block error'
         end
@@ -445,6 +525,8 @@ RSpec.describe Git::Repository::ContextHelpers do
       expect(temp_dir).not_to be_nil
       expect(Dir.exist?(temp_dir)).to be(false)
     end
+
+    it_behaves_like 'a context helper that deprecates blocks with no parameter', :with_temp_working
   end
 
   # ---------------------------------------------------------------------------
@@ -457,8 +539,8 @@ RSpec.describe Git::Repository::ContextHelpers do
       allow(Dir).to receive(:chdir).and_yield
 
       Dir.mktmpdir do |outer_work|
-        described_instance.with_working(outer_work) do
-          described_instance.with_index('/tmp/inner_idx') { nil }
+        described_instance.with_working(outer_work) do |_repo|
+          described_instance.with_index('/tmp/inner_idx') { |_repo| nil }
         end
       end
 


### PR DESCRIPTION
## Summary

Implements issue 1835 on the `5.x` branch.

`Git::Repository#with_index`, `#with_temp_index`, `#with_working`, and
`#with_temp_working` emit a `Git::Deprecation` warning when the block declares no
positional parameter (`do ... end`, `{ }`, `{ || }`, or only keyword or block
parameters). Blocks that declare a required, optional, or splat positional
parameter and symbol-to-proc blocks do not warn. The warning names the helper that
was called and reports the caller's location.

Behavior is otherwise unchanged in v5.x: the helpers still yield `self`, and a call
with no block still raises `LocalJumpError`.

In v6.0.0 these helpers yield a separate repository bound to the other index or
working tree and raise `ArgumentError` for that block form using the same
positional-parameter rule, read from `Proc#parameters` rather than arity (issue
1830, PR 1834). Per ADR-0007, that change merges to `main` only after a
v5.x release ships this warning, so v5.6.0 must be cut from this PR before the
issue 1830 branch merges.

## Changes

- Positional-parameter check and warning in `lib/git/repository/context_helpers.rb`, with the YARD
  examples updated to the block-parameter form
- Unit specs for empty, keyword-only, required, optional, splat, symbol-to-proc, and
  missing blocks on all four helpers
- UPGRADING.md entry under "Deprecated methods"

## Deliberate deviations

- No `@deprecated` YARD tag. Only one calling form is deprecated, not the methods,
  and the tag would mark the whole method deprecated in the generated docs. Each
  method's doc describes the deprecated form in prose instead.
- The temp helpers pass an inner block with a parameter to `with_index` and
  `with_working` instead of forwarding `&block`, so the inner helper does not warn a
  second time under its own name. RuboCop's `Style/ExplicitBlockArgument` is
  disabled on those two lines with a comment.
- The deprecation specs live in a file-local shared example group included by all
  four `describe` blocks. The alternative is four copies of the same six examples.

Existing unit specs that called the helpers with a zero-arity block were updated to
declare a parameter, since the spec helper raises on any deprecation warning.

## Checklist

- [x] `bundle exec rake default` passes
- [x] UPGRADING.md entry added
- [x] v5.x release containing the warning is published (unblocks issue 1830)

Refs: #1835
