### PR TITLE
feat(repository)!: remove the v4.x option shims from clean, diff_path_status, commit, and set_*

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -17,6 +17,7 @@ to update your code when upgrading from the preceding major version.
   - [`Git.clone` legacy options removed](#gitclone-legacy-options-removed)
   - [Filesystem errors raised as `Git::Error`](#filesystem-errors-raised-as-giterror)
   - [Context helpers yield a separate repository](#context-helpers-yield-a-separate-repository)
+  - [`Git::Repository` option shims removed](#gitrepository-option-shims-removed)
 - [Upgrading to v5.x](#upgrading-to-v5x)
   - [Overview](#overview)
   - [Breaking changes](#breaking-changes)
@@ -332,6 +333,28 @@ exception.
 `with_working` and `with_temp_working` still change the process working directory
 with `Dir.chdir` for the duration of the block, so they remain unsafe to call from
 more than one thread at a time.
+
+### `Git::Repository` option shims removed
+
+v6.0.0 removes the four v4.x option and argument shapes that `Git::Repository`
+methods accepted with a deprecation warning throughout v5.x:
+
+- `clean` no longer accepts `:ff` or `:force_force`. Pass `force: 2` to run
+  `git clean -ff`.
+- `diff_path_status` no longer accepts `:path`. Use `:path_limiter`, which takes
+  the same values.
+- `commit` no longer accepts `:add_all`. Use `:all`.
+- `set_working` and `set_index` no longer take a positional `check` argument.
+  Pass `must_exist:` instead; it defaults to `true`. An explicit `must_exist:
+  nil` no longer means "not given": v5.x treated it as `true`, and v6.0.0 treats
+  it as `false` like any other falsy value. Omit the keyword to get the default.
+
+The removed option keys now fall through to the normal option validation, so
+passing one raises `ArgumentError` (see [Unsupported options raise
+`ArgumentError`](#unsupported-options-raise-argumenterror)). A positional `check`
+argument raises `ArgumentError` for the wrong number of arguments. The
+[`Git::Repository` option renames](#gitrepository-option-renames) entry under
+"Upgrading to v5.x" maps each removed form to its replacement.
 
 ---
 

--- a/lib/git/repository/committing.rb
+++ b/lib/git/repository/committing.rb
@@ -73,7 +73,6 @@ module Git
       # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def commit(message, opts = {})
-        opts = normalize_commit_options(opts)
         SharedPrivate.assert_valid_opts!(COMMIT_ALLOWED_OPTS, **opts)
 
         call_opts = { no_edit: true }
@@ -216,30 +215,6 @@ module Git
       #
       def write_and_commit_tree(opts = {})
         commit_tree(write_tree, opts)
-      end
-
-      private
-
-      # Normalizes deprecated commit options into their supported form
-      #
-      # @param opts [Hash] caller-provided commit options
-      #
-      # @option opts [Boolean, nil] :add_all (nil) deprecated alias for `:all`
-      #
-      # @return [Hash] options with deprecated aliases translated
-      #
-      # @api private
-      #
-      def normalize_commit_options(opts)
-        opts = opts.dup
-        return opts unless opts.key?(:add_all)
-
-        Git::Deprecation.warn(
-          'The :add_all option for #commit is deprecated and will be removed in v6.0.0. ' \
-          'Use :all instead.'
-        )
-        opts[:all] = opts.delete(:add_all)
-        opts
       end
     end
   end

--- a/lib/git/repository/context_helpers.rb
+++ b/lib/git/repository/context_helpers.rb
@@ -253,10 +253,7 @@ module Git
       #
       # @param index_file [String, Pathname] path to the new index file
       #
-      # @param check [Boolean, nil] deprecated positional argument — use
-      #   `must_exist:` instead; emits a deprecation warning when non-`nil`
-      #
-      # @param must_exist [Boolean, nil] when `true` (the default), raises
+      # @param must_exist [Boolean] when `true` (the default), raises
       #   `ArgumentError` if `index_file` does not exist on disk
       #
       # @return [void]
@@ -264,8 +261,7 @@ module Git
       # @raise [ArgumentError] if `must_exist: true` (the default) and
       #   `index_file` does not exist
       #
-      def set_index(index_file, check = nil, must_exist: nil)
-        must_exist = context_helpers_deprecate_check_argument(check, must_exist)
+      def set_index(index_file, must_exist: true)
         new_path = context_helpers_validate_path(index_file, must_exist)
         @execution_context = @execution_context.dup_with(git_index_file: new_path.to_s)
         nil
@@ -282,10 +278,7 @@ module Git
       #
       # @param work_dir [String, Pathname] path to the new working directory
       #
-      # @param check [Boolean, nil] deprecated positional argument — use
-      #   `must_exist:` instead; emits a deprecation warning when non-`nil`
-      #
-      # @param must_exist [Boolean, nil] when `true` (the default), raises
+      # @param must_exist [Boolean] when `true` (the default), raises
       #   `ArgumentError` if `work_dir` does not exist on disk
       #
       # @return [void]
@@ -293,8 +286,7 @@ module Git
       # @raise [ArgumentError] if `must_exist: true` (the default) and
       #   `work_dir` does not exist
       #
-      def set_working(work_dir, check = nil, must_exist: nil)
-        must_exist = context_helpers_deprecate_check_argument(check, must_exist)
+      def set_working(work_dir, must_exist: true)
         new_path = context_helpers_validate_path(work_dir, must_exist)
         @execution_context = @execution_context.dup_with(git_work_dir: new_path.to_s)
         nil
@@ -368,33 +360,6 @@ module Git
       #
       def context_helpers_mktmpdir(prefix)
         Git::SystemCallGuard.call('Failed to create a temporary directory') { Dir.mktmpdir(prefix) }
-      end
-
-      # Resolves deprecated `check` argument semantics with `must_exist:`
-      #
-      # @param check [Boolean, nil] deprecated positional existence-check value
-      #
-      # @param must_exist [Boolean, nil] keyword existence-check override
-      #
-      # @return [Boolean] whether path existence must be enforced
-      #
-      def context_helpers_deprecate_check_argument(check, must_exist)
-        if !check.nil? && defined?(Git::Deprecation)
-          Git::Deprecation.warn(
-            'The "check" argument is deprecated and will be removed in v6.0.0. ' \
-            'Use "must_exist:" instead.'
-          )
-        end
-        # Preserve the original Git::Base semantics: when both the deprecated
-        # positional `check` and the new `must_exist:` keyword are given, OR
-        # them so the more restrictive value wins.
-        #
-        # NilClass#| is defined in Ruby: nil | false → false, nil | true → true.
-        # This means single-argument callers (check only, or must_exist: only)
-        # are handled correctly without any nil-special-casing.
-        return true if must_exist.nil? && check.nil?
-
-        must_exist | check
       end
 
       # Expands `path` and validates existence when required

--- a/lib/git/repository/diffing.rb
+++ b/lib/git/repository/diffing.rb
@@ -299,7 +299,7 @@ module Git
       #
       # @api private
       #
-      DIFF_PATH_STATUS_ALLOWED_OPTS = %i[path_limiter path].freeze
+      DIFF_PATH_STATUS_ALLOWED_OPTS = %i[path_limiter].freeze
       private_constant :DIFF_PATH_STATUS_ALLOWED_OPTS
 
       # Returns the file path status between two trees
@@ -349,9 +349,6 @@ module Git
       # @option opts [String, Pathname, Array<String, Pathname>, nil] :path_limiter (nil)
       #   limit the status report to the given path(s)
       #
-      # @option opts [String, Pathname, Array<String, Pathname>, nil] :path (nil)
-      #   **deprecated** — use `:path_limiter` instead
-      #
       # @return [Git::DiffPathStatus] the name-status report for the comparison
       #
       # @raise [ArgumentError] if unsupported options are provided
@@ -366,8 +363,7 @@ module Git
         SharedPrivate.assert_valid_opts!(DIFF_PATH_STATUS_ALLOWED_OPTS, **opts)
         raise ArgumentError, 'Invalid arguments: `from` is nil but `to` is not' if from.nil? && !to.nil?
 
-        path_limiter = Private.resolve_path_limiter(opts)
-        pathspecs = Private.normalize_pathspecs(path_limiter, 'path limiter')
+        pathspecs = Private.normalize_pathspecs(opts[:path_limiter], 'path limiter')
 
         result = Private.call_diff_command(@execution_context, from, to, pathspecs)
         Git::DiffPathStatus.new(Private.extract_name_status_from_raw(result.stdout))
@@ -494,35 +490,6 @@ module Git
       #
       module Private
         module_function
-
-        # Resolves the effective path limiter from the options hash
-        #
-        # When `:path_limiter` is present it is used directly and no warning is
-        # emitted. When only `:path` is present a deprecation warning is emitted
-        # and its value is used. Returns `nil` when neither key is present.
-        #
-        # @param opts [Hash] the options hash from {#diff_path_status}
-        #
-        # @option opts [String, Pathname, Array<String, Pathname>, nil] :path_limiter (nil)
-        #   primary path limiter value used as-is when present
-        #
-        # @option opts [String, Pathname, Array<String, Pathname>, nil] :path (nil)
-        #   **deprecated** — fallback path limiter when `:path_limiter` is not provided
-        #
-        # @return [String, Pathname, Array<String, Pathname>, nil]
-        #   the effective path limiter
-        #
-        def resolve_path_limiter(opts)
-          if opts.key?(:path_limiter)
-            opts[:path_limiter]
-          elsif opts.key?(:path)
-            Git::Deprecation.warn(
-              'Git::Repository#diff_path_status :path option is deprecated and will be removed in v6.0.0. ' \
-              'Use :path_limiter instead.'
-            )
-            opts[:path]
-          end
-        end
 
         # Extracts only the patch text from combined diff command output
         #

--- a/lib/git/repository/staging.rb
+++ b/lib/git/repository/staging.rb
@@ -330,10 +330,6 @@ module Git
       end
 
       # Option keys accepted by {#clean}
-      #
-      # The deprecated `:ff` and `:force_force` keys are handled by
-      # {Git::Repository::Staging::Private.migrate_clean_legacy_options} before this
-      # whitelist is enforced, so they are intentionally absent here.
       CLEAN_ALLOWED_OPTS = %i[d force f dry_run n quiet q exclude e x X pathspec].freeze
       private_constant :CLEAN_ALLOWED_OPTS
 
@@ -382,13 +378,11 @@ module Git
       #
       # @return [String] git's stdout from the clean
       #
-      # @raise [ArgumentError] when unsupported options are provided, or when a
-      #   deprecated `:ff`/`:force_force` value is not `true`, `false`, or `nil`
+      # @raise [ArgumentError] when unsupported options are provided
       #
       # @raise [Git::FailedError] when git exits with a non-zero exit status
       #
       def clean(opts = {})
-        opts = Private.migrate_clean_legacy_options(opts)
         SharedPrivate.assert_valid_opts!(CLEAN_ALLOWED_OPTS, **opts)
         Git::Commands::Clean.new(@execution_context).call(**opts).stdout
       end
@@ -421,151 +415,6 @@ module Git
       #
       module Private
         module_function
-
-        # Translate deprecated `git clean` option keys into their modern form
-        #
-        # Maps the legacy `:ff` and `:force_force` boolean options onto the
-        # `:force` option, emitting a deprecation warning for each.
-        #
-        # @param opts [Hash] the caller-provided clean options
-        #
-        # @option opts [Boolean, nil] :ff (nil) deprecated alias for requesting a
-        #   double-force clean
-        #
-        # @option opts [Boolean, nil] :force_force (nil) deprecated alias for
-        #   requesting a double-force clean
-        #
-        # @option opts [Boolean, Integer, nil] :force (nil) existing force value
-        #   merged with deprecated options when present
-        #
-        # @return [Hash] a new options hash with deprecated keys translated
-        #
-        # @raise [ArgumentError] when a deprecated value is not `true`, `false`, or `nil`
-        #
-        def migrate_clean_legacy_options(opts)
-          opts = deprecate_clean_option(
-            :ff,
-            ':ff option is deprecated and will be removed in v6.0.0. Use force: 2 instead.',
-            opts
-          )
-
-          deprecate_clean_option(
-            :force_force,
-            ':force_force option is deprecated and will be removed in v6.0.0. Use force: 2 instead.',
-            opts
-          )
-        end
-
-        # Translate a single deprecated clean option key onto `:force`
-        #
-        # @param key [Symbol] the deprecated option key (`:ff` or `:force_force`)
-        #
-        # @param message [String] the deprecation message to emit
-        #
-        # @param opts [Hash] the clean options
-        #
-        # @option opts [Boolean, nil] :ff (nil) deprecated alias for requesting a
-        #   double-force clean
-        #
-        # @option opts [Boolean, nil] :force_force (nil) deprecated alias for
-        #   requesting a double-force clean
-        #
-        # @option opts [Boolean, Integer, nil] :force (nil) existing force value
-        #   updated when the deprecated key is true
-        #
-        # @return [Hash] a new options hash with the deprecated key removed
-        #
-        # @raise [ArgumentError] when the deprecated value is not `true`, `false`,
-        #   or `nil`
-        #
-        def deprecate_clean_option(key, message, opts)
-          return opts unless opts.key?(key)
-
-          opts = opts.dup
-          deprecated_value = opts.delete(key)
-          validate_deprecated_clean_option_value!(key, deprecated_value)
-
-          Git::Deprecation.warn(message)
-          return opts unless deprecated_value
-
-          opts[:force] = merge_clean_force_option(opts[:force], force_specified: force_option_specified?(opts))
-          opts
-        end
-
-        # Whether the caller explicitly set a non-nil `:force` value
-        #
-        # @param opts [Hash] the clean options
-        #
-        # @option opts [Boolean, Integer, nil] :force (nil) the clean force value
-        #   to inspect
-        #
-        # @return [Boolean] true if `:force` was set to a non-nil value, false
-        #   otherwise
-        #
-        def force_option_specified?(opts)
-          opts.key?(:force) && !opts[:force].nil?
-        end
-
-        # Validate the value passed to a deprecated clean option
-        #
-        # @param key [Symbol] the deprecated option key
-        #
-        # @param value [Object] the value provided for the deprecated key
-        #
-        # @return [void]
-        #
-        # @raise [ArgumentError] when `value` is not `true`, `false`, or `nil`
-        #
-        def validate_deprecated_clean_option_value!(key, value)
-          return if value.nil? || value == true || value == false
-
-          raise ArgumentError, "#{key} option only accepts true, false, or nil"
-        end
-
-        # Merge a deprecated force request into the existing `:force` value
-        #
-        # @param existing_force [Boolean, Integer, nil] the caller's `:force` value
-        #
-        # @param force_specified [Boolean] whether the caller explicitly set `:force`
-        #
-        # @return [Integer] the resolved `:force` value
-        #
-        def merge_clean_force_option(existing_force, force_specified: false)
-          return 2 unless force_specified
-
-          normalized_force = normalize_clean_force_option(existing_force)
-
-          case normalized_force
-          when Integer then merge_integer_clean_force_option(normalized_force)
-          when false then 2
-          else normalized_force
-          end
-        end
-
-        # Merge an integer `:force` value with the deprecated force request
-        #
-        # @param normalized_force [Integer] the caller's normalized `:force` value
-        #
-        # @return [Integer] the resolved `:force` value
-        #
-        def merge_integer_clean_force_option(normalized_force)
-          return normalized_force if normalized_force < 1
-
-          [normalized_force, 2].max
-        end
-
-        # Normalize a `:force` value, coercing `true` to the integer `1`
-        #
-        # @param value [Boolean, Integer, nil] the `:force` value
-        #
-        # @return [Integer, Boolean, nil] the normalized value
-        #
-        def normalize_clean_force_option(value)
-          case value
-          when true then 1
-          else value
-          end
-        end
 
         # Unescape a git-quoted path
         #

--- a/spec/unit/git/repository/committing_spec.rb
+++ b/spec/unit/git/repository/committing_spec.rb
@@ -16,7 +16,7 @@ require 'git/repository/committing'
 #   spec/integration/git/repository/committing_spec.rb
 #
 # The unit specs below cover the facade's own behavior: option whitelisting,
-# argument pre-processing, deprecation handling, and delegation contracts.
+# argument pre-processing, and delegation contracts.
 
 RSpec.describe Git::Repository::Committing do
   let(:execution_context) { instance_double(Git::ExecutionContext::Repository) }
@@ -170,20 +170,20 @@ RSpec.describe Git::Repository::Committing do
       end
     end
 
-    context 'with deprecated :add_all option' do
+    context 'with the removed :add_all option' do
       subject(:result) { described_instance.commit('msg', add_all: true) }
 
-      it 'emits a deprecation warning' do
-        allow(commit_command).to receive(:call).and_return(commit_result)
-        expect(Git::Deprecation).to receive(:warn).with(a_string_including(':add_all'))
-        result
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: add_all/)
       end
 
-      it 'converts :add_all to :all and forwards to the command' do
-        allow(Git::Deprecation).to receive(:warn)
-        expect(commit_command).to receive(:call).with(no_edit: true, message: 'msg',
-                                                      all: true).and_return(commit_result)
-        result
+      it 'does not call Git::Commands::Commit' do
+        expect(commit_command).not_to receive(:call)
+        begin
+          result
+        rescue ArgumentError
+          # expected
+        end
       end
     end
 
@@ -209,15 +209,6 @@ RSpec.describe Git::Repository::Committing do
         opts = { all: true }
         allow(commit_command).to receive(:call).and_return(commit_result)
         expect { described_instance.commit('msg', opts) }.not_to raise_error
-      end
-
-      it 'does not mutate the caller-provided Hash when :add_all is present' do
-        opts = { add_all: true }
-        original = opts.dup
-        allow(Git::Deprecation).to receive(:warn)
-        allow(commit_command).to receive(:call).and_return(commit_result)
-        described_instance.commit('msg', opts)
-        expect(opts).to eq(original)
       end
     end
   end

--- a/spec/unit/git/repository/context_helpers_spec.rb
+++ b/spec/unit/git/repository/context_helpers_spec.rb
@@ -206,31 +206,10 @@ RSpec.describe Git::Repository::ContextHelpers do
       end
     end
 
-    context 'signature compatibility (legacy-contract)' do
-      it 'accepts a positional check argument with a deprecation warning' do
-        expect(Git::Deprecation).to receive(:warn).once
-        expect { described_instance.set_index('/nonexistent/index', false) }.not_to raise_error
-      end
-
-      it 'warns with the documented "check" argument deprecation message' do
-        expect(Git::Deprecation).to receive(:warn).with(
-          'The "check" argument is deprecated and will be removed in v6.0.0. ' \
-          'Use "must_exist:" instead.'
-        )
-        described_instance.set_index('/nonexistent/index', false)
-      end
-
-      it 'performs existence check when both check=true and must_exist: false are given (more restrictive wins)' do
-        expect(Git::Deprecation).to receive(:warn).once
-        expect { described_instance.set_index('/nonexistent/index', true, must_exist: false) }
-          .to raise_error(ArgumentError, /path does not exist/)
-      end
-
-      it 'raises when both check=false and must_exist: true are given (more restrictive wins)' do
-        # must_exist: true | check: false → true → raises
-        expect(Git::Deprecation).to receive(:warn).once
-        expect { described_instance.set_index('/nonexistent/index', false, must_exist: true) }
-          .to raise_error(ArgumentError, /path does not exist/)
+    context 'with the removed positional check argument' do
+      it 'raises ArgumentError' do
+        expect { described_instance.set_index('/nonexistent/index', false) }
+          .to raise_error(ArgumentError, /wrong number of arguments/)
       end
     end
   end
@@ -476,30 +455,10 @@ RSpec.describe Git::Repository::ContextHelpers do
       end
     end
 
-    context 'signature compatibility (legacy-contract)' do
-      it 'accepts a positional check argument with a deprecation warning' do
-        expect(Git::Deprecation).to receive(:warn).once
-        expect { described_instance.set_working('/nonexistent/dir', false) }.not_to raise_error
-      end
-
-      it 'warns with the documented "check" argument deprecation message' do
-        expect(Git::Deprecation).to receive(:warn).with(
-          'The "check" argument is deprecated and will be removed in v6.0.0. ' \
-          'Use "must_exist:" instead.'
-        )
-        described_instance.set_working('/nonexistent/dir', false)
-      end
-
-      it 'performs existence check when both check=true and must_exist: false are given (more restrictive wins)' do
-        expect(Git::Deprecation).to receive(:warn).once
-        expect { described_instance.set_working('/nonexistent/dir', true, must_exist: false) }
-          .to raise_error(ArgumentError, /path does not exist/)
-      end
-
-      it 'raises when both check=false and must_exist: true are given (more restrictive wins)' do
-        expect(Git::Deprecation).to receive(:warn).once
-        expect { described_instance.set_working('/nonexistent/dir', false, must_exist: true) }
-          .to raise_error(ArgumentError, /path does not exist/)
+    context 'with the removed positional check argument' do
+      it 'raises ArgumentError' do
+        expect { described_instance.set_working('/nonexistent/dir', false) }
+          .to raise_error(ArgumentError, /wrong number of arguments/)
       end
     end
   end

--- a/spec/unit/git/repository/diffing_spec.rb
+++ b/spec/unit/git/repository/diffing_spec.rb
@@ -619,50 +619,11 @@ RSpec.describe Git::Repository::Diffing do
       end
     end
 
-    context 'when the deprecated :path option is provided' do
+    context 'when the removed :path option is provided' do
       let(:opts) { { path: 'lib/' } }
 
-      before do
-        allow(diff_command).to receive(:call).with(
-          'HEAD',
-          raw: true, numstat: true, shortstat: true,
-          src_prefix: 'a/', dst_prefix: 'b/',
-          path: ['lib/']
-        ).and_return(diff_result)
-        allow(Git::Deprecation).to receive(:warn)
-      end
-
-      it 'emits a deprecation warning naming the facade method' do
-        expect(Git::Deprecation).to receive(:warn).with(
-          'Git::Repository#diff_path_status :path option is deprecated and will be removed in v6.0.0. ' \
-          'Use :path_limiter instead.'
-        )
-        subject
-      end
-
-      it 'uses the :path value as the path limiter' do
-        expect(diff_command).to receive(:call).with(
-          'HEAD',
-          raw: true, numstat: true, shortstat: true,
-          src_prefix: 'a/', dst_prefix: 'b/',
-          path: ['lib/']
-        ).and_return(diff_result)
-        subject
-      end
-    end
-
-    context 'when both :path_limiter and :path are provided' do
-      let(:opts) { { path_limiter: 'lib/', path: 'other/' } }
-
-      it 'uses :path_limiter and does not emit a deprecation warning' do
-        expect(Git::Deprecation).not_to receive(:warn)
-        expect(diff_command).to receive(:call).with(
-          'HEAD',
-          raw: true, numstat: true, shortstat: true,
-          src_prefix: 'a/', dst_prefix: 'b/',
-          path: ['lib/']
-        ).and_return(diff_result)
-        subject
+      it 'raises an ArgumentError naming the unknown key' do
+        expect { subject }.to raise_error(ArgumentError, /Unknown options: path/)
       end
     end
 

--- a/spec/unit/git/repository/staging_spec.rb
+++ b/spec/unit/git/repository/staging_spec.rb
@@ -387,59 +387,11 @@ RSpec.describe Git::Repository::Staging do
       end
     end
 
-    context 'with the deprecated :ff option set to true' do
+    context 'with the removed :ff option' do
       subject(:result) { described_instance.clean(ff: true) }
 
-      it 'warns about the deprecation' do
-        allow(clean_command).to receive(:call).and_return(clean_result)
-        expect(Git::Deprecation).to receive(:warn).with(/:ff option is deprecated/)
-        result
-      end
-
-      it 'translates :ff to force: 2' do
-        allow(Git::Deprecation).to receive(:warn)
-        expect(clean_command).to receive(:call).with(force: 2).and_return(clean_result)
-        result
-      end
-    end
-
-    context 'with the deprecated :ff option set to false' do
-      subject(:result) { described_instance.clean(ff: false) }
-
-      it 'warns about the deprecation' do
-        allow(clean_command).to receive(:call).and_return(clean_result)
-        expect(Git::Deprecation).to receive(:warn).with(/:ff option is deprecated/)
-        result
-      end
-
-      it 'does not pass force to Git::Commands::Clean#call' do
-        allow(Git::Deprecation).to receive(:warn)
-        expect(clean_command).to receive(:call).with(no_args).and_return(clean_result)
-        result
-      end
-    end
-
-    context 'with the deprecated :force_force option set to true' do
-      subject(:result) { described_instance.clean(force_force: true) }
-
-      it 'warns about the deprecation' do
-        allow(clean_command).to receive(:call).and_return(clean_result)
-        expect(Git::Deprecation).to receive(:warn).with(/:force_force option is deprecated/)
-        result
-      end
-
-      it 'translates :force_force to force: 2' do
-        allow(Git::Deprecation).to receive(:warn)
-        expect(clean_command).to receive(:call).with(force: 2).and_return(clean_result)
-        result
-      end
-    end
-
-    context 'with the deprecated :ff option set to a non-boolean value' do
-      subject(:result) { described_instance.clean(ff: 0) }
-
       it 'raises ArgumentError' do
-        expect { result }.to raise_error(ArgumentError, /ff option only accepts true, false, or nil/)
+        expect { result }.to raise_error(ArgumentError, /Unknown options: ff/)
       end
 
       it 'does not call Git::Commands::Clean' do
@@ -452,71 +404,20 @@ RSpec.describe Git::Repository::Staging do
       end
     end
 
-    context 'with the deprecated :ff option combined with an explicit force: true' do
-      subject(:result) { described_instance.clean(ff: true, force: true) }
+    context 'with the removed :force_force option' do
+      subject(:result) { described_instance.clean(force_force: true) }
 
-      before { allow(Git::Deprecation).to receive(:warn) }
-
-      it 'normalizes force: true to 1 then raises it to force: 2' do
-        expect(clean_command).to receive(:call).with(force: 2).and_return(clean_result)
-        result
+      it 'raises ArgumentError' do
+        expect { result }.to raise_error(ArgumentError, /Unknown options: force_force/)
       end
-    end
 
-    context 'with the deprecated :ff option combined with an explicit force: false' do
-      subject(:result) { described_instance.clean(ff: true, force: false) }
-
-      before { allow(Git::Deprecation).to receive(:warn) }
-
-      it 'translates the explicit false force to force: 2' do
-        expect(clean_command).to receive(:call).with(force: 2).and_return(clean_result)
-        result
-      end
-    end
-
-    context 'with the deprecated :ff option combined with an explicit integer force >= 1' do
-      subject(:result) { described_instance.clean(ff: true, force: 3) }
-
-      before { allow(Git::Deprecation).to receive(:warn) }
-
-      it 'keeps the larger of the explicit force and 2' do
-        expect(clean_command).to receive(:call).with(force: 3).and_return(clean_result)
-        result
-      end
-    end
-
-    context 'with the deprecated :ff option combined with an explicit force: 0' do
-      subject(:result) { described_instance.clean(ff: true, force: 0) }
-
-      it 'emits the deprecation warning and propagates the ArgumentError from the command' do
-        # The facade passes force: 0 through to the Clean command, which rejects
-        # values <= 0. The ff: true should not mask the invalid force value.
-        allow(Git::Commands::Clean).to receive(:new).with(execution_context).and_call_original
-        expected_message = ':ff option is deprecated and will be removed in v6.0.0. Use force: 2 instead.'
-        expect(Git::Deprecation).to receive(:warn).with(expected_message)
-        expect { result }.to raise_error(ArgumentError, /force.*positive Integer/)
-      end
-    end
-
-    context 'with the deprecated :ff option combined with an explicit force: nil' do
-      subject(:result) { described_instance.clean(ff: true, force: nil) }
-
-      before { allow(Git::Deprecation).to receive(:warn) }
-
-      it 'treats the explicit nil as unspecified and applies the ff default of force: 2' do
-        expect(clean_command).to receive(:call).with(force: 2).and_return(clean_result)
-        result
-      end
-    end
-
-    context 'with the deprecated :ff option combined with a non-integer force value' do
-      subject(:result) { described_instance.clean(ff: true, force: 1.5) }
-
-      before { allow(Git::Deprecation).to receive(:warn) }
-
-      it 'forwards the non-integer force value unchanged' do
-        expect(clean_command).to receive(:call).with(force: 1.5).and_return(clean_result)
-        result
+      it 'does not call Git::Commands::Clean' do
+        expect(clean_command).not_to receive(:call)
+        begin
+          result
+        rescue ArgumentError
+          # expected
+        end
       end
     end
 


### PR DESCRIPTION
## Summary

Removes the four v4.x option and argument shapes that `Git::Repository` methods
accepted with a deprecation warning throughout v5.x:

| Removed | Replacement (unchanged) | After removal |
|---|---|---|
| `clean` options `:ff` and `:force_force` | `force: 2` | `ArgumentError` (unknown option) |
| `diff_path_status` option `:path` | `:path_limiter` | `ArgumentError` (unknown option) |
| `commit` option `:add_all` | `:all` | `ArgumentError` (unknown option) |
| positional `check` argument of `set_working` and `set_index` | `must_exist:` | `ArgumentError` (wrong number of arguments); `must_exist:` defaults to `true` |

The private translators are gone with their unit spec examples: `clean`'s
legacy-option migration helpers in `Staging::Private`, `diff_path_status`'s limiter
resolver in `Diffing::Private`, `commit`'s option normalizer, and the context helpers'
`check` argument resolver. A spec covers each removed key. No `Git::Deprecation.warn`
call remains in `Staging`'s `clean` helpers, `Diffing`, `Committing`, or
`ContextHelpers`.

## ADR-0007 gate

The warnings shipped in v5.0.0 and the UPGRADING.md entry (#1766) shipped in v5.4.1
(#1767). The gate check is recorded on #1776.

## Documentation

The "Upgrading to v6.x" section of UPGRADING.md states the removals. The
"`Git::Repository` option renames" entry under "Upgrading to v5.x" stays as the
migration reference.

## Verification

`bundle exec rake default` passes: unit and integration specs, RuboCop, yard build
and lint.

Closes #1776
